### PR TITLE
fix(kb): website import and file upload bugs

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/parser_registry.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/parser_registry.py
@@ -35,7 +35,7 @@ PARSER_COMPATIBILITY: Dict[str, List[str]] = {
     ".rb": [],
     ".sh": [],
     ".sql": [],
-    ".html": [],
+    ".html": ["deepdoc", "unstructured"],
     ".xml": [],
     ".yaml": [],
     ".yml": [],

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -229,7 +229,38 @@ class CollectionManager:
                     table.delete(f"name = '{safe_name}'")
 
                 # Add new record
-                table.add([data])
+                # Ensure data strictly matches table schema to prevent LanceDB schema errors
+                # (e.g. "missing=[owners]" or "contains null values")
+                import pyarrow as pa  # type: ignore[import-not-found]
+
+                clean_data: dict[str, Any] = {}
+                for field in table.schema:
+                    val = data.get(field.name)
+                    if val is None:
+                        # Provide default for missing or None values if not nullable
+                        if not field.nullable:
+                            if pa.types.is_string(
+                                field.type
+                            ) or pa.types.is_large_string(field.type):
+                                clean_data[field.name] = ""
+                            elif pa.types.is_integer(field.type):
+                                clean_data[field.name] = 0
+                            elif pa.types.is_floating(field.type):
+                                clean_data[field.name] = 0.0
+                            elif pa.types.is_boolean(field.type):
+                                clean_data[field.name] = False
+                            elif pa.types.is_timestamp(field.type):
+                                clean_data[field.name] = datetime.now(
+                                    timezone.utc
+                                ).replace(tzinfo=None)
+                            else:
+                                clean_data[field.name] = ""
+                        else:
+                            clean_data[field.name] = None
+                    else:
+                        clean_data[field.name] = val
+
+                table.add([clean_data])
                 return
 
             except Exception as e:

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/content_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/content_cleaner.py
@@ -45,6 +45,9 @@ class ContentCleaner:
             # Extract title
             title = self._extract_title(soup)
 
+            # Extract meta descriptions and keywords before removing unwanted elements
+            meta_content = self._extract_meta_content(soup)
+
             # Remove unwanted elements
             self._remove_unwanted(soup)
 
@@ -63,6 +66,13 @@ class ContentCleaner:
             # Convert to markdown
             markdown = self._to_markdown(soup)
 
+            # Enhance markdown with meta content if it exists
+            if meta_content:
+                if markdown:
+                    markdown = f"{meta_content}\n\n{markdown}"
+                else:
+                    markdown = meta_content
+
             return {
                 "title": title,
                 "content_markdown": markdown,
@@ -76,6 +86,38 @@ class ContentCleaner:
                 "content_markdown": "",
                 "content_length": 0,
             }
+
+    def _extract_meta_content(self, soup: BeautifulSoup) -> str:
+        """Extract description and keywords from meta tags.
+
+        Args:
+            soup: BeautifulSoup object
+
+        Returns:
+            Formatted string of meta content or empty string
+        """
+        from bs4 import Tag
+
+        meta_parts = []
+
+        # Extract description
+        desc_tag = soup.find("meta", attrs={"name": "description"})
+        if not desc_tag:
+            desc_tag = soup.find("meta", property="og:description")
+
+        if isinstance(desc_tag, Tag):
+            content = desc_tag.get("content")
+            if isinstance(content, str) and content.strip():
+                meta_parts.append(content.strip())
+
+        # Extract keywords
+        keywords_tag = soup.find("meta", attrs={"name": "keywords"})
+        if isinstance(keywords_tag, Tag):
+            content = keywords_tag.get("content")
+            if isinstance(content, str) and content.strip():
+                meta_parts.append(f"Keywords: {content.strip()}")
+
+        return "\n\n".join(meta_parts)
 
     def _extract_title(self, soup: BeautifulSoup) -> Optional[str]:
         """Extract page title from HTML.

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -198,7 +198,7 @@ class WebCrawler:
 
                 # Validate content
                 content = cleaned["content_markdown"]
-                if not self.content_cleaner.is_valid_content(content):
+                if not self.content_cleaner.is_valid_content(content, min_length=10):
                     logger.warning(f"Insufficient content at {url}")
                     self.failed_urls[url] = "Insufficient content"
                     return None, set()

--- a/src/xagent/core/tools/core/document_parser.py
+++ b/src/xagent/core/tools/core/document_parser.py
@@ -134,6 +134,7 @@ async def parse_document(
                 ".txt",
                 ".md",
                 ".json",
+                ".html",
             )
             and "unstructured" in available_parsers
         ):

--- a/src/xagent/providers/pdf_parser/basic.py
+++ b/src/xagent/providers/pdf_parser/basic.py
@@ -52,6 +52,7 @@ class UnstructuredParser(
         ".txt",
         ".md",
         ".json",
+        ".html",
     ]
 
     async def _parse_impl(self, file_path: str, **kwargs: Any) -> ParseResult:
@@ -169,6 +170,10 @@ async def extract_text_with_unstructured(file_path: str, **kwargs: Any) -> Parse
             from unstructured.partition.xlsx import partition_xlsx
 
             elements = partition_xlsx(filename=file_path)
+        elif file_ext == ".html":
+            from unstructured.partition.html import partition_html
+
+            elements = partition_html(filename=file_path)
         elif file_ext in (".txt", ".md", ".json"):
             # For plain text files, read directly
             with open(file_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
Fix bugs in website import and file upload:

1. Website import:
- Fixed missing content in SPA pages: For single-page applications rendered with JS, the crawler's direct HTTP request to the HTML `<body>` tag resulted in only `<div id="root"></div>`, causing the HTML to Markdown conversion to return an empty string.
- Fixed overly strict validation: The default `is_valid_content` logic during the crawling process required converted text to be at least 100 characters. Pages with no content or minimal text were incorrectly flagged as invalid with the error "Insufficient content."

2. File upload:
- Fixed issue when handling `.html` files: The lack of a dedicated parser route for `.html` files caused the fallback to the default parser (PyPdfParser), leading to the exception "Document parsing failed with pypdf: PyPdfParser only supports PDF files."