### PR TITLE
fix: pin json-repair version to 0.35.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "alembic>=1.13.0",
   "python-jose[cryptography]>=3.3.0",
   "psycopg2-binary>=2.9.0",
-  "json-repair>=0.35.0",
+  "json-repair==0.35.0",
   "pre-commit>=4.3.0",
   "jsonschema>=4.25.1",
   "playwright>=1.40.0",


### PR DESCRIPTION
This is to avoid different behaviors in newer versions