### PR TITLE
fix(models): prevent incompatible default model mappings by category

### DIFF
--- a/frontend/src/components/settings/default-models.tsx
+++ b/frontend/src/components/settings/default-models.tsx
@@ -51,6 +51,19 @@ const modelTypeConfig = {
   },
 }
 
+const getModelCategory = (model: Model): string => {
+  const record = model as unknown as Record<string, unknown>
+  const category = record.category
+  return typeof category === 'string' ? category : ''
+}
+
+const getCompatibleModels = (models: Model[], configType: keyof typeof modelTypeConfig): Model[] => {
+  if (configType === 'embedding') {
+    return models.filter((model) => getModelCategory(model) === 'embedding')
+  }
+  return models.filter((model) => getModelCategory(model) === 'llm')
+}
+
 export function DefaultModelsSettings() {
   const { token } = useAuth()
   const [models, setModels] = useState<Model[]>([])
@@ -171,6 +184,10 @@ export function DefaultModelsSettings() {
             const currentDefault = defaultModels[configType as keyof typeof modelTypeConfig]
             const Icon = config.icon
             const isSaving = saving === configType
+            const compatibleModels = getCompatibleModels(
+              models,
+              configType as keyof typeof modelTypeConfig,
+            )
 
             return (
               <Card key={configType} className="relative">
@@ -229,13 +246,13 @@ export function DefaultModelsSettings() {
                         onValueChange={(value) =>
                           handleSetDefault(configType as keyof typeof modelTypeConfig, parseInt(value))
                         }
-                        options={models.map((model) => ({
+                        options={compatibleModels.map((model) => ({
                           value: model.id.toString(),
                           label: `${model.name} (${model.provider})`,
                         }))}
                         placeholder={t('settings.defaultModels.labels.selectModel')}
                       />
-                      {models.length === 0 && (
+                      {compatibleModels.length === 0 && (
                         <p className="text-xs text-muted-foreground">
                           {t('settings.defaultModels.empty.noModels')}
                         </p>

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -93,6 +93,27 @@ def _serialize_model_with_access(
     }
 
 
+def _is_default_config_type_compatible(model: Any, config_type: str) -> bool:
+    category_by_config_type = {
+        "general": "llm",
+        "small_fast": "llm",
+        "visual": "llm",
+        "compact": "llm",
+        "embedding": "embedding",
+        "image": "image",
+        "image_edit": "image",
+        "asr": "speech",
+        "tts": "speech",
+        "speech": "speech",
+    }
+
+    expected_category = category_by_config_type.get(config_type)
+    if expected_category is None:
+        return False
+    current_category = str(getattr(model, "category", ""))
+    return current_category == expected_category
+
+
 @model_router.post("/", response_model=ModelWithAccessInfo)
 @model_router.post("/register", response_model=ModelWithAccessInfo)
 async def create_model(
@@ -1238,6 +1259,15 @@ async def set_user_default_model(
             config_type = config.config_type  # Fallback to user-specified
     else:
         config_type = config.config_type
+
+    if not _is_default_config_type_compatible(model, config_type):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Config type '{config_type}' is incompatible with model category "
+                f"'{model.category}'"
+            ),
+        )
 
     # Remove existing configuration for this config_type
     db.query(UserDefaultModel).filter(

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -147,6 +147,22 @@ def sample_model_data():
     }
 
 
+@pytest.fixture(scope="function")
+def sample_embedding_model_data():
+    return {
+        "model_id": "test-embedding-model",
+        "category": "embedding",
+        "model_provider": "openai",
+        "model_name": "text-embedding-3-small",
+        "api_key": "test-api-key",
+        "base_url": "https://api.openai.com/v1",
+        "dimension": 1536,
+        "abilities": ["embedding"],
+        "description": "Test embedding model",
+        "share_with_users": False,
+    }
+
+
 class TestModelAPI:
     """Test model management API endpoints"""
 
@@ -505,3 +521,51 @@ class TestModelAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["abilities"] == ["chat", "tool_calling", "vision"]
+
+    def test_reject_embedding_model_as_general_default(
+        self,
+        test_db,
+        regular_user,
+        regular_headers,
+        sample_embedding_model_data,
+    ):
+        create_response = client.post(
+            "/api/models/",
+            json=sample_embedding_model_data,
+            headers=regular_headers,
+        )
+        assert create_response.status_code == 200
+        embedding_model_id = create_response.json()["id"]
+
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": embedding_model_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+
+        assert default_response.status_code == 400
+        assert "incompatible" in default_response.json()["detail"]
+
+    def test_allow_embedding_model_as_embedding_default(
+        self,
+        test_db,
+        regular_user,
+        regular_headers,
+        sample_embedding_model_data,
+    ):
+        create_response = client.post(
+            "/api/models/",
+            json=sample_embedding_model_data,
+            headers=regular_headers,
+        )
+        assert create_response.status_code == 200
+        embedding_model_id = create_response.json()["id"]
+
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": embedding_model_id, "config_type": "embedding"},
+            headers=regular_headers,
+        )
+
+        assert default_response.status_code == 200
+        assert default_response.json()["config_type"] == "embedding"


### PR DESCRIPTION
## Summary
- Add backend validation in `POST /api/models/user-default` to reject incompatible `config_type` and model category mappings (e.g. embedding -> general).
- Add frontend filtering in default model settings so users only see compatible model candidates per default type.
- Add regression tests to verify embedding models are rejected for `general` and allowed for `embedding`.

## Why
Users could be guided into assigning non-LLM models as chat defaults. This causes invalid default configuration and confusing behavior.