### PR TITLE
fix(docker): add OpenSSL libraries for ARM64 SSL support

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -27,6 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     python3-dev \
     curl \
+    libssl-dev \
+    libffi-dev \
     libgl1 \
     libglib2.0-0 \
     libsm6 \


### PR DESCRIPTION
Add libssl-dev and libffi-dev to fix SSL module availability issues when building Docker images on ARM64 architecture. This resolves pip installation failures when connecting to HTTPS repositories.