### PR TITLE
feat: add knowledge base tool validation and system prompt enhancement

### DIFF
--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -11,7 +11,7 @@ import { ChatInput } from "@/components/chat/ChatInput"
 import { ChatMessage } from "@/components/chat/ChatMessage"
 import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl, getWsUrl } from "@/lib/utils"
-import { PlusCircle, MessageSquare, Upload, Download, Info, Settings2, Check, Zap, BookOpen, ChevronLeft, Sparkles, Loader2 } from "lucide-react"
+import { PlusCircle, MessageSquare, Upload, Download, Info, Settings2, Check, Zap, BookOpen, ChevronLeft, Sparkles, Loader2, AlertTriangle } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { useAuth } from "@/contexts/auth-context"
 import { FileAttachment } from "@/components/file-attachment"
@@ -142,6 +142,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   // Create Success Dialog State
   const [showSuccessDialog, setShowSuccessDialog] = useState(false)
   const [createdAgent, setCreatedAgent] = useState<any>(null)
+
+  // Knowledge-base tool validation dialog
+  const [showKbToolWarning, setShowKbToolWarning] = useState(false)
 
   // Data State
   const [models, setModels] = useState<Model[]>([])
@@ -709,6 +712,11 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
     if (!modelConfig.general) {
       toast.error(t("builds.editor.validation.modelRequired"))
+      return
+    }
+
+    if (selectedKbs.length > 0 && !selectedToolCategories.includes("knowledge")) {
+      setShowKbToolWarning(true)
       return
     }
 
@@ -1471,6 +1479,40 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           </div>
         </SheetContent>
       </Sheet>
