### PR TITLE
feat: add unified tool output length limitation filter mechanism

### DIFF
--- a/example.env
+++ b/example.env
@@ -148,6 +148,21 @@ XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
 ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 
 # ===========================================
+# Tool Output Configuration
+# ===========================================
+# Maximum length per string in tool output (default: 51200, ~50KB)
+# This limits individual string values, not total output size
+# XAGENT_TOOL_MAX_OUTPUT_LENGTH="51200"
+
+# Maximum number of fields/items in dict/list (default: 1000)
+# This limits collection cardinality to prevent excessive output
+# XAGENT_TOOL_MAX_FIELD_COUNT="1000"
+
+# Maximum recursion depth for nested structures (default: 20)
+# This prevents excessively deep nesting in tool output
+# XAGENT_TOOL_MAX_RECURSION_DEPTH="20"
+
+# ===========================================
 # External Database Connections (for SQL Query Tool)
 # ===========================================
 # SQL tool supports PostgreSQL, MySQL, and SQLite

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -40,6 +40,10 @@ SANDBOX_ENV = "SANDBOX_ENV"
 SANDBOX_VOLUMES = "SANDBOX_VOLUMES"
 BOXLITE_HOME_DIR = "BOXLITE_HOME_DIR"
 
+TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
+TOOL_MAX_RECURSION_DEPTH = "XAGENT_TOOL_MAX_RECURSION_DEPTH"
+TOOL_MAX_FIELD_COUNT = "XAGENT_TOOL_MAX_FIELD_COUNT"
+
 
 def get_web_dir() -> Path:
     """Get the web directory path.
@@ -354,3 +358,59 @@ def get_boxlite_home_dir() -> Path | None:
     if env_str:
         return Path(env_str)
     return None
+
+
+def get_tool_max_output_length() -> int:
+    """Get the maximum per-string output length for tools.
+
+    This limit applies to individual string values within the output structure,
+    not the total output size. The total output size is indirectly controlled
+    by the combination of per-string limit, max field count, and max recursion depth.
+
+    Returns:
+        Maximum per-string length from TOOL_MAX_OUTPUT_LENGTH env var, or 50k by default
+    """
+    env_str = os.getenv(TOOL_MAX_OUTPUT_LENGTH)
+    if env_str:
+        try:
+            return int(env_str)
+        except ValueError:
+            logger.warning("Invalid TOOL_MAX_OUTPUT_LENGTH value: {env_str}")
+    return 50 * 1024
+
+
+def get_tool_max_recursion_depth() -> int:
+    """Get the maximum recursion depth for tools.
+
+    Returns:
+        Maximum recursion depth from TOOL_MAX_RECURSION_DEPTH env var, or 20 by default.
+        20 layers is sufficient for most real-world data structures while preventing
+        excessively deep nesting that could cause performance issues.
+    """
+    env_str = os.getenv(TOOL_MAX_RECURSION_DEPTH)
+    if env_str:
+        try:
+            return int(env_str)
+        except ValueError:
+            logger.warning("Invalid TOOL_MAX_RECURSION_DEPTH value: {env_str}")
+    return 20
+
+
+def get_tool_max_field_count() -> int:
+    """Get the maximum number of fields/items in dict/list for tools.
+
+    This helps control total output size by limiting the cardinality of
+    collections. Combined with per-string length and recursion depth limits,
+    it provides reasonable protection against excessive output without
+    requiring expensive total size calculation.
+
+    Returns:
+        Maximum fields from TOOL_MAX_FIELD_COUNT env var, or 1000 by default
+    """
+    env_str = os.getenv(TOOL_MAX_FIELD_COUNT)
+    if env_str:
+        try:
+            return int(env_str)
+        except ValueError:
+            logger.warning("Invalid TOOL_MAX_FIELDS value: {env_str}")
+    return 1000

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -966,10 +966,14 @@ class AgentService:
             # Create basic tool config without database dependency
             class DefaultToolConfig(ToolConfig):
                 def __init__(self, workspace_config: Optional[Dict[str, Any]] = None):
-                    self._workspace_config = workspace_config
+                    # Build config dict for parent class initialization
+                    config_dict: Dict[str, Any] = {"workspace": workspace_config}
+                    if workspace_config:
+                        config_dict["task_id"] = workspace_config.get("task_id")
+                    super().__init__(config_dict)
 
                 def get_workspace_config(self) -> Optional[Dict[str, Any]]:
-                    return self._workspace_config
+                    return self.workspace_config
 
                 def get_file_tools_enabled(self) -> bool:
                     return True
@@ -993,8 +997,8 @@ class AgentService:
                     return True
 
                 def get_task_id(self) -> Optional[str]:
-                    if self._workspace_config:
-                        return self._workspace_config.get("task_id")
+                    if self.workspace_config:
+                        return self.workspace_config.get("task_id")
                     return None
 
                 def get_user_id(self) -> Optional[int]:

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -129,6 +129,22 @@ class BaseToolConfig(ABC):
         """Get default LLM for general tasks."""
         pass
 
+    @abstractmethod
+    def get_max_output_length(self) -> int:
+        """Get default maximum output length in characters.
+
+        Default: 50K characters (~12K tokens, suitable for most LLMs)
+        """
+        pass
+
+    @abstractmethod
+    def get_truncation_message(self) -> str:
+        """Get message to append when output is truncated.
+
+        Default: "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+        """
+        pass
+
 
 class ToolConfig(BaseToolConfig):
     """Tool configuration that uses provided config dict for standalone usage."""
@@ -152,6 +168,17 @@ class ToolConfig(BaseToolConfig):
         user_id = config_dict.get("user_id")
         is_admin = config_dict.get("is_admin", False)
         tool_credentials = config_dict.get("tool_credentials", {})
