### PR TITLE
feat(frontend): add sandbox indicator badge to tool execution trace

### DIFF
--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -9,6 +9,7 @@ import {
   Terminal,
   Cpu,
   Info,
+  Shield,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useApp } from '@/contexts/app-context-chat';
@@ -83,6 +84,7 @@ interface StepAction {
     reasoning?: string;
     error?: any;
     tool_calls?: any;
+    sandboxed?: boolean;
   };
 }
 
@@ -243,7 +245,8 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
           data: {
             tool: toolName,
             args: toolArgs,
-            code: step.code
+            code: step.code,
+            sandboxed: !!event.data?.sandboxed
           }
         });
       }
@@ -276,7 +279,7 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
             title: t('traceEventRenderer.toolExecutionFinished'),
             status: 'completed',
             timestamp,
-            data: { output }
+            data: { output, sandboxed: !!event.data?.sandboxed }
           });
         }
       }
@@ -463,6 +466,13 @@ function StepActionItem({ action, onViewDetail, onOpenTerminal, onFileClick }: S
           </span>
 
           <span className="font-medium whitespace-nowrap">{action.title}</span>
+
+          {action.data.sandboxed && (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20 whitespace-nowrap">
+              <Shield className="w-3 h-3" />
+              {t('traceEventRenderer.sandboxedExecution')}
+            </span>
+          )}
 
           {summary && (
               <span className="text-muted-foreground/50 font-normal truncate ml-1 hidden sm:block max-w-[600px]">

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2483,6 +2483,7 @@ Build when you need.`
     llmResponse: "LLM Response",
     unknownTool: "Unknown Tool",
     executeTool: "Execute Tool: {tool}",
+    sandboxedExecution: "Safely sandboxed",
     toolExecutionFinished: "Tool Execution Finished",
     unknownError: "Unknown error",
     executionFailed: "Execution Failed",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2483,6 +2483,7 @@ Build when you need.`
     llmResponse: "LLM 响应",
     unknownTool: "未知工具",
     executeTool: "执行工具: {tool}",
+    sandboxedExecution: "沙盒安全运行",
     toolExecutionFinished: "工具执行完成",
     unknownError: "未知错误",
     executionFailed: "执行失败",

--- a/src/xagent/core/agent/pattern/react.py
+++ b/src/xagent/core/agent/pattern/react.py
@@ -1754,24 +1754,30 @@ Failed final answer:
             # Execute tool
             tool_args = action.tool_args or {}
             tool_execution_id = f"tool_{action.tool_name}_{uuid4().hex[:8]}"
-
-            # Trace tool execution start
-            if task_id is not None and step_id is not None:
-                await trace_tool_execution_start(
-                    self.tracer,
-                    task_id,
-                    step_id,
-                    action.tool_name,
-                    data={
-                        "tool_args": tool_args,
-                        "tool_execution_id": tool_execution_id,
-                        "step_id": step_id,
-                        "step_name": getattr(self, "_current_step_name", "main"),
-                    },
-                )
+            is_sandboxed = False
 
             try:
                 tool = self.tool_registry.get(action.tool_name)
+
+                # Check if tool runs in sandbox (duck-type detection)
+                is_sandboxed = getattr(tool, "is_sandboxed", False)
+
+                # Trace tool execution start
+                if task_id is not None and step_id is not None:
+                    await trace_tool_execution_start(
+                        self.tracer,
+                        task_id,
+                        step_id,
+                        action.tool_name,
+                        data={
+                            "tool_args": tool_args,
+                            "tool_execution_id": tool_execution_id,
+                            "step_id": step_id,
+                            "step_name": getattr(self, "_current_step_name", "main"),
+                            "sandboxed": is_sandboxed,
+                        },
+                    )
+
                 result = await tool.run_json_async(tool_args)
 
                 # Trace tool execution end
@@ -1789,6 +1795,7 @@ Failed final answer:
                             "success": True,
                             "step_id": step_id,
                             "step_name": getattr(self, "_current_step_name", "main"),
+                            "sandboxed": is_sandboxed,
                         },
                     )
 
@@ -1816,6 +1823,7 @@ Failed final answer:
                             "tool_execution_id": tool_execution_id,
                             "step_id": step_id,
                             "step_name": getattr(self, "_current_step_name", "main"),
+                            "sandboxed": is_sandboxed,
                         },
                     )
 

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -142,6 +142,11 @@ class SandboxedToolWrapper(AbstractBaseTool):
         self._init_params_b64 = _serialize_init_params(init_params)
 
     @property
+    def is_sandboxed(self) -> bool:
+        """Marker for sandboxed."""
+        return True
+
+    @property
     def name(self) -> str:
         return self._target.name
 


### PR DESCRIPTION
Example badge:
<img width="754" height="397" alt="截屏2026-03-26 11 56 08" src="https://github.com/user-attachments/assets/bce66dab-250f-49ba-a719-fa207648b7f0" />
