### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
           - anthropic
           - python-pptx
           - cloudpickle
+          - exa-py
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/example.env
+++ b/example.env
@@ -78,12 +78,15 @@ LANGFUSE_HOST="http://127.0.0.1:3000"
 LANGFUSE_PUBLIC_KEY="public key"
 LANGFUSE_SECRET_KEY="secret key"
 
-# Web Search API Keys (priority: Zhipu > Tavily > Google)
+# Web Search API Keys (priority: Zhipu > Tavily > Exa > Google)
 # Zhipu Web Search (recommended for Chinese users, get key at https://open.bigmodel.cn/)
 ZHIPU_API_KEY=""
 
 # Tavily Search API (alternative, get key at https://tavily.com)
 TAVILY_API_KEY=""
+
+# Exa AI-powered Search (get key at https://exa.ai)
+EXA_API_KEY=""
 
 # Google Custom Search (fallback, requires Google Cloud setup)
 GOOGLE_API_KEY=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
   "boxlite>=0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "filelock>=3.0.0",
   "cloudpickle>=3.0.0",
+  "exa-py>=2.0.0",
   # Data science libraries (core for RAG and analysis)
   "pandas>=1.3.0",
   # Special handling - AI-enhanced document processing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,8 @@ module = [
   "aiogram.*",
   "lark_oapi",
   "lark_oapi.*",
+  "exa_py",
+  "exa_py.*",
 ]
 ignore_missing_imports = true
 

--- a/src/xagent/core/tools/adapters/vibe/basic_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/basic_tools.py
@@ -27,6 +27,8 @@ async def create_basic_tools(config: "BaseToolConfig") -> List[Any]:
     google_api_key = config.get_tool_credential("web_search", "api_key")
     google_cse_id = config.get_tool_credential("web_search", "cse_id")
 
+    exa_api_key = config.get_tool_credential("exa_web_search", "api_key")
+
     if zhipu_api_key:
         from .zhipu_web_search import ZhipuWebSearchTool
 
@@ -35,6 +37,10 @@ async def create_basic_tools(config: "BaseToolConfig") -> List[Any]:
         from .tavily_web_search import TavilyWebSearchTool
 
         tools.append(TavilyWebSearchTool(api_key=tavily_api_key))
+    elif exa_api_key:
+        from .exa_web_search import ExaWebSearchTool
+
+        tools.append(ExaWebSearchTool(api_key=exa_api_key))
     elif google_api_key and google_cse_id:
         from .web_search import WebSearchTool
 

