### PR TITLE
fix(kb): respect Form chunk_size in ingest (issue #199, part 1)

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
@@ -88,11 +88,10 @@ def chunk_document(
     Chunk parsed paragraphs and write to chunks table.
 
     Concurrency note:
-        This function uses **last-write-wins** semantics. If two concurrent
-        calls target the same (collection, doc_id, parse_hash) with different
-        parameters, the last one to reach ``_write_chunks_to_db`` will replace
-        the other's output. Callers requiring mutual exclusion should hold a
-        collection-level lock before invoking this function.
+        This function uses **last-write-wins** semantics. The ingestion
+        pipeline serialises calls per (collection, source_path) via
+        ``_get_ingestion_lock``, so concurrent chunk replacement races are
+        prevented at the pipeline level.
 
     Args:
         collection: Collection name for data isolation
@@ -544,9 +543,6 @@ def _write_chunks_to_db(
             }
             rows.append(row)
 
-        if not rows:
-            return False
-
         vector_store = get_vector_index_store()
         vector_store.replace_chunks(
             rows,
@@ -558,6 +554,9 @@ def _write_chunks_to_db(
             user_id=user_id,
             is_admin=is_admin,
         )
+
+        if not rows:
+            return False
 
         logger.info(
             "Chunk records written to database: doc_id=%s, parse_hash=%s, config_hash=%s",

--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
@@ -88,10 +88,10 @@ def chunk_document(
     Chunk parsed paragraphs and write to chunks table.
 
     Concurrency note:
-        This function uses **last-write-wins** semantics. The ingestion
-        pipeline serialises calls per (collection, source_path) via
-        ``_get_ingestion_lock``, so concurrent chunk replacement races are
-        prevented at the pipeline level.
+        Chunk replacement is serialised per
+        ``(collection, doc_id, parse_hash, user scope)`` via
+        ``generation_ingestion_lock`` (in ``replace_chunks`` and the ingestion
+        pipeline through embedding writes).
 
     Args:
         collection: Collection name for data isolation

--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
@@ -87,6 +87,13 @@ def chunk_document(
     """
     Chunk parsed paragraphs and write to chunks table.
 
+    Concurrency note:
+        This function uses **last-write-wins** semantics. If two concurrent
+        calls target the same (collection, doc_id, parse_hash) with different
+        parameters, the last one to reach ``_write_chunks_to_db`` will replace
+        the other's output. Callers requiring mutual exclusion should hold a
+        collection-level lock before invoking this function.
+
     Args:
         collection: Collection name for data isolation
         doc_id: Document ID whose parsed result to chunk
@@ -506,7 +513,12 @@ def _write_chunks_to_db(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> bool:
-    """Write chunk records to database using abstraction layer."""
+    """Write chunk records to database using abstraction layer.
+
+    Replaces any existing rows for the same document parse (collection, doc_id,
+    parse_hash) and tenancy scope before inserting, so a new ``config_hash`` does
+    not leave stale chunks from a previous configuration (issue #199).
+    """
     try:
         rows = []
         for chunk in chunks:
@@ -535,9 +547,17 @@ def _write_chunks_to_db(
         if not rows:
             return False
 
-        # Use abstraction layer for upsert
         vector_store = get_vector_index_store()
-        vector_store.upsert_chunks(rows)
+        vector_store.replace_chunks(
+            rows,
+            replace_scope={
+                "collection": collection,
+                "doc_id": doc_id,
+                "parse_hash": parse_hash,
+            },
+            user_id=user_id,
+            is_admin=is_admin,
+        )
 
         logger.info(
             "Chunk records written to database: doc_id=%s, parse_hash=%s, config_hash=%s",

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -53,6 +52,7 @@ from ..utils.embedding_utils import (
     normalize_raw_embedding_to_vectors,
     normalize_single_embedding,
 )
+from ..utils.generation_lock import generation_ingestion_lock
 from ..utils.model_resolver import resolve_embedding_adapter
 from ..utils.token_utils import get_token_counter
 from ..utils.user_scope import resolve_user_scope
@@ -62,24 +62,6 @@ from ..vector_storage.vector_manager import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Per-document ingestion lock keyed by (collection, source_path).
-# Prevents concurrent ingestion of the same document which can cause
-# data loss in the chunk replacement flow (see PR #202 comment 7).
-_ingestion_locks: Dict[tuple, threading.Lock] = {}
-_ingestion_locks_guard = threading.Lock()
-
-
-def _get_ingestion_lock(collection: str, source_path: str) -> threading.Lock:
-    """Get or create a per-document threading lock."""
-    key = (collection, source_path)
-    if key in _ingestion_locks:
-        return _ingestion_locks[key]
-    with _ingestion_locks_guard:
-        if key not in _ingestion_locks:
-            _ingestion_locks[key] = threading.Lock()
-        return _ingestion_locks[key]
-
 
 _SPREADSHEET_EXTENSIONS = {".xlsx", ".xls", ".csv"}
 _SPREADSHEET_CHUNK_SIZE_TOKENS = 512
@@ -540,20 +522,18 @@ def process_document(
           inputs will reuse existing records when possible.
         - Downstream API layers should surface `result.failed_step` and
           `result.warnings` to callers for better observability.
-        - A per-document lock serialises concurrent calls for the same
-          (collection, source_path) to prevent chunk replacement races.
+        - A per-generation lock (collection, doc_id, parse_hash, user scope)
+          serialises chunk replacement through embedding writes (PR #202).
     """
-    lock = _get_ingestion_lock(collection, source_path)
-    with lock:
-        return _process_document_impl(
-            collection,
-            source_path,
-            config=config,
-            progress_manager=progress_manager,
-            user_id=user_id,
-            is_admin=is_admin,
-            file_id=file_id,
-        )
+    return _process_document_impl(
+        collection,
+        source_path,
+        config=config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_id=file_id,
+    )
 
 
 def _process_document_impl(
@@ -566,7 +546,7 @@ def _process_document_impl(
     is_admin: bool = False,
     file_id: Optional[str] = None,
 ) -> IngestionResult:
-    """Internal implementation of process_document (runs under per-document lock)."""
+    """Internal implementation of process_document."""
     cfg = _apply_spreadsheet_ingestion_safeguards(
         coerce_ingestion_config(config),
         source_path,
@@ -830,445 +810,479 @@ def _process_document_impl(
             },
         )
 
-        # Step 3: Chunk document
-        with progress_tracker.track_step("chunk_document"):
-            pass  # Step marked
-        current_step = "chunk_document"
-        logger.info(
-            "Step chunk_document started",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "parse_hash": parse_hash,
-                "strategy": str(cfg.chunk_strategy),
-                "chunk_size": cfg.chunk_size,
-                "chunk_overlap": cfg.chunk_overlap,
-            },
-        )
-        chunk_start = time.time()
-        chunk_response = chunk_document(
-            collection=collection,
-            doc_id=doc_id,
-            parse_hash=parse_hash,
-            chunk_strategy=cfg.chunk_strategy,
-            chunk_size=cfg.chunk_size,
-            chunk_overlap=cfg.chunk_overlap,
-            headers_to_split_on=getattr(cfg, "headers_to_split_on", None),
-            separators=getattr(cfg, "separators", None),
-            use_token_count=getattr(cfg, "use_token_count", False),
-            tiktoken_encoding=getattr(
-                cfg, "tiktoken_encoding", DEFAULT_TIKTOKEN_ENCODING
-            ),
-            enable_protected_content=getattr(cfg, "enable_protected_content", True),
-            protected_patterns=getattr(cfg, "protected_patterns", None),
-            table_context_size=getattr(
-                cfg, "table_context_size", DEFAULT_TABLE_CONTEXT_SIZE
-            ),
-            image_context_size=getattr(
-                cfg, "image_context_size", DEFAULT_IMAGE_CONTEXT_SIZE
-            ),
-            user_id=user_id,
-        )
-        chunk_count = int(chunk_response.get("chunk_count", 0))
-        chunk_elapsed = int((time.time() - chunk_start) * 1000)
-        completed_steps.append(
-            IngestionStepResult(
-                name="chunk_document",
-                metadata={
+        last_write_response: Optional[EmbeddingWriteResponse] = None
+        generation_early_result: Optional[IngestionResult] = None
+
+        def _run_chunk_and_embedding_steps() -> None:
+            nonlocal current_step, chunk_count, embedding_count, vector_count
+            nonlocal \
+                completed_steps, \
+                warnings, \
+                last_write_response, \
+                generation_early_result
+
+            # Step 3: Chunk document
+            with progress_tracker.track_step("chunk_document"):
+                pass  # Step marked
+            current_step = "chunk_document"
+            logger.info(
+                "Step chunk_document started",
+                extra={
+                    "collection": collection,
+                    "doc_id": doc_id,
+                    "parse_hash": parse_hash,
+                    "strategy": str(cfg.chunk_strategy),
+                    "chunk_size": cfg.chunk_size,
+                    "chunk_overlap": cfg.chunk_overlap,
+                },
+            )
+            chunk_start = time.time()
+            chunk_response = chunk_document(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_strategy=cfg.chunk_strategy,
+                chunk_size=cfg.chunk_size,
+                chunk_overlap=cfg.chunk_overlap,
+                headers_to_split_on=getattr(cfg, "headers_to_split_on", None),
+                separators=getattr(cfg, "separators", None),
+                use_token_count=getattr(cfg, "use_token_count", False),
+                tiktoken_encoding=getattr(
+                    cfg, "tiktoken_encoding", DEFAULT_TIKTOKEN_ENCODING
+                ),
+                enable_protected_content=getattr(cfg, "enable_protected_content", True),
+                protected_patterns=getattr(cfg, "protected_patterns", None),
+                table_context_size=getattr(
+                    cfg, "table_context_size", DEFAULT_TABLE_CONTEXT_SIZE
+                ),
+                image_context_size=getattr(
+                    cfg, "image_context_size", DEFAULT_IMAGE_CONTEXT_SIZE
+                ),
+                user_id=user_id,
+            )
+            chunk_count = int(chunk_response.get("chunk_count", 0))
+            chunk_elapsed = int((time.time() - chunk_start) * 1000)
+            completed_steps.append(
+                IngestionStepResult(
+                    name="chunk_document",
+                    metadata={
+                        "chunk_count": chunk_count,
+                        "created": chunk_response.get("created"),
+                        "elapsed_ms": chunk_elapsed,
+                    },
+                )
+            )
+            logger.info(
+                "[RAG][chunk] step=chunk_document completed doc_id=%s chunk_count=%s "
+                "stats=%s config_hash_fields chunk_size=%s overlap=%s use_token_count=%s "
+                "protected=%s",
+                doc_id,
+                chunk_count,
+                chunk_response.get("stats"),
+                cfg.chunk_size,
+                cfg.chunk_overlap,
+                getattr(cfg, "use_token_count", False),
+                getattr(cfg, "enable_protected_content", True),
+            )
+            logger.info(
+                "Step chunk_document completed",
+                extra={
+                    "collection": collection,
+                    "doc_id": doc_id,
+                    "parse_hash": parse_hash,
                     "chunk_count": chunk_count,
-                    "created": chunk_response.get("created"),
                     "elapsed_ms": chunk_elapsed,
                 },
             )
-        )
-        logger.info(
-            "[RAG][chunk] step=chunk_document completed doc_id=%s chunk_count=%s "
-            "stats=%s config_hash_fields chunk_size=%s overlap=%s use_token_count=%s "
-            "protected=%s",
-            doc_id,
-            chunk_count,
-            chunk_response.get("stats"),
-            cfg.chunk_size,
-            cfg.chunk_overlap,
-            getattr(cfg, "use_token_count", False),
-            getattr(cfg, "enable_protected_content", True),
-        )
-        logger.info(
-            "Step chunk_document completed",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "parse_hash": parse_hash,
-                "chunk_count": chunk_count,
-                "elapsed_ms": chunk_elapsed,
-            },
-        )
 
-        # Step 4: Read chunks for embedding
-        with progress_tracker.track_step("read_chunks_for_embedding"):
-            pass  # Step marked
-        current_step = "read_chunks_for_embedding"
-        logger.info(
-            "Step read_chunks_for_embedding started",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "parse_hash": parse_hash,
-                "embedding_model": embedding_config.id,
-            },
-        )
-        read_start = time.time()
-        embedding_read_response = read_chunks_for_embedding(
-            collection=collection,
-            doc_id=doc_id,
-            parse_hash=parse_hash,
-            # IMPORTANT: Use Hub model ID as the single source of truth,
-            # matching the write path (embedding writes use embedding_config.id).
-            model=embedding_config.id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
-        read_model = (
-            embedding_read_response
-            if isinstance(embedding_read_response, EmbeddingReadResponse)
-            else EmbeddingReadResponse.model_validate(embedding_read_response)
-        )
-        chunks: List[ChunkForEmbedding] = read_model.chunks
-        pending_count = read_model.pending_count
-        if _is_spreadsheet_source(source_path):
-            _validate_spreadsheet_chunk_token_budget(
-                chunks,
-                encoding_name=cfg.tiktoken_encoding or DEFAULT_TIKTOKEN_ENCODING,
+            # Step 4: Read chunks for embedding
+            with progress_tracker.track_step("read_chunks_for_embedding"):
+                pass  # Step marked
+            current_step = "read_chunks_for_embedding"
+            logger.info(
+                "Step read_chunks_for_embedding started",
+                extra={
+                    "collection": collection,
+                    "doc_id": doc_id,
+                    "parse_hash": parse_hash,
+                    "embedding_model": embedding_config.id,
+                },
             )
-        read_elapsed = int((time.time() - read_start) * 1000)
+            read_start = time.time()
+            embedding_read_response = read_chunks_for_embedding(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                # IMPORTANT: Use Hub model ID as the single source of truth,
+                # matching the write path (embedding writes use embedding_config.id).
+                model=embedding_config.id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            read_model = (
+                embedding_read_response
+                if isinstance(embedding_read_response, EmbeddingReadResponse)
+                else EmbeddingReadResponse.model_validate(embedding_read_response)
+            )
+            chunks: List[ChunkForEmbedding] = read_model.chunks
+            pending_count = read_model.pending_count
+            if _is_spreadsheet_source(source_path):
+                _validate_spreadsheet_chunk_token_budget(
+                    chunks,
+                    encoding_name=cfg.tiktoken_encoding or DEFAULT_TIKTOKEN_ENCODING,
+                )
+            read_elapsed = int((time.time() - read_start) * 1000)
 
-        completed_steps.append(
-            IngestionStepResult(
-                name="read_chunks_for_embedding",
-                metadata={
+            completed_steps.append(
+                IngestionStepResult(
+                    name="read_chunks_for_embedding",
+                    metadata={
+                        "total_count": len(chunks),
+                        "pending_count": pending_count,
+                        "elapsed_ms": read_elapsed,
+                    },
+                )
+            )
+            logger.info(
+                "Step read_chunks_for_embedding completed",
+                extra={
+                    "collection": collection,
+                    "doc_id": doc_id,
                     "total_count": len(chunks),
                     "pending_count": pending_count,
                     "elapsed_ms": read_elapsed,
                 },
             )
-        )
-        logger.info(
-            "Step read_chunks_for_embedding completed",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "total_count": len(chunks),
-                "pending_count": pending_count,
-                "elapsed_ms": read_elapsed,
-            },
-        )
-        _log_pending_chunks_text_stats(
-            f"read_chunks_for_embedding doc_id={doc_id}", chunks
-        )
-
-        if pending_count == 0:
-            logger.info(
-                "No pending chunks for embedding; returning early",
-                extra={"collection": collection, "doc_id": doc_id},
-            )
-            _record_ingestion_status(
-                collection,
-                doc_id,
-                status=DocumentProcessingStatus.SUCCESS,
-                message="Document ingestion completed with no pending embeddings.",
-                parse_hash=parse_hash,
-                user_id=user_id,
-            )
-            return IngestionResult(
-                status="success",
-                doc_id=doc_id,
-                parse_hash=parse_hash,
-                chunk_count=chunk_count,
-                embedding_count=0,
-                vector_count=0,
-                completed_steps=completed_steps,
-                failed_step=None,
-                message="Document ingestion completed with no pending embeddings",
-                warnings=[],
+            _log_pending_chunks_text_stats(
+                f"read_chunks_for_embedding doc_id={doc_id}", chunks
             )
 
-        # Step 5: Compute embeddings and write
-        # Note: Some models (e.g., DashScope text-embedding-v4) do not support batch processing.
-        # When embedding_use_async is True, we use async concurrent processing instead of batch API calls.
-        # This wraps individual encode() calls with asyncio.to_thread for concurrent execution.
-        with progress_tracker.track_step(
-            "compute_embeddings",
-            total_count=pending_count,
-            message="Embedding chunks...",
-        ) as embedding_step_tracker:
-            current_step = "compute_embeddings"
+            if pending_count == 0:
+                logger.info(
+                    "No pending chunks for embedding; returning early",
+                    extra={"collection": collection, "doc_id": doc_id},
+                )
+                _record_ingestion_status(
+                    collection,
+                    doc_id,
+                    status=DocumentProcessingStatus.SUCCESS,
+                    message="Document ingestion completed with no pending embeddings.",
+                    parse_hash=parse_hash,
+                    user_id=user_id,
+                )
+                generation_early_result = IngestionResult(
+                    status="success",
+                    doc_id=doc_id,
+                    parse_hash=parse_hash,
+                    chunk_count=chunk_count,
+                    embedding_count=0,
+                    vector_count=0,
+                    completed_steps=completed_steps,
+                    failed_step=None,
+                    message="Document ingestion completed with no pending embeddings",
+                    warnings=[],
+                )
+                return
+
+            # Step 5: Compute embeddings and write
+            # Note: Some models (e.g., DashScope text-embedding-v4) do not support batch processing.
+            # When embedding_use_async is True, we use async concurrent processing instead of batch API calls.
+            # This wraps individual encode() calls with asyncio.to_thread for concurrent execution.
+            with progress_tracker.track_step(
+                "compute_embeddings",
+                total_count=pending_count,
+                message="Embedding chunks...",
+            ) as embedding_step_tracker:
+                current_step = "compute_embeddings"
+                logger.info(
+                    "Step compute_embeddings started",
+                    extra={
+                        "collection": collection,
+                        "doc_id": doc_id,
+                        "pending_count": pending_count,
+                        "use_async": cfg.embedding_use_async,
+                        "batch_size": cfg.embedding_batch_size
+                        if not cfg.embedding_use_async
+                        else None,
+                        "concurrent": cfg.embedding_concurrent
+                        if cfg.embedding_use_async
+                        else None,
+                    },
+                )
+                embedding_start = time.time()
+                total_embedding_count = 0
+                total_vector_count = 0
+                write_elapsed_total = 0.0
+
+                def _update_embedding_progress(current: int, total: int) -> None:
+                    embedding_step_tracker.update(
+                        current_count=current,
+                        total_count=total,
+                        message=f"Embedding {current}/{total}",
+                        completed_count=current,
+                        remaining_count=max(total - current, 0),
+                    )
+
+                if cfg.embedding_use_async:
+                    logger.info(
+                        "Using async concurrent embedding computation (model does not support batch processing)"
+                    )
+                    embeddings_list = asyncio.run(
+                        _compute_embeddings_async(
+                            chunks=chunks,
+                            embedding_adapter=embedding_adapter,
+                            embedding_config=embedding_config,
+                            max_concurrent=cfg.embedding_concurrent,
+                            max_retries=cfg.max_retries,
+                            retry_delay=cfg.retry_delay,
+                            progress_callback=_update_embedding_progress,
+                        )
+                    )
+                    total_embedding_count = len(embeddings_list)
+
+                    with progress_tracker.track_step(
+                        "write_vectors_to_db",
+                        total_count=len(embeddings_list),
+                        message="Writing vectors...",
+                    ) as write_step_tracker:
+                        for batch_start in range(
+                            0, len(embeddings_list), cfg.embedding_batch_size
+                        ):
+                            embeddings_batch_async = embeddings_list[
+                                batch_start : batch_start + cfg.embedding_batch_size
+                            ]
+
+                            if not embeddings_batch_async:
+                                continue
+
+                            write_batch_start = time.time()
+                            current_step = "write_vectors_to_db"
+                            try:
+                                write_response = write_vectors_to_db(
+                                    collection=collection,
+                                    embeddings=embeddings_batch_async,
+                                    create_index=(
+                                        batch_start + cfg.embedding_batch_size
+                                        >= len(embeddings_list)
+                                    ),
+                                    user_id=user_id,
+                                )
+                                last_write_response = (
+                                    write_response
+                                    if isinstance(
+                                        write_response, EmbeddingWriteResponse
+                                    )
+                                    else EmbeddingWriteResponse.model_validate(
+                                        write_response
+                                    )
+                                )
+                                current_step = "compute_embeddings"
+                            except Exception as exc:  # noqa: BLE001
+                                embedding_count = total_embedding_count
+                                raise DatabaseOperationError(
+                                    "Failed to write embedding batch to vector store",
+                                    details={
+                                        "batch_start": batch_start,
+                                        "batch_size": len(embeddings_batch_async),
+                                        "error": str(exc),
+                                    },
+                                ) from exc
+                            write_elapsed_total += time.time() - write_batch_start
+                            total_vector_count += last_write_response.upsert_count
+                            written_count = min(
+                                batch_start + len(embeddings_batch_async),
+                                len(embeddings_list),
+                            )
+                            write_step_tracker.update(
+                                current_count=written_count,
+                                total_count=len(embeddings_list),
+                                message=f"Writing vectors {written_count}/{len(embeddings_list)}",
+                                written_count=written_count,
+                                remaining_count=max(
+                                    len(embeddings_list) - written_count, 0
+                                ),
+                            )
+
+                else:
+                    processed_batches = 0
+                    with progress_tracker.track_step(
+                        "write_vectors_to_db",
+                        total_count=len(chunks),
+                        message="Writing vectors...",
+                    ) as write_step_tracker:
+                        for batch_start in range(
+                            0, len(chunks), cfg.embedding_batch_size
+                        ):
+                            batch_chunks = chunks[
+                                batch_start : batch_start + cfg.embedding_batch_size
+                            ]
+                            batch_texts = [chunk.text for chunk in batch_chunks]
+                            _log_embedding_text_batch_stats(
+                                f"compute_embeddings(batch) doc_id={doc_id}",
+                                batch_texts,
+                                batch_index=processed_batches,
+                            )
+                            raw_vectors = embedding_adapter.encode(batch_texts)
+                            vectors = normalize_raw_embedding_to_vectors(raw_vectors)
+
+                            if len(vectors) != len(batch_chunks):
+                                raise VectorValidationError(
+                                    "Embedding provider returned mismatched batch size",
+                                    details={
+                                        "batch_index": processed_batches,
+                                        "expected": len(batch_chunks),
+                                        "actual": len(vectors),
+                                    },
+                                )
+
+                            embeddings_batch: List[ChunkEmbeddingData] = [
+                                ChunkEmbeddingData(
+                                    doc_id=chunk.doc_id,
+                                    chunk_id=chunk.chunk_id,
+                                    parse_hash=chunk.parse_hash,
+                                    model=embedding_config.id,
+                                    vector=vector,
+                                    text=chunk.text,
+                                    chunk_hash=chunk.chunk_hash,
+                                    metadata=chunk.metadata,
+                                )
+                                for chunk, vector in zip(batch_chunks, vectors)
+                            ]
+                            total_embedding_count += len(embeddings_batch)
+                            processed_batches += 1
+                            _update_embedding_progress(
+                                total_embedding_count, len(chunks)
+                            )
+
+                            if not embeddings_batch:
+                                continue
+
+                            write_batch_start = time.time()
+                            current_step = "write_vectors_to_db"
+                            try:
+                                write_response = write_vectors_to_db(
+                                    collection=collection,
+                                    embeddings=embeddings_batch,
+                                    create_index=(
+                                        batch_start + cfg.embedding_batch_size
+                                        >= len(chunks)
+                                    ),
+                                    user_id=user_id,
+                                )
+                                last_write_response = (
+                                    write_response
+                                    if isinstance(
+                                        write_response, EmbeddingWriteResponse
+                                    )
+                                    else EmbeddingWriteResponse.model_validate(
+                                        write_response
+                                    )
+                                )
+                                current_step = "compute_embeddings"
+                            except Exception as exc:  # noqa: BLE001
+                                embedding_count = total_embedding_count
+                                raise DatabaseOperationError(
+                                    "Failed to write embedding batch to vector store",
+                                    details={
+                                        "batch_index": processed_batches - 1,
+                                        "batch_size": len(embeddings_batch),
+                                        "error": str(exc),
+                                    },
+                                ) from exc
+                            write_elapsed_total += time.time() - write_batch_start
+                            total_vector_count += last_write_response.upsert_count
+                            write_step_tracker.update(
+                                current_count=total_vector_count,
+                                total_count=len(chunks),
+                                message=f"Writing vectors {total_vector_count}/{len(chunks)}",
+                                written_count=total_vector_count,
+                                remaining_count=max(
+                                    len(chunks) - total_vector_count, 0
+                                ),
+                            )
+
+            embedding_count = total_embedding_count
+            embedding_elapsed = int((time.time() - embedding_start) * 1000)
+
+            # Check if embedding generation failed completely
+            if chunk_count > 0 and embedding_count == 0:
+                raise EmbeddingAdapterError(
+                    "Failed to generate any embeddings",
+                    details={
+                        "chunk_count": chunk_count,
+                        "use_async": cfg.embedding_use_async,
+                        "embedding_model": embedding_config.model_name
+                        if embedding_config
+                        else None,
+                    },
+                )
+
+            completed_steps.append(
+                IngestionStepResult(
+                    name="compute_embeddings",
+                    metadata={
+                        "embedding_count": embedding_count,
+                        "use_async": cfg.embedding_use_async,
+                        "batch_size": cfg.embedding_batch_size
+                        if not cfg.embedding_use_async
+                        else None,
+                        "concurrent": cfg.embedding_concurrent
+                        if cfg.embedding_use_async
+                        else None,
+                        "elapsed_ms": embedding_elapsed,
+                    },
+                )
+            )
             logger.info(
-                "Step compute_embeddings started",
+                "Step compute_embeddings completed",
                 extra={
                     "collection": collection,
                     "doc_id": doc_id,
-                    "pending_count": pending_count,
-                    "use_async": cfg.embedding_use_async,
-                    "batch_size": cfg.embedding_batch_size
-                    if not cfg.embedding_use_async
-                    else None,
-                    "concurrent": cfg.embedding_concurrent
-                    if cfg.embedding_use_async
-                    else None,
-                },
-            )
-            embedding_start = time.time()
-            total_embedding_count = 0
-            total_vector_count = 0
-            write_elapsed_total = 0.0
-            last_write_response: Optional[EmbeddingWriteResponse] = None
-
-            def _update_embedding_progress(current: int, total: int) -> None:
-                embedding_step_tracker.update(
-                    current_count=current,
-                    total_count=total,
-                    message=f"Embedding {current}/{total}",
-                    completed_count=current,
-                    remaining_count=max(total - current, 0),
-                )
-
-            if cfg.embedding_use_async:
-                logger.info(
-                    "Using async concurrent embedding computation (model does not support batch processing)"
-                )
-                embeddings_list = asyncio.run(
-                    _compute_embeddings_async(
-                        chunks=chunks,
-                        embedding_adapter=embedding_adapter,
-                        embedding_config=embedding_config,
-                        max_concurrent=cfg.embedding_concurrent,
-                        max_retries=cfg.max_retries,
-                        retry_delay=cfg.retry_delay,
-                        progress_callback=_update_embedding_progress,
-                    )
-                )
-                total_embedding_count = len(embeddings_list)
-
-                with progress_tracker.track_step(
-                    "write_vectors_to_db",
-                    total_count=len(embeddings_list),
-                    message="Writing vectors...",
-                ) as write_step_tracker:
-                    for batch_start in range(
-                        0, len(embeddings_list), cfg.embedding_batch_size
-                    ):
-                        embeddings_batch_async = embeddings_list[
-                            batch_start : batch_start + cfg.embedding_batch_size
-                        ]
-
-                        if not embeddings_batch_async:
-                            continue
-
-                        write_batch_start = time.time()
-                        current_step = "write_vectors_to_db"
-                        try:
-                            write_response = write_vectors_to_db(
-                                collection=collection,
-                                embeddings=embeddings_batch_async,
-                                create_index=(
-                                    batch_start + cfg.embedding_batch_size
-                                    >= len(embeddings_list)
-                                ),
-                                user_id=user_id,
-                            )
-                            last_write_response = (
-                                write_response
-                                if isinstance(write_response, EmbeddingWriteResponse)
-                                else EmbeddingWriteResponse.model_validate(
-                                    write_response
-                                )
-                            )
-                            current_step = "compute_embeddings"
-                        except Exception as exc:  # noqa: BLE001
-                            embedding_count = total_embedding_count
-                            raise DatabaseOperationError(
-                                "Failed to write embedding batch to vector store",
-                                details={
-                                    "batch_start": batch_start,
-                                    "batch_size": len(embeddings_batch_async),
-                                    "error": str(exc),
-                                },
-                            ) from exc
-                        write_elapsed_total += time.time() - write_batch_start
-                        total_vector_count += last_write_response.upsert_count
-                        written_count = min(
-                            batch_start + len(embeddings_batch_async),
-                            len(embeddings_list),
-                        )
-                        write_step_tracker.update(
-                            current_count=written_count,
-                            total_count=len(embeddings_list),
-                            message=f"Writing vectors {written_count}/{len(embeddings_list)}",
-                            written_count=written_count,
-                            remaining_count=max(
-                                len(embeddings_list) - written_count, 0
-                            ),
-                        )
-
-            else:
-                processed_batches = 0
-                with progress_tracker.track_step(
-                    "write_vectors_to_db",
-                    total_count=len(chunks),
-                    message="Writing vectors...",
-                ) as write_step_tracker:
-                    for batch_start in range(0, len(chunks), cfg.embedding_batch_size):
-                        batch_chunks = chunks[
-                            batch_start : batch_start + cfg.embedding_batch_size
-                        ]
-                        batch_texts = [chunk.text for chunk in batch_chunks]
-                        _log_embedding_text_batch_stats(
-                            f"compute_embeddings(batch) doc_id={doc_id}",
-                            batch_texts,
-                            batch_index=processed_batches,
-                        )
-                        raw_vectors = embedding_adapter.encode(batch_texts)
-                        vectors = normalize_raw_embedding_to_vectors(raw_vectors)
-
-                        if len(vectors) != len(batch_chunks):
-                            raise VectorValidationError(
-                                "Embedding provider returned mismatched batch size",
-                                details={
-                                    "batch_index": processed_batches,
-                                    "expected": len(batch_chunks),
-                                    "actual": len(vectors),
-                                },
-                            )
-
-                        embeddings_batch: List[ChunkEmbeddingData] = [
-                            ChunkEmbeddingData(
-                                doc_id=chunk.doc_id,
-                                chunk_id=chunk.chunk_id,
-                                parse_hash=chunk.parse_hash,
-                                model=embedding_config.id,
-                                vector=vector,
-                                text=chunk.text,
-                                chunk_hash=chunk.chunk_hash,
-                                metadata=chunk.metadata,
-                            )
-                            for chunk, vector in zip(batch_chunks, vectors)
-                        ]
-                        total_embedding_count += len(embeddings_batch)
-                        processed_batches += 1
-                        _update_embedding_progress(total_embedding_count, len(chunks))
-
-                        if not embeddings_batch:
-                            continue
-
-                        write_batch_start = time.time()
-                        current_step = "write_vectors_to_db"
-                        try:
-                            write_response = write_vectors_to_db(
-                                collection=collection,
-                                embeddings=embeddings_batch,
-                                create_index=(
-                                    batch_start + cfg.embedding_batch_size
-                                    >= len(chunks)
-                                ),
-                                user_id=user_id,
-                            )
-                            last_write_response = (
-                                write_response
-                                if isinstance(write_response, EmbeddingWriteResponse)
-                                else EmbeddingWriteResponse.model_validate(
-                                    write_response
-                                )
-                            )
-                            current_step = "compute_embeddings"
-                        except Exception as exc:  # noqa: BLE001
-                            embedding_count = total_embedding_count
-                            raise DatabaseOperationError(
-                                "Failed to write embedding batch to vector store",
-                                details={
-                                    "batch_index": processed_batches - 1,
-                                    "batch_size": len(embeddings_batch),
-                                    "error": str(exc),
-                                },
-                            ) from exc
-                        write_elapsed_total += time.time() - write_batch_start
-                        total_vector_count += last_write_response.upsert_count
-                        write_step_tracker.update(
-                            current_count=total_vector_count,
-                            total_count=len(chunks),
-                            message=f"Writing vectors {total_vector_count}/{len(chunks)}",
-                            written_count=total_vector_count,
-                            remaining_count=max(len(chunks) - total_vector_count, 0),
-                        )
-
-        embedding_count = total_embedding_count
-        embedding_elapsed = int((time.time() - embedding_start) * 1000)
-
-        # Check if embedding generation failed completely
-        if chunk_count > 0 and embedding_count == 0:
-            raise EmbeddingAdapterError(
-                "Failed to generate any embeddings",
-                details={
-                    "chunk_count": chunk_count,
-                    "use_async": cfg.embedding_use_async,
-                    "embedding_model": embedding_config.model_name
-                    if embedding_config
-                    else None,
-                },
-            )
-
-        completed_steps.append(
-            IngestionStepResult(
-                name="compute_embeddings",
-                metadata={
                     "embedding_count": embedding_count,
                     "use_async": cfg.embedding_use_async,
-                    "batch_size": cfg.embedding_batch_size
-                    if not cfg.embedding_use_async
-                    else None,
-                    "concurrent": cfg.embedding_concurrent
-                    if cfg.embedding_use_async
-                    else None,
                     "elapsed_ms": embedding_elapsed,
                 },
             )
-        )
-        logger.info(
-            "Step compute_embeddings completed",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "embedding_count": embedding_count,
-                "use_async": cfg.embedding_use_async,
-                "elapsed_ms": embedding_elapsed,
-            },
-        )
 
-        vector_count = total_vector_count
-        write_elapsed_ms = int(write_elapsed_total * 1000)
-        current_step = "write_vectors_to_db"
-        completed_steps.append(
-            IngestionStepResult(
-                name="write_vectors_to_db",
-                metadata={
+            vector_count = total_vector_count
+            write_elapsed_ms = int(write_elapsed_total * 1000)
+            current_step = "write_vectors_to_db"
+            completed_steps.append(
+                IngestionStepResult(
+                    name="write_vectors_to_db",
+                    metadata={
+                        "vector_count": vector_count,
+                        "elapsed_ms": write_elapsed_ms,
+                    },
+                )
+            )
+            logger.info(
+                "Step write_vectors_to_db completed",
+                extra={
+                    "collection": collection,
+                    "doc_id": doc_id,
                     "vector_count": vector_count,
+                    "index_status": (
+                        last_write_response.index_status
+                        if last_write_response is not None
+                        else "skipped"
+                    ),
                     "elapsed_ms": write_elapsed_ms,
                 },
             )
-        )
-        logger.info(
-            "Step write_vectors_to_db completed",
-            extra={
-                "collection": collection,
-                "doc_id": doc_id,
-                "vector_count": vector_count,
-                "index_status": (
-                    last_write_response.index_status
-                    if last_write_response is not None
-                    else "skipped"
-                ),
-                "elapsed_ms": write_elapsed_ms,
-            },
-        )
+
+        with generation_ingestion_lock(
+            collection=collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+        ):
+            _run_chunk_and_embedding_steps()
+
+        if generation_early_result is not None:
+            progress_manager.complete_task(task_id, success=True)
+            return generation_early_result
 
         # Update collection statistics
         try:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -61,6 +62,24 @@ from ..vector_storage.vector_manager import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Per-document ingestion lock keyed by (collection, source_path).
+# Prevents concurrent ingestion of the same document which can cause
+# data loss in the chunk replacement flow (see PR #202 comment 7).
+_ingestion_locks: Dict[tuple, threading.Lock] = {}
+_ingestion_locks_guard = threading.Lock()
+
+
+def _get_ingestion_lock(collection: str, source_path: str) -> threading.Lock:
+    """Get or create a per-document threading lock."""
+    key = (collection, source_path)
+    if key in _ingestion_locks:
+        return _ingestion_locks[key]
+    with _ingestion_locks_guard:
+        if key not in _ingestion_locks:
+            _ingestion_locks[key] = threading.Lock()
+        return _ingestion_locks[key]
+
 
 _SPREADSHEET_EXTENSIONS = {".xlsx", ".xls", ".csv"}
 _SPREADSHEET_CHUNK_SIZE_TOKENS = 512
@@ -521,7 +540,33 @@ def process_document(
           inputs will reuse existing records when possible.
         - Downstream API layers should surface `result.failed_step` and
           `result.warnings` to callers for better observability.
+        - A per-document lock serialises concurrent calls for the same
+          (collection, source_path) to prevent chunk replacement races.
     """
+    lock = _get_ingestion_lock(collection, source_path)
+    with lock:
+        return _process_document_impl(
+            collection,
+            source_path,
+            config=config,
+            progress_manager=progress_manager,
+            user_id=user_id,
+            is_admin=is_admin,
+            file_id=file_id,
+        )
+
+
+def _process_document_impl(
+    collection: str,
+    source_path: str,
+    *,
+    config: Optional[IngestionConfig] = None,
+    progress_manager: Optional[ProgressManager] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+    file_id: Optional[str] = None,
+) -> IngestionResult:
+    """Internal implementation of process_document (runs under per-document lock)."""
     cfg = _apply_spreadsheet_ingestion_safeguards(
         coerce_ingestion_config(config),
         source_path,

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -727,19 +727,31 @@ class VectorIndexStore(ABC):
         user_id: Optional[int] = None,
         is_admin: bool = False,
     ) -> None:
-        """Replace chunk records within a scope (delete old + insert new).
+        """Replace chunk records within a scope (insert new, then delete old).
 
-        Deletes all existing chunk rows matching *replace_scope* (and tenancy
-        filters), then inserts *records*. This guarantees that re-chunking with
-        different parameters does not leave stale rows from a previous
-        configuration (issue #199).
+        Inserts *records* first via idempotent merge_insert, then deletes rows
+        matching *replace_scope* that do not belong to the new generation.
+        This insert-before-delete order avoids data loss if the process crashes
+        between the two operations (worst case: brief duplicate data, not zero
+        data). Guarantees that re-chunking with different parameters does not
+        leave stale rows from a previous configuration (issue #199).
+
+        After updating the chunks table, cascade-deletes orphaned rows from
+        all ``embeddings_*`` tables whose chunk_id no longer belongs to the
+        new generation, preventing stale embeddings from appearing in search
+        results.
 
         Args:
-            records: New chunk records to insert after deletion.
-            replace_scope: Filter dict (e.g. collection, doc_id, parse_hash)
-                identifying rows to delete before inserting.
+            records: New chunk records to insert. Each record must contain a
+                ``chunk_id`` field.
+            replace_scope: Non-empty filter dict (e.g. collection, doc_id,
+                parse_hash) identifying the scope of rows to replace.
             user_id: Optional user ID for multi-tenancy scoped deletion.
             is_admin: Whether the caller can operate across tenants.
+
+        Raises:
+            ValueError: If *replace_scope* is empty or contains disallowed
+                keys, or if any record is missing ``chunk_id``.
         """
 
     @abstractmethod

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -719,6 +719,30 @@ class VectorIndexStore(ABC):
         """
 
     @abstractmethod
+    def replace_chunks(
+        self,
+        records: List[Dict[str, Any]],
+        *,
+        replace_scope: Dict[str, Any],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Replace chunk records within a scope (delete old + insert new).
+
+        Deletes all existing chunk rows matching *replace_scope* (and tenancy
+        filters), then inserts *records*. This guarantees that re-chunking with
+        different parameters does not leave stale rows from a previous
+        configuration (issue #199).
+
+        Args:
+            records: New chunk records to insert after deletion.
+            replace_scope: Filter dict (e.g. collection, doc_id, parse_hash)
+                identifying rows to delete before inserting.
+            user_id: Optional user ID for multi-tenancy scoped deletion.
+            is_admin: Whether the caller can operate across tenants.
+        """
+
+    @abstractmethod
     def upsert_embeddings(self, model_tag: str, records: List[Dict[str, Any]]) -> None:
         """Upsert embedding records (sync).
 

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1501,26 +1501,42 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         user_id: Optional[int] = None,
         is_admin: bool = False,
     ) -> None:
-        """Replace chunk records within a scope (delete old + insert new).
+        """Replace chunk records within a scope (insert new, then delete old).
 
-        Safety: inserts new records first, then deletes rows that do NOT belong
-        to the new generation. This avoids data loss if the process crashes
+        Inserts *records* first via idempotent merge_insert, then deletes rows
+        matching *replace_scope* that do not belong to the new generation.
+        This insert-before-delete order avoids data loss if the process crashes
         between the two operations (worst case: brief duplicate data, not zero
-        data).
+        data). Also cascade-deletes orphaned embedding rows from all
+        ``embeddings_*`` tables.
         """
         from ..LanceDB.schema_manager import _safe_close_table, ensure_chunks_table
+
+        if not replace_scope:
+            raise ValueError("replace_scope must not be empty")
 
         for key in replace_scope:
             if key not in self._REPLACE_CHUNKS_ALLOWED_KEYS:
                 raise ValueError(f"Invalid replace_scope column: {key}")
 
+        if records:
+            missing = [i for i, r in enumerate(records) if "chunk_id" not in r]
+            if missing:
+                raise ValueError(
+                    f"records at index {missing} missing required 'chunk_id' field"
+                )
+
         conn = self._get_connection()
         ensure_chunks_table(conn)
         table = conn.open_table("chunks")
         try:
-            # Step 1: Insert new records (safe — idempotent add)
+            # Step 1: Upsert new records (merge_insert is idempotent on retry)
             if records:
-                table.add(records)
+                table.merge_insert(
+                    ["collection", "doc_id", "parse_hash", "chunk_id"]
+                ).when_matched_update_all().when_not_matched_insert_all().execute(
+                    records
+                )
 
             # Step 2: Build delete filter targeting old generations
             scope_parts = [
@@ -1550,6 +1566,48 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         finally:
             _safe_close_table(table)
         self.invalidate_table_cache("chunks")
+
+        # Step 3: Cascade-delete orphaned embeddings for the same scope.
+        # After chunk replacement, old chunk_ids no longer exist in the chunks
+        # table but their embedding rows would still be searchable.
+        embed_scope_parts = [
+            f"{k} == '{escape_lancedb_string(str(v))}'"
+            for k, v in replace_scope.items()
+            if k in ("collection", "doc_id", "parse_hash")
+        ]
+        if not embed_scope_parts:
+            return
+
+        embed_base = " AND ".join(embed_scope_parts)
+        embed_user = UserPermissions.get_user_filter(user_id, is_admin)
+        if embed_base and embed_user:
+            embed_filter = f"({embed_base}) AND ({embed_user})"
+        elif embed_user:
+            embed_filter = embed_user
+        else:
+            embed_filter = embed_base
+
+        if records:
+            new_ids = [r["chunk_id"] for r in records]
+            id_list = ", ".join(f"'{escape_lancedb_string(cid)}'" for cid in new_ids)
+            embed_filter = f"({embed_filter}) AND chunk_id NOT IN ({id_list})"
+
+        for tname in self.list_table_names():
+            if not tname.startswith("embeddings_"):
+                continue
+            try:
+                etable = conn.open_table(tname)
+                try:
+                    etable.delete(embed_filter)
+                finally:
+                    _safe_close_table(etable)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to cascade-delete embeddings from %s",
+                    tname,
+                    exc_info=True,
+                )
+        self.invalidate_table_cache()
 
     def upsert_embeddings(self, model_tag: str, records: List[Dict[str, Any]]) -> None:
         """Upsert embedding records to LanceDB with fallback pattern.

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -16,8 +16,10 @@ from lancedb.db import DBConnection
 from xagent.providers.vector_store.lancedb import get_connection_from_env
 
 from ..core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT, IndexPolicy
+from ..core.exceptions import DatabaseOperationError
 from ..core.schemas import CollectionInfo, IndexResult
 from ..LanceDB.schema_manager import ensure_documents_table
+from ..utils.generation_lock import generation_ingestion_lock
 from ..utils.lancedb_query_utils import list_table_names, query_to_list
 from ..utils.string_utils import build_lancedb_filter_expression, escape_lancedb_string
 from ..utils.user_permissions import UserPermissions
@@ -1507,10 +1509,13 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         matching *replace_scope* that do not belong to the new generation.
         This insert-before-delete order avoids data loss if the process crashes
         between the two operations (worst case: brief duplicate data, not zero
-        data). Also cascade-deletes orphaned embedding rows from all
+        data).         Also cascade-deletes orphaned embedding rows from all
         ``embeddings_*`` tables.
+
+        Raises:
+            DatabaseOperationError: If cascade deletion from any embeddings table
+                fails (stale embeddings would remain searchable).
         """
-        from ..LanceDB.schema_manager import _safe_close_table, ensure_chunks_table
 
         if not replace_scope:
             raise ValueError("replace_scope must not be empty")
@@ -1519,12 +1524,41 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             if key not in self._REPLACE_CHUNKS_ALLOWED_KEYS:
                 raise ValueError(f"Invalid replace_scope column: {key}")
 
+        collection = str(replace_scope["collection"])
+        doc_id = str(replace_scope["doc_id"])
+        parse_hash = str(replace_scope["parse_hash"])
+
         if records:
             missing = [i for i, r in enumerate(records) if "chunk_id" not in r]
             if missing:
                 raise ValueError(
                     f"records at index {missing} missing required 'chunk_id' field"
                 )
+
+        with generation_ingestion_lock(
+            collection=collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+        ):
+            self._replace_chunks_locked(
+                records,
+                replace_scope=replace_scope,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def _replace_chunks_locked(
+        self,
+        records: List[Dict[str, Any]],
+        *,
+        replace_scope: Dict[str, Any],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Internal replace_chunks body (caller must hold generation lock)."""
+        from ..LanceDB.schema_manager import _safe_close_table, ensure_chunks_table
 
         conn = self._get_connection()
         ensure_chunks_table(conn)
@@ -1592,6 +1626,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             id_list = ", ".join(f"'{escape_lancedb_string(cid)}'" for cid in new_ids)
             embed_filter = f"({embed_filter}) AND chunk_id NOT IN ({id_list})"
 
+        failed_tables: List[str] = []
         for tname in self.list_table_names():
             if not tname.startswith("embeddings_"):
                 continue
@@ -1601,13 +1636,23 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                     etable.delete(embed_filter)
                 finally:
                     _safe_close_table(etable)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 logger.warning(
-                    "Failed to cascade-delete embeddings from %s",
+                    "Failed to cascade-delete embeddings from %s: %s",
                     tname,
+                    exc,
                     exc_info=True,
                 )
+                failed_tables.append(tname)
         self.invalidate_table_cache()
+        if failed_tables:
+            raise DatabaseOperationError(
+                "Failed to cascade-delete stale embeddings after chunk replacement",
+                details={
+                    "failed_tables": failed_tables,
+                    "replace_scope": replace_scope,
+                },
+            )
 
     def upsert_embeddings(self, model_tag: str, records: List[Dict[str, Any]]) -> None:
         """Upsert embedding records to LanceDB with fallback pattern.

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1489,6 +1489,68 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             _safe_close_table(table)
         self.invalidate_table_cache("chunks")
 
+    _REPLACE_CHUNKS_ALLOWED_KEYS: frozenset = frozenset(
+        {"collection", "doc_id", "parse_hash"}
+    )
+
+    def replace_chunks(
+        self,
+        records: List[Dict[str, Any]],
+        *,
+        replace_scope: Dict[str, Any],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Replace chunk records within a scope (delete old + insert new).
+
+        Safety: inserts new records first, then deletes rows that do NOT belong
+        to the new generation. This avoids data loss if the process crashes
+        between the two operations (worst case: brief duplicate data, not zero
+        data).
+        """
+        from ..LanceDB.schema_manager import _safe_close_table, ensure_chunks_table
+
+        for key in replace_scope:
+            if key not in self._REPLACE_CHUNKS_ALLOWED_KEYS:
+                raise ValueError(f"Invalid replace_scope column: {key}")
+
+        conn = self._get_connection()
+        ensure_chunks_table(conn)
+        table = conn.open_table("chunks")
+        try:
+            # Step 1: Insert new records (safe — idempotent add)
+            if records:
+                table.add(records)
+
+            # Step 2: Build delete filter targeting old generations
+            scope_parts = [
+                f"{k} == '{escape_lancedb_string(str(v))}'"
+                for k, v in replace_scope.items()
+            ]
+            base_filter = " AND ".join(scope_parts)
+
+            user_filter = UserPermissions.get_user_filter(user_id, is_admin)
+            if base_filter and user_filter:
+                delete_expr = f"({base_filter}) AND ({user_filter})"
+            elif user_filter:
+                delete_expr = user_filter
+            else:
+                delete_expr = base_filter
+
+            # Exclude newly inserted chunk_ids from deletion
+            if records and delete_expr:
+                new_ids = [r["chunk_id"] for r in records]
+                id_list = ", ".join(
+                    f"'{escape_lancedb_string(cid)}'" for cid in new_ids
+                )
+                delete_expr = f"({delete_expr}) AND chunk_id NOT IN ({id_list})"
+
+            if delete_expr:
+                table.delete(delete_expr)
+        finally:
+            _safe_close_table(table)
+        self.invalidate_table_cache("chunks")
+
     def upsert_embeddings(self, model_tag: str, records: List[Dict[str, Any]]) -> None:
         """Upsert embedding records to LanceDB with fallback pattern.
 

--- a/src/xagent/core/tools/core/RAG_tools/utils/generation_lock.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/generation_lock.py
@@ -1,0 +1,122 @@
+"""Cross-process locks for document generation (chunk + embedding) scopes.
+
+Serialises work keyed by ``(collection, doc_id, parse_hash, user scope)`` so
+concurrent re-chunk / re-embed runs for the same logical document cannot race
+across chunk replacement and embedding writes (PR #202).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional, Tuple
+
+from filelock import FileLock, Timeout
+
+logger = logging.getLogger(__name__)
+
+# Re-entrant per-process locks; paired with FileLock for multi-worker safety.
+_thread_locks: dict[Tuple[str, str, str, str, str], threading.RLock] = {}
+_thread_locks_guard = threading.Lock()
+
+_lock_depth = threading.local()
+
+DEFAULT_GENERATION_LOCK_TIMEOUT = float(
+    os.environ.get("XAGENT_INGESTION_GENERATION_LOCK_TIMEOUT_SEC", "3600")
+)
+
+
+def generation_lock_key(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    user_id: Optional[int],
+    is_admin: bool,
+) -> Tuple[str, str, str, str, str]:
+    """Build the canonical lock key for a document generation scope."""
+    return (
+        collection,
+        doc_id,
+        parse_hash,
+        str(user_id) if user_id is not None else "",
+        "admin" if is_admin else "user",
+    )
+
+
+def _get_thread_lock(key: Tuple[str, str, str, str, str]) -> threading.RLock:
+    if key in _thread_locks:
+        return _thread_locks[key]
+    with _thread_locks_guard:
+        if key not in _thread_locks:
+            _thread_locks[key] = threading.RLock()
+        return _thread_locks[key]
+
+
+def _locks_directory() -> Path:
+    lancedb_dir = os.getenv("LANCEDB_DIR")
+    if not lancedb_dir:
+        from xagent.providers.vector_store.lancedb import LanceDBConnectionManager
+
+        lancedb_dir = LanceDBConnectionManager.get_default_lancedb_dir()
+    locks_dir = Path(lancedb_dir) / ".ingestion_generation_locks"
+    locks_dir.mkdir(parents=True, exist_ok=True)
+    return locks_dir
+
+
+def _file_lock_path(key: Tuple[str, str, str, str, str]) -> Path:
+    digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()
+    return _locks_directory() / f"{digest}.lock"
+
+
+@contextmanager
+def generation_ingestion_lock(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    user_id: Optional[int],
+    is_admin: bool,
+    *,
+    timeout: float = DEFAULT_GENERATION_LOCK_TIMEOUT,
+) -> Iterator[None]:
+    """Acquire a generation-scope lock (in-process re-entrant + cross-process).
+
+    Nested calls for the same scope from one thread only acquire the file lock
+    once, so ``process_document`` can call ``replace_chunks`` safely.
+    """
+    key = generation_lock_key(collection, doc_id, parse_hash, user_id, is_admin)
+    thread_lock = _get_thread_lock(key)
+
+    depth = getattr(_lock_depth, "value", 0)
+    acquire_file = depth == 0
+    _lock_depth.value = depth + 1
+
+    thread_lock.acquire()
+    file_lock: Optional[FileLock] = None
+    try:
+        if acquire_file:
+            file_lock = FileLock(str(_file_lock_path(key)))
+            try:
+                file_lock.acquire(timeout=timeout)
+            except Timeout as exc:
+                logger.warning(
+                    "Generation lock timeout: collection=%s doc_id=%s parse_hash=%s "
+                    "timeout=%.1fs",
+                    collection,
+                    doc_id,
+                    parse_hash,
+                    timeout,
+                )
+                raise Timeout(
+                    f"Timed out waiting for ingestion generation lock on "
+                    f"{collection}/{doc_id}/{parse_hash}"
+                ) from exc
+        yield
+    finally:
+        if acquire_file and file_lock is not None:
+            file_lock.release()
+        _lock_depth.value = max(getattr(_lock_depth, "value", 1) - 1, 0)
+        thread_lock.release()

--- a/tests/core/tools/core/RAG_tools/chunk/test_chunk_document.py
+++ b/tests/core/tools/core/RAG_tools/chunk/test_chunk_document.py
@@ -810,7 +810,7 @@ class TestChunkDocument:
     def test_chunk_separators_create_new_version(
         self, temp_lancedb_dir, test_collection, test_doc_id
     ):
-        """Test that different separators create new version."""
+        """Re-chunking with different separators replaces prior rows (single config_hash)."""
         # Step 1: Register and parse document
         txt_path = "tests/resources/test_files/test.txt"
         register_document(
@@ -852,11 +852,9 @@ class TestChunkDocument:
             user_id=1,
         )
 
-        # Both should write (different versions)
         assert chunk_result1["created"] is True
         assert chunk_result2["created"] is True
 
-        # Verify database has two different config_hash versions
         from xagent.core.tools.core.RAG_tools.storage.factory import (
             get_vector_store_raw_connection,
         )
@@ -871,14 +869,11 @@ class TestChunkDocument:
             .to_pandas()
         )
 
-        # Should have two different config_hash values
+        # Only the latest chunking generation is kept for this parse (issue #199).
         config_hashes = df["config_hash"].unique()
-        assert len(config_hashes) == 2
-
-        # Each version should have > 0 rows
-        for config_hash in config_hashes:
-            version_rows = df[df["config_hash"] == config_hash]
-            assert len(version_rows) > 0
+        assert len(config_hashes) == 1
+        assert len(df) == chunk_result2["chunk_count"]
+        assert len(df) > 0
 
     def test_chunk_recursive_custom_separators_integration(
         self, temp_lancedb_dir, test_collection, test_doc_id
@@ -934,13 +929,19 @@ class TestChunkDocument:
         )
 
     def test_chunk_recursive_custom_separators_vs_default_different_result(
-        self, temp_lancedb_dir, test_collection, test_doc_id
+        self, temp_lancedb_dir, test_collection, test_doc_id, tmp_path
     ):
-        """Integration: custom separators produce different chunk count or config than default."""
-        txt_path = "tests/resources/test_files/test.txt"
+        """Integration: default then custom separators; DB keeps only the last generation."""
+        # Generate deterministic long text to guarantee different chunk counts
+        lines = [
+            f"Line {i}: The quick brown fox jumps over the lazy dog." for i in range(20)
+        ]
+        long_doc = tmp_path / "long_doc.txt"
+        long_doc.write_text("\n".join(lines), encoding="utf-8")
+
         register_document(
             collection=test_collection,
-            source_path=txt_path,
+            source_path=str(long_doc),
             doc_id=test_doc_id,
             user_id=1,
         )
@@ -953,13 +954,14 @@ class TestChunkDocument:
         )
         parse_hash = parse_result["parse_hash"]
 
+        # Large chunk_size → few chunks; small chunk_size with newline separator → many chunks.
         chunk_default = chunk_document(
             collection=test_collection,
             doc_id=test_doc_id,
             parse_hash=parse_hash,
             chunk_strategy=ChunkStrategy.RECURSIVE,
-            chunk_size=50,
-            chunk_overlap=10,
+            chunk_size=500,
+            chunk_overlap=0,
             separators=None,
             user_id=1,
         )
@@ -968,14 +970,16 @@ class TestChunkDocument:
             doc_id=test_doc_id,
             parse_hash=parse_hash,
             chunk_strategy=ChunkStrategy.RECURSIVE,
-            chunk_size=50,
-            chunk_overlap=10,
-            separators=["。", "\n"],
+            chunk_size=25,
+            chunk_overlap=5,
+            separators=["\n"],
             user_id=1,
         )
         assert chunk_default["created"] is True
         assert chunk_custom["created"] is True
-        # Different separators must yield different config_hash (hence different version)
+        assert chunk_default["chunk_count"] != chunk_custom["chunk_count"], (
+            "Expected distinct chunking outcomes so the replacement semantics are observable"
+        )
         from xagent.core.tools.core.RAG_tools.storage.factory import (
             get_vector_store_raw_connection,
         )
@@ -990,9 +994,8 @@ class TestChunkDocument:
             .to_pandas()
         )
         config_hashes = df["config_hash"].unique()
-        assert len(config_hashes) == 2, (
-            "Default and custom separators should produce two distinct chunk versions"
-        )
+        assert len(config_hashes) == 1
+        assert len(df) == chunk_custom["chunk_count"]
 
     def test_chunk_row_level_hash_uniqueness(
         self, temp_lancedb_dir, test_collection, test_doc_id

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Dict, List, Union
 
 import pytest
@@ -972,3 +974,117 @@ def test_process_document_rejects_absolute_paths_outside_allowed_dir(
             or "permission" in message_lower
             or "denied" in message_lower
         ), f"Unexpected error message for {abs_path}: {result.message}"
+
+
+# ---------------------------------------------------------------------------
+# Ingestion lock tests (PR #202 comment 7)
+# ---------------------------------------------------------------------------
+
+
+def test_get_ingestion_lock_returns_same_instance() -> None:
+    """_get_ingestion_lock returns the same Lock for the same key."""
+    document_ingestion._ingestion_locks.clear()
+    lock_a = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
+    lock_b = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
+    assert lock_a is lock_b
+
+
+def test_get_ingestion_lock_different_keys() -> None:
+    """Different (collection, source_path) pairs get independent locks."""
+    document_ingestion._ingestion_locks.clear()
+    lock_a = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
+    lock_b = document_ingestion._get_ingestion_lock("col", "/tmp/b.pdf")
+    lock_c = document_ingestion._get_ingestion_lock("other", "/tmp/a.pdf")
+    assert lock_a is not lock_b
+    assert lock_a is not lock_c
+
+
+def test_ingestion_lock_serialises_same_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent process_document calls for the same document run serially."""
+    document_ingestion._ingestion_locks.clear()
+
+    execution_log: List[str] = []
+    original_impl = document_ingestion._process_document_impl
+
+    def _slow_impl(*args: object, **kwargs: object) -> IngestionResult:
+        execution_log.append("enter")
+        # Without the lock, both threads would be here simultaneously
+        time.sleep(0.1)
+        execution_log.append("exit")
+        return original_impl(*args, **kwargs)
+
+    _patch_pipeline_dependencies(monkeypatch)
+    monkeypatch.setattr(document_ingestion, "_process_document_impl", _slow_impl)
+
+    results: List[IngestionResult] = [None, None]  # type: ignore[list-item]
+
+    def _run(idx: int) -> None:
+        results[idx] = document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/doc.pdf",
+            config=IngestionConfig(),
+        )
+
+    t1 = threading.Thread(target=_run, args=(0,))
+    t2 = threading.Thread(target=_run, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    # With serialisation the pattern must be [enter, exit, enter, exit],
+    # never [enter, enter, ...] which would indicate overlap.
+    assert len(execution_log) == 4
+    assert execution_log == ["enter", "exit", "enter", "exit"]
+
+
+def test_ingestion_lock_allows_different_documents_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Calls for different documents are NOT serialised (they use independent locks)."""
+    document_ingestion._ingestion_locks.clear()
+
+    entered = threading.Event()
+    gate = threading.Event()
+
+    original_impl = document_ingestion._process_document_impl
+
+    def _blocking_impl(*args: object, **kwargs: object) -> IngestionResult:
+        entered.set()
+        gate.wait(timeout=5)
+        return original_impl(*args, **kwargs)
+
+    _patch_pipeline_dependencies(monkeypatch)
+    monkeypatch.setattr(document_ingestion, "_process_document_impl", _blocking_impl)
+
+    def _run_a() -> None:
+        document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/a.pdf",
+            config=IngestionConfig(),
+        )
+
+    def _run_b() -> None:
+        document_ingestion.process_document(
+            collection="demo",
+            source_path="/tmp/b.pdf",
+            config=IngestionConfig(),
+        )
+
+    t1 = threading.Thread(target=_run_a)
+    t2 = threading.Thread(target=_run_b)
+    t1.start()
+    # Wait for thread 1 to enter _blocking_impl
+    assert entered.wait(timeout=5)
+    entered.clear()
+
+    t2.start()
+    # Thread 2 should also enter _blocking_impl (different document, no lock contention)
+    both_entered = entered.wait(timeout=2)
+    gate.set()  # Release both threads
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert both_entered, "Different documents should not block each other"

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -977,114 +977,38 @@ def test_process_document_rejects_absolute_paths_outside_allowed_dir(
 
 
 # ---------------------------------------------------------------------------
-# Ingestion lock tests (PR #202 comment 7)
+# Generation-scope lock integration (PR #202)
 # ---------------------------------------------------------------------------
 
 
-def test_get_ingestion_lock_returns_same_instance() -> None:
-    """_get_ingestion_lock returns the same Lock for the same key."""
-    document_ingestion._ingestion_locks.clear()
-    lock_a = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
-    lock_b = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
-    assert lock_a is lock_b
-
-
-def test_get_ingestion_lock_different_keys() -> None:
-    """Different (collection, source_path) pairs get independent locks."""
-    document_ingestion._ingestion_locks.clear()
-    lock_a = document_ingestion._get_ingestion_lock("col", "/tmp/a.pdf")
-    lock_b = document_ingestion._get_ingestion_lock("col", "/tmp/b.pdf")
-    lock_c = document_ingestion._get_ingestion_lock("other", "/tmp/a.pdf")
-    assert lock_a is not lock_b
-    assert lock_a is not lock_c
-
-
-def test_ingestion_lock_serialises_same_document(
+def test_same_generation_scope_serialises_different_source_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Two concurrent process_document calls for the same document run serially."""
-    document_ingestion._ingestion_locks.clear()
+    """Same doc_id/parse_hash must serialise even when source_path differs (file_id path)."""
+    chunk_log: List[str] = []
 
-    execution_log: List[str] = []
-    original_impl = document_ingestion._process_document_impl
-
-    def _slow_impl(*args: object, **kwargs: object) -> IngestionResult:
-        execution_log.append("enter")
-        # Without the lock, both threads would be here simultaneously
-        time.sleep(0.1)
-        execution_log.append("exit")
-        return original_impl(*args, **kwargs)
+    def _slow_chunk(**_: object) -> Dict[str, object]:
+        chunk_log.append("enter")
+        time.sleep(0.15)
+        chunk_log.append("exit")
+        return {"chunk_count": 2, "created": True}
 
     _patch_pipeline_dependencies(monkeypatch)
-    monkeypatch.setattr(document_ingestion, "_process_document_impl", _slow_impl)
+    monkeypatch.setattr(document_ingestion, "chunk_document", _slow_chunk)
 
-    results: List[IngestionResult] = [None, None]  # type: ignore[list-item]
-
-    def _run(idx: int) -> None:
-        results[idx] = document_ingestion.process_document(
-            collection="demo",
-            source_path="/tmp/doc.pdf",
-            config=IngestionConfig(),
-        )
-
-    t1 = threading.Thread(target=_run, args=(0,))
-    t2 = threading.Thread(target=_run, args=(1,))
-    t1.start()
-    t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
-
-    # With serialisation the pattern must be [enter, exit, enter, exit],
-    # never [enter, enter, ...] which would indicate overlap.
-    assert len(execution_log) == 4
-    assert execution_log == ["enter", "exit", "enter", "exit"]
-
-
-def test_ingestion_lock_allows_different_documents_concurrently(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Calls for different documents are NOT serialised (they use independent locks)."""
-    document_ingestion._ingestion_locks.clear()
-
-    entered = threading.Event()
-    gate = threading.Event()
-
-    original_impl = document_ingestion._process_document_impl
-
-    def _blocking_impl(*args: object, **kwargs: object) -> IngestionResult:
-        entered.set()
-        gate.wait(timeout=5)
-        return original_impl(*args, **kwargs)
-
-    _patch_pipeline_dependencies(monkeypatch)
-    monkeypatch.setattr(document_ingestion, "_process_document_impl", _blocking_impl)
-
-    def _run_a() -> None:
+    def _run(source_path: str) -> None:
         document_ingestion.process_document(
             collection="demo",
-            source_path="/tmp/a.pdf",
+            source_path=source_path,
             config=IngestionConfig(),
+            user_id=1,
         )
 
-    def _run_b() -> None:
-        document_ingestion.process_document(
-            collection="demo",
-            source_path="/tmp/b.pdf",
-            config=IngestionConfig(),
-        )
-
-    t1 = threading.Thread(target=_run_a)
-    t2 = threading.Thread(target=_run_b)
+    t1 = threading.Thread(target=_run, args=("/uploads/a/doc.pdf",))
+    t2 = threading.Thread(target=_run, args=("/uploads/b/doc.pdf",))
     t1.start()
-    # Wait for thread 1 to enter _blocking_impl
-    assert entered.wait(timeout=5)
-    entered.clear()
-
     t2.start()
-    # Thread 2 should also enter _blocking_impl (different document, no lock contention)
-    both_entered = entered.wait(timeout=2)
-    gate.set()  # Release both threads
-    t1.join(timeout=5)
-    t2.join(timeout=5)
+    t1.join(timeout=15)
+    t2.join(timeout=15)
 
-    assert both_entered, "Different documents should not block each other"
+    assert chunk_log == ["enter", "exit", "enter", "exit"]

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -1695,6 +1695,129 @@ def test_replace_chunks_admin_skips_user_filter(mock_get_connection: Mock) -> No
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
+def test_replace_chunks_raises_when_embedding_cascade_delete_fails(
+    mock_get_connection: Mock,
+) -> None:
+    """Cascade embedding delete failures must surface as DatabaseOperationError."""
+    from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.list_tables.return_value = ["embeddings_model_a"]
+
+    mock_chunks = Mock()
+    mock_chunks.schema = Mock(names=["collection", "doc_id", "chunk_id"])
+
+    mock_embeddings = Mock()
+    mock_embeddings.delete.side_effect = RuntimeError("delete failed")
+
+    def _open_table(name: str) -> Mock:
+        if name == "chunks":
+            return mock_chunks
+        return mock_embeddings
+
+    mock_conn.open_table.side_effect = _open_table
+
+    store = LanceDBVectorIndexStore()
+    store.list_table_names = Mock(return_value=["embeddings_model_a"])  # type: ignore[method-assign]
+
+    records = [
+        {
+            "collection": "col1",
+            "doc_id": "doc1",
+            "parse_hash": "hash1",
+            "chunk_id": "c1",
+            "text": "t",
+        }
+    ]
+    replace_scope = {
+        "collection": "col1",
+        "doc_id": "doc1",
+        "parse_hash": "hash1",
+    }
+
+    with pytest.raises(DatabaseOperationError, match="cascade-delete stale embeddings"):
+        store.replace_chunks(
+            records, replace_scope=replace_scope, user_id=1, is_admin=False
+        )
+
+
+def test_replace_chunks_rejects_empty_scope() -> None:
+    """Empty replace_scope must not trigger unbounded delete (PR #202 review)."""
+    store = LanceDBVectorIndexStore()
+
+    with pytest.raises(ValueError, match="replace_scope must not be empty"):
+        store.replace_chunks(
+            [{"chunk_id": "c1"}],
+            replace_scope={},
+            user_id=1,
+            is_admin=False,
+        )
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_replace_chunks_reports_all_failed_embedding_tables(
+    mock_get_connection: Mock,
+) -> None:
+    """When some embeddings_* deletes fail, all failed table names are reported."""
+    from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    mock_chunks = Mock()
+    mock_chunks.schema = Mock(names=["collection", "doc_id", "chunk_id"])
+
+    mock_embeddings_ok = Mock()
+    mock_embeddings_fail = Mock()
+    mock_embeddings_fail.delete.side_effect = RuntimeError("delete failed")
+
+    def _open_table(name: str) -> Mock:
+        if name == "chunks":
+            return mock_chunks
+        if name == "embeddings_model_a":
+            return mock_embeddings_ok
+        return mock_embeddings_fail
+
+    mock_conn.open_table.side_effect = _open_table
+
+    store = LanceDBVectorIndexStore()
+    store.list_table_names = Mock(  # type: ignore[method-assign]
+        return_value=["embeddings_model_a", "embeddings_model_b"]
+    )
+
+    replace_scope = {
+        "collection": "col1",
+        "doc_id": "doc1",
+        "parse_hash": "hash1",
+    }
+
+    with pytest.raises(DatabaseOperationError) as exc_info:
+        store.replace_chunks(
+            [
+                {
+                    "collection": "col1",
+                    "doc_id": "doc1",
+                    "parse_hash": "hash1",
+                    "chunk_id": "c1",
+                    "text": "t",
+                }
+            ],
+            replace_scope=replace_scope,
+            user_id=1,
+            is_admin=False,
+        )
+
+    failed = exc_info.value.details.get("failed_tables", [])
+    assert "embeddings_model_b" in failed
+    mock_embeddings_ok.delete.assert_called_once()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
 def test_replace_chunks_rejects_invalid_scope_key(mock_get_connection: Mock) -> None:
     """replace_chunks should reject scope keys not in the allowed whitelist."""
     mock_conn = Mock()

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -1570,6 +1570,148 @@ def test_upsert_chunks_basic(mock_get_connection: Mock) -> None:
 
 
 # ============================================================================
+# replace_chunks Tests
+# ============================================================================
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_replace_chunks_inserts_then_deletes_old(mock_get_connection: Mock) -> None:
+    """replace_chunks should add new records first, then delete old generation rows."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.list_tables.return_value = []
+
+    mock_table = Mock()
+    mock_table.schema = Mock(names=["collection", "doc_id", "chunk_id"])
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+
+    records = [
+        {
+            "collection": "col1",
+            "doc_id": "doc1",
+            "parse_hash": "hash1",
+            "chunk_id": "chunk_new_1",
+            "text": "new content",
+        }
+    ]
+    replace_scope = {
+        "collection": "col1",
+        "doc_id": "doc1",
+        "parse_hash": "hash1",
+    }
+
+    store.replace_chunks(
+        records, replace_scope=replace_scope, user_id=1, is_admin=False
+    )
+
+    # Verify add was called with records (insert first)
+    mock_table.add.assert_called_once_with(records)
+
+    # Verify delete was called with scope filter + user filter + NOT IN exclusion
+    mock_table.delete.assert_called_once()
+    delete_expr = mock_table.delete.call_args[0][0]
+    assert "col1" in delete_expr
+    assert "doc1" in delete_expr
+    assert "hash1" in delete_expr
+    assert "user_id" in delete_expr
+    assert "chunk_new_1" in delete_expr
+    assert "NOT IN" in delete_expr
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_replace_chunks_empty_records_only_deletes(mock_get_connection: Mock) -> None:
+    """replace_chunks with empty records should only delete, not insert."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.list_tables.return_value = []
+
+    mock_table = Mock()
+    mock_table.schema = Mock(names=["collection", "doc_id", "chunk_id"])
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+
+    replace_scope = {
+        "collection": "col1",
+        "doc_id": "doc1",
+        "parse_hash": "hash1",
+    }
+
+    store.replace_chunks([], replace_scope=replace_scope, user_id=1, is_admin=False)
+
+    # Should delete scope without NOT IN clause (no new ids to exclude)
+    mock_table.delete.assert_called_once()
+    delete_expr = mock_table.delete.call_args[0][0]
+    assert "NOT IN" not in delete_expr
+    mock_table.add.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_replace_chunks_admin_skips_user_filter(mock_get_connection: Mock) -> None:
+    """replace_chunks with is_admin=True should not include user_id filter."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.list_tables.return_value = []
+
+    mock_table = Mock()
+    mock_table.schema = Mock(names=["collection", "doc_id", "chunk_id"])
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+
+    records = [
+        {
+            "collection": "col1",
+            "doc_id": "doc1",
+            "parse_hash": "hash1",
+            "chunk_id": "c1",
+            "text": "txt",
+        }
+    ]
+    replace_scope = {
+        "collection": "col1",
+        "doc_id": "doc1",
+        "parse_hash": "hash1",
+    }
+
+    store.replace_chunks(
+        records, replace_scope=replace_scope, user_id=99, is_admin=True
+    )
+
+    delete_expr = mock_table.delete.call_args[0][0]
+    assert "user_id" not in delete_expr
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_replace_chunks_rejects_invalid_scope_key(mock_get_connection: Mock) -> None:
+    """replace_chunks should reject scope keys not in the allowed whitelist."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.list_tables.return_value = []
+
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+
+    with pytest.raises(ValueError, match="Invalid replace_scope column"):
+        store.replace_chunks(
+            [{"chunk_id": "c1"}],
+            replace_scope={"collection": "col1", "malicious_key": "payload"},
+        )
+
+
+# ============================================================================
 # Error Handling Tests
 # ============================================================================
 

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -1578,7 +1578,7 @@ def test_upsert_chunks_basic(mock_get_connection: Mock) -> None:
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
 def test_replace_chunks_inserts_then_deletes_old(mock_get_connection: Mock) -> None:
-    """replace_chunks should add new records first, then delete old generation rows."""
+    """replace_chunks should merge_insert new records first, then delete old generation rows."""
     mock_conn = Mock()
     mock_get_connection.return_value = mock_conn
     mock_conn.list_tables.return_value = []
@@ -1608,12 +1608,14 @@ def test_replace_chunks_inserts_then_deletes_old(mock_get_connection: Mock) -> N
         records, replace_scope=replace_scope, user_id=1, is_admin=False
     )
 
-    # Verify add was called with records (insert first)
-    mock_table.add.assert_called_once_with(records)
+    # Verify merge_insert was called (idempotent upsert)
+    mock_table.merge_insert.assert_called_once_with(
+        ["collection", "doc_id", "parse_hash", "chunk_id"]
+    )
 
     # Verify delete was called with scope filter + user filter + NOT IN exclusion
-    mock_table.delete.assert_called_once()
-    delete_expr = mock_table.delete.call_args[0][0]
+    mock_table.delete.assert_called()
+    delete_expr = mock_table.delete.call_args_list[0][0][0]
     assert "col1" in delete_expr
     assert "doc1" in delete_expr
     assert "hash1" in delete_expr
@@ -1649,7 +1651,7 @@ def test_replace_chunks_empty_records_only_deletes(mock_get_connection: Mock) ->
     mock_table.delete.assert_called_once()
     delete_expr = mock_table.delete.call_args[0][0]
     assert "NOT IN" not in delete_expr
-    mock_table.add.assert_not_called()
+    mock_table.merge_insert.assert_not_called()
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/utils/test_generation_lock.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_generation_lock.py
@@ -1,0 +1,121 @@
+"""Tests for generation-scoped ingestion locks (PR #202)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.utils import generation_lock
+from xagent.core.tools.core.RAG_tools.utils.generation_lock import (
+    generation_ingestion_lock,
+    generation_lock_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_thread_lock_registry() -> None:
+    generation_lock._thread_locks.clear()
+    yield
+    generation_lock._thread_locks.clear()
+
+
+def test_generation_lock_key_includes_scope_not_source_path() -> None:
+    """Lock key is tied to doc generation scope, not file path."""
+    key_a = generation_lock_key("col", "doc-1", "parse-1", 42, False)
+    key_b = generation_lock_key("col", "doc-1", "parse-1", 42, False)
+    key_c = generation_lock_key("col", "doc-1", "parse-2", 42, False)
+    key_d = generation_lock_key("col", "doc-1", "parse-1", 99, False)
+    assert key_a == key_b
+    assert key_a != key_c
+    assert key_a != key_d
+
+
+def test_generation_ingestion_lock_serialises_same_scope() -> None:
+    """Two threads for the same generation scope cannot overlap."""
+    execution_log: list[str] = []
+
+    def _worker() -> None:
+        with generation_ingestion_lock(
+            "col", "doc1", "hash1", user_id=1, is_admin=False
+        ):
+            execution_log.append("enter")
+            time.sleep(0.1)
+            execution_log.append("exit")
+
+    t1 = threading.Thread(target=_worker)
+    t2 = threading.Thread(target=_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert execution_log == ["enter", "exit", "enter", "exit"]
+
+
+def test_generation_ingestion_lock_allows_different_scopes() -> None:
+    """Different (doc_id, parse_hash) pairs do not block each other."""
+    entered = threading.Event()
+    gate = threading.Event()
+
+    def _worker(doc_id: str) -> None:
+        with generation_ingestion_lock(
+            "col", doc_id, "hash1", user_id=1, is_admin=False
+        ):
+            entered.set()
+            gate.wait(timeout=5)
+
+    t1 = threading.Thread(target=_worker, args=("doc-a",))
+    t2 = threading.Thread(target=_worker, args=("doc-b",))
+    t1.start()
+    assert entered.wait(timeout=5)
+    entered.clear()
+    t2.start()
+    both = entered.wait(timeout=2)
+    gate.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert both
+
+
+def test_generation_ingestion_lock_allows_different_user_ids() -> None:
+    """Same doc scope for different users must not block each other (tenancy)."""
+    entered = threading.Event()
+    gate = threading.Event()
+
+    def _worker(user_id: int) -> None:
+        with generation_ingestion_lock(
+            "col", "doc-1", "hash-1", user_id=user_id, is_admin=False
+        ):
+            entered.set()
+            gate.wait(timeout=5)
+
+    t1 = threading.Thread(target=_worker, args=(1,))
+    t2 = threading.Thread(target=_worker, args=(2,))
+    t1.start()
+    assert entered.wait(timeout=5)
+    entered.clear()
+    t2.start()
+    both = entered.wait(timeout=2)
+    gate.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert both
+
+
+@patch("xagent.core.tools.core.RAG_tools.utils.generation_lock.FileLock")
+def test_generation_ingestion_lock_reentrant_nested(mock_file_lock: object) -> None:
+    """Nested acquire for the same scope only takes the file lock once."""
+    mock_file_lock.return_value.acquire.return_value = None
+    mock_file_lock.return_value.release.return_value = None
+
+    with generation_ingestion_lock("col", "doc1", "hash1", user_id=None, is_admin=True):
+        with generation_ingestion_lock(
+            "col", "doc1", "hash1", user_id=None, is_admin=True
+        ):
+            pass
+
+    assert mock_file_lock.return_value.acquire.call_count == 1
+    assert mock_file_lock.return_value.release.call_count == 1


### PR DESCRIPTION
The streaming upload loop used a local variable named chunk_size for the 1MiB read buffer, shadowing the FastAPI Form field and forcing ~1M char chunks. Rename it to file_read_buffer_size.

Also delete chunk rows for the same collection/doc_id/parse_hash before merge_insert so re-chunking does not leave stale rows across config_hash (issue #199). Update chunk tests for single-generation semantics.

Refs: https://github.com/xorbitsai/xagent/issues/199