### PR TITLE
ci: skip PR checks for draft pull requests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Skip CI jobs when a pull request is in draft state.
- Trigger checks automatically when draft is converted to ready for review.

## Changes
- Add job-level condition to all PR checks jobs:
  - `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`
- Add `ready_for_review` to pull_request event types.

## Why
This saves CI/CD resources during draft iteration while keeping review-time checks automatic and consistent.