--- a/src/xagent/core/tools/adapters/vibe/exa_web_search.py
+++ b/src/xagent/core/tools/adapters/vibe/exa_web_search.py
@@ -1,0 +1,110 @@
+"""
+Exa Web Search Tool for xagent
+Framework wrapper around the Exa AI-powered search API.
+"""
+
+from typing import Any, Dict, List, Mapping, Optional, Type
+
+from pydantic import BaseModel, Field
+
+from ...core.exa_web_search import ExaWebSearchCore
+from .base import AbstractBaseTool, ToolCategory, ToolVisibility
+
+
+class ExaWebSearchArgs(BaseModel):
+    query: str = Field(description="The search query string")
+    num_results: int = Field(
+        default=10, description="Number of results to return (max 100)"
+    )
+    search_type: str = Field(
+        default="auto",
+        description="Search type: 'auto', 'neural', 'fast', or 'instant'",
+    )
+    content_mode: str = Field(
+        default="highlights",
+        description="Content retrieval mode: 'highlights', 'text', 'summary', or 'none'",
+    )
+    category: Optional[str] = Field(
+        default=None,
+        description="Focus category: 'company', 'research paper', 'news', 'personal site', 'financial report', 'people'",
+    )
+    include_domains: Optional[List[str]] = Field(
+        default=None, description="Restrict results to these domains"
+    )
+    exclude_domains: Optional[List[str]] = Field(
+        default=None, description="Exclude results from these domains"
+    )
+    include_text: Optional[List[str]] = Field(
+        default=None, description="Strings that must appear in webpage text"
+    )
+    exclude_text: Optional[List[str]] = Field(
+        default=None, description="Strings to exclude from results"
+    )
+    start_published_date: Optional[str] = Field(
+        default=None, description="Filter by published date start (ISO 8601)"
+    )
+    end_published_date: Optional[str] = Field(
+        default=None, description="Filter by published date end (ISO 8601)"
+    )
+
+
+class ExaWebSearchResult(BaseModel):
+    results: List[Dict[str, str]] = Field(
+        description="Search results with title, link, snippet and content"
+    )
+
+
+class ExaWebSearchTool(AbstractBaseTool):
+    """Framework wrapper for the Exa AI-powered web search tool."""
+
+    category = ToolCategory.BASIC
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._visibility = ToolVisibility.PUBLIC
+        self._api_key = api_key
+
+    @property
+    def name(self) -> str:
+        return "exa_web_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the web using Exa AI-powered search. "
+            "Returns results with titles, links, snippets, and content (highlights, full text, or summaries). "
+            "Supports category filtering, domain filtering, text filtering, and date range filtering. "
+            "Useful for finding current information, research, news, and company data."
+        )
+
+    @property
+    def tags(self) -> list[str]:
+        return ["search", "web", "information", "research", "exa"]
+
+    def args_type(self) -> Type[BaseModel]:
+        return ExaWebSearchArgs
+
+    def return_type(self) -> Type[BaseModel]:
+        return ExaWebSearchResult
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        raise NotImplementedError("ExaWebSearchTool only supports async execution.")
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        search_args = ExaWebSearchArgs.model_validate(args)
+        searcher = ExaWebSearchCore(api_key=self._api_key)
+
+        results = await searcher.search(
+            query=search_args.query,
+            num_results=search_args.num_results,
+            search_type=search_args.search_type,
+            content_mode=search_args.content_mode,
+            category=search_args.category,
+            include_domains=search_args.include_domains,
+            exclude_domains=search_args.exclude_domains,
+            include_text=search_args.include_text,
+            exclude_text=search_args.exclude_text,
+            start_published_date=search_args.start_published_date,
+            end_published_date=search_args.end_published_date,
+        )
+
+        return ExaWebSearchResult(results=results).model_dump()

--- a/src/xagent/core/tools/core/exa_web_search.py
+++ b/src/xagent/core/tools/core/exa_web_search.py
@@ -3,6 +3,7 @@ Exa Web Search Tool
 Standalone web search functionality using Exa AI-powered search API.
 """
 
+import asyncio
 import logging
 import os
 from typing import Any, Dict, List, Optional
@@ -66,57 +67,54 @@ class ExaWebSearchCore:
 
         num_results = min(max(1, num_results), 100)
 
+        from exa_py import Exa
+
+        client = Exa(api_key=api_key)
+        client.headers["x-exa-integration"] = "xagent"
+
+        # Build search kwargs
+        search_kwargs: Dict[str, Any] = {
+            "query": query,
+            "num_results": num_results,
+            "type": search_type,
+        }
+
+        if category:
+            search_kwargs["category"] = category
+        if include_domains:
+            search_kwargs["include_domains"] = include_domains
+        if exclude_domains:
+            search_kwargs["exclude_domains"] = exclude_domains
+        if include_text:
+            search_kwargs["include_text"] = include_text
+        if exclude_text:
+            search_kwargs["exclude_text"] = exclude_text
+        if start_published_date:
+            search_kwargs["start_published_date"] = start_published_date
+        if end_published_date:
+            search_kwargs["end_published_date"] = end_published_date
+
+        # Build contents parameter based on content_mode
+        contents_param = self._build_contents_param(content_mode)
+
         try:
-            from exa_py import Exa
-
-            client = Exa(api_key=api_key)
-            client.headers["x-exa-integration"] = "xagent"
-
-            # Build search kwargs
-            search_kwargs: Dict[str, Any] = {
-                "query": query,
-                "num_results": num_results,
-                "type": search_type,
-            }
-
-            if category:
-                search_kwargs["category"] = category
-            if include_domains:
-                search_kwargs["include_domains"] = include_domains
-            if exclude_domains:
-                search_kwargs["exclude_domains"] = exclude_domains
-            if include_text:
-                search_kwargs["include_text"] = include_text
-            if exclude_text:
-                search_kwargs["exclude_text"] = exclude_text
-            if start_published_date:
-                search_kwargs["start_published_date"] = start_published_date
-            if end_published_date:
-                search_kwargs["end_published_date"] = end_published_date
-
-            # Build contents parameter based on content_mode
-            contents_param = self._build_contents_param(content_mode)
-
             if contents_param is not None:
                 search_kwargs.update(contents_param)
-                response = client.search_and_contents(**search_kwargs)
+                response = await asyncio.to_thread(
+                    lambda: client.search_and_contents(**search_kwargs)
+                )
             else:
-                response = client.search(**search_kwargs)
-
-            logger.info("✅ Exa API request successful")
-            return self._normalize_results(response, content_mode)
-
-        except ImportError:
-            logger.error("❌ exa-py package not installed")
-            raise ValueError(
-                "exa-py package is required for Exa search. "
-                "Install it with: pip install exa-py"
-            )
+                response = await asyncio.to_thread(
+                    lambda: client.search(**search_kwargs)
+                )
         except ValueError:
             raise
         except Exception as e:
             logger.error("❌ Error during Exa search: %s", str(e))
             raise ValueError(f"Error during Exa search: {str(e)}") from e
+
+        logger.info("✅ Exa API request successful")
+        return self._normalize_results(response, content_mode)
 
     @staticmethod
     def _build_contents_param(content_mode: str) -> Optional[Dict[str, Any]]:
@@ -130,7 +128,10 @@ class ExaWebSearchCore:
         elif content_mode == "none":
             return None
         else:
-            return {"highlights": {"max_characters": 4000}}
+            raise ValueError(
+                f"Unknown content_mode '{content_mode}'. "
+                "Must be one of: 'highlights', 'text', 'summary', 'none'"
+            )
 
     @staticmethod
     def _normalize_results(

--- a/src/xagent/core/tools/core/exa_web_search.py
+++ b/src/xagent/core/tools/core/exa_web_search.py
@@ -134,9 +134,7 @@ class ExaWebSearchCore:
             )
 
     @staticmethod
-    def _normalize_results(
-        response: Any, content_mode: str
-    ) -> List[Dict[str, str]]:
+    def _normalize_results(response: Any, content_mode: str) -> List[Dict[str, str]]:
         """Normalize Exa search results into xagent's standard format."""
         results: List[Dict[str, str]] = []
 

