### PR TITLE
fix(models): normalize xinference and embedding provider integrations

### DIFF
--- a/frontend/src/components/pages/models.tsx
+++ b/frontend/src/components/pages/models.tsx
@@ -764,13 +764,15 @@ export function ModelsPage() {
 
       for (let i = 0; i < selectedModels.length; i++) {
          const model = selectedModels[i]
+         const providerAbilities = Array.isArray((model as any).abilities)
+           ? (model as any).abilities.filter((ability: unknown): ability is string => typeof ability === 'string' && ability.length > 0)
+           : []
 
          const payload: ModelCreate = {
             ...formData,
             model_id: generateModelId(model.id, formData.model_provider, user?.id),
             model_name: model.id,
-            // Use abilities from provider model instead of form data
-            abilities: (model as any).abilities || formData.abilities,
+            abilities: providerAbilities.length > 0 ? providerAbilities : formData.abilities,
             default_config_types: (defaultTypeToSet && defaultModelId && model.id === defaultModelId) ? [defaultTypeToSet] : []
          }
 

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -15,6 +15,33 @@ from .base import BaseLLM
 logger = logging.getLogger(__name__)
 
 
+def _normalize_model_list_response(
+    model_list: Any,
+) -> List[tuple[str, dict[str, Any]]]:
+    if isinstance(model_list, dict):
+        return [
+            (str(model_uid), model_info)
+            for model_uid, model_info in model_list.items()
+            if isinstance(model_info, dict)
+        ]
+
+    if isinstance(model_list, list):
+        normalized: List[tuple[str, dict[str, Any]]] = []
+        for model_info in model_list:
+            if not isinstance(model_info, dict):
+                continue
+            model_uid = str(
+                model_info.get("model_uid")
+                or model_info.get("id")
+                or model_info.get("model_name")
+                or ""
+            )
+            normalized.append((model_uid, model_info))
+        return normalized
+
+    return []
+
+
 class XinferenceLLM(BaseLLM):
     """
     Xinference LLM client using the xinference-client SDK.
@@ -83,9 +110,13 @@ class XinferenceLLM(BaseLLM):
                 base_url=self.base_url, api_key=self.api_key
             )
 
+        client = self._client
+        if client is None:
+            raise RuntimeError("Failed to initialize Xinference client")
+
         if self._model_handle is None:
             # Get the model handle (assumes model is already launched on the server)
-            self._model_handle = self._client.get_model(self._model_uid)
+            self._model_handle = client.get_model(self._model_uid)
 
     def _build_generate_config(
         self,
@@ -580,6 +611,7 @@ class XinferenceLLM(BaseLLM):
             "chat": "chat",
             "vision": "vision",
             "tool_calling": "tool_calling",
+            "embedding": "embedding",
         }
 
         # Retry logic for transient network issues
@@ -597,10 +629,10 @@ class XinferenceLLM(BaseLLM):
 
                 # Use SDK's list_models method
                 model_list = client.list_models()
+                normalized_models = _normalize_model_list_response(model_list)
 
                 result = []
-                for model_info in model_list:
-                    model_uid = model_info.get("id", "")
+                for model_uid, model_info in normalized_models:
                     if not model_uid:
                         continue
 
@@ -617,6 +649,7 @@ class XinferenceLLM(BaseLLM):
                             "chat",
                             "vision",
                             "tool_calling",
+                            "embedding",
                         ]:
                             if mapped_ability not in mapped_abilities:
                                 mapped_abilities.append(mapped_ability)

--- a/src/xagent/core/model/embedding/openai.py
+++ b/src/xagent/core/model/embedding/openai.py
@@ -58,13 +58,42 @@ class OpenAIEmbedding(BaseEmbedding):
         """Get or create HTTP session."""
         if self._session is None:
             self._session = requests.Session()
-            self._session.headers.update(
-                {
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                }
-            )
+            headers = {"Content-Type": "application/json"}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            self._session.headers.update(headers)
         return self._session
+
+    def _requires_api_key(self) -> bool:
+        return self.base_url == "https://api.openai.com/v1/embeddings"
+
+    @staticmethod
+    def _extract_error_detail(response: requests.Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                message = error.get("message") or error.get("detail")
+                if message:
+                    return str(message)
+
+            detail = payload.get("detail")
+            if detail:
+                return str(detail)
+
+            message = payload.get("message")
+            if message:
+                return str(message)
+
+        response_text = response.text.strip()
+        if response_text:
+            return response_text
+
+        return f"HTTP {response.status_code} error"
 
     def encode(
         self,
@@ -87,7 +116,7 @@ class OpenAIEmbedding(BaseEmbedding):
         Raises:
             RuntimeError: If API call fails or returns invalid response
         """
-        if not self.api_key:
+        if self._requires_api_key() and not self.api_key:
             raise RuntimeError("OPENAI_API_KEY is required")
 
         session = self._get_session()
@@ -111,6 +140,8 @@ class OpenAIEmbedding(BaseEmbedding):
         if final_dimension:
             payload["dimensions"] = final_dimension
 
+        response: Optional[requests.Response] = None
+
         try:
             response = session.post(self.base_url or "", json=payload)
             response.raise_for_status()
@@ -132,6 +163,15 @@ class OpenAIEmbedding(BaseEmbedding):
                 ]
                 return embedding_list
 
+        except requests.HTTPError as e:
+            if response is None and e.response is not None:
+                response = e.response
+
+            if response is None:
+                raise RuntimeError(f"OpenAI embedding failed: {str(e)}") from e
+
+            detail = self._extract_error_detail(response)
+            raise RuntimeError(f"OpenAI embedding failed: {detail}") from e
         except Exception as e:
             import traceback
 

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xagent.core.model.chat.basic.xinference import XinferenceLLM
+
+
+class TestXinferenceLLM:
+    @pytest.mark.asyncio
+    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    async def test_list_available_models_handles_dict_response(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.list_models.return_value = {
+            "qwen-chat-uid": {
+                "model_name": "Qwen3-8B-Instruct",
+                "model_type": "LLM",
+                "model_ability": ["chat", "vision", "tool_calling"],
+                "model_description": "Qwen chat model",
+            },
+            "whisper-uid": {
+                "model_name": "whisper-large-v3",
+                "model_type": "audio",
+                "model_ability": ["audio2text"],
+                "model_description": "ASR model",
+            },
+        }
+        mock_client_class.return_value = mock_client
+
+        models = await XinferenceLLM.list_available_models(
+            base_url="http://localhost:9997", api_key="test-key"
+        )
+
+        assert len(models) == 2
+        assert models[0] == {
+            "id": "Qwen3-8B-Instruct",
+            "model_uid": "qwen-chat-uid",
+            "model_type": "LLM",
+            "model_ability": ["chat", "vision", "tool_calling"],
+            "abilities": ["chat", "vision", "tool_calling"],
+            "description": "Qwen chat model",
+        }
+        assert models[1] == {
+            "id": "whisper-large-v3",
+            "model_uid": "whisper-uid",
+            "model_type": "audio",
+            "model_ability": ["asr"],
+            "abilities": ["asr"],
+            "description": "ASR model",
+        }
+
+    @pytest.mark.asyncio
+    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    async def test_list_available_models_preserves_embedding_ability(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.list_models.return_value = {
+            "embedding-uid": {
+                "model_name": "Qwen3-Embedding-8B",
+                "model_type": "embedding",
+                "model_ability": ["embedding"],
+                "model_description": "Embedding model",
+            }
+        }
+        mock_client_class.return_value = mock_client
+
+        models = await XinferenceLLM.list_available_models(
+            base_url="http://localhost:9997", api_key="test-key"
+        )
+
+        assert models == [
+            {
+                "id": "Qwen3-Embedding-8B",
+                "model_uid": "embedding-uid",
+                "model_type": "embedding",
+                "model_ability": ["embedding"],
+                "abilities": ["embedding"],
+                "description": "Embedding model",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    async def test_list_available_models_handles_legacy_list_response(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.list_models.return_value = [
+            {
+                "id": "legacy-chat-uid",
+                "model_name": "legacy-chat",
+                "model_type": "LLM",
+                "model_ability": ["chat"],
+                "model_description": "Legacy chat model",
+            }
+        ]
+        mock_client_class.return_value = mock_client
+
+        models = await XinferenceLLM.list_available_models(
+            base_url="http://localhost:9997", api_key="test-key"
+        )
+
+        assert models == [
+            {
+                "id": "legacy-chat",
+                "model_uid": "legacy-chat-uid",
+                "model_type": "LLM",
+                "model_ability": ["chat"],
+                "abilities": ["chat"],
+                "description": "Legacy chat model",
+            }
+        ]

--- a/tests/core/model/embedding/test_openai.py
+++ b/tests/core/model/embedding/test_openai.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Type
 
+import requests
+
 import pytest
 
 from xagent.core.model.embedding import OpenAIEmbedding
@@ -48,6 +50,43 @@ class TestOpenAIEmbedding(BaseEmbeddingTest):
         """Test base URL initialization."""
         client = OpenAIEmbedding(api_key="test_key", base_url="https://custom.api.com")
         assert client.base_url == "https://custom.api.com"
+
+    def test_encode_surfaces_provider_error_detail(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.status_code = 500
+        mock_response.text = '{"detail": "upstream exploded"}'
+        mock_response.json.return_value = {
+            "detail": "upstream exploded",
+        }
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "500 Server Error", response=mock_response
+        )
+
+        mocker.patch("requests.Session.post", return_value=mock_response)
+
+        client = OpenAIEmbedding(api_key="test_key")
+
+        with pytest.raises(RuntimeError, match="upstream exploded"):
+            client.encode("Hello")
+
+    def test_encode_allows_custom_base_url_without_api_key(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+
+        post_mock = mocker.patch("requests.Session.post", return_value=mock_response)
+
+        client = OpenAIEmbedding(
+            api_key=None,
+            base_url="http://localhost:9997/v1",
+            model="test-embedding-model",
+        )
+
+        embedding = client.encode("Hello")
+
+        assert embedding == [0.1, 0.2]
+        post_mock.assert_called_once()
+        assert "Authorization" not in client._get_session().headers
 
 
 if __name__ == "__main__":

--- a/tests/core/model/embedding/test_openai.py
+++ b/tests/core/model/embedding/test_openai.py
@@ -1,8 +1,7 @@
 from typing import Any, Dict, List, Type
 
-import requests
-
 import pytest
+import requests
 
 from xagent.core.model.embedding import OpenAIEmbedding
 


### PR DESCRIPTION
## Summary
- normalize Xinference model list handling across dict and legacy list responses
- improve OpenAI-compatible embedding endpoint handling and surface provider error details
- align the models page with the provider compatibility updates and add regression tests
