### PR TITLE
draft(vdb-phase1): control-plane decoupling and metadata RDB migration

### DIFF
--- a/docs/vector_store/vdb_phase1_control_plane_rdb_spec.rst
+++ b/docs/vector_store/vdb_phase1_control_plane_rdb_spec.rst
@@ -1,0 +1,43 @@
+VDB Phase 1: Control Plane Decoupling + Metadata RDB Migration
+=============================================================
+
+Goal
+----
+- Decouple KB control-plane logic from LanceDB implementation details.
+- Move control-plane metadata to RDB with safe migration gates.
+
+Scope
+-----
+- Introduce control-plane facade and ``MetadataStore`` contract.
+- Migrate to RDB (phase-1 entities):
+  - ``collection_metadata``
+  - ``main_pointers``
+  - ``prompt_templates``
+  - ``ingestion_runs``
+  - ``documents``
+- Keep vector index data in VDB.
+
+Non-goals
+---------
+- No Milvus/Chroma runtime switching in this phase.
+- No full migration of large payload fields (e.g. parse/chunk large blobs).
+
+Execution Plan
+--------------
+1. Add anti-corruption layer for control-plane operations.
+2. Add RDB tables + SQLAlchemy repository implementation.
+3. Enable dual-write (RDB primary, VDB compatibility).
+4. Backfill historical metadata.
+5. Switch read path to RDB behind feature flag.
+6. Stop VDB control-plane writes after stable window.
+
+Audit Gates
+-----------
+- Contract tests for control-plane API behavior parity.
+- Data consistency checks (count/hash/sampling) >= 99.99%.
+- Verified rollback path via feature flags.
+
+Definition of Done
+------------------
+- API/service layer no longer directly depends on LanceDB control-plane semantics.
+- Control-plane reads are stable from RDB in production-like validation.


### PR DESCRIPTION
## Summary
This draft defines Phase 1 for backend pluggability:
- decouple control-plane API/service logic from LanceDB details
- migrate control-plane metadata to RDB with safe rollout gates

## Scope
- `MetadataStore` contract + control-plane facade
- RDB migration targets: `collection_metadata`, `main_pointers`, `prompt_templates`, `ingestion_runs`, `documents`
- dual-write, backfill, feature-flag read switch

## Out of Scope
- runtime Milvus/Chroma switching
- full migration of large parse/chunk payloads

## Validation Gates
- contract parity tests
- consistency check >= 99.99%
- rollback path verified