### PR TITLE
fix(web): keep task token usage updating across follow-up messages

### DIFF
--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -191,6 +191,11 @@ def reset_token_usage() -> TokenUsage:
     return new_usage
 
 
+def set_token_usage(usage: TokenUsage) -> TokenUsage:
+    token_context.set(usage)
+    return usage
+
+
 def get_and_reset_token_usage() -> TokenUsage:
     """Get current usage and reset the context."""
     usage = token_context.get()

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -855,6 +855,7 @@ class AgentServiceManager:
         task: str,
         context: Optional[Dict[str, Any]] = None,
         task_id: Optional[str] = None,
+        tracking_task_id: Optional[str] = None,
         db_session: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
@@ -866,7 +867,8 @@ class AgentServiceManager:
             agent_service: The AgentService instance to use
             task: Task description
             context: Optional context data
-            task_id: Optional task identifier for tracking
+            task_id: Optional task identifier passed to agent execution
+            tracking_task_id: Optional task identifier used only for token tracking
             db_session: Optional database session for token tracking
 
         Returns:
@@ -874,16 +876,20 @@ class AgentServiceManager:
         """
         # Initialize tracker if db_session and task_id are provided
         tracker = None
-        if db_session and task_id:
+        tracker_task_id = tracking_task_id or task_id
+        if db_session and tracker_task_id:
             try:
                 from ..tracking.task_tracker import TaskTracker
 
-                tracker = TaskTracker(task_id=int(task_id), db_session=db_session)
+                tracker = TaskTracker(
+                    task_id=int(tracker_task_id),
+                    db_session=db_session,
+                )
                 await tracker.start_tracking()
-                logger.info(f"Started token tracking for task {task_id}")
+                logger.info(f"Started token tracking for task {tracker_task_id}")
             except Exception as e:
                 logger.warning(
-                    f"Failed to start token tracking for task {task_id}: {e}"
+                    f"Failed to start token tracking for task {tracker_task_id}: {e}"
                 )
                 tracker = None
 
@@ -911,10 +917,10 @@ class AgentServiceManager:
             if tracker:
                 try:
                     await tracker.complete_tracking()
-                    logger.info(f"Completed token tracking for task {task_id}")
+                    logger.info(f"Completed token tracking for task {tracker_task_id}")
                 except Exception as e:
                     logger.error(
-                        f"Failed to complete token tracking for task {task_id}: {e}"
+                        f"Failed to complete token tracking for task {tracker_task_id}: {e}"
                     )
 
     def _cleanup_workspace_directory(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -491,6 +491,7 @@ async def execute_task_background(
                 task=user_message,
                 context=context,
                 task_id=actual_task_id,
+                tracking_task_id=str(task_id),
                 db_session=db,
             )
 

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 from ...core.model.chat.token_context import (
     TokenUsage,
     get_token_usage,
-    reset_token_usage,
+    set_token_usage,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,8 +76,32 @@ class TaskTracker:
             logger.warning(f"Task {self.task_id} is already being tracked")
             return
 
-        # Initialize token context
-        reset_token_usage()
+        details: list[dict[str, Any]] = []
+        raw_details = getattr(self.task, "token_usage_details", None)
+        if isinstance(raw_details, list):
+            details = [item for item in raw_details if isinstance(item, dict)]
+
+        def _safe_int(value: Any) -> int:
+            if isinstance(value, bool):
+                return int(value)
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+            if isinstance(value, str):
+                try:
+                    return int(value)
+                except ValueError:
+                    return 0
+            return 0
+
+        initial_usage = TokenUsage(
+            input_tokens=_safe_int(getattr(self.task, "input_tokens", 0)),
+            output_tokens=_safe_int(getattr(self.task, "output_tokens", 0)),
+            llm_calls=_safe_int(getattr(self.task, "llm_calls", 0)),
+            details=details,
+        )
+        set_token_usage(initial_usage)
 
         logger.info(f"Started token tracking for task {self.task_id}")
 

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -80,6 +80,23 @@ class TestTaskTracker:
         assert task_tracker.is_tracking
 
     @pytest.mark.asyncio
+    async def test_start_tracking_uses_existing_task_totals(self, db_session):
+        mock_task = db_session.query.return_value.filter.return_value.first.return_value
+        mock_task.input_tokens = 120
+        mock_task.output_tokens = 80
+        mock_task.llm_calls = 4
+        mock_task.token_usage_details = [{"type": "input", "tokens": 120}]
+
+        tracker = TaskTracker(task_id=123, db_session=db_session)
+        await tracker.start_tracking()
+
+        usage = get_token_usage()
+        assert usage.input_tokens == 120
+        assert usage.output_tokens == 80
+        assert usage.llm_calls == 4
+        assert usage.details == [{"type": "input", "tokens": 120}]
+
+    @pytest.mark.asyncio
     async def test_start_tracking_already_tracking(self, task_tracker, caplog):
         """Test starting tracking when already tracking."""
         await task_tracker.start_tracking()


### PR DESCRIPTION
## Summary
- Fix an issue where task token usage stopped increasing after a new follow-up message.
- Initialize tracking context from existing task token totals so each new turn continues accumulation.
- Ensure token tracking is still bound to the task in fresh-execution paths (`task_id=None`) by passing a dedicated tracking task id.
- Add a regression test to verify `TaskTracker.start_tracking()` restores and continues existing totals.