--- a/src/xagent/core/tools/core/exa_web_search.py
+++ b/src/xagent/core/tools/core/exa_web_search.py
@@ -1,0 +1,170 @@
+"""
+Exa Web Search Tool
+Standalone web search functionality using Exa AI-powered search API.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ExaWebSearchCore:
+    """Pure Exa web search tool without framework dependencies."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key
+
+    async def search(
+        self,
+        query: str,
+        num_results: int = 10,
+        search_type: str = "auto",
+        content_mode: str = "highlights",
+        category: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        """
+        Search the web using Exa AI-powered search API.
+
+        Args:
+            query: The search query string
+            num_results: Number of results to return (max 100)
+            search_type: Search type - 'auto', 'neural', 'fast', or 'instant'
+            content_mode: Content retrieval mode - 'highlights', 'text', 'summary', or 'none'
+            category: Focus category - 'company', 'research paper', 'news', etc.
+            include_domains: Restrict results to these domains
+            exclude_domains: Exclude results from these domains
+            include_text: Strings that must appear in webpage text
+            exclude_text: Strings to exclude from results
+            start_published_date: Filter by published date start (ISO 8601)
+            end_published_date: Filter by published date end (ISO 8601)
+
+        Returns:
+            List of search results with title, link, snippet and optionally content
+        """
+        logger.info(
+            "🔍 Exa web search query='%s' num_results=%s type=%s content=%s",
+            query,
+            num_results,
+            search_type,
+            content_mode,
+        )
+
+        api_key = self._api_key or os.getenv("EXA_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Missing required environment variable EXA_API_KEY. "
+                "Get one at https://exa.ai"
+            )
+
+        num_results = min(max(1, num_results), 100)
+
+        try:
+            from exa_py import Exa
+
+            client = Exa(api_key=api_key)
+            client.headers["x-exa-integration"] = "xagent"
+
+            # Build search kwargs
+            search_kwargs: Dict[str, Any] = {
+                "query": query,
+                "num_results": num_results,
+                "type": search_type,
+            }
+
+            if category:
+                search_kwargs["category"] = category
+            if include_domains:
+                search_kwargs["include_domains"] = include_domains
+            if exclude_domains:
+                search_kwargs["exclude_domains"] = exclude_domains
+            if include_text:
+                search_kwargs["include_text"] = include_text
+            if exclude_text:
+                search_kwargs["exclude_text"] = exclude_text
+            if start_published_date:
+                search_kwargs["start_published_date"] = start_published_date
+            if end_published_date:
+                search_kwargs["end_published_date"] = end_published_date
+
+            # Build contents parameter based on content_mode
+            contents_param = self._build_contents_param(content_mode)
+
+            if contents_param is not None:
+                search_kwargs.update(contents_param)
+                response = client.search_and_contents(**search_kwargs)
+            else:
+                response = client.search(**search_kwargs)
+
+            logger.info("✅ Exa API request successful")
+            return self._normalize_results(response, content_mode)
+
+        except ImportError:
+            logger.error("❌ exa-py package not installed")
+            raise ValueError(
+                "exa-py package is required for Exa search. "
+                "Install it with: pip install exa-py"
+            )
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error("❌ Error during Exa search: %s", str(e))
+            raise ValueError(f"Error during Exa search: {str(e)}") from e
+
+    @staticmethod
+    def _build_contents_param(content_mode: str) -> Optional[Dict[str, Any]]:
+        """Build the contents parameter for Exa API calls."""
+        if content_mode == "highlights":
+            return {"highlights": {"max_characters": 4000}}
+        elif content_mode == "text":
+            return {"text": {"max_characters": 10000}}
+        elif content_mode == "summary":
+            return {"summary": True}
+        elif content_mode == "none":
+            return None
+        else:
+            return {"highlights": {"max_characters": 4000}}
+
+    @staticmethod
+    def _normalize_results(
+        response: Any, content_mode: str
+    ) -> List[Dict[str, str]]:
+        """Normalize Exa search results into xagent's standard format."""
+        results: List[Dict[str, str]] = []
+
+        for item in response.results:
+            title = getattr(item, "title", "") or ""
+            url = getattr(item, "url", "") or ""
+
+            # Extract content based on mode
+            content = ""
+            if content_mode == "highlights":
+                highlights = getattr(item, "highlights", None)
+                if highlights:
+                    content = "\n".join(highlights)
+            elif content_mode == "text":
+                content = getattr(item, "text", "") or ""
+            elif content_mode == "summary":
+                content = getattr(item, "summary", "") or ""
+
+            # Build snippet from content or highlights
+            snippet = content[:500] if content else ""
+
+            result: Dict[str, str] = {
+                "title": title,
+                "link": url,
+                "snippet": snippet,
+                "content": content[:8192] if content else "",
+            }
+
+            results.append(result)
+
+        logger.info("🎯 Exa search returned %d results", len(results))
+        return results

--- a/src/xagent/web/init_tool_configs.py
+++ b/src/xagent/web/init_tool_configs.py
@@ -64,6 +64,20 @@ def get_default_tool_configs() -> list[Dict[str, Any]]:
             "dependencies": ["tavily_api_key"],
         },
         {
+            "tool_name": "exa_web_search",
+            "tool_type": "builtin",
+            "category": "search",
+            "display_name": "Exa AI Search",
+            "description": "AI-powered web search using Exa, with content extraction and category filtering",
+            "enabled": True,
+            "requires_configuration": True,
+            "config": {
+                "provider": "exa",
+                "api_key_env": "EXA_API_KEY",
+            },
+            "dependencies": ["exa_api_key"],
+        },
+        {
             "tool_name": "zhipu_web_search",
             "tool_type": "builtin",
             "category": "search",

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -18,6 +18,14 @@ ToolFieldSpec = Dict[str, Any]
 
 
 TOOL_CREDENTIAL_SPECS: Dict[str, Dict[str, ToolFieldSpec]] = {
+    "exa_web_search": {
+        "api_key": {
+            "secret": True,
+            "env": ["EXA_API_KEY"],
+            "required": True,
+            "label": "API Key",
+        }
+    },
     "zhipu_web_search": {
         "api_key": {
             "secret": True,

--- a/tests/core/tools/test_exa_web_search.py
+++ b/tests/core/tools/test_exa_web_search.py
@@ -85,7 +85,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
                     {"query": "test search", "num_results": 2, "content_mode": "highlights"}
                 )
@@ -105,7 +105,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
                     {"query": "test search", "content_mode": "text"}
                 )
@@ -122,7 +122,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
                     {"query": "test search", "content_mode": "summary"}
                 )
@@ -139,7 +139,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
                     {"query": "test search", "content_mode": "none"}
                 )
