### PR TITLE
fix: add /health endpoint for backend probes

### DIFF
--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -41,6 +41,12 @@ app = FastAPI(
 )
 
 
+@app.get("/health")
+async def health_check() -> dict[str, str]:
+    """Health check endpoint for container probes."""
+    return {"status": "ok"}
+
+
 # 添加全局异常处理器
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(


### PR DESCRIPTION
Add `/health` endpoint to the FastAPI app.

This fixes 404 responses from backend health probes by returning:
- `200 OK`
- `{"status":"ok"}`