### PR TITLE
feat(models): unify add flow and category-based provider listing

### DIFF
--- a/frontend/src/components/pages/models.tsx
+++ b/frontend/src/components/pages/models.tsx
@@ -50,7 +50,6 @@ import {
   X
 } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { toast } from "sonner"
 
 function doubleEncodeModelId(modelId: string): string {
@@ -444,9 +443,8 @@ export function ModelsPage() {
   const handleConfirmDefault = async () => {
     setShowDefaultConfirm(false)
     if (viewMode === 'connect') {
-      const selected = fetchedModels.filter(m => selectedFetchedModels.includes(m.id))
       // If user selected a specific model to be default
-      await submitSelectedModels(selected, pendingDefaultType || undefined, selectedDefaultModel)
+      await submitSelectedModelNames(selectedFetchedModels, pendingDefaultType || undefined, selectedDefaultModel)
     } else {
       if (pendingDefaultType) {
         // Handle batch create with selected default
@@ -472,8 +470,7 @@ export function ModelsPage() {
   const handleCancelDefault = async () => {
     setShowDefaultConfirm(false)
     if (viewMode === 'connect') {
-      const selected = fetchedModels.filter(m => selectedFetchedModels.includes(m.id))
-      await submitSelectedModels(selected)
+      await submitSelectedModelNames(selectedFetchedModels)
     } else {
       await submitModelData(formData)
     }
@@ -626,7 +623,8 @@ export function ModelsPage() {
       setIsFetchingModels(true)
       const models = await getProviderModels(formData.model_provider, {
         api_key: formData.api_key,
-        base_url: formData.base_url
+        base_url: formData.base_url,
+        category: formData.category as 'llm' | 'embedding' | 'image',
       })
       setFetchedModels(models)
     } catch (err) {
@@ -640,7 +638,7 @@ export function ModelsPage() {
 
   const handleSaveSelectedModels = async () => {
     try {
-      const selected = fetchedModels.filter(m => selectedFetchedModels.includes(m.id))
+      const selected = selectedFetchedModels
 
       // Check for default model for the first selected model
       // Only check if we are creating LLM models
@@ -650,31 +648,31 @@ export function ModelsPage() {
 
         if (!hasDefault && selected.length > 0) {
           setPendingDefaultType(targetType)
-          setPendingModels(selected.map(m => m.id))
-          setSelectedDefaultModel(selected[0].id)
+          setPendingModels(selected)
+          setSelectedDefaultModel(selected[0])
           setShowDefaultConfirm(true)
           return
         }
       }
 
-      await submitSelectedModels(selected)
+      await submitSelectedModelNames(selected)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('models.errors.saveFailed'))
     }
   }
 
-  const submitSelectedModels = async (selectedModels: ProviderModel[], defaultTypeToSet?: string, defaultModelId?: string) => {
+  const submitSelectedModelNames = async (selectedModelNames: string[], defaultTypeToSet?: string, defaultModelId?: string) => {
     try {
       setLoading(true)
 
-      for (let i = 0; i < selectedModels.length; i++) {
-         const model = selectedModels[i]
+      for (let i = 0; i < selectedModelNames.length; i++) {
+         const modelName = selectedModelNames[i]
 
          const payload: ModelCreate = {
             ...formData,
-            model_id: `${model.id}-${formData.model_provider}-${user?.id}`,
-            model_name: model.id,
-            default_config_types: (defaultTypeToSet && defaultModelId && model.id === defaultModelId) ? [defaultTypeToSet] : []
+            model_id: `${modelName}-${formData.model_provider}-${user?.id}`,
+            model_name: modelName,
+            default_config_types: (defaultTypeToSet && defaultModelId && modelName === defaultModelId) ? [defaultTypeToSet] : []
          }
 
          const url = `${getApiUrl()}/api/models/`
@@ -687,7 +685,7 @@ export function ModelsPage() {
          if (!response.ok) {
           const errorData = await response.json()
           throw new Error(errorData.detail || t('models.errors.createFailed'))
-        } else if (defaultTypeToSet && defaultModelId && model.id === defaultModelId) {
+        } else if (defaultTypeToSet && defaultModelId && modelName === defaultModelId) {
              const modelResponse = await response.json()
              // Set default
              await apiRequest(`${getApiUrl()}/api/models/user-default`, {
@@ -1039,6 +1037,43 @@ export function ModelsPage() {
             </DialogHeader>
 
             <div className="flex flex-col gap-4 mt-4">
+               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                 <div>
+                   <Label htmlFor="connect_category">{t('models.form.category')}</Label>
+                   <Select
+                     value={formData.category}
+                     onValueChange={(value) => setFormData({ ...formData, category: value })}
+                     options={[
+                       { value: "llm", label: t('models.tabs.llm') },
+                       { value: "embedding", label: t('models.tabs.embedding') },
+                       { value: "image", label: t('models.tabs.image') }
+                     ]}
+                   />
+                 </div>
+                 <div>
+                   <Label htmlFor="connect_model_provider">{t('models.form.provider')}</Label>
+                   <Select
+                     value={formData.model_provider}
+                     onValueChange={(value) => {
+                       const providerConfig = providers.find(p => p.id === value)
+                       setFormData({
+                         ...formData,
+                         model_provider: value,
+                         base_url: providerConfig?.defaultBaseUrl || "",
+                         abilities: formData.category === 'llm' ? ["chat"] : formData.category === 'embedding' ? ["embedding"] : ["generate"],
+                       })
+                       setFetchedModels([])
+                       setSelectedFetchedModels([])
+                     }}
+                     options={providers
+                       .filter(p => p.category.includes(formData.category as any))
+                       .map((provider) => ({
+                         value: provider.id,
+                         label: provider.name
+                       }))}
+                   />
+                 </div>
+               </div>
                <div className="grid grid-cols-1 gap-4">
                  <div>
                    <Label htmlFor="api_key">{t('models.form.apiKey')}</Label>
@@ -1075,46 +1110,30 @@ export function ModelsPage() {
                      <RefreshCw className={`h-3 w-3 ${isFetchingModels ? 'animate-spin' : ''}`} />
                    </Button>
                  </div>
-                 {isFetchingModels ? (
-                   <div className="flex items-center justify-center p-8 border rounded-md text-muted-foreground">
-                     <Loader2 className="w-6 h-6 animate-spin mr-2" />
-                     {t('models.dialog.fetchingModels')}
-                   </div>
-                 ) : fetchedModels.length > 0 ? (
-                   <>
-                     <ScrollArea className="max-h-[200px] overflow-y-scroll border p-4">
-                       <div className="space-y-2">
-                         {fetchedModels.map(model => (
-                           <div key={model.id} className="flex items-center space-x-2">
-                             <input
-                               type="checkbox"
-                               id={`model-${model.id}`}
-                               className="h-4 w-4 rounded border-gray-300"
-                               checked={selectedFetchedModels.includes(model.id)}
-                               onChange={(e) => {
-                                 if (e.target.checked) {
-                                   setSelectedFetchedModels([...selectedFetchedModels, model.id])
-                                 } else {
-                                   setSelectedFetchedModels(selectedFetchedModels.filter(id => id !== model.id))
-                                 }
-                               }}
-                             />
-                             <Label htmlFor={`model-${model.id}`} className="font-normal cursor-pointer flex-1">
-                               {model.id}
-                             </Label>
-                           </div>
-                         ))}
-                       </div>
-                     </ScrollArea>
-                     <div className="text-sm text-muted-foreground mt-2">
-                       {selectedFetchedModels.length} models selected
-                     </div>
-                   </>
-                 ) : (
-                   <div className="flex items-center justify-center p-8 border rounded-md text-muted-foreground italic bg-muted/30">
-                     {t('models.dialog.modelsFetchedAfterConnect')}
-                   </div>
-                 )}
+                {isFetchingModels ? (
+                  <div className="flex items-center justify-center p-8 border rounded-md text-muted-foreground">
+                    <Loader2 className="w-6 h-6 animate-spin mr-2" />
+                    {t('models.dialog.fetchingModels')}
+                  </div>
+                ) : (
+                  <>
+                    <MultiSelect
+                      creatable
+                      values={selectedFetchedModels}
+                      onValuesChange={setSelectedFetchedModels}
+                      options={fetchedModels.map(m => ({ value: m.id, label: m.id }))}
+                      placeholder={t('models.form.selectModel')}
+                    />
+                    <div className="text-sm text-muted-foreground mt-2">
+                      {selectedFetchedModels.length} models selected
+                    </div>
+                    {fetchedModels.length === 0 && (
+                      <div className="flex items-center justify-center p-4 border rounded-md text-muted-foreground italic bg-muted/30">
+                        {t('models.dialog.modelsFetchedAfterConnect')}
+                      </div>
+                    )}
+                  </>
+                )}
                </div>
             </div>
 

--- a/frontend/src/components/settings/default-models.tsx
+++ b/frontend/src/components/settings/default-models.tsx
@@ -51,6 +51,14 @@ const modelTypeConfig = {
   },
 }
 
+const configTypeCategoryMap: Record<keyof typeof modelTypeConfig, Model["model_provider"]> = {
+  general: "llm",
+  small_fast: "llm",
+  visual: "llm",
+  compact: "llm",
+  embedding: "embedding",
+}
+
 export function DefaultModelsSettings() {
   const { token } = useAuth()
   const [models, setModels] = useState<Model[]>([])
@@ -126,8 +134,9 @@ export function DefaultModelsSettings() {
     }
   }
 
-  const getModelById = (modelId: number) => {
-    return models.find(model => model.id === modelId)
+  const getOptionsForConfigType = (configType: keyof typeof modelTypeConfig) => {
+    const category = configTypeCategoryMap[configType]
+    return models.filter((model) => model.model_provider === category)
   }
 
   if (loading) {
@@ -171,6 +180,7 @@ export function DefaultModelsSettings() {
             const currentDefault = defaultModels[configType as keyof typeof modelTypeConfig]
             const Icon = config.icon
             const isSaving = saving === configType
+            const availableModels = getOptionsForConfigType(configType as keyof typeof modelTypeConfig)
 
             return (
               <Card key={configType} className="relative">
@@ -229,13 +239,13 @@ export function DefaultModelsSettings() {
                         onValueChange={(value) =>
                           handleSetDefault(configType as keyof typeof modelTypeConfig, parseInt(value))
                         }
-                        options={models.map((model) => ({
+                        options={availableModels.map((model) => ({
                           value: model.id.toString(),
                           label: `${model.name} (${model.provider})`,
                         }))}
                         placeholder={t('settings.defaultModels.labels.selectModel')}
                       />
-                      {models.length === 0 && (
+                      {availableModels.length === 0 && (
                         <p className="text-xs text-muted-foreground">
                           {t('settings.defaultModels.empty.noModels')}
                         </p>

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -182,7 +182,7 @@ export async function getSupportedProviders(): Promise<Provider[]> {
  */
 export async function getProviderModels(
   provider: string,
-  config?: { api_key?: string; base_url?: string }
+  config?: { api_key?: string; base_url?: string; category?: 'llm' | 'embedding' | 'image' }
 ): Promise<ProviderModel[]> {
   const apiUrl = getApiUrl()
 
@@ -194,6 +194,7 @@ export async function getProviderModels(
     body: JSON.stringify({
       api_key: config?.api_key ?? '',
       base_url: config?.base_url,
+      category: config?.category,
     }),
   });
 

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -1417,6 +1417,7 @@ async def fetch_provider_models(
     provider: str,
     api_key: str = Body(...),
     base_url: Optional[str] = Body(None),
+    category: Optional[str] = Body(None),
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:
@@ -1446,7 +1447,9 @@ async def fetch_provider_models(
         )
 
     try:
-        models = await fetch_models_from_provider(provider, api_key, base_url)
+        models = await fetch_models_from_provider(
+            provider, api_key, base_url, category=category
+        )
 
         return {
             "provider": provider,

--- a/src/xagent/web/services/model_list_service.py
+++ b/src/xagent/web/services/model_list_service.py
@@ -112,6 +112,7 @@ async def fetch_models_from_provider(
     provider: str,
     api_key: str,
     base_url: Optional[str] = None,
+    category: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Fetch available models from a specific provider.
 
@@ -119,6 +120,7 @@ async def fetch_models_from_provider(
         provider: Provider name (openai, zhipu, claude, etc.)
         api_key: API key for the provider
         base_url: Custom base URL (optional)
+        category: Requested category (llm, embedding, image)
 
     Returns:
         List of available models
@@ -131,6 +133,8 @@ async def fetch_models_from_provider(
 
     try:
         result: List[Dict[str, Any]] = await fetcher(api_key, base_url)
+        if category:
+            result = _filter_models_by_category(result, category)
         return result
     except Exception as e:
         logger.error(
@@ -139,6 +143,53 @@ async def fetch_models_from_provider(
             redact_sensitive_text(str(e)),
         )
         raise
+
+
+def _model_name(model: Dict[str, Any]) -> str:
+    """Get a normalized model name for category filtering."""
+    return str(model.get("id") or model.get("model") or model.get("name") or "").lower()
+
+
+def _is_embedding_model(model: Dict[str, Any]) -> bool:
+    """Heuristic detection of embedding models from provider list output."""
+    name = _model_name(model)
+    return "embedding" in name
+
+
+def _is_image_model(model: Dict[str, Any]) -> bool:
+    """Heuristic detection of image generation/edit models."""
+    name = _model_name(model)
+    image_keywords = (
+        "image",
+        "dall-e",
+        "sdxl",
+        "stable-diffusion",
+        "flux",
+        "vision-image",
+    )
+    return any(keyword in name for keyword in image_keywords)
+
+
+def _filter_models_by_category(
+    models: List[Dict[str, Any]], category: str
+) -> List[Dict[str, Any]]:
+    """Filter provider model list by requested category."""
+    normalized = category.lower().strip()
+
+    if normalized == "embedding":
+        return [model for model in models if _is_embedding_model(model)]
+
+    if normalized == "image":
+        return [model for model in models if _is_image_model(model)]
+
+    if normalized == "llm":
+        return [
+            model
+            for model in models
+            if not _is_embedding_model(model) and not _is_image_model(model)
+        ]
+
+    return models
 
 
 def get_supported_providers() -> List[Dict[str, Any]]:


### PR DESCRIPTION
Unify model selection UX between provider cards and the top-right add flow, including searchable and creatable model picking. Add category-aware provider model filtering so embedding pages only list embedding-capable models.
Trying to fix https://github.com/xorbitsai/xagent/pull/97
