### PR TITLE
fix(version-management): main pointer NULL model_tag and merge_insert

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/version_management/main_pointer_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/main_pointer_manager.py
@@ -24,6 +24,27 @@ def _normalize_model_tag(model_tag: Optional[str]) -> str:
     return model_tag if model_tag is not None else ""
 
 
+def _build_base_filter_expression(collection: str, doc_id: str, step_type: str) -> str:
+    """Build the base LanceDB filter expression for a main pointer row.
+
+    This helper escapes all string values to avoid malformed expressions and
+    injection-like issues.
+
+    Args:
+        collection: Collection name.
+        doc_id: Document ID.
+        step_type: Processing stage type (parse, chunk, embed).
+
+    Returns:
+        A filter expression covering collection/doc_id/step_type.
+    """
+    return (
+        f"collection == '{escape_lancedb_string(collection)}' AND "
+        f"doc_id == '{escape_lancedb_string(doc_id)}' AND "
+        f"step_type == '{escape_lancedb_string(step_type)}'"
+    )
+
+
 def get_main_pointer(
     collection: str, doc_id: str, step_type: str, model_tag: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
@@ -51,11 +72,7 @@ def get_main_pointer(
         normalized_tag = _normalize_model_tag(model_tag)
 
         # Base filters for collection, doc_id, and step_type
-        base_expr = (
-            f"collection == '{escape_lancedb_string(collection)}' AND "
-            f"doc_id == '{escape_lancedb_string(doc_id)}' AND "
-            f"step_type == '{escape_lancedb_string(step_type)}'"
-        )
+        base_expr = _build_base_filter_expression(collection, doc_id, step_type)
 
         # Handle model_tag: check for both normalized empty string AND NULL for backward compatibility
         if normalized_tag == "":
@@ -134,11 +151,7 @@ def set_main_pointer(
 
             # Fix-up: normalize NULL model_tag to "" in DB before merge_insert to avoid duplicates
             if normalized_tag == "":
-                base_expr = (
-                    f"collection == '{escape_lancedb_string(collection)}' AND "
-                    f"doc_id == '{escape_lancedb_string(doc_id)}' AND "
-                    f"step_type == '{escape_lancedb_string(step_type)}'"
-                )
+                base_expr = _build_base_filter_expression(collection, doc_id, step_type)
                 null_filter = f"{base_expr} AND model_tag IS NULL"
                 try:
                     table.update(where=null_filter, values={"model_tag": ""})
@@ -241,6 +254,10 @@ def delete_main_pointer(
 ) -> bool:
     """Delete a main pointer.
 
+    Behavior note (backward compatibility):
+        When ``model_tag`` is ``None`` (normalized to empty string), this function deletes
+        pointers whose ``model_tag`` is either ``''`` OR ``NULL``.
+
     Args:
         collection: Collection name
         doc_id: Document ID
@@ -261,11 +278,7 @@ def delete_main_pointer(
 
         # Build safe filter conditions
         normalized_tag = _normalize_model_tag(model_tag)
-        base_expr = (
-            f"collection == '{escape_lancedb_string(collection)}' AND "
-            f"doc_id == '{escape_lancedb_string(doc_id)}' AND "
-            f"step_type == '{escape_lancedb_string(step_type)}'"
-        )
+        base_expr = _build_base_filter_expression(collection, doc_id, step_type)
 
         if normalized_tag == "":
             filter_expr = f"{base_expr} AND (model_tag == '' OR model_tag IS NULL)"

--- a/tests/core/tools/core/RAG_tools/version_management/test_main_pointer_manager.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_main_pointer_manager.py
@@ -169,6 +169,12 @@ class TestMainPointerManager:
         assert deleted is True
         table.delete.assert_called_once()
 
+        # Verify delete filter expression includes NULL check (backward compatibility)
+        call_args = table.delete.call_args
+        filter_used = call_args[0][0] if call_args[0] else call_args[1].get("where")
+        assert filter_used is not None
+        assert "model_tag IS NULL" in filter_used
+
     @patch(
         "xagent.core.tools.core.RAG_tools.version_management.main_pointer_manager.get_connection_from_env"
     )


### PR DESCRIPTION
- Add _normalize_model_tag() to treat None as '' for backward compatibility
- get_main_pointer: use escape_lancedb_string for filters; support both '' and NULL for model_tag; prefer non-NULL when multiple rows exist
- set_main_pointer: use merge_insert instead of delete-then-add to avoid race conditions; preserve created_at; migrate NULL model_tag to '' on write before merge_insert
- list_main_pointers: return model_tag as '' when NULL
- delete_main_pointer: use normalized_tag and escape_lancedb_string for filter expression
- Sync test_main_pointer_manager with new behavior and patch targets.