### PR TITLE
fix(upload): harden large file upload limits and error handling

### DIFF
--- a/docker-compose-sandbox.yml
+++ b/docker-compose-sandbox.yml
@@ -39,6 +39,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-xagent_password}
       - BACKEND_PORT=8000
       - XAGENT_UPLOADS_DIR=/root/.xagent/uploads
+      - XAGENT_MAX_UPLOAD_SIZE=${XAGENT_MAX_UPLOAD_SIZE:-100M}
       - SANDBOX_ENABLED=true
       - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.3.1 # pinned version (`latest` may lead to caching problems)
       - SANDBOX_CPUS=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-xagent_password}
       - BACKEND_PORT=8000
       - XAGENT_UPLOADS_DIR=/root/.xagent/uploads
+      - XAGENT_MAX_UPLOAD_SIZE=${XAGENT_MAX_UPLOAD_SIZE:-100M}
     env_file:
       - .env
     volumes:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,9 +10,9 @@ server {
     listen 80;
     server_name _;
 
-    # Backend enforces per-file upload limits so multipart overhead and multi-file
-    # requests are not rejected prematurely by the reverse proxy.
-    client_max_body_size 0;
+    # Backend still enforces per-file limits, but keep a proxy-side ceiling as
+    # defense in depth against unbounded request bodies before the backend can reject them.
+    client_max_body_size 500M;
 
     # Proxy to backend API
     location /api/ {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,8 +10,9 @@ server {
     listen 80;
     server_name _;
 
-    # Client body size limit
-    client_max_body_size 100M;
+    # Backend enforces per-file upload limits so multipart overhead and multi-file
+    # requests are not rejected prematurely by the reverse proxy.
+    client_max_body_size 0;
 
     # Proxy to backend API
     location /api/ {

--- a/example.env
+++ b/example.env
@@ -135,7 +135,8 @@ XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
 # For containerized deployments, use a persistent volume path
 # XAGENT_UPLOADS_DIR=""
 
-# Maximum upload size for both nginx and backend validation.
+# Maximum per-file upload size enforced by the backend.
+# Nginx maintains a separate, larger defense-in-depth ceiling (see docker/nginx.conf).
 # Supports raw bytes or human-readable values like 100M, 1G, 512K.
 XAGENT_MAX_UPLOAD_SIZE="100M"
 

--- a/example.env
+++ b/example.env
@@ -135,6 +135,10 @@ XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS=""
 # For containerized deployments, use a persistent volume path
 # XAGENT_UPLOADS_DIR=""
 
+# Maximum upload size for both nginx and backend validation.
+# Supports raw bytes or human-readable values like 100M, 1G, 512K.
+XAGENT_MAX_UPLOAD_SIZE="100M"
+
 # External upload directories for knowledge base file access
 # Comma-separated list of directory paths (existing dirs only)
 # XAGENT_EXTERNAL_UPLOAD_DIRS="/path/to/uploads1,/path/to/uploads2"

--- a/frontend/src/app/agent/[id]/page.tsx
+++ b/frontend/src/app/agent/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Bot } from "lucide-react"
@@ -102,10 +102,12 @@ export default function AgentChatPage() {
 
           const parsed = await parseApiResponse(uploadResponse)
 
-          if (uploadResponse.ok && parsed.data) {
+          if (uploadResponse.ok && isJsonRecord(parsed.data)) {
             const uploadData = parsed.data
-            if (uploadData.success && uploadData.files) {
-              uploadedFileIds = uploadData.files.map((f: any) => f.file_id)
+            if (uploadData.success && Array.isArray(uploadData.files)) {
+              uploadedFileIds = uploadData.files
+                .filter((f): f is { file_id: string } => isJsonRecord(f) && typeof f.file_id === 'string')
+                .map(f => f.file_id)
             }
           } else {
             throw new Error(getUploadErrorMessage(uploadResponse, parsed, {

--- a/frontend/src/app/agent/[id]/page.tsx
+++ b/frontend/src/app/agent/[id]/page.tsx
@@ -111,9 +111,9 @@ export default function AgentChatPage() {
             }
           } else {
             throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
-              generic: 'Upload failed',
-              tooLarge: 'File is too large. Please reduce the upload size and try again.',
-              proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+              generic: t("files.uploadFailed") || "Upload failed",
+              tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
+              proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
             }))
           }
         } catch (e) {

--- a/frontend/src/app/agent/[id]/page.tsx
+++ b/frontend/src/app/agent/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Bot } from "lucide-react"
@@ -112,8 +112,7 @@ export default function AgentChatPage() {
           } else {
             throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
               generic: t("files.uploadFailed") || "Upload failed",
-              tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
-              proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+              ...UPLOAD_ERROR_MESSAGES,
             }))
           }
         } catch (e) {

--- a/frontend/src/app/agent/[id]/page.tsx
+++ b/frontend/src/app/agent/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Bot } from "lucide-react"
@@ -100,16 +100,23 @@ export default function AgentChatPage() {
             body: formData
           })
 
-          if (uploadResponse.ok) {
-            const uploadData = await uploadResponse.json()
+          const parsed = await parseApiResponse(uploadResponse)
+
+          if (uploadResponse.ok && parsed.data) {
+            const uploadData = parsed.data
             if (uploadData.success && uploadData.files) {
               uploadedFileIds = uploadData.files.map((f: any) => f.file_id)
             }
           } else {
-            console.error('Failed to upload files:', uploadResponse.statusText)
+            throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
+              generic: 'Upload failed',
+              tooLarge: 'File is too large. Please reduce the upload size and try again.',
+              proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+            }))
           }
         } catch (e) {
           console.error('Error uploading files before task creation:', e)
+          throw e
         }
       }
 
@@ -156,7 +163,7 @@ export default function AgentChatPage() {
       }
     } catch (err) {
       console.error("Failed to send message:", err)
-      toast.error(t('builds.list.chat.sendFailed'))
+      toast.error(err instanceof Error ? err.message : t('builds.list.chat.sendFailed'))
     } finally {
       setIsSending(false)
     }

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -7,7 +7,7 @@ import { cn, getApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ConfigDialog } from "@/components/config-dialog";
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper";
 import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "sonner";
