### PR TITLE
fix(kb): parse HTML with unstructured and fail fast on unsupported types

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/parser_registry.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/parser_registry.py
@@ -36,6 +36,7 @@ PARSER_COMPATIBILITY: Dict[str, List[str]] = {
     ".sh": [],
     ".sql": [],
     ".html": ["deepdoc", "unstructured"],
+    ".htm": ["unstructured"],
     ".xml": [],
     ".yaml": [],
     ".yml": [],

--- a/src/xagent/core/tools/core/document_parser.py
+++ b/src/xagent/core/tools/core/document_parser.py
@@ -109,8 +109,9 @@ async def parse_document(
     # If auto-routing, narrow parsers by file extension using the single
     # source of truth (parser_registry) to avoid drift between the static
     # compatibility table and individual parser class attributes.
-    ext = Path(resolved_file_path).suffix.lower()
+    ext: str | None = None
     if not tool_args.parser_name:
+        ext = Path(resolved_file_path).suffix.lower()
         # Lazy import to avoid circular dependency:
         # parser_registry imports document_parser_registry from this module.
         from .RAG_tools.core.parser_registry import get_supported_parsers
@@ -141,6 +142,7 @@ async def parse_document(
         selected_parser = tool_args.parser_name
     else:
         # Auto-route based on file extension
+        assert ext is not None
         if ext == ".pdf" and "deepdoc" in available_parsers:
             selected_parser = "deepdoc"
             logger.info(
@@ -165,11 +167,10 @@ async def parse_document(
                 ".pptx",
                 ".doc",
                 ".docx",
+                ".csv",
                 ".txt",
                 ".md",
                 ".json",
-                ".html",
-                ".csv",
             )
             and "unstructured" in available_parsers
         ):

--- a/src/xagent/core/tools/core/document_parser.py
+++ b/src/xagent/core/tools/core/document_parser.py
@@ -106,32 +106,25 @@ async def parse_document(
             f"local={tool_args.capabilities.use_local_parser}"
         )
 
-    # If auto-routing, further narrow parsers by file extension compatibility.
-    # This prevents accidental selection of the first registered parser (e.g. pypdf)
-    # for unsupported formats (e.g. .html) when capabilities happen to match.
+    # If auto-routing, narrow parsers by file extension using the single
+    # source of truth (parser_registry) to avoid drift between the static
+    # compatibility table and individual parser class attributes.
     ext = Path(resolved_file_path).suffix.lower()
     if not tool_args.parser_name:
-        ext_compatible: list[str] = []
-        for parser_name in available_parsers:
-            parser_class = parsers.get(parser_name)
-            supported = (
-                getattr(parser_class, "supported_extensions", None)
-                if parser_class
-                else None
-            )
-            if not supported:
-                # If a parser doesn't declare supported_extensions, keep it eligible.
-                ext_compatible.append(parser_name)
-                continue
-            if ext in {e.lower() for e in supported}:
-                ext_compatible.append(parser_name)
+        # Lazy import to avoid circular dependency:
+        # parser_registry imports document_parser_registry from this module.
+        from .RAG_tools.core.parser_registry import get_supported_parsers
+
+        registry_supported = set(get_supported_parsers(ext))
+        ext_compatible = [p for p in available_parsers if p in registry_supported]
 
         if not ext_compatible:
             logger.warning(
                 "No compatible document parsers found for extension '%s'. "
-                "Available parsers by capability: %s",
+                "Available parsers by capability: %s, registry supported: %s",
                 ext,
                 ", ".join(available_parsers),
+                ", ".join(registry_supported) or "(none)",
             )
             raise ValueError(
                 f"Unsupported file type '{ext}'. No available parser can handle this extension."
@@ -161,7 +154,9 @@ async def parse_document(
         elif ext in (".html", ".htm") and "unstructured" in available_parsers:
             selected_parser = "unstructured"
             logger.info(
-                f"Auto-selected 'unstructured' parser for {ext} file: {resolved_file_path}"
+                "Auto-selected 'unstructured' parser for %s file: %s",
+                ext,
+                resolved_file_path,
             )
         elif (
             ext

--- a/src/xagent/core/tools/core/document_parser.py
+++ b/src/xagent/core/tools/core/document_parser.py
@@ -106,6 +106,39 @@ async def parse_document(
             f"local={tool_args.capabilities.use_local_parser}"
         )
 
+    # If auto-routing, further narrow parsers by file extension compatibility.
+    # This prevents accidental selection of the first registered parser (e.g. pypdf)
+    # for unsupported formats (e.g. .html) when capabilities happen to match.
+    ext = Path(resolved_file_path).suffix.lower()
+    if not tool_args.parser_name:
+        ext_compatible: list[str] = []
+        for parser_name in available_parsers:
+            parser_class = parsers.get(parser_name)
+            supported = (
+                getattr(parser_class, "supported_extensions", None)
+                if parser_class
+                else None
+            )
+            if not supported:
+                # If a parser doesn't declare supported_extensions, keep it eligible.
+                ext_compatible.append(parser_name)
+                continue
+            if ext in {e.lower() for e in supported}:
+                ext_compatible.append(parser_name)
+
+        if not ext_compatible:
+            logger.warning(
+                "No compatible document parsers found for extension '%s'. "
+                "Available parsers by capability: %s",
+                ext,
+                ", ".join(available_parsers),
+            )
+            raise ValueError(
+                f"Unsupported file type '{ext}'. No available parser can handle this extension."
+            )
+
+        available_parsers = ext_compatible
+
     # If a specific parser is requested, validate it's in the available list
     if tool_args.parser_name:
         if tool_args.parser_name not in available_parsers:
@@ -115,8 +148,6 @@ async def parse_document(
         selected_parser = tool_args.parser_name
     else:
         # Auto-route based on file extension
-        ext = Path(resolved_file_path).suffix.lower()
-
         if ext == ".pdf" and "deepdoc" in available_parsers:
             selected_parser = "deepdoc"
             logger.info(
@@ -126,6 +157,11 @@ async def parse_document(
             selected_parser = "deepdoc"
             logger.info(
                 f"Auto-selected 'deepdoc' parser for spreadsheet file {ext}: {resolved_file_path}"
+            )
+        elif ext in (".html", ".htm") and "unstructured" in available_parsers:
+            selected_parser = "unstructured"
+            logger.info(
+                f"Auto-selected 'unstructured' parser for {ext} file: {resolved_file_path}"
             )
         elif (
             ext

--- a/src/xagent/providers/pdf_parser/basic.py
+++ b/src/xagent/providers/pdf_parser/basic.py
@@ -53,6 +53,7 @@ class UnstructuredParser(
         ".md",
         ".json",
         ".html",
+        ".htm",
     ]
 
     async def _parse_impl(self, file_path: str, **kwargs: Any) -> ParseResult:
@@ -134,6 +135,10 @@ async def extract_text_with_unstructured(file_path: str, **kwargs: Any) -> Parse
             from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(filename=file_path)
+        elif file_ext in (".html", ".htm"):
+            from unstructured.partition.html import partition_html
+
+            elements = partition_html(filename=file_path)
         elif file_ext == ".docx":
             from unstructured.partition.docx import partition_docx
 

--- a/src/xagent/providers/pdf_parser/basic.py
+++ b/src/xagent/providers/pdf_parser/basic.py
@@ -175,10 +175,6 @@ async def extract_text_with_unstructured(file_path: str, **kwargs: Any) -> Parse
             from unstructured.partition.xlsx import partition_xlsx
 
             elements = partition_xlsx(filename=file_path)
-        elif file_ext == ".html":
-            from unstructured.partition.html import partition_html
-
-            elements = partition_html(filename=file_path)
         elif file_ext in (".txt", ".md", ".json"):
             # For plain text files, read directly
             with open(file_path, "r", encoding="utf-8") as f:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -31,6 +31,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from ...core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
+from ...core.tools.core.RAG_tools.core.parser_registry import (
+    get_supported_parsers,
+    validate_parser_compatibility,
+)
 from ...core.tools.core.RAG_tools.core.schemas import (
     ChunkStrategy,
     CollectionDocumentMetadata,
@@ -1130,6 +1134,45 @@ async def ingest(
             status_code=422,
             detail=f"File type {Path(safe_filename).suffix.lower()} not supported",
         )
+
+    file_ext = Path(safe_filename).suffix.lower()
+    effective_parse_method = _normalize_parse_method_for_filename(
+        parse_method, safe_filename
+    )
+    if effective_parse_method == ParseMethod.DEFAULT:
+        supported = get_supported_parsers(file_ext)
+        if not supported:
+            logger.warning(
+                "KB ingest rejected: no parser supports extension=%s filename=%s user_id=%s",
+                file_ext,
+                safe_filename,
+                getattr(_user, "id", None),
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Unsupported file type '{file_ext}' for ingestion. "
+                    "No available parser supports this format."
+                ),
+            )
+    else:
+        if not validate_parser_compatibility(file_ext, str(effective_parse_method)):
+            supported = get_supported_parsers(file_ext)
+            logger.warning(
+                "KB ingest rejected: parser=%s not compatible with extension=%s filename=%s supported=%s",
+                str(effective_parse_method),
+                file_ext,
+                safe_filename,
+                supported,
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Parser '{str(effective_parse_method)}' is not compatible with "
+                    f"file type '{file_ext}'. "
+                    f"Supported parsers for this type: {supported}"
+                ),
+            )
 
     if not collection or not collection.strip():
         collection = Path(safe_filename).stem

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -155,6 +155,57 @@ def _normalize_parse_method_for_filename(
     return normalized
 
 
+def _validate_parser_for_file(
+    filename: str,
+    parse_method: Optional[ParseMethod],
+    *,
+    user_id: Any = None,
+) -> None:
+    """Fail-fast validation: reject files with no parser or incompatible parser.
+
+    Raises:
+        HTTPException(422): if no parser supports the extension or the
+            requested parser is incompatible.
+    """
+    file_ext = Path(filename).suffix.lower()
+    effective = _normalize_parse_method_for_filename(parse_method, filename)
+
+    if effective == ParseMethod.DEFAULT:
+        supported = get_supported_parsers(file_ext)
+        if not supported:
+            logger.warning(
+                "KB ingest rejected: no parser supports extension=%s filename=%s user_id=%s",
+                file_ext,
+                filename,
+                user_id,
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Unsupported file type '{file_ext}' for ingestion. "
+                    "No available parser supports this format."
+                ),
+            )
+    else:
+        if not validate_parser_compatibility(file_ext, str(effective)):
+            supported = get_supported_parsers(file_ext)
+            logger.warning(
+                "KB ingest rejected: parser=%s not compatible with extension=%s filename=%s supported=%s",
+                str(effective),
+                file_ext,
+                filename,
+                supported,
+            )
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Parser '{str(effective)}' is not compatible with "
+                    f"file type '{file_ext}'. "
+                    f"Supported parsers for this type: {supported}"
+                ),
+            )
+
+
 def _get_completed_step_metadata(
     result: IngestionResult, step_name: str
 ) -> Optional[Dict[str, Any]]:
@@ -1135,44 +1186,9 @@ async def ingest(
             detail=f"File type {Path(safe_filename).suffix.lower()} not supported",
         )
 
-    file_ext = Path(safe_filename).suffix.lower()
-    effective_parse_method = _normalize_parse_method_for_filename(
-        parse_method, safe_filename
+    _validate_parser_for_file(
+        safe_filename, parse_method, user_id=getattr(_user, "id", None)
     )
-    if effective_parse_method == ParseMethod.DEFAULT:
-        supported = get_supported_parsers(file_ext)
-        if not supported:
-            logger.warning(
-                "KB ingest rejected: no parser supports extension=%s filename=%s user_id=%s",
-                file_ext,
-                safe_filename,
-                getattr(_user, "id", None),
-            )
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Unsupported file type '{file_ext}' for ingestion. "
-                    "No available parser supports this format."
-                ),
-            )
-    else:
-        if not validate_parser_compatibility(file_ext, str(effective_parse_method)):
-            supported = get_supported_parsers(file_ext)
-            logger.warning(
-                "KB ingest rejected: parser=%s not compatible with extension=%s filename=%s supported=%s",
-                str(effective_parse_method),
-                file_ext,
-                safe_filename,
-                supported,
-            )
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Parser '{str(effective_parse_method)}' is not compatible with "
-                    f"file type '{file_ext}'. "
-                    f"Supported parsers for this type: {supported}"
-                ),
-            )
 
     if not collection or not collection.strip():
         collection = Path(safe_filename).stem
@@ -1486,6 +1502,18 @@ async def ingest_cloud(
                 file_info.fileId,
             )
             file_path = Path(get_upload_path(storage_filename, user_id=int(_user.id)))
+            try:
+                _validate_parser_for_file(
+                    safe_filename,
+                    request.parse_method,
+                    user_id=int(_user.id),
+                )
+            except HTTPException as ve:
+                return IngestionResult(
+                    status="error",
+                    message=ve.detail,
+                    doc_id=file_info.fileName,
+                )
             try:
                 if file_info.provider == "google-drive":
                     # Get credentials (run in thread to avoid blocking)

--- a/tests/web/api/test_kb_ingest_unsupported_types.py
+++ b/tests/web/api/test_kb_ingest_unsupported_types.py
@@ -1,0 +1,177 @@
+"""Tests for KB ingest friendly errors on unsupported formats.
+
+These tests define the expected fail-fast behavior for the /ingest endpoint:
+- Files whose extension is allowed to upload but has no available parser → 422
+- Explicit parser that is incompatible with the file extension → 422
+- HTML / HTM files with 'unstructured' parser available → accepted (not 422)
+"""
+
+import io
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xagent.core.tools.core.RAG_tools.core.parser_registry import get_supported_parsers
+from xagent.web.api.kb import kb_router
+from xagent.web.models.database import get_db
+
+
+@pytest.fixture
+def mock_user():
+    """Minimal user-like object for ingest dependency."""
+    return type("User", (), {"id": 1, "is_admin": False})()
+
+
+@pytest.fixture
+def mock_db():
+    """Minimal mock DB session so FastAPI dependency resolution succeeds."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+@pytest.fixture
+def app_with_kb(mock_user, mock_db):
+    """FastAPI app with kb_router and mocked auth + db."""
+    from xagent.web.api.kb import get_current_user
+
+    app = FastAPI()
+    app.include_router(kb_router)
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.dependency_overrides[get_db] = lambda: mock_db
+    return app
+
+
+def _post_ingest(client: TestClient, filename: str, content: bytes = b"x", **form_data):
+    """Helper to POST a file to /api/kb/ingest."""
+    return client.post(
+        "/api/kb/ingest",
+        data={"collection": "test_coll", **form_data},
+        files={"file": (filename, io.BytesIO(content), "application/octet-stream")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestParserRegistrySupport:
+    """Verify parser registry declares correct support for file types."""
+
+    def test_html_has_unstructured(self):
+        supported = get_supported_parsers(".html")
+        assert "unstructured" in supported
+
+    def test_htm_has_unstructured(self):
+        supported = get_supported_parsers(".htm")
+        assert "unstructured" in supported
+
+    def test_code_files_have_no_parsers(self):
+        for ext in (".py", ".go", ".rs", ".sh"):
+            supported = get_supported_parsers(ext)
+            assert supported == [], f"Expected no parsers for {ext}, got {supported}"
+
+    def test_pdf_has_multiple_parsers(self):
+        supported = get_supported_parsers(".pdf")
+        assert len(supported) >= 2
+        assert "deepdoc" in supported
+
+
+# ---------------------------------------------------------------------------
+# Ingest endpoint: reject unsupported / incompatible files (fail-fast)
+# ---------------------------------------------------------------------------
+
+
+class TestIngestFailFast:
+    """Fail-fast validation at API boundary before file is written to disk."""
+
+    def test_rejects_allowed_but_unparsable_extension(self, app_with_kb):
+        """Uploading an allowed-but-unparsable file (.py) returns a friendly 422."""
+        client = TestClient(app_with_kb)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch("xagent.web.api.kb.get_upload_path") as mock_path,
+                patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest,
+            ):
+                mock_path.return_value = str(Path(tmpdir) / "test.py")
+                resp = _post_ingest(client, "test.py", b"print('hi')\n")
+
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "Unsupported file type" in body.get("detail", "")
+        mock_ingest.assert_not_called()
+
+    def test_rejects_incompatible_explicit_parser(self, app_with_kb):
+        """Specifying deepdoc for a .pptx file should be rejected as incompatible.
+
+        .pptx only supports 'unstructured', and 'deepdoc' is not a PDF-only
+        parser (so it won't be auto-normalized to default).
+        """
+        client = TestClient(app_with_kb)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch("xagent.web.api.kb.get_upload_path") as mock_path,
+                patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest,
+            ):
+                mock_path.return_value = str(Path(tmpdir) / "slides.pptx")
+                resp = _post_ingest(
+                    client,
+                    "slides.pptx",
+                    b"PK\x03\x04",
+                    parse_method="deepdoc",
+                )
+
+        assert resp.status_code == 422
+        detail = resp.json().get("detail", "")
+        assert "not compatible" in detail or "incompatible" in detail.lower()
+        mock_ingest.assert_not_called()
+
+    def test_html_not_rejected_by_fail_fast(self, app_with_kb):
+        """HTML files must pass the parser validation check.
+
+        The request may fail later (deeper mocking gaps) but must NOT be rejected
+        with an 'Unsupported file type' or 'not compatible' 422 error.
+        """
+        client = TestClient(app_with_kb, raise_server_exceptions=False)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "xagent.web.api.kb.get_upload_path",
+                return_value=str(Path(tmpdir) / "page.html"),
+            ):
+                resp = _post_ingest(
+                    client, "page.html", b"<html><body>hi</body></html>"
+                )
+
+        if resp.status_code == 422:
+            detail = resp.json().get("detail", "")
+            assert "Unsupported file type" not in detail, (
+                f"HTML should not be rejected as unsupported: {detail}"
+            )
+            assert "not compatible" not in detail.lower(), (
+                f"HTML should not be rejected as incompatible: {detail}"
+            )
+
+    def test_htm_not_rejected_by_fail_fast(self, app_with_kb):
+        """HTM files must also pass the parser validation check."""
+        client = TestClient(app_with_kb, raise_server_exceptions=False)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "xagent.web.api.kb.get_upload_path",
+                return_value=str(Path(tmpdir) / "page.htm"),
+            ):
+                resp = _post_ingest(client, "page.htm", b"<html><body>hi</body></html>")
+
+        if resp.status_code == 422:
+            detail = resp.json().get("detail", "")
+            assert "Unsupported file type" not in detail, (
+                f"HTM should not be rejected as unsupported: {detail}"
+            )

--- a/tests/web/api/test_kb_ingest_unsupported_types.py
+++ b/tests/web/api/test_kb_ingest_unsupported_types.py
@@ -170,34 +170,33 @@ class TestIngestFailFast:
         mock_ingest.assert_not_called()
 
     def test_html_passes_fail_fast(self, app_with_kb):
-        """HTML files must pass the parser validation (may fail later in pipeline)."""
+        """HTML files must pass the parser validation and reach downstream ingestion."""
         client = TestClient(app_with_kb, raise_server_exceptions=False)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch(
-                "xagent.web.api.kb.get_upload_path",
-                return_value=str(Path(tmpdir) / "page.html"),
+            with (
+                patch(
+                    "xagent.web.api.kb.get_upload_path",
+                    return_value=str(Path(tmpdir) / "page.html"),
+                ),
+                patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest,
             ):
-                resp = _post_ingest(
-                    client, "page.html", b"<html><body>hi</body></html>"
-                )
+                _post_ingest(client, "page.html", b"<html><body>hi</body></html>")
 
-        assert resp.status_code != 422 or (
-            "Unsupported file type" not in resp.json().get("detail", "")
-            and "not compatible" not in resp.json().get("detail", "").lower()
-        ), f"HTML rejected by fail-fast: {resp.json()}"
+        mock_ingest.assert_called_once()
 
     def test_htm_passes_fail_fast(self, app_with_kb):
-        """HTM files must also pass the parser validation."""
+        """HTM files must also pass the parser validation and reach downstream ingestion."""
         client = TestClient(app_with_kb, raise_server_exceptions=False)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch(
-                "xagent.web.api.kb.get_upload_path",
-                return_value=str(Path(tmpdir) / "page.htm"),
+            with (
+                patch(
+                    "xagent.web.api.kb.get_upload_path",
+                    return_value=str(Path(tmpdir) / "page.htm"),
+                ),
+                patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest,
             ):
-                resp = _post_ingest(client, "page.htm", b"<html><body>hi</body></html>")
+                _post_ingest(client, "page.htm", b"<html><body>hi</body></html>")
 
-        assert resp.status_code != 422 or (
-            "Unsupported file type" not in resp.json().get("detail", "")
-        ), f"HTM rejected by fail-fast: {resp.json()}"
+        mock_ingest.assert_called_once()

--- a/tests/web/api/test_kb_ingest_unsupported_types.py
+++ b/tests/web/api/test_kb_ingest_unsupported_types.py
@@ -4,6 +4,7 @@ These tests define the expected fail-fast behavior for the /ingest endpoint:
 - Files whose extension is allowed to upload but has no available parser → 422
 - Explicit parser that is incompatible with the file extension → 422
 - HTML / HTM files with 'unstructured' parser available → accepted (not 422)
+- PDF-only parsers auto-fallback to default for non-PDF files (no reject)
 """
 
 import io
@@ -12,11 +13,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from xagent.core.tools.core.RAG_tools.core.parser_registry import get_supported_parsers
-from xagent.web.api.kb import kb_router
+from xagent.core.tools.core.RAG_tools.core.schemas import ParseMethod
+from xagent.web.api.kb import _validate_parser_for_file, kb_router
 from xagent.web.models.database import get_db
 
 
@@ -83,7 +85,45 @@ class TestParserRegistrySupport:
 
 
 # ---------------------------------------------------------------------------
-# Ingest endpoint: reject unsupported / incompatible files (fail-fast)
+# Unit tests for _validate_parser_for_file (single source of truth)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateParserForFile:
+    """Direct unit tests for the fail-fast validation function."""
+
+    def test_rejects_unparsable_extension(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_parser_for_file("test.py", None)
+        assert exc_info.value.status_code == 422
+        assert "Unsupported file type" in exc_info.value.detail
+
+    def test_rejects_incompatible_explicit_parser(self):
+        """deepdoc is not compatible with .pptx (only unstructured is)."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_parser_for_file("slides.pptx", ParseMethod.DEEPDOC)
+        assert exc_info.value.status_code == 422
+        assert "not compatible" in exc_info.value.detail
+
+    def test_accepts_html_default(self):
+        _validate_parser_for_file("page.html", None)
+
+    def test_accepts_htm_default(self):
+        _validate_parser_for_file("page.htm", None)
+
+    def test_accepts_pdf_default(self):
+        _validate_parser_for_file("doc.pdf", None)
+
+    def test_pdf_only_parser_falls_back_for_non_pdf(self):
+        """pypdf on .xlsx should NOT raise — it auto-normalizes to default."""
+        _validate_parser_for_file("table.xlsx", ParseMethod.PYPDF)
+
+    def test_accepts_compatible_explicit_parser(self):
+        _validate_parser_for_file("report.docx", ParseMethod.UNSTRUCTURED)
+
+
+# ---------------------------------------------------------------------------
+# Ingest endpoint integration tests
 # ---------------------------------------------------------------------------
 
 
@@ -108,11 +148,7 @@ class TestIngestFailFast:
         mock_ingest.assert_not_called()
 
     def test_rejects_incompatible_explicit_parser(self, app_with_kb):
-        """Specifying deepdoc for a .pptx file should be rejected as incompatible.
-
-        .pptx only supports 'unstructured', and 'deepdoc' is not a PDF-only
-        parser (so it won't be auto-normalized to default).
-        """
+        """Specifying deepdoc for a .pptx file should be rejected as incompatible."""
         client = TestClient(app_with_kb)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -130,15 +166,11 @@ class TestIngestFailFast:
 
         assert resp.status_code == 422
         detail = resp.json().get("detail", "")
-        assert "not compatible" in detail or "incompatible" in detail.lower()
+        assert "not compatible" in detail
         mock_ingest.assert_not_called()
 
-    def test_html_not_rejected_by_fail_fast(self, app_with_kb):
-        """HTML files must pass the parser validation check.
-
-        The request may fail later (deeper mocking gaps) but must NOT be rejected
-        with an 'Unsupported file type' or 'not compatible' 422 error.
-        """
+    def test_html_passes_fail_fast(self, app_with_kb):
+        """HTML files must pass the parser validation (may fail later in pipeline)."""
         client = TestClient(app_with_kb, raise_server_exceptions=False)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -150,17 +182,13 @@ class TestIngestFailFast:
                     client, "page.html", b"<html><body>hi</body></html>"
                 )
 
-        if resp.status_code == 422:
-            detail = resp.json().get("detail", "")
-            assert "Unsupported file type" not in detail, (
-                f"HTML should not be rejected as unsupported: {detail}"
-            )
-            assert "not compatible" not in detail.lower(), (
-                f"HTML should not be rejected as incompatible: {detail}"
-            )
+        assert resp.status_code != 422 or (
+            "Unsupported file type" not in resp.json().get("detail", "")
+            and "not compatible" not in resp.json().get("detail", "").lower()
+        ), f"HTML rejected by fail-fast: {resp.json()}"
 
-    def test_htm_not_rejected_by_fail_fast(self, app_with_kb):
-        """HTM files must also pass the parser validation check."""
+    def test_htm_passes_fail_fast(self, app_with_kb):
+        """HTM files must also pass the parser validation."""
         client = TestClient(app_with_kb, raise_server_exceptions=False)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,8 +198,6 @@ class TestIngestFailFast:
             ):
                 resp = _post_ingest(client, "page.htm", b"<html><body>hi</body></html>")
 
-        if resp.status_code == 422:
-            detail = resp.json().get("detail", "")
-            assert "Unsupported file type" not in detail, (
-                f"HTM should not be rejected as unsupported: {detail}"
-            )
+        assert resp.status_code != 422 or (
+            "Unsupported file type" not in resp.json().get("detail", "")
+        ), f"HTM rejected by fail-fast: {resp.json()}"

--- a/tests/web_integration/test_document_parsing_behavior_e2e.py
+++ b/tests/web_integration/test_document_parsing_behavior_e2e.py
@@ -384,10 +384,9 @@ class TestDocumentTypeDefaultParsing:
                 headers=auth_headers,
             )
 
-        assert response.status_code == 500
+        assert response.status_code == 422
         result = response.json()
-        assert result["status"] == "error"
-        assert "Unsupported file type" in str(result.get("message", ""))
+        assert "Unsupported file type" in result.get("detail", "")
 
 
 # ==========================================


### PR DESCRIPTION
Add HTML/HTM support to the unstructured parser path and tighten default parser routing to avoid selecting PDF-only parsers for incompatible extensions. Return a clear 422 error when ingestion receives an allowed upload type that has no available parser.

Fixes #161