### PR TITLE
fix(kb): make document and collection deletes reliable

### DIFF
--- a/frontend/src/components/kb/knowledge-base-detail-helpers.test.ts
+++ b/frontend/src/components/kb/knowledge-base-detail-helpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+
+import { buildDeleteDocumentUrl, getCollectionDocuments, getDeleteErrorMessage } from "./knowledge-base-detail-helpers"
+
+describe("knowledge-base-detail helpers", () => {
+  it("prefers richer document metadata over legacy names", () => {
+    expect(
+      getCollectionDocuments({
+        document_names: ["report.pdf"],
+        document_metadata: [{ filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" }],
+      })
+    ).toEqual([{ filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" }])
+  })
+
+  it("falls back to legacy document_names when metadata is absent", () => {
+    expect(
+      getCollectionDocuments({
+        document_names: ["legacy.txt", "nested/path.md"],
+      })
+    ).toEqual([{ filename: "legacy.txt" }, { filename: "nested/path.md" }])
+  })
+
+  it("preserves legacy document_names when metadata is partial", () => {
+    expect(
+      getCollectionDocuments({
+        document_names: ["report.pdf", "legacy.txt", "extra.md"],
+        document_metadata: [{ filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" }],
+      })
+    ).toEqual([
+      { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+      { filename: "legacy.txt" },
+      { filename: "extra.md" },
+    ])
+  })
+
+  it("keeps same-filename metadata entries when their identifiers differ", () => {
+    expect(
+      getCollectionDocuments({
+        document_names: ["report.pdf"],
+        document_metadata: [
+          { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+          { filename: " report.pdf ", file_id: "file-456", doc_id: "doc-123" },
+          { filename: "report.pdf", file_id: "file-123", doc_id: "doc-789" },
+        ],
+      })
+    ).toEqual([
+      { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+      { filename: "report.pdf", file_id: "file-456", doc_id: "doc-123" },
+      { filename: "report.pdf", file_id: "file-123", doc_id: "doc-789" },
+    ])
+  })
+
+  it("dedupes exact metadata duplicates before considering legacy names", () => {
+    expect(
+      getCollectionDocuments({
+        document_names: ["report.pdf", "legacy.txt", "legacy.txt"],
+        document_metadata: [
+          { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+          { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+        ],
+      })
+    ).toEqual([
+      { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+      { filename: "legacy.txt" },
+    ])
+  })
+
+  it("builds delete urls with file_id first, then doc_id, then filename only", () => {
+    expect(
+      buildDeleteDocumentUrl("http://api.local", "demo", {
+        filename: "report.pdf",
+        file_id: "file-123",
+        doc_id: "doc-123",
+      })
+    ).toBe("http://api.local/api/kb/collections/demo/documents/report.pdf?file_id=file-123")
+
+    expect(
+      buildDeleteDocumentUrl("http://api.local", "demo", {
+        filename: "page.html",
+        doc_id: "doc-9",
+      })
+    ).toBe("http://api.local/api/kb/collections/demo/documents/page.html?doc_id=doc-9")
+
+    expect(
+      buildDeleteDocumentUrl("http://api.local", "demo", {
+        filename: "legacy.txt",
+      })
+    ).toBe("http://api.local/api/kb/collections/demo/documents/legacy.txt")
+  })
+
+  it("extracts the most useful delete error message defensively", () => {
+    expect(getDeleteErrorMessage({ detail: "ambiguous" }, "fallback")).toBe("ambiguous")
+    expect(getDeleteErrorMessage({ message: "failed" }, "fallback")).toBe("failed")
+    expect(getDeleteErrorMessage({ errors: ["first error"] }, "fallback")).toBe("first error")
+    expect(getDeleteErrorMessage(null, "fallback")).toBe("fallback")
+  })
+})

--- a/frontend/src/components/kb/knowledge-base-detail-helpers.ts
+++ b/frontend/src/components/kb/knowledge-base-detail-helpers.ts
@@ -1,0 +1,123 @@
+export interface CollectionDocumentInfo {
+  filename: string
+  file_id?: string
+  doc_id?: string
+}
+
+export interface CollectionDocumentSource {
+  document_names?: string[]
+  document_metadata?: CollectionDocumentInfo[]
+}
+
+export interface CollectionTranslator {
+  (key: string, vars?: Record<string, string | number>): string
+}
+
+function normalizeOptionalIdentifier(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined
+  }
+
+  const normalizedValue = value.trim()
+  return normalizedValue || undefined
+}
+
+function getDocumentIdentityKey(document: CollectionDocumentInfo): string {
+  return JSON.stringify([
+    document.filename,
+    normalizeOptionalIdentifier(document.file_id) ?? null,
+    normalizeOptionalIdentifier(document.doc_id) ?? null,
+  ])
+}
+
+export function getCollectionDocuments(collectionInfo: CollectionDocumentSource | null): CollectionDocumentInfo[] {
+  if (!collectionInfo) {
+    return []
+  }
+
+  const representedFilenames = new Set<string>()
+  const seenDocumentKeys = new Set<string>()
+  const documents: CollectionDocumentInfo[] = []
+
+  if (Array.isArray(collectionInfo.document_metadata) && collectionInfo.document_metadata.length > 0) {
+    for (const document of collectionInfo.document_metadata) {
+      if (typeof document.filename !== "string") {
+        continue
+      }
+      const normalizedFilename = document.filename.trim()
+      if (!normalizedFilename) {
+        continue
+      }
+
+      const normalizedDocument = {
+        ...document,
+        filename: normalizedFilename,
+        file_id: normalizeOptionalIdentifier(document.file_id),
+        doc_id: normalizeOptionalIdentifier(document.doc_id),
+      }
+      const documentKey = getDocumentIdentityKey(normalizedDocument)
+      if (seenDocumentKeys.has(documentKey)) {
+        continue
+      }
+
+      seenDocumentKeys.add(documentKey)
+      representedFilenames.add(normalizedFilename)
+      documents.push(normalizedDocument)
+    }
+  }
+
+  if (!Array.isArray(collectionInfo.document_names)) {
+    return documents
+  }
+
+  for (const filename of collectionInfo.document_names) {
+    if (typeof filename !== "string") {
+      continue
+    }
+    const normalizedFilename = filename.trim()
+    if (!normalizedFilename || representedFilenames.has(normalizedFilename)) {
+      continue
+    }
+
+    representedFilenames.add(normalizedFilename)
+    documents.push({ filename: normalizedFilename })
+  }
+
+  return documents
+}
+
+export function buildDeleteDocumentUrl(apiUrl: string, collectionName: string, document: CollectionDocumentInfo): string {
+  const baseUrl = `${apiUrl}/api/kb/collections/${encodeURIComponent(collectionName)}/documents/${encodeURIComponent(document.filename)}`
+  const query = new URLSearchParams()
+
+  if (document.file_id) {
+    query.set("file_id", document.file_id)
+  } else if (document.doc_id) {
+    query.set("doc_id", document.doc_id)
+  }
+
+  const queryString = query.toString()
+  return queryString ? `${baseUrl}?${queryString}` : baseUrl
+}
+
+export function getDeleteErrorMessage(result: unknown, fallbackMessage: string): string {
+  if (!result || typeof result !== "object") {
+    return fallbackMessage
+  }
+
+  const response = result as { detail?: unknown; message?: unknown; errors?: unknown }
+  if (typeof response.detail === "string" && response.detail) {
+    return response.detail
+  }
+  if (typeof response.message === "string" && response.message) {
+    return response.message
+  }
+  if (Array.isArray(response.errors)) {
+    const firstError = response.errors.find((error): error is string => typeof error === "string" && error.length > 0)
+    if (firstError) {
+      return firstError
+    }
+  }
+
+  return fallbackMessage
+}

--- a/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
@@ -1,0 +1,229 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: apiRequestMock,
+}))
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: () => "http://api.local",
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+vi.mock("lucide-react", () => {
+  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+  return {
+    FileIcon: Icon,
+    Trash2: Icon,
+  }
+})
+
+vi.mock("@radix-ui/react-tabs", () => ({
+  Trigger: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => <label {...props}>{children}</label>,
+}))
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) => (
+    isOpen ? <button onClick={onConfirm}>confirm-delete</button> : null
+  ),
+}))
+
+import { KnowledgeBaseDocumentList } from "./knowledge-base-document-list"
+
+function createJsonResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+function installApiMocks() {
+  apiRequestMock.mockImplementation((url: string) => {
+    if (url.startsWith("http://api.local/api/kb/collections/demo/documents/")) {
+      return Promise.resolve(createJsonResponse({ status: "success", message: "deleted" }))
+    }
+
+    throw new Error(`Unhandled apiRequest: ${url}`)
+  })
+}
+
+function renderDocumentList(collectionInfo: unknown, onRefresh = vi.fn().mockResolvedValue(undefined)) {
+  return render(
+    <KnowledgeBaseDocumentList
+      collectionInfo={collectionInfo as Parameters<typeof KnowledgeBaseDocumentList>[0]["collectionInfo"]}
+      collectionName="demo"
+      onRefresh={onRefresh}
+      t={(key: string) => key}
+    />
+  )
+}
+
+describe("KnowledgeBaseDetailContent delete flow", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("prefers file_id in the delete request when metadata is present", async () => {
+    installApiMocks()
+
+    renderDocumentList({
+      name: "demo",
+      documents: 1,
+      chunks: 0,
+      embeddings: 0,
+      parses: 0,
+      document_names: ["report.pdf"],
+      document_metadata: [{ filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" }],
+    })
+
+    fireEvent.click(screen.getByTitle("kb.detail.uploaded.delete"))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/collections/demo/documents/report.pdf?file_id=file-123",
+        { method: "DELETE" }
+      )
+    })
+  })
+
+  it("falls back to filename-only delete when metadata is absent", async () => {
+    installApiMocks()
+
+    renderDocumentList({
+      name: "demo",
+      documents: 1,
+      chunks: 0,
+      embeddings: 0,
+      parses: 0,
+      document_names: ["legacy.txt"],
+    })
+
+    fireEvent.click(screen.getByTitle("kb.detail.uploaded.delete"))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/collections/demo/documents/legacy.txt",
+        { method: "DELETE" }
+      )
+    })
+  })
+
+  it("refreshes the document list after a successful delete", async () => {
+    installApiMocks()
+    const onRefresh = vi.fn().mockResolvedValue(undefined)
+
+    renderDocumentList({
+      name: "demo",
+      documents: 1,
+      chunks: 0,
+      embeddings: 0,
+      parses: 0,
+      document_names: ["report.pdf"],
+      document_metadata: [{ filename: "report.pdf", file_id: "file-123" }],
+    }, onRefresh)
+
+    fireEvent.click(screen.getByTitle("kb.detail.uploaded.delete"))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("keeps duplicate filenames with different identifiers addressable for delete", async () => {
+    installApiMocks()
+
+    renderDocumentList({
+      name: "demo",
+      documents: 2,
+      chunks: 0,
+      embeddings: 0,
+      parses: 0,
+      document_names: ["report.pdf"],
+      document_metadata: [
+        { filename: "report.pdf", file_id: "file-123", doc_id: "doc-123" },
+        { filename: "report.pdf", file_id: "file-456", doc_id: "doc-456" },
+      ],
+    })
+
+    const deleteButtons = screen.getAllByTitle("kb.detail.uploaded.delete")
+    expect(deleteButtons).toHaveLength(2)
+
+    fireEvent.click(deleteButtons[1])
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/collections/demo/documents/report.pdf?file_id=file-456",
+        { method: "DELETE" }
+      )
+    })
+  })
+})

--- a/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
@@ -197,6 +197,33 @@ describe("KnowledgeBaseDetailContent delete flow", () => {
     })
   })
 
