### PR TITLE
feat(model): add vector DB config persistence support

### DIFF
--- a/src/xagent/core/model/model.py
+++ b/src/xagent/core/model/model.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class VectorDBType(str, Enum):
@@ -10,6 +10,17 @@ class VectorDBType(str, Enum):
     LANCEDB = "lancedb"
     WEAVIATE = "weaviate"
     WEAVIATE_SAAS = "weaviate_saas"
+    CHROMADB = "chromadb"
+    MILVUS = "milvus"
+    QDRANT = "qdrant"
+    PINECONE = "pinecone"
+    PGVECTOR = "pgvector"
+    ELASTICSEARCH = "elasticsearch"
+    OPEN_SEARCH = "open_search"
+    REDIS = "redis"
+    FAISS = "faiss"
+    TYPESENSE = "typesense"
+    ZILLIZ = "zilliz"
 
 
 class ModelConfig(BaseModel):
@@ -48,7 +59,12 @@ class RerankModelConfig(ModelConfig):
 
 
 class VectorDBConfig(ModelConfig):
-    """Configuration for vector database backend (e.g. LanceDB, Weaviate)."""
+    """Configuration for vector database backend (e.g. LanceDB, Weaviate).
+
+    Note: When persisted via SQLAlchemyModelHub, the optional extra config dict
+    is stored in the base model's ``abilities`` JSON column (semantic repurpose;
+    for other categories ``abilities`` is Optional[List[str]]).
+    """
 
     db_type: VectorDBType = VectorDBType.LANCEDB
-    config: dict = {}
+    config: dict = Field(default_factory=dict)

--- a/src/xagent/core/model/storage/db/adapter.py
+++ b/src/xagent/core/model/storage/db/adapter.py
@@ -9,6 +9,7 @@ from xagent.core.model.model import (
     ModelConfig,
     RerankModelConfig,
     VectorDBConfig,
+    VectorDBType,
 )
 
 
@@ -32,10 +33,27 @@ class SQLAlchemyModelHub:
         if raw_value is None:
             return "lancedb"
         normalized = str(getattr(raw_value, "value", raw_value)).strip().lower()
+        if not normalized:
+            return "lancedb"
         legacy_aliases = {
             "weaviate_local": "weaviate",  # backward compatibility
         }
         return legacy_aliases.get(normalized, normalized)
+
+    def _load_vector_db_config(
+        self, db_model: Any, common_fields: dict[str, Any]
+    ) -> VectorDBConfig:
+        """Build VectorDBConfig from DB row; mutates common_fields (pops abilities)."""
+        db_type_val = self._normalize_vector_db_type(db_model.model_provider)
+        try:
+            db_type = VectorDBType(db_type_val) if db_type_val else VectorDBType.LANCEDB
+        except ValueError:
+            db_type = VectorDBType.LANCEDB
+        # VectorDBConfig repurposes abilities column for config dict (ModelConfig.abilities is List[str] elsewhere).
+        config_data = common_fields.pop("abilities", {})
+        if not isinstance(config_data, dict):
+            config_data = {}
+        return VectorDBConfig(**common_fields, db_type=db_type, config=config_data)
 
     def store(self, model: ModelConfig) -> None:
         db_data: dict[str, Any] = {
@@ -82,13 +100,12 @@ class SQLAlchemyModelHub:
                 }
             )
         elif isinstance(model, VectorDBConfig):
+            # VectorDBConfig repurposes abilities column for config dict (ModelConfig.abilities is List[str] elsewhere).
             db_data.update(
                 {
-                    "model_provider": model.db_type.value
-                    if hasattr(model.db_type, "value")
-                    else str(model.db_type),
+                    "model_provider": model.db_type.value,
                     "category": "vector_db",
-                    "abilities": model.config,  # Store extra config in abilities JSON field
+                    "abilities": model.config,
                 }
             )
         else:
@@ -151,21 +168,7 @@ class SQLAlchemyModelHub:
         elif db_model.category == "rerank":
             return RerankModelConfig(**common)
         elif db_model.category == "vector_db":
-            from xagent.core.model.model import VectorDBType
-
-            db_type_val = self._normalize_vector_db_type(db_model.model_provider)
-            try:
-                db_type = (
-                    VectorDBType(db_type_val) if db_type_val else VectorDBType.LANCEDB
-                )
-            except ValueError:
-                db_type = VectorDBType.LANCEDB
-
-            # Load extra config from abilities and remove it from common to avoid Pydantic validation error
-            config = common.pop("abilities", {})
-            if not isinstance(config, dict):
-                config = {}
-            return VectorDBConfig(**common, db_type=db_type, config=config)
+            return self._load_vector_db_config(db_model, common)
         else:
             raise ValueError(f"Unknown model category: {db_model.category}")
 
@@ -210,25 +213,7 @@ class SQLAlchemyModelHub:
             elif db_model.category == "rerank":
                 config = RerankModelConfig(**common_fields)
             elif db_model.category == "vector_db":
-                from xagent.core.model.model import VectorDBType
-
-                db_type_val = self._normalize_vector_db_type(db_model.model_provider)
-                try:
-                    db_type = (
-                        VectorDBType(db_type_val)
-                        if db_type_val
-                        else VectorDBType.LANCEDB
-                    )
-                except ValueError:
-                    db_type = VectorDBType.LANCEDB
-
-                # Load extra config from abilities and remove it from common_fields to avoid Pydantic validation error
-                config_data = common_fields.pop("abilities", {})
-                if not isinstance(config_data, dict):
-                    config_data = {}
-                config = VectorDBConfig(
-                    **common_fields, db_type=db_type, config=config_data
-                )
+                config = self._load_vector_db_config(db_model, common_fields)
 
             if config:
                 result[db_model.model_id] = config