@@ -225,8 +225,7 @@ export function ChatInput({
           failedFiles.add(file);
           uploadErrorMessage = uploadErrorMessage || getUploadErrorMessage(response, parsed, {
             generic: t("files.uploadFailed") || "Failed to upload some files",
-            tooLarge: t("files.fileTooLarge") || "File is too large",
-            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+            ...UPLOAD_ERROR_MESSAGES,
           });
         }
       } catch (error: any) {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -7,7 +7,7 @@ import { cn, getApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ConfigDialog } from "@/components/config-dialog";
-import { apiRequest } from "@/lib/api-wrapper";
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper";
 import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "sonner";
@@ -191,6 +191,7 @@ export function ChatInput({
     });
 
     const failedFiles = new Set<File>();
+    let uploadErrorMessage: string | null = null;
 
     // Upload files individually to ensure better reliability and progress tracking
     await Promise.all(newFiles.map(async (file) => {
@@ -210,8 +211,10 @@ export function ChatInput({
           signal: controller.signal
         });
 
-        if (response.ok) {
-          const data = await response.json();
+        const parsed = await parseApiResponse(response);
+
+        if (response.ok && parsed.data) {
+          const data = parsed.data;
           if (data.success && data.file_id) {
             // Attach file_id to the File object
             (file as any).file_id = data.file_id;
@@ -220,6 +223,11 @@ export function ChatInput({
           }
         } else {
           failedFiles.add(file);
+          uploadErrorMessage = uploadErrorMessage || getUploadErrorMessage(response, parsed, {
+            generic: t("files.uploadFailed") || "Failed to upload some files",
+            tooLarge: t("files.fileTooLarge") || "File is too large",
+            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          });
         }
       } catch (error: any) {
         if (error.name === 'AbortError') {
@@ -227,6 +235,7 @@ export function ChatInput({
         } else {
           console.error("Error uploading file:", error);
           failedFiles.add(file);
+          uploadErrorMessage = uploadErrorMessage || (error instanceof Error ? error.message : null);
         }
       } finally {
         uploadAbortControllersRef.current.delete(fileId);
@@ -240,7 +249,7 @@ export function ChatInput({
 
     // Handle failed files
     if (failedFiles.size > 0) {
-      toast.error(t("files.uploadFailed") || "Failed to upload some files");
+      toast.error(uploadErrorMessage || t("files.uploadFailed") || "Failed to upload some files");
       if (onFilesChange) {
         onFilesChange(filesRef.current.filter(f => !failedFiles.has(f)));
       }

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -7,7 +7,7 @@ import { cn, getApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ConfigDialog } from "@/components/config-dialog";
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper";
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper";
 import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "sonner";
@@ -213,11 +213,11 @@ export function ChatInput({
 
         const parsed = await parseApiResponse(response);
 
-        if (response.ok && parsed.data) {
+        if (response.ok && isJsonRecord(parsed.data)) {
           const data = parsed.data;
-          if (data.success && data.file_id) {
+          if (data.success && typeof data.file_id === 'string') {
             // Attach file_id to the File object
-            (file as any).file_id = data.file_id;
+            (file as File & { file_id?: string }).file_id = data.file_id;
           } else {
             failedFiles.add(file);
           }

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -13,7 +13,7 @@ import { Select } from "@/components/ui/select"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { useI18n } from "@/contexts/i18n-context"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { Model } from "@/lib/models"
 import {
   Upload,
@@ -273,21 +273,30 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         formData.append("collection", collectionName)
         appendIngestionConfigToFormData(formData, ingestionConfig)
 
-        const response = await apiRequest(`${getApiUrl()}/api/kb/ingest`, {
-          method: "POST",
-          body: formData
-        })
+      const response = await apiRequest(`${getApiUrl()}/api/kb/ingest`, {
+        method: "POST",
+        body: formData
+      })
 
-        if (!response.ok) {
-          const errorData = await response.json()
+      const parsed = await parseApiResponse(response)
+
+      if (!response.ok) {
+          const errorData = parsed.data || {}
           if (errorData.status === 'error') {
             setIngestionResults(prev => [...prev, errorData])
             throw new Error(errorData.message || t("kb.errors.uploadFailedFile", { name: file.name }))
           }
-          throw new Error(errorData.detail || t("kb.errors.uploadFailedFile", { name: file.name }))
+          throw new Error(getUploadErrorMessage(response, parsed, {
+            generic: t("kb.errors.uploadFailedFile", { name: file.name }) || `Failed to upload file: ${file.name}`,
+            tooLarge: t("files.fileTooLarge") || "File is too large",
+            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          }))
         }
 
-        const result = await response.json()
+        const result = parsed.data
+        if (!result) {
+          throw new Error(t("kb.errors.uploadFailedFile", { name: file.name }))
+        }
         setIngestionResults(prev => [...prev, result])
 
         if (result.status === "partial" && result.failed_step) {
@@ -358,18 +367,27 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         body: formData
       })
 
+      const parsed = await parseApiResponse(response)
+
       setWebIngestionProgress(50)
 
       if (!response.ok) {
-        const errorData = await response.json()
+        const errorData = parsed.data || {}
         if (errorData.status === 'error') {
           setWebIngestionResult(errorData)
           throw new Error(errorData.message || t("kb.errors.webIngestFailed"))
         }
-        throw new Error(errorData.detail || t("kb.errors.webIngestFailed"))
+        throw new Error(getUploadErrorMessage(response, parsed, {
+          generic: t("kb.errors.webIngestFailed") || "Website import failed",
+          tooLarge: t("files.fileTooLarge") || "File is too large",
+          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+        }))
       }
 
-      const result: WebIngestionResult = await response.json()
+      const result: WebIngestionResult | null = parsed.data
+      if (!result) {
+        throw new Error(t("kb.errors.webIngestFailed"))
+      }
       setWebIngestionResult(result)
       setWebIngestionProgress(100)
 
@@ -440,12 +458,17 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         body: JSON.stringify(requestBody)
       })
 
+      const parsed = await parseApiResponse(response)
+
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || t("kb.errors.cloudIngestFailed"))
+        throw new Error(getUploadErrorMessage(response, parsed, {
+          generic: t("kb.errors.cloudIngestFailed") || "Cloud ingest failed",
+          tooLarge: t("files.fileTooLarge") || "File is too large",
+          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+        }))
       }
 
-      const results: IngestionResult[] = await response.json()
+      const results: IngestionResult[] = parsed.data || []
       setIngestionResults(results)
 
       // Check for errors

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -13,7 +13,7 @@ import { Select } from "@/components/ui/select"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { useI18n } from "@/contexts/i18n-context"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { Model } from "@/lib/models"
 import {
   Upload,
@@ -289,8 +289,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
           }
           throw new Error(getUploadErrorMessage(response, parsed, {
             generic: t("kb.errors.uploadFailedFile", { name: file.name }) || `Failed to upload file: ${file.name}`,
-            tooLarge: t("files.fileTooLarge") || "File is too large",
-            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+            ...UPLOAD_ERROR_MESSAGES,
           }))
         }
 
@@ -380,8 +379,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         }
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t("kb.errors.webIngestFailed") || "Website import failed",
-          tooLarge: t("files.fileTooLarge") || "File is too large",
-          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          ...UPLOAD_ERROR_MESSAGES,
         }))
       }
 
@@ -466,8 +464,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
       if (!response.ok) {
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t("kb.errors.cloudIngestFailed") || "Cloud ingest failed",
-          tooLarge: t("files.fileTooLarge") || "File is too large",
-          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          ...UPLOAD_ERROR_MESSAGES,
         }))
       }
 

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -13,7 +13,7 @@ import { Select } from "@/components/ui/select"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { useI18n } from "@/contexts/i18n-context"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { Model } from "@/lib/models"
 import {
   Upload,
@@ -35,6 +35,7 @@ interface IngestionResult {
   chunks_count: number
   status: string
   message: string
+  failed_step?: string
 }
 
 interface WebIngestionResult {
@@ -273,18 +274,18 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         formData.append("collection", collectionName)
         appendIngestionConfigToFormData(formData, ingestionConfig)
 
-      const response = await apiRequest(`${getApiUrl()}/api/kb/ingest`, {
-        method: "POST",
-        body: formData
-      })
+        const response = await apiRequest(`${getApiUrl()}/api/kb/ingest`, {
+          method: "POST",
+          body: formData
+        })
 
-      const parsed = await parseApiResponse(response)
+        const parsed = await parseApiResponse(response)
 
-      if (!response.ok) {
-          const errorData = parsed.data || {}
+        if (!response.ok) {
+          const errorData = isJsonRecord(parsed.data) ? parsed.data : {}
           if (errorData.status === 'error') {
-            setIngestionResults(prev => [...prev, errorData])
-            throw new Error(errorData.message || t("kb.errors.uploadFailedFile", { name: file.name }))
+            setIngestionResults(prev => [...prev, errorData as unknown as IngestionResult])
+            throw new Error((typeof errorData.message === 'string' && errorData.message) || t("kb.errors.uploadFailedFile", { name: file.name }))
           }
           throw new Error(getUploadErrorMessage(response, parsed, {
             generic: t("kb.errors.uploadFailedFile", { name: file.name }) || `Failed to upload file: ${file.name}`,
@@ -293,7 +294,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
           }))
         }
 
-        const result = parsed.data
+        const result = isJsonRecord(parsed.data) ? parsed.data as unknown as IngestionResult : null
         if (!result) {
           throw new Error(t("kb.errors.uploadFailedFile", { name: file.name }))
         }
@@ -372,10 +373,10 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
       setWebIngestionProgress(50)
 
       if (!response.ok) {
-        const errorData = parsed.data || {}
+        const errorData = isJsonRecord(parsed.data) ? parsed.data : {}
         if (errorData.status === 'error') {
-          setWebIngestionResult(errorData)
-          throw new Error(errorData.message || t("kb.errors.webIngestFailed"))
+          setWebIngestionResult(errorData as unknown as WebIngestionResult)
+          throw new Error((typeof errorData.message === 'string' && errorData.message) || t("kb.errors.webIngestFailed"))
         }
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t("kb.errors.webIngestFailed") || "Website import failed",
@@ -384,7 +385,9 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         }))
       }
 
-      const result: WebIngestionResult | null = parsed.data
+      const result: WebIngestionResult | null = isJsonRecord(parsed.data)
+        ? (parsed.data as unknown as WebIngestionResult)
+        : null
       if (!result) {
         throw new Error(t("kb.errors.webIngestFailed"))
       }
@@ -468,7 +471,9 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         }))
       }
 
-      const results: IngestionResult[] = parsed.data || []
+      const results: IngestionResult[] = Array.isArray(parsed.data)
+        ? (parsed.data as unknown as IngestionResult[])
+        : []
       setIngestionResults(results)
 
       // Check for errors

--- a/frontend/src/components/kb/knowledge-base-detail.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { parseSeparatorsInput, formatSeparatorsOutput } from "@/lib/separators"
@@ -57,6 +57,14 @@ interface SearchConfig {
   top_k: number
   embedding_model_id: string
   rerank_model_id: string
+}
+
+interface IngestionResult {
+  collection: string
+  document_count: number
+  chunks_count: number
+  status: string
+  message: string
 }
 
 interface WebIngestionResult {
@@ -303,10 +311,10 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
         const parsed = await parseApiResponse(response)
 
         if (!response.ok) {
-          const errorData = parsed.data || {}
+          const errorData = isJsonRecord(parsed.data) ? parsed.data : {}
           if (errorData.status === 'error') {
-            setIngestionResults(prev => [...prev, errorData])
-            throw new Error(errorData.message || t("kb.errors.uploadFailedFile", { name: file.name }))
+            setIngestionResults(prev => [...prev, errorData as unknown as IngestionResult])
+            throw new Error((typeof errorData.message === 'string' && errorData.message) || t("kb.errors.uploadFailedFile", { name: file.name }))
           }
           throw new Error(getUploadErrorMessage(response, parsed, {
             generic: t("kb.detail.errors.uploadFailedWithName", { name: file.name }) || `Failed to upload file: ${file.name}`,
@@ -315,7 +323,7 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
           }))
         }
 
-        const result = parsed.data
+        const result = isJsonRecord(parsed.data) ? parsed.data as unknown as IngestionResult : null
         if (!result) {
           throw new Error(t("kb.detail.errors.uploadFailedWithName", { name: file.name }))
         }
@@ -436,10 +444,10 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
       setWebIngestionProgress(50)
 
       if (!response.ok) {
-        const errorData = parsed.data || {}
+        const errorData = isJsonRecord(parsed.data) ? parsed.data : {}
         if (errorData.status === 'error') {
-          setWebIngestionResult(errorData)
-          throw new Error(errorData.message || t("kb.errors.webIngestFailed"))
+          setWebIngestionResult(errorData as unknown as WebIngestionResult)
+          throw new Error((typeof errorData.message === 'string' && errorData.message) || t("kb.errors.webIngestFailed"))
         }
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t("kb.detail.errors.webImportFailed") || "Website import failed",
@@ -448,7 +456,9 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
         }))
       }
 
