### PR TITLE
chore: bump deepdoc to 0.2.0

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -58,11 +58,8 @@ COPY alembic.ini .
 
 # Install app + deepdoc into venv
 RUN /opt/venv/bin/pip install --no-cache-dir ${PYPI_INDEX_URL:+--index-url $PYPI_INDEX_URL} . \
-    && git clone https://github.com/xorbitsai/deepdoc-lib /opt/xagent/deepdoc-lib \
-    && cd /opt/xagent/deepdoc-lib && git checkout 356098f9aaa063c74cb5c55b05fd1add75ceb8d4 \
-    && /opt/venv/bin/pip install --no-cache-dir ${PYPI_INDEX_URL:+--index-url $PYPI_INDEX_URL} /opt/xagent/deepdoc-lib \
-    && /opt/venv/bin/python -c "from deepdoc.common.tiktoken_cache import download_cl100k_base; download_cl100k_base()" \
-    && rm -rf /opt/xagent/deepdoc-lib .git
+    && /opt/venv/bin/pip install --no-cache-dir ${PYPI_INDEX_URL:+--index-url $PYPI_INDEX_URL} deepdoc-lib \
+    && /opt/venv/bin/deepdoc-download-models
 
 ############################
 # Runtime
@@ -143,8 +140,6 @@ COPY frontend/package.json frontend/package-lock.json /opt/xagent/frontend/
 RUN cd /opt/xagent/frontend && npm ci \
     && npm install -g pptxgenjs@4.0.1 \
     && python -m playwright install chromium \
-    && python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('wordnet'); nltk.download('averaged_perceptron_tagger')" \
-    && unzip /root/nltk_data/corpora/wordnet.zip -d /root/nltk_data/corpora \
     && chmod +x /opt/xagent/deploy/entrypoint.sh
 
 EXPOSE 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
 
 [project.optional-dependencies]
 deepdoc = [
-  "deepdoc-lib @ git+https://github.com/xorbitsai/deepdoc-lib.git@356098f9aaa063c74cb5c55b05fd1add75ceb8d4",
+  "deepdoc-lib==0.2.0",
 ]
 dev = [
   "pre-commit>=4.2.0",


### PR DESCRIPTION
- bump to latest version
- use deepdoc builtin downloader in backend docker image build