@@ -158,7 +158,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 await exa_search_tool.run_json_async(
                     {
                         "query": "AI startups",
@@ -186,7 +186,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 await exa_search_tool.run_json_async({"query": "test"})
 
                 assert mock_client.headers["x-exa-integration"] == "xagent"
@@ -200,7 +200,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
                     {"query": "nonexistent query"}
                 )
@@ -215,7 +215,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 with pytest.raises(ValueError, match="Error during Exa search"):
                     await exa_search_tool.run_json_async({"query": "test"})
 
@@ -228,7 +228,7 @@ class TestExaWebSearchTool:
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
-            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+            with patch("exa_py.Exa", return_value=mock_client):
                 # Test with num_results > 100 (should be limited to 100)
                 await exa_search_tool.run_json_async(
                     {"query": "test", "num_results": 150}

--- a/tests/core/tools/test_exa_web_search.py
+++ b/tests/core/tools/test_exa_web_search.py
@@ -20,7 +20,9 @@ def exa_search_tool():
     return ExaWebSearchTool()
 
 
-def _make_mock_result(title="Test Article", url="https://example.com/article", **kwargs):
+def _make_mock_result(
+    title="Test Article", url="https://example.com/article", **kwargs
+):
     """Create a mock Exa result object."""
     result = MagicMock()
     result.title = title
@@ -73,7 +75,9 @@ class TestExaWebSearchTool:
     async def test_missing_api_key(self, exa_search_tool):
         """Test behavior when API key is missing"""
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="Missing required environment variable EXA_API_KEY"):
+            with pytest.raises(
+                ValueError, match="Missing required environment variable EXA_API_KEY"
+            ):
                 await exa_search_tool.run_json_async({"query": "test search"})
 
     @pytest.mark.asyncio
@@ -87,7 +91,11 @@ class TestExaWebSearchTool:
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
             with patch("exa_py.Exa", return_value=mock_client):
                 result = await exa_search_tool.run_json_async(
-                    {"query": "test search", "num_results": 2, "content_mode": "highlights"}
+                    {
+                        "query": "test search",
+                        "num_results": 2,
+                        "content_mode": "highlights",
+                    }
                 )
 
                 assert result["results"]
@@ -211,7 +219,9 @@ class TestExaWebSearchTool:
     async def test_api_error_handling(self, exa_search_tool):
         """Test handling of Exa API errors"""
         mock_client = MagicMock()
-        mock_client.search_and_contents.side_effect = Exception("API rate limit exceeded")
+        mock_client.search_and_contents.side_effect = Exception(
+            "API rate limit exceeded"
+        )
         mock_client.headers = {}
 
         with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):

