### PR TITLE
fix(kb): improve ingestion error handling and return HTTP 500 on failure

### DIFF
--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -342,11 +342,6 @@ async def ingest(
             _user.id,
             collection,
         )
-    except (PermissionError, OSError) as e:
-        logger.error("File system error saving file %s: %s", safe_filename, e)
-        raise HTTPException(
-            status_code=403, detail=f"File system error: {str(e)}"
-        ) from e
     except HTTPException:
         # Ensure partial file is removed on early abort (e.g., file too large)
         try:

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -269,6 +269,26 @@ def test_ingest_separators_empty_array_uses_none(app_with_kb, mock_user):
     assert captured_config[0].separators == []
 
 
+def test_ingest_returns_403_when_file_save_fails(app_with_kb, mock_user):
+    """File system save errors should be normalized to HTTP 403 by decorator."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            patch("xagent.web.api.kb.get_upload_path") as mock_path,
+            patch("builtins.open", side_effect=PermissionError("disk denied")),
+        ):
+            mock_path.return_value = str(Path(tmpdir) / "test.txt")
+
+            client = TestClient(app_with_kb)
+            response = client.post(
+                "/api/kb/ingest",
+                data={"collection": "test_coll"},
+                files={"file": ("test.txt", io.BytesIO(b"hello"), "text/plain")},
+            )
+
+    assert response.status_code == 403
+    assert "File system error:" in str(response.json().get("detail", ""))
+
+
 async def _fake_run_web_ingestion(
     collection, crawl_config, *, ingestion_config, user_id, is_admin=False
 ):


### PR DESCRIPTION
ingest: when result.status == "error", return JSONResponse(status_code=500, content=result.model_dump()); when status == "partial", log a warning and return the normal success payload (including file_id).
ingest_web: when result.status == "error", return JSONResponse(status_code=500, content=result.model_dump()); when status == "partial", log a warning and return the partial result.
No custom fixed Chinese detail message is returned in these paths; full error payload comes from result.model_dump().