### PR TITLE
fix(kb): allow unicode collection names

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/utils/string_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/string_utils.py
@@ -229,7 +229,7 @@ def generate_deterministic_doc_id(collection: str, source_path: str) -> str:
 
 
 # Security validation patterns
-_COLLECTION_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[\w-]+$")
+_COLLECTION_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[\w -]+$")
 _DOC_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9_.-]+$")
 
 
@@ -237,9 +237,9 @@ def validate_collection_name(name: str) -> str:
     """
     Validate collection name for safe use in LanceDB queries.
 
-    Allows Unicode word characters (letters, numbers, underscore) and hyphens.
-    This prevents injection attacks while remaining compatible with
-    internationalized collection names.
+    Allows Unicode word characters (letters, numbers, underscore), spaces,
+    and hyphens. This prevents injection attacks while remaining compatible
+    with internationalized collection names.
 
     Args:
         name: Collection name to validate
@@ -252,12 +252,13 @@ def validate_collection_name(name: str) -> str:
     """
     if not isinstance(name, str):
         raise ValueError(f"Collection name must be a string, got {type(name)}")
-    if not name:
+    if not name or not name.strip():
         raise ValueError("Collection name cannot be empty")
+    name = name.strip()
     if not _COLLECTION_NAME_PATTERN.match(name):
         raise ValueError(
             f"Invalid collection name '{name}'. "
-            "Only letters, numbers, underscores, and hyphens are allowed."
+            "Only letters, numbers, spaces, underscores, and hyphens are allowed."
         )
     return name
 

--- a/src/xagent/core/tools/core/RAG_tools/utils/string_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/string_utils.py
@@ -229,7 +229,7 @@ def generate_deterministic_doc_id(collection: str, source_path: str) -> str:
 
 
 # Security validation patterns
-_COLLECTION_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9_-]+$")
+_COLLECTION_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[\w-]+$")
 _DOC_ID_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9_.-]+$")
 
 
@@ -237,9 +237,9 @@ def validate_collection_name(name: str) -> str:
     """
     Validate collection name for safe use in LanceDB queries.
 
-    Only allows alphanumeric characters, underscores, and hyphens.
-    This prevents injection attacks while being restrictive enough
-    to avoid problematic characters in collection names.
+    Allows Unicode word characters (letters, numbers, underscore) and hyphens.
+    This prevents injection attacks while remaining compatible with
+    internationalized collection names.
 
     Args:
         name: Collection name to validate

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1457,10 +1457,19 @@ async def check_documents_exist_api(
         if not requested:
             return {"existing_filenames": []}
 
+        try:
+            safe_collection_name = sanitize_path_component(
+                collection_name, "collection"
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=422, detail=f"Invalid collection name: {str(e)}"
+            ) from e
+
         # Use storage abstraction layer to fetch document records
         vector_store = get_vector_index_store()
         records = vector_store.list_document_records(
-            collection_name=collection_name,
+            collection_name=safe_collection_name,
             user_id=int(_user.id),
             is_admin=False,
             max_results=DEFAULT_VECTOR_STORE_SCAN_LIMIT,
@@ -2256,6 +2265,13 @@ async def get_parse_result_api(
     from ...core.tools.core.RAG_tools.core.exceptions import DocumentNotFoundError
     from ...core.tools.core.RAG_tools.utils.string_utils import sanitize_for_doc_id
 
+    try:
+        safe_collection_name = sanitize_path_component(collection_name, "collection")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid collection name: {str(e)}"
+        ) from e
+
     safe_doc_id = sanitize_for_doc_id(doc_id)
     if safe_doc_id != doc_id:
         logger.warning("Invalid doc_id format detected: %s", doc_id)
@@ -2270,7 +2286,7 @@ async def get_parse_result_api(
 
     try:
         elements, actual_parse_hash = reconstruct_parse_result_from_db(
-            collection_name,
+            safe_collection_name,
             doc_id,
             parse_hash,
             user_id=int(_user.id),

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -190,21 +190,28 @@ async def save_collection_config(
     """Save ingestion configuration for a specific collection."""
     from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
 
+    try:
+        safe_collection = sanitize_path_component(collection, "collection")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid collection name: {str(e)}"
+        ) from e
+
     config_json = config.model_dump_json(exclude_unset=True)
 
     try:
         metadata_store = get_metadata_store()
         await metadata_store.save_collection_config(
-            collection=collection,
+            collection=safe_collection,
             config_json=config_json,
             user_id=int(_user.id),
         )
 
         return CollectionOperationResult(
             status="success",
-            collection=collection,
+            collection=safe_collection,
             operation="save_config",
-            message=f"Configuration saved for collection '{collection}'",
+            message=f"Configuration saved for collection '{safe_collection}'",
         )
     except Exception as e:
         logger.error(f"Failed to save collection config: {e}", exc_info=True)
@@ -304,6 +311,7 @@ async def ingest(
     try:
         # SECURITY: Validate collection name at API boundary
         safe_collection = sanitize_path_component(collection, "collection")
+        collection = safe_collection
 
         try:
             file_path = get_upload_path(
@@ -460,6 +468,13 @@ async def ingest_cloud(
     _user: User = Depends(get_current_user),
 ) -> List[IngestionResult]:
     """Ingest files from cloud storage."""
+    try:
+        safe_collection = sanitize_path_component(request.collection, "collection")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid collection name: {str(e)}"
+        ) from e
+
     results = []
 
     # Common configuration setup
@@ -556,7 +571,7 @@ async def ingest_cloud(
                     try:
                         result = await asyncio.to_thread(
                             run_document_ingestion,
-                            collection=request.collection,
+                            collection=safe_collection,
                             source_path=str(file_path),
                             ingestion_config=config,
                             progress_manager=progress_manager,
@@ -952,6 +967,13 @@ async def search(
     if not collection or not query_text:
         raise HTTPException(status_code=422, detail="Missing required parameters")
 
+    try:
+        safe_collection = sanitize_path_component(collection, "collection")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid collection name: {str(e)}"
+        ) from e
+
     if not embedding_model_id:
         raise HTTPException(
             status_code=422,
@@ -979,7 +1001,7 @@ async def search(
 
     progress_manager = get_progress_manager()
     result = run_document_search(
-        collection=collection,
+        collection=safe_collection,
         query_text=query_text,
         config=config,
         progress_manager=progress_manager,
@@ -1278,7 +1300,6 @@ async def delete_collection_api(
     Raises:
         HTTPException: If physical deletion fails (prevents database deletion)
     """
