### PR TITLE
fix(models): move provider credentials to request body to avoid API key URL logging

### DIFF
--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -186,17 +186,15 @@ export async function getProviderModels(
 ): Promise<ProviderModel[]> {
   const apiUrl = getApiUrl()
 
-  // Construct query parameters
-  const params = new URLSearchParams();
-  if (config?.api_key) params.append('api_key', config.api_key);
-  if (config?.base_url) params.append('base_url', config.base_url);
-
-  const response = await apiRequest(`${apiUrl}/api/models/providers/${provider}/models?${params.toString()}`, {
+  const response = await apiRequest(`${apiUrl}/api/models/providers/${provider}/models`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify({
+      api_key: config?.api_key ?? '',
+      base_url: config?.base_url,
+    }),
   });
 
   if (!response.ok) {

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Any, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from xagent.core.model.model import (
@@ -1397,8 +1397,8 @@ async def list_supported_providers() -> dict:
 @model_router.post("/providers/{provider}/models")
 async def fetch_provider_models(
     provider: str,
-    api_key: str,
-    base_url: Optional[str] = None,
+    api_key: str = Body(...),
+    base_url: Optional[str] = Body(None),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:


### PR DESCRIPTION
- Move `api_key`/`base_url` from query string to JSON body in provider model fetch request.
- Update backend endpoint to read these fields from request body.
- Query-only credential requests now fail validation, preventing accidental key exposure in URL logs.

Local test status:
- Verified on local backend (`python -m xagent.web --port 18000`).
- Body request returns `200` with model list.
- Query credential request returns `422` (`body.api_key` required).

Closes #40
