### PR TITLE
feat: add Gemini image editing support

### DIFF
--- a/src/xagent/core/model/image/gemini.py
+++ b/src/xagent/core/model/image/gemini.py
@@ -447,12 +447,20 @@ class GeminiImageModel(BaseImageModel):
 
         # Handle single or multiple images
         images = [image_url] if isinstance(image_url, str) else image_url
+        if not images:
+            raise ValueError("At least one image must be provided for editing")
 
         for img in images:
             # Determine mime type and get base64 data
             if img.startswith("data:"):
                 # Data URL: data:image/png;base64,xxxxx
-                mime_type = "image/png"
+                # Parse MIME type from data URL format
+                try:
+                    mime_type = img[5:].split(";base64,")[0]
+                    if not mime_type or "/" not in mime_type:
+                        mime_type = "image/png"
+                except IndexError:
+                    mime_type = "image/png"
                 base64_data = img.split(",", 1)[1]
                 parts.append(
                     {"inlineData": {"mimeType": mime_type, "data": base64_data}}
@@ -485,34 +493,35 @@ class GeminiImageModel(BaseImageModel):
                     raise RuntimeError(f"Failed to process image URL {img}: {e}") from e
             else:
                 # Local file path - read and encode
-                try:
-                    # Check if it's a valid file path
-                    path = pathlib.Path(img)
-                    if path.is_file():
-                        # Read file and determine mime type
-                        with open(path, "rb") as f:
-                            image_bytes = f.read()
+                # Check if it's a valid file path
+                path = pathlib.Path(img)
+                if not path.is_file():
+                    raise ValueError(f"File not found: {img}")
 
-                        # Determine mime type from extension
-                        ext = path.suffix.lower()
-                        mime_map = {
-                            ".jpg": "image/jpeg",
-                            ".jpeg": "image/jpeg",
-                            ".png": "image/png",
-                            ".gif": "image/gif",
-                            ".webp": "image/webp",
-                        }
-                        mime_type = mime_map.get(ext, "image/jpeg")
-                        base64_data = base64.b64encode(image_bytes).decode("utf-8")
-                        parts.append(
-                            {"inlineData": {"mimeType": mime_type, "data": base64_data}}
-                        )
-                    else:
-                        raise ValueError(f"File not found: {img}")
-                except Exception as e:
-                    raise ValueError(
-                        f"Unsupported image URL format or file not found: {img}"
-                    ) from e
+                try:
+                    # Read file and determine mime type
+                    with open(path, "rb") as f:
+                        image_bytes = f.read()
+                except (OSError, IOError) as e:
+                    raise ValueError(f"Failed to read file {img}: {e}") from e
+
+                # Determine mime type from extension
+                ext = path.suffix.lower()
+                mime_map = {
+                    ".jpg": "image/jpeg",
+                    ".jpeg": "image/jpeg",
+                    ".png": "image/png",
+                    ".gif": "image/gif",
+                    ".webp": "image/webp",
+                    ".bmp": "image/bmp",
+                    ".tiff": "image/tiff",
+                    ".tif": "image/tiff",
+                }
+                mime_type = mime_map.get(ext, "image/jpeg")
+                base64_data = base64.b64encode(image_bytes).decode("utf-8")
+                parts.append(
+                    {"inlineData": {"mimeType": mime_type, "data": base64_data}}
+                )
 
         # Add the text prompt
         parts.append({"text": prompt})
@@ -569,14 +578,14 @@ class GeminiImageModel(BaseImageModel):
             first_candidate = candidates[0]
             finish_reason = first_candidate.get("finishReason")
             content = first_candidate.get("content", {})
-            parts = content.get("parts", [])
+            response_parts = content.get("parts", [])
 
-            if not parts:
+            if not response_parts:
                 raise RuntimeError("No parts in response content")
 
             # Look for image URL in Markdown text response (most common format)
             edited_image_url = None
-            for part in parts:
+            for part in response_parts:
                 text = part.get("text", "")
                 if text:
                     # Extract image URL from Markdown format: ![Image](url)
@@ -587,7 +596,7 @@ class GeminiImageModel(BaseImageModel):
 
             # Also check for inlineData as fallback
             if not edited_image_url:
-                for part in parts:
+                for part in response_parts:
                     inline_data = part.get("inlineData")
                     if inline_data:
                         mime_type = inline_data.get("mimeType", "image/png")

--- a/tests/core/model/image/test_gemini.py
+++ b/tests/core/model/image/test_gemini.py
@@ -72,6 +72,18 @@ class TestGeminiImageModel:
         model6 = GeminiImageModel(model_name="gemini-3-pro-image-preview-2k")
         assert model6.abilities == ["generate", "edit"]
 
+        # Test auto-detection with "edit" in model name
+        model7 = GeminiImageModel(model_name="gemini-edit-image-preview")
+        assert model7.abilities == ["generate", "edit"]
+
+        # Test case insensitivity
+        model8 = GeminiImageModel(model_name="GEMINI-3-PRO-IMAGE")
+        assert model8.abilities == ["generate", "edit"]
+
+        # Test with both patterns (3-pro and edit)
+        model9 = GeminiImageModel(model_name="gemini-3-pro-edit-image")
+        assert model9.abilities == ["generate", "edit"]
+
     def test_has_ability_method(self):
         """Test the has_ability method."""
         model = GeminiImageModel(abilities=["generate"])
@@ -224,3 +236,189 @@ class TestGeminiImageModel:
             # Clean up temp file
             if os.path.exists(temp_file):
                 os.remove(temp_file)
+
+    @pytest.mark.asyncio
+    async def test_edit_image_with_http_url(self):
+        """Test edit_image with HTTP URL."""
+        model = GeminiImageModel(
+            model_name="gemini-3-pro-image-preview-2k",
+            api_key="test_key",
+            abilities=["generate", "edit"],
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            # Mock the image download GET response
+            mock_get_response = MagicMock()
+            mock_get_response.status_code = 200
+            mock_get_response.content = b"fake_image_bytes"
+            mock_get_response.headers = {"content-type": "image/jpeg"}
+
+            # Mock the API POST response
+            mock_post_response = MagicMock()
+            mock_post_response.status_code = 200
+            mock_post_response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "![Image](https://example.com/edited.jpg)"}
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 100,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 150,
+                },
+            }
+
+            # Set up get and post methods
+            mock_client.get = AsyncMock(return_value=mock_get_response)
+            mock_client.post = AsyncMock(return_value=mock_post_response)
+
+            result = await model.edit_image(
+                image_url="https://example.com/image.jpg", prompt="Edit the image"
+            )
+
+            assert result["image_url"] == "https://example.com/edited.jpg"
+            assert mock_client.get.called
+            assert mock_client.post.called
+
+    @pytest.mark.asyncio
+    async def test_edit_image_with_data_url(self):
+        """Test edit_image with data URL (MIME type extraction)."""
+        model = GeminiImageModel(
+            model_name="gemini-3-pro-image-preview-2k",
+            api_key="test_key",
+            abilities=["generate", "edit"],
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "![Image](https://example.com/edited.webp)"}
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 100,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 150,
+                },
+            }
+            mock_client.post = AsyncMock(return_value=mock_response)
+
+            # Test with JPEG data URL
+            jpeg_data_url = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+            result = await model.edit_image(
+                image_url=jpeg_data_url, prompt="Edit the image"
+            )
+
+            assert result["image_url"] == "https://example.com/edited.webp"
+            call_args = mock_client.post.call_args
+            request_body = call_args[1]["json"]
+            parts = request_body["contents"][0]["parts"]
+            assert parts[0]["inlineData"]["mimeType"] == "image/jpeg"
+
+    @pytest.mark.asyncio
+    async def test_edit_image_with_multiple_images(self):
+        """Test edit_image with multiple image URLs."""
+        model = GeminiImageModel(
+            model_name="gemini-3-pro-image-preview-2k",
+            api_key="test_key",
+            abilities=["generate", "edit"],
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "![Image](https://example.com/edited.png)"}
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 150,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 200,
+                },
+            }
+            mock_client.post = AsyncMock(return_value=mock_response)
+
+            # Test with multiple data URLs
+            images = [
+                "data:image/png;base64,iVBORw0KG==",
+                "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+            ]
+            result = await model.edit_image(image_url=images, prompt="Combine these")
+
+            assert result["image_url"] == "https://example.com/edited.png"
+            call_args = mock_client.post.call_args
+            request_body = call_args[1]["json"]
+            parts = request_body["contents"][0]["parts"]
+            assert len(parts) == 3  # 2 images + 1 text prompt
+            assert parts[0]["inlineData"]["mimeType"] == "image/png"
+            assert parts[1]["inlineData"]["mimeType"] == "image/jpeg"
+            assert parts[2]["text"] == "Combine these"
+
+    @pytest.mark.asyncio
+    async def test_edit_image_with_empty_list(self):
+        """Test edit_image with empty list raises ValueError."""
+        model = GeminiImageModel(
+            model_name="gemini-3-pro-image-preview-2k",
+            api_key="test_key",
+            abilities=["generate", "edit"],
+        )
+
+        with pytest.raises(
+            ValueError, match="At least one image must be provided for editing"
+        ):
+            await model.edit_image(image_url=[], prompt="Edit the image")
+
+    @pytest.mark.asyncio
+    async def test_edit_image_with_http_error(self):
+        """Test edit_image with non-200 HTTP response."""
+        model = GeminiImageModel(
+            model_name="gemini-3-pro-image-preview-2k",
+            api_key="test_key",
+            abilities=["generate", "edit"],
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            # Mock failed image download
+            mock_get_response = MagicMock()
+            mock_get_response.status_code = 404
+            mock_client.get = AsyncMock(return_value=mock_get_response)
+
+            with pytest.raises(RuntimeError, match="Failed to download image: 404"):
+                await model.edit_image(
+                    image_url="https://example.com/notfound.jpg",
+                    prompt="Edit the image",
+                )


### PR DESCRIPTION
Add image editing capability for Gemini models like gemini-3-pro-image-preview-2k. Features:
- Implement edit_image method with local file path, HTTP URL, and data URL support
- Auto-detect edit capability based on model name (3-pro models support editing)
- Add comprehensive tests for image editing functionality
- Fix type annotations for mypy compliance

This enables users to perform image editing tasks using compatible Gemini models through the existing image tool interface.