-      const result: WebIngestionResult | null = parsed.data
+      const result: WebIngestionResult | null = isJsonRecord(parsed.data)
+        ? (parsed.data as unknown as WebIngestionResult)
+        : null
       if (!result) {
         throw new Error(t("kb.detail.errors.webImportFailed"))
       }

--- a/frontend/src/components/kb/knowledge-base-detail.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { parseSeparatorsInput, formatSeparatorsOutput } from "@/lib/separators"
@@ -318,8 +318,7 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
           }
           throw new Error(getUploadErrorMessage(response, parsed, {
             generic: t("kb.detail.errors.uploadFailedWithName", { name: file.name }) || `Failed to upload file: ${file.name}`,
-            tooLarge: t("files.fileTooLarge") || "File is too large",
-            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+            ...UPLOAD_ERROR_MESSAGES,
           }))
         }
 
@@ -451,8 +450,7 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
         }
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t("kb.detail.errors.webImportFailed") || "Website import failed",
-          tooLarge: t("files.fileTooLarge") || "File is too large",
-          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          ...UPLOAD_ERROR_MESSAGES,
         }))
       }
 

--- a/frontend/src/components/kb/knowledge-base-detail.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 import { appendIngestionConfigToFormData } from "@/lib/ingestion-form"
 import { parseSeparatorsInput, formatSeparatorsOutput } from "@/lib/separators"
@@ -300,16 +300,25 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
           body: formData
         })
 
+        const parsed = await parseApiResponse(response)
+
         if (!response.ok) {
-          const errorData = await response.json()
+          const errorData = parsed.data || {}
           if (errorData.status === 'error') {
             setIngestionResults(prev => [...prev, errorData])
             throw new Error(errorData.message || t("kb.errors.uploadFailedFile", { name: file.name }))
           }
-          throw new Error(errorData.detail || t("kb.detail.errors.uploadFailedWithName", { name: file.name }))
+          throw new Error(getUploadErrorMessage(response, parsed, {
+            generic: t("kb.detail.errors.uploadFailedWithName", { name: file.name }) || `Failed to upload file: ${file.name}`,
+            tooLarge: t("files.fileTooLarge") || "File is too large",
+            proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+          }))
         }
 
-        const result = await response.json()
+        const result = parsed.data
+        if (!result) {
+          throw new Error(t("kb.detail.errors.uploadFailedWithName", { name: file.name }))
+        }
         setIngestionResults(prev => [...prev, result])
         setUploadProgress(((i + 1) / selectedFiles.length) * 100)
       }
@@ -422,18 +431,27 @@ export function KnowledgeBaseDetailContent({ collectionName }: { collectionName:
         body: formData
       })
 
+      const parsed = await parseApiResponse(response)
+
       setWebIngestionProgress(50)
 
       if (!response.ok) {
-        const errorData = await response.json()
+        const errorData = parsed.data || {}
         if (errorData.status === 'error') {
           setWebIngestionResult(errorData)
           throw new Error(errorData.message || t("kb.errors.webIngestFailed"))
         }
-        throw new Error(errorData.detail || t("kb.detail.errors.webImportFailed"))
+        throw new Error(getUploadErrorMessage(response, parsed, {
+          generic: t("kb.detail.errors.webImportFailed") || "Website import failed",
+          tooLarge: t("files.fileTooLarge") || "File is too large",
+          proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+        }))
       }
 
-      const result: WebIngestionResult = await response.json()
+      const result: WebIngestionResult | null = parsed.data
+      if (!result) {
+        throw new Error(t("kb.detail.errors.webImportFailed"))
+      }
       setWebIngestionResult(result)
       setWebIngestionProgress(100)
 

--- a/frontend/src/components/pages/files.tsx
+++ b/frontend/src/components/pages/files.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { StandaloneFilePreviewDialog } from "@/components/file/standalone-file-preview-dialog"
 import { SearchInput } from "@/components/ui/search-input"
@@ -188,8 +188,7 @@ export function FilesPage() {
       } else {
         throw new Error(getUploadErrorMessage(response, parsed, {
           generic: t('files.actions.upload') || 'Upload failed',
-          tooLarge: t('files.fileTooLarge') || 'File is too large',
-          proxy: t('files.uploadProxyError') || 'Upload failed before reaching the application. Please check the server upload limit.',
+          ...UPLOAD_ERROR_MESSAGES,
         }))
       }
     } catch (error) {

--- a/frontend/src/components/pages/files.tsx
+++ b/frontend/src/components/pages/files.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { StandaloneFilePreviewDialog } from "@/components/file/standalone-file-preview-dialog"
 import { SearchInput } from "@/components/ui/search-input"
@@ -180,14 +180,23 @@ export function FilesPage() {
         body: formData
       })
 
+      const parsed = await parseApiResponse(response)
+
       if (response.ok) {
         await loadFiles()
         if (fileInputRef.current) {
           fileInputRef.current.value = ''
         }
+      } else {
+        throw new Error(getUploadErrorMessage(response, parsed, {
+          generic: t('files.actions.upload') || 'Upload failed',
+          tooLarge: t('files.fileTooLarge') || 'File is too large',
+          proxy: t('files.uploadProxyError') || 'Upload failed before reaching the application. Please check the server upload limit.',
+        }))
       }
     } catch (error) {
       console.error('Upload failed:', error)
+      toast.error(error instanceof Error ? error.message : (t('files.actions.upload') || 'Upload failed'))
     } finally {
       setUploading(false)
     }

--- a/frontend/src/components/pages/files.tsx
+++ b/frontend/src/components/pages/files.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
@@ -17,7 +16,6 @@ import {
   Image as ImageIcon,
   Video,
   Archive,
-  Search,
   Download,
   Trash2,
   FileCode,
@@ -182,7 +180,7 @@ export function FilesPage() {
 
       const parsed = await parseApiResponse(response)
 
-      if (response.ok) {
+      if (response.ok && parsed.data) {
         await loadFiles()
         if (fileInputRef.current) {
           fileInputRef.current.value = ''

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -35,7 +35,7 @@ export interface Interaction {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 
@@ -3490,10 +3490,12 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
               const parsed = await parseApiResponse(uploadResponse)
 
-              if (uploadResponse.ok && parsed.data) {
+              if (uploadResponse.ok && isJsonRecord(parsed.data)) {
                 const uploadData = parsed.data
-                if (uploadData.success && uploadData.files) {
-                  uploadData.files.forEach((f: any) => uploadedFileIds.push(f.file_id))
+                if (uploadData.success && Array.isArray(uploadData.files)) {
+                  uploadData.files
+                    .filter((f): f is { file_id: string } => isJsonRecord(f) && typeof f.file_id === 'string')
+                    .forEach(f => uploadedFileIds.push(f.file_id))
                 }
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -35,7 +35,7 @@ export interface Interaction {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 
@@ -3500,8 +3500,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
                   generic: t("files.uploadFailed") || "Upload failed",
-                  tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
-                  proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+                  ...UPLOAD_ERROR_MESSAGES,
                 }))
               }
             } catch (e) {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -3499,9 +3499,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 }
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
-                  generic: 'Upload failed',
-                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
-                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                  generic: t("files.uploadFailed") || "Upload failed",
+                  tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
+                  proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
                 }))
               }
             } catch (e) {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -35,7 +35,7 @@ export interface Interaction {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 
@@ -3488,16 +3488,23 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 body: formData
               })
 