+
+      {/* Knowledge Base Tool Warning Dialog */}
+      <Dialog open={showKbToolWarning} onOpenChange={setShowKbToolWarning}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-500" />
+              {t("builds.editor.kbToolWarning.title")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("builds.editor.kbToolWarning.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-3 text-sm text-amber-800 dark:text-amber-200">
+            {t("builds.editor.kbToolWarning.hint")}
+          </div>
+          <DialogFooter className="gap-2 sm:justify-end">
+            <div className="flex w-full sm:w-auto gap-2 justify-end">
+              <Button variant="outline" onClick={() => setShowKbToolWarning(false)}>
+                {t("builds.editor.kbToolWarning.cancel")}
+              </Button>
+              <Button onClick={() => {
+                setSelectedToolCategories(prev =>
+                  prev.includes("knowledge") ? prev : [...prev, "knowledge"]
+                )
+                setShowKbToolWarning(false)
+                toast.success(t("builds.editor.kbToolWarning.enabled"))
+              }}>
+                {t("builds.editor.kbToolWarning.enableAndContinue")}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Success Dialog */}
       <Dialog open={showSuccessDialog} onOpenChange={handleDialogClose}>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1575,8 +1575,17 @@ Build when you need.`
         failed: "Failed to create agent",
         publishFailed: "Failed to publish agent",
         unpublishFailed: "Failed to unpublish agent",
+        kbToolsNotEnabled: "Knowledge bases are selected but the Knowledge tool category is not enabled. Please enable the Knowledge tools before saving.",
         unknown: "An unknown error occurred",
-      }
+      },
+      kbToolWarning: {
+        title: "Knowledge Tools Required",
+        description: "You have selected knowledge bases but haven't enabled the Knowledge tool category. The agent needs Knowledge tools to search and retrieve content from the knowledge bases.",
+        hint: "Click the button below to enable Knowledge tools, then save again.",
+        cancel: "Later",
+        enableAndContinue: "Enable Knowledge Tools",
+        enabled: "Knowledge tools enabled. Please save again.",
+      },
     },
     configForm: {
       logo: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1575,8 +1575,17 @@ Build when you need.`
         failed: "创建 Agent 失败",
         publishFailed: "发布 Agent 失败",
         unpublishFailed: "取消发布 Agent 失败",
+        kbToolsNotEnabled: "选择了知识库但未启用知识库工具，请在工具类别中勾选「知识库」工具后再保存。",
         unknown: "发生未知错误",
-      }
+      },
+      kbToolWarning: {
+        title: "需要启用知识库工具",
+        description: "您已选择了知识库，但尚未启用「知识库」工具类别。Agent 需要知识库工具才能检索和使用知识库中的内容。",
+        hint: "点击下方按钮可一键启用知识库工具，启用后请重新保存。",
+        cancel: "稍后处理",
+        enableAndContinue: "启用知识库工具",
+        enabled: "已启用知识库工具，请重新保存",
+      },
     },
     configForm: {
       logo: {

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -124,7 +124,43 @@ class OptimizeInstructionsRequest(BaseModel):
     )
 
 
+KNOWLEDGE_TOOL_CATEGORY = "knowledge"
+
+KB_PRIORITY_PROMPT = (
+    "\n\n[Knowledge Base Instructions]\n"
+    "You have access to the following knowledge base(s). "
+    "When answering user questions, you MUST first search the knowledge base(s) "
+    "using the available knowledge tools before relying on your own knowledge. "
+    "Always prioritize information retrieved from the knowledge base(s) over "
+    "your built-in knowledge. If the knowledge base does not contain relevant "
+    "information, you may then use your own knowledge to answer, but clearly "
+    "indicate that the answer is not from the knowledge base."
+)
+
+
+def enhance_system_prompt_with_kb(
+    system_prompt: Optional[str], knowledge_bases: Optional[List[str]]
+) -> Optional[str]:
+    """Append knowledge-base priority instructions when KBs are configured."""
+    if not knowledge_bases:
+        return system_prompt
+    if system_prompt:
+        return system_prompt + KB_PRIORITY_PROMPT
+    return KB_PRIORITY_PROMPT.lstrip("\n")
+
+
 # ===== Helper Functions =====
+
+
+def _validate_knowledge_base_tools(
+    knowledge_bases: List[str], tool_categories: List[str]
+) -> None:
+    """Raise HTTPException if knowledge bases are selected without the knowledge tool category."""
+    if knowledge_bases and KNOWLEDGE_TOOL_CATEGORY not in tool_categories:
+        raise HTTPException(
+            status_code=400,
+            detail="Knowledge bases are selected but the Knowledge tool category is not enabled. Please enable the Knowledge tools before saving.",
+        )
 
 
 def _save_logo(base64_data: Optional[str], agent_id: int) -> Optional[str]:
@@ -286,6 +322,10 @@ async def create_agent(
                 status_code=400, detail="Agent with this name already exists"
             )
 
+        _validate_knowledge_base_tools(
+            agent_data.knowledge_bases, agent_data.tool_categories
+        )
+
         # Create agent
         agent = Agent(
             user_id=current_user.id,
@@ -398,6 +438,19 @@ async def update_agent(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+
+        # Validate knowledge base + tool category consistency
+        effective_kb = (
+            agent_data.knowledge_bases
+            if agent_data.knowledge_bases is not None
+            else (agent.knowledge_bases or [])
+        )
+        effective_tools = (
+            agent_data.tool_categories
+            if agent_data.tool_categories is not None
+            else (agent.tool_categories or [])
+        )
+        _validate_knowledge_base_tools(effective_kb, effective_tools)  # type: ignore[arg-type]
 
         # Update fields
         if agent_data.name is not None:
@@ -770,9 +823,11 @@ async def preview_agent(
         # Execute task with system prompt in context
         execution_context = {}
         if request.instructions:
-            # User's instructions are added as a prefix (role definition)
-            # Planning capabilities are preserved
             execution_context["system_prompt"] = request.instructions
+        execution_context["system_prompt"] = enhance_system_prompt_with_kb(  # type: ignore[assignment]
+            execution_context.get("system_prompt"),
+            request.knowledge_bases if request.knowledge_bases else None,
+        )
 
         with UserContext(int(current_user.id)):
             result = await agent_service.execute_task(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -635,8 +635,16 @@ class AgentServiceManager:
                     tools_list, tool_config = tools
 
                     # Get system prompt from agent config (if available)
+                    from .agents import enhance_system_prompt_with_kb
+
                     system_prompt = (
                         agent_config.get("instructions") if agent_config else None
+                    )
+                    kb_list = (
+                        agent_config.get("knowledge_bases") if agent_config else None
+                    )
+                    system_prompt = enhance_system_prompt_with_kb(
+                        system_prompt, kb_list
                     )
 
                     # Create AgentService first (this creates the workspace)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2107,6 +2107,8 @@ async def handle_build_preview_execution(
                 return
 
         # Execute task
+        from .agents import enhance_system_prompt_with_kb
+
         execution_context = {}
         if instructions:
             execution_context["system_prompt"] = instructions
@@ -2118,6 +2120,10 @@ async def handle_build_preview_execution(
                 )
             else:
                 execution_context["system_prompt"] = file_prompt
+        # Emphasize KB priority when knowledge bases are configured
+        execution_context["system_prompt"] = enhance_system_prompt_with_kb(
+            execution_context.get("system_prompt"), knowledge_bases
+        )
         if uploaded_files:
             execution_context["uploaded_files"] = uploaded_files
         if file_info_list:

--- a/tests/web/api/test_agents_kb_tool_validation.py
+++ b/tests/web/api/test_agents_kb_tool_validation.py
@@ -1,0 +1,303 @@
+"""Tests for knowledge-base + tool-category validation and KB system prompt enhancement."""
+
+import os
+import shutil
+import tempfile
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xagent.web.api.agents import KB_PRIORITY_PROMPT, enhance_system_prompt_with_kb
+from xagent.web.api.agents import router as agents_router
+from xagent.web.api.auth import auth_router
+from xagent.web.models.database import Base, get_db, get_engine
+
+
+def _override_get_db():
+    db = None
+    try:
+        db = next(get_db())
+        yield db
+    finally:
+        if db is not None:
+            db.close()
+
+
+app_for_tests = FastAPI()
+app_for_tests.include_router(auth_router)
+app_for_tests.include_router(agents_router)
+app_for_tests.dependency_overrides[get_db] = _override_get_db
+client = TestClient(app_for_tests)
+
+
+@pytest.fixture(autouse=True)
+def _test_db():
+    """Create and tear down a temporary SQLite database for each test."""
+    from xagent.web.models.database import init_db
+
+    temp_dir = tempfile.mkdtemp()
+    temp_db_path = os.path.join(temp_dir, "test.db")
+    db_url = f"sqlite:///{temp_db_path}"
+
+    with patch("xagent.web.models.database.try_upgrade_db"):
+        init_db(db_url=db_url)
+
+    yield
+
+    Base.metadata.drop_all(bind=get_engine())
+    try:
+        shutil.rmtree(temp_dir)
+    except OSError:
+        pass
+
+
+def _setup_admin() -> None:
+    status = client.get("/api/auth/setup-status")
+    assert status.status_code == 200
+    if status.json().get("needs_setup", True):
+        resp = client.post(
+            "/api/auth/setup-admin",
+            json={"username": "admin", "password": "admin123"},
+        )
+        assert resp.status_code == 200
+
+
+def _login(username: str = "admin", password: str = "admin123") -> dict[str, str]:
+    resp = client.post(
+        "/api/auth/login", json={"username": username, "password": password}
+    )
+    assert resp.status_code == 200
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _headers() -> dict[str, str]:
+    _setup_admin()
+    return _login()
+
+
+AGENT_BASE = {
+    "name": "Test Agent",
+    "description": "test",
+    "instructions": "You are a test agent.",
+    "execution_mode": "react",
+}
+
+
+# ── Create ──────────────────────────────────────────────────────────
+
+
+class TestCreateAgentKbValidation:
+    """POST /api/agents — knowledge-base + tool-category validation."""
+
+    def test_create_with_kb_without_knowledge_tool_returns_400(self):
+        headers = _headers()
+        resp = client.post(
+            "/api/agents",
+            headers=headers,
+            json={
+                **AGENT_BASE,
+                "knowledge_bases": ["my_kb"],
+                "tool_categories": ["basic"],
+            },
+        )
+        assert resp.status_code == 400
+        assert "Knowledge" in resp.json()["detail"]
+
+    def test_create_with_kb_and_knowledge_tool_succeeds(self):
+        headers = _headers()
+        resp = client.post(
+            "/api/agents",
+            headers=headers,
+            json={
+                **AGENT_BASE,
+                "knowledge_bases": ["my_kb"],
+                "tool_categories": ["basic", "knowledge"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["knowledge_bases"] == ["my_kb"]
+        assert "knowledge" in data["tool_categories"]
+
+    def test_create_without_kb_without_knowledge_tool_succeeds(self):
+        headers = _headers()
+        resp = client.post(
+            "/api/agents",
+            headers=headers,
+            json={
+                **AGENT_BASE,
+                "knowledge_bases": [],
+                "tool_categories": ["basic"],
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_create_with_empty_kb_no_tools_succeeds(self):
+        headers = _headers()
+        resp = client.post(
+            "/api/agents",
+            headers=headers,
+            json={**AGENT_BASE},
+        )
+        assert resp.status_code == 200
+
+    def test_create_with_multiple_kbs_without_knowledge_tool_returns_400(self):
+        headers = _headers()
+        resp = client.post(
+            "/api/agents",
+            headers=headers,
+            json={
+                **AGENT_BASE,
+                "name": "Multi KB Agent",
+                "knowledge_bases": ["kb1", "kb2", "kb3"],
+                "tool_categories": ["file", "browser"],
+            },
+        )
+        assert resp.status_code == 400
+
+
+# ── Update ──────────────────────────────────────────────────────────
+
+
+class TestUpdateAgentKbValidation:
+    """PUT /api/agents/{id} — knowledge-base + tool-category validation."""
+
+    def _create_agent(self, headers: dict[str, str], **overrides) -> int:
+        payload = {**AGENT_BASE, **overrides}
+        resp = client.post("/api/agents", headers=headers, json=payload)
+        assert resp.status_code == 200
+        return int(resp.json()["id"])
+
+    def test_update_add_kb_without_knowledge_tool_returns_400(self):
+        headers = _headers()
+        agent_id = self._create_agent(headers, tool_categories=["basic"])
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={"knowledge_bases": ["new_kb"]},
+        )
+        assert resp.status_code == 400
+        assert "Knowledge" in resp.json()["detail"]
+
+    def test_update_remove_knowledge_tool_with_existing_kb_returns_400(self):
+        headers = _headers()
+        agent_id = self._create_agent(
+            headers,
+            knowledge_bases=["my_kb"],
+            tool_categories=["basic", "knowledge"],
+        )
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={"tool_categories": ["basic"]},
+        )
+        assert resp.status_code == 400
+
+    def test_update_add_kb_with_knowledge_tool_succeeds(self):
+        headers = _headers()
+        agent_id = self._create_agent(headers, tool_categories=["basic", "knowledge"])
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={"knowledge_bases": ["new_kb"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["knowledge_bases"] == ["new_kb"]
+
+    def test_update_add_kb_and_knowledge_tool_together_succeeds(self):
+        headers = _headers()
+        agent_id = self._create_agent(headers)
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={
+                "knowledge_bases": ["new_kb"],
+                "tool_categories": ["knowledge"],
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_update_remove_kb_and_knowledge_tool_together_succeeds(self):
+        headers = _headers()
+        agent_id = self._create_agent(
+            headers,
+            knowledge_bases=["my_kb"],
+            tool_categories=["basic", "knowledge"],
+        )
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={
+                "knowledge_bases": [],
+                "tool_categories": ["basic"],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["knowledge_bases"] == []
+
+    def test_update_unrelated_field_preserves_valid_state(self):
+        headers = _headers()
+        agent_id = self._create_agent(
+            headers,
+            knowledge_bases=["my_kb"],
+            tool_categories=["basic", "knowledge"],
+        )
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={"description": "updated description"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["knowledge_bases"] == ["my_kb"]
+        assert "knowledge" in resp.json()["tool_categories"]
+
+    def test_update_unrelated_field_on_no_kb_agent_succeeds(self):
+        headers = _headers()
+        agent_id = self._create_agent(headers, tool_categories=["basic"])
+        resp = client.put(
+            f"/api/agents/{agent_id}",
+            headers=headers,
+            json={"description": "no kb, just updating desc"},
+        )
+        assert resp.status_code == 200
+
+
+# ── enhance_system_prompt_with_kb ───────────────────────────────────
+
+
+class TestEnhanceSystemPromptWithKb:
+    """Unit tests for enhance_system_prompt_with_kb helper."""
+
+    def test_no_kb_returns_original_prompt(self):
+        assert enhance_system_prompt_with_kb("Hello", None) == "Hello"
+        assert enhance_system_prompt_with_kb("Hello", []) == "Hello"
+
+    def test_no_kb_returns_none_when_prompt_is_none(self):
+        assert enhance_system_prompt_with_kb(None, None) is None
+        assert enhance_system_prompt_with_kb(None, []) is None
+
+    def test_with_kb_appends_priority_prompt(self):
+        result = enhance_system_prompt_with_kb("Be helpful.", ["my_kb"])
+        assert result is not None
+        assert result.startswith("Be helpful.")
+        assert "MUST first search the knowledge base" in result
+        assert KB_PRIORITY_PROMPT in result
+
+    def test_with_kb_no_system_prompt_returns_priority_only(self):
+        result = enhance_system_prompt_with_kb(None, ["kb1"])
+        assert result is not None
+        assert not result.startswith("\n")
+        assert "MUST first search the knowledge base" in result
+
+    def test_with_multiple_kbs(self):
+        result = enhance_system_prompt_with_kb("Assist user.", ["kb1", "kb2", "kb3"])
+        assert result is not None
+        assert result.startswith("Assist user.")
+        assert "knowledge base" in result
+
+    def test_empty_string_prompt_with_kb(self):
+        result = enhance_system_prompt_with_kb("", ["kb1"])
+        assert result is not None
+        assert "MUST first search" in result


### PR DESCRIPTION
- Frontend: Add warning dialog when KBs selected without knowledge tools
- Backend: Validate KB + tool category consistency on create/update
- Add KB_PRIORITY_PROMPT constant with instructions for prioritizing KB search
- Add enhance_system_prompt_with_kb() helper to append KB instructions to system prompts
- Integrate KB prompt enhancement in preview_agent endpoint
- Integrate KB prompt enhancement in AgentServiceManager chat flow
- Integrate KB prompt enhancement in WebSocket build preview execution
- i18n: Add translations for KB tool warning (EN/ZH)
- Tests: Add comprehensive API validation and unit tests for KB prompt enhancement


### Example

> Check the knowledge base, and you will be given priority to the knowledge base for inquiry.
---
<img width="2880" height="1558" alt="image" src="https://github.com/user-attachments/assets/e47fd0f4-4fc5-4bc9-86b8-1fddee3b032f" />
---
Check the knowledge base. If you don't add the knowledge base tool, you will be prompted.

<img width="2880" height="1558" alt="image" src="https://github.com/user-attachments/assets/93b1d273-ce90-4c35-b4da-94c35be95a78" />