+
+        # Output limit configuration (uses environment variable as default)
+        # Import here to avoid circular dependency (config <-> output_filter)
+        from .output_filter import _get_default_max_output_length
+
+        max_output_length = config_dict.get(
+            "max_output_length", _get_default_max_output_length()
+        )
+        truncation_message = config_dict.get(
+            "truncation_message", "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+        )
 
         self.workspace_config: Optional[Dict[str, Any]] = workspace_config
         self.vision_model: Optional[Any] = (
@@ -178,6 +205,8 @@ class ToolConfig(BaseToolConfig):
         self.user_id: Optional[int] = user_id
         self.is_admin_value: bool = bool(is_admin)
         self.tool_credentials: Dict[str, Dict[str, str]] = tool_credentials
+        self.max_output_length: int = max_output_length
+        self.truncation_message: str = truncation_message
 
     def get_workspace_config(self) -> Optional[Dict[str, Any]]:
         return self.workspace_config
@@ -257,3 +286,9 @@ class ToolConfig(BaseToolConfig):
 
     def get_sql_connections(self) -> Dict[str, str]:
         return {}
+
+    def get_max_output_length(self) -> int:
+        return self.max_output_length
+
+    def get_truncation_message(self) -> str:
+        return self.truncation_message

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -9,6 +9,8 @@ to the ToolFactory in a unified way.
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
+from ..... import config as _root_config
+
 
 class BaseToolConfig(ABC):
     """Abstract base class for tool configuration."""
@@ -115,6 +117,11 @@ class BaseToolConfig(ABC):
         return {}
 
     @abstractmethod
+    def get_db(self) -> Optional[Any]:
+        """Get database session. Returns None for standalone usage."""
+        pass
+
+    @abstractmethod
     def get_asr_model(self) -> Optional[Any]:
         """Get default ASR (speech-to-text) model."""
         pass
@@ -129,21 +136,29 @@ class BaseToolConfig(ABC):
         """Get default LLM for general tasks."""
         pass
 
-    @abstractmethod
     def get_max_output_length(self) -> int:
-        """Get default maximum output length in characters.
+        """Get maximum output length in characters.
 
-        Default: 50K characters (~12K tokens, suitable for most LLMs)
+        Reads from XAGENT_TOOL_MAX_OUTPUT_LENGTH env var if set.
+        See :mod:`xagent.config` for details.
         """
-        pass
+        return _root_config.get_tool_max_output_length()
 
-    @abstractmethod
-    def get_truncation_message(self) -> str:
-        """Get message to append when output is truncated.
+    def get_max_field_count(self) -> int:
+        """Get maximum number of fields/items in dict/list for output filtering.
 
-        Default: "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+        Reads from XAGENT_TOOL_MAX_FIELD_COUNT env var if set.
+        See :mod:`xagent.config` for details.
         """
-        pass
+        return _root_config.get_tool_max_field_count()
+
+    def get_max_recursion_depth(self) -> int:
+        """Get maximum recursion depth for output filtering.
+
+        Reads from XAGENT_TOOL_MAX_RECURSION_DEPTH env var if set.
+        See :mod:`xagent.config` for details.
+        """
+        return _root_config.get_tool_max_recursion_depth()
 
 
 class ToolConfig(BaseToolConfig):
@@ -170,15 +185,28 @@ class ToolConfig(BaseToolConfig):
         tool_credentials = config_dict.get("tool_credentials", {})
 
         # Output limit configuration (uses environment variable as default)
-        # Import here to avoid circular dependency (config <-> output_filter)
-        from .output_filter import _get_default_max_output_length
-
-        max_output_length = config_dict.get(
-            "max_output_length", _get_default_max_output_length()
-        )
-        truncation_message = config_dict.get(
-            "truncation_message", "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
-        )
+        # Store custom values if provided, otherwise use None to fall back to base class defaults
+        self._custom_max_output_length: int | None = None
+        try:
+            self._custom_max_output_length = int(
+                config_dict.get("max_output_length")  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError):
+            pass
+        self._custom_max_field_count: int | None = None
+        try:
+            self._custom_max_field_count = int(
+                config_dict.get("max_field_count")  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError):
+            pass
+        self._custom_max_recursion_depth: int | None = None
+        try:
+            self._custom_max_recursion_depth = int(
+                config_dict.get("max_recursion_depth")  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError):
+            pass
 
         self.workspace_config: Optional[Dict[str, Any]] = workspace_config
         self.vision_model: Optional[Any] = (
@@ -205,8 +233,6 @@ class ToolConfig(BaseToolConfig):
         self.user_id: Optional[int] = user_id
         self.is_admin_value: bool = bool(is_admin)
         self.tool_credentials: Dict[str, Dict[str, str]] = tool_credentials
-        self.max_output_length: int = max_output_length
-        self.truncation_message: str = truncation_message
 
     def get_workspace_config(self) -> Optional[Dict[str, Any]]:
         return self.workspace_config
@@ -288,7 +314,20 @@ class ToolConfig(BaseToolConfig):
         return {}
 
     def get_max_output_length(self) -> int:
-        return self.max_output_length
+        if self._custom_max_output_length is not None:
+            return self._custom_max_output_length
+        return super().get_max_output_length()
 
-    def get_truncation_message(self) -> str:
-        return self.truncation_message
+    def get_max_field_count(self) -> int:
+        if self._custom_max_field_count is not None:
+            return self._custom_max_field_count
+        return super().get_max_field_count()
+
+    def get_max_recursion_depth(self) -> int:
+        if self._custom_max_recursion_depth is not None:
+            return self._custom_max_recursion_depth
+        return super().get_max_recursion_depth()
+
+    def get_db(self) -> Optional[Any]:
+        """ToolConfig (standalone) does not have database access."""
+        return None

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -14,8 +14,9 @@ from sqlalchemy.orm import Session
 
 from .....config import get_uploads_dir
 from .....core.workspace import TaskWorkspace
-from .base import Tool
+from .base import AbstractBaseTool, Tool
 from .config import BaseToolConfig
+from .output_filter_wrapper import OutputFilteredToolWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -211,11 +212,9 @@ class ToolFactory:
         Returns:
             Tool list with output filtering applied
         """
-        from .base import AbstractBaseTool
-        from .output_filter_wrapper import OutputFilteredToolWrapper
-
         max_chars = config.get_max_output_length()
-        truncation_message = config.get_truncation_message()
+        max_fields = config.get_max_field_count()
+        max_recursion = config.get_max_recursion_depth()
 
         filtered_tools: List[Tool] = []
         for tool in tools:
@@ -224,7 +223,8 @@ class ToolFactory:
                 wrapper = OutputFilteredToolWrapper(
                     target_tool=tool,
                     max_chars=max_chars,
-                    truncation_message=truncation_message,
+                    max_fields=max_fields,
+                    max_recursion=max_recursion,
                 )
                 filtered_tools.append(wrapper)
             else:
@@ -234,7 +234,7 @@ class ToolFactory:
         if filtered_tools:
             logger.debug(
                 f"Applied output filtering to {len(filtered_tools)} tools "
-                f"(max_chars={max_chars})"
+                f"(max_chars={max_chars}, max_fields={max_fields}, max_recursion={max_recursion})"
             )
 
         return filtered_tools

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -194,8 +194,50 @@ class ToolFactory:
                 await create_workspace_in_sandbox(sandbox, workspace)
             tools = await ToolFactory._wrap_sandbox_tools(tools, sandbox)
 
+        # Apply output filtering to all tools
+        tools = ToolFactory._apply_output_filters(tools, config)
+
         logger.info(f"Created {len(tools)} tools from configuration")
         return tools
+
+    @staticmethod
+    def _apply_output_filters(tools: List[Tool], config: BaseToolConfig) -> List[Tool]:
+        """Apply output filtering to all tools.
+
+        Args:
+            tools: Original tool list
+            config: Tool configuration
+
+        Returns:
+            Tool list with output filtering applied
+        """
+        from .base import AbstractBaseTool
+        from .output_filter_wrapper import OutputFilteredToolWrapper
+
+        max_chars = config.get_max_output_length()
+        truncation_message = config.get_truncation_message()
+
+        filtered_tools: List[Tool] = []
+        for tool in tools:
+            # Only wrap AbstractBaseTool instances
+            if isinstance(tool, AbstractBaseTool):
+                wrapper = OutputFilteredToolWrapper(
+                    target_tool=tool,
+                    max_chars=max_chars,
+                    truncation_message=truncation_message,
+                )
+                filtered_tools.append(wrapper)
+            else:
+                # For non-AbstractBaseTool tools, keep as is
+                filtered_tools.append(tool)
+
+        if filtered_tools:
+            logger.debug(
+                f"Applied output filtering to {len(filtered_tools)} tools "
+                f"(max_chars={max_chars})"
+            )
+
+        return filtered_tools
 
     @staticmethod
     async def _wrap_sandbox_tools(tools: List[Tool], sandbox: Any) -> List[Tool]:

--- a/src/xagent/core/tools/adapters/vibe/output_filter.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter.py
@@ -236,8 +236,9 @@ class OutputValueFilter:
             return value
 
         truncated = value[: self.max_chars]
+        result = truncated + DEFAULT_TRUNCATION_MESSAGE
         logger.info(
             f"Tool '{tool_name}' output truncated: "
-            f"{len(value)} -> {len(truncated)} characters"
+            f"{len(value)} -> {len(result)} characters"
         )
-        return truncated + DEFAULT_TRUNCATION_MESSAGE
+        return result

--- a/src/xagent/core/tools/adapters/vibe/output_filter.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter.py
@@ -1,69 +1,73 @@
 """
 Tool Output Value Filtering Module
 
-Provides unified output length limiting for all tools.
+Provides multi-layered output limiting for all tools to prevent excessive output.
+
+This module implements a three-pronged approach to control tool output size:
+1. Per-string length limit: Truncates individual string values
+2. Field count limit: Limits the number of items in dicts/lists
+3. Recursion depth limit: Prevents excessively deep nesting
+
+Rather than calculating total output size (which would be expensive), these
+limits work together to provide reasonable protection while maintaining good
+performance. For token safety, the combination of these limits is sufficient
+for most real-world scenarios.
 """
 
 import logging
-import os
 from typing import Any
+
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
-# Default max output length (50K chars, ~12K tokens, suitable for most LLMs)
-DEFAULT_MAX_OUTPUT_LENGTH = 50 * 1024
-
-# Environment variable name for overriding default max output length
-_ENV_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
-
-
-def _get_default_max_output_length() -> int:
-    """Get default max output length from environment variable or fallback to DEFAULT."""
-    env_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
-    if env_value:
-        try:
-            return int(env_value)
-        except ValueError:
-            logger.warning(
-                f"Invalid value for {_ENV_MAX_OUTPUT_LENGTH}: '{env_value}'. "
-                f"Using default: {DEFAULT_MAX_OUTPUT_LENGTH}"
-            )
-    return DEFAULT_MAX_OUTPUT_LENGTH
+__all__ = [
+    "OutputValueFilter",
+    "DEFAULT_TRUNCATION_MESSAGE",
+    "NESTED_TOO_DEEP_MESSAGE",
+    "CIRCULAR_REFERENCE_MESSAGE",
+    "TRUNCATED_FIELDS_MESSAGE",
+    "TRUNCATED_ITEMS_MESSAGE",
+    "TRUNCATED_DICT_TEMPLATE",
+    "TRUNCATED_ITEMS_TEMPLATE",
+]
 
 
-# Default truncation message
+# Message constants for output filtering
 DEFAULT_TRUNCATION_MESSAGE = "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+NESTED_TOO_DEEP_MESSAGE = "[... nested too deep ...]"
+CIRCULAR_REFERENCE_MESSAGE = "[... circular reference ...]"
+TRUNCATED_FIELDS_MESSAGE = "[truncated]"
+TRUNCATED_ITEMS_MESSAGE = " [truncated]"
+TRUNCATED_DICT_TEMPLATE = "... and {count} more keys"
+TRUNCATED_ITEMS_TEMPLATE = "... and {count} more items" + TRUNCATED_ITEMS_MESSAGE
 
 
 class OutputValueFilter:
-    """Filter and truncate tool return values based on character limit."""
+    """Filter and truncate tool return values using multi-layered limits.
 
-    def __init__(
-        self,
-        max_chars: int | None = None,
-        truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
-    ):
+    This class applies three types of limits to control tool output size:
+    - Per-string length (max_chars): Limits individual string values
+    - Field/item count (max_fields): Limits collection cardinality
+    - Recursion depth (max_recursion): Prevents deep nesting
+
+    Note: This does NOT enforce a hard total output size limit. The combination
+    of these limits provides practical protection for token usage without the
+    performance cost of calculating total serialized size.
+    """
+
+    def __init__(self, max_chars: int, max_fields: int, max_recursion: int):
         """
         Initialize output filter.
 
         Args:
-            max_chars: Maximum output length in characters. If None, reads from
-                      XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses DEFAULT_MAX_OUTPUT_LENGTH.
-            truncation_message: Message to append when output is truncated
-        """
-        if max_chars is None:
-            max_chars = _get_default_max_output_length()
-        self.max_chars = max_chars
-        self.truncation_message = truncation_message
-        """
-        Initialize output filter.
-
-        Args:
-            max_chars: Maximum output length in characters
-            truncation_message: Message to append when output is truncated
+            max_chars: Maximum length per string value (not total output).
+            max_fields: Maximum number of fields/items in dicts/lists.
+            max_recursion: Maximum nesting depth for recursive structures.
         """
         self.max_chars = max_chars
-        self.truncation_message = truncation_message
+        self.max_fields = max_fields
+        self.max_recursion = max_recursion
 
     def filter(self, value: Any, tool_name: str = "unknown") -> Any:
         """
@@ -76,8 +80,48 @@ class OutputValueFilter:
         Returns:
             Filtered value (may be truncated)
         """
+        return self._filter_with_depth(value, tool_name, depth=0, memo_set=None)
+
+    def _filter_with_depth(
+        self, value: Any, tool_name: str, depth: int, memo_set: set | None
+    ) -> Any:
+        """
+        Internal filter method with recursion depth and circular reference tracking.
+
+        Args:
+            value: Return value to filter
+            tool_name: Name of the tool (for logging)
+            depth: Current recursion depth
+            memo_set: Set of object ids to detect circular references
+
+        Returns:
+            Filtered value (may be truncated)
+        """
+        # Check recursion depth limit
+        if depth > self.max_recursion:
+            logger.warning(
+                f"Tool '{tool_name}' output nested too deep (>{self.max_recursion} levels). "
+                f"Truncating to prevent stack overflow."
+            )
+            return NESTED_TOO_DEEP_MESSAGE
+
+        # Initialize memo_set for circular reference detection
+        if memo_set is None:
+            memo_set = set()
+
         if value is None:
             return None
+
+        # Check for circular references (only for container types)
+        if isinstance(value, (dict, list)):
+            value_id = id(value)
+            if value_id in memo_set:
+                logger.warning(
+                    f"Tool '{tool_name}' output contains circular reference. "
+                    f"Breaking the cycle to prevent infinite recursion."
+                )
+                return CIRCULAR_REFERENCE_MESSAGE
+            memo_set = memo_set | {value_id}
 
         # Handle strings
         if isinstance(value, str):
@@ -85,18 +129,87 @@ class OutputValueFilter:
 
         # Handle dicts - recursively filter each string value
         elif isinstance(value, dict):
-            return {k: self.filter(v, tool_name) for k, v in value.items()}
+            dist_result = {}
+            for i, (k, v) in enumerate(value.items()):
+                if i >= self.max_fields:
+                    dist_result[
+                        TRUNCATED_DICT_TEMPLATE.format(count=len(value) - i)
+                    ] = TRUNCATED_FIELDS_MESSAGE
+                    break
+                dist_result[k] = self._filter_with_depth(
+                    v, tool_name, depth + 1, memo_set
+                )
+            return dist_result
 
         # Handle lists - recursively filter each element
         elif isinstance(value, list):
-            return [self.filter(item, tool_name) for item in value]
+            list_result = []
+            for i, item in enumerate(value):
+                if i >= self.max_fields:
+                    list_result.append(
+                        TRUNCATED_ITEMS_TEMPLATE.format(count=len(value) - i)
+                    )
+                    break
+                list_result.append(
+                    self._filter_with_depth(item, tool_name, depth + 1, memo_set)
+                )
+            return list_result
+
+        # Handle tuples - recursively filter each element, convert to list if truncated
+        elif isinstance(value, tuple):
+            tuple_result = []
+            for i, item in enumerate(value):
+                if i >= self.max_fields:
+                    tuple_result.append(
+                        TRUNCATED_ITEMS_TEMPLATE.format(count=len(value) - i)
+                    )
+                    break
+                tuple_result.append(
+                    self._filter_with_depth(item, tool_name, depth + 1, memo_set)
+                )
+            # Return as list if truncated, otherwise as tuple
+            if len(tuple_result) < len(value):
+                return tuple_result  # Truncated, return as list
+            return tuple(tuple_result)  # Not truncated, return as tuple
+
+        # Handle sets - convert to sorted list for deterministic filtering
+        elif isinstance(value, set):
+            # Sort for deterministic order when truncating
+            sorted_items = sorted(value, key=lambda x: str(x))
+            set_result = []
+            for i, item in enumerate(sorted_items):
+                if i >= self.max_fields:
+                    set_result.append(
+                        TRUNCATED_ITEMS_TEMPLATE.format(count=len(value) - i)
+                    )
+                    break
+                set_result.append(
+                    self._filter_with_depth(item, tool_name, depth + 1, memo_set)
+                )
+            # Return as list since sets can't be reconstructed after filtering
+            return set_result
+
+        # Handle bytes - decode to string
+        elif isinstance(value, bytes):
+            str_value = value.decode("utf-8", errors="replace")
+            return self._filter_string(str_value, tool_name)
 
         # Handle Pydantic models
         elif hasattr(value, "model_dump"):
-            filtered_dict = self.filter(value.model_dump(), tool_name)
+            filtered_dict = self._filter_with_depth(
+                value.model_dump(), tool_name, depth + 1, memo_set
+            )
             try:
                 return value.__class__(**filtered_dict)
-            except Exception:
+            except (ValidationError, TypeError, ValueError) as e:
+                # ValidationError: truncated value violates constraints (e.g., min_length)
+                # TypeError: unexpected constructor arguments
+                # ValueError: invalid value for constructor
+                logger.warning(
+                    f"Failed to reconstruct Pydantic model {value.__class__.__name__} "
+                    f"after filtering (value may be truncated): {e}. "
+                    f"Returning filtered dict instead."
+                )
                 return filtered_dict
 
         # Handle primitives (bool, int, float, etc.) - return as-is
@@ -123,26 +236,8 @@ class OutputValueFilter:
             return value
 
         truncated = value[: self.max_chars]
-        logger.warning(
+        logger.info(
             f"Tool '{tool_name}' output truncated: "
             f"{len(value)} -> {len(truncated)} characters"
         )
-        return truncated + self.truncation_message
-
-
-def create_output_filter(
-    max_chars: int | None = None,
-    truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
-) -> OutputValueFilter:
-    """
-    Create an output value filter.
-
-    Args:
-        max_chars: Maximum output length in characters. If None, reads from
-                  XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses DEFAULT_MAX_OUTPUT_LENGTH.
-        truncation_message: Message to append when output is truncated
-
-    Returns:
-        Configured output filter
-    """
-    return OutputValueFilter(max_chars, truncation_message)
+        return truncated + DEFAULT_TRUNCATION_MESSAGE

--- a/src/xagent/core/tools/adapters/vibe/output_filter.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter.py
@@ -1,0 +1,148 @@
+"""
+Tool Output Value Filtering Module
+
+Provides unified output length limiting for all tools.
+"""
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default max output length (50K chars, ~12K tokens, suitable for most LLMs)
+DEFAULT_MAX_OUTPUT_LENGTH = 50 * 1024
+
+# Environment variable name for overriding default max output length
+_ENV_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
+
+
+def _get_default_max_output_length() -> int:
+    """Get default max output length from environment variable or fallback to DEFAULT."""
+    env_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            logger.warning(
+                f"Invalid value for {_ENV_MAX_OUTPUT_LENGTH}: '{env_value}'. "
+                f"Using default: {DEFAULT_MAX_OUTPUT_LENGTH}"
+            )
+    return DEFAULT_MAX_OUTPUT_LENGTH
+
+
+# Default truncation message
+DEFAULT_TRUNCATION_MESSAGE = "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+
+
+class OutputValueFilter:
+    """Filter and truncate tool return values based on character limit."""
+
+    def __init__(
+        self,
+        max_chars: int | None = None,
+        truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
+    ):
+        """
+        Initialize output filter.
+
+        Args:
+            max_chars: Maximum output length in characters. If None, reads from
+                      XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses DEFAULT_MAX_OUTPUT_LENGTH.
+            truncation_message: Message to append when output is truncated
+        """
+        if max_chars is None:
+            max_chars = _get_default_max_output_length()
+        self.max_chars = max_chars
+        self.truncation_message = truncation_message
+        """
+        Initialize output filter.
+
+        Args:
+            max_chars: Maximum output length in characters
+            truncation_message: Message to append when output is truncated
+        """
+        self.max_chars = max_chars
+        self.truncation_message = truncation_message
+
+    def filter(self, value: Any, tool_name: str = "unknown") -> Any:
+        """
+        Filter return value based on character limit.
+
+        Args:
+            value: Return value to filter
+            tool_name: Name of the tool (for logging)
+
+        Returns:
+            Filtered value (may be truncated)
+        """
+        if value is None:
+            return None
+
+        # Handle strings
+        if isinstance(value, str):
+            return self._filter_string(value, tool_name)
+
+        # Handle dicts - recursively filter each string value
+        elif isinstance(value, dict):
+            return {k: self.filter(v, tool_name) for k, v in value.items()}
+
+        # Handle lists - recursively filter each element
+        elif isinstance(value, list):
+            return [self.filter(item, tool_name) for item in value]
+
+        # Handle Pydantic models
+        elif hasattr(value, "model_dump"):
+            filtered_dict = self.filter(value.model_dump(), tool_name)
+            try:
+                return value.__class__(**filtered_dict)
+            except Exception:
+                return filtered_dict
+
+        # Handle primitives (bool, int, float, etc.) - return as-is
+        elif isinstance(value, (bool, int, float)):
+            return value
+
+        # Handle other types by converting to string (as last resort)
+        else:
+            str_value = str(value)
+            return self._filter_string(str_value, tool_name)
+
+    def _filter_string(self, value: str, tool_name: str) -> str:
+        """
+        Filter a string value.
+
+        Args:
+            value: String value to filter
+            tool_name: Name of the tool (for logging)
+
+        Returns:
+            Filtered string value
+        """
+        if len(value) <= self.max_chars:
+            return value
+
+        truncated = value[: self.max_chars]
+        logger.warning(
+            f"Tool '{tool_name}' output truncated: "
+            f"{len(value)} -> {len(truncated)} characters"
+        )
+        return truncated + self.truncation_message
+
+
+def create_output_filter(
+    max_chars: int | None = None,
+    truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
+) -> OutputValueFilter:
+    """
+    Create an output value filter.
+
+    Args:
+        max_chars: Maximum output length in characters. If None, reads from
+                  XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses DEFAULT_MAX_OUTPUT_LENGTH.
+        truncation_message: Message to append when output is truncated
+
+    Returns:
+        Configured output filter
+    """
+    return OutputValueFilter(max_chars, truncation_message)

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -11,10 +11,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 from pydantic import BaseModel
 
 from .base import AbstractBaseTool
-from .output_filter import (
-    DEFAULT_TRUNCATION_MESSAGE,
-    OutputValueFilter,
-)
+from .output_filter import OutputValueFilter
 
 if TYPE_CHECKING:
     from .base import ToolCategory
@@ -33,24 +30,23 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
     def __init__(
         self,
         target_tool: AbstractBaseTool,
-        max_chars: int | None = None,
-        truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
+        max_chars: int,
+        max_fields: int,
+        max_recursion: int,
     ):
         """
         Initialize output filter wrapper.
 
         Args:
             target_tool: Tool to wrap
-            max_chars: Maximum output length in characters. If None, reads from
-                      XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses default.
-            truncation_message: Message to append when truncated
+            max_chars: Maximum output length in characters.
+            max_fields: Maximum number of fields/items in dict/list.
+            max_recursion: Maximum recursion depth.
         """
         self._target = target_tool
-        self._visibility = getattr(target_tool, "_visibility", None)
-        self._allow_users = getattr(target_tool, "_allow_users", None)
 
         # Create output filter
-        self._filter = OutputValueFilter(max_chars, truncation_message)
+        self._filter = OutputValueFilter(max_chars, max_fields, max_recursion)
 
     @property
     def name(self) -> str:

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -116,21 +116,35 @@ class OutputFilteredToolWrapper(AbstractBaseTool):
     @property
     def func(self) -> Any:
         """Get the underlying function, wrapped with output filtering."""
-        if (func_obj := getattr(self._target, "func", None)) is None:
-            raise AttributeError(f"Tool '{self._target.name}' has no 'func' attribute")
+        if not hasattr(self, "_wrapped_func"):
+            func_obj = getattr(self._target, "func", None)
+            if func_obj is None:
+                raise AttributeError(
+                    f"Tool '{self._target.name}' has no 'func' attribute"
+                )
 
-        # Return a wrapped function that applies output filtering
-        original_func = func_obj
+            # Create wrapper based on function type
+            if inspect.iscoroutinefunction(func_obj):
+                self._wrapped_func = self._make_async_wrapper(func_obj)
+            else:
+                self._wrapped_func = self._make_sync_wrapper(func_obj)
+
+        return self._wrapped_func
+
+    def _make_sync_wrapper(self, original_func: Any) -> Any:
+        """Create a sync wrapper that applies output filtering."""
 
         def wrapped_func(*args: Any, **kwargs: Any) -> Any:
             result = original_func(*args, **kwargs)
             return self._filter.filter(result, self._target.name)
 
+        return wrapped_func
+
+    def _make_async_wrapper(self, original_func: Any) -> Any:
+        """Create an async wrapper that applies output filtering."""
+
         async def wrapped_func_async(*args: Any, **kwargs: Any) -> Any:
             result = await original_func(*args, **kwargs)
             return self._filter.filter(result, self._target.name)
 
-        # Return async wrapper if original function is async
-        if inspect.iscoroutinefunction(original_func):
-            return wrapped_func_async
-        return wrapped_func
+        return wrapped_func_async

--- a/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/output_filter_wrapper.py
@@ -1,0 +1,140 @@
+"""
+Output Filter Tool Wrapper
+
+Wraps any tool with output length filtering capabilities.
+"""
+
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
+
+from pydantic import BaseModel
+
+from .base import AbstractBaseTool
+from .output_filter import (
+    DEFAULT_TRUNCATION_MESSAGE,
+    OutputValueFilter,
+)
+
+if TYPE_CHECKING:
+    from .base import ToolCategory
+
+logger = logging.getLogger(__name__)
+
+
+class OutputFilteredToolWrapper(AbstractBaseTool):
+    """
+    Wrapper that applies output filtering to any tool.
+
+    This wrapper intercepts the return value from run_json_sync/async
+    and applies length limiting before returning to the caller.
+    """
+
+    def __init__(
+        self,
+        target_tool: AbstractBaseTool,
+        max_chars: int | None = None,
+        truncation_message: str = DEFAULT_TRUNCATION_MESSAGE,
+    ):
+        """
+        Initialize output filter wrapper.
+
+        Args:
+            target_tool: Tool to wrap
+            max_chars: Maximum output length in characters. If None, reads from
+                      XAGENT_TOOL_MAX_OUTPUT_LENGTH env var or uses default.
+            truncation_message: Message to append when truncated
+        """
+        self._target = target_tool
+        self._visibility = getattr(target_tool, "_visibility", None)
+        self._allow_users = getattr(target_tool, "_allow_users", None)
+
+        # Create output filter
+        self._filter = OutputValueFilter(max_chars, truncation_message)
+
+    @property
+    def name(self) -> str:
+        return self._target.name
+
+    @property
+    def description(self) -> str:
+        return self._target.description
+
+    @property
+    def tags(self) -> list[str]:
+        return self._target.tags
+
+    @property
+    def category(self) -> "ToolCategory":
+        """Get tool category (delegates to target tool)."""
+        return getattr(self._target, "category", None)  # type: ignore[return-value]
+
+    @property
+    def metadata(self) -> Any:  # ToolMetadata (avoid circular import)
+        return self._target.metadata
+
+    def args_type(self) -> Type[BaseModel]:
+        return self._target.args_type()
+
+    def return_type(self) -> Type[BaseModel]:
+        return self._target.return_type()
+
+    def state_type(self) -> Optional[Type[BaseModel]]:
+        return self._target.state_type()
+
+    def is_async(self) -> bool:
+        return self._target.is_async()
+
+    def return_value_as_string(self, value: Any) -> str:
+        """Convert return value to string (delegates to target tool)."""
+        return self._target.return_value_as_string(value)
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        """Execute tool synchronously with output filtering."""
+        result = self._target.run_json_sync(args)
+        return self._filter.filter(result, self._target.name)
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        """Execute tool asynchronously with output filtering."""
+        result = await self._target.run_json_async(args)
+        return self._filter.filter(result, self._target.name)
+
+    async def save_state_json(self) -> Mapping[str, Any]:
+        """Save state (delegates to target tool)."""
+        return await self._target.save_state_json()
+
+    async def load_state_json(self, state: Mapping[str, Any]) -> None:
+        """Load state (delegates to target tool)."""
+        await self._target.load_state_json(state)
+
+    async def setup(self, task_id: Optional[str] = None) -> None:
+        """Setup tool (delegates to target tool)."""
+        if hasattr(self._target, "setup"):
+            await self._target.setup(task_id)
+
+    async def teardown(self, task_id: Optional[str] = None) -> None:
+        """Teardown tool (delegates to target tool)."""
+        if hasattr(self._target, "teardown"):
+            await self._target.teardown(task_id)
+
+    @property
+    def func(self) -> Any:
+        """Get the underlying function, wrapped with output filtering."""
+        if (func_obj := getattr(self._target, "func", None)) is None:
+            raise AttributeError(f"Tool '{self._target.name}' has no 'func' attribute")
+
+        # Return a wrapped function that applies output filtering
+        original_func = func_obj
+
+        def wrapped_func(*args: Any, **kwargs: Any) -> Any:
+            result = original_func(*args, **kwargs)
+            return self._filter.filter(result, self._target.name)
+
+        async def wrapped_func_async(*args: Any, **kwargs: Any) -> Any:
+            result = await original_func(*args, **kwargs)
+            return self._filter.filter(result, self._target.name)
+
+        # Return async wrapper if original function is async
+        if inspect.iscoroutinefunction(original_func):
+            return wrapped_func_async
+        return wrapped_func

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -231,26 +231,6 @@ class WebToolConfig(BaseToolConfig):
         """Set sandbox instance for this config."""
         self._sandbox = sandbox
 
-    def get_max_output_length(self) -> int:
-        """Get default maximum output length in characters.
-
-        Reads from XAGENT_TOOL_MAX_OUTPUT_LENGTH env var if set.
-        Default: 50K characters (~12K tokens, suitable for most LLMs)
-        """
-        # Import here to avoid circular dependency (web/tools/config <-> core/tools/adapters/vibe/output_filter)
-        from ...core.tools.adapters.vibe.output_filter import (
-            _get_default_max_output_length,
-        )
-
-        return _get_default_max_output_length()
-
-    def get_truncation_message(self) -> str:
-        """Get message to append when output is truncated.
-
-        Default: "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
-        """
-        return "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
-
     def _load_embedding_model(self) -> Optional[str]:
         """Load embedding model ID from database via model service."""
         from ...web.services.model_service import get_default_embedding_model

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -231,6 +231,26 @@ class WebToolConfig(BaseToolConfig):
         """Set sandbox instance for this config."""
         self._sandbox = sandbox
 
+    def get_max_output_length(self) -> int:
+        """Get default maximum output length in characters.
+
+        Reads from XAGENT_TOOL_MAX_OUTPUT_LENGTH env var if set.
+        Default: 50K characters (~12K tokens, suitable for most LLMs)
+        """
+        # Import here to avoid circular dependency (web/tools/config <-> core/tools/adapters/vibe/output_filter)
+        from ...core.tools.adapters.vibe.output_filter import (
+            _get_default_max_output_length,
+        )
+
+        return _get_default_max_output_length()
+
+    def get_truncation_message(self) -> str:
+        """Get message to append when output is truncated.
+
+        Default: "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+        """
+        return "\n\n[OUTPUT TRUNCATED: exceeded maximum length]"
+
     def _load_embedding_model(self) -> Optional[str]:
         """Load embedding model ID from database via model service."""
         from ...web.services.model_service import get_default_embedding_model

--- a/tests/core/tools/adapters/vibe/test_output_filter.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for output filter module.
+"""
+
+from xagent.core.tools.adapters.vibe.output_filter import (
+    DEFAULT_MAX_OUTPUT_LENGTH,
+    OutputValueFilter,
+    create_output_filter,
+)
+
+
+def test_string_within_limit():
+    """Test that strings within limit are not modified."""
+    filter = OutputValueFilter(max_chars=100)
+    result = filter.filter("a" * 50, "test_tool")
+    assert len(result) == 50
+    assert result == "a" * 50
+
+
+def test_string_exceeds_limit():
+    """Test that strings exceeding limit are truncated."""
+    filter = OutputValueFilter(max_chars=100, truncation_message=" [TRUNCATED]")
+    result = filter.filter("a" * 200, "test_tool")
+    assert len(result) == 100 + len(" [TRUNCATED]")
+    assert result.endswith(" [TRUNCATED]")
+    assert result.startswith("a" * 100)
+
+
+def test_dict_preservation():
+    """Test that dict structure is preserved."""
+    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    data = {"short": "ok", "long": "a" * 100, "nested": {"value": "b" * 100}}
+    result = filter.filter(data, "test_tool")
+    assert result["short"] == "ok"
+    # After truncation, length is max_chars + truncation_message length
+    assert len(result["long"]) == 50 + len(" [TRUNCATED]")
+    assert len(result["nested"]["value"]) == 50 + len(" [TRUNCATED]")
+
+
+def test_dict_with_non_string_values():
+    """Test that dict with non-string values is handled correctly."""
+    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    data = {
+        "number": 42,
+        "boolean": True,
+        "none": None,
+        "list": [1, 2, 3],
+        "long_string": "a" * 100,
+    }
+    result = filter.filter(data, "test_tool")
+    # Primitive types are preserved (better design)
+    assert result["number"] == 42
+    assert result["boolean"] is True
+    assert result["none"] is None
+    # List elements are also preserved
+    assert result["list"] == [1, 2, 3]
+    assert len(result["long_string"]) == 50 + len(" [TRUNCATED]")
+
+
+def test_list_filtering():
+    """Test that list items are filtered."""
+    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    data = ["short", "a" * 100, {"key": "b" * 100}]
+    result = filter.filter(data, "test_tool")
+    assert result[0] == "short"
+    # After truncation, length is max_chars + truncation_message length
+    assert len(result[1]) == 50 + len(" [TRUNCATED]")
+    assert len(result[2]["key"]) == 50 + len(" [TRUNCATED]")
+
+
+def test_none_passthrough():
+    """Test that None values pass through."""
+    filter = OutputValueFilter()
+    assert filter.filter(None, "test_tool") is None
+
+
+def test_empty_string():
+    """Test that empty strings pass through."""
+    filter = OutputValueFilter(max_chars=100)
+    result = filter.filter("", "test_tool")
+    assert result == ""
+
+
+def test_exact_limit():
+    """Test that strings at exact limit are not modified."""
+    filter = OutputValueFilter(max_chars=100)
+    result = filter.filter("a" * 100, "test_tool")
+    assert len(result) == 100
+    assert not result.endswith("[TRUNCATED]")
+
+
+def test_default_limit():
+    """Test default limit is 50K characters."""
+    filter = create_output_filter()
+    assert filter.max_chars == DEFAULT_MAX_OUTPUT_LENGTH
+    assert DEFAULT_MAX_OUTPUT_LENGTH == 50 * 1024
+
+
+def test_custom_truncation_message():
+    """Test custom truncation message."""
+    filter = OutputValueFilter(max_chars=10, truncation_message=" ... [CUT]")
+    result = filter.filter("a" * 100, "test_tool")
+    assert result.endswith(" ... [CUT]")
+    assert len(result) == 10 + len(" ... [CUT]")
+
+
+def test_unicode_string():
+    """Test that unicode strings are handled correctly."""
+    filter = OutputValueFilter(max_chars=20)
+    result = filter.filter("你好世界" * 10, "test_tool")
+    # Each Chinese character is counted as 1 character
+    assert len(result) <= 20 + len(filter.truncation_message)
+
+
+def test_nested_structures():
+    """Test deeply nested structures."""
+    filter = OutputValueFilter(max_chars=10, truncation_message=" [CUT]")
+    data = {"level1": {"level2": {"level3": {"value": "a" * 100}}}}
+    result = filter.filter(data, "test_tool")
+    # After truncation, length is max_chars + truncation_message length
+    assert len(result["level1"]["level2"]["level3"]["value"]) == 10 + len(" [CUT]")
+
+
+def test_list_of_dicts():
+    """Test list of dictionaries."""
+    filter = OutputValueFilter(max_chars=20, truncation_message=" [CUT]")
+    data = [
+        {"name": "short", "value": "ok"},
+        {"name": "long", "value": "a" * 100},
+    ]
+    result = filter.filter(data, "test_tool")
+    assert result[0]["name"] == "short"
+    assert result[0]["value"] == "ok"
+    # After truncation, length is max_chars + truncation_message length
+    assert len(result[1]["value"]) == 20 + len(" [CUT]")
+
+
+def test_number_conversion():
+    """Test that numbers are preserved (not converted to strings)."""
+    filter = OutputValueFilter(max_chars=5, truncation_message=" [CUT]")
+    result = filter.filter(1234567890, "test_tool")
+    # Numbers are preserved as-is (no conversion)
+    assert result == 1234567890
+    assert isinstance(result, int)
+
+
+def test_boolean_conversion():
+    """Test that booleans are preserved (not converted to strings)."""
+    filter = OutputValueFilter(max_chars=10)
+    result = filter.filter(True, "test_tool")
+    # Booleans are preserved as-is
+    assert result is True
+
+
+def test_zero_max_chars():
+    """Test edge case of zero max_chars."""
+    filter = OutputValueFilter(max_chars=0)
+    result = filter.filter("a" * 100, "test_tool")
+    assert result == filter.truncation_message
+
+
+def test_small_limit():
+    """Test very small limit."""
+    filter = OutputValueFilter(max_chars=5, truncation_message=" [CUT]")
+    result = filter.filter("a" * 100, "test_tool")
+    assert result.startswith("a" * 5)
+    assert result.endswith(" [CUT]")
+
+
+def test_env_variable_default():
+    """Test that environment variable is used as default."""
+    import os
+
+    from xagent.core.tools.adapters.vibe.output_filter import (
+        _ENV_MAX_OUTPUT_LENGTH,
+        _get_default_max_output_length,
+    )
+
+    # Save original value
+    original_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
+
+    try:
+        # Test with valid env var
+        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "100000"
+        assert _get_default_max_output_length() == 100000
+
+        # Test with invalid env var (should fallback to default)
+        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "invalid"
+        result = _get_default_max_output_length()
+        assert result == 50 * 1024  # Fallback to default
+
+        # Test without env var (should use default)
+        os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
+        assert _get_default_max_output_length() == 50 * 1024
+    finally:
+        # Restore original value
+        if original_value is None:
+            os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
+        else:
+            os.environ[_ENV_MAX_OUTPUT_LENGTH] = original_value
+
+
+def test_filter_uses_env_var_when_none():
+    """Test that filter uses env var when max_chars is None."""
+    import os
+
+    from xagent.core.tools.adapters.vibe.output_filter import (
+        _ENV_MAX_OUTPUT_LENGTH,
+        OutputValueFilter,
+    )
+
+    # Save original value
+    original_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
+
+    try:
+        # Set env var
+        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "25"
+        filter = OutputValueFilter()  # max_chars=None, should use env var
+        assert filter.max_chars == 25
+    finally:
+        # Restore original value
+        if original_value is None:
+            os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
+        else:
+            os.environ[_ENV_MAX_OUTPUT_LENGTH] = original_value

--- a/tests/core/tools/adapters/vibe/test_output_filter.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter.py
@@ -2,16 +2,40 @@
 Unit tests for output filter module.
 """
 
-from xagent.core.tools.adapters.vibe.output_filter import (
-    DEFAULT_MAX_OUTPUT_LENGTH,
-    OutputValueFilter,
-    create_output_filter,
+from xagent.config import (
+    get_tool_max_field_count,
+    get_tool_max_output_length,
+    get_tool_max_recursion_depth,
 )
+from xagent.core.tools.adapters.vibe.output_filter import (
+    CIRCULAR_REFERENCE_MESSAGE,
+    DEFAULT_TRUNCATION_MESSAGE,
+    NESTED_TOO_DEEP_MESSAGE,
+    TRUNCATED_DICT_TEMPLATE,
+    TRUNCATED_FIELDS_MESSAGE,
+    TRUNCATED_ITEMS_MESSAGE,
+    TRUNCATED_ITEMS_TEMPLATE,
+    OutputValueFilter,
+)
+
+# Get default values from config module
+DEFAULT_MAX_OUTPUT_LENGTH = get_tool_max_output_length()
+DEFAULT_MAX_FIELDS = get_tool_max_field_count()
+DEFAULT_MAX_RECURSION = get_tool_max_recursion_depth()
+
+
+def _create_filter(
+    max_chars: int = DEFAULT_MAX_OUTPUT_LENGTH,
+    max_fields: int = DEFAULT_MAX_FIELDS,
+    max_recursion: int = DEFAULT_MAX_RECURSION,
+) -> OutputValueFilter:
+    """Helper to create filter with default values."""
+    return OutputValueFilter(max_chars, max_fields, max_recursion)
 
 
 def test_string_within_limit():
     """Test that strings within limit are not modified."""
-    filter = OutputValueFilter(max_chars=100)
+    filter = _create_filter(max_chars=100)
     result = filter.filter("a" * 50, "test_tool")
     assert len(result) == 50
     assert result == "a" * 50
@@ -19,27 +43,27 @@ def test_string_within_limit():
 
 def test_string_exceeds_limit():
     """Test that strings exceeding limit are truncated."""
-    filter = OutputValueFilter(max_chars=100, truncation_message=" [TRUNCATED]")
+    filter = _create_filter(max_chars=100)
     result = filter.filter("a" * 200, "test_tool")
-    assert len(result) == 100 + len(" [TRUNCATED]")
-    assert result.endswith(" [TRUNCATED]")
+    assert len(result) == 100 + len(DEFAULT_TRUNCATION_MESSAGE)
+    assert result.endswith(DEFAULT_TRUNCATION_MESSAGE)
     assert result.startswith("a" * 100)
 
 
 def test_dict_preservation():
     """Test that dict structure is preserved."""
-    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    filter = _create_filter(max_chars=50)
     data = {"short": "ok", "long": "a" * 100, "nested": {"value": "b" * 100}}
     result = filter.filter(data, "test_tool")
     assert result["short"] == "ok"
-    # After truncation, length is max_chars + truncation_message length
-    assert len(result["long"]) == 50 + len(" [TRUNCATED]")
-    assert len(result["nested"]["value"]) == 50 + len(" [TRUNCATED]")
+    # After truncation, length is max_chars + truncation message length
+    assert len(result["long"]) == 50 + len(DEFAULT_TRUNCATION_MESSAGE)
+    assert len(result["nested"]["value"]) == 50 + len(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_dict_with_non_string_values():
     """Test that dict with non-string values is handled correctly."""
-    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    filter = _create_filter(max_chars=50)
     data = {
         "number": 42,
         "boolean": True,
@@ -54,36 +78,36 @@ def test_dict_with_non_string_values():
     assert result["none"] is None
     # List elements are also preserved
     assert result["list"] == [1, 2, 3]
-    assert len(result["long_string"]) == 50 + len(" [TRUNCATED]")
+    assert len(result["long_string"]) == 50 + len(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_list_filtering():
     """Test that list items are filtered."""
-    filter = OutputValueFilter(max_chars=50, truncation_message=" [TRUNCATED]")
+    filter = _create_filter(max_chars=50)
     data = ["short", "a" * 100, {"key": "b" * 100}]
     result = filter.filter(data, "test_tool")
     assert result[0] == "short"
-    # After truncation, length is max_chars + truncation_message length
-    assert len(result[1]) == 50 + len(" [TRUNCATED]")
-    assert len(result[2]["key"]) == 50 + len(" [TRUNCATED]")
+    # After truncation, length is max_chars + truncation message length
+    assert len(result[1]) == 50 + len(DEFAULT_TRUNCATION_MESSAGE)
+    assert len(result[2]["key"]) == 50 + len(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_none_passthrough():
     """Test that None values pass through."""
-    filter = OutputValueFilter()
+    filter = _create_filter()
     assert filter.filter(None, "test_tool") is None
 
 
 def test_empty_string():
     """Test that empty strings pass through."""
-    filter = OutputValueFilter(max_chars=100)
+    filter = _create_filter(max_chars=100)
     result = filter.filter("", "test_tool")
     assert result == ""
 
 
 def test_exact_limit():
     """Test that strings at exact limit are not modified."""
-    filter = OutputValueFilter(max_chars=100)
+    filter = _create_filter(max_chars=100)
     result = filter.filter("a" * 100, "test_tool")
     assert len(result) == 100
     assert not result.endswith("[TRUNCATED]")
@@ -91,39 +115,33 @@ def test_exact_limit():
 
 def test_default_limit():
     """Test default limit is 50K characters."""
-    filter = create_output_filter()
+    filter = _create_filter()
     assert filter.max_chars == DEFAULT_MAX_OUTPUT_LENGTH
     assert DEFAULT_MAX_OUTPUT_LENGTH == 50 * 1024
 
 
-def test_custom_truncation_message():
-    """Test custom truncation message."""
-    filter = OutputValueFilter(max_chars=10, truncation_message=" ... [CUT]")
-    result = filter.filter("a" * 100, "test_tool")
-    assert result.endswith(" ... [CUT]")
-    assert len(result) == 10 + len(" ... [CUT]")
-
-
 def test_unicode_string():
     """Test that unicode strings are handled correctly."""
-    filter = OutputValueFilter(max_chars=20)
+    filter = _create_filter(max_chars=20)
     result = filter.filter("你好世界" * 10, "test_tool")
     # Each Chinese character is counted as 1 character
-    assert len(result) <= 20 + len(filter.truncation_message)
+    assert len(result) <= 20 + len(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_nested_structures():
     """Test deeply nested structures."""
-    filter = OutputValueFilter(max_chars=10, truncation_message=" [CUT]")
+    filter = _create_filter(max_chars=10)
     data = {"level1": {"level2": {"level3": {"value": "a" * 100}}}}
     result = filter.filter(data, "test_tool")
-    # After truncation, length is max_chars + truncation_message length
-    assert len(result["level1"]["level2"]["level3"]["value"]) == 10 + len(" [CUT]")
+    # After truncation, length is max_chars + truncation message length
+    assert len(result["level1"]["level2"]["level3"]["value"]) == 10 + len(
+        DEFAULT_TRUNCATION_MESSAGE
+    )
 
 
 def test_list_of_dicts():
     """Test list of dictionaries."""
-    filter = OutputValueFilter(max_chars=20, truncation_message=" [CUT]")
+    filter = _create_filter(max_chars=20)
     data = [
         {"name": "short", "value": "ok"},
         {"name": "long", "value": "a" * 100},
@@ -131,13 +149,13 @@ def test_list_of_dicts():
     result = filter.filter(data, "test_tool")
     assert result[0]["name"] == "short"
     assert result[0]["value"] == "ok"
-    # After truncation, length is max_chars + truncation_message length
-    assert len(result[1]["value"]) == 20 + len(" [CUT]")
+    # After truncation, length is max_chars + truncation message length
+    assert len(result[1]["value"]) == 20 + len(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_number_conversion():
     """Test that numbers are preserved (not converted to strings)."""
-    filter = OutputValueFilter(max_chars=5, truncation_message=" [CUT]")
+    filter = _create_filter(max_chars=5)
     result = filter.filter(1234567890, "test_tool")
     # Numbers are preserved as-is (no conversion)
     assert result == 1234567890
@@ -146,7 +164,7 @@ def test_number_conversion():
 
 def test_boolean_conversion():
     """Test that booleans are preserved (not converted to strings)."""
-    filter = OutputValueFilter(max_chars=10)
+    filter = _create_filter(max_chars=10)
     result = filter.filter(True, "test_tool")
     # Booleans are preserved as-is
     assert result is True
@@ -154,72 +172,238 @@ def test_boolean_conversion():
 
 def test_zero_max_chars():
     """Test edge case of zero max_chars."""
-    filter = OutputValueFilter(max_chars=0)
+    filter = _create_filter(max_chars=0)
     result = filter.filter("a" * 100, "test_tool")
-    assert result == filter.truncation_message
+    assert result == DEFAULT_TRUNCATION_MESSAGE
 
 
 def test_small_limit():
     """Test very small limit."""
-    filter = OutputValueFilter(max_chars=5, truncation_message=" [CUT]")
+    filter = _create_filter(max_chars=5)
     result = filter.filter("a" * 100, "test_tool")
     assert result.startswith("a" * 5)
-    assert result.endswith(" [CUT]")
+    assert result.endswith(DEFAULT_TRUNCATION_MESSAGE)
 
 
 def test_env_variable_default():
-    """Test that environment variable is used as default."""
+    """Test that environment variable is used for config values."""
     import os
 
-    from xagent.core.tools.adapters.vibe.output_filter import (
-        _ENV_MAX_OUTPUT_LENGTH,
-        _get_default_max_output_length,
-    )
+    from xagent.config import TOOL_MAX_OUTPUT_LENGTH, get_tool_max_output_length
 
     # Save original value
-    original_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
+    original_value = os.getenv(TOOL_MAX_OUTPUT_LENGTH)
 
     try:
         # Test with valid env var
-        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "100000"
-        assert _get_default_max_output_length() == 100000
+        os.environ[TOOL_MAX_OUTPUT_LENGTH] = "100000"
+        assert get_tool_max_output_length() == 100000
 
         # Test with invalid env var (should fallback to default)
-        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "invalid"
-        result = _get_default_max_output_length()
+        os.environ[TOOL_MAX_OUTPUT_LENGTH] = "invalid"
+        result = get_tool_max_output_length()
         assert result == 50 * 1024  # Fallback to default
 
         # Test without env var (should use default)
-        os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
-        assert _get_default_max_output_length() == 50 * 1024
+        os.environ.pop(TOOL_MAX_OUTPUT_LENGTH, None)
+        assert get_tool_max_output_length() == 50 * 1024
     finally:
         # Restore original value
         if original_value is None:
-            os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
+            os.environ.pop(TOOL_MAX_OUTPUT_LENGTH, None)
         else:
-            os.environ[_ENV_MAX_OUTPUT_LENGTH] = original_value
+            os.environ[TOOL_MAX_OUTPUT_LENGTH] = original_value
 
 
-def test_filter_uses_env_var_when_none():
-    """Test that filter uses env var when max_chars is None."""
-    import os
+def test_filter_uses_default_when_none():
+    """Test that filter uses default value from config."""
+    from xagent.config import get_tool_max_output_length
 
-    from xagent.core.tools.adapters.vibe.output_filter import (
-        _ENV_MAX_OUTPUT_LENGTH,
-        OutputValueFilter,
-    )
+    filter = _create_filter()  # Uses defaults from config
+    assert filter.max_chars == get_tool_max_output_length()
+    assert filter.max_chars == 50 * 1024
 
-    # Save original value
-    original_value = os.getenv(_ENV_MAX_OUTPUT_LENGTH)
 
-    try:
-        # Set env var
-        os.environ[_ENV_MAX_OUTPUT_LENGTH] = "25"
-        filter = OutputValueFilter()  # max_chars=None, should use env var
-        assert filter.max_chars == 25
-    finally:
-        # Restore original value
-        if original_value is None:
-            os.environ.pop(_ENV_MAX_OUTPUT_LENGTH, None)
-        else:
-            os.environ[_ENV_MAX_OUTPUT_LENGTH] = original_value
+def test_bytes_handling():
+    """Test that bytes are decoded correctly."""
+    filter = _create_filter(max_chars=11)
+    data = b"hello world, this is a test"
+    result = filter.filter(data, "test_tool")
+    # Bytes should be decoded to string and truncated
+    assert isinstance(result, str)
+    # Decoded string is 27 chars, max_chars=11, so truncated to 11 + message
+    assert len(result) == 11 + len(DEFAULT_TRUNCATION_MESSAGE)
+    assert result.startswith("hello world")
+    assert result.endswith(DEFAULT_TRUNCATION_MESSAGE)
+
+
+def test_tuple_handling():
+    """Test that tuples are handled correctly."""
+    filter = _create_filter(max_chars=50)
+    data = ("a" * 100, "b" * 100, "c" * 100)
+    result = filter.filter(data, "test_tool")
+    # Tuple should be processed and returned as tuple (not truncated)
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    # Each element should be truncated (truncation message adds to length)
+    assert all("a" in s and "TRUNCATED" in s for s in result)
+
+
+def test_tuple_truncated_to_list():
+    """Test that truncated tuples are converted to list."""
+    filter = _create_filter(max_chars=10, max_fields=2)
+    data = tuple("item" + str(i) for i in range(10))  # 10 items
+    result = filter.filter(data, "test_tool")
+    # Truncated tuple should return as list
+    assert isinstance(result, list)
+    assert len(result) == 3  # 2 items + 1 truncation message
+
+
+def test_set_handling():
+    """Test that sets are handled correctly."""
+    filter = _create_filter(max_fields=3)
+    data = {10, 20, 30, 40, 50}
+    result = filter.filter(data, "test_tool")
+    # Set should be converted to sorted list with truncation
+    assert isinstance(result, list)
+    # First 3 items (sorted) + truncation message
+    assert len(result) == 4
+    assert TRUNCATED_ITEMS_MESSAGE in result[3]
+    assert result[0] in {10, 20, 30, 40, 50}
+
+
+def test_nested_tuple():
+    """Test nested tuple with strings."""
+    filter = _create_filter(max_chars=20)
+    data = {"key": ("a" * 100, "b" * 100)}
+    result = filter.filter(data, "test_tool")
+    assert isinstance(result, dict)
+    assert isinstance(result["key"], tuple)
+    # Strings in tuple should be truncated
+    assert all("TRUNCATED" in s for s in result["key"])
+
+
+def test_max_recursion_depth():
+    """Test that deeply nested structures are handled correctly."""
+    filter = _create_filter(max_recursion=3)
+
+    # Create a structure with depth 5 (exceeds max_recursion=3)
+    data = {"l1": {"l2": {"l3": {"l4": {"l5": "deep"}}}}}
+    result = filter.filter(data, "test_tool")
+
+    # Should truncate at depth limit
+    assert result["l1"]["l2"]["l3"]["l4"] == NESTED_TOO_DEEP_MESSAGE
+    # l5 should not be processed
+    assert "l5" not in str(result)
+
+
+def test_circular_reference_detection():
+    """Test that circular references are detected and handled."""
+    filter = _create_filter()
+
+    # Create a circular reference
+    data: dict = {}
+    data["key"] = "value"
+    data["self"] = data  # Circular reference (type: ignore)
+
+    result = filter.filter(data, "test_tool")
+
+    # Should detect circular reference and return special message
+    assert result["self"] == CIRCULAR_REFERENCE_MESSAGE
+    assert result["key"] == "value"
+
+
+def test_circular_reference_in_list():
+    """Test circular reference in list."""
+    filter = _create_filter()
+
+    # Create a circular reference in list
+    data: list = [1, 2, 3]
+    data.append(data)  # Circular reference (type: ignore)
+
+    result = filter.filter(data, "test_tool")
+
+    # Should detect circular reference
+    assert CIRCULAR_REFERENCE_MESSAGE in str(result)
+    # First elements should be preserved
+    assert result[0] == 1
+    assert result[1] == 2
+    assert result[2] == 3
+
+
+def test_max_recursion_with_large_max():
+    """Test that larger max_recursion allows deeper nesting."""
+    filter = _create_filter(max_recursion=10)
+
+    # Create a structure with depth 5
+    data = {"l1": {"l2": {"l3": {"l4": {"l5": "deep"}}}}}
+    result = filter.filter(data, "test_tool")
+
+    # Should process fully since max_recursion=10 > depth=5
+    assert result["l1"]["l2"]["l3"]["l4"]["l5"] == "deep"
+
+
+def test_max_recursion_at_exact_limit():
+    """Test that depth exactly at limit is processed correctly."""
+    filter = _create_filter(max_recursion=3)
+
+    # Create a structure with depth exactly 3
+    data = {"l1": {"l2": {"l3": "exact_limit"}}}
+    result = filter.filter(data, "test_tool")
+
+    # Should process fully since depth=3 == max_recursion=3
+    # (check happens at depth > max_recursion, so depth=3 is allowed)
+    assert result["l1"]["l2"]["l3"] == "exact_limit"
+
+
+def test_max_recursion_at_limit_plus_one():
+    """Test that depth at limit+1 triggers truncation."""
+    filter = _create_filter(max_recursion=3)
+
+    # Create a structure with depth exactly 4 (limit+1)
+    data = {"l1": {"l2": {"l3": {"l4": "too_deep"}}}}
+    result = filter.filter(data, "test_tool")
+
+    # Should truncate at l4 since depth=4 > max_recursion=3
+    assert result["l1"]["l2"]["l3"]["l4"] == NESTED_TOO_DEEP_MESSAGE
+
+
+def test_dict_max_fields_truncation():
+    """Test that dict with too many fields uses TRUNCATED_FIELDS_MESSAGE."""
+    filter = _create_filter(max_fields=3)
+    data = {"field1": "a", "field2": "b", "field3": "c", "field4": "d", "field5": "e"}
+    result = filter.filter(data, "test_tool")
+    # Should have 4 items: 3 fields + 1 truncation message
+    assert len(result) == 4
+    assert "field1" in result
+    assert "field2" in result
+    assert "field3" in result
+    expected_key = TRUNCATED_DICT_TEMPLATE.format(count=2)
+    assert expected_key in result
+    assert result[expected_key] == TRUNCATED_FIELDS_MESSAGE
+
+
+def test_list_max_fields_truncation():
+    """Test that list with too many items uses TRUNCATED_ITEMS_TEMPLATE."""
+    filter = _create_filter(max_fields=3)
+    data = ["item1", "item2", "item3", "item4", "item5"]
+    result = filter.filter(data, "test_tool")
+    # Should have 4 items: 3 items + 1 truncation message
+    assert len(result) == 4
+    assert result[0] == "item1"
+    assert result[1] == "item2"
+    assert result[2] == "item3"
+    assert TRUNCATED_ITEMS_TEMPLATE.format(count=2) == result[3]
+
+
+def test_tuple_max_fields_truncation():
+    """Test that tuple with too many items is converted to list with truncation."""
+    filter = _create_filter(max_fields=2)
+    data = ("item1", "item2", "item3", "item4")
+    result = filter.filter(data, "test_tool")
+    # Truncated tuple should return as list
+    assert isinstance(result, list)
+    assert len(result) == 3  # 2 items + 1 truncation message
+    assert result[0] == "item1"
+    assert result[1] == "item2"
+    assert result[2] == TRUNCATED_ITEMS_TEMPLATE.format(count=2)

--- a/tests/core/tools/adapters/vibe/test_output_filter_integration.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter_integration.py
@@ -1,0 +1,93 @@
+"""
+Integration tests for output filter with tool factory.
+"""
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.config import ToolConfig
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+
+
+@pytest.mark.asyncio
+async def test_tool_factory_applies_filters():
+    """Test that tools created by factory have output filtering."""
+    config = ToolConfig(
+        {
+            "workspace": None,
+            "max_output_length": 100,
+            "truncation_message": " [TRUNCATED]",
+        }
+    )
+
+    tools = await ToolFactory.create_all_tools(config)
+
+    # Check that tools were created
+    assert len(tools) > 0
+
+    # Find any wrapped tool (all tools should be wrapped with _filter)
+    wrapped_tools = [t for t in tools if hasattr(t, "_filter")]
+    assert len(wrapped_tools) > 0, "No tools with output filter found"
+
+    # Check that the filter has the correct configuration
+    tool = wrapped_tools[0]
+    assert hasattr(tool, "_filter")
+    assert tool._filter.max_chars == 100
+    assert tool._filter.truncation_message == " [TRUNCATED]"
+
+
+@pytest.mark.asyncio
+async def test_filtered_tool_execution():
+    """Test that filtered tools truncate output correctly."""
+    config = ToolConfig(
+        {
+            "workspace": None,
+            "max_output_length": 50,
+            "truncation_message": " [TRUNCATED]",
+        }
+    )
+
+    tools = await ToolFactory.create_all_tools(config)
+
+    # Find a tool with run_json_sync method
+    executable_tool = next((t for t in tools if hasattr(t, "run_json_sync")), None)
+    assert executable_tool is not None, "No executable tool found"
+
+    # Verify the tool has the filter
+    assert hasattr(executable_tool, "_filter")
+
+
+@pytest.mark.asyncio
+async def test_default_max_output_length():
+    """Test that default max output length is 50K characters."""
+    config = ToolConfig({"workspace": None})
+
+    tools = await ToolFactory.create_all_tools(config)
+
+    # Check that at least one tool was created
+    assert len(tools) > 0
+
+    # Check that tools have the default limit
+    for tool in tools:
+        if hasattr(tool, "_filter"):
+            assert tool._filter.max_chars == 50 * 1024
+
+
+@pytest.mark.asyncio
+async def test_custom_truncation_message():
+    """Test custom truncation message."""
+    custom_message = " ... [OUTPUT WAS TOO LONG]"
+    config = ToolConfig(
+        {
+            "workspace": None,
+            "max_output_length": 10,
+            "truncation_message": custom_message,
+        }
+    )
+
+    tools = await ToolFactory.create_all_tools(config)
+
+    # Find a tool and check its truncation message
+    for tool in tools:
+        if hasattr(tool, "_filter"):
+            assert tool._filter.truncation_message == custom_message
+            break

--- a/tests/core/tools/adapters/vibe/test_output_filter_integration.py
+++ b/tests/core/tools/adapters/vibe/test_output_filter_integration.py
@@ -6,6 +6,7 @@ import pytest
 
 from xagent.core.tools.adapters.vibe.config import ToolConfig
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
+from xagent.core.tools.adapters.vibe.output_filter import DEFAULT_TRUNCATION_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -15,7 +16,6 @@ async def test_tool_factory_applies_filters():
         {
             "workspace": None,
             "max_output_length": 100,
-            "truncation_message": " [TRUNCATED]",
         }
     )
 
@@ -32,28 +32,87 @@ async def test_tool_factory_applies_filters():
     tool = wrapped_tools[0]
     assert hasattr(tool, "_filter")
     assert tool._filter.max_chars == 100
-    assert tool._filter.truncation_message == " [TRUNCATED]"
 
 
 @pytest.mark.asyncio
 async def test_filtered_tool_execution():
-    """Test that filtered tools truncate output correctly."""
-    config = ToolConfig(
-        {
-            "workspace": None,
-            "max_output_length": 50,
-            "truncation_message": " [TRUNCATED]",
-        }
+    """Test that filtered tools truncate output correctly when executed."""
+    from langchain_core.tools.structured import StructuredTool
+    from pydantic import BaseModel, Field
+
+    from xagent.core.tools.adapters.vibe.base import AbstractBaseTool, ToolMetadata
+    from xagent.core.tools.adapters.vibe.output_filter_wrapper import (
+        OutputFilteredToolWrapper,
     )
 
-    tools = await ToolFactory.create_all_tools(config)
+    # Create a simple test tool that returns predictable long output
+    class TestInput(BaseModel):
+        text: str = Field(description="Text to repeat")
 
-    # Find a tool with run_json_sync method
-    executable_tool = next((t for t in tools if hasattr(t, "run_json_sync")), None)
-    assert executable_tool is not None, "No executable tool found"
+    def test_long_output_func(text: str) -> str:
+        """Return the input text repeated 100 times for testing output filtering."""
+        return text * 100
 
-    # Verify the tool has the filter
-    assert hasattr(executable_tool, "_filter")
+    # Create a StructuredTool
+    langchain_tool = StructuredTool.from_function(
+        func=test_long_output_func,
+        name="test_long_output",
+        description="Test tool that returns long output",
+        args_schema=TestInput,
+    )
+
+    # Create AbstractBaseTool wrapper
+    class TestTool(AbstractBaseTool):
+        @property
+        def name(self) -> str:
+            return "test_long_output"
+
+        @property
+        def description(self) -> str:
+            return "Test tool that returns long output"
+
+        @property
+        def metadata(self) -> ToolMetadata:
+            return ToolMetadata(
+                name="test_long_output",
+                description="Test tool that returns long output",
+                category="BASIC",
+            )
+
+        def args_type(self):
+            return TestInput
+
+        def return_type(self):
+            return str
+
+        def state_type(self):
+            return None
+
+        def is_async(self):
+            return False
+
+        def run_json_sync(self, args):
+            result = langchain_tool.invoke(args)
+            return result
+
+        async def run_json_async(self, args):
+            return self.run_json_sync(args)
+
+    # Wrap it with the same wrapper used by ToolFactory
+    wrapped = OutputFilteredToolWrapper(
+        target_tool=TestTool(),
+        max_chars=50,
+        max_fields=1000,
+        max_recursion=20,
+    )
+
+    # Execute the tool and verify truncation
+    result = wrapped.run_json_sync({"text": "abcdefghij" * 10})  # 100 chars
+
+    # Result should be truncated to 50 chars + message
+    assert len(result) <= 50 + len(DEFAULT_TRUNCATION_MESSAGE)
+    assert result.endswith(DEFAULT_TRUNCATION_MESSAGE)
+    assert result.startswith("abcdefghij")
 
 
 @pytest.mark.asyncio
@@ -73,21 +132,20 @@ async def test_default_max_output_length():
 
 
 @pytest.mark.asyncio
-async def test_custom_truncation_message():
-    """Test custom truncation message."""
-    custom_message = " ... [OUTPUT WAS TOO LONG]"
+async def test_hardcoded_truncation_message():
+    """Test that truncation message uses the hardcoded default from output_filter.py."""
     config = ToolConfig(
         {
             "workspace": None,
             "max_output_length": 10,
-            "truncation_message": custom_message,
         }
     )
 
     tools = await ToolFactory.create_all_tools(config)
 
-    # Find a tool and check its truncation message
+    # Find a tool and verify truncation message is used
     for tool in tools:
         if hasattr(tool, "_filter"):
-            assert tool._filter.truncation_message == custom_message
+            # The filter uses the hardcoded message from output_filter.py
+            assert tool._filter.max_chars == 10
             break


### PR DESCRIPTION
## Summary

Add a unified output length limiting mechanism for all AI Agent tools (Layer 2 of the three-layer protection model proposed in #213) to prevent excessive text from entering LLM context.

## Problem

Currently, Xagent lacks a unified output length limiting mechanism. Only `command_executor.py` has a 10MB output limit, while other tools like `file_tool`, etc. can return arbitrarily long text, leading to:

- **Context overflow**: Excessive text enters LLM context, potentially exceeding model limits
- **Cost waste**: Processing unnecessary large amounts of tokens increases costs
- **Performance degradation**: Large data processing affects response speed
- **Inconsistent behavior**: Different tools handle long outputs differently

## Solution

Implement a **multi-layered output limiting mechanism** using a wrapper pattern that applies to all tools. This approach uses three dimensions of limits that work together to control output size:

1. **Per-string limit** (`max_chars`): Limits individual string length
2. **Field count limit** (`max_fields`): Limits dict/list element count
3. **Recursion depth limit** (`max_recursion`): Prevents excessively deep nesting

This implements **Layer 2** of the three-layer protection model described in #213.

### Changes

- **`src/xagent/config.py`**: Added `get_tool_max_output_length()`, `get_tool_max_field_count()`, `get_tool_max_recursion_depth()`
- **`output_filter.py`**: New `OutputValueFilter` class with template-based truncation messages
- **`output_filter_wrapper.py`**: New `OutputFilteredToolWrapper` to apply filtering to any tool
- **`config.py` (vibe)**: Extended `BaseToolConfig` with limit-related abstract methods
- **`factory.py`**: Integrated filtering into `ToolFactory.create_all_tools()`
- **`WebToolConfig`**: Added implementations for new abstract methods
- **`example.env`**: Added documentation for tool output environment variables

### Features

- **Per-string limit**: **50K characters** default (configurable via `XAGENT_TOOL_MAX_OUTPUT_LENGTH`)
- **Field count limit**: **1000 items** default (configurable via `XAGENT_TOOL_MAX_FIELD_COUNT`)
- **Recursion depth limit**: **20 levels** default (configurable via `XAGENT_TOOL_MAX_RECURSION_DEPTH`)
- **Transparent**: No changes needed to existing tool implementations
- **Logging**: Records truncation events with WARNING level
- **Recursive filtering**: Truncates strings at **any nesting level** (dicts, lists, etc.)
- **Type preservation**: Primitives (bool/int/float) are preserved, not converted to strings
- **Template-based messages**: Consistent truncation messages using constants (e.g., `[... and 5 more keys]`, `[... nested too deep ...]`)
- **Circular reference detection**: Prevents infinite loops in recursive data structures

### Filtering Behavior

The filter recursively processes nested data structures:

```python
# Example input
{
    "status": True,                              # ← bool: preserved
    "count": 42,                                 # ← int: preserved  
    "message": "short text",                     # ← short string: kept
    "description": "a" * 100000,                 # ← long string: TRUNCATED
    "nested": {
        "notes": "b" * 80000                     # ← nested long string: TRUNCATED
    },
    "items": [{"content": "c" * 50000}]          # ← list items: processed
}

# Result (50K char limit per string)
{
    "status": True,
    "count": 42,
    "message": "short text",
    "description": "aaaa...\\n\\n[OUTPUT TRUNCATED: exceeded maximum length]",
    "nested": {
        "notes": "bbbb...\\n\\n[OUTPUT TRUNCATED: exceeded maximum length]"
    },
    "items": [{"content": "cccc...\\n\\n[OUTPUT TRUNCATED: exceeded maximum length]"}]
}
```

### Real-World Example

When testing with `XAGENT_TOOL_MAX_OUTPUT_LENGTH=32`, the `execute_command` tool output is effectively limited:

```
# Original output (truncated for display)
/root/workspaces/xagen

[OUTPUT TRUNCATED: exceeded maximum length]
```

This demonstrates the filter working as expected - long command outputs are truncated to prevent them from flooding the LLM context, while still preserving the essential information (the current directory path).

### Design Rationale

**Q: Why use three separate limits instead of calculating total output size?**

This is a **pragmatic engineering decision**:

- **Performance**: Calculating total serialized size would require expensive recursive traversal or JSON serialization
- **Effectiveness**: The combination of three limits covers 99.9% of real-world scenarios
- **Simplicity**: Clean, maintainable code without complex size tracking logic
- **Token safety**: For most practical purposes, these limits provide adequate protection

While extreme cases (e.g., 50K chars × 1000 fields × 20 levels) could theoretically produce large output, such scenarios likely indicate underlying tool design issues rather than a missing feature. If needed, a total size limit can be added in the future without breaking the current API.

### Architecture Note

This PR implements **Layer 2** of a three-layer protection system proposed in #213:

```
Layer 1: Tool-level memory limits (e.g., command_executor's 10MB limit)
         → Protects server memory during data reads
         
Layer 2: Unified output filter (this PR)
         → Protects LLM context by limiting output structure
         
Layer 3: LLM token limits
         → Protects API costs and context window
```

The filter operates on **already-loaded data** after tool execution. It protects the LLM context but does not prevent tools from loading large files into memory during execution. Each tool should implement its own memory protection (Layer 1) appropriate to its use case, as outlined in #213.

## Usage

### Via Environment Variables (Global Defaults)
```bash
# Set per-string limit to 100K characters
export XAGENT_TOOL_MAX_OUTPUT_LENGTH=100000

# Set max field count to 500
export XAGENT_TOOL_MAX_FIELD_COUNT=500

# Set max recursion depth to 10
export XAGENT_TOOL_MAX_RECURSION_DEPTH=10
```

### Via Config (Per-Instance)
```python
# Use defaults (50K per string, 1000 fields, 20 recursion)
config = ToolConfig({"workspace": None})

# Custom limits (override environment variables)
config = ToolConfig({
    "workspace": None,
    "max_output_length": 100000,
    "max_field_count": 500,
    "max_recursion_depth": 10
})

tools = await ToolFactory.create_all_tools(config)
```

## Related Issues

See #213 for the overall three-layer protection model and guidelines for implementing Layer 1 (tool-level memory protection).

## Future Work

From #213 - Layer 1 implementations (tool-level memory protection):

- [ ] Add streaming file read support for `file_tool` to avoid loading huge files
- [ ] Add row limit for `sql_tool` query results
- [ ] Add size limit for `document_parser` output
- [ ] Establish best practices documentation for tool-level memory protection