-              if (uploadResponse.ok) {
-                const uploadData = await uploadResponse.json()
+              const parsed = await parseApiResponse(uploadResponse)
+
+              if (uploadResponse.ok && parsed.data) {
+                const uploadData = parsed.data
                 if (uploadData.success && uploadData.files) {
                   uploadData.files.forEach((f: any) => uploadedFileIds.push(f.file_id))
                 }
               } else {
-                console.error('Failed to upload files:', uploadResponse.statusText)
+                throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
+                  generic: 'Upload failed',
+                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
+                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                }))
               }
             } catch (e) {
               console.error('Error uploading files before task creation:', e)
+              throw e
             }
           }
 

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -20,7 +20,7 @@ interface WebSocketMessage {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 
 // Unique ID generator for messages
@@ -2989,16 +2989,23 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 body: formData
               })
 
-              if (uploadResponse.ok) {
-                const uploadData = await uploadResponse.json()
+              const parsed = await parseApiResponse(uploadResponse)
+
+              if (uploadResponse.ok && parsed.data) {
+                const uploadData = parsed.data
                 if (uploadData.success && uploadData.files) {
                   uploadData.files.forEach((f: any) => uploadedFileIds.push(f.file_id))
                 }
               } else {
-                console.error('Failed to upload files:', uploadResponse.statusText)
+                throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
+                  generic: 'Upload failed',
+                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
+                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                }))
               }
             } catch (e) {
               console.error('Error uploading files before task creation:', e)
+              throw e
             }
           }
 

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -20,7 +20,7 @@ interface WebSocketMessage {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 
 // Unique ID generator for messages
@@ -3001,8 +3001,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
                   generic: t("files.uploadFailed") || "Upload failed",
-                  tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
-                  proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
+                  ...UPLOAD_ERROR_MESSAGES,
                 }))
               }
             } catch (e) {

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -20,7 +20,7 @@ interface WebSocketMessage {
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl } from "@/lib/utils"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 
 // Unique ID generator for messages
@@ -2991,10 +2991,12 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
               const parsed = await parseApiResponse(uploadResponse)
 
-              if (uploadResponse.ok && parsed.data) {
+              if (uploadResponse.ok && isJsonRecord(parsed.data)) {
                 const uploadData = parsed.data
-                if (uploadData.success && uploadData.files) {
-                  uploadData.files.forEach((f: any) => uploadedFileIds.push(f.file_id))
+                if (uploadData.success && Array.isArray(uploadData.files)) {
+                  uploadData.files
+                    .filter((f): f is { file_id: string } => isJsonRecord(f) && typeof f.file_id === 'string')
+                    .forEach(f => uploadedFileIds.push(f.file_id))
                 }
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -3000,9 +3000,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 }
               } else {
                 throw new Error(getUploadErrorMessage(uploadResponse, parsed, {
-                  generic: 'Upload failed',
-                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
-                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                  generic: t("files.uploadFailed") || "Upload failed",
+                  tooLarge: t("files.fileTooLarge") || "File is too large. Please reduce the upload size and try again.",
+                  proxy: t("files.uploadProxyError") || "Upload failed before reaching the application. Please check the server upload limit.",
                 }))
               }
             } catch (e) {

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react"
 import { useAuth } from "@/contexts/auth-context"
-import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { toast } from "sonner"
 import { getWsUrl, getApiUrl } from "@/lib/utils"
 
@@ -455,7 +455,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
           })
             .then(async res => ({ response: res, parsed: await parseApiResponse(res) }))
             .then(({ response, parsed }) => {
-              if (!response.ok || !parsed.data) {
+              if (!response.ok || !isJsonRecord(parsed.data)) {
                 throw new Error(getUploadErrorMessage(response, parsed, {
                   generic: 'Upload failed',
                   tooLarge: 'File is too large. Please reduce the upload size and try again.',
@@ -465,14 +465,18 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
 
               const data = parsed.data
               messageData.files = [...preUploadedFiles];
-              if (data.success && data.files) {
+              if (data.success && Array.isArray(data.files)) {
                 // Send file_ids in the websocket message
-                const newUploadedFiles = data.files.map((f: any) => ({
-                  file_id: f.file_id,
-                  name: f.filename,
-                  size: f.file_size,
-                  type: f.mime_type || ''
-                }));
+                const newUploadedFiles = data.files
+                  .filter((f): f is { file_id: string; filename?: string; file_size?: number; mime_type?: string } => (
+                    isJsonRecord(f) && typeof f.file_id === 'string'
+                  ))
+                  .map((f) => ({
+                    file_id: f.file_id,
+                    name: typeof f.filename === 'string' ? f.filename : '',
+                    size: typeof f.file_size === 'number' ? f.file_size : 0,
+                    type: typeof f.mime_type === 'string' ? f.mime_type : ''
+                  }));
                 messageData.files = messageData.files.concat(newUploadedFiles);
               }
 

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState, useCallback } from "react"
 import { useAuth } from "@/contexts/auth-context"
+import { apiRequest, getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+import { toast } from "sonner"
 import { getWsUrl, getApiUrl } from "@/lib/utils"
 
 // Duplicate message detection: record recently sent messages
@@ -444,15 +446,24 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             formData.append('task_id', taskIdRef.current.toString())
           }
 
-          fetch(`${getApiUrl()}/api/files/upload`, {
+          apiRequest(`${getApiUrl()}/api/files/upload`, {
             method: 'POST',
             headers: {
               'Authorization': `Bearer ${token || localStorage.getItem('token') || ''}`
             },
             body: formData
           })
-            .then(res => res.json())
-            .then(data => {
+            .then(async res => ({ response: res, parsed: await parseApiResponse(res) }))
+            .then(({ response, parsed }) => {
+              if (!response.ok || !parsed.data) {
+                throw new Error(getUploadErrorMessage(response, parsed, {
+                  generic: 'Upload failed',
+                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
+                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                }))
+              }
+
+              const data = parsed.data
               messageData.files = [...preUploadedFiles];
               if (data.success && data.files) {
                 // Send file_ids in the websocket message
@@ -482,11 +493,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             })
             .catch(err => {
               console.error('Failed to upload files:', err)
-              if (preUploadedFiles.length > 0) {
-                messageData.files = preUploadedFiles;
-              }
-              // Send without newly uploaded files if upload fails
-              socketRef.current?.send(JSON.stringify(messageData))
+              toast.error(err instanceof Error ? err.message : 'Upload failed')
             })
         } else {
           messageData.files = preUploadedFiles;

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react"
 import { useAuth } from "@/contexts/auth-context"
-import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
+import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { toast } from "sonner"
 import { getWsUrl, getApiUrl } from "@/lib/utils"
 
@@ -458,8 +458,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
               if (!response.ok || !isJsonRecord(parsed.data)) {
                 throw new Error(getUploadErrorMessage(response, parsed, {
                   generic: 'Upload failed',
-                  tooLarge: 'File is too large. Please reduce the upload size and try again.',
-                  proxy: 'Upload failed before reaching the application. Please check the server upload limit.',
+                  ...UPLOAD_ERROR_MESSAGES,
                 }))
               }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -816,7 +816,8 @@ Build when you need.`
     },
   },
   files: {
-    fileTooLarge: "File is too large (max 100MB)",
+    fileTooLarge: "File is too large for the configured upload limit",
+    uploadProxyError: "Upload failed before reaching the application. Please check the server upload limit.",
     header: {
       title: "File Management",
       description: "Manage project files: upload, preview, download, and delete.",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -816,6 +816,7 @@ Build when you need.`
     },
   },
   files: {
+    uploadFailed: "Upload failed",
     fileTooLarge: "File is too large for the configured upload limit",
     uploadProxyError: "Upload failed before reaching the application. Please check the server upload limit.",
     header: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -816,7 +816,8 @@ Build when you need.`
     },
   },
   files: {
-    fileTooLarge: "文件过大（最大 100MB）",
+    fileTooLarge: "文件大小超过当前配置的上传限制",
+    uploadProxyError: "上传在到达应用前被拦截，请检查服务器上传大小限制。",
     header: {
       title: "文件管理",
       description: "管理项目文件：上传、预览、下载与删除",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -816,6 +816,7 @@ Build when you need.`
     },
   },
   files: {
+    uploadFailed: "上传失败",
     fileTooLarge: "文件大小超过当前配置的上传限制",
     uploadProxyError: "上传在到达应用前被拦截，请检查服务器上传大小限制。",
     header: {

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest"
 
 import { getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
 
+const MESSAGES = {
+  generic: "Upload failed",
+  tooLarge: "File too large",
+  proxy: "Proxy rejected upload",
+}
+
 describe("api-wrapper upload helpers", () => {
   it("parses json error payloads", async () => {
     const response = new Response(JSON.stringify({ detail: "too large" }), {
@@ -15,6 +21,32 @@ describe("api-wrapper upload helpers", () => {
     expect(parsed.isHtml).toBe(false)
   })
 
+  it("returns empty parsed payload for empty body", async () => {
+    const response = new Response(null, {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    })
+
+    const parsed = await parseApiResponse(response)
+
+    expect(parsed.data).toBeNull()
+    expect(parsed.text).toBeNull()
+    expect(parsed.isHtml).toBe(false)
+  })
+
+  it("treats malformed non-json bodies as raw text", async () => {
+    const response = new Response("{not-json", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    })
+
+    const parsed = await parseApiResponse(response)
+
+    expect(parsed.data).toBeNull()
+    expect(parsed.text).toBe("{not-json")
+    expect(parsed.isHtml).toBe(false)
+  })
+
   it("falls back to friendly proxy error for html responses", async () => {
     const response = new Response("<html><body>413 Request Entity Too Large</body></html>", {
       status: 413,
@@ -22,13 +54,44 @@ describe("api-wrapper upload helpers", () => {
     })
 
     const parsed = await parseApiResponse(response)
-    const message = getUploadErrorMessage(response, parsed, {
-      generic: "Upload failed",
-      tooLarge: "File too large",
-      proxy: "Proxy rejected upload",
-    })
+    const message = getUploadErrorMessage(response, parsed, MESSAGES)
 
     expect(parsed.isHtml).toBe(true)
     expect(message).toBe("File too large")
+  })
+
+  it("prefers detail messages from parsed json", () => {
+    const response = new Response(null, { status: 400 })
+    const message = getUploadErrorMessage(response, {
+      data: { detail: "explicit detail" },
+      text: null,
+      isHtml: false,
+    }, MESSAGES)
+
+    expect(message).toBe("explicit detail")
+  })
+
+  it("returns truncated raw text for non-413 non-html responses", () => {
+    const response = new Response(null, { status: 500 })
+    const rawText = "x".repeat(240)
+    const message = getUploadErrorMessage(response, {
+      data: null,
+      text: rawText,
+      isHtml: false,
+    }, MESSAGES)
+
+    expect(message).toHaveLength(203)
+    expect(message.endsWith("...")).toBe(true)
+  })
+
+  it("falls back to generic when nothing else is available", () => {
+    const response = new Response(null, { status: 500 })
+    const message = getUploadErrorMessage(response, {
+      data: null,
+      text: null,
+      isHtml: false,
+    }, MESSAGES)
+
+    expect(message).toBe("Upload failed")
   })
 })

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import { getUploadErrorMessage, parseApiResponse } from "@/lib/api-wrapper"
+
+describe("api-wrapper upload helpers", () => {
+  it("parses json error payloads", async () => {
+    const response = new Response(JSON.stringify({ detail: "too large" }), {
+      status: 413,
+      headers: { "Content-Type": "application/json" },
+    })
+
+    const parsed = await parseApiResponse(response)
+
+    expect(parsed.data).toEqual({ detail: "too large" })
+    expect(parsed.isHtml).toBe(false)
+  })
+
+  it("falls back to friendly proxy error for html responses", async () => {
+    const response = new Response("<html><body>413 Request Entity Too Large</body></html>", {
+      status: 413,
+      headers: { "Content-Type": "text/html" },
+    })
+
+    const parsed = await parseApiResponse(response)
+    const message = getUploadErrorMessage(response, parsed, {
+      generic: "Upload failed",
+      tooLarge: "File too large",
+      proxy: "Proxy rejected upload",
+    })
+
+    expect(parsed.isHtml).toBe(true)
+    expect(message).toBe("File too large")
+  })
+})

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -47,6 +47,21 @@ describe("api-wrapper upload helpers", () => {
     expect(parsed.isHtml).toBe(false)
   })
 
+  it("preserves html proxy bodies even when content type claims json", async () => {
+    const response = new Response("<html><body>502 Bad Gateway</body></html>", {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    })
+
+    const parsed = await parseApiResponse(response)
+    const message = getUploadErrorMessage(response, parsed, MESSAGES)
+
+    expect(parsed.data).toBeNull()
+    expect(parsed.text).toContain("502 Bad Gateway")
+    expect(parsed.isHtml).toBe(true)
+    expect(message).toBe("Proxy rejected upload")
+  })
+
   it("falls back to friendly proxy error for html responses", async () => {
     const response = new Response("<html><body>413 Request Entity Too Large</body></html>", {
       status: 413,

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -263,40 +263,28 @@ export function isJsonRecord(value: unknown): value is JsonRecord {
 
 export async function parseApiResponse(response: Response): Promise<ParsedApiResponse> {
   const contentType = response.headers.get("content-type")?.toLowerCase() || ""
-
-  if (contentType.includes("application/json")) {
-    try {
-      return {
-        data: await response.json(),
-        text: null,
-        isHtml: false,
-      }
-    } catch {
-      // Fall through to text parsing for broken proxy responses.
-    }
-  }
-
   const text = await response.text().catch(() => "")
-  if (text) {
-    try {
-      return {
-        data: JSON.parse(text),
-        text,
-        isHtml: /^\s*</.test(text),
-      }
-    } catch {
-      return {
-        data: null,
-        text,
-        isHtml: contentType.includes("text/html") || /^\s*</.test(text),
-      }
+
+  if (!text) {
+    return {
+      data: null,
+      text: null,
+      isHtml: contentType.includes("text/html"),
     }
   }
 
-  return {
-    data: null,
-    text: null,
-    isHtml: contentType.includes("text/html"),
+  try {
+    return {
+      data: JSON.parse(text),
+      text,
+      isHtml: /^\s*</.test(text),
+    }
+  } catch {
+    return {
+      data: null,
+      text,
+      isHtml: contentType.includes("text/html") || /^\s*</.test(text),
+    }
   }
 }
 

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -101,7 +101,7 @@ function getCurrentTokens(): { accessToken: string | null; refreshToken: string 
 
 // Refresh token
 async function refreshToken(): Promise<string | null> {
-  const { accessToken, refreshToken: refresh } = getCurrentTokens()
+  const { refreshToken: refresh } = getCurrentTokens()
   if (!refresh) return null
 
   try {
@@ -163,7 +163,7 @@ export async function apiRequest(
   url: string,
   options: RequestInit = {}
 ): Promise<Response> {
-  const { accessToken, refreshToken: refresh } = getCurrentTokens()
+  const { accessToken } = getCurrentTokens()
 
   // If no token, request directly
   if (!accessToken) {
@@ -239,10 +239,26 @@ export async function apiRequest(
   return response
 }
 
+const MAX_RAW_UPLOAD_MESSAGE_LENGTH = 200
+
+function truncateUploadMessage(text: string): string {
+  const trimmed = text.trim()
+  if (trimmed.length <= MAX_RAW_UPLOAD_MESSAGE_LENGTH) {
+    return trimmed
+  }
+  return `${trimmed.slice(0, MAX_RAW_UPLOAD_MESSAGE_LENGTH)}...`
+}
+
+type JsonRecord = Record<string, unknown>
+
 export interface ParsedApiResponse {
-  data: any | null
+  data: JsonRecord | JsonRecord[] | null
   text: string | null
   isHtml: boolean
+}
+
+export function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 export async function parseApiResponse(response: Response): Promise<ParsedApiResponse> {
@@ -293,11 +309,11 @@ export function getUploadErrorMessage(
     proxy: string
   }
 ): string {
-  if (typeof parsed.data?.detail === "string" && parsed.data.detail.trim()) {
+  if (isJsonRecord(parsed.data) && typeof parsed.data.detail === "string" && parsed.data.detail.trim()) {
     return parsed.data.detail
   }
 
-  if (typeof parsed.data?.message === "string" && parsed.data.message.trim()) {
+  if (isJsonRecord(parsed.data) && typeof parsed.data.message === "string" && parsed.data.message.trim()) {
     return parsed.data.message
   }
 
@@ -310,7 +326,7 @@ export function getUploadErrorMessage(
   }
 
   if (parsed.text?.trim()) {
-    return parsed.text
+    return truncateUploadMessage(parsed.text)
   }
 
   return messages.generic
@@ -321,7 +337,7 @@ export const api = {
   get: (url: string, options?: RequestInit) =>
     apiRequest(url, { ...options, method: "GET" }),
 
-  post: (url: string, data?: any, options?: RequestInit) =>
+  post: (url: string, data?: unknown, options?: RequestInit) =>
     apiRequest(url, {
       ...options,
       method: "POST",
@@ -332,7 +348,7 @@ export const api = {
       body: data ? JSON.stringify(data) : undefined,
     }),
 
-  put: (url: string, data?: any, options?: RequestInit) =>
+  put: (url: string, data?: unknown, options?: RequestInit) =>
     apiRequest(url, {
       ...options,
       method: "PUT",

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -288,6 +288,11 @@ export async function parseApiResponse(response: Response): Promise<ParsedApiRes
   }
 }
 
+export const UPLOAD_ERROR_MESSAGES = {
+  tooLarge: "File is too large. Please reduce the upload size and try again.",
+  proxy: "Upload failed before reaching the application. Please check the server upload limit.",
+}
+
 export function getUploadErrorMessage(
   response: Response,
   parsed: ParsedApiResponse,

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -239,6 +239,83 @@ export async function apiRequest(
   return response
 }
 
+export interface ParsedApiResponse {
+  data: any | null
+  text: string | null
+  isHtml: boolean
+}
+
+export async function parseApiResponse(response: Response): Promise<ParsedApiResponse> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() || ""
+
+  if (contentType.includes("application/json")) {
+    try {
+      return {
+        data: await response.json(),
+        text: null,
+        isHtml: false,
+      }
+    } catch {
+      // Fall through to text parsing for broken proxy responses.
+    }
+  }
+
+  const text = await response.text().catch(() => "")
+  if (text) {
+    try {
+      return {
+        data: JSON.parse(text),
+        text,
+        isHtml: /^\s*</.test(text),
+      }
+    } catch {
+      return {
+        data: null,
+        text,
+        isHtml: contentType.includes("text/html") || /^\s*</.test(text),
+      }
+    }
+  }
+
+  return {
+    data: null,
+    text: null,
+    isHtml: contentType.includes("text/html"),
+  }
+}
+
+export function getUploadErrorMessage(
+  response: Response,
+  parsed: ParsedApiResponse,
+  messages: {
+    generic: string
+    tooLarge: string
+    proxy: string
+  }
+): string {
+  if (typeof parsed.data?.detail === "string" && parsed.data.detail.trim()) {
+    return parsed.data.detail
+  }
+
+  if (typeof parsed.data?.message === "string" && parsed.data.message.trim()) {
+    return parsed.data.message
+  }
+
+  if (response.status === 413) {
+    return messages.tooLarge
+  }
+
+  if (parsed.isHtml) {
+    return messages.proxy
+  }
+
+  if (parsed.text?.trim()) {
+    return parsed.text
+  }
+
+  return messages.generic
+}
+
 // Convenience methods
 export const api = {
   get: (url: string, options?: RequestInit) =>

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -31,6 +31,7 @@ WEB_DIR = "XAGENT_WEB_DIR"
 EXTERNAL_UPLOAD_DIRS = "XAGENT_EXTERNAL_UPLOAD_DIRS"
 EXTERNAL_SKILLS_LIBRARY_DIRS = "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
+MAX_UPLOAD_SIZE = "XAGENT_MAX_UPLOAD_SIZE"
 SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 DATABASE_URL = "DATABASE_URL"
@@ -78,6 +79,81 @@ def get_uploads_dir() -> Path:
     # Default: web/uploads
     web_dir = get_web_dir()
     return web_dir / "uploads"
+
+
+def get_max_upload_size_bytes() -> int:
+    """Get the maximum allowed upload size in bytes.
+
+    Priority:
+    1. XAGENT_MAX_UPLOAD_SIZE environment variable
+    2. Default to 100MB
+
+    Supported formats:
+    - Raw bytes: ``104857600``
+    - Human-readable: ``100M``, ``100MB``, ``1G``, ``512K``
+
+    Returns:
+        Maximum upload size in bytes.
+
+    Raises:
+        ValueError: If the configured value is invalid.
+    """
+
+    env_value = os.getenv(MAX_UPLOAD_SIZE)
+    if not env_value:
+        return 100 * 1024 * 1024
+
+    normalized = env_value.strip().upper()
+    if not normalized:
+        return 100 * 1024 * 1024
+
+    suffix_multipliers = [
+        ("GB", 1024 * 1024 * 1024),
+        ("G", 1024 * 1024 * 1024),
+        ("MB", 1024 * 1024),
+        ("M", 1024 * 1024),
+        ("KB", 1024),
+        ("K", 1024),
+        ("B", 1),
+    ]
+
+    for suffix, multiplier in suffix_multipliers:
+        if normalized.endswith(suffix):
+            number_part = normalized[: -len(suffix)].strip()
+            if not number_part:
+                raise ValueError(
+                    f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}. Missing numeric value."
+                )
+            try:
+                return int(float(number_part) * multiplier)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}."
+                ) from exc
+
+    try:
+        return int(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}.") from exc
+
+
+def format_file_size(size_bytes: int) -> str:
+    """Format a byte count for user-facing messages."""
+    if size_bytes < 1024:
+        return f"{size_bytes}B"
+    if size_bytes < 1024 * 1024:
+        value = size_bytes / 1024
+        unit = "KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        value = size_bytes / (1024 * 1024)
+        unit = "MB"
+    else:
+        value = size_bytes / (1024 * 1024 * 1024)
+        unit = "GB"
+
+    if float(value).is_integer():
+        return f"{int(value)}{unit}"
+    return f"{value:.1f}{unit}"
 
 
 def get_external_upload_dirs() -> list[Path]:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -117,6 +117,7 @@ def get_max_upload_size_bytes() -> int:
         ("B", 1),
     ]
 
+    result: int | None = None
     for suffix, multiplier in suffix_multipliers:
         if normalized.endswith(suffix):
             number_part = normalized[: -len(suffix)].strip()
@@ -125,35 +126,42 @@ def get_max_upload_size_bytes() -> int:
                     f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}. Missing numeric value."
                 )
             try:
-                return int(float(number_part) * multiplier)
+                result = int(float(number_part) * multiplier)
             except ValueError as exc:
                 raise ValueError(
                     f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}."
                 ) from exc
+            break
 
-    try:
-        return int(normalized)
-    except ValueError as exc:
-        raise ValueError(f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}.") from exc
+    if result is None:
+        try:
+            result = int(float(normalized))
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}."
+            ) from exc
+
+    if result <= 0:
+        raise ValueError(
+            f"Invalid {MAX_UPLOAD_SIZE} value: {env_value!r}. Value must be positive."
+        )
+
+    return result
 
 
 def format_file_size(size_bytes: int) -> str:
     """Format a byte count for user-facing messages."""
-    if size_bytes < 1024:
-        return f"{size_bytes}B"
-    if size_bytes < 1024 * 1024:
-        value = size_bytes / 1024
-        unit = "KB"
-    elif size_bytes < 1024 * 1024 * 1024:
-        value = size_bytes / (1024 * 1024)
-        unit = "MB"
-    else:
-        value = size_bytes / (1024 * 1024 * 1024)
-        unit = "GB"
+    units = [("GB", 1024 * 1024 * 1024), ("MB", 1024 * 1024), ("KB", 1024)]
 
-    if float(value).is_integer():
-        return f"{int(value)}{unit}"
-    return f"{value:.1f}{unit}"
+    for unit, divisor in units:
+        value = size_bytes / divisor
+        if value >= 0.9995:
+            rounded = round(value, 1)
+            if float(rounded).is_integer():
+                return f"{int(rounded)}{unit}"
+            return f"{rounded:.1f}{unit}"
+
+    return f"{size_bytes}B"
 
 
 def get_external_upload_dirs() -> list[Path]:

--- a/src/xagent/sandbox/boxlite_sandbox.py
+++ b/src/xagent/sandbox/boxlite_sandbox.py
@@ -16,7 +16,7 @@ from typing import Optional
 import boxlite  # type: ignore[import-not-found]
 from boxlite import SimpleBox  # type: ignore[unused-ignore]
 
-from . import DEFAULT_SANDBOX_IMAGE
+from ..config import get_sandbox_image
 from .base import (
     CodeType,
     ExecResult,
@@ -29,6 +29,8 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_SANDBOX_IMAGE = get_sandbox_image()
 
 
 class BoxliteStore(abc.ABC):
@@ -188,13 +190,14 @@ class BoxliteSandbox(Sandbox):
             return await self.exec("python", "-c", code, env=env)
         elif code_type == "javascript":
             return await self.exec("node", "-e", code, env=env)
+        raise ValueError(f"Unsupported code type: {code_type}")
 
     # --- File Operations ---
 
     async def upload_file(
         self, local_path: str, remote_path: str, overwrite: bool = False
     ) -> None:
-        if not os.path.exists(local_path):
+        if not os.path.isfile(local_path):
             raise FileNotFoundError(f"Local file not found: {local_path}")
 
         if not overwrite:

--- a/src/xagent/web/README.md
+++ b/src/xagent/web/README.md
@@ -147,7 +147,7 @@ Configuration is managed through environment variables:
 - `WEB_HOST`: Server host (default: `0.0.0.0`)
 - `WEB_PORT`: Server port (default: `8000`)
 - `CORS_ORIGINS`: Allowed CORS origins
-- `MAX_UPLOAD_SIZE`: Maximum file upload size in bytes
+- `XAGENT_MAX_UPLOAD_SIZE`: Maximum per-file upload size (supports bytes or values like `100M`); nginx defers file-size enforcement to the backend so multipart overhead does not trigger premature 413 responses
 
 ## Testing
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -16,6 +16,7 @@ from ..auth_dependencies import get_current_user
 from ..config import (
     BINARY_EXTENSIONS,
     MAX_FILE_SIZE,
+    MAX_FILE_SIZE_LABEL,
     get_upload_path,
     is_allowed_file,
 )
@@ -42,6 +43,37 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 file_router = APIRouter(prefix="/api/files", tags=["files"])
+
+
+async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path) -> int:
+    """Persist an uploaded file while enforcing the configured size limit."""
+    total_size = 0
+    read_buffer_size = 1024 * 1024  # 1MB chunks keep memory bounded for large files.
+
+    try:
+        with open(target_path, "wb") as buffer:
+            while True:
+                chunk = await uploaded.read(read_buffer_size)
+                if not chunk:
+                    break
+                total_size += len(chunk)
+                if total_size > MAX_FILE_SIZE:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"File size exceeds maximum limit of {MAX_FILE_SIZE_LABEL}"
+                        ),
+                    )
+                buffer.write(chunk)
+    except Exception:
+        try:
+            if target_path.exists():
+                target_path.unlink()
+        except OSError:
+            pass
+        raise
+
+    return total_size
 
 
 def _user_id_value(user: User) -> int:
@@ -435,74 +467,80 @@ async def upload_file(
     single_file_mode = file is not None and (not files)
     parsed_task_id = _parse_task_id(task_id)
     uploaded_files = []
+    written_paths: list[Path] = []
 
-    for uploaded in upload_items:
-        if not uploaded.filename or not uploaded.filename.strip():
-            raise HTTPException(status_code=422, detail="No filename provided")
-        if not is_allowed_file(uploaded.filename, task_type):
-            raise HTTPException(
-                status_code=500,
-                detail=f"File type {Path(uploaded.filename).suffix.lower()} not supported for task type {task_type}",
-            )
-
-        content = await uploaded.read()
-        if len(content) > MAX_FILE_SIZE:
-            raise HTTPException(
-                status_code=500,
-                detail=f"File size exceeds maximum limit of {MAX_FILE_SIZE // (1024 * 1024)}MB",
-            )
-
-        # get_upload_path may raise ValueError for invalid folder/collection names
-        try:
-            target_path = _build_unique_file_path(
-                get_upload_path(
-                    uploaded.filename, task_id, folder, _user_id_value(user)
+    try:
+        for uploaded in upload_items:
+            if not uploaded.filename or not uploaded.filename.strip():
+                raise HTTPException(status_code=422, detail="No filename provided")
+            if not is_allowed_file(uploaded.filename, task_type):
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"File type {Path(uploaded.filename).suffix.lower()} not supported for task type {task_type}",
                 )
-            )
-        except ValueError as e:
-            logger.warning(f"Invalid folder name rejected: {folder!r} - {e}")
-            raise HTTPException(
-                status_code=422, detail=f"Invalid folder name: {str(e)}"
-            ) from e
-        with open(target_path, "wb") as buffer:
-            buffer.write(content)
 
-        file_record = UploadedFile(
-            user_id=_user_id_value(user),
-            task_id=parsed_task_id,
-            filename=Path(uploaded.filename).name,
-            storage_path=str(target_path),
-            mime_type=uploaded.content_type,
-            file_size=len(content),
-        )
-        db.add(file_record)
-        db.flush()
-
-        content_preview = ""
-        # Skip preview generation for binary files (images, videos, etc.)
-        file_extension = Path(uploaded.filename).suffix.lower()
-        if file_extension not in BINARY_EXTENSIONS:
+            # get_upload_path may raise ValueError for invalid folder/collection names
             try:
-                preview_content = read_file(str(target_path))
-                content_preview = (
-                    preview_content[:500] + "..."
-                    if isinstance(preview_content, str) and len(preview_content) > 500
-                    else preview_content
+                target_path = _build_unique_file_path(
+                    get_upload_path(
+                        uploaded.filename, task_id, folder, _user_id_value(user)
+                    )
                 )
-            except Exception:
-                content_preview = ""
+            except ValueError as e:
+                logger.warning(f"Invalid folder name rejected: {folder!r} - {e}")
+                raise HTTPException(
+                    status_code=422, detail=f"Invalid folder name: {str(e)}"
+                ) from e
 
-        uploaded_files.append(
-            {
-                "file_id": file_record.file_id,
-                "filename": file_record.filename,
-                "file_size": file_record.file_size,
-                "mime_type": file_record.mime_type,
-                "content_preview": content_preview,
-            }
-        )
+            file_size = await _write_upload_with_size_limit(uploaded, target_path)
+            written_paths.append(target_path)
 
-    db.commit()
+            file_record = UploadedFile(
+                user_id=_user_id_value(user),
+                task_id=parsed_task_id,
+                filename=Path(uploaded.filename).name,
+                storage_path=str(target_path),
+                mime_type=uploaded.content_type,
+                file_size=file_size,
+            )
+            db.add(file_record)
+            db.flush()
+
+            content_preview = ""
+            # Skip preview generation for binary files (images, videos, etc.)
+            file_extension = Path(uploaded.filename).suffix.lower()
+            if file_extension not in BINARY_EXTENSIONS:
+                try:
+                    preview_content = read_file(str(target_path))
+                    content_preview = (
+                        preview_content[:500] + "..."
+                        if isinstance(preview_content, str)
+                        and len(preview_content) > 500
+                        else preview_content
+                    )
+                except Exception:
+                    content_preview = ""
+
+            uploaded_files.append(
+                {
+                    "file_id": file_record.file_id,
+                    "filename": file_record.filename,
+                    "file_size": file_record.file_size,
+                    "mime_type": file_record.mime_type,
+                    "content_preview": content_preview,
+                }
+            )
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        for path in written_paths:
+            try:
+                if path.exists():
+                    path.unlink()
+            except OSError:
+                pass
+        raise
 
     if single_file_mode:
         first_file = uploaded_files[0]

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -69,6 +69,7 @@ from ...core.tools.core.RAG_tools.utils.string_utils import (
 from ..auth_dependencies import get_current_user
 from ..config import (
     MAX_FILE_SIZE,
+    MAX_FILE_SIZE_LABEL,
     get_upload_path,
     is_allowed_file,
     sanitize_path_component,
@@ -343,10 +344,9 @@ async def ingest(
                 total_size += len(chunk)
                 if total_size > MAX_FILE_SIZE:
                     raise HTTPException(
-                        status_code=422,
+                        status_code=413,
                         detail=(
-                            "File size exceeds maximum limit of "
-                            f"{MAX_FILE_SIZE // (1024 * 1024)}MB"
+                            f"File size exceeds maximum limit of {MAX_FILE_SIZE_LABEL}"
                         ),
                     )
                 buffer.write(chunk)

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 from contextlib import suppress
@@ -81,8 +82,6 @@ async def validation_exception_handler(
         for key, value in error.items():
             # Try to serialize each value to check if it's JSON-serializable
             try:
-                import json
-
                 json.dumps(value)
                 sanitized_error[key] = value
             except (TypeError, ValueError):

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import quote
 
-from ..config import get_uploads_dir
+from ..config import format_file_size, get_max_upload_size_bytes, get_uploads_dir
 
 # File storage paths for AI tools (computed dynamically when needed)
 FILE_STORAGE_URL_BASE = "/uploads"
@@ -85,8 +85,9 @@ ALLOWED_EXTENSIONS = {
     "image": [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".ico"],
 }
 
-# Maximum file size (100MB)
-MAX_FILE_SIZE = 100 * 1024 * 1024
+# Maximum file size (configurable via XAGENT_MAX_UPLOAD_SIZE)
+MAX_FILE_SIZE = get_max_upload_size_bytes()
+MAX_FILE_SIZE_LABEL = format_file_size(MAX_FILE_SIZE)
 
 # Word characters (\w = letters/digits/underscore in any language), spaces, and hyphens.
 ALLOWED_NAME_PATTERN = re.compile(r"^[\w -]+$")

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -86,6 +86,8 @@ ALLOWED_EXTENSIONS = {
 }
 
 # Maximum file size (configurable via XAGENT_MAX_UPLOAD_SIZE)
+# These values are evaluated at import time for consistent app-wide messaging.
+# If runtime env reloading is ever needed, switch callers to the config functions instead.
 MAX_FILE_SIZE = get_max_upload_size_bytes()
 MAX_FILE_SIZE_LABEL = format_file_size(MAX_FILE_SIZE)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3,12 +3,15 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from xagent.config import (
     BOXLITE_HOME_DIR,
     DATABASE_URL,
     EXTERNAL_SKILLS_LIBRARY_DIRS,
     EXTERNAL_UPLOAD_DIRS,
     LANCEDB_PATH,
+    MAX_UPLOAD_SIZE,
     SANDBOX_CPUS,
     SANDBOX_ENV,
     SANDBOX_IMAGE,
@@ -17,12 +20,14 @@ from xagent.config import (
     STORAGE_ROOT,
     UPLOADS_DIR,
     WEB_DIR,
+    format_file_size,
     get_boxlite_home_dir,
     get_database_url,
     get_default_sqlite_db_path,
     get_external_skills_dirs,
     get_external_upload_dirs,
     get_lancedb_path,
+    get_max_upload_size_bytes,
     get_sandbox_cpus,
     get_sandbox_env,
     get_sandbox_image,
@@ -60,6 +65,38 @@ class TestEnvironmentVariableConstants:
 
     def test_database_url_constant(self):
         assert DATABASE_URL == "DATABASE_URL"
+
+    def test_max_upload_size_constant(self):
+        assert MAX_UPLOAD_SIZE == "XAGENT_MAX_UPLOAD_SIZE"
+
+
+class TestGetMaxUploadSizeBytes:
+    """Test get_max_upload_size_bytes() function."""
+
+    def test_default_max_upload_size(self, monkeypatch):
+        monkeypatch.delenv(MAX_UPLOAD_SIZE, raising=False)
+        assert get_max_upload_size_bytes() == 100 * 1024 * 1024
+
+    def test_numeric_max_upload_size(self, monkeypatch):
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "2048")
+        assert get_max_upload_size_bytes() == 2048
+
+    def test_human_readable_max_upload_size(self, monkeypatch):
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "150M")
+        assert get_max_upload_size_bytes() == 150 * 1024 * 1024
+
+    def test_invalid_max_upload_size_raises(self, monkeypatch):
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "banana")
+        with pytest.raises(ValueError, match="XAGENT_MAX_UPLOAD_SIZE"):
+            get_max_upload_size_bytes()
+
+
+class TestFormatFileSize:
+    def test_formats_kilobytes(self):
+        assert format_file_size(512 * 1024) == "512KB"
+
+    def test_formats_fractional_megabytes(self):
+        assert format_file_size(1572864) == "1.5MB"
 
 
 class TestGetUploadsDir:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -81,6 +81,19 @@ class TestGetMaxUploadSizeBytes:
         monkeypatch.setenv(MAX_UPLOAD_SIZE, "2048")
         assert get_max_upload_size_bytes() == 2048
 
+    def test_numeric_float_max_upload_size(self, monkeypatch):
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "1.5")
+        assert get_max_upload_size_bytes() == 1
+
+    def test_rejects_non_positive_max_upload_size(self, monkeypatch):
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "0")
+        with pytest.raises(ValueError, match="positive"):
+            get_max_upload_size_bytes()
+
+        monkeypatch.setenv(MAX_UPLOAD_SIZE, "-1")
+        with pytest.raises(ValueError, match="positive"):
+            get_max_upload_size_bytes()
+
     def test_human_readable_max_upload_size(self, monkeypatch):
         monkeypatch.setenv(MAX_UPLOAD_SIZE, "150M")
         assert get_max_upload_size_bytes() == 150 * 1024 * 1024
@@ -97,6 +110,9 @@ class TestFormatFileSize:
 
     def test_formats_fractional_megabytes(self):
         assert format_file_size(1572864) == "1.5MB"
+
+    def test_promotes_boundary_values_to_next_unit(self):
+        assert format_file_size(1048575) == "1MB"
 
 
 class TestGetUploadsDir:

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -167,6 +167,23 @@ def test_ingest_separators_missing_uses_none(app_with_kb, mock_user):
     assert captured_config[0].separators is None
 
 
+def test_ingest_returns_413_when_file_exceeds_limit(app_with_kb, monkeypatch):
+    """KB ingest should return 413 when the uploaded file exceeds the configured limit."""
+    import xagent.web.api.kb
+
+    monkeypatch.setattr(xagent.web.api.kb, "MAX_FILE_SIZE", 4)
+
+    client = TestClient(app_with_kb)
+    response = client.post(
+        "/api/kb/ingest",
+        data={"collection": "test_coll"},
+        files={"file": ("big.txt", io.BytesIO(b"12345"), "text/plain")},
+    )
+
+    assert response.status_code == 413
+    assert "maximum limit" in response.json()["detail"].lower()
+
+
 def test_ingest_separators_invalid_json_request_succeeds_uses_default(
     app_with_kb, mock_user
 ):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -326,6 +326,46 @@ class TestFileUpload:
         # as the API response will indicate success/failure
         assert response.status_code in [200, 201]
 
+    def test_upload_file_returns_413_when_size_exceeds_limit(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        """Upload endpoint should return 413 with a friendly message when too large."""
+        import xagent.web.api.files
+
+        monkeypatch.setattr(xagent.web.api.files, "MAX_FILE_SIZE", 4)
+
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("big.txt", b"12345", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 413
+        assert "maximum limit" in response.json()["detail"].lower()
+
+    def test_upload_multiple_files_cleans_up_partial_writes_on_limit_error(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        """A later oversized file should not leave earlier uploaded files on disk."""
+        import xagent.web.api.files
+
+        monkeypatch.setattr(xagent.web.api.files, "MAX_FILE_SIZE", 4)
+        monkeypatch.setattr(xagent.web.api.files, "MAX_FILE_SIZE_LABEL", "4B")
+
+        response = client.post(
+            "/api/files/upload",
+            files=[
+                ("files", ("small.txt", b"1234", "text/plain")),
+                ("files", ("big.txt", b"12345", "text/plain")),
+            ],
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 413
+        assert [path for path in temp_uploads_dir.rglob("*") if path.is_file()] == []
+
 
 class TestFileManagement:
     """Test file management operations"""


### PR DESCRIPTION
## Summary
- unify upload-size handling under `XAGENT_MAX_UPLOAD_SIZE` and expose consistent backend size labels
- move upload-size enforcement to per-file backend streaming checks so multipart overhead does not trigger premature proxy failures
- make frontend upload flows tolerate proxy/non-JSON failures and stop task creation when file uploads fail
## What changed
- added upload-size parsing and formatting helpers in core config
- exposed the configured per-file upload limit through web config and docs
- updated docker/nginx deployment behavior to defer file-size enforcement to the backend instead of request-body prechecks
- hardened `/api/files/upload` to:
  - stream-check file size
  - roll back partial multi-file writes on failure
  - return clearer size-limit errors
- updated KB ingest to use the same configured size label in 413 responses
- added frontend response parsing helpers so upload flows no longer break on proxy or non-JSON error responses
- updated direct file uploads, KB upload/import flows, websocket/task creation flows, and agent page flows to surface friendly upload errors and stop continuing after failed uploads
## Why
Large `.xlsx` uploads around the configured limit could previously fail at the proxy or request-body level, and frontend upload flows could receive HTML or non-JSON failures that produced poor or confusing UX. Some task flows also continued after upload failure, which could create tasks without the intended files.
This change makes upload behavior more predictable by enforcing the limit on actual file bytes at the backend, improving cleanup on partial failures, and showing clearer user-facing errors across the UI.