### PR TITLE
fix(version-migration): normalize compact schema versions and prevent…

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1324,10 +1324,13 @@ class CollectionInfo(BaseModel):
                 data[key] = None
 
         # 3. Check version and migrate if needed
-        current_version = "1.0.0"
         data_version = data.get("schema_version", "0.0.0")
-
-        if data_version < current_version:
+        normalized_data_version = str(data_version).strip()
+        # Accept legacy compact forms as current version to avoid false migration loops:
+        # "1", "1.0", "1.0.0" are treated as equivalent.
+        if normalized_data_version in {"1", "1.0", "1.0.0"}:
+            data["schema_version"] = "1.0.0"
+        elif normalized_data_version.startswith("0") or not normalized_data_version:
             data = migrate_collection_metadata(data)
             # Note: In LanceDB, we don't auto-save migrated data here
             # It will be saved when the collection is next updated

--- a/src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py
@@ -10,6 +10,33 @@ from .string_utils import escape_lancedb_string
 logger = logging.getLogger(__name__)
 
 
+def _normalize_schema_version(version: Any) -> str:
+    """Normalize schema version to ``major.minor.patch`` string.
+
+    Examples:
+        1 -> "1.0.0"
+        "1.0" -> "1.0.0"
+        "1.0.0" -> "1.0.0"
+    """
+    raw = str(version).strip() if version is not None else "0.0.0"
+    if not raw:
+        return "0.0.0"
+    parts = raw.split(".")
+    numeric_parts: list[str] = []
+    for part in parts[:3]:
+        digits = "".join(ch for ch in part if ch.isdigit())
+        numeric_parts.append(digits or "0")
+    while len(numeric_parts) < 3:
+        numeric_parts.append("0")
+    return ".".join(numeric_parts[:3])
+
+
+def _version_tuple(version: str) -> Tuple[int, int, int]:
+    """Convert normalized version string to tuple for comparison."""
+    major, minor, patch = _normalize_schema_version(version).split(".")
+    return int(major), int(minor), int(patch)
+
+
 def migrate_collection_metadata(legacy_data: Dict[str, Any]) -> Dict[str, Any]:
     """Migrate legacy collection metadata to current schema version.
 
@@ -21,10 +48,11 @@ def migrate_collection_metadata(legacy_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     data = legacy_data.copy()
     current_version = "1.0.0"
-    data_version = data.get("schema_version", "0.0.0")
+    data_version = _normalize_schema_version(data.get("schema_version", "0.0.0"))
+    data["schema_version"] = data_version
     collection_name = data.get("name", "unknown")
 
-    logger.info(
+    logger.debug(
         f"[MIGRATION_START] Collection: {collection_name}, From: {data_version}, To: {current_version}"
     )
     logger.debug(
@@ -33,17 +61,26 @@ def migrate_collection_metadata(legacy_data: Dict[str, Any]) -> Dict[str, Any]:
 
     try:
         # Apply migrations sequentially
-        while data_version < current_version:
+        while _version_tuple(data_version) < _version_tuple(current_version):
             previous_version = data_version
             if data_version == "0.0.0":
                 data = _migrate_0_0_0_to_1_0_0(data)
                 data_version = "1.0.0"
 
-            logger.info(
+            # Safety guard: avoid infinite loops if a migration step does not advance version.
+            if data_version == previous_version:
+                logger.warning(
+                    "[MIGRATION_NO_PROGRESS] Collection '%s' migration stopped at %s",
+                    collection_name,
+                    data_version,
+                )
+                break
+
+            logger.debug(
                 f"[MIGRATION_STEP] {collection_name}: {previous_version} -> {data_version} completed."
             )
 
-        logger.info(
+        logger.debug(
             f"[MIGRATION_SUCCESS] Collection '{collection_name}' is now at version {data_version}"
         )
         return data
@@ -66,7 +103,7 @@ def _migrate_0_0_0_to_1_0_0(data: Dict[str, Any]) -> Dict[str, Any]:
     )
 
     if embedding_model_id:
-        logger.info(
+        logger.debug(
             f"[MIGRATION_INFERENCE] Inferred embedding model '{embedding_model_id}' "
             f"(dimension: {embedding_dimension}) for collection '{collection_name}'"
         )
@@ -130,13 +167,13 @@ def _infer_embedding_config_from_collection(
         # Get all table names that contain embeddings
         table_names_fn = getattr(conn, "table_names", None)
         if table_names_fn is None:
-            logger.info(
+            logger.debug(
                 f"LanceDB connection missing table_names() for collection '{collection_name}' - will use lazy initialization"
             )
             return None, None
         all_table_names = table_names_fn()
         if all_table_names is None:
-            logger.info(
+            logger.debug(
                 f"No table names returned for collection '{collection_name}' - will use lazy initialization"
             )
             return None, None
@@ -146,7 +183,7 @@ def _infer_embedding_config_from_collection(
         logger.debug(f"Found {len(table_names)} embedding tables: {table_names}")
 
         if not table_names:
-            logger.info(
+            logger.debug(
                 f"No embedding tables found for collection '{collection_name}' - will use lazy initialization"
             )
             return None, None
@@ -221,12 +258,12 @@ def _infer_embedding_config_from_collection(
                 continue
 
         if not model_stats:
-            logger.info(
+            logger.debug(
                 f"No vectors found for collection '{collection_name}' in any embedding table - will use lazy initialization"
             )
             return None, None
 
-        logger.info(
+        logger.debug(
             f"Found vectors from {len(model_stats)} different models for collection '{collection_name}': {list(model_stats.keys())}"
         )
 
@@ -240,7 +277,7 @@ def _infer_embedding_config_from_collection(
         embedding_model_id = _model_tag_to_model_id(model_tag)
         embedding_dimension = stats["dimension"]
 
-        logger.info(
+        logger.debug(
             f"Selected embedding model '{embedding_model_id}' (dimension: {embedding_dimension}) "
             f"for collection '{collection_name}' based on {stats['count']} vectors"
         )

--- a/tests/core/tools/core/RAG_tools/core/test_schemas.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas.py
@@ -1408,6 +1408,34 @@ class TestCollectionInfo:
         assert collection.embedding_dimension is None
         assert collection.is_initialized is False
 
+    def test_collection_info_from_storage_compact_v1_versions(self):
+        """Compact v1 schema versions should be accepted as current."""
+        for version in ("1", "1.0", "1.0.0"):
+            storage_data = {
+                "name": "test_collection",
+                "schema_version": version,
+                "embedding_model_id": "text-embedding-ada-002",
+                "embedding_dimension": 1536,
+                "documents": 1,
+                "processed_documents": 1,
+                "parses": 1,
+                "chunks": 2,
+                "embeddings": 2,
+                "document_names": '["doc1.pdf"]',
+                "collection_locked": False,
+                "allow_mixed_parse_methods": False,
+                "skip_config_validation": False,
+                "created_at": "2024-01-01T00:00:00",
+                "updated_at": "2024-01-02T00:00:00",
+                "last_accessed_at": "2024-01-02T00:00:00",
+                "extra_metadata": "{}",
+            }
+
+            collection = CollectionInfo.from_storage(storage_data)
+            assert collection.schema_version == "1.0.0"
+            assert collection.embedding_model_id == "text-embedding-ada-002"
+            assert collection.embedding_dimension == 1536
+
     def test_collection_info_to_storage(self):
         """Test serializing CollectionInfo to storage format."""
         collection = CollectionInfo(

--- a/tests/core/tools/core/RAG_tools/utils/test_migration_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_migration_utils.py
@@ -53,6 +53,27 @@ class TestMigrateCollectionMetadata:
     @patch(
         "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
     )
+    def test_migrate_compact_v1_versions_should_not_reinfer(self, mock_infer):
+        """Compact v1 versions (1/1.0) should be treated as up-to-date."""
+        mock_infer.return_value = ("should-not-be-used", 999)
+
+        for version in ("1", "1.0", "1.0.0"):
+            data = {
+                "schema_version": version,
+                "name": "test_collection",
+                "embedding_model_id": "text-embedding-ada-002",
+                "embedding_dimension": 1536,
+            }
+            result = migrate_collection_metadata(data)
+            assert result["schema_version"] == "1.0.0"
+            assert result["embedding_model_id"] == "text-embedding-ada-002"
+            assert result["embedding_dimension"] == 1536
+
+        mock_infer.assert_not_called()
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
+    )
     def test_migrate_with_embedding_inference(self, mock_infer):
         """Test migration with embedding config inference."""
         mock_infer.return_value = ("text-embedding-ada-002", 1536)


### PR DESCRIPTION
… infinite loops

Treat compact schema versions like 1 and 1.0 as 1.0.0 to avoid false migrations, and add a no-progress guard to stop repeated 1 -> 1 loops. Add regression tests to cover compact version handling in migration and schema deserialization.