### PR TITLE
fix: revert incorrect base_url fallback logic that breaks task execution

### DIFF
--- a/src/xagent/core/model/chat/basic/adapter.py
+++ b/src/xagent/core/model/chat/basic/adapter.py
@@ -1,10 +1,6 @@
 import os
 
 from ....model import ChatModelConfig, ModelConfig
-from ....model.providers import (
-    default_base_url_for_provider,
-    provider_compatibility_for_provider,
-)
 from ....retry import create_retry_wrapper
 from ..error import retry_on
 from .azure_openai import AzureOpenAILLM
@@ -23,25 +19,11 @@ def create_base_llm(model: ModelConfig) -> BaseLLM:
     if not isinstance(model, ChatModelConfig):
         raise TypeError(f"Invalid model type: {type(model).__name__}")
 
-    compatibility = provider_compatibility_for_provider(model.model_provider)
-
-    if compatibility == "openai_compatible":
+    if model.model_provider == "openai":
         llm: BaseLLM = OpenAILLM(
             model_name=model.model_name,
             api_key=model.api_key,
-            base_url=model.base_url
-            or default_base_url_for_provider(model.model_provider),
-            default_temperature=model.default_temperature,
-            default_max_tokens=model.default_max_tokens,
-            timeout=model.timeout,
-            abilities=model.abilities,
-        )
-    elif compatibility == "claude_compatible":
-        llm = ClaudeLLM(
-            model_name=model.model_name,
-            api_key=model.api_key,
-            base_url=model.base_url
-            or default_base_url_for_provider(model.model_provider),
+            base_url=model.base_url,
             default_temperature=model.default_temperature,
             default_max_tokens=model.default_max_tokens,
             timeout=model.timeout,
@@ -70,6 +52,16 @@ def create_base_llm(model: ModelConfig) -> BaseLLM:
         )
     elif model.model_provider == "gemini":
         llm = GeminiLLM(
+            model_name=model.model_name,
+            api_key=model.api_key,
+            base_url=model.base_url,
+            default_temperature=model.default_temperature,
+            default_max_tokens=model.default_max_tokens,
+            timeout=model.timeout,
+            abilities=model.abilities,
+        )
+    elif model.model_provider == "claude":
+        llm = ClaudeLLM(
             model_name=model.model_name,
             api_key=model.api_key,
             base_url=model.base_url,

--- a/src/xagent/core/model/chat/langchain.py
+++ b/src/xagent/core/model/chat/langchain.py
@@ -10,10 +10,6 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from ...model import ChatModelConfig, ModelConfig
-from ...model.providers import (
-    default_base_url_for_provider,
-    provider_compatibility_for_provider,
-)
 from ...retry import ExponentialBackoff, RetryStrategy, create_retry_wrapper
 from .error import retry_on
 
@@ -101,16 +97,14 @@ def create_base_chat_model(
         raise TypeError(f"Unsupported Chat model type: {type(model).__name__}")
 
     temp = temperature if temperature is not None else model.default_temperature
-    compatibility = provider_compatibility_for_provider(model.model_provider)
 
-    if compatibility == "openai_compatible":
+    if model.model_provider == "openai":
         return ChatOpenAI(
             model=model.model_name,
             temperature=temp,
             max_tokens=model.default_max_tokens,
             api_key=model.api_key,
-            base_url=model.base_url
-            or default_base_url_for_provider(model.model_provider),
+            base_url=model.base_url,
             timeout=model.timeout,
         )
     elif model.model_provider == "zhipu":


### PR DESCRIPTION
## Summary

This PR fixes a critical regression introduced by PR #138 (commit `cee1e49`) that **prevents tasks from executing**.

## Root Cause

PR #138 introduced a new provider compatibility system that changed how LLM adapters are created:

**Before (working):**
```python
if model.model_provider == "openai":
    llm = OpenAILLM(..., base_url=model.base_url, ...)
```

**After PR #138 (broken):**
```python
compatibility = provider_compatibility_for_provider(model.model_provider)

if compatibility == "openai_compatible":
    llm = OpenAILLM(
        ...,
        base_url=model.base_url or default_base_url_for_provider(model.model_provider),
        ...
    )
```

The problem stems from two issues:

1. **Indirect compatibility-based routing**: The new system relies on `providers.py` metadata which may have missing or incorrect `compatibility` values, causing some providers to fall through to the `else` branch and throw `TypeError: Unsupported LLM model type`.

2. **Unnecessary base_url fallback**: The `or default_base_url_for_provider()` fallback is redundant and error-prone. Model configurations already have correct `base_url` values from the database (set during model creation via the same fallback logic in `model.py`). Re-applying fallback at LLM creation time adds no value but introduces potential bugs.

## The Fix

- Reverts to direct `model_provider` string comparison (`if model.model_provider == "openai"`)
- Removes the unnecessary `base_url or default_base_url_for_provider()` fallback
- Trusts database configuration as-is

## Acknowledgments

Thanks to @bsbds for PR #137 which identified this regression and proposed a fix. This PR takes a more minimal approach by only reverting the LLM adapter changes without removing the `providers.py` infrastructure (which may be useful for other purposes).

## Testing

- Verified task execution works correctly after fix
- Pre-commit checks pass (ruff, mypy, isort, codespell)

Fixes task execution regression introduced in cee1e49 (PR #138)