+  it("closes the confirm dialog before refresh failures surface", async () => {
+    installApiMocks()
+    const onRefresh = vi.fn().mockRejectedValue(new Error("refresh failed"))
+
+    renderDocumentList({
+      name: "demo",
+      documents: 1,
+      chunks: 0,
+      embeddings: 0,
+      parses: 0,
+      document_names: ["report.pdf"],
+      document_metadata: [{ filename: "report.pdf", file_id: "file-123" }],
+    }, onRefresh)
+
+    fireEvent.click(screen.getByTitle("kb.detail.uploaded.delete"))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(screen.queryByText("confirm-delete")).not.toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1)
+      expect(toastErrorMock).toHaveBeenCalledWith("refresh failed")
+    })
+  })
+
   it("keeps duplicate filenames with different identifiers addressable for delete", async () => {
     installApiMocks()
 

--- a/frontend/src/components/kb/knowledge-base-detail.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.tsx
@@ -19,6 +19,8 @@ import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { parseSeparatorsInput, formatSeparatorsOutput } from "@/lib/separators"
 import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "sonner"
+import { CollectionDocumentInfo } from "./knowledge-base-detail-helpers"
+import { KnowledgeBaseDocumentList } from "./knowledge-base-document-list"
 
 interface CollectionInfo {
   name: string
@@ -27,6 +29,7 @@ interface CollectionInfo {
   embeddings: number
   parses: number
   document_names?: string[]
+  document_metadata?: CollectionDocumentInfo[]
   ingestion_config?: Partial<IngestionConfig>
 }
 
@@ -274,56 +277,6 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
 
   const removeFile = (index: number) => {
     setSelectedFiles(prev => prev.filter((_, i) => i !== index))
-  }
-
-  const [documentToDelete, setDocumentToDelete] = useState<string | null>(null)
-  const [isDeletingDocument, setIsDeletingDocument] = useState(false)
-
-  const confirmDeleteDocument = async () => {
-    if (!documentToDelete) return
-    const fileName = documentToDelete
-    setIsDeletingDocument(true)
-
-    try {
-      console.log("Deleting document:", fileName)
-      const response = await apiRequest(
-        `${getApiUrl()}/api/kb/collections/${encodeURIComponent(collectionName)}/documents/${encodeURIComponent(fileName)}`,
-        { method: "DELETE" }
-      )
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || t("kb.detail.errors.deleteFailed"))
-      }
-
-      const result = await response.json()
-      console.log("Delete result:", result)
-
-      // Handle partial success or failure
-      if (result.status === "partial_success") {
-        toast.error(t("kb.detail.errors.partialSuccess", { message: result.message }))
-      } else if (result.status === "failed") {
-        toast.error(t("kb.detail.errors.deleteFailedWithMessage", { message: result.message }))
-        return
-      }
-
-      // Add brief delay to ensure backend data is updated
-      await new Promise(resolve => setTimeout(resolve, 500))
-
-      // Reload collection info
-      await fetchCollectionInfo()
-      console.log("Collection info refreshed")
-      setDocumentToDelete(null)
-    } catch (error) {
-      console.error("Delete error:", error)
-      toast.error(error instanceof Error ? error.message : t("kb.detail.errors.deleteFailed"))
-    } finally {
-      setIsDeletingDocument(false)
-    }
-  }
-
-  const handleDeleteDocument = (fileName: string) => {
-    setDocumentToDelete(fileName)
   }
 
   const doUpload = async () => {
@@ -680,42 +633,12 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
                 </Button>
               </div>
 
-              {collectionInfo.document_names && collectionInfo.document_names.length > 0 ? (
-                <ScrollArea className="h-96">
-                  <div className="space-y-3">
-                    {collectionInfo.document_names.map((fileName, index) => (
-                      <div key={index} className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors">
-                        <div className="flex items-center gap-3">
-                          <FileIcon className="h-5 w-5 text-blue-500" />
-                          <div className="flex-1">
-                            <p className="font-medium text-sm">{fileName.split('/').pop() || fileName}</p>
-                            <p className="text-xs text-muted-foreground">{fileName}</p>
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="secondary" className="text-xs">
-                            {t("kb.detail.uploaded.indexed")}
-                          </Badge>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDeleteDocument(fileName)}
-                            title={t("kb.detail.uploaded.delete") || "Delete document"}
-                          >
-                            <Trash2 size={14} />
-                          </Button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </ScrollArea>
-              ) : (
-                <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-                  <FileIcon className="h-16 w-16 mb-4 opacity-30" />
-                  <p className="text-lg font-medium mb-2">{t("kb.detail.uploaded.emptyTitle")}</p>
-                  <p className="text-sm text-center">{t("kb.detail.uploaded.emptyHint")}</p>
-                </div>
-              )}
+              <KnowledgeBaseDocumentList
+                collectionInfo={collectionInfo}
+                collectionName={collectionName}
+                onRefresh={fetchCollectionInfo}
+                t={t}
+              />
             </div>
 
             {/* Hidden Input for File Selection */}
@@ -1285,13 +1208,6 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
             )}
           </DialogContent>
         </Dialog>
-      <ConfirmDialog
-        isOpen={!!documentToDelete}
-        onOpenChange={(open) => !open && setDocumentToDelete(null)}
-        onConfirm={confirmDeleteDocument}
-        isLoading={isDeletingDocument}
-        description={t("kb.detail.uploaded.confirmDelete")}
-      />
     </div>
   )
 }

--- a/frontend/src/components/kb/knowledge-base-document-list.tsx
+++ b/frontend/src/components/kb/knowledge-base-document-list.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react"
+import { FileIcon, Trash2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { apiRequest } from "@/lib/api-wrapper"
+import { getApiUrl } from "@/lib/utils"
+import { toast } from "sonner"
+
+import { buildDeleteDocumentUrl, CollectionDocumentInfo, CollectionDocumentSource, getCollectionDocuments, getDeleteErrorMessage } from "./knowledge-base-detail-helpers"
+
+interface KnowledgeBaseDocumentListProps {
+  collectionInfo: CollectionDocumentSource
+  collectionName: string
+  onRefresh: () => Promise<void>
+  t: (key: string, vars?: Record<string, string | number>) => string
+}
+
+export function KnowledgeBaseDocumentList({
+  collectionInfo,
+  collectionName,
+  onRefresh,
+  t,
+}: KnowledgeBaseDocumentListProps) {
+  const [documentToDelete, setDocumentToDelete] = useState<CollectionDocumentInfo | null>(null)
+  const [isDeletingDocument, setIsDeletingDocument] = useState(false)
+  const collectionDocuments = getCollectionDocuments(collectionInfo)
+
+  const confirmDeleteDocument = async () => {
+    if (!documentToDelete) return
+    setIsDeletingDocument(true)
+
+    try {
+      const response = await apiRequest(buildDeleteDocumentUrl(getApiUrl(), collectionName, documentToDelete), { method: "DELETE" })
+      const result = await response.json().catch(() => null)
+
+      if (!response.ok) {
+        throw new Error(getDeleteErrorMessage(result, t("kb.detail.errors.deleteFailed")))
+      }
+
+      const status = typeof result?.status === "string" ? result.status : undefined
+      const message = typeof result?.message === "string" ? result.message : t("kb.detail.errors.deleteFailed")
+      const rawErrors: unknown[] = Array.isArray(result?.errors) ? result.errors : []
+      const errors = rawErrors.filter((error): error is string => typeof error === "string" && error.length > 0)
+
+      if (status === "partial_success") {
+        toast.error(errors[0] || t("kb.detail.errors.partialSuccess", { message }))
+      } else if (status === "failed") {
+        toast.error(errors[0] || t("kb.detail.errors.deleteFailedWithMessage", { message }))
+        return
+      } else if (status && status !== "success") {
+        toast.error(errors[0] || message)
+        return
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 500))
+      await onRefresh()
+      setDocumentToDelete(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t("kb.detail.errors.deleteFailed"))
+    } finally {
+      setIsDeletingDocument(false)
+    }
+  }
+
+  if (collectionDocuments.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+        <FileIcon className="h-16 w-16 mb-4 opacity-30" />
+        <p className="text-lg font-medium mb-2">{t("kb.detail.uploaded.emptyTitle")}</p>
+        <p className="text-sm text-center">{t("kb.detail.uploaded.emptyHint")}</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <ScrollArea className="h-96">
+        <div className="space-y-3">
+          {collectionDocuments.map((document, index) => (
+            <div key={`${document.filename}-${document.file_id || document.doc_id || index}`} className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+              <div className="flex items-center gap-3">
+                <FileIcon className="h-5 w-5 text-blue-500" />
+                <div className="flex-1">
+                  <p className="font-medium text-sm">{document.filename.split('/').pop() || document.filename}</p>
+                  <p className="text-xs text-muted-foreground">{document.filename}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary" className="text-xs">
+                  {t("kb.detail.uploaded.indexed")}
+                </Badge>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setDocumentToDelete(document)}
+                  title={t("kb.detail.uploaded.delete") || "Delete document"}
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+      <ConfirmDialog
+        isOpen={!!documentToDelete}
+        onOpenChange={(open) => !open && setDocumentToDelete(null)}
+        onConfirm={confirmDeleteDocument}
+        isLoading={isDeletingDocument}
+        description={t("kb.detail.uploaded.confirmDelete")}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/kb/knowledge-base-document-list.tsx
+++ b/frontend/src/components/kb/knowledge-base-document-list.tsx
@@ -55,9 +55,9 @@ export function KnowledgeBaseDocumentList({
         return
       }
 
+      setDocumentToDelete(null)
       await new Promise(resolve => setTimeout(resolve, 500))
       await onRefresh()
-      setDocumentToDelete(null)
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t("kb.detail.errors.deleteFailed"))
     } finally {

--- a/frontend/src/components/pages/knowledge-base.test.tsx
+++ b/frontend/src/components/pages/knowledge-base.test.tsx
@@ -1,0 +1,219 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+const toastWarningMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: apiRequestMock,
+}))
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: () => "http://api.local",
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string, vars?: Record<string, string | number>) => {
+      if (vars?.name) {
+        return `${key}:${vars.name}`
+      }
+
+      return key
+    },
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: vi.fn(),
+    warning: toastWarningMock,
+  },
+}))
+
+vi.mock("lucide-react", () => {
+  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+  return {
+    Plus: Icon,
+    FileText: Icon,
+    FolderOpen: Icon,
+    HardDrive: Icon,
+    Trash2: Icon,
+  }
+})
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock("@/components/ui/search-input", () => ({
+  SearchInput: ({ value, onChange, containerClassName: _containerClassName, ...props }: { value: string; onChange: (value: string) => void; containerClassName?: string }) => (
+    <input {...props} value={value} onChange={(event) => onChange(event.target.value)} />
+  ),
+}))
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}))
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) => (open ? <div>{children}</div> : null),
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/kb/knowledge-base-detail", () => ({
+  KnowledgeBaseDetailContent: ({ collectionName }: { collectionName: string }) => <div>{collectionName}</div>,
+}))
+
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+
+vi.mock("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) => (
+    isOpen ? <button onClick={onConfirm}>confirm-delete</button> : null
+  ),
+}))
+
+import { KnowledgeBasePage } from "./knowledge-base"
+
+function createJsonResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+describe("KnowledgeBasePage", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
+    toastWarningMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("shows the collection delete action in the detail sheet flow", async () => {
+    let collectionFetchCount = 0
+
+    apiRequestMock.mockImplementation((url: string, options?: { method?: string }) => {
+      if (url === "http://api.local/api/kb/collections" && !options) {
+        collectionFetchCount += 1
+
+        if (collectionFetchCount === 1) {
+          return Promise.resolve(createJsonResponse({
+            collections: [{
+              name: "demo",
+              documents: 1,
+              parses: 0,
+              chunks: 2,
+              embeddings: 3,
+              document_names: ["report.pdf"],
+            }],
+          }))
+        }
+
+        return Promise.resolve(createJsonResponse({ collections: [] }))
+      }
+
+      if (url === "http://api.local/api/kb/collections/demo" && options?.method === "DELETE") {
+        return Promise.resolve(createJsonResponse({ status: "success" }))
+      }
+
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    render(<KnowledgeBasePage />)
+
+    await screen.findByText("demo")
+
+    fireEvent.click(screen.getByText("demo"))
+
+    expect(screen.getByRole("button", { name: "common.delete" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "common.delete" }))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/collections/demo",
+        { method: "DELETE" }
+      )
+    })
+
+    await waitFor(() => {
+      expect(collectionFetchCount).toBe(2)
+      expect(screen.getByText("kb.empty.noKB")).toBeInTheDocument()
+    })
+  })
+
+  it("warns but still refreshes when collection delete is only partially successful", async () => {
+    let collectionFetchCount = 0
+
+    apiRequestMock.mockImplementation((url: string, options?: { method?: string }) => {
+      if (url === "http://api.local/api/kb/collections" && !options) {
+        collectionFetchCount += 1
+
+        if (collectionFetchCount === 1) {
+          return Promise.resolve(createJsonResponse({
+            collections: [{
+              name: "demo",
+              documents: 1,
+              parses: 0,
+              chunks: 2,
+              embeddings: 3,
+              document_names: ["report.pdf"],
+            }],
+          }))
+        }
+
+        return Promise.resolve(createJsonResponse({ collections: [] }))
+      }
+
+      if (url === "http://api.local/api/kb/collections/demo" && options?.method === "DELETE") {
+        return Promise.resolve(createJsonResponse({
+          status: "partial_success",
+          message: "cleanup warning",
+          warnings: ["cleanup warning"],
+        }))
+      }
+
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    render(<KnowledgeBasePage />)
+
+    await screen.findByText("demo")
+
+    fireEvent.click(screen.getByText("demo"))
+    fireEvent.click(screen.getByRole("button", { name: "common.delete" }))
+    fireEvent.click(screen.getByText("confirm-delete"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/collections/demo",
+        { method: "DELETE" }
+      )
+    })
+
+    await waitFor(() => {
+      expect(collectionFetchCount).toBe(2)
+      expect(screen.getByText("kb.empty.noKB")).toBeInTheDocument()
+      expect(toastWarningMock).toHaveBeenCalledWith("cleanup warning")
+    })
+  })
+})

