### PR TITLE
feat(logging): add token usage debug logging and fix debug mode

### DIFF
--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -6,8 +6,11 @@ statistics to be automatically collected during task execution.
 """
 
 import contextvars
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -182,6 +185,13 @@ def add_token_usage(
         usage.add_input_tokens(input_tokens, model, call_type)
     if output_tokens:
         usage.add_output_tokens(output_tokens, model, call_type)
+
+    logger.debug(
+        f"Token usage added: input={input_tokens}, output={output_tokens}, "
+        f"model={model}, call_type={call_type}, "
+        f"total_input={usage.input_tokens}, total_output={usage.output_tokens}, "
+        f"total_calls={usage.llm_calls}"
+    )
 
 
 def reset_token_usage() -> TokenUsage:

--- a/src/xagent/web/__main__.py
+++ b/src/xagent/web/__main__.py
@@ -122,8 +122,8 @@ def main() -> None:
     args = parse_args()
 
     # Configure logging BEFORE importing app
-    log_level = "debug" if args.debug else args.log_level
-    setup_logging(level=cast(LogLevel, log_level) if log_level else None)
+    log_level = "DEBUG" if args.debug else (args.log_level or "").upper()
+    setup_logging(level=cast(LogLevel, log_level) if log_level else None, force=True)
 
     logger = logging.getLogger(__name__)
     warn_if_example_jwt_config(logger)
@@ -149,7 +149,7 @@ def main() -> None:
             host=args.host,
             port=args.port,
             reload=args.reload,
-            log_level=log_level,
+            log_level=log_level.lower() if log_level else None,
         )
     except KeyboardInterrupt:
         logger.info("⏹️  Service stopped")

--- a/src/xagent/web/logging_config.py
+++ b/src/xagent/web/logging_config.py
@@ -11,15 +11,16 @@ LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 _is_applied = False
 
 
-def setup_logging(level: LogLevel | None = None) -> None:
+def setup_logging(level: LogLevel | None = None, force: bool = False) -> None:
     """Configure logging for the entire application.
 
     Args:
         level: Log level. If None, reads from XAGENT_LOG_LEVEL env var,
                defaults to "INFO" if env var is not set or invalid.
+        force: If True, reconfigure logging even if already applied.
     """
     global _is_applied
-    if _is_applied:
+    if _is_applied and not force:
         return
     # Read log level from env var if not provided
     if level is None:
@@ -55,6 +56,7 @@ def setup_logging(level: LogLevel | None = None) -> None:
                 "uvicorn.error": {"level": "INFO"},
                 "httpx": {"level": "WARNING"},
                 "httpcore": {"level": "WARNING"},
+                "xagent": {"level": level},
             },
             "root": {
                 "level": level,


### PR DESCRIPTION
- Add debug logging to add_token_usage() to track LLM token usage in real-time
- Fix --debug flag not working due to log level case sensitivity issues
- Add force parameter to setup_logging() to allow overriding default config
- Configure xagent logger level explicitly to ensure debug logs are shown
- Fix uvicorn log_level parameter to use lowercase values

This enables detailed token usage tracking when running with --debug flag, helping with monitoring and debugging agent execution costs.