-    safe_collection = collection_name
     try:
         try:
             safe_collection = sanitize_path_component(collection_name, "collection")
@@ -1442,6 +1463,15 @@ async def check_documents_exist_api(
     for admins), so "already exists" matches what will be overwritten on re-upload.
     """
     try:
+        try:
+            safe_collection_name = sanitize_path_component(
+                collection_name, "collection"
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=422, detail=f"Invalid collection name: {str(e)}"
+            ) from e
+
         filenames = body.get("filenames")
         if not isinstance(filenames, list):
             raise HTTPException(
@@ -2092,11 +2122,6 @@ async def rename_collection_api(
             detail="New collection name cannot be empty",
         )
 
-    new_name = new_name.strip()
-
-    if new_name == collection_name:
-        return {"status": "success", "message": "Collection name unchanged"}
-
     warnings: list[str] = []
 
     # SECURITY: Validate both old and new collection names to prevent path traversal
@@ -2108,12 +2133,15 @@ async def rename_collection_api(
             status_code=422, detail=f"Invalid collection name: {str(e)}"
         ) from e
 
+    if safe_new_collection == safe_old_collection:
+        return {"status": "success", "message": "Collection name unchanged"}
+
     physical_rename_status = "not_found"
     physical_rename_error: Optional[str] = None
     old_collection_dir: Optional[Path] = None
     new_collection_dir: Optional[Path] = None
     collection_records = vector_store.list_document_records(
-        collection_name=collection_name,
+        collection_name=safe_old_collection,
         user_id=int(_user.id),
         is_admin=bool(_user.is_admin),
     )
@@ -2156,25 +2184,25 @@ async def rename_collection_api(
     vector_store = get_vector_index_store()
     warnings.extend(
         vector_store.rename_collection_data(
-            collection_name=collection_name,
-            new_name=new_name,
+            collection_name=safe_old_collection,
+            new_name=safe_new_collection,
         )
     )
 
     # Migrate ingestion status from old collection name to new
     try:
-        status_entries = load_ingestion_status(collection=collection_name)
+        status_entries = load_ingestion_status(collection=safe_old_collection)
         for entry in status_entries:
             doc_id = entry.get("doc_id")
             if doc_id:
                 write_ingestion_status(
-                    new_name,
+                    safe_new_collection,
                     doc_id,
                     status=entry.get("status", "pending"),
                     message=entry.get("message", ""),
                     parse_hash=entry.get("parse_hash", ""),
                 )
-                clear_ingestion_status(collection_name, doc_id)
+                clear_ingestion_status(safe_old_collection, doc_id)
     except Exception as e:
         logger.warning("Failed to update ingestion status: %s", e)
         warnings.append(f"Failed to update ingestion status: {e}")
@@ -2213,7 +2241,9 @@ async def rename_collection_api(
             rename_info_message = " Database rename succeeded, but physical directory rename encountered issues."
 
     # Step 5: Build final message
-    base_message = f"Collection renamed from '{collection_name}' to '{new_name}'"
+    base_message = (
+        f"Collection renamed from '{safe_old_collection}' to '{safe_new_collection}'"
+    )
     if warnings and len(warnings) > (1 if physical_rename_status != "not_found" else 0):
         final_message = f"{base_message} with some warnings"
     else:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1487,15 +1487,6 @@ async def check_documents_exist_api(
         if not requested:
             return {"existing_filenames": []}
 
-        try:
-            safe_collection_name = sanitize_path_component(
-                collection_name, "collection"
-            )
-        except ValueError as e:
-            raise HTTPException(
-                status_code=422, detail=f"Invalid collection name: {str(e)}"
-            ) from e
-
         # Use storage abstraction layer to fetch document records
         vector_store = get_vector_index_store()
         records = vector_store.list_document_records(

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -90,6 +90,7 @@ MAX_FILE_SIZE = 100 * 1024 * 1024
 
 # Word characters (\w = letters/digits/underscore in any language), spaces, and hyphens.
 ALLOWED_NAME_PATTERN = re.compile(r"^[\w -]+$")
+ALLOWED_NAME_PATTERN_NO_SPACES = re.compile(r"^[\w-]+$")
 _CONFUSABLE_SCRIPT_FAMILIES = ("LATIN", "GREEK", "CYRILLIC")
 
 
@@ -195,12 +196,25 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
             f"Invalid {component_type} name: exceeds maximum byte length of {MAX_COLLECTION_NAME_BYTES}"
         )
 
+    # Collections allow internal spaces, but task folders remain stricter to
+    # preserve existing upload path semantics and security expectations.
+    allowed_pattern = (
+        ALLOWED_NAME_PATTERN
+        if component_type == "collection"
+        else ALLOWED_NAME_PATTERN_NO_SPACES
+    )
+
     # Validate against allowed character pattern
     # This ensures only safe characters are used
-    if not ALLOWED_NAME_PATTERN.match(safe_name):
+    if not allowed_pattern.match(safe_name):
+        allowed_chars = (
+            "Only letters, numbers, spaces, underscores, and hyphens are allowed."
+            if component_type == "collection"
+            else "Only letters, numbers, underscores, and hyphens are allowed."
+        )
         raise ValueError(
             f"Invalid {component_type} name: contains invalid characters. "
-            f"Only letters, numbers, spaces, underscores, and hyphens are allowed."
+            f"{allowed_chars}"
         )
 
     if _has_mixed_confusable_scripts(safe_name):

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -198,10 +198,10 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
             f"Only letters, numbers, underscores, and hyphens are allowed."
         )
 
-        if _has_mixed_confusable_scripts(safe_name):
-            raise ValueError(
-                f"Invalid {component_type} name: contains mixed-script confusable characters"
-            )
+    if _has_mixed_confusable_scripts(safe_name):
+        raise ValueError(
+            f"Invalid {component_type} name: contains mixed-script confusable characters"
+        )
 
     # Ensure the sanitized name matches the original (after stripping)
     # This prevents silent truncation of valid names

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -196,10 +196,10 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
             f"Only letters, numbers, underscores, and hyphens are allowed."
         )
 
-    if _has_mixed_confusable_scripts(safe_name):
-        raise ValueError(
-            f"Invalid {component_type} name: contains mixed-script confusable characters"
-        )
+        if _has_mixed_confusable_scripts(safe_name):
+            raise ValueError(
+                f"Invalid {component_type} name: contains mixed-script confusable characters"
+            )
 
     # Ensure the sanitized name matches the original (after stripping)
     # This prevents silent truncation of valid names

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -88,8 +88,8 @@ ALLOWED_EXTENSIONS = {
 # Maximum file size (100MB)
 MAX_FILE_SIZE = 100 * 1024 * 1024
 
-# Word characters (\w = letters/digits/underscore in any language) and hyphens.
-ALLOWED_NAME_PATTERN = re.compile(r"^[\w-]+$")
+# Word characters (\w = letters/digits/underscore in any language), spaces, and hyphens.
+ALLOWED_NAME_PATTERN = re.compile(r"^[\w -]+$")
 _CONFUSABLE_SCRIPT_FAMILIES = ("LATIN", "GREEK", "CYRILLIC")
 
 
@@ -122,6 +122,7 @@ def _has_mixed_confusable_scripts(value: str) -> bool:
 # Maximum length for collection and folder names (reasonable limit for file system and database)
 # This prevents path length issues and database field overflow
 MAX_COLLECTION_NAME_LENGTH = 100
+MAX_COLLECTION_NAME_BYTES = 255
 MIN_COLLECTION_NAME_LENGTH = 1
 
 
@@ -166,7 +167,7 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
     if normalized_name != name:
         raise ValueError(
             f"Invalid {component_type} name: contains invalid characters. "
-            f"Only letters, numbers, underscores, and hyphens are allowed."
+            f"Only letters, numbers, spaces, underscores, and hyphens are allowed."
         )
     name = normalized_name
 
@@ -189,13 +190,17 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
         raise ValueError(
             f"Invalid {component_type} name: exceeds maximum length of {MAX_COLLECTION_NAME_LENGTH} characters"
         )
+    if len(safe_name.encode("utf-8")) > MAX_COLLECTION_NAME_BYTES:
+        raise ValueError(
+            f"Invalid {component_type} name: exceeds maximum byte length of {MAX_COLLECTION_NAME_BYTES}"
+        )
 
     # Validate against allowed character pattern
     # This ensures only safe characters are used
     if not ALLOWED_NAME_PATTERN.match(safe_name):
         raise ValueError(
             f"Invalid {component_type} name: contains invalid characters. "
-            f"Only letters, numbers, underscores, and hyphens are allowed."
+            f"Only letters, numbers, spaces, underscores, and hyphens are allowed."
         )
 
     if _has_mixed_confusable_scripts(safe_name):

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -9,6 +9,7 @@ import re
 import unicodedata
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 from ..config import get_uploads_dir
 
@@ -87,6 +88,7 @@ ALLOWED_EXTENSIONS = {
 # Maximum file size (100MB)
 MAX_FILE_SIZE = 100 * 1024 * 1024
 
+# Word characters (\w = letters/digits/underscore in any language) and hyphens.
 ALLOWED_NAME_PATTERN = re.compile(r"^[\w-]+$")
 _CONFUSABLE_SCRIPT_FAMILIES = ("LATIN", "GREEK", "CYRILLIC")
 
@@ -308,17 +310,24 @@ def get_file_url(
         if collection:
             # SECURITY: Sanitize collection name to prevent path traversal and URL injection
             safe_collection = sanitize_path_component(collection, "collection")
-            return f"{FILE_STORAGE_URL_BASE}/user_{user_id}/{safe_collection}/{safe_filename}"
+            encoded_collection = quote(safe_collection, safe="")
+            encoded_filename = quote(safe_filename, safe="")
+            return f"{FILE_STORAGE_URL_BASE}/user_{user_id}/{encoded_collection}/{encoded_filename}"
         if task_id and folder:
-            return f"{FILE_STORAGE_URL_BASE}/{safe_filename}"
+            encoded_filename = quote(safe_filename, safe="")
+            return f"{FILE_STORAGE_URL_BASE}/{encoded_filename}"
         else:
-            return f"{FILE_STORAGE_URL_BASE}/user_{user_id}/{safe_filename}"
+            encoded_filename = quote(safe_filename, safe="")
+            return f"{FILE_STORAGE_URL_BASE}/user_{user_id}/{encoded_filename}"
     elif task_id and folder:
         # SECURITY: Sanitize folder name to prevent path traversal and URL injection
         safe_folder = sanitize_path_component(folder, "folder")
-        return f"{FILE_STORAGE_URL_BASE}/task_{task_id}/{safe_folder}/{safe_filename}"
+        encoded_folder = quote(safe_folder, safe="")
+        encoded_filename = quote(safe_filename, safe="")
+        return f"{FILE_STORAGE_URL_BASE}/task_{task_id}/{encoded_folder}/{encoded_filename}"
     else:
-        return f"{FILE_STORAGE_URL_BASE}/{safe_filename}"
+        encoded_filename = quote(safe_filename, safe="")
+        return f"{FILE_STORAGE_URL_BASE}/{encoded_filename}"
 
 
 def is_allowed_file(filename: str, task_type: str = "general") -> bool:

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -257,6 +257,36 @@ def test_kb_ingest_rejects_invalid_characters_in_collection_name(
             assert "Invalid collection name" in response.json()["detail"]
 
 
+def test_kb_ingest_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    collection_name = "示例知识库集合"
+    filename = "test_doc.txt"
+
+    with patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest:
+        from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+        mock_ingest.return_value = IngestionResult(
+            status="success",
+            doc_id="test_doc_id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": (filename, b"content", "text/plain")},
+            data={"collection": collection_name},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        expected_path = temp_uploads / f"user_{user.id}" / collection_name / filename
+        assert expected_path.exists()
+
+
 def test_kb_ingest_rejects_too_long_collection_name(test_env, temp_uploads):
     """Test that ingest API rejects collection names exceeding length limit."""
     app, headers, user, _ = test_env

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -924,67 +924,6 @@ def test_check_documents_exist_rejects_path_traversal_in_collection_name(
         assert "Invalid collection name" in response.json()["detail"]
 
 
-def test_delete_document_accepts_unicode_collection_name(test_env, temp_uploads):
-    app, headers, user, _ = test_env
-    client = TestClient(app)
-
-    from urllib.parse import quote
-
-    collection_name = "示例知识库集合"
-    file_path = temp_uploads / f"user_{user.id}" / collection_name / "demo.txt"
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text("content")
-
-    records = [
-        {
-            "doc_id": "doc-1",
-            "source_path": str(file_path),
-        }
-    ]
-
-    with (
-        patch("xagent.web.api.kb._list_documents_for_user", return_value=records),
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
-    ):
-        response = client.delete(
-            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt?doc_id=doc-1",
-            headers=headers,
-        )
-
-    assert response.status_code == 200
-    mock_delete_document.assert_called_once_with(
-        collection_name,
-        "doc-1",
-        int(user.id),
-        False,
-    )
-
-
-def test_delete_document_rejects_path_traversal_in_collection_name(
-    test_env, temp_uploads
-):
-    app, headers, user, _ = test_env
-    client = TestClient(app)
-
-    from urllib.parse import quote
-
-    malicious_collections = [
-        r"collection\\other",
-        r"collection\\..\\other",
-    ]
-
-    for collection_name in malicious_collections:
-        response = client.delete(
-            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt",
-            headers=headers,
-        )
-
-        assert response.status_code == 422
-        assert "Invalid collection name" in response.json()["detail"]
-
-
 def test_delete_document_prefers_file_id_and_cleans_orphan_file(test_env, temp_uploads):
     """Deleting by file_id should remove the UploadedFile row when it becomes orphaned."""
     app, headers, user, TestingSessionLocal = test_env

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -236,7 +236,6 @@ def test_kb_ingest_rejects_invalid_characters_in_collection_name(
     client = TestClient(app)
 
     invalid_collections = [
-        "collection name",  # Space
         "collection@name",  # @ symbol
         "collection#name",  # # symbol
         "collection/name",  # Path separator
@@ -288,6 +287,70 @@ def test_kb_ingest_accepts_unicode_collection_name(test_env, temp_uploads):
         assert expected_path.exists()
 
 
+def test_kb_ingest_accepts_space_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    collection_name = "team notes"
+    filename = "test_doc.txt"
+
+    with patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest:
+        from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+        mock_ingest.return_value = IngestionResult(
+            status="success",
+            doc_id="test_doc_id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": (filename, b"content", "text/plain")},
+            data={"collection": collection_name},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        expected_path = temp_uploads / f"user_{user.id}" / collection_name / filename
+        assert expected_path.exists()
+
+
+def test_kb_ingest_normalizes_padded_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    collection_name = "  team notes  "
+    filename = "test_doc.txt"
+    captured_collections: list[str] = []
+
+    def _capture_ingest(*, collection=None, **kwargs):
+        captured_collections.append(str(collection))
+        from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+        return IngestionResult(
+            status="success",
+            doc_id="test_doc_id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+    with patch("xagent.web.api.kb.run_document_ingestion", side_effect=_capture_ingest):
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": (filename, b"content", "text/plain")},
+            data={"collection": collection_name},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert captured_collections == ["team notes"]
+    expected_path = temp_uploads / f"user_{user.id}" / "team notes" / filename
+    assert expected_path.exists()
+
+
 def test_kb_ingest_rejects_too_long_collection_name(test_env, temp_uploads):
     """Test that ingest API rejects collection names exceeding length limit."""
     app, headers, user, _ = test_env
@@ -321,7 +384,6 @@ def test_kb_ingest_validates_derived_collection_name_from_filename(
     # Note: "../../../etc.txt" becomes "etc.txt" after basename, which is valid
     # So we test actual invalid cases
     malicious_filenames = [
-        "file name.txt",  # Would create "file name" with space
         "file@name.txt",  # Would create "file@name" with invalid character
     ]
 
@@ -338,6 +400,104 @@ def test_kb_ingest_validates_derived_collection_name_from_filename(
             assert response.status_code == 422
             detail = response.json().get("detail", "")
             assert "Invalid collection name" in detail or "invalid" in detail.lower()
+
+
+def test_kb_ingest_accepts_derived_collection_name_with_spaces(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    filename = "file name.txt"
+
+    with patch("xagent.web.api.kb.run_document_ingestion") as mock_ingest:
+        from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+        mock_ingest.return_value = IngestionResult(
+            status="success",
+            doc_id="test_doc_id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": (filename, b"content", "text/plain")},
+            data={},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        expected_path = temp_uploads / f"user_{user.id}" / "file name" / filename
+        assert expected_path.exists()
+
+
+def test_kb_delete_accepts_space_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "team notes"
+    coll_dir = temp_uploads / f"user_{user.id}" / collection_name
+    coll_dir.mkdir(parents=True, exist_ok=True)
+    (coll_dir / "some_file.txt").write_text("data")
+
+    with patch("xagent.web.api.kb.delete_collection") as mock_delete:
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+
+        mock_delete.return_value = CollectionOperationResult(
+            status="success",
+            collection=collection_name,
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+        response = client.delete(
+            f"/api/kb/collections/{quote(collection_name, safe='')}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+
+
+def test_kb_delete_normalizes_padded_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "team notes"
+    coll_dir = temp_uploads / f"user_{user.id}" / collection_name
+    coll_dir.mkdir(parents=True, exist_ok=True)
+    (coll_dir / "some_file.txt").write_text("data")
+
+    deleted_collections: list[str] = []
+
+    def _capture_delete(collection, user_id, is_admin):
+        deleted_collections.append(str(collection))
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+
+        return CollectionOperationResult(
+            status="success",
+            collection=collection,
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+    with patch("xagent.web.api.kb.delete_collection", side_effect=_capture_delete):
+        response = client.delete(
+            f"/api/kb/collections/{quote('  team notes  ', safe='')}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert deleted_collections == [collection_name]
 
 
 def test_kb_delete_rejects_path_traversal_in_collection_name(test_env, temp_uploads):
@@ -408,6 +568,93 @@ def test_kb_delete_rejects_mixed_script_confusable_collection_name(
 
     assert response.status_code == 422
     assert "Invalid collection name" in response.json()["detail"]
+
+
+def test_kb_ingest_rejects_utf8_byte_overflow_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    collection_name = "知" * 86
+    filename = "test_doc.txt"
+
+    with patch("xagent.web.api.kb.run_document_ingestion"):
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": (filename, b"content", "text/plain")},
+            data={"collection": collection_name},
+            headers=headers,
+        )
+
+    assert response.status_code == 422
+    assert "maximum byte length" in response.json()["detail"]
+
+
+def test_save_collection_config_normalizes_padded_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_store = MagicMock()
+    mock_store.save_collection_config = AsyncMock()
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+        return_value=mock_store,
+    ):
+        response = client.post(
+            "/api/kb/collections/%20%20team%20notes%20%20/config",
+            json={},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    mock_store.save_collection_config.assert_awaited_once_with(
+        collection="team notes",
+        config_json="{}",
+        user_id=int(user.id),
+    )
+    assert response.json()["collection"] == "team notes"
+
+
+def test_kb_search_normalizes_padded_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    captured_collections: list[str] = []
+
+    def _capture_search(*, collection=None, **kwargs):
+        captured_collections.append(str(collection))
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            SearchPipelineResult,
+            SearchType,
+        )
+
+        return SearchPipelineResult(
+            status="success",
+            search_type=SearchType.HYBRID,
+            results=[],
+            result_count=0,
+            warnings=[],
+            message="ok",
+            used_rerank=False,
+        )
+
+    with patch("xagent.web.api.kb.run_document_search", side_effect=_capture_search):
+        response = client.post(
+            "/api/kb/search",
+            data={
+                "collection": "  team notes  ",
+                "query_text": "hello",
+                "embedding_model_id": "text-embedding-v4",
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert captured_collections == ["team notes"]
 
 
 def test_kb_delete_physical_cleanup_failure_aborts_operation(test_env, temp_uploads):
@@ -615,6 +862,47 @@ def test_kb_rename_physical_directory_rename(test_env, temp_uploads):
             # If database operations failed, old directory should still exist
             # (physical rename might have happened but was rolled back, or didn't happen)
             pass
+
+
+def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    old_collection_name = "team notes"
+    new_collection_name = "project archive"
+
+    old_coll_dir = temp_uploads / f"user_{user.id}" / old_collection_name
+    old_coll_dir.mkdir(parents=True, exist_ok=True)
+    (old_coll_dir / "some_file.txt").write_text("data")
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections._list_table_names"
+        ) as mock_list_tables,
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+    ):
+        from unittest.mock import MagicMock
+
+        mock_list_tables.return_value = []
+        mock_store = MagicMock()
+        mock_db_conn = MagicMock()
+        mock_table = MagicMock()
+        mock_table.count_rows.return_value = 0
+        mock_db_conn.open_table.return_value = mock_table
+        mock_store.get_raw_connection.return_value = mock_db_conn
+        mock_store_factory.return_value = mock_store
+
+        response = client.put(
+            "/api/kb/collections/%20%20team%20notes%20%20",
+            data={"new_name": "  project archive  "},
+            headers=headers,
+        )
+
+    assert response.status_code in [200, 500]
+    if response.status_code == 200:
+        new_coll_dir = temp_uploads / f"user_{user.id}" / new_collection_name
+        assert new_coll_dir.exists()
+        assert not old_coll_dir.exists()
 
 
 def test_kb_rename_physical_rename_failure_aborts_operation(test_env, temp_uploads):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
 from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.core.tools.core.RAG_tools.utils.string_utils import (
     generate_deterministic_doc_id,
@@ -350,7 +351,6 @@ def test_kb_delete_rejects_path_traversal_in_collection_name(test_env, temp_uplo
     ]
 
     for collection_name in malicious_collections:
-        # URL encode the collection name for the path parameter
         from urllib.parse import quote
 
         encoded_name = quote(collection_name, safe="")
@@ -870,6 +870,119 @@ def test_check_documents_exist_prefers_uploaded_file_filename(test_env, temp_upl
 
     assert response.status_code == 200
     assert response.json()["existing_filenames"] == ["actual_name.txt", "old_name.txt"]
+
+
+def test_check_documents_exist_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "示例知识库集合"
+
+    with patch("xagent.web.api.kb.get_vector_index_store") as mock_get_store:
+        mock_store = mock_get_store.return_value
+        mock_store.list_document_records.return_value = []
+
+        response = client.post(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/check",
+            json={"filenames": ["demo.txt"]},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    mock_store.list_document_records.assert_called_once_with(
+        collection_name=collection_name,
+        user_id=int(user.id),
+        is_admin=False,
+        max_results=DEFAULT_VECTOR_STORE_SCAN_LIMIT,
+    )
+    assert response.json()["existing_filenames"] == []
+
+
+def test_check_documents_exist_rejects_path_traversal_in_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    malicious_collections = [
+        r"collection\\other",
+        r"collection\\..\\other",
+    ]
+
+    for collection_name in malicious_collections:
+        response = client.post(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/check",
+            json={"filenames": ["demo.txt"]},
+            headers=headers,
+        )
+
+        assert response.status_code == 422
+        assert "Invalid collection name" in response.json()["detail"]
+
+
+def test_delete_document_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "示例知识库集合"
+    file_path = temp_uploads / f"user_{user.id}" / collection_name / "demo.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    records = [
+        {
+            "doc_id": "doc-1",
+            "source_path": str(file_path),
+        }
+    ]
+
+    with (
+        patch("xagent.web.api.kb._list_documents_for_user", return_value=records),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
+        ) as mock_delete_document,
+    ):
+        response = client.delete(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt?doc_id=doc-1",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    mock_delete_document.assert_called_once_with(
+        collection_name,
+        "doc-1",
+        int(user.id),
+        False,
+    )
+
+
+def test_delete_document_rejects_path_traversal_in_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    malicious_collections = [
+        r"collection\\other",
+        r"collection\\..\\other",
+    ]
+
+    for collection_name in malicious_collections:
+        response = client.delete(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt",
+            headers=headers,
+        )
+
+        assert response.status_code == 422
+        assert "Invalid collection name" in response.json()["detail"]
 
 
 def test_delete_document_prefers_file_id_and_cleans_orphan_file(test_env, temp_uploads):
@@ -1742,6 +1855,64 @@ def test_kb_delete_collection_cleans_file_id_managed_root_file(test_env, temp_up
         assert deleted_record is None
     finally:
         session.close()
+
+
+def test_get_parse_result_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "示例知识库集合"
+    elements = [{"type": "text", "text": "hello", "metadata": {}}]
+    pagination = {"page": 1, "page_size": 20, "total_count": 1, "total_pages": 1}
+
+    with (
+        patch(
+            "xagent.web.api.kb.reconstruct_parse_result_from_db",
+            return_value=(elements, "hash-1"),
+        ) as mock_reconstruct,
+        patch(
+            "xagent.web.api.kb.paginate_parse_results",
+            return_value=(elements, pagination),
+        ),
+    ):
+        response = client.get(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/parses/doc-1/parse_result",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    mock_reconstruct.assert_called_once_with(
+        collection_name,
+        "doc-1",
+        None,
+        user_id=int(user.id),
+        is_admin=False,
+    )
+
+
+def test_get_parse_result_rejects_path_traversal_in_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    malicious_collections = [
+        r"collection\\other",
+        r"collection\\..\\other",
+    ]
+
+    for collection_name in malicious_collections:
+        response = client.get(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/parses/doc-1/parse_result",
+            headers=headers,
+        )
+
+        assert response.status_code == 422
+        assert "Invalid collection name" in response.json()["detail"]
 
 
 def test_list_collections_secondary_fallback_avoids_n_plus_one(test_env, temp_uploads):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -905,6 +905,49 @@ def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
         assert not old_coll_dir.exists()
 
 
+def test_kb_rename_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    old_collection_name = "示例知识库集合"
+    new_collection_name = "知识库归档"
+
+    old_coll_dir = temp_uploads / f"user_{user.id}" / old_collection_name
+    old_coll_dir.mkdir(parents=True, exist_ok=True)
+    (old_coll_dir / "some_file.txt").write_text("data")
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections._list_table_names"
+        ) as mock_list_tables,
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+    ):
+        from unittest.mock import MagicMock
+
+        mock_list_tables.return_value = []
+        mock_store = MagicMock()
+        mock_db_conn = MagicMock()
+        mock_table = MagicMock()
+        mock_table.count_rows.return_value = 0
+        mock_db_conn.open_table.return_value = mock_table
+        mock_store.get_raw_connection.return_value = mock_db_conn
+        mock_store_factory.return_value = mock_store
+
+        response = client.put(
+            f"/api/kb/collections/{quote(old_collection_name, safe='')}",
+            data={"new_name": new_collection_name},
+            headers=headers,
+        )
+
+    assert response.status_code in [200, 500]
+    if response.status_code == 200:
+        new_coll_dir = temp_uploads / f"user_{user.id}" / new_collection_name
+        assert new_coll_dir.exists()
+        assert not old_coll_dir.exists()
+
+
 def test_kb_rename_physical_rename_failure_aborts_operation(test_env, temp_uploads):
     """Test that physical rename failure aborts database update."""
     app, headers, user, _ = test_env

--- a/tests/web/test_config.py
+++ b/tests/web/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from xagent.web.config import (
     FILE_STORAGE_URL_BASE,
+    MAX_COLLECTION_NAME_BYTES,
     MAX_COLLECTION_NAME_LENGTH,
     get_file_url,
     sanitize_path_component,
@@ -17,6 +18,7 @@ class TestSanitizePathComponent:
         """Test that valid collection names are accepted."""
         valid_names = [
             "my_collection",
+            "my collection",
             "collection-123",
             "test123",
             "a",
@@ -84,10 +86,29 @@ class TestSanitizePathComponent:
         ):
             sanitize_path_component(too_long_name, "collection")
 
+    def test_utf8_byte_length_limit(self):
+        """Test that UTF-8 byte-length limits are enforced for Unicode names."""
+        within_limit_name = "知" * (
+            MAX_COLLECTION_NAME_BYTES // len("知".encode("utf-8"))
+        )
+        assert (
+            sanitize_path_component(within_limit_name, "collection")
+            == within_limit_name
+        )
+
+        over_limit_name = "知" * (
+            (MAX_COLLECTION_NAME_BYTES // len("知".encode("utf-8"))) + 1
+        )
+        assert len(over_limit_name) < MAX_COLLECTION_NAME_LENGTH
+        with pytest.raises(
+            ValueError,
+            match=f"exceeds maximum byte length of {MAX_COLLECTION_NAME_BYTES}",
+        ):
+            sanitize_path_component(over_limit_name, "collection")
+
     def test_invalid_characters(self):
         """Test that invalid characters are rejected."""
         invalid_names = [
-            "collection name",  # Space
             "collection@name",  # @ symbol
             "collection#name",  # # symbol
             "collection$name",  # $ symbol
@@ -119,10 +140,12 @@ class TestSanitizePathComponent:
                 sanitize_path_component(name, "collection")
 
     def test_valid_special_characters(self):
-        """Test that allowed special characters (underscore, hyphen) are accepted."""
+        """Test that allowed spaces and special characters are accepted."""
         valid_names = [
+            "collection name",
             "collection_name",
             "collection-name",
+            "collection name-123",
             "collection_name-123",
             "collection-123_name",
             "_collection",
@@ -138,9 +161,9 @@ class TestSanitizePathComponent:
     def test_whitespace_stripping(self):
         """Test that leading/trailing whitespace is stripped before validation."""
         # Valid name with whitespace should be stripped and accepted
-        name_with_whitespace = "  my_collection  "
+        name_with_whitespace = "  my collection  "
         result = sanitize_path_component(name_with_whitespace, "collection")
-        assert result == "my_collection"
+        assert result == "my collection"
 
         # But if after stripping it becomes invalid, it should be rejected
         with pytest.raises(ValueError, match="cannot be empty"):

--- a/tests/web/test_config.py
+++ b/tests/web/test_config.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from xagent.web.config import MAX_COLLECTION_NAME_LENGTH, sanitize_path_component
+from xagent.web.config import (
+    FILE_STORAGE_URL_BASE,
+    MAX_COLLECTION_NAME_LENGTH,
+    get_file_url,
+    sanitize_path_component,
+)
 
 
 class TestSanitizePathComponent:
@@ -201,3 +206,17 @@ class TestSanitizePathComponent:
         for name in mixed_names:
             result = sanitize_path_component(name, "collection")
             assert result == name
+
+
+class TestGetFileUrl:
+    def test_get_file_url_encodes_unicode_collection_and_filename(self):
+        collection_name = "示例知识库集合"
+        filename = "报告.txt"
+
+        url = get_file_url(filename, user_id=7, collection=collection_name)
+
+        assert url == (
+            f"{FILE_STORAGE_URL_BASE}/user_7/"
+            "%E7%A4%BA%E4%BE%8B%E7%9F%A5%E8%AF%86%E5%BA%93%E9%9B%86%E5%90%88/"
+            "%E6%8A%A5%E5%91%8A.txt"
+        )


### PR DESCRIPTION
## Summary
- allow Unicode characters in knowledge base collection names
- keep the existing path-safety checks while rejecting invalid or unsafe names
- add regression coverage for Unicode collection names in config and KB API tests