--- a/frontend/src/components/pages/knowledge-base.tsx
+++ b/frontend/src/components/pages/knowledge-base.tsx
@@ -1,23 +1,24 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import React, { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { SearchInput } from "@/components/ui/search-input"
 import { Badge } from "@/components/ui/badge"
 import { Card } from "@/components/ui/card"
 import { getApiUrl } from "@/lib/utils"
-import { useAuth } from "@/contexts/auth-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { apiRequest } from "@/lib/api-wrapper"
 import {
   Plus,
   FileText,
   FolderOpen,
-  HardDrive
+  HardDrive,
+  Trash2,
 } from "lucide-react"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet"
 import { KnowledgeBaseDetailContent } from "@/components/kb/knowledge-base-detail"
 import { KnowledgeBaseCreationDialog } from "@/components/kb/knowledge-base-creation-dialog"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { toast } from "sonner"
 
 interface Collection {
@@ -30,8 +31,7 @@ interface Collection {
 }
 
 export function KnowledgeBasePage() {
-  const { token } = useAuth()
-  const { t, locale } = useI18n()
+  const { t } = useI18n()
   const [collections, setCollections] = useState<Collection[]>([])
   const [loading, setLoading] = useState(true)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
@@ -39,6 +39,8 @@ export function KnowledgeBasePage() {
   const [filteredCollections, setFilteredCollections] = useState<Collection[]>([])
   const [selectedCollection, setSelectedCollection] = useState<string | null>(null)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [collectionToDelete, setCollectionToDelete] = useState<string | null>(null)
+  const [isDeletingCollection, setIsDeletingCollection] = useState(false)
 
   useEffect(() => {
     fetchCollections()
@@ -77,6 +79,69 @@ export function KnowledgeBasePage() {
   const handleViewDetail = (collectionName: string) => {
     setSelectedCollection(collectionName)
     setIsDrawerOpen(true)
+  }
+
+  const handleDrawerOpenChange = (open: boolean) => {
+    setIsDrawerOpen(open)
+
+    if (!open) {
+      setSelectedCollection(null)
+    }
+  }
+
+  const handleDeleteCollection = async () => {
+    if (!collectionToDelete) {
+      return
+    }
+
+    const targetCollection = collectionToDelete
+    setIsDeletingCollection(true)
+
+    try {
+      const response = await apiRequest(
+        `${getApiUrl()}/api/kb/collections/${encodeURIComponent(targetCollection)}`,
+        { method: "DELETE" }
+      )
+      const result = await response.json().catch(() => null)
+
+      if (!response.ok) {
+        const errorMessage = typeof result?.detail === "string"
+          ? result.detail
+          : typeof result?.message === "string"
+            ? result.message
+            : t("kb.errors.deleteFailed", { name: targetCollection })
+
+        throw new Error(errorMessage)
+      }
+
+      const status = typeof result?.status === "string" ? result.status : undefined
+      const message = typeof result?.message === "string" ? result.message : ""
+      const rawWarnings: unknown[] = Array.isArray(result?.warnings) ? result.warnings : []
+      const warnings = rawWarnings.filter(
+        (warning: unknown): warning is string => typeof warning === "string" && warning.length > 0
+      )
+
+      if (status === "failed") {
+        throw new Error(warnings[0] || message || t("kb.errors.deleteFailed", { name: targetCollection }))
+      }
+
+      if (status && status !== "success" && status !== "partial_success") {
+        throw new Error(warnings[0] || message || t("kb.errors.deleteFailed", { name: targetCollection }))
+      }
+
+      setCollectionToDelete(null)
+      setSelectedCollection(null)
+      setIsDrawerOpen(false)
+      await fetchCollections()
+
+      if (status === "partial_success") {
+        toast.warning(warnings[0] || message || t("kb.errors.deleteFailedGeneric"))
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t("kb.errors.deleteFailedGeneric"))
+    } finally {
+      setIsDeletingCollection(false)
+    }
   }
 
   if (loading) {
@@ -186,13 +251,28 @@ export function KnowledgeBasePage() {
       />
 
       {/* Detail Drawer */}
-      <Sheet open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+      <Sheet open={isDrawerOpen} onOpenChange={handleDrawerOpenChange}>
         <SheetContent className="w-[90vw] sm:max-w-[85vw] md:max-w-[1000px] overflow-y-auto">
           <SheetHeader>
-            <SheetTitle>{selectedCollection || ""}</SheetTitle>
-            <SheetDescription>
-              {selectedCollection ? t("kb.detail.viewingDetails", { name: selectedCollection }) : ""}
-            </SheetDescription>
+            <div className="flex items-start justify-between gap-4 pr-8">
+              <div className="space-y-1">
+                <SheetTitle>{selectedCollection || ""}</SheetTitle>
+                <SheetDescription>
+                  {selectedCollection ? t("kb.detail.viewingDetails", { name: selectedCollection }) : ""}
+                </SheetDescription>
+              </div>
+              {selectedCollection && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 text-destructive hover:text-destructive"
+                  onClick={() => setCollectionToDelete(selectedCollection)}
+                >
+                  <Trash2 size={16} />
+                  {t("common.delete")}
+                </Button>
+              )}
+            </div>
           </SheetHeader>
           <div className="h-full pb-10">
             {selectedCollection && (
@@ -201,6 +281,14 @@ export function KnowledgeBasePage() {
           </div>
         </SheetContent>
       </Sheet>
+
+      <ConfirmDialog
+        isOpen={!!collectionToDelete}
+        onOpenChange={(open) => !open && setCollectionToDelete(null)}
+        onConfirm={handleDeleteCollection}
+        isLoading={isDeletingCollection}
+        description={t("kb.actions.deleteConfirm", { name: collectionToDelete || "" })}
+      />
     </div>
   )
 }

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1258,6 +1258,18 @@ class DocumentProcessingRecord(BaseModel):
     )
 
 
+class CollectionDocumentMetadata(BaseModel):
+    filename: str = Field(..., description="Display filename for the document")
+    file_id: Optional[str] = Field(
+        default=None,
+        description="UploadedFile identifier when available",
+    )
+    doc_id: Optional[str] = Field(
+        default=None,
+        description="Knowledge base document identifier when available",
+    )
+
+
 class CollectionInfo(BaseModel):
     """Aggregate metadata for a single collection with embedding binding."""
 
@@ -1295,6 +1307,10 @@ class CollectionInfo(BaseModel):
     document_names: List[str] = Field(
         default_factory=list,
         description="Distinct source paths for documents within the collection",
+    )
+    document_metadata: List[CollectionDocumentMetadata] = Field(
+        default_factory=list,
+        description="Minimal per-document metadata for UI actions like unambiguous delete",
     )
 
     # ⚙️ Configuration management
@@ -1393,7 +1409,7 @@ class CollectionInfo(BaseModel):
         """Serialize for LanceDB storage."""
         import json
 
-        data = self.model_dump()
+        data = self.model_dump(exclude={"document_metadata"})
 
         # Serialize complex types to JSON strings for LanceDB
         data["extra_metadata"] = json.dumps(data["extra_metadata"])

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -21,6 +21,7 @@ from ..core.config import (
     DEFAULT_VECTOR_STORE_EXTENDED_SCAN_LIMIT,
 )
 from ..core.schemas import (
+    CollectionDocumentMetadata,
     CollectionInfo,
     CollectionOperationDetail,
     CollectionOperationResult,
@@ -524,18 +525,65 @@ async def list_collections(
             is_admin=is_admin,
         )
 
-        # Collect document names using storage abstraction
         document_names: Dict[str, Set[str]] = defaultdict(set)
+        document_metadata: Dict[str, List[CollectionDocumentMetadata]] = defaultdict(
+            list
+        )
+        document_metadata_seen: Dict[str, Set[tuple[str, str, str]]] = defaultdict(set)
+
+        def _normalize_optional_identifier(value: Any) -> Optional[str]:
+            if not isinstance(value, str):
+                return None
+            normalized = value.strip()
+            return normalized or None
+
+        def _add_document_entry(
+            collection_key: str,
+            source_value: Any,
+            doc_id_value: Any,
+            file_id_value: Any,
+        ) -> None:
+            import os
+
+            normalized_doc_id = _normalize_optional_identifier(doc_id_value)
+            normalized_file_id = _normalize_optional_identifier(file_id_value)
+            display_name = None
+            if source_value:
+                display_name = os.path.basename(str(source_value))
+            display_name = (display_name or normalized_doc_id or "").strip()
+            if not display_name:
+                return
+
+            document_names[collection_key].add(display_name)
+
+            dedupe_key = (
+                display_name,
+                normalized_file_id or "",
+                normalized_doc_id or "",
+            )
+            seen_keys = document_metadata_seen[collection_key]
+            if dedupe_key in seen_keys:
+                return
+            seen_keys.add(dedupe_key)
+            document_metadata[collection_key].append(
+                CollectionDocumentMetadata(
+                    filename=display_name,
+                    file_id=normalized_file_id,
+                    doc_id=normalized_doc_id,
+                )
+            )
 
         def _collect_document_names() -> None:
             for batch in vector_store.iter_batches(
                 table_name="documents",
-                columns=["collection", "source_path"],
+                columns=["collection", "source_path", "doc_id", "file_id"],
                 user_id=user_id,
                 is_admin=is_admin,
             ):
                 collection_idx = batch.schema.get_field_index("collection")
                 source_idx = batch.schema.get_field_index("source_path")
+                doc_id_idx = batch.schema.get_field_index("doc_id")
+                file_id_idx = batch.schema.get_field_index("file_id")
                 if collection_idx == -1:
                     continue
                 collection_array = batch.column(collection_idx)
@@ -544,18 +592,27 @@ async def list_collections(
                     if source_idx != -1
                     else pa.array([None] * batch.num_rows)
                 )
+                doc_id_array = (
+                    batch.column(doc_id_idx)
+                    if doc_id_idx != -1
+                    else pa.array([None] * batch.num_rows)
+                )
+                file_id_array = (
+                    batch.column(file_id_idx)
+                    if file_id_idx != -1
+                    else pa.array([None] * batch.num_rows)
+                )
                 for idx in range(batch.num_rows):
                     collection_raw = collection_array[idx].as_py()
                     if not collection_raw:
                         continue
                     collection_key = str(collection_raw)
-                    source_value = source_array[idx].as_py()
-                    if source_value:
-                        import os
-
-                        document_names[collection_key].add(
-                            os.path.basename(str(source_value))
-                        )
+                    _add_document_entry(
+                        collection_key,
+                        source_array[idx].as_py(),
+                        doc_id_array[idx].as_py(),
+                        file_id_array[idx].as_py(),
+                    )
 
         _collect_document_names()
 
@@ -594,6 +651,14 @@ async def list_collections(
                     "parses"
                 ],  # Use parses count as processed documents
                 document_names=sorted(document_names[collection]),
+                document_metadata=sorted(
+                    document_metadata[collection],
+                    key=lambda item: (
+                        item.filename,
+                        item.file_id or "",
+                        item.doc_id or "",
+                    ),
+                ),
                 ingestion_config=collection_configs.get(collection),
             )
             for collection in collection_keys

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from ...core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
 from ...core.tools.core.RAG_tools.core.schemas import (
     ChunkStrategy,
+    CollectionDocumentMetadata,
     CollectionOperationResult,
     FusionConfig,
     IngestionConfig,
@@ -625,10 +626,98 @@ async def list_collections_api(
         # be needed and can be removed.
         if result.collections:
             collection_name_set = {c.name for c in result.collections}
+            document_metadata_by_collection: Dict[
+                str, List[CollectionDocumentMetadata]
+            ] = {}
+            document_metadata_seen: Dict[str, set[tuple[str, str, str]]] = {}
 
-            # Optimize: Only query UploadedFile for collections that actually need fallback
+            def _normalize_optional_identifier(value: Any) -> Optional[str]:
+                if not isinstance(value, str):
+                    return None
+                normalized = value.strip()
+                return normalized or None
+
+            def _add_collection_document_metadata(
+                collection_name: str,
+                filename: Any,
+                *,
+                file_id: Optional[str] = None,
+                doc_id: Optional[str] = None,
+            ) -> None:
+                if collection_name not in collection_name_set:
+                    return
+                if not isinstance(filename, str):
+                    return
+                normalized_filename = filename.strip()
+                if not normalized_filename:
+                    return
+
+                normalized_file_id = _normalize_optional_identifier(file_id)
+                normalized_doc_id = _normalize_optional_identifier(doc_id)
+                dedupe_key = (
+                    normalized_filename,
+                    normalized_file_id or "",
+                    normalized_doc_id or "",
+                )
+                seen_keys = document_metadata_seen.setdefault(collection_name, set())
+                if dedupe_key in seen_keys:
+                    return
+                seen_keys.add(dedupe_key)
+                document_metadata_by_collection.setdefault(collection_name, []).append(
+                    CollectionDocumentMetadata(
+                        filename=normalized_filename,
+                        file_id=normalized_file_id,
+                        doc_id=normalized_doc_id,
+                    )
+                )
+
+            try:
+                doc_records = _list_documents_for_user(
+                    user_id=int(_user.id),
+                    is_admin=bool(_user.is_admin),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to list documents for metadata fallback: %s", exc
+                )
+                doc_records = []
+
+            if doc_records:
+                filename_map = _build_uploaded_filename_map(
+                    db,
+                    user_id=int(_user.id),
+                    file_ids=[
+                        file_id
+                        for file_id in (
+                            _get_document_record_file_id(record)
+                            for record in doc_records
+                        )
+                        if file_id
+                    ],
+                )
+                for doc_rec in doc_records:
+                    rec_collection = doc_rec.get("collection")
+                    if not isinstance(rec_collection, str) or not rec_collection:
+                        continue
+                    if rec_collection not in collection_name_set:
+                        continue
+                    resolved_filename = _resolve_document_filename(
+                        doc_rec, filename_map
+                    )
+                    resolved_doc_id = _normalize_optional_identifier(
+                        doc_rec.get("doc_id")
+                    )
+                    _add_collection_document_metadata(
+                        rec_collection,
+                        resolved_filename or resolved_doc_id,
+                        file_id=_get_document_record_file_id(doc_rec),
+                        doc_id=resolved_doc_id,
+                    )
+
             collections_needing_fallback = [
-                c for c in result.collections if not c.document_names
+                c
+                for c in result.collections
+                if not document_metadata_by_collection.get(c.name)
             ]
 
             if collections_needing_fallback:
@@ -679,12 +768,45 @@ async def list_collections_api(
                     collection_name = parts[user_idx + 1]
                     if collection_name not in collection_name_set:
                         continue
+                    fallback_filename = str(getattr(rec, "filename", "")).strip()
                     fallback_names.setdefault(collection_name, set()).add(
-                        str(getattr(rec, "filename", "")).strip()
+                        fallback_filename
+                    )
+                    fallback_file_id = _normalize_optional_identifier(
+                        getattr(rec, "file_id", None)
+                    )
+                    fallback_doc_id = None
+                    if str(getattr(rec, "storage_path", "")).strip():
+                        fallback_doc_id = generate_deterministic_doc_id(
+                            collection_name,
+                            str(getattr(rec, "storage_path", "")).strip(),
+                        )
+                    _add_collection_document_metadata(
+                        collection_name,
+                        fallback_filename,
+                        file_id=fallback_file_id,
+                        doc_id=fallback_doc_id,
                     )
 
                 for collection in result.collections:
+                    metadata = sorted(
+                        document_metadata_by_collection.get(collection.name, []),
+                        key=lambda item: (
+                            item.filename,
+                            item.file_id or "",
+                            item.doc_id or "",
+                        ),
+                    )
+                    if metadata:
+                        collection.document_metadata = metadata
                     if collection.document_names:
+                        continue
+                    if metadata:
+                        collection.document_names = sorted(
+                            {item.filename for item in metadata if item.filename}
+                        )
+                        if collection.documents == 0:
+                            collection.documents = len(collection.document_names)
                         continue
                     fallback = sorted(
                         name
@@ -698,53 +820,25 @@ async def list_collections_api(
                             collection.documents = len(fallback)
                         continue
 
-                # Secondary fallback for web-ingested docs (no UploadedFile rows):
-                # derive names from documents metadata; prefer source basename, then doc_id.
-                # Avoid N+1 list_documents() calls by fetching all docs for this user once.
-                collections_missing_names = [
-                    c for c in result.collections if not c.document_names
-                ]
-                if collections_missing_names:
-                    try:
-                        doc_records = _list_documents_for_user(
-                            user_id=int(_user.id),
-                            is_admin=bool(_user.is_admin),
-                        )
-                        derived_by_collection: Dict[str, set[str]] = {}
-                        for doc_rec in doc_records:
-                            rec_collection = doc_rec.get("collection")
-                            if (
-                                not isinstance(rec_collection, str)
-                                or not rec_collection
-                            ):
-                                continue
-                            if rec_collection not in collection_name_set:
-                                continue
-                            source_path = doc_rec.get("source_path")
-                            if isinstance(source_path, str) and source_path.strip():
-                                derived_by_collection.setdefault(
-                                    rec_collection, set()
-                                ).add(Path(source_path).name)
-                                continue
-                            raw_doc_id = doc_rec.get("doc_id")
-                            if isinstance(raw_doc_id, str) and raw_doc_id.strip():
-                                derived_by_collection.setdefault(
-                                    rec_collection, set()
-                                ).add(raw_doc_id)
-
-                        for collection in collections_missing_names:
-                            derived_names = derived_by_collection.get(
-                                collection.name, set()
-                            )
-                            if not derived_names:
-                                continue
-                            collection.document_names = sorted(derived_names)
-                            if collection.documents == 0:
-                                collection.documents = len(derived_names)
-                    except Exception as exc:  # noqa: BLE001
-                        logger.warning(
-                            "Secondary document name fallback failed: %s", exc
-                        )
+            for collection in result.collections:
+                if collection.document_metadata:
+                    continue
+                metadata = sorted(
+                    document_metadata_by_collection.get(collection.name, []),
+                    key=lambda item: (
+                        item.filename,
+                        item.file_id or "",
+                        item.doc_id or "",
+                    ),
+                )
+                if metadata:
+                    collection.document_metadata = metadata
+                if not collection.document_names and metadata:
+                    collection.document_names = sorted(
+                        {item.filename for item in metadata if item.filename}
+                    )
+                    if collection.documents == 0:
+                        collection.documents = len(collection.document_names)
 
         return result
     except asyncio.TimeoutError:
@@ -1433,6 +1527,174 @@ async def delete_document_api(
                 candidate.add(raw)
         return sorted(candidate)
 
+    def _append_matching_uploaded_file_candidate(rec: UploadedFile) -> bool:
+        file_id_str = str(getattr(rec, "file_id", "")).strip()
+        if not file_id_str:
+            return False
+        storage_path = str(getattr(rec, "storage_path", "")).strip()
+        if not storage_path:
+            return False
+        derived_doc_id = generate_deterministic_doc_id(collection_name, storage_path)
+        if doc_id and derived_doc_id != doc_id:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Provided `file_id` and `doc_id` do not reference the same document"
+                ),
+            )
+        matching_docs.append(
+            {
+                "doc_id": derived_doc_id,
+                "file_id": file_id_str,
+                "filename": str(getattr(rec, "filename", "")).strip() or filename,
+            }
+        )
+        return True
+
+    def _resolve_cleanup_file_id(doc_info: dict[str, Any]) -> Optional[str]:
+        current_file_id = str(doc_info.get("file_id") or "").strip()
+        if current_file_id:
+            return current_file_id
+
+        source_path = str(doc_info.get("source_path") or "").strip()
+        if source_path:
+            exact_match = (
+                db.query(UploadedFile)
+                .filter(
+                    UploadedFile.user_id == user_id_int,
+                    UploadedFile.storage_path == source_path,
+                )
+                .first()
+            )
+            if exact_match is not None:
+                exact_file_id = str(getattr(exact_match, "file_id", "")).strip()
+                if exact_file_id:
+                    return exact_file_id
+
+        normalized_filename = str(doc_info.get("filename") or "").strip()
+        normalized_doc_id = str(doc_info.get("doc_id") or "").strip()
+        user_segment = f"/user_{user_id_int}/{collection_name}/"
+        uploaded_query = db.query(UploadedFile).filter(
+            UploadedFile.user_id == user_id_int,
+            UploadedFile.storage_path.like(f"%{user_segment}%"),
+        )
+        if normalized_filename:
+            uploaded_query = uploaded_query.filter(
+                UploadedFile.filename == normalized_filename
+            )
+
+        matched_file_ids: set[str] = set()
+        for rec in uploaded_query.all():
+            candidate_file_id = str(getattr(rec, "file_id", "")).strip()
+            if not candidate_file_id:
+                continue
+            if normalized_doc_id:
+                candidate_storage_path = str(getattr(rec, "storage_path", "")).strip()
+                if not candidate_storage_path:
+                    continue
+                derived_doc_id = generate_deterministic_doc_id(
+                    collection_name,
+                    candidate_storage_path,
+                )
+                if derived_doc_id != normalized_doc_id:
+                    continue
+            matched_file_ids.add(candidate_file_id)
+
+        if len(matched_file_ids) == 1:
+            return next(iter(matched_file_ids))
+
+        return None
+
+    def _resolve_list_documents_match() -> Optional[dict[str, Any]]:
+        uploaded_file_record: Optional[UploadedFile] = None
+        if file_id:
+            uploaded_file_record = (
+                db.query(UploadedFile)
+                .filter(
+                    UploadedFile.user_id == user_id_int,
+                    UploadedFile.file_id == file_id,
+                )
+                .first()
+            )
+
+        doc_list = list_documents(
+            collection=collection_name,
+            user_id=user_id_int,
+            is_admin=bool(_user.is_admin),
+        )
+        for summary in doc_list.documents:
+            summary_doc_id = getattr(summary, "doc_id", None)
+            if not isinstance(summary_doc_id, str) or not summary_doc_id:
+                continue
+
+            summary_source_path = getattr(summary, "source_path", None)
+            normalized_source_path = (
+                str(summary_source_path).strip()
+                if isinstance(summary_source_path, str)
+                else ""
+            )
+            summary_basename = (
+                Path(normalized_source_path).name if normalized_source_path else None
+            )
+
+            if doc_id and summary_doc_id != doc_id:
+                continue
+
+            if file_id:
+                if uploaded_file_record is not None:
+                    uploaded_storage_path = str(
+                        getattr(uploaded_file_record, "storage_path", "")
+                    ).strip()
+                    if normalized_source_path == uploaded_storage_path:
+                        return {
+                            "doc_id": summary_doc_id,
+                            "file_id": file_id,
+                            "filename": (
+                                str(
+                                    getattr(uploaded_file_record, "filename", "")
+                                ).strip()
+                                or summary_basename
+                                or filename
+                            ),
+                            "source_path": normalized_source_path or None,
+                        }
+                    if uploaded_storage_path:
+                        derived_doc_id = generate_deterministic_doc_id(
+                            collection_name,
+                            uploaded_storage_path,
+                        )
+                        if derived_doc_id == summary_doc_id:
+                            return {
+                                "doc_id": summary_doc_id,
+                                "file_id": file_id,
+                                "filename": (
+                                    str(
+                                        getattr(uploaded_file_record, "filename", "")
+                                    ).strip()
+                                    or summary_basename
+                                    or filename
+                                ),
+                                "source_path": normalized_source_path or None,
+                            }
+
+                if doc_id:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            "Provided `file_id` and `doc_id` do not reference the same document"
+                        ),
+                    )
+                continue
+
+            return {
+                "doc_id": summary_doc_id,
+                "file_id": None,
+                "filename": summary_basename or filename,
+                "source_path": normalized_source_path or None,
+            }
+
+        return None
+
     user_id_int = int(_user.id)
     records: List[Dict[str, Any]] = []
     try:
@@ -1478,6 +1740,7 @@ async def delete_document_api(
                 "doc_id": current_doc_id,
                 "file_id": current_file_id,
                 "filename": resolved_filename or filename,
+                "source_path": record.get("source_path"),
             }
         )
 
@@ -1498,42 +1761,32 @@ async def delete_document_api(
             ),
         )
 
+    if not matching_docs and file_id:
+        user_segment = f"/user_{user_id_int}/{collection_name}/"
+        uploaded_candidates = (
+            db.query(UploadedFile)
+            .filter(
+                UploadedFile.user_id == user_id_int,
+                UploadedFile.file_id == file_id,
+                UploadedFile.storage_path.like(f"%{user_segment}%"),
+            )
+            .all()
+        )
+        for rec in uploaded_candidates:
+            _append_matching_uploaded_file_candidate(rec)
+
     if not matching_docs and (doc_id or file_id):
         # Explicit identifiers: validate through other data sources before allowing deletion
         # to prevent accidental deletion of non-existent or wrong documents.
         try:
-            doc_list = list_documents(
-                collection=collection_name,
-                user_id=user_id_int,
-                is_admin=bool(_user.is_admin),
-            )
-            target_exists = False
-            for summary in doc_list.documents:
-                if doc_id and summary.doc_id == doc_id:
-                    target_exists = True
-                    break
-                if file_id:
-                    # Check source_path basename for uploaded docs
-                    source_path = getattr(summary, "source_path", None)
-                    if source_path:
-                        source_basename = Path(source_path).name
-                        if source_basename == filename:
-                            target_exists = True
-                            break
-
-            if not target_exists:
+            resolved_match = _resolve_list_documents_match()
+            if resolved_match is None:
                 raise HTTPException(
                     status_code=404,
                     detail=f"Document not found in collection '{collection_name}'",
                 )
 
-            matching_docs.append(
-                {
-                    "doc_id": doc_id,
-                    "file_id": file_id,
-                    "filename": filename,
-                }
-            )
+            matching_docs.append(resolved_match)
         except HTTPException:
             raise
         except Exception as exc:
@@ -1553,27 +1806,15 @@ async def delete_document_api(
         user_segment = f"/user_{user_id_int}/{collection_name}/"
         uploaded_query = db.query(UploadedFile).filter(
             UploadedFile.user_id == user_id_int,
-            UploadedFile.filename == filename,
             UploadedFile.storage_path.like(f"%{user_segment}%"),
         )
         if file_id:
             uploaded_query = uploaded_query.filter(UploadedFile.file_id == file_id)
+        else:
+            uploaded_query = uploaded_query.filter(UploadedFile.filename == filename)
         uploaded_candidates = uploaded_query.all()
         for rec in uploaded_candidates:
-            file_id_str = str(getattr(rec, "file_id", "")).strip()
-            if not file_id_str:
-                continue
-            # Use storage_path as source_path for deterministic doc_id generation
-            storage_path = str(getattr(rec, "storage_path", "")).strip()
-            matching_docs.append(
-                {
-                    "doc_id": generate_deterministic_doc_id(
-                        collection_name, storage_path
-                    ),
-                    "file_id": file_id_str,
-                    "filename": filename,
-                }
-            )
+            _append_matching_uploaded_file_candidate(rec)
 
     if not doc_id and not file_id and len(matching_docs) > 1:
         candidate_doc_ids = _collect_candidate_doc_ids(matching_docs)
@@ -1675,7 +1916,7 @@ async def delete_document_api(
                 collection_name, doc_id, int(_user.id), bool(_user.is_admin)
             )
             deleted_doc_ids.append(doc_id)
-            current_file_id = doc_info.get("file_id")
+            current_file_id = _resolve_cleanup_file_id(doc_info)
             if current_file_id:
                 remaining_file_ids.discard(current_file_id)
                 if _delete_uploaded_file_if_orphaned(
@@ -1699,8 +1940,14 @@ async def delete_document_api(
     # Commit all orphan file cleanups in a single batch after the loop
     try:
         db.commit()
-    except Exception:
+    except Exception as exc:
         db.rollback()
+        deletion_errors.append(f"Failed to persist orphan cleanup changes: {str(exc)}")
+        logger.error(
+            "Failed to commit orphan cleanup changes for collection %s: %s",
+            collection_name,
+            exc,
+        )
 
     if deletion_errors:
         return {

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -696,12 +696,12 @@ async def list_collections_api(
                 )
 
             for collection in result.collections:
-                for metadata in collection.document_metadata:
+                for document_metadata in collection.document_metadata:
                     _add_collection_document_metadata(
                         collection.name,
-                        metadata.filename,
-                        file_id=metadata.file_id,
-                        doc_id=metadata.doc_id,
+                        document_metadata.filename,
+                        file_id=document_metadata.file_id,
+                        doc_id=document_metadata.doc_id,
                     )
 
             if collections_needing_scan:
@@ -828,7 +828,7 @@ async def list_collections_api(
                         )
 
             for collection in result.collections:
-                metadata = sorted(
+                resolved_metadata = sorted(
                     document_metadata_by_collection.get(collection.name, []),
                     key=lambda item: (
                         item.filename,
@@ -836,10 +836,10 @@ async def list_collections_api(
                         item.doc_id or "",
                     ),
                 )
-                collection.document_metadata = metadata
-                if not collection.document_names and metadata:
+                collection.document_metadata = resolved_metadata
+                if not collection.document_names and resolved_metadata:
                     collection.document_names = sorted(
-                        {item.filename for item in metadata if item.filename}
+                        {item.filename for item in resolved_metadata if item.filename}
                     )
                     if collection.documents == 0:
                         collection.documents = len(collection.document_names)

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -636,11 +636,26 @@ async def list_collections_api(
         # the backfill migration (backfill_documents_file_id.py), this should no longer
         # be needed and can be removed.
         if result.collections:
-            collection_name_set = {c.name for c in result.collections}
             document_metadata_by_collection: Dict[
                 str, List[CollectionDocumentMetadata]
             ] = {}
             document_metadata_seen: Dict[str, set[tuple[str, str, str]]] = {}
+            fallback_names: Dict[str, set[str]] = {}
+
+            def _collection_needs_document_scan(collection: Any) -> bool:
+                if collection.document_metadata:
+                    return False
+                return (not collection.document_names) or (
+                    collection.documents != len(collection.document_names)
+                )
+
+            collections_needing_scan = [
+                collection
+                for collection in result.collections
+                if _collection_needs_document_scan(collection)
+                and not document_metadata_by_collection.get(collection.name)
+            ]
+            scan_target_names = {c.name for c in collections_needing_scan}
 
             def _normalize_optional_identifier(value: Any) -> Optional[str]:
                 if not isinstance(value, str):
@@ -655,8 +670,6 @@ async def list_collections_api(
                 file_id: Optional[str] = None,
                 doc_id: Optional[str] = None,
             ) -> None:
-                if collection_name not in collection_name_set:
-                    return
                 if not isinstance(filename, str):
                     return
                 normalized_filename = filename.strip()
@@ -682,164 +695,139 @@ async def list_collections_api(
                     )
                 )
 
-            try:
-                doc_records = _list_documents_for_user(
-                    user_id=int(_user.id),
-                    is_admin=bool(_user.is_admin),
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Failed to list documents for metadata fallback: %s", exc
-                )
-                doc_records = []
-
-            if doc_records:
-                filename_map = _build_uploaded_filename_map(
-                    db,
-                    user_id=int(_user.id),
-                    file_ids=[
-                        file_id
-                        for file_id in (
-                            _get_document_record_file_id(record)
-                            for record in doc_records
-                        )
-                        if file_id
-                    ],
-                )
-                for doc_rec in doc_records:
-                    rec_collection = doc_rec.get("collection")
-                    if not isinstance(rec_collection, str) or not rec_collection:
-                        continue
-                    if rec_collection not in collection_name_set:
-                        continue
-                    resolved_filename = _resolve_document_filename(
-                        doc_rec, filename_map
-                    )
-                    resolved_doc_id = _normalize_optional_identifier(
-                        doc_rec.get("doc_id")
-                    )
+            for collection in result.collections:
+                for metadata in collection.document_metadata:
                     _add_collection_document_metadata(
-                        rec_collection,
-                        resolved_filename or resolved_doc_id,
-                        file_id=_get_document_record_file_id(doc_rec),
-                        doc_id=resolved_doc_id,
+                        collection.name,
+                        metadata.filename,
+                        file_id=metadata.file_id,
+                        doc_id=metadata.doc_id,
                     )
 
-            collections_needing_fallback = [
-                c
-                for c in result.collections
-                if not document_metadata_by_collection.get(c.name)
-            ]
+            if collections_needing_scan:
+                try:
+                    doc_records = _list_documents_for_user(
+                        user_id=int(_user.id),
+                        is_admin=bool(_user.is_admin),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to list documents for metadata fallback: %s", exc
+                    )
+                    doc_records = []
 
-            if collections_needing_fallback:
-                # Filter at SQL level to only load relevant uploaded files
-                collection_patterns = [
-                    _like_contains_pattern(f"/user_{int(_user.id)}/{c.name}/")
-                    for c in collections_needing_fallback
+                if doc_records:
+                    filename_map = _build_uploaded_filename_map(
+                        db,
+                        user_id=int(_user.id),
+                        file_ids=[
+                            file_id
+                            for file_id in (
+                                _get_document_record_file_id(record)
+                                for record in doc_records
+                            )
+                            if file_id
+                        ],
+                    )
+                    for doc_rec in doc_records:
+                        rec_collection = doc_rec.get("collection")
+                        if not isinstance(rec_collection, str) or not rec_collection:
+                            continue
+                        if rec_collection not in scan_target_names:
+                            continue
+                        resolved_filename = _resolve_document_filename(
+                            doc_rec, filename_map
+                        )
+                        resolved_doc_id = _normalize_optional_identifier(
+                            doc_rec.get("doc_id")
+                        )
+                        _add_collection_document_metadata(
+                            rec_collection,
+                            resolved_filename or resolved_doc_id,
+                            file_id=_get_document_record_file_id(doc_rec),
+                            doc_id=resolved_doc_id,
+                        )
+
+                collections_needing_fallback = [
+                    collection
+                    for collection in collections_needing_scan
+                    if not document_metadata_by_collection.get(collection.name)
                 ]
 
-                uploaded_records = []
-                if len(collection_patterns) == 1:
-                    uploaded_records = (
-                        db.query(UploadedFile)
-                        .filter(
-                            UploadedFile.user_id == int(_user.id),
-                            UploadedFile.storage_path.like(
-                                collection_patterns[0],
-                                escape=_SQL_LIKE_ESCAPE,
-                            ),
-                        )
-                        .all()
-                    )
-                else:
-                    # Multiple collections: use OR logic
-                    from sqlalchemy import or_
+                if collections_needing_fallback:
+                    # Filter at SQL level to only load relevant uploaded files
+                    collection_patterns = [
+                        _like_contains_pattern(f"/user_{int(_user.id)}/{c.name}/")
+                        for c in collections_needing_fallback
+                    ]
 
-                    uploaded_records = (
-                        db.query(UploadedFile)
-                        .filter(
-                            UploadedFile.user_id == int(_user.id),
-                            or_(
-                                *[
-                                    UploadedFile.storage_path.like(
-                                        pattern,
-                                        escape=_SQL_LIKE_ESCAPE,
-                                    )
-                                    for pattern in collection_patterns
-                                ]
-                            ),
+                    uploaded_records = []
+                    if len(collection_patterns) == 1:
+                        uploaded_records = (
+                            db.query(UploadedFile)
+                            .filter(
+                                UploadedFile.user_id == int(_user.id),
+                                UploadedFile.storage_path.like(
+                                    collection_patterns[0],
+                                    escape=_SQL_LIKE_ESCAPE,
+                                ),
+                            )
+                            .all()
                         )
-                        .all()
-                    )
+                    else:
+                        # Multiple collections: use OR logic
+                        from sqlalchemy import or_
 
-                fallback_names: Dict[str, set[str]] = {}
-                user_segment = f"user_{int(_user.id)}"
-                for rec in uploaded_records:
-                    storage_path = Path(str(getattr(rec, "storage_path", "")))
-                    parts = storage_path.parts
-                    if user_segment not in parts:
-                        continue
-                    user_idx = parts.index(user_segment)
-                    if user_idx + 2 >= len(parts):
-                        continue
-                    collection_name = parts[user_idx + 1]
-                    if collection_name not in collection_name_set:
-                        continue
-                    fallback_filename = str(getattr(rec, "filename", "")).strip()
-                    fallback_names.setdefault(collection_name, set()).add(
-                        fallback_filename
-                    )
-                    fallback_file_id = _normalize_optional_identifier(
-                        getattr(rec, "file_id", None)
-                    )
-                    fallback_doc_id = None
-                    if str(getattr(rec, "storage_path", "")).strip():
-                        fallback_doc_id = generate_deterministic_doc_id(
+                        uploaded_records = (
+                            db.query(UploadedFile)
+                            .filter(
+                                UploadedFile.user_id == int(_user.id),
+                                or_(
+                                    *[
+                                        UploadedFile.storage_path.like(
+                                            pattern,
+                                            escape=_SQL_LIKE_ESCAPE,
+                                        )
+                                        for pattern in collection_patterns
+                                    ]
+                                ),
+                            )
+                            .all()
+                        )
+
+                    user_segment = f"user_{int(_user.id)}"
+                    for rec in uploaded_records:
+                        storage_path = Path(str(getattr(rec, "storage_path", "")))
+                        parts = storage_path.parts
+                        if user_segment not in parts:
+                            continue
+                        user_idx = parts.index(user_segment)
+                        if user_idx + 2 >= len(parts):
+                            continue
+                        collection_name = parts[user_idx + 1]
+                        if collection_name not in scan_target_names:
+                            continue
+                        fallback_filename = str(getattr(rec, "filename", "")).strip()
+                        fallback_names.setdefault(collection_name, set()).add(
+                            fallback_filename
+                        )
+                        fallback_file_id = _normalize_optional_identifier(
+                            getattr(rec, "file_id", None)
+                        )
+                        fallback_doc_id = None
+                        if str(getattr(rec, "storage_path", "")).strip():
+                            fallback_doc_id = generate_deterministic_doc_id(
+                                collection_name,
+                                str(getattr(rec, "storage_path", "")).strip(),
+                            )
+                        _add_collection_document_metadata(
                             collection_name,
-                            str(getattr(rec, "storage_path", "")).strip(),
+                            fallback_filename,
+                            file_id=fallback_file_id,
+                            doc_id=fallback_doc_id,
                         )
-                    _add_collection_document_metadata(
-                        collection_name,
-                        fallback_filename,
-                        file_id=fallback_file_id,
-                        doc_id=fallback_doc_id,
-                    )
-
-                for collection in result.collections:
-                    metadata = sorted(
-                        document_metadata_by_collection.get(collection.name, []),
-                        key=lambda item: (
-                            item.filename,
-                            item.file_id or "",
-                            item.doc_id or "",
-                        ),
-                    )
-                    if metadata:
-                        collection.document_metadata = metadata
-                    if collection.document_names:
-                        continue
-                    if metadata:
-                        collection.document_names = sorted(
-                            {item.filename for item in metadata if item.filename}
-                        )
-                        if collection.documents == 0:
-                            collection.documents = len(collection.document_names)
-                        continue
-                    fallback = sorted(
-                        name
-                        for name in fallback_names.get(collection.name, set())
-                        if name
-                    )
-                    if fallback:
-                        collection.document_names = fallback
-                        # Keep UI card counters aligned with visible files when docs table is unreadable.
-                        if collection.documents == 0:
-                            collection.documents = len(fallback)
-                        continue
 
             for collection in result.collections:
-                if collection.document_metadata:
-                    continue
                 metadata = sorted(
                     document_metadata_by_collection.get(collection.name, []),
                     key=lambda item: (
@@ -848,14 +836,22 @@ async def list_collections_api(
                         item.doc_id or "",
                     ),
                 )
-                if metadata:
-                    collection.document_metadata = metadata
+                collection.document_metadata = metadata
                 if not collection.document_names and metadata:
                     collection.document_names = sorted(
                         {item.filename for item in metadata if item.filename}
                     )
                     if collection.documents == 0:
                         collection.documents = len(collection.document_names)
+                    continue
+
+                fallback = sorted(
+                    name for name in fallback_names.get(collection.name, set()) if name
+                )
+                if fallback:
+                    collection.document_names = fallback
+                    if collection.documents == 0:
+                        collection.documents = len(fallback)
 
         return result
     except asyncio.TimeoutError:
@@ -1643,6 +1639,59 @@ async def delete_document_api(
 
         return None
 
+    def _build_resolved_document_match(
+        summary_doc_id: str,
+        summary_basename: Optional[str],
+        normalized_source_path: str,
+        *,
+        matched_file_id: Optional[str],
+        matched_filename: Optional[str],
+    ) -> dict[str, Any]:
+        return {
+            "doc_id": summary_doc_id,
+            "file_id": matched_file_id,
+            "filename": matched_filename or summary_basename or filename,
+            "source_path": normalized_source_path or None,
+        }
+
+    def _match_uploaded_file_summary(
+        uploaded_file_record: UploadedFile,
+        summary_doc_id: str,
+        summary_basename: Optional[str],
+        normalized_source_path: str,
+    ) -> Optional[dict[str, Any]]:
+        uploaded_storage_path = str(
+            getattr(uploaded_file_record, "storage_path", "")
+        ).strip()
+        uploaded_filename = str(getattr(uploaded_file_record, "filename", "")).strip()
+
+        if normalized_source_path == uploaded_storage_path:
+            return _build_resolved_document_match(
+                summary_doc_id,
+                summary_basename,
+                normalized_source_path,
+                matched_file_id=file_id,
+                matched_filename=uploaded_filename,
+            )
+
+        if not uploaded_storage_path:
+            return None
+
+        derived_doc_id = generate_deterministic_doc_id(
+            safe_collection_name,
+            uploaded_storage_path,
+        )
+        if derived_doc_id != summary_doc_id:
+            return None
+
+        return _build_resolved_document_match(
+            summary_doc_id,
+            summary_basename,
+            normalized_source_path,
+            matched_file_id=file_id,
+            matched_filename=uploaded_filename,
+        )
+
     def _resolve_list_documents_match() -> Optional[dict[str, Any]]:
         uploaded_file_record: Optional[UploadedFile] = None
         if file_id:
@@ -1678,68 +1727,42 @@ async def delete_document_api(
             if doc_id and summary_doc_id != doc_id:
                 continue
 
-            if file_id:
-                if uploaded_file_record is not None:
-                    uploaded_storage_path = str(
-                        getattr(uploaded_file_record, "storage_path", "")
-                    ).strip()
-                    if normalized_source_path == uploaded_storage_path:
-                        return {
-                            "doc_id": summary_doc_id,
-                            "file_id": file_id,
-                            "filename": (
-                                str(
-                                    getattr(uploaded_file_record, "filename", "")
-                                ).strip()
-                                or summary_basename
-                                or filename
-                            ),
-                            "source_path": normalized_source_path or None,
-                        }
-                    if uploaded_storage_path:
-                        derived_doc_id = generate_deterministic_doc_id(
-                            safe_collection_name,
-                            uploaded_storage_path,
-                        )
-                        if derived_doc_id == summary_doc_id:
-                            return {
-                                "doc_id": summary_doc_id,
-                                "file_id": file_id,
-                                "filename": (
-                                    str(
-                                        getattr(uploaded_file_record, "filename", "")
-                                    ).strip()
-                                    or summary_basename
-                                    or filename
-                                ),
-                                "source_path": normalized_source_path or None,
-                            }
+            if not file_id:
+                return _build_resolved_document_match(
+                    summary_doc_id,
+                    summary_basename,
+                    normalized_source_path,
+                    matched_file_id=None,
+                    matched_filename=None,
+                )
 
-                if uploaded_file_record is None:
-                    if doc_id:
-                        return {
-                            "doc_id": summary_doc_id,
-                            "file_id": None,
-                            "filename": summary_basename or filename,
-                            "source_path": normalized_source_path or None,
-                        }
-                    continue
-
+            if uploaded_file_record is None:
                 if doc_id:
-                    raise HTTPException(
-                        status_code=409,
-                        detail=(
-                            "Provided `file_id` and `doc_id` do not reference the same document"
-                        ),
+                    return _build_resolved_document_match(
+                        summary_doc_id,
+                        summary_basename,
+                        normalized_source_path,
+                        matched_file_id=None,
+                        matched_filename=None,
                     )
                 continue
 
-            return {
-                "doc_id": summary_doc_id,
-                "file_id": None,
-                "filename": summary_basename or filename,
-                "source_path": normalized_source_path or None,
-            }
+            uploaded_match = _match_uploaded_file_summary(
+                uploaded_file_record,
+                summary_doc_id,
+                summary_basename,
+                normalized_source_path,
+            )
+            if uploaded_match is not None:
+                return uploaded_match
+
+            if doc_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "Provided `file_id` and `doc_id` do not reference the same document"
+                    ),
+                )
 
         return None
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1265,6 +1265,7 @@ async def delete_collection_api(
     Raises:
         HTTPException: If physical deletion fails (prevents database deletion)
     """
+    safe_collection = collection_name
     try:
         try:
             safe_collection = sanitize_path_component(collection_name, "collection")
@@ -1297,7 +1298,7 @@ async def delete_collection_api(
 
         vector_store = get_vector_index_store()
         collection_records = vector_store.list_document_records(
-            collection_name=collection_name,
+            collection_name=safe_collection,
             user_id=int(_user.id),
             is_admin=bool(_user.is_admin),
         )
@@ -1309,7 +1310,7 @@ async def delete_collection_api(
             if file_id
         }
 
-        result = delete_collection(collection_name, int(_user.id), bool(_user.is_admin))
+        result = delete_collection(safe_collection, int(_user.id), bool(_user.is_admin))
 
         remaining_records = vector_store.list_document_records(
             collection_name=None,
@@ -1334,7 +1335,7 @@ async def delete_collection_api(
             logger.info(
                 "Deleted %s UploadedFile record(s) for collection %s",
                 deleted_uploaded_files,
-                collection_name,
+                safe_collection,
             )
 
         # Step 3: Add physical cleanup status to warnings and message for visibility
@@ -1400,7 +1401,7 @@ async def delete_collection_api(
         # Re-raise HTTP exceptions (including physical deletion failures)
         raise
     except Exception as e:
-        logger.exception(f"Failed to delete collection '{collection_name}': {e}")
+        logger.exception(f"Failed to delete collection '{safe_collection}': {e}")
         raise HTTPException(
             status_code=500,
             detail=f"Failed to delete collection: {str(e)}",
@@ -1517,6 +1518,13 @@ async def delete_document_api(
     # NOTE: Exceptions are normalized by @handle_kb_exceptions for consistent API responses.
     from ...core.tools.core.RAG_tools.management.collections import delete_document
 
+    try:
+        safe_collection_name = sanitize_path_component(collection_name, "collection")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid collection name: {str(e)}"
+        ) from e
+
     def _collect_candidate_doc_ids(
         docs: list[dict[str, Any]],
     ) -> list[str]:
@@ -1534,7 +1542,9 @@ async def delete_document_api(
         storage_path = str(getattr(rec, "storage_path", "")).strip()
         if not storage_path:
             return False
-        derived_doc_id = generate_deterministic_doc_id(collection_name, storage_path)
+        derived_doc_id = generate_deterministic_doc_id(
+            safe_collection_name, storage_path
+        )
         if doc_id and derived_doc_id != doc_id:
             raise HTTPException(
                 status_code=409,
@@ -1573,7 +1583,7 @@ async def delete_document_api(
 
         normalized_filename = str(doc_info.get("filename") or "").strip()
         normalized_doc_id = str(doc_info.get("doc_id") or "").strip()
-        user_segment = f"/user_{user_id_int}/{collection_name}/"
+        user_segment = f"/user_{user_id_int}/{safe_collection_name}/"
         uploaded_query = db.query(UploadedFile).filter(
             UploadedFile.user_id == user_id_int,
             UploadedFile.storage_path.like(f"%{user_segment}%"),
@@ -1593,7 +1603,7 @@ async def delete_document_api(
                 if not candidate_storage_path:
                     continue
                 derived_doc_id = generate_deterministic_doc_id(
-                    collection_name,
+                    safe_collection_name,
                     candidate_storage_path,
                 )
                 if derived_doc_id != normalized_doc_id:
@@ -1618,7 +1628,7 @@ async def delete_document_api(
             )
 
         doc_list = list_documents(
-            collection=collection_name,
+            collection=safe_collection_name,
             user_id=user_id_int,
             is_admin=bool(_user.is_admin),
         )
@@ -1660,7 +1670,7 @@ async def delete_document_api(
                         }
                     if uploaded_storage_path:
                         derived_doc_id = generate_deterministic_doc_id(
-                            collection_name,
+                            safe_collection_name,
                             uploaded_storage_path,
                         )
                         if derived_doc_id == summary_doc_id:
@@ -1701,13 +1711,13 @@ async def delete_document_api(
         records = _list_documents_for_user(
             user_id=user_id_int,
             is_admin=bool(_user.is_admin),
-            collection_name=collection_name,
+            collection_name=safe_collection_name,
         )
     except Exception as exc:
         # Degrade gracefully when LanceDB cannot decode legacy rows.
         logger.warning(
             "Failed to read documents for delete resolution (collection=%s): %s",
-            collection_name,
+            safe_collection_name,
             exc,
         )
     filename_map = _build_uploaded_filename_map(
@@ -1762,7 +1772,7 @@ async def delete_document_api(
         )
 
     if not matching_docs and file_id:
-        user_segment = f"/user_{user_id_int}/{collection_name}/"
+        user_segment = f"/user_{user_id_int}/{safe_collection_name}/"
         uploaded_candidates = (
             db.query(UploadedFile)
             .filter(
@@ -1783,7 +1793,7 @@ async def delete_document_api(
             if resolved_match is None:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Document not found in collection '{collection_name}'",
+                    detail=f"Document not found in collection '{safe_collection_name}'",
                 )
 
             matching_docs.append(resolved_match)
@@ -1793,7 +1803,7 @@ async def delete_document_api(
             # If validation fails, err on the side of caution and refuse deletion
             logger.warning(
                 "Failed to validate document existence for deletion (collection=%s): %s",
-                collection_name,
+                safe_collection_name,
                 exc,
             )
             raise HTTPException(
@@ -1803,7 +1813,7 @@ async def delete_document_api(
 
     if not matching_docs:
         # Fallback 1: derive doc_id from UploadedFile linkage for uploaded docs.
-        user_segment = f"/user_{user_id_int}/{collection_name}/"
+        user_segment = f"/user_{user_id_int}/{safe_collection_name}/"
         uploaded_query = db.query(UploadedFile).filter(
             UploadedFile.user_id == user_id_int,
             UploadedFile.storage_path.like(f"%{user_segment}%"),
@@ -1832,7 +1842,7 @@ async def delete_document_api(
         # Fallback 2: allow web-ingested docs to be deleted by doc_id-like filename.
         try:
             doc_list = list_documents(
-                collection=collection_name,
+                collection=safe_collection_name,
                 user_id=user_id_int,
                 is_admin=bool(_user.is_admin),
             )
@@ -1853,7 +1863,7 @@ async def delete_document_api(
         except Exception as exc:
             logger.warning(
                 "Fallback doc resolution via list_documents failed (collection=%s): %s",
-                collection_name,
+                safe_collection_name,
                 exc,
             )
 
@@ -1883,6 +1893,7 @@ async def delete_document_api(
         remaining_records = _list_documents_for_user(
             user_id=user_id_int,
             is_admin=bool(_user.is_admin),
+            collection_name=safe_collection_name,
         )
         remaining_file_ids = {
             current_file_id
@@ -1913,7 +1924,7 @@ async def delete_document_api(
             continue
         try:
             delete_document(
-                collection_name, doc_id, int(_user.id), bool(_user.is_admin)
+                safe_collection_name, doc_id, int(_user.id), bool(_user.is_admin)
             )
             deleted_doc_ids.append(doc_id)
             current_file_id = _resolve_cleanup_file_id(doc_info)
@@ -1930,7 +1941,7 @@ async def delete_document_api(
                 "Deleted document '%s' (doc_id: %s) from collection '%s'",
                 doc_info.get("filename", filename),
                 doc_id,
-                collection_name,
+                safe_collection_name,
             )
         except Exception as e:
             error_msg = f"Failed to delete doc_id {doc_id}: {str(e)}"
@@ -1945,7 +1956,7 @@ async def delete_document_api(
         deletion_errors.append(f"Failed to persist orphan cleanup changes: {str(exc)}")
         logger.error(
             "Failed to commit orphan cleanup changes for collection %s: %s",
-            collection_name,
+            safe_collection_name,
             exc,
         )
 
@@ -1953,7 +1964,7 @@ async def delete_document_api(
         return {
             "status": "partial_success" if deleted_doc_ids else "failed",
             "message": f"Deleted {len(deleted_doc_ids)} of {len(matching_docs)} documents",
-            "collection": collection_name,
+            "collection": safe_collection_name,
             "filename": filename,
             "deleted_doc_ids": deleted_doc_ids,
             "errors": deletion_errors,
@@ -1962,7 +1973,7 @@ async def delete_document_api(
     return {
         "status": "success",
         "message": f"Successfully deleted {len(deleted_doc_ids)} document(s)",
-        "collection": collection_name,
+        "collection": safe_collection_name,
         "filename": filename,
         "deleted_doc_ids": deleted_doc_ids,
     }

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -98,6 +98,17 @@ from .cloud_storage import get_google_credentials
 T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
+_SQL_LIKE_ESCAPE = "\\"
+
+
+def _like_contains_pattern(value: str) -> str:
+    escaped = (
+        value.replace(_SQL_LIKE_ESCAPE, _SQL_LIKE_ESCAPE * 2)
+        .replace("%", f"{_SQL_LIKE_ESCAPE}%")
+        .replace("_", f"{_SQL_LIKE_ESCAPE}_")
+    )
+    return f"%{escaped}%"
+
 
 def handle_kb_exceptions(func: T) -> T:
     """Decorator to handle common exceptions in KB API routes."""
@@ -723,7 +734,7 @@ async def list_collections_api(
             if collections_needing_fallback:
                 # Filter at SQL level to only load relevant uploaded files
                 collection_patterns = [
-                    f"%/user_{int(_user.id)}/{c.name}/%"
+                    _like_contains_pattern(f"/user_{int(_user.id)}/{c.name}/")
                     for c in collections_needing_fallback
                 ]
 
@@ -733,7 +744,10 @@ async def list_collections_api(
                         db.query(UploadedFile)
                         .filter(
                             UploadedFile.user_id == int(_user.id),
-                            UploadedFile.storage_path.like(collection_patterns[0]),
+                            UploadedFile.storage_path.like(
+                                collection_patterns[0],
+                                escape=_SQL_LIKE_ESCAPE,
+                            ),
                         )
                         .all()
                     )
@@ -747,7 +761,10 @@ async def list_collections_api(
                             UploadedFile.user_id == int(_user.id),
                             or_(
                                 *[
-                                    UploadedFile.storage_path.like(pattern)
+                                    UploadedFile.storage_path.like(
+                                        pattern,
+                                        escape=_SQL_LIKE_ESCAPE,
+                                    )
                                     for pattern in collection_patterns
                                 ]
                             ),
@@ -1586,7 +1603,10 @@ async def delete_document_api(
         user_segment = f"/user_{user_id_int}/{safe_collection_name}/"
         uploaded_query = db.query(UploadedFile).filter(
             UploadedFile.user_id == user_id_int,
-            UploadedFile.storage_path.like(f"%{user_segment}%"),
+            UploadedFile.storage_path.like(
+                _like_contains_pattern(user_segment),
+                escape=_SQL_LIKE_ESCAPE,
+            ),
         )
         if normalized_filename:
             uploaded_query = uploaded_query.filter(
@@ -1612,6 +1632,14 @@ async def delete_document_api(
 
         if len(matched_file_ids) == 1:
             return next(iter(matched_file_ids))
+        if len(matched_file_ids) > 1:
+            logger.warning(
+                "Multiple UploadedFile candidates matched cleanup resolution "
+                "(collection=%s, filename=%s, doc_id=%s)",
+                safe_collection_name,
+                normalized_filename,
+                normalized_doc_id,
+            )
 
         return None
 
@@ -1686,6 +1714,16 @@ async def delete_document_api(
                                 ),
                                 "source_path": normalized_source_path or None,
                             }
+
+                if uploaded_file_record is None:
+                    if doc_id:
+                        return {
+                            "doc_id": summary_doc_id,
+                            "file_id": None,
+                            "filename": summary_basename or filename,
+                            "source_path": normalized_source_path or None,
+                        }
+                    continue
 
                 if doc_id:
                     raise HTTPException(
@@ -1778,7 +1816,10 @@ async def delete_document_api(
             .filter(
                 UploadedFile.user_id == user_id_int,
                 UploadedFile.file_id == file_id,
-                UploadedFile.storage_path.like(f"%{user_segment}%"),
+                UploadedFile.storage_path.like(
+                    _like_contains_pattern(user_segment),
+                    escape=_SQL_LIKE_ESCAPE,
+                ),
             )
             .all()
         )
@@ -1816,7 +1857,10 @@ async def delete_document_api(
         user_segment = f"/user_{user_id_int}/{safe_collection_name}/"
         uploaded_query = db.query(UploadedFile).filter(
             UploadedFile.user_id == user_id_int,
-            UploadedFile.storage_path.like(f"%{user_segment}%"),
+            UploadedFile.storage_path.like(
+                _like_contains_pattern(user_segment),
+                escape=_SQL_LIKE_ESCAPE,
+            ),
         )
         if file_id:
             uploaded_query = uploaded_query.filter(UploadedFile.file_id == file_id)
@@ -1916,17 +1960,20 @@ async def delete_document_api(
         }
 
     for doc_info in matching_docs:
-        doc_id = doc_info["doc_id"]
-        if not isinstance(doc_id, str) or not doc_id:
+        resolved_doc_id = doc_info["doc_id"]
+        if not isinstance(resolved_doc_id, str) or not resolved_doc_id:
             error_msg = "Failed to delete document: resolved doc_id is missing"
             deletion_errors.append(error_msg)
             logger.error("%s", error_msg)
             continue
         try:
             delete_document(
-                safe_collection_name, doc_id, int(_user.id), bool(_user.is_admin)
+                safe_collection_name,
+                resolved_doc_id,
+                int(_user.id),
+                bool(_user.is_admin),
             )
-            deleted_doc_ids.append(doc_id)
+            deleted_doc_ids.append(resolved_doc_id)
             current_file_id = _resolve_cleanup_file_id(doc_info)
             if current_file_id:
                 remaining_file_ids.discard(current_file_id)
@@ -1940,11 +1987,11 @@ async def delete_document_api(
             logger.info(
                 "Deleted document '%s' (doc_id: %s) from collection '%s'",
                 doc_info.get("filename", filename),
-                doc_id,
+                resolved_doc_id,
                 safe_collection_name,
             )
         except Exception as e:
-            error_msg = f"Failed to delete doc_id {doc_id}: {str(e)}"
+            error_msg = f"Failed to delete doc_id {resolved_doc_id}: {str(e)}"
             deletion_errors.append(error_msg)
             logger.error("%s", error_msg)
 

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -6,6 +6,7 @@ dynamically to support environment variable changes at runtime.
 """
 
 import re
+import unicodedata
 from pathlib import Path
 from typing import Optional
 
@@ -130,6 +131,14 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
 
     # Remove leading/trailing whitespace
     name = name.strip()
+
+    normalized_name = unicodedata.normalize("NFKC", name)
+    if normalized_name != name:
+        raise ValueError(
+            f"Invalid {component_type} name: contains invalid characters. "
+            f"Only letters, numbers, underscores, and hyphens are allowed."
+        )
+    name = normalized_name
 
     # Extract only the basename to prevent path traversal
     # This handles cases like "../../../etc" -> "etc"

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -88,6 +88,34 @@ ALLOWED_EXTENSIONS = {
 MAX_FILE_SIZE = 100 * 1024 * 1024
 
 ALLOWED_NAME_PATTERN = re.compile(r"^[\w-]+$")
+_CONFUSABLE_SCRIPT_FAMILIES = ("LATIN", "GREEK", "CYRILLIC")
+
+
+def _get_confusable_script_family(char: str) -> Optional[str]:
+    if not char.isalpha():
+        return None
+
+    try:
+        unicode_name = unicodedata.name(char)
+    except ValueError:
+        return None
+
+    for script_family in _CONFUSABLE_SCRIPT_FAMILIES:
+        if script_family in unicode_name:
+            return script_family
+
+    return None
+
+
+def _has_mixed_confusable_scripts(value: str) -> bool:
+    script_families: set[str] = set()
+    for char in value:
+        script_family = _get_confusable_script_family(char)
+        if script_family:
+            script_families.add(script_family)
+
+    return len(script_families) > 1
+
 
 # Maximum length for collection and folder names (reasonable limit for file system and database)
 # This prevents path length issues and database field overflow
@@ -166,6 +194,11 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
         raise ValueError(
             f"Invalid {component_type} name: contains invalid characters. "
             f"Only letters, numbers, underscores, and hyphens are allowed."
+        )
+
+    if _has_mixed_confusable_scripts(safe_name):
+        raise ValueError(
+            f"Invalid {component_type} name: contains mixed-script confusable characters"
         )
 
     # Ensure the sanitized name matches the original (after stripping)

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -86,9 +86,7 @@ ALLOWED_EXTENSIONS = {
 # Maximum file size (100MB)
 MAX_FILE_SIZE = 100 * 1024 * 1024
 
-# Allowed characters for collection and folder names (alphanumeric, underscore, hyphen)
-# This prevents path traversal and other security issues
-ALLOWED_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+ALLOWED_NAME_PATTERN = re.compile(r"^[\w-]+$")
 
 # Maximum length for collection and folder names (reasonable limit for file system and database)
 # This prevents path length issues and database field overflow
@@ -158,7 +156,7 @@ def sanitize_path_component(name: str, component_type: str = "path") -> str:
     if not ALLOWED_NAME_PATTERN.match(safe_name):
         raise ValueError(
             f"Invalid {component_type} name: contains invalid characters. "
-            f"Only alphanumeric characters, underscores, and hyphens are allowed."
+            f"Only letters, numbers, underscores, and hyphens are allowed."
         )
 
     # Ensure the sanitized name matches the original (after stripping)

--- a/tests/core/tools/test_command_executor.py
+++ b/tests/core/tools/test_command_executor.py
@@ -3,6 +3,7 @@ Tests for CommandExecutor tool
 """
 
 import os
+import shlex
 import sys
 
 import pytest
@@ -60,9 +61,11 @@ class TestCommandExecutorTool:
         assert "banana" in result["output"]
         assert result["return_code"] == 0
 
-    def test_list_directory(self, command_executor):
+    def test_list_directory(self, command_executor, temp_dir):
         """Test listing directory contents"""
-        result = command_executor.run_json_sync({"command": "ls -la /tmp"})
+        result = command_executor.run_json_sync(
+            {"command": f"ls -la {shlex.quote(temp_dir)}"}
+        )
 
         assert result["success"] is True
         assert len(result["output"]) > 0

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -9,6 +9,9 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.tools.core.RAG_tools.utils.string_utils import (
+    generate_deterministic_doc_id,
+)
 from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.web.api.auth import hash_password
 from xagent.web.api.kb import kb_router
@@ -903,6 +906,535 @@ def test_delete_document_by_filename_refuses_ambiguous_match(test_env, temp_uplo
 
     assert response.status_code == 409
     assert "ambiguous" in response.json()["detail"].lower()
+
+
+def test_delete_document_by_doc_id_disambiguates_duplicate_filename(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "dup.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    document_state = [
+        {
+            "collection": "demo",
+            "doc_id": "doc-a",
+            "file_id": "file-a",
+            "source_path": str(file_path),
+        },
+        {
+            "collection": "demo",
+            "doc_id": "doc-b",
+            "file_id": "file-b",
+            "source_path": str(file_path),
+        },
+    ]
+    deleted_doc_ids: list[str] = []
+
+    def _fake_list_documents_for_user(*args, **kwargs):
+        return list(document_state)
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        deleted_doc_ids.append(doc_id)
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=_fake_list_documents_for_user,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        response = client.delete(
+            "/api/kb/collections/demo/documents/dup.txt?doc_id=doc-b",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["deleted_doc_ids"] == ["doc-b"]
+    assert deleted_doc_ids == ["doc-b"]
+
+
+def test_delete_document_by_file_id_survives_degraded_document_listing(
+    test_env, temp_uploads
+):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "fallback.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="fallback.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+        session.refresh(file_record)
+        target_file_id = str(file_record.file_id)
+    finally:
+        session.close()
+
+    deleted_doc_ids: list[str] = []
+    expected_doc_id = generate_deterministic_doc_id("demo", str(file_path))
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        deleted_doc_ids.append(doc_id)
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=RuntimeError("documents unavailable"),
+        ),
+        patch(
+            "xagent.web.api.kb.list_documents",
+            side_effect=RuntimeError("documents unavailable"),
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        response = client.delete(
+            f"/api/kb/collections/demo/documents/ignored.txt?file_id={target_file_id}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["deleted_doc_ids"] == [expected_doc_id]
+    assert deleted_doc_ids == [expected_doc_id]
+
+
+def test_delete_document_without_file_id_does_not_resurface_on_collection_refresh(
+    test_env, temp_uploads
+):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionInfo,
+        ListCollectionsResult,
+    )
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "resurface.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="resurface.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+    finally:
+        session.close()
+
+    document_state = [
+        {
+            "collection": "demo",
+            "doc_id": generate_deterministic_doc_id("demo", str(file_path)),
+            "file_id": None,
+            "source_path": str(file_path),
+        }
+    ]
+
+    def _fake_list_documents_for_user(*args, **kwargs):
+        collection_name = kwargs.get("collection_name")
+        if collection_name == "demo":
+            return list(document_state)
+        return []
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        document_state.clear()
+
+    fake_result = ListCollectionsResult(
+        status="success",
+        collections=[CollectionInfo(name="demo", documents=0, document_names=[])],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=_fake_list_documents_for_user,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        delete_response = client.delete(
+            "/api/kb/collections/demo/documents/resurface.txt",
+            headers=headers,
+        )
+
+        assert delete_response.status_code == 200
+
+        with patch("xagent.web.api.kb.list_collections", return_value=fake_result):
+            refresh_response = client.get("/api/kb/collections", headers=headers)
+
+    assert refresh_response.status_code == 200
+    collection = refresh_response.json()["collections"][0]
+    assert collection["document_names"] == []
+    assert collection["document_metadata"] == []
+
+    session = TestingSessionLocal()
+    try:
+        lingering_record = (
+            session.query(UploadedFile)
+            .filter(UploadedFile.filename == "resurface.txt")
+            .first()
+        )
+        assert lingering_record is None
+    finally:
+        session.close()
+
+
+def test_delete_document_without_file_id_does_not_resurface_in_uploaded_file_fallback(
+    test_env, temp_uploads
+):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionInfo,
+        ListCollectionsResult,
+    )
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "fallback-refresh.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="fallback-refresh.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+    finally:
+        session.close()
+
+    document_state = [
+        {
+            "collection": "demo",
+            "doc_id": generate_deterministic_doc_id("demo", str(file_path)),
+            "file_id": None,
+            "source_path": str(file_path),
+        }
+    ]
+
+    def _fake_list_documents_for_user(*args, **kwargs):
+        collection_name = kwargs.get("collection_name")
+        if collection_name == "demo":
+            return list(document_state)
+        raise RuntimeError("documents unavailable")
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        document_state.clear()
+
+    fake_result = ListCollectionsResult(
+        status="success",
+        collections=[CollectionInfo(name="demo", documents=0, document_names=[])],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=_fake_list_documents_for_user,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        delete_response = client.delete(
+            "/api/kb/collections/demo/documents/fallback-refresh.txt",
+            headers=headers,
+        )
+
+        assert delete_response.status_code == 200
+
+        with patch("xagent.web.api.kb.list_collections", return_value=fake_result):
+            refresh_response = client.get("/api/kb/collections", headers=headers)
+
+    assert refresh_response.status_code == 200
+    collection = refresh_response.json()["collections"][0]
+    assert collection["document_names"] == []
+    assert collection["document_metadata"] == []
+
+
+def test_delete_document_by_file_id_resolves_doc_id_via_list_documents(
+    test_env, temp_uploads
+):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DocumentListResult,
+        DocumentSummary,
+    )
+
+    file_path = temp_uploads / f"user_{user.id}" / "list-docs.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="list-docs.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+        session.refresh(file_record)
+        target_file_id = str(file_record.file_id)
+    finally:
+        session.close()
+
+    expected_doc_id = "doc-from-list-documents"
+    deleted_doc_ids: list[str] = []
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        deleted_doc_ids.append(doc_id)
+
+    doc_list = DocumentListResult(
+        status="success",
+        documents=[
+            DocumentSummary(
+                collection="demo",
+                doc_id=expected_doc_id,
+                source_path=str(file_path),
+            )
+        ],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch("xagent.web.api.kb._list_documents_for_user", return_value=[]),
+        patch("xagent.web.api.kb.list_documents", return_value=doc_list),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        response = client.delete(
+            f"/api/kb/collections/demo/documents/ignored.txt?file_id={target_file_id}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["deleted_doc_ids"] == [expected_doc_id]
+    assert deleted_doc_ids == [expected_doc_id]
+
+
+def test_delete_document_by_file_id_rejects_unlinked_basename_match(
+    test_env, temp_uploads
+):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DocumentListResult,
+        DocumentSummary,
+    )
+
+    file_path = temp_uploads / f"user_{user.id}" / "other" / "shared-name.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="shared-name.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+        session.refresh(file_record)
+        target_file_id = str(file_record.file_id)
+    finally:
+        session.close()
+
+    doc_list = DocumentListResult(
+        status="success",
+        documents=[
+            DocumentSummary(
+                collection="demo",
+                doc_id="doc-from-basename-only",
+                source_path=f"/tmp/user_{user.id}/demo/shared-name.txt",
+            )
+        ],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch("xagent.web.api.kb._list_documents_for_user", return_value=[]),
+        patch("xagent.web.api.kb.list_documents", return_value=doc_list),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
+        ) as mock_delete_document,
+    ):
+        response = client.delete(
+            f"/api/kb/collections/demo/documents/shared-name.txt?file_id={target_file_id}",
+            headers=headers,
+        )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+    mock_delete_document.assert_not_called()
+
+
+def test_delete_document_reports_cleanup_commit_failure(test_env, temp_uploads):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "commit-failure.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="commit-failure.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+        session.refresh(file_record)
+        target_file_id = str(file_record.file_id)
+    finally:
+        session.close()
+
+    document_state = [
+        {
+            "collection": "demo",
+            "doc_id": "doc-commit-failure",
+            "file_id": target_file_id,
+            "source_path": str(file_path),
+        }
+    ]
+
+    def _fake_list_documents_for_user(*args, **kwargs):
+        return list(document_state)
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        document_state.clear()
+
+    def _failing_commit(self):
+        raise RuntimeError("commit failed")
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=_fake_list_documents_for_user,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+        patch("sqlalchemy.orm.session.Session.commit", new=_failing_commit),
+    ):
+        response = client.delete(
+            f"/api/kb/collections/demo/documents/commit-failure.txt?file_id={target_file_id}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "partial_success"
+    assert payload["deleted_doc_ids"] == ["doc-commit-failure"]
+    assert any(
+        "Failed to persist orphan cleanup changes" in err for err in payload["errors"]
+    )
+
+
+def test_delete_document_rejects_mismatched_doc_id_and_file_id(test_env, temp_uploads):
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "mismatch.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    session = TestingSessionLocal()
+    try:
+        file_record = UploadedFile(
+            user_id=int(user.id),
+            filename="mismatch.txt",
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=7,
+        )
+        session.add(file_record)
+        session.commit()
+        session.refresh(file_record)
+        target_file_id = str(file_record.file_id)
+    finally:
+        session.close()
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=RuntimeError("documents unavailable"),
+        ),
+        patch(
+            "xagent.web.api.kb.list_documents",
+            side_effect=RuntimeError("documents unavailable"),
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
+        ) as mock_delete_document,
+    ):
+        response = client.delete(
+            (
+                "/api/kb/collections/demo/documents/ignored.txt"
+                f"?file_id={target_file_id}&doc_id=wrong-doc-id"
+            ),
+            headers=headers,
+        )
+
+    assert response.status_code == 409
+    assert "same document" in response.json()["detail"].lower()
+    mock_delete_document.assert_not_called()
 
 
 def test_kb_delete_collection_cleans_file_id_managed_root_file(test_env, temp_uploads):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -1117,7 +1117,6 @@ def test_delete_document_without_file_id_does_not_resurface_on_collection_refres
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
-        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )
@@ -1210,7 +1209,6 @@ def test_delete_document_without_file_id_does_not_resurface_in_uploaded_file_fal
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
-        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )
@@ -1686,7 +1684,6 @@ def test_list_collections_secondary_fallback_avoids_n_plus_one(test_env, temp_up
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
-        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -1352,6 +1352,62 @@ def test_delete_document_by_file_id_resolves_doc_id_via_list_documents(
     assert deleted_doc_ids == [expected_doc_id]
 
 
+def test_delete_document_by_doc_id_succeeds_without_uploaded_file_record(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DocumentListResult,
+        DocumentSummary,
+    )
+
+    file_path = temp_uploads / f"user_{user.id}" / "demo" / "already-cleaned.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    expected_doc_id = "doc-existing-without-file-row"
+    deleted_doc_ids: list[str] = []
+
+    def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
+        deleted_doc_ids.append(doc_id)
+
+    doc_list = DocumentListResult(
+        status="success",
+        documents=[
+            DocumentSummary(
+                collection="demo",
+                doc_id=expected_doc_id,
+                source_path=str(file_path),
+            )
+        ],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch("xagent.web.api.kb._list_documents_for_user", return_value=[]),
+        patch("xagent.web.api.kb.list_documents", return_value=doc_list),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        response = client.delete(
+            (
+                "/api/kb/collections/demo/documents/already-cleaned.txt"
+                f"?file_id=missing-file-id&doc_id={expected_doc_id}"
+            ),
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["deleted_doc_ids"] == [expected_doc_id]
+    assert deleted_doc_ids == [expected_doc_id]
+
+
 def test_delete_document_by_file_id_rejects_unlinked_basename_match(
     test_env, temp_uploads
 ):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -362,7 +362,9 @@ def test_kb_delete_accepts_unicode_collection_name(test_env, temp_uploads):
     assert response.status_code == 200
 
 
-def test_kb_delete_rejects_mixed_script_confusable_collection_name(test_env, temp_uploads):
+def test_kb_delete_rejects_mixed_script_confusable_collection_name(
+    test_env, temp_uploads
+):
     app, headers, user, _ = test_env
     client = TestClient(app)
 

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -1117,6 +1117,7 @@ def test_delete_document_without_file_id_does_not_resurface_on_collection_refres
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )
@@ -1209,6 +1210,7 @@ def test_delete_document_without_file_id_does_not_resurface_in_uploaded_file_fal
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )
@@ -1509,24 +1511,39 @@ def test_delete_document_reports_cleanup_commit_failure(test_env, temp_uploads):
     def _fake_delete_document(collection_name, doc_id, user_id, is_admin):
         document_state.clear()
 
-    def _failing_commit(self):
+    def _failing_commit():
         raise RuntimeError("commit failed")
 
-    with (
-        patch(
-            "xagent.web.api.kb._list_documents_for_user",
-            side_effect=_fake_list_documents_for_user,
-        ),
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
-            side_effect=_fake_delete_document,
-        ),
-        patch("sqlalchemy.orm.session.Session.commit", new=_failing_commit),
-    ):
-        response = client.delete(
-            f"/api/kb/collections/demo/documents/commit-failure.txt?file_id={target_file_id}",
-            headers=headers,
-        )
+    original_override = app.dependency_overrides[get_db]
+
+    def override_get_db_with_failing_commit():
+        db = TestingSessionLocal()
+        original_commit = db.commit
+        db.commit = _failing_commit
+        try:
+            yield db
+        finally:
+            db.commit = original_commit
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db_with_failing_commit
+    try:
+        with (
+            patch(
+                "xagent.web.api.kb._list_documents_for_user",
+                side_effect=_fake_list_documents_for_user,
+            ),
+            patch(
+                "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+                side_effect=_fake_delete_document,
+            ),
+        ):
+            response = client.delete(
+                f"/api/kb/collections/demo/documents/commit-failure.txt?file_id={target_file_id}",
+                headers=headers,
+            )
+    finally:
+        app.dependency_overrides[get_db] = original_override
 
     assert response.status_code == 200
     payload = response.json()
@@ -1669,6 +1686,7 @@ def test_list_collections_secondary_fallback_avoids_n_plus_one(test_env, temp_up
     client = TestClient(app)
 
     from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionDocumentMetadata,
         CollectionInfo,
         ListCollectionsResult,
     )
@@ -1704,3 +1722,102 @@ def test_list_collections_secondary_fallback_avoids_n_plus_one(test_env, temp_up
 
     assert response.status_code == 200
     assert call_counts["list_documents"] == 0
+
+
+def test_list_collections_skips_document_scan_when_names_are_complete(test_env):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionDocumentMetadata,
+        CollectionInfo,
+        ListCollectionsResult,
+    )
+
+    fake_result = ListCollectionsResult(
+        status="success",
+        collections=[
+            CollectionInfo(
+                name="complete",
+                documents=1,
+                document_names=["a.md"],
+                document_metadata=[
+                    CollectionDocumentMetadata(
+                        filename="a.md",
+                        file_id="file-1",
+                        doc_id="doc-1",
+                    )
+                ],
+            ),
+        ],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch("xagent.web.api.kb.list_collections", return_value=fake_result),
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=AssertionError("_list_documents_for_user should not be called"),
+        ),
+    ):
+        response = client.get("/api/kb/collections", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["collections"][0]["name"] == "complete"
+    assert payload["collections"][0]["document_names"] == ["a.md"]
+
+
+def test_list_collections_skips_document_scan_when_duplicate_names_have_metadata(
+    test_env,
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionDocumentMetadata,
+        CollectionInfo,
+        ListCollectionsResult,
+    )
+
+    fake_result = ListCollectionsResult(
+        status="success",
+        collections=[
+            CollectionInfo(
+                name="duplicate",
+                documents=2,
+                document_names=["shared.txt"],
+                document_metadata=[
+                    CollectionDocumentMetadata(
+                        filename="shared.txt",
+                        file_id="file-1",
+                        doc_id="doc-1",
+                    ),
+                    CollectionDocumentMetadata(
+                        filename="shared.txt",
+                        file_id="file-2",
+                        doc_id="doc-2",
+                    ),
+                ],
+            ),
+        ],
+        total_count=1,
+        message="ok",
+        warnings=[],
+    )
+
+    with (
+        patch("xagent.web.api.kb.list_collections", return_value=fake_result),
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            side_effect=AssertionError("_list_documents_for_user should not be called"),
+        ),
+    ):
+        response = client.get("/api/kb/collections", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["collections"][0]["name"] == "duplicate"
+    assert len(payload["collections"][0]["document_metadata"]) == 2

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -9,10 +9,10 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.core.tools.core.RAG_tools.utils.string_utils import (
     generate_deterministic_doc_id,
 )
-from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.web.api.auth import hash_password
 from xagent.web.api.kb import kb_router
 from xagent.web.models.database import Base, get_db

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -362,6 +362,22 @@ def test_kb_delete_accepts_unicode_collection_name(test_env, temp_uploads):
     assert response.status_code == 200
 
 
+def test_kb_delete_rejects_mixed_script_confusable_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "cоllection"
+    response = client.delete(
+        f"/api/kb/collections/{quote(collection_name, safe='')}",
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert "Invalid collection name" in response.json()["detail"]
+
+
 def test_kb_delete_physical_cleanup_failure_aborts_operation(test_env, temp_uploads):
     """Test that physical cleanup (move-to-trash) failure aborts database deletion."""
     app, headers, user, _ = test_env
@@ -936,6 +952,24 @@ def test_delete_document_accepts_unicode_collection_name(test_env, temp_uploads)
 
     assert response.status_code == 200
     assert deleted_doc_ids == ["doc-1"]
+
+
+def test_delete_document_rejects_mixed_script_confusable_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "cоllection"
+    response = client.delete(
+        f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt",
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert "Invalid collection name" in response.json()["detail"]
 
 
 def test_delete_document_rejects_path_traversal_in_collection_name(

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -314,12 +314,9 @@ def test_kb_delete_rejects_path_traversal_in_collection_name(test_env, temp_uplo
     app, headers, user, _ = test_env
     client = TestClient(app)
 
-    # Note: Paths with special characters in URL path parameter may cause 404
-    # due to URL encoding/routing issues. Test with URL-encoded versions or
-    # simpler invalid names that still trigger validation
     malicious_collections = [
-        "collection/../other",  # Path separator
-        "collection%2Fother",  # URL-encoded path separator
+        r"collection\\other",
+        r"collection\\..\\other",
     ]
 
     for collection_name in malicious_collections:
@@ -329,11 +326,40 @@ def test_kb_delete_rejects_path_traversal_in_collection_name(test_env, temp_uplo
         encoded_name = quote(collection_name, safe="")
         response = client.delete(f"/api/kb/collections/{encoded_name}", headers=headers)
 
-        # Should reject with 422 (validation error) or 404 (if routing fails)
-        # If routing fails, the validation happens but returns 404
-        assert response.status_code in [422, 404]
-        if response.status_code == 422:
-            assert "Invalid collection name" in response.json()["detail"]
+        assert response.status_code == 422
+        assert "Invalid collection name" in response.json()["detail"]
+
+
+def test_kb_delete_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "示例知识库集合"
+    coll_dir = temp_uploads / f"user_{user.id}" / collection_name
+    coll_dir.mkdir(parents=True, exist_ok=True)
+    (coll_dir / "some_file.txt").write_text("data")
+
+    with patch("xagent.web.api.kb.delete_collection") as mock_delete:
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+
+        mock_delete.return_value = CollectionOperationResult(
+            status="success",
+            collection=collection_name,
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+        response = client.delete(
+            f"/api/kb/collections/{quote(collection_name, safe='')}",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
 
 
 def test_kb_delete_physical_cleanup_failure_aborts_operation(test_env, temp_uploads):
@@ -866,6 +892,74 @@ def test_delete_document_prefers_file_id_and_cleans_orphan_file(test_env, temp_u
         assert deleted_record is None
     finally:
         session.close()
+
+
+def test_delete_document_accepts_unicode_collection_name(test_env, temp_uploads):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    collection_name = "示例知识库集合"
+    file_path = temp_uploads / f"user_{user.id}" / collection_name / "demo.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content")
+
+    deleted_doc_ids: list[str] = []
+    document_state = [
+        {
+            "collection": collection_name,
+            "doc_id": "doc-1",
+            "file_id": None,
+            "source_path": str(file_path),
+        }
+    ]
+
+    def _fake_delete_document(collection_name_arg, doc_id, user_id, is_admin):
+        deleted_doc_ids.append(doc_id)
+        assert collection_name_arg == collection_name
+
+    with (
+        patch(
+            "xagent.web.api.kb._list_documents_for_user",
+            return_value=document_state,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            side_effect=_fake_delete_document,
+        ),
+    ):
+        response = client.delete(
+            f"/api/kb/collections/{quote(collection_name, safe='')}/documents/demo.txt?doc_id=doc-1",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert deleted_doc_ids == ["doc-1"]
+
+
+def test_delete_document_rejects_path_traversal_in_collection_name(
+    test_env, temp_uploads
+):
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+
+    from urllib.parse import quote
+
+    malicious_collections = [
+        r"collection\\other",
+        r"collection\\..\\other",
+    ]
+
+    for collection_name in malicious_collections:
+        encoded_name = quote(collection_name, safe="")
+        response = client.delete(
+            f"/api/kb/collections/{encoded_name}/documents/demo.txt",
+            headers=headers,
+        )
+
+        assert response.status_code == 422
+        assert "Invalid collection name" in response.json()["detail"]
 
 
 def test_delete_document_by_filename_refuses_ambiguous_match(test_env, temp_uploads):

--- a/tests/web/test_config.py
+++ b/tests/web/test_config.py
@@ -161,16 +161,22 @@ class TestSanitizePathComponent:
             sanitize_path_component(malicious, "collection")
 
     def test_unicode_and_special_unicode(self):
-        """Test that unicode characters are rejected (only ASCII alphanumeric allowed)."""
-        unicode_names = [
+        valid_unicode_names = [
             "collection中文",
-            "collection🚀",
             "collectioné",
             "collectionñ",
             "collectionα",
+            "示例知识库集合",
+            "collection١٢٣",
+            "知识库_123-β",
         ]
 
-        for name in unicode_names:
+        for name in valid_unicode_names:
+            result = sanitize_path_component(name, "collection")
+            assert result == name
+
+        invalid_unicode_names = ["collection🚀"]
+        for name in invalid_unicode_names:
             with pytest.raises(ValueError, match="contains invalid characters"):
                 sanitize_path_component(name, "collection")
 

--- a/tests/web/test_config.py
+++ b/tests/web/test_config.py
@@ -165,7 +165,6 @@ class TestSanitizePathComponent:
             "collection中文",
             "collectioné",
             "collectionñ",
-            "collectionα",
             "示例知识库集合",
             "collection١٢٣",
             "知识库_123-β",
@@ -175,9 +174,14 @@ class TestSanitizePathComponent:
             result = sanitize_path_component(name, "collection")
             assert result == name
 
-        invalid_unicode_names = ["collection🚀"]
+        invalid_unicode_names = [
+            "collection🚀",
+            "collectiοn",  # Greek omicron mixed with Latin
+            "cоllection",  # Cyrillic o mixed with Latin
+            "collectionα",  # Greek alpha mixed with Latin
+        ]
         for name in invalid_unicode_names:
-            with pytest.raises(ValueError, match="contains invalid characters"):
+            with pytest.raises(ValueError, match="contains"):
                 sanitize_path_component(name, "collection")
 
     def test_rejects_compatibility_homoglyph_forms(self):

--- a/tests/web/test_config.py
+++ b/tests/web/test_config.py
@@ -180,6 +180,10 @@ class TestSanitizePathComponent:
             with pytest.raises(ValueError, match="contains invalid characters"):
                 sanitize_path_component(name, "collection")
 
+    def test_rejects_compatibility_homoglyph_forms(self):
+        with pytest.raises(ValueError, match="contains invalid characters"):
+            sanitize_path_component("Ａgent", "collection")
+
     def test_numeric_only_names(self):
         """Test that numeric-only names are accepted."""
         numeric_names = ["123", "0", "999999"]


### PR DESCRIPTION
## Summary
- prefer stable identifiers (`file_id` / `doc_id`) for document deletes so duplicate filenames remain safely deletable
- clean up fallback file metadata after delete so removed documents do not reappear after refresh
- expose collection delete from the knowledge base page and keep delete feedback/status handling consistent
- allow Unicode collection names in validation and delete routes while preserving traversal rejection