--- a/tests/core/model/test_vector_db_config.py
+++ b/tests/core/model/test_vector_db_config.py
@@ -3,7 +3,11 @@ from cryptography.fernet import Fernet
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-from xagent.core.model.model import VectorDBConfig, VectorDBType
+from xagent.core.model.model import (
+    ChatModelConfig,
+    VectorDBConfig,
+    VectorDBType,
+)
 from xagent.core.model.storage.db.adapter import SQLAlchemyModelHub
 from xagent.core.model.storage.db.db_models import create_model_table
 
@@ -129,3 +133,146 @@ def test_vector_db_legacy_weaviate_local_alias(db_session, setup_encryption_key)
     loaded = hub.load("legacy-weaviate-local")
     assert isinstance(loaded, VectorDBConfig)
     assert loaded.db_type == VectorDBType.WEAVIATE
+
+
+def test_vector_db_config_with_other_models(db_session):
+    """list() returns correct mix of ChatModelConfig and VectorDBConfig."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    hub.store(
+        ChatModelConfig(
+            id="chat1",
+            model_name="GPT-4",
+            model_provider="openai",
+            api_key="sk-test",
+        )
+    )
+    hub.store(
+        VectorDBConfig(
+            id="v1",
+            model_name="V1",
+            db_type=VectorDBType.LANCEDB,
+            api_key="",
+        )
+    )
+    configs = hub.list()
+    assert "chat1" in configs
+    assert "v1" in configs
+    assert isinstance(configs["chat1"], ChatModelConfig)
+    assert isinstance(configs["v1"], VectorDBConfig)
+    assert configs["chat1"].model_name == "GPT-4"
+    assert configs["v1"].db_type == VectorDBType.LANCEDB
+
+
+def test_vector_db_config_empty_config(db_session):
+    """Roundtrip with config={} or no extra config."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    hub.store(
+        VectorDBConfig(
+            id="empty-cfg",
+            model_name="Empty",
+            db_type=VectorDBType.CHROMADB,
+            config={},
+            api_key="",
+        )
+    )
+    loaded = hub.load("empty-cfg")
+    assert isinstance(loaded, VectorDBConfig)
+    assert loaded.config == {}
+    assert loaded.db_type == VectorDBType.CHROMADB
+
+
+def test_vector_db_config_non_dict_abilities(db_session, setup_encryption_key):
+    """When DB has non-dict abilities for vector_db, config becomes {} and no crash."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"key").decode()
+    db_record = Model(
+        model_id="bad-abilities",
+        category="vector_db",
+        model_provider="lancedb",
+        model_name="Bad",
+        _api_key_encrypted=valid_encrypted,
+        abilities=["list", "not", "dict"],  # wrong type for vector_db config
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+    loaded = hub.load("bad-abilities")
+    assert isinstance(loaded, VectorDBConfig)
+    assert loaded.config == {}
+    assert loaded.db_type == VectorDBType.LANCEDB
+
+
+def test_vector_db_config_delete(db_session):
+    """delete() removes vector_db config; load() then raises."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    hub.store(
+        VectorDBConfig(
+            id="to-delete",
+            model_name="Del",
+            db_type=VectorDBType.LANCEDB,
+            api_key="",
+        )
+    )
+    assert hub.exists("to-delete")
+    hub.delete("to-delete")
+    assert not hub.exists("to-delete")
+    with pytest.raises(ValueError, match="Model not found"):
+        hub.load("to-delete")
+
+
+def test_vector_db_config_normalize_case(db_session, setup_encryption_key):
+    """Provider value is normalized to lowercase (e.g. LanceDB -> lancedb)."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"k").decode()
+    db_record = Model(
+        model_id="case-test",
+        category="vector_db",
+        model_provider="LanceDB",
+        model_name="Case",
+        _api_key_encrypted=valid_encrypted,
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+    loaded = hub.load("case-test")
+    assert loaded.db_type == VectorDBType.LANCEDB
+
+
+def test_vector_db_config_normalize_whitespace_legacy(db_session, setup_encryption_key):
+    """Legacy value with whitespace (e.g. ' weaviate_local ') normalizes to weaviate."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"k").decode()
+    db_record = Model(
+        model_id="ws-test",
+        category="vector_db",
+        model_provider=" weaviate_local ",
+        model_name="WS",
+        _api_key_encrypted=valid_encrypted,
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+    loaded = hub.load("ws-test")
+    assert loaded.db_type == VectorDBType.WEAVIATE
+
+
+def test_vector_db_config_empty_string_provider(db_session, setup_encryption_key):
+    """Empty or whitespace-only model_provider falls back to lancedb."""
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"k").decode()
+    db_record = Model(
+        model_id="empty-provider",
+        category="vector_db",
+        model_provider="",
+        model_name="EmptyProvider",
+        _api_key_encrypted=valid_encrypted,
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+    loaded = hub.load("empty-provider")
+    assert loaded.db_type == VectorDBType.LANCEDB


### PR DESCRIPTION
Introduce VectorDBConfig and VectorDBType in the model layer, persist vector_db records through SQLAlchemyModelHub, and normalize legacy weaviate_local values for backward compatibility while adding roundtrip tests.

Made-with: Cursor