--- a/tests/core/tools/test_exa_web_search.py
+++ b/tests/core/tools/test_exa_web_search.py
@@ -1,0 +1,288 @@
+"""
+Tests for Exa Web Search tool
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.exa_web_search import (
+    ExaWebSearchArgs,
+    ExaWebSearchResult,
+    ExaWebSearchTool,
+)
+
+
+@pytest.fixture
+def exa_search_tool():
+    """Create ExaWebSearchTool instance for testing"""
+    return ExaWebSearchTool()
+
+
+def _make_mock_result(title="Test Article", url="https://example.com/article", **kwargs):
+    """Create a mock Exa result object."""
+    result = MagicMock()
+    result.title = title
+    result.url = url
+    result.highlights = kwargs.get("highlights", ["Key highlight from article"])
+    result.text = kwargs.get("text", "Full text content of the article")
+    result.summary = kwargs.get("summary", "Summary of the article")
+    result.published_date = kwargs.get("published_date", None)
+    result.author = kwargs.get("author", None)
+    return result
+
+
+def _make_mock_response(results=None):
+    """Create a mock Exa search response."""
+    response = MagicMock()
+    if results is None:
+        results = [
+            _make_mock_result(
+                title="Test Article 1",
+                url="https://example.com/article1",
+                highlights=["First highlight from article 1"],
+            ),
+            _make_mock_result(
+                title="Test Article 2",
+                url="https://example.com/article2",
+                highlights=["Second highlight from article 2"],
+            ),
+        ]
+    response.results = results
+    return response
+
+
+class TestExaWebSearchTool:
+    """Test cases for ExaWebSearchTool"""
+
+    def test_tool_properties(self, exa_search_tool):
+        """Test basic tool properties"""
+        assert exa_search_tool.name == "exa_web_search"
+        assert "search" in exa_search_tool.tags
+        assert "exa" in exa_search_tool.tags
+        assert exa_search_tool.args_type() == ExaWebSearchArgs
+        assert exa_search_tool.return_type() == ExaWebSearchResult
+
+    def test_sync_not_implemented(self, exa_search_tool):
+        """Test that sync execution raises NotImplementedError"""
+        with pytest.raises(NotImplementedError):
+            exa_search_tool.run_json_sync({"query": "test"})
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self, exa_search_tool):
+        """Test behavior when API key is missing"""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Missing required environment variable EXA_API_KEY"):
+                await exa_search_tool.run_json_async({"query": "test search"})
+
+    @pytest.mark.asyncio
+    async def test_successful_search_highlights(self, exa_search_tool):
+        """Test successful search with highlights content mode"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                result = await exa_search_tool.run_json_async(
+                    {"query": "test search", "num_results": 2, "content_mode": "highlights"}
+                )
+
+                assert result["results"]
+                assert len(result["results"]) == 2
+                assert result["results"][0]["title"] == "Test Article 1"
+                assert result["results"][0]["link"] == "https://example.com/article1"
+                assert "First highlight" in result["results"][0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_successful_search_text(self, exa_search_tool):
+        """Test successful search with text content mode"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                result = await exa_search_tool.run_json_async(
+                    {"query": "test search", "content_mode": "text"}
+                )
+
+                assert result["results"]
+                assert "Full text content" in result["results"][0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_successful_search_summary(self, exa_search_tool):
+        """Test successful search with summary content mode"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                result = await exa_search_tool.run_json_async(
+                    {"query": "test search", "content_mode": "summary"}
+                )
+
+                assert result["results"]
+                assert "Summary of the article" in result["results"][0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_successful_search_no_content(self, exa_search_tool):
+        """Test successful search without content retrieval"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                result = await exa_search_tool.run_json_async(
+                    {"query": "test search", "content_mode": "none"}
+                )
+
+                assert result["results"]
+                # search() should be called instead of search_and_contents()
+                mock_client.search.assert_called_once()
+                mock_client.search_and_contents.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters(self, exa_search_tool):
+        """Test search with domain and category filters"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                await exa_search_tool.run_json_async(
+                    {
+                        "query": "AI startups",
+                        "category": "company",
+                        "include_domains": ["techcrunch.com"],
+                        "exclude_domains": ["reddit.com"],
+                        "include_text": ["funding"],
+                        "start_published_date": "2024-01-01T00:00:00Z",
+                    }
+                )
+
+                call_kwargs = mock_client.search_and_contents.call_args[1]
+                assert call_kwargs["category"] == "company"
+                assert call_kwargs["include_domains"] == ["techcrunch.com"]
+                assert call_kwargs["exclude_domains"] == ["reddit.com"]
+                assert call_kwargs["include_text"] == ["funding"]
+                assert call_kwargs["start_published_date"] == "2024-01-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_integration_header_set(self, exa_search_tool):
+        """Test that the x-exa-integration header is set correctly"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                await exa_search_tool.run_json_async({"query": "test"})
+
+                assert mock_client.headers["x-exa-integration"] == "xagent"
+
+    @pytest.mark.asyncio
+    async def test_empty_search_results(self, exa_search_tool):
+        """Test handling when no search results are found"""
+        mock_response = _make_mock_response(results=[])
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                result = await exa_search_tool.run_json_async(
+                    {"query": "nonexistent query"}
+                )
+
+                assert result["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_api_error_handling(self, exa_search_tool):
+        """Test handling of Exa API errors"""
+        mock_client = MagicMock()
+        mock_client.search_and_contents.side_effect = Exception("API rate limit exceeded")
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                with pytest.raises(ValueError, match="Error during Exa search"):
+                    await exa_search_tool.run_json_async({"query": "test"})
+
+    @pytest.mark.asyncio
+    async def test_num_results_limits(self, exa_search_tool):
+        """Test that num_results is properly limited between 1 and 100"""
+        mock_response = _make_mock_response()
+        mock_client = MagicMock()
+        mock_client.search_and_contents.return_value = mock_response
+        mock_client.headers = {}
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test_key"}):
+            with patch("xagent.core.tools.core.exa_web_search.Exa", return_value=mock_client):
+                # Test with num_results > 100 (should be limited to 100)
+                await exa_search_tool.run_json_async(
+                    {"query": "test", "num_results": 150}
+                )
+                call_kwargs = mock_client.search_and_contents.call_args[1]
+                assert call_kwargs["num_results"] == 100
+
+                # Test with num_results < 1 (should be set to 1)
+                await exa_search_tool.run_json_async(
+                    {"query": "test", "num_results": 0}
+                )
+                call_kwargs = mock_client.search_and_contents.call_args[1]
+                assert call_kwargs["num_results"] == 1
+
+    def test_args_validation(self):
+        """Test ExaWebSearchArgs validation"""
+        # Valid args with defaults
+        args = ExaWebSearchArgs(query="test search")
+        assert args.query == "test search"
+        assert args.num_results == 10
+        assert args.search_type == "auto"
+        assert args.content_mode == "highlights"
+        assert args.category is None
+
+        # Custom args
+        args = ExaWebSearchArgs(
+            query="AI research",
+            num_results=20,
+            search_type="neural",
+            content_mode="text",
+            category="research paper",
+            include_domains=["arxiv.org"],
+        )
+        assert args.query == "AI research"
+        assert args.num_results == 20
+        assert args.search_type == "neural"
+        assert args.content_mode == "text"
+        assert args.category == "research paper"
+        assert args.include_domains == ["arxiv.org"]
+
+    def test_result_model(self):
+        """Test ExaWebSearchResult model"""
+        results = [
+            {
+                "title": "Test",
+                "link": "https://example.com",
+                "snippet": "Test snippet",
+                "content": "Test content",
+            }
+        ]
+
+        result = ExaWebSearchResult(results=results)
+        assert result.results == results
+
+        dumped = result.model_dump()
+        assert "results" in dumped
+        assert dumped["results"] == results


### PR DESCRIPTION
## Summary

- Add **Exa** as a new web search provider, integrated into xagent's existing search tool infrastructure
- Follows the same core + vibe adapter pattern used by Tavily, Zhipu, and Google search tools
- Supports key Exa features: multiple search types (`auto`, `neural`, `fast`, `instant`), content modes (`highlights`, `text`, `summary`), category filtering (`company`, `research paper`, `news`, etc.), domain filtering, text filtering, and date range filtering
- Registers Exa in the tool credential system, tool config defaults, and `basic_tools` factory (priority: Zhipu > Tavily > Exa > Google)

## Code example

```python
# Using the Exa search tool directly
from xagent.core.tools.core.exa_web_search import ExaWebSearchCore

searcher = ExaWebSearchCore(api_key="your-exa-api-key")
results = await searcher.search(
    query="latest AI research papers",
    num_results=10,
    search_type="auto",
    content_mode="highlights",
    category="research paper",
    include_domains=["arxiv.org"],
)
```

## Files changed

- `src/xagent/core/tools/core/exa_web_search.py` — Core search implementation using `exa-py` SDK
- `src/xagent/core/tools/adapters/vibe/exa_web_search.py` — Vibe adapter with Pydantic args/result models
- `src/xagent/core/tools/adapters/vibe/basic_tools.py` — Register Exa in the search provider priority chain
- `src/xagent/web/init_tool_configs.py` — Add default tool config entry for Exa
- `src/xagent/web/services/tool_credentials.py` — Add credential spec for `EXA_API_KEY`
- `example.env` — Add `EXA_API_KEY` placeholder
- `pyproject.toml` — Add `exa-py>=2.0.0` dependency
- `tests/core/tools/test_exa_web_search.py` — Unit tests covering all search modes, filters, error handling

## Test plan

- [x] Unit tests for all content modes (highlights, text, summary, none)
- [x] Unit tests for domain/category/text/date filters
- [x] Unit tests for error handling (missing API key, API errors)
- [x] Unit tests for num_results clamping (1-100)
- [x] Unit tests for integration tracking header (`x-exa-integration: xagent`)
- [ ] Manual test with real `EXA_API_KEY` env var