### PR TITLE
fix(kb): use collection embedding config for knowledge search

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
@@ -22,7 +22,6 @@ async def create_knowledge_tools(config: "BaseToolConfig") -> List[Any]:
             get_list_knowledge_bases_tool,
         )
 
-        embedding_model = config.get_embedding_model()
         allowed_collections = config.get_allowed_collections()
         user_id = config.get_user_id()
         is_admin = config.is_admin()
@@ -37,7 +36,6 @@ async def create_knowledge_tools(config: "BaseToolConfig") -> List[Any]:
 
         # Add search tool
         knowledge_tool = get_knowledge_search_tool(
-            embedding_model_id=embedding_model,
             allowed_collections=allowed_collections,
             user_id=user_id,
             is_admin=is_admin,

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -560,12 +560,21 @@ def resolve_effective_embedding_model_sync(
         inferred_model_id: Optional[str] = None
         inferred_dimension: Optional[int] = None
         if collection_info.embeddings > 0:
-            from ..utils.migration_utils import _infer_embedding_config_from_collection
+            try:
+                from ..utils.migration_utils import (
+                    _infer_embedding_config_from_collection,
+                )
 
-            inferred_model_id, inferred_dimension = (
-                _infer_embedding_config_from_collection(collection_name)
-            )
-            inferred_model_id = _normalize_model_id(inferred_model_id)
+                inferred_model_id, inferred_dimension = (
+                    _infer_embedding_config_from_collection(collection_name)
+                )
+                inferred_model_id = _normalize_model_id(inferred_model_id)
+            except Exception as exc:
+                logger.warning(
+                    "Embedding inference failed for collection '%s': %s",
+                    collection_name,
+                    exc,
+                )
 
         if inferred_model_id:
             logger.info(

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -492,9 +492,11 @@ def resolve_effective_embedding_model_sync(
     """Resolve the effective embedding model ID for a collection.
 
     Logic:
-    1. If collection is initialized, use its bound model ID (and warn if config differs).
-    2. If collection is not initialized, use config model ID.
-    3. If neither is available, raise ValueError.
+    1. If collection is initialized, use its bound model ID.
+    2. Else if collection ingestion_config stores an embedding model, use it.
+    3. Else if existing embedding tables can be inferred for this collection, use that.
+    4. Else if config provides an embedding model, use it.
+    5. If none are available, raise ValueError.
 
     Args:
         collection_name: Name of the collection
@@ -506,20 +508,25 @@ def resolve_effective_embedding_model_sync(
     Raises:
         ValueError: If model cannot be resolved or collection not found.
     """
-    # Treat empty/whitespace-only model IDs as missing values.
-    config_model_id = (
-        config_model_id.strip()
-        if isinstance(config_model_id, str) and config_model_id.strip()
-        else None
-    )
+
+    def _normalize_model_id(model_id: Optional[str]) -> Optional[str]:
+        if not isinstance(model_id, str):
+            return None
+        normalized = model_id.strip()
+        if not normalized or normalized.lower() == "none":
+            return None
+        return normalized
+
+    # Treat empty/whitespace-only IDs and the tool-layer "none" placeholder as missing.
+    config_model_id = _normalize_model_id(config_model_id)
     try:
         mark_collection_accessed_sync(collection_name)
         collection_info = get_collection_sync(collection_name)
 
-        bound_model_id = (
-            collection_info.embedding_model_id.strip()
-            if isinstance(collection_info.embedding_model_id, str)
-            and collection_info.embedding_model_id.strip()
+        bound_model_id = _normalize_model_id(collection_info.embedding_model_id)
+        indexed_model_id = _normalize_model_id(
+            collection_info.ingestion_config.embedding_model_id
+            if collection_info.ingestion_config is not None
             else None
         )
 
@@ -533,6 +540,56 @@ def resolve_effective_embedding_model_sync(
                     bound_model_id,
                 )
             return bound_model_id
+
+        if indexed_model_id:
+            if config_model_id and config_model_id != indexed_model_id:
+                logger.warning(
+                    "Config embedding_model_id '%s' overridden by "
+                    "collection '%s' ingestion config model '%s'",
+                    config_model_id,
+                    collection_name,
+                    indexed_model_id,
+                )
+            logger.info(
+                "Collection '%s' using ingestion config embedding_model_id '%s'",
+                collection_name,
+                indexed_model_id,
+            )
+            return indexed_model_id
+
+        inferred_model_id: Optional[str] = None
+        inferred_dimension: Optional[int] = None
+        if collection_info.embeddings > 0:
+            from ..utils.migration_utils import _infer_embedding_config_from_collection
+
+            inferred_model_id, inferred_dimension = (
+                _infer_embedding_config_from_collection(collection_name)
+            )
+            inferred_model_id = _normalize_model_id(inferred_model_id)
+
+        if inferred_model_id:
+            logger.info(
+                "Collection '%s' inferred embedding_model_id '%s' from existing embedding tables",
+                collection_name,
+                inferred_model_id,
+            )
+            try:
+                updated_collection = collection_info.model_copy(
+                    update={
+                        "embedding_model_id": inferred_model_id,
+                        "embedding_dimension": inferred_dimension
+                        if inferred_dimension is not None
+                        else collection_info.embedding_dimension,
+                    }
+                )
+                _sync_wrapper(collection_manager.save_collection)(updated_collection)
+            except Exception as save_error:
+                logger.warning(
+                    "Failed to persist inferred embedding metadata for collection '%s': %s",
+                    collection_name,
+                    save_error,
+                )
+            return inferred_model_id
 
         if config_model_id:
             logger.info(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
@@ -672,7 +672,11 @@ def search_documents(
                         warnings.extend(_serialize_warnings(hybrid_response.warnings))
                         results = list(hybrid_response.results)
                         status = hybrid_response.status or "success"
-                        message = "Hybrid search completed successfully"
+                        message = (
+                            "Hybrid search completed successfully"
+                            if status == "success"
+                            else "Hybrid search completed with warnings"
+                        )
 
         # Apply optional rerank
         current_step = "apply_rerank"

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -225,6 +225,8 @@ async def search_knowledge_base(
 
         # Search across collections and aggregate results
         all_results = []
+        collection_errors: list[str] = []
+        collection_warnings: list[str] = []
         total_searched = 0
 
         for collection_info in collections_to_iterate:
@@ -250,6 +252,26 @@ async def search_knowledge_base(
                     is_admin=is_admin,
                 )
 
+                if result.status not in {"success", "partial_success"}:
+                    error_message = result.message or "; ".join(result.warnings)
+                    collection_errors.append(
+                        f"{collection_name}: {error_message or 'search failed'}"
+                    )
+                    logger.warning(
+                        "Search pipeline returned status '%s' for collection '%s': %s",
+                        result.status,
+                        collection_name,
+                        error_message,
+                    )
+                    continue
+
+                if result.status != "success" or result.warnings:
+                    warning_message = result.message or "; ".join(result.warnings)
+                    if warning_message:
+                        collection_warnings.append(
+                            f"{collection_name}: {warning_message}"
+                        )
+
                 if result.results:
                     for res in result.results:
                         res_dict = dict(res)
@@ -259,21 +281,38 @@ async def search_knowledge_base(
                     total_searched += collection_info.documents
 
             except Exception as e:
+                collection_errors.append(f"{collection_name}: {e}")
                 logger.warning(f"Failed to search collection '{collection_name}': {e}")
                 continue
 
         if not all_results:
-            return KnowledgeSearchResult(
-                results=[],
-                summary=f"No relevant documents found in any knowledge base. "
+            if collection_errors:
+                summary = (
+                    "Knowledge base search failed for one or more collections: "
+                    + " | ".join(collection_errors)
+                )
+                if collection_warnings:
+                    summary = (
+                        summary + "\n\nWarnings: " + " | ".join(collection_warnings)
+                    )
+                return KnowledgeSearchResult(results=[], summary=summary)
+            summary = (
+                f"No relevant documents found in any knowledge base. "
                 f"Searched {total_searched} documents across "
-                f"{len(collections_result.collections)} collections. Query: {tool_args.query}",
+                f"{len(collections_result.collections)} collections. Query: {tool_args.query}"
             )
+            if collection_warnings:
+                summary = summary + "\n\nWarnings: " + " | ".join(collection_warnings)
+            return KnowledgeSearchResult(results=[], summary=summary)
 
         # Format results (structured + summary)
         formatted_results, summary = _format_search_results(
             all_results, tool_args.query, total_searched
         )
+        if collection_warnings:
+            summary = summary + "\n\nWarnings: " + " | ".join(collection_warnings)
+        if collection_errors:
+            summary = summary + "\n\nErrors: " + " | ".join(collection_errors)
 
         return KnowledgeSearchResult(results=formatted_results, summary=summary)
 
@@ -296,7 +335,7 @@ def _format_search_results(
         collection = result.get("collection", "unknown")
         score = result.get("score", 0.0)
         text = result.get("text", "")
-        metadata = result.get("metadata", {})
+        metadata = result.get("metadata") or {}
 
         # Extract file information from metadata
         source_path = metadata.get("source", "")

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -194,7 +194,7 @@ class TaskWorkspace:
                 db.rollback()
             raise  # Re-raise so caller knows registration failed
         finally:
-            if should_close:
+            if should_close and db is not None:
                 db.close()
 
     def _get_file_id_from_db(
@@ -743,21 +743,24 @@ class TaskWorkspace:
         from ..web.models.uploaded_file import UploadedFile
         from .storage.manager import create_db_session
 
-        # Use existing session or create temporary one
-        db = self.db_session if self.db_session else create_db_session()
-        should_close = self.db_session is None
+        # Extract user_id from workspace id (e.g., 'web_task_265' -> 265)
+        task_id = None
+        user_id = None
+        try:
+            task_id = int(self.id.split("_")[-1])
+        except (ValueError, IndexError):
+            task_id = None
+
+        # Only open a database session when this workspace can actually map to a task.
+        db = None
+        should_close = False
+        if task_id is not None:
+            db = self.db_session if self.db_session else create_db_session()
+            should_close = self.db_session is None
 
         try:
-            # Extract user_id from workspace id (e.g., 'web_task_265' -> 265)
-            task_id = None
-            user_id = None
-            try:
-                task_id = int(self.id.split("_")[-1])
-            except (ValueError, IndexError):
-                task_id = None
-
-            # Try to get user_id from task if we have a valid task_id
-            if task_id:
+            # Try to get user_id from task if we have a valid task_id and db session
+            if task_id and db is not None:
                 task = db.query(Task).filter(Task.id == task_id).first()
                 if task:
                     user_id = task.user_id
@@ -766,7 +769,7 @@ class TaskWorkspace:
             result_files = []
             total_count = 0
 
-            if user_id:
+            if user_id and db is not None:
                 # Query uploaded files for this user
                 query = db.query(UploadedFile).filter(UploadedFile.user_id == user_id)
                 total_count = query.count()

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -848,7 +848,7 @@ class TaskWorkspace:
             }
 
         finally:
-            if should_close:
+            if should_close and db is not None:
                 db.close()
 
     def __enter__(self) -> "TaskWorkspace":

--- a/src/xagent/sandbox/boxlite_sandbox.py
+++ b/src/xagent/sandbox/boxlite_sandbox.py
@@ -8,6 +8,7 @@ import abc
 import asyncio
 import logging
 import os
+import shlex
 import tempfile
 import textwrap
 import uuid
@@ -227,8 +228,24 @@ class BoxliteSandbox(Sandbox):
         if remote_dir:
             await self.exec("mkdir", "-p", remote_dir)
 
-        # Use mv command to move to target location (supports volume mounts)
-        result = await self.exec("mv", temp_remote, remote_path)
+        temp_remote_quoted = shlex.quote(temp_remote)
+        remote_path_quoted = shlex.quote(remote_path)
+
+        if overwrite:
+            result = await self.exec(
+                "sh",
+                "-c",
+                f"mv {temp_remote_quoted} {remote_path_quoted}",
+            )
+        else:
+            result = await self.exec(
+                "sh",
+                "-c",
+                f"if [ -e {remote_path_quoted} ]; then exit 100; fi; mv {temp_remote_quoted} {remote_path_quoted}",
+            )
+            if result.exit_code == 100:
+                await self.exec("rm", "-f", temp_remote)
+                raise FileExistsError(f"Remote file already exists: {remote_path}")
 
         if result.exit_code != 0:
             # Clean up temporary file

--- a/tests/core/tools/adapters/vibe/test_knowledge_search.py
+++ b/tests/core/tools/adapters/vibe/test_knowledge_search.py
@@ -768,6 +768,132 @@ class TestKnowledgeSearchTool:
         assert "Hybrid search completed with warnings" in result.summary
 
     @pytest.mark.asyncio
+    async def test_search_partial_success_with_results_keeps_results_and_warning(
+        self,
+    ):
+        """Partial-success responses with hits should keep both results and warnings."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            )
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                return_value=SearchPipelineResult(
+                    status="partial_success",
+                    search_type="hybrid",
+                    results=_successful_pipeline_result(
+                        [
+                            {
+                                "text": "Recovered result",
+                                "score": 0.88,
+                                "metadata": {"doc_id": "doc1", "chunk_id": "chunk1"},
+                            }
+                        ]
+                    ).results,
+                    result_count=1,
+                    warnings=["FTS fallback used"],
+                    message="Hybrid search completed with warnings",
+                    used_rerank=False,
+                ),
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert result.results
+        assert result.results[0].text == "Recovered result"
+        assert "Recovered result" in result.summary
+        assert "Warnings:" in result.summary
+        assert "Hybrid search completed with warnings" in result.summary
+        assert "Knowledge base search failed" not in result.summary
+
+    @pytest.mark.asyncio
+    async def test_search_appends_errors_alongside_successful_results(self):
+        """Mixed collection outcomes should include both hits and per-collection errors."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            ),
+            CollectionInfo(
+                name="kb2",
+                total_documents=8,
+                embeddings=120,
+                document_names=["doc2.pdf"],
+            ),
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        def _search_side_effect(*, collection, **kwargs):
+            if collection == "kb1":
+                return _successful_pipeline_result(
+                    [
+                        {
+                            "text": "Successful result",
+                            "score": 0.92,
+                            "metadata": {"doc_id": "doc1", "chunk_id": "chunk1"},
+                        }
+                    ]
+                )
+            return SearchPipelineResult(
+                status="error",
+                search_type="hybrid",
+                results=[],
+                result_count=0,
+                warnings=["index unavailable"],
+                message="index unavailable",
+                used_rerank=False,
+            )
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                side_effect=_search_side_effect,
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1", "kb2"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert result.results
+        assert result.results[0].text == "Successful result"
+        assert "Successful result" in result.summary
+        assert "Errors:" in result.summary
+        assert "kb2: index unavailable" in result.summary
+
+    @pytest.mark.asyncio
     async def test_search_collection_exception_is_surfaced_in_summary(self):
         """Per-collection exceptions should be surfaced instead of hidden as empty results."""
         mock_collections = [

--- a/tests/core/tools/adapters/vibe/test_knowledge_search.py
+++ b/tests/core/tools/adapters/vibe/test_knowledge_search.py
@@ -10,8 +10,38 @@ from xagent.core.tools.adapters.vibe.document_search import (
     get_knowledge_search_tool,
     get_list_knowledge_bases_tool,
 )
+from xagent.core.tools.adapters.vibe.knowledge_tools import create_knowledge_tools
 from xagent.core.tools.core.document_search import _format_search_results
-from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    SearchPipelineResult,
+)
+
+
+def _successful_pipeline_result(results):
+    normalized_results = []
+    for idx, result in enumerate(results, start=1):
+        metadata = dict(result.get("metadata", {}))
+        normalized_results.append(
+            {
+                "doc_id": metadata.get("doc_id", f"doc{idx}"),
+                "chunk_id": metadata.get("chunk_id", f"chunk{idx}"),
+                "text": result.get("text", ""),
+                "score": result.get("score", 0.0),
+                "parse_hash": result.get("parse_hash", f"parse{idx}"),
+                "model_tag": result.get("model_tag", "test-model"),
+                "metadata": metadata or None,
+            }
+        )
+    return SearchPipelineResult(
+        status="success",
+        search_type="hybrid",
+        results=normalized_results,
+        result_count=len(normalized_results),
+        warnings=[],
+        message="ok",
+        used_rerank=False,
+    )
 
 
 class TestListKnowledgeBasesTool:
@@ -188,6 +218,22 @@ class TestKnowledgeSearchTool:
         assert "search" in tool.description.lower()
 
     @pytest.mark.asyncio
+    async def test_factory_does_not_inject_global_default_embedding_model(self):
+        """Factory should let each knowledge base use its own indexed embedding model."""
+        config = MagicMock()
+        config.get_allowed_collections.return_value = ["kb1"]
+        config.get_user_id.return_value = 7
+        config.is_admin.return_value = False
+        config.get_embedding_model.return_value = "global-default-embed"
+
+        tools = await create_knowledge_tools(config)
+
+        knowledge_tool = next(tool for tool in tools if tool.name == "knowledge_search")
+        assert isinstance(knowledge_tool, KnowledgeSearchTool)
+        assert knowledge_tool.embedding_model_id is None
+        assert knowledge_tool.allowed_collections == ["kb1"]
+
+    @pytest.mark.asyncio
     async def test_search_no_collections_available(self):
         """Test searching when no collections exist."""
         mock_result = MagicMock()
@@ -232,14 +278,15 @@ class TestKnowledgeSearchTool:
         mock_list_result.collections = mock_collections
 
         # Mock search result
-        mock_search_result = MagicMock()
-        mock_search_result.results = [
-            {
-                "text": "Test content",
-                "score": 0.85,
-                "metadata": {"doc_id": "doc1", "chunk_id": "chunk1"},
-            }
-        ]
+        mock_search_result = _successful_pipeline_result(
+            [
+                {
+                    "text": "Test content",
+                    "score": 0.85,
+                    "metadata": {"doc_id": "doc1", "chunk_id": "chunk1"},
+                }
+            ]
+        )
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -313,8 +360,7 @@ class TestKnowledgeSearchTool:
         mock_list_result = MagicMock()
         mock_list_result.collections = mock_collections
 
-        mock_search_result = MagicMock()
-        mock_search_result.results = []
+        mock_search_result = _successful_pipeline_result([])
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -359,8 +405,7 @@ class TestKnowledgeSearchTool:
         mock_list_result = MagicMock()
         mock_list_result.collections = mock_collections
 
-        mock_search_result = MagicMock()
-        mock_search_result.results = []
+        mock_search_result = _successful_pipeline_result([])
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -413,8 +458,7 @@ class TestKnowledgeSearchTool:
         mock_list_result = MagicMock()
         mock_list_result.collections = mock_collections
 
-        mock_search_result = MagicMock()
-        mock_search_result.results = []
+        mock_search_result = _successful_pipeline_result([])
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -506,8 +550,9 @@ class TestKnowledgeSearchTool:
         mock_list_result = MagicMock()
         mock_list_result.collections = mock_collections
 
-        mock_search_result = MagicMock()
-        mock_search_result.results = [{"text": "Test content", "score": 0.85}]
+        mock_search_result = _successful_pipeline_result(
+            [{"text": "Test content", "score": 0.85}]
+        )
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -554,8 +599,7 @@ class TestKnowledgeSearchTool:
         mock_list_result = MagicMock()
         mock_list_result.collections = mock_collections
 
-        mock_search_result = MagicMock()
-        mock_search_result.results = []
+        mock_search_result = _successful_pipeline_result([])
 
         with patch(
             "xagent.core.tools.core.document_search.list_collections",
@@ -583,6 +627,182 @@ class TestKnowledgeSearchTool:
                     call[1]["collection"] for call in mock_search.call_args_list
                 }
                 assert searched_collections == {"kb1", "kb2"}
+
+    @pytest.mark.asyncio
+    async def test_search_surfaces_pipeline_errors_in_summary(self):
+        """Pipeline failures should not be silently reported as empty results."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            )
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                return_value=SearchPipelineResult(
+                    status="error",
+                    search_type="hybrid",
+                    results=[],
+                    result_count=0,
+                    warnings=["initialize failed: missing embedding model"],
+                    message="initialize failed: missing embedding model",
+                    used_rerank=False,
+                ),
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert "Knowledge base search failed" in result.summary
+        assert "kb1" in result.summary
+        assert "missing embedding model" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_search_failed_status_is_reported_as_error(self):
+        """Failed pipeline statuses should remain hard failures."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            )
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                return_value=SearchPipelineResult(
+                    status="failed",
+                    search_type="hybrid",
+                    results=[],
+                    result_count=0,
+                    warnings=["index unavailable"],
+                    message="index unavailable",
+                    used_rerank=False,
+                ),
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert "Knowledge base search failed" in result.summary
+        assert "kb1" in result.summary
+        assert "index unavailable" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_search_partial_success_is_reported_as_warning_not_failure(self):
+        """Partial-success pipeline responses should not be treated as hard failures."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            )
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                return_value=SearchPipelineResult(
+                    status="partial_success",
+                    search_type="hybrid",
+                    results=[],
+                    result_count=0,
+                    warnings=["FTS fallback used"],
+                    message="Hybrid search completed with warnings",
+                    used_rerank=False,
+                ),
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert "Knowledge base search failed" not in result.summary
+        assert "No relevant documents found" in result.summary
+        assert "Warnings:" in result.summary
+        assert "Hybrid search completed with warnings" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_search_collection_exception_is_surfaced_in_summary(self):
+        """Per-collection exceptions should be surfaced instead of hidden as empty results."""
+        mock_collections = [
+            CollectionInfo(
+                name="kb1",
+                total_documents=10,
+                embeddings=100,
+                document_names=["doc1.pdf"],
+            )
+        ]
+
+        mock_list_result = MagicMock()
+        mock_list_result.collections = mock_collections
+
+        with patch(
+            "xagent.core.tools.core.document_search.list_collections",
+            return_value=mock_list_result,
+        ):
+            with patch(
+                "xagent.core.tools.core.document_search.run_document_search",
+                side_effect=RuntimeError("boom"),
+            ):
+                tool = get_knowledge_search_tool()
+                result = await tool.run_json_async(
+                    {
+                        "query": "test query",
+                        "collections": ["kb1"],
+                        "search_type": "hybrid",
+                        "top_k": 5,
+                        "min_score": 0.3,
+                    }
+                )
+
+        assert "Knowledge base search failed" in result.summary
+        assert "kb1: boom" in result.summary
 
 
 class TestFormatSearchResults:

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    IngestionConfig,
+)
 from xagent.core.tools.core.RAG_tools.management.collection_manager import (
     CollectionManager,
     get_collection_sync,
@@ -314,6 +317,88 @@ class TestResolveEffectiveEmbeddingModel:
             "test_collection", config_model_id="text-embedding-v4"
         )
         assert resolved == "text-embedding-v4"
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
+    )
+    def test_ingestion_config_model_used_when_bound_model_missing(
+        self, mock_get_collection: Mock, _mock_mark: Mock
+    ) -> None:
+        """Collection ingestion config should supply the search embedding model."""
+        mock_get_collection.return_value = CollectionInfo(
+            name="test_collection",
+            embedding_model_id=None,
+            embedding_dimension=None,
+            ingestion_config=IngestionConfig(embedding_model_id="kb-index-embed"),
+        )
+
+        resolved = resolve_effective_embedding_model_sync(
+            "test_collection", config_model_id=None
+        )
+
+        assert resolved == "kb-index-embed"
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
+    )
+    def test_none_placeholder_does_not_override_ingestion_config_model(
+        self, mock_get_collection: Mock, _mock_mark: Mock
+    ) -> None:
+        """Tool placeholder values should still fall back to the indexed model."""
+        mock_get_collection.return_value = CollectionInfo(
+            name="test_collection",
+            embedding_model_id=None,
+            embedding_dimension=None,
+            ingestion_config=IngestionConfig(embedding_model_id="kb-index-embed"),
+        )
+
+        resolved = resolve_effective_embedding_model_sync(
+            "test_collection", config_model_id="none"
+        )
+
+        assert resolved == "kb-index-embed"
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
+    )
+    def test_infers_model_from_existing_embeddings_when_metadata_missing(
+        self,
+        mock_infer: Mock,
+        mock_get_collection: Mock,
+        _mock_mark: Mock,
+        mock_sync_wrapper: Mock,
+    ) -> None:
+        """Legacy collections should infer the model from existing embedding tables."""
+        mock_get_collection.return_value = CollectionInfo(
+            name="legacy_collection",
+            embedding_model_id=None,
+            embedding_dimension=None,
+            embeddings=12,
+            ingestion_config=None,
+        )
+        mock_infer.return_value = ("legacy-index-embed", 768)
+        mock_save = Mock()
+        mock_sync_wrapper.return_value = mock_save
+
+        resolved = resolve_effective_embedding_model_sync("legacy_collection")
+
+        assert resolved == "legacy-index-embed"
+        mock_save.assert_called_once()
 
 
 # --- rebuild_collection_metadata Tests (Issue #14) ---

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -400,6 +400,43 @@ class TestResolveEffectiveEmbeddingModel:
         assert resolved == "legacy-index-embed"
         mock_save.assert_called_once()
 
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
+    )
+    def test_inference_failure_falls_back_to_config_model(
+        self,
+        mock_infer: Mock,
+        mock_get_collection: Mock,
+        _mock_mark: Mock,
+        mock_sync_wrapper: Mock,
+    ) -> None:
+        """Inference failures should not block config fallback for legacy collections."""
+        mock_get_collection.return_value = CollectionInfo(
+            name="legacy_collection",
+            embedding_model_id=None,
+            embedding_dimension=None,
+            embeddings=12,
+            ingestion_config=None,
+        )
+        mock_infer.side_effect = RuntimeError("connection failed")
+
+        resolved = resolve_effective_embedding_model_sync(
+            "legacy_collection",
+            config_model_id="fallback-embed",
+        )
+
+        assert resolved == "fallback-embed"
+        mock_sync_wrapper.assert_not_called()
+
 
 # --- rebuild_collection_metadata Tests (Issue #14) ---
 

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_search.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_search.py
@@ -17,6 +17,9 @@ from xagent.core.tools.core.RAG_tools.chunk.chunk_document import chunk_document
 from xagent.core.tools.core.RAG_tools.core.config import IndexPolicy
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     ChunkEmbeddingData,
+    FusionConfig,
+    HybridSearchResponse,
+    IndexStatus,
     ParseMethod,
     SearchConfig,
     SearchPipelineResult,
@@ -671,3 +674,42 @@ def test_apply_rerank_rrf_fallback_with_scores(
     # RRF should reorder based on ranks
     # Both results should be present, order may vary based on RRF calculation
     assert all(r.text in ["doc1", "doc2"] for r in reranked)
+
+
+def test_hybrid_partial_success_uses_warning_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hybrid partial_success should not claim unconditional success."""
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_effective_embedding_model_sync",
+        lambda collection, model_id=None: "resolved-embed",
+    )
+    _patch_embedding_adapter(monkeypatch, "resolved-embed")
+    monkeypatch.setattr(
+        document_search,
+        "search_hybrid",
+        lambda **kwargs: HybridSearchResponse(
+            results=[],
+            total_count=0,
+            status="partial_success",
+            warnings=[],
+            fusion_config=kwargs["fusion_config"] or FusionConfig(),
+            dense_count=0,
+            sparse_count=0,
+            index_status=IndexStatus.INDEX_READY,
+            index_advice=None,
+        ),
+    )
+
+    result = document_search.search_documents(
+        collection="kb1",
+        query_text="test query",
+        config=SearchConfig(
+            search_type=SearchType.HYBRID,
+            top_k=5,
+            embedding_model_id="placeholder-model",
+        ),
+    )
+
+    assert result.status == "partial_success"
+    assert result.message == "Hybrid search completed with warnings"


### PR DESCRIPTION
## Summary
- fix `knowledge_search` so it resolves the embedding model from the knowledge base itself instead of depending on a globally default embedding model
- add fallback paths for legacy collections by using `ingestion_config.embedding_model_id` and inferring the model from existing embedding tables when metadata is missing
- preserve real KB search failures while treating `partial_success` as warnings, and align hybrid-search messages with the actual pipeline status
## What changed
- removed global default embedding injection from `knowledge_search` tool creation
- updated collection embedding resolution precedence to:
  - bound collection embedding model
  - `ingestion_config.embedding_model_id`
  - inferred model from existing embedding tables
  - explicit config fallback
- changed KB search aggregation so only true failures are reported as errors:
  - `success` and `partial_success` continue
  - `failed` and `error` are surfaced as hard failures
- aligned hybrid pipeline messages so `partial_success` reports `completed with warnings` instead of `completed successfully`
- added regression tests for:
  - no global default embedding injection
  - ingestion-config fallback
  - legacy embedding-table inference
  - `error` and `failed` status surfacing
  - `partial_success` warning handling
  - hybrid message semantics
