### PR TITLE
fix(nginx): avoid proxying /files page route to backend

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -42,18 +42,6 @@ server {
         proxy_send_timeout 1d;
     }
 
-    # Files download
-    location /files/ {
-        proxy_pass http://backend;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_buffering off;
-        proxy_read_timeout 300s;
-    }
-
     # Proxy to frontend
     location / {
         proxy_pass http://frontend;


### PR DESCRIPTION
**Summary**
- Remove the `location /files/` proxy rule from `docker/nginx.conf`.
- Keep `/api/files/...` traffic routed through the existing `/api/` backend proxy.

**Why**
In Docker deployment, `/files` is a frontend page route, but it was being forwarded to backend due to the `/files/` nginx rule, causing:
`{"detail":"Not Found"}`

**Result**
- `/files` now resolves to the Next.js frontend page as expected.
- File APIs (download/preview/upload) continue to work via `/api/files/...`.