### PR TITLE
fix(web-ingestion): harden file refresh and reconciliation consistency

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -61,13 +61,17 @@ def _build_collection_filter(
         table = conn.open_table(table_name)
         if not is_admin and user_id is not None:
             if _table_has_column(table, "user_id"):
-                base_expr = build_lancedb_filter_expression(base)
+                base_expr = build_lancedb_filter_expression(
+                    base, user_id=user_id, is_admin=is_admin, skip_user_filter=True
+                )
                 user_expr = build_user_id_filter_for_table(table, int(user_id))
                 return f"{base_expr} AND {user_expr}"
+            # Legacy schemas without user_id must remain compatible.
+            return build_lancedb_filter_expression(base)
+        return build_lancedb_filter_expression(base, user_id=user_id, is_admin=is_admin)
     except Exception:
-        # If we cannot open the table here, fall back to base filter.
-        pass
-    return build_lancedb_filter_expression(base)
+        # If table introspection fails, keep tenant-safe fallback.
+        return build_lancedb_filter_expression(base, user_id=user_id, is_admin=is_admin)
 
 
 def _build_document_filter(
@@ -85,12 +89,17 @@ def _build_document_filter(
         table = conn.open_table(table_name)
         if not is_admin and user_id is not None:
             if _table_has_column(table, "user_id"):
-                base_expr = build_lancedb_filter_expression(base)
+                base_expr = build_lancedb_filter_expression(
+                    base, user_id=user_id, is_admin=is_admin, skip_user_filter=True
+                )
                 user_expr = build_user_id_filter_for_table(table, int(user_id))
                 return f"{base_expr} AND {user_expr}"
+            # Legacy schemas without user_id must remain compatible.
+            return build_lancedb_filter_expression(base)
+        return build_lancedb_filter_expression(base, user_id=user_id, is_admin=is_admin)
     except Exception:
-        pass
-    return build_lancedb_filter_expression(base)
+        # If table introspection fails, keep tenant-safe fallback.
+        return build_lancedb_filter_expression(base, user_id=user_id, is_admin=is_admin)
 
 
 def _append_user_filter_if_needed(
@@ -289,6 +298,9 @@ def _delete_by_predicates(
             "documents",
         ):
             continue
+        if name.startswith("embeddings_"):
+            # Already handled in the explicit embeddings pass above.
+            continue
         if name not in table_names:
             deleted[name] = 0
             continue
@@ -470,7 +482,9 @@ def cleanup_cascade(
                 "doc_id": doc_id,
                 "parse_hash": old_parse_hash,
             }
-            base = build_lancedb_filter_expression(base_filters)
+            base = build_lancedb_filter_expression(
+                base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
+            )
             predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
                 conn=conn,
                 base_expr=base,
@@ -523,7 +537,9 @@ def cleanup_cascade(
                 "doc_id": doc_id,
                 "parse_hash": old_parse_hash,
             }
-            base = build_lancedb_filter_expression(base_filters)
+            base = build_lancedb_filter_expression(
+                base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
+            )
             predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
                 conn=conn,
                 base_expr=base,

--- a/src/xagent/migrations/lancedb/backfill_uploaded_file_links.py
+++ b/src/xagent/migrations/lancedb/backfill_uploaded_file_links.py
@@ -1,0 +1,306 @@
+"""LanceDB migration: backfill documents.file_id from UploadedFile records.
+
+This migration links legacy ``documents`` rows without ``file_id`` to
+``uploaded_files`` records using ``source_path`` as the primary join key.
+
+Migration behavior:
+- Reuse existing ``UploadedFile`` when ``storage_path == source_path``.
+- Create missing ``UploadedFile`` when source file exists on disk.
+- Mark unresolved rows as ``unbackfillable`` in migration report.
+
+The script is idempotent and supports dry-run mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import logging
+import mimetypes
+import os
+import re
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from lancedb.db import DBConnection
+
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+    ensure_documents_table,
+)
+from xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils import query_to_list
+from xagent.core.tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
+from xagent.providers.vector_store.lancedb import get_connection_from_env
+from xagent.web.models.database import get_session_local
+from xagent.web.models.uploaded_file import UploadedFile
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 500
+_migration_lock = threading.Lock()
+
+
+def _get_migration_lock_file_path() -> str:
+    lock_file = os.environ.get("LANCEDB_MIGRATION_LOCK_FILE")
+    if lock_file:
+        return lock_file
+
+    lancedb_dir = os.environ.get("LANCEDB_DIR")
+    if lancedb_dir:
+        return os.path.join(lancedb_dir, ".lancedb_uploaded_file_links.lock")
+
+    return os.path.join(
+        tempfile.gettempdir(), "xagent_lancedb_uploaded_file_links.lock"
+    )
+
+
+def _acquire_file_lock() -> Any | None:
+    lock_path = _get_migration_lock_file_path()
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    lock_file = open(lock_path, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(str(os.getpid()))
+        lock_file.flush()
+        return lock_file
+    except BlockingIOError:
+        lock_file.close()
+        return None
+    except Exception:
+        lock_file.close()
+        raise
+
+
+def _release_file_lock(lock_file: Any) -> None:
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock_file.close()
+
+
+def _extract_user_id_from_source_path(source_path: str) -> Optional[int]:
+    match = re.search(r"/user_(\d+)(?:/|$)", source_path)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_update_filter(row: dict[str, Any]) -> str:
+    collection = escape_lancedb_string(str(row.get("collection") or ""))
+    doc_id = escape_lancedb_string(str(row.get("doc_id") or ""))
+    return f"collection == '{collection}' and doc_id == '{doc_id}' and file_id IS NULL"
+
+
+def _resolve_or_create_uploaded_file(
+    db: Session, row: dict[str, Any], dry_run: bool
+) -> tuple[Optional[str], str]:
+    source_path = str(row.get("source_path") or "").strip()
+    if not source_path:
+        return None, "missing_source_path"
+
+    user_id_raw = row.get("user_id")
+    user_id: Optional[int] = None
+    if user_id_raw is not None:
+        try:
+            user_id = int(user_id_raw)
+        except (TypeError, ValueError):
+            user_id = None
+    if user_id is None:
+        user_id = _extract_user_id_from_source_path(source_path)
+    if user_id is None:
+        return None, "missing_user_id"
+
+    existing = (
+        db.query(UploadedFile)
+        .filter(
+            UploadedFile.user_id == user_id,
+            UploadedFile.storage_path == source_path,
+        )
+        .first()
+    )
+    if existing:
+        return str(existing.file_id), "matched_existing"
+
+    source_file = Path(source_path)
+    if not source_file.exists() or not source_file.is_file():
+        return None, "missing_file_on_disk"
+
+    if dry_run:
+        return "__DRY_RUN_NEW_FILE_ID__", "would_create_uploaded_file"
+
+    record = UploadedFile(
+        user_id=user_id,
+        filename=source_file.name,
+        storage_path=source_path,
+        mime_type=mimetypes.guess_type(source_file.name)[0]
+        or "application/octet-stream",
+        file_size=source_file.stat().st_size,
+    )
+    db.add(record)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raced = (
+            db.query(UploadedFile)
+            .filter(
+                UploadedFile.user_id == user_id,
+                UploadedFile.storage_path == source_path,
+            )
+            .first()
+        )
+        if raced:
+            return str(raced.file_id), "matched_existing_after_race"
+        return None, "uploaded_file_integrity_error"
+
+    db.refresh(record)
+    return str(record.file_id), "created_uploaded_file"
+
+
+def backfill_documents_file_links(
+    *,
+    dry_run: bool = False,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    conn: DBConnection | None = None,
+) -> dict[str, Any]:
+    if conn is None:
+        conn = get_connection_from_env()
+
+    ensure_documents_table(conn)
+    docs_table = conn.open_table("documents")
+
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+
+    stats: dict[str, Any] = {
+        "dry_run": dry_run,
+        "scanned": 0,
+        "backfilled_by_match": 0,
+        "backfilled_by_create": 0,
+        "unbackfillable": 0,
+        "failures": 0,
+        "unbackfillable_samples": [],
+    }
+
+    try:
+        while True:
+            rows = query_to_list(
+                docs_table.search().where("file_id IS NULL").limit(batch_size)
+            )
+            if not rows:
+                break
+
+            updated_in_batch = 0
+            for row in rows:
+                stats["scanned"] += 1
+                file_id, reason = _resolve_or_create_uploaded_file(db, row, dry_run)
+                if file_id is None:
+                    stats["unbackfillable"] += 1
+                    if len(stats["unbackfillable_samples"]) < 20:
+                        stats["unbackfillable_samples"].append(
+                            {
+                                "collection": row.get("collection"),
+                                "doc_id": row.get("doc_id"),
+                                "source_path": row.get("source_path"),
+                                "reason": reason,
+                            }
+                        )
+                    continue
+
+                if reason in {"matched_existing", "matched_existing_after_race"}:
+                    stats["backfilled_by_match"] += 1
+                elif reason in {"created_uploaded_file", "would_create_uploaded_file"}:
+                    stats["backfilled_by_create"] += 1
+
+                if dry_run:
+                    continue
+
+                try:
+                    update_filter = _build_update_filter(row)
+                    docs_table.update(update_filter, {"file_id": file_id})
+                    updated_in_batch += 1
+                except Exception as exc:  # noqa: BLE001
+                    stats["failures"] += 1
+                    logger.warning(
+                        "Failed to update documents.file_id for %s: %s",
+                        row.get("doc_id"),
+                        exc,
+                    )
+
+            if dry_run:
+                # Dry-run does not mutate table rows; avoid reprocessing same batch forever.
+                break
+            if updated_in_batch == 0:
+                # No rows were updated in this batch, so additional loops will not make progress.
+                break
+    finally:
+        db.close()
+
+    return stats
+
+
+def backfill_all(
+    *, dry_run: bool = False, batch_size: int = DEFAULT_BATCH_SIZE
+) -> dict[str, Any]:
+    if not _migration_lock.acquire(blocking=False):
+        logger.warning("Another migration is already in progress")
+        return {"error": "Migration lock already held"}
+
+    file_lock = None
+    try:
+        file_lock = _acquire_file_lock()
+        if file_lock is None:
+            logger.warning("Another migration is running in a different process")
+            return {"error": "Migration file lock already held"}
+
+        result = backfill_documents_file_links(dry_run=dry_run, batch_size=batch_size)
+        logger.info("Backfill uploaded file links result: %s", result)
+        return result
+    finally:
+        if file_lock is not None:
+            _release_file_lock(file_lock)
+        _migration_lock.release()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill LanceDB documents.file_id using uploaded_files records.\n"
+            "Supports dry-run mode and idempotent re-runs."
+        )
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Simulate without writing data"
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Rows processed per batch (default: {DEFAULT_BATCH_SIZE})",
+    )
+    args = parser.parse_args()
+
+    if args.batch_size <= 0:
+        logger.error("--batch-size must be > 0")
+        sys.exit(2)
+
+    try:
+        backfill_all(dry_run=args.dry_run, batch_size=args.batch_size)
+        sys.exit(0)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Backfill migration failed: %s", exc, exc_info=True)
+        sys.exit(2)

--- a/src/xagent/migrations/lancedb/backfill_uploaded_file_links.py
+++ b/src/xagent/migrations/lancedb/backfill_uploaded_file_links.py
@@ -40,12 +40,10 @@ from xagent.providers.vector_store.lancedb import get_connection_from_env
 from xagent.web.models.database import get_session_local
 from xagent.web.models.uploaded_file import UploadedFile
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 500
+_MAX_BACKFILL_ITERATIONS = 10000  # Safety cap to prevent pathological infinite loops
 _migration_lock = threading.Lock()
 
 
@@ -194,10 +192,12 @@ def backfill_documents_file_links(
         "unbackfillable": 0,
         "failures": 0,
         "unbackfillable_samples": [],
+        "iterations": 0,
     }
 
     try:
-        while True:
+        while stats["iterations"] < _MAX_BACKFILL_ITERATIONS:
+            stats["iterations"] += 1
             rows = query_to_list(
                 docs_table.search().where("file_id IS NULL").limit(batch_size)
             )
@@ -247,6 +247,14 @@ def backfill_documents_file_links(
             if updated_in_batch == 0:
                 # No rows were updated in this batch, so additional loops will not make progress.
                 break
+        else:
+            # Loop terminated due to reaching max iterations (pathological case)
+            logger.warning(
+                "Backfill reached maximum iteration limit (%d). "
+                "This may indicate a pathological condition or alternating success/failure pattern.",
+                _MAX_BACKFILL_ITERATIONS,
+            )
+            stats["hit_iteration_limit"] = True
     finally:
         db.close()
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -22,6 +22,7 @@ from ..config import (
 from ..models.database import get_db
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
+from ..services.kb_file_service import aggregate_uploaded_file_statuses
 from .legacy_file import (
     infer_user_id_from_legacy_path,
     is_valid_uuid,
@@ -535,6 +536,11 @@ async def list_files(
         query = query.filter(UploadedFile.user_id == _user_id_value(user))
 
     records = query.order_by(UploadedFile.created_at.desc()).all()
+    file_status_map = aggregate_uploaded_file_statuses(
+        file_ids=[str(record.file_id) for record in records if record.file_id],
+        user_id=_user_id_value(user),
+        is_admin=_is_admin_user(user),
+    )
     files = []
     for record in records:
         path = Path(_file_storage_path_value(record))
@@ -550,6 +556,7 @@ async def list_files(
                 "relative_path": relative_path,
                 "task_id": record.task_id,
                 "user_id": record_user_id,
+                "ingestion_status": file_status_map.get(str(record.file_id), "UNKNOWN"),
             }
         )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -108,7 +108,8 @@ T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 _SQL_LIKE_ESCAPE = "\\"
-_WEB_FILE_LOCKS: Dict[str, threading.Lock] = {}
+# lock_key -> (lock, active waiter/holder count)
+_WEB_FILE_LOCKS: Dict[str, tuple[threading.Lock, int]] = {}
 _WEB_FILE_LOCKS_GUARD = threading.Lock()
 
 
@@ -372,10 +373,13 @@ class _WebFileLock:
 
     def __enter__(self) -> "_WebFileLock":
         with _WEB_FILE_LOCKS_GUARD:
-            lock = _WEB_FILE_LOCKS.get(self._lock_key)
-            if lock is None:
+            lock_entry = _WEB_FILE_LOCKS.get(self._lock_key)
+            if lock_entry is None:
                 lock = threading.Lock()
-                _WEB_FILE_LOCKS[self._lock_key] = lock
+                _WEB_FILE_LOCKS[self._lock_key] = (lock, 1)
+            else:
+                lock, ref_count = lock_entry
+                _WEB_FILE_LOCKS[self._lock_key] = (lock, ref_count + 1)
             self._lock = lock
         # Acquire the per-key lock outside the global guard to avoid
         # blocking other threads from accessing the registry for different keys.
@@ -385,6 +389,15 @@ class _WebFileLock:
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self._lock is not None:
             self._lock.release()
+        with _WEB_FILE_LOCKS_GUARD:
+            lock_entry = _WEB_FILE_LOCKS.get(self._lock_key)
+            if lock_entry is None:
+                return
+            lock, ref_count = lock_entry
+            if ref_count <= 1:
+                _WEB_FILE_LOCKS.pop(self._lock_key, None)
+                return
+            _WEB_FILE_LOCKS[self._lock_key] = (lock, ref_count - 1)
 
 
 def handle_kb_exceptions(func: T) -> T:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -8,6 +8,7 @@ import json
 import logging
 import mimetypes
 import shutil
+import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
 
@@ -105,6 +106,8 @@ T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 _SQL_LIKE_ESCAPE = "\\"
+_WEB_FILE_LOCKS: Dict[str, threading.Lock] = {}
+_WEB_FILE_LOCKS_GUARD = threading.Lock()
 
 
 def _like_contains_pattern(value: str) -> str:
@@ -114,6 +117,96 @@ def _like_contains_pattern(value: str) -> str:
         .replace("_", f"{_SQL_LIKE_ESCAPE}_")
     )
     return f"%{escaped}%"
+
+
+def _get_file_sha256(file_path: Path) -> str:
+    """Compute SHA256 hash for a local file."""
+    hash_obj = hashlib.sha256()
+    with file_path.open("rb") as file_obj:
+        while True:
+            chunk = file_obj.read(1024 * 1024)
+            if not chunk:
+                break
+            hash_obj.update(chunk)
+    return hash_obj.hexdigest()
+
+
+def _atomic_replace_file(source_path: Path, target_path: Path) -> None:
+    """Atomically replace target file with source file content."""
+    temp_target = target_path.with_suffix(f"{target_path.suffix}.tmp-replace")
+    shutil.copy2(source_path, temp_target)
+    temp_target.replace(target_path)
+
+
+def _mark_uploaded_file_for_reindex(file_id: str) -> bool:
+    """Clear ingestion run markers so changed file can be re-indexed."""
+    try:
+        from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+            ensure_documents_table,
+            ensure_ingestion_runs_table,
+        )
+        from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import query_to_list
+        from ...core.tools.core.RAG_tools.utils.string_utils import (
+            escape_lancedb_string,
+        )
+        from ...providers.vector_store.lancedb import get_connection_from_env
+
+        conn = get_connection_from_env()
+        ensure_documents_table(conn)
+        ensure_ingestion_runs_table(conn)
+        documents_table = conn.open_table("documents")
+        ingestion_runs_table = conn.open_table("ingestion_runs")
+
+        safe_file_id = escape_lancedb_string(file_id)
+        rows = query_to_list(
+            documents_table.search()
+            .where(f"file_id = '{safe_file_id}'")
+            .select(["collection", "doc_id"])
+            .limit(-1)
+        )
+        for row in rows:
+            collection = str(row.get("collection") or "").strip()
+            doc_id = str(row.get("doc_id") or "").strip()
+            if not collection or not doc_id:
+                continue
+            safe_collection = escape_lancedb_string(collection)
+            safe_doc_id = escape_lancedb_string(doc_id)
+            ingestion_runs_table.delete(
+                f"collection = '{safe_collection}' and doc_id = '{safe_doc_id}'"
+            )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to mark uploaded file for re-index: file_id=%s, error=%s",
+            file_id,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
+class _WebFileLock:
+    """Per-key in-process lock for web ingestion file operations."""
+
+    def __init__(self, lock_key: str) -> None:
+        self._lock_key = lock_key
+        self._lock: Optional[threading.Lock] = None
+
+    def __enter__(self) -> "_WebFileLock":
+        with _WEB_FILE_LOCKS_GUARD:
+            lock = _WEB_FILE_LOCKS.get(self._lock_key)
+            if lock is None:
+                lock = threading.Lock()
+                _WEB_FILE_LOCKS[self._lock_key] = lock
+            self._lock = lock
+            # Acquire the same lock object while still under guard to avoid
+            # any follow-up lookup race on the lock registry.
+            lock.acquire()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self._lock is not None:
+            self._lock.release()
 
 
 def handle_kb_exceptions(func: T) -> T:
@@ -1269,106 +1362,177 @@ async def ingest_web(
                 sanitize_path_component(title, "filename") if title else "untitled"
             )
             filename = f"{url_hash}_{safe_title}.md"
+            lock_key = f"{int(_user.id)}:{url_hash}"
 
-            # Check if we've already processed this URL (in-memory cache)
-            if url_hash in _processed_urls:
-                existing_file_id = _processed_urls[url_hash]
-                logger.info(
-                    f"Reusing existing UploadedFile record for web ingestion: "
-                    f"url={url}, file_id={existing_file_id}"
-                )
-                # Query the database to get the storage path
-                existing_record = (
-                    db_session.query(UploadedFile)
-                    .filter(UploadedFile.file_id == existing_file_id)
-                    .first()
-                )
-                if existing_record:
-                    return FileHandlerResult(
-                        file_path=str(existing_record.storage_path),
-                        file_id=str(existing_record.file_id),
+            with _WebFileLock(lock_key):
+                # Check if we've already processed this URL (in-memory cache)
+                if url_hash in _processed_urls:
+                    existing_file_id = _processed_urls[url_hash]
+                    logger.info(
+                        f"Reusing existing UploadedFile record for web ingestion: "
+                        f"url={url}, file_id={existing_file_id}"
                     )
-                else:
+                    # Query the database to get the storage path
+                    existing_record = (
+                        db_session.query(UploadedFile)
+                        .filter(UploadedFile.file_id == existing_file_id)
+                        .first()
+                    )
+                    if existing_record:
+                        existing_path = Path(str(existing_record.storage_path))
+                        if existing_path.exists():
+                            old_hash = _get_file_sha256(existing_path)
+                            new_hash = _get_file_sha256(temp_file_path)
+                            if old_hash != new_hash:
+                                _atomic_replace_file(temp_file_path, existing_path)
+                                file_record = _upsert_uploaded_file_record(
+                                    db_session,
+                                    user_id=int(_user.id),
+                                    filename=filename,
+                                    storage_path=existing_path,
+                                    mime_type="text/markdown",
+                                    file_size=existing_path.stat().st_size,
+                                )
+                                _processed_urls[url_hash] = str(file_record.file_id)
+                                if _mark_uploaded_file_for_reindex(
+                                    str(file_record.file_id)
+                                ):
+                                    logger.info(
+                                        "Marked changed web file as PENDING_REINDEX: url=%s, file_id=%s",
+                                        url,
+                                        file_record.file_id,
+                                    )
+                                logger.info(
+                                    "Refreshed web ingestion file due to content change: url=%s, file_id=%s",
+                                    url,
+                                    file_record.file_id,
+                                )
+                        return FileHandlerResult(
+                            file_path=str(existing_record.storage_path),
+                            file_id=str(existing_record.file_id),
+                        )
                     # Cached file_id was deleted from DB, fall through to recreate
                     logger.warning(
                         f"Cached file_id {existing_file_id} not found in DB (record was deleted), "
                         f"will create new record for url={url}"
                     )
 
-            # Check database for existing file with same URL hash (cross-session deduplication)
-            existing_record = (
-                db_session.query(UploadedFile)
-                .filter(
-                    UploadedFile.user_id == int(_user.id),
-                    UploadedFile.filename == filename,
-                )
-                .first()
-            )
-
-            if existing_record:
-                logger.info(
-                    f"Found existing UploadedFile record from previous session: "
-                    f"url={url}, file_id={existing_record.file_id}"
-                )
-                _processed_urls[url_hash] = str(existing_record.file_id)
-                return FileHandlerResult(
-                    file_path=str(existing_record.storage_path),
-                    file_id=str(existing_record.file_id),
+                # Check database for existing file with same URL hash (cross-session deduplication)
+                existing_record = (
+                    db_session.query(UploadedFile)
+                    .filter(
+                        UploadedFile.user_id == int(_user.id),
+                        UploadedFile.filename == filename,
+                    )
+                    .first()
                 )
 
-            # Generate persistent file path
-            persistent_file = get_upload_path(
-                filename,
-                user_id=int(_user.id),
-                collection=collection_name,
-                collection_is_sanitized=True,
-            )
+                if existing_record:
+                    existing_path = Path(str(existing_record.storage_path))
+                    if existing_path.exists():
+                        old_hash = _get_file_sha256(existing_path)
+                        new_hash = _get_file_sha256(temp_file_path)
+                        if old_hash != new_hash:
+                            _atomic_replace_file(temp_file_path, existing_path)
+                            file_record = _upsert_uploaded_file_record(
+                                db_session,
+                                user_id=int(_user.id),
+                                filename=filename,
+                                storage_path=existing_path,
+                                mime_type="text/markdown",
+                                file_size=existing_path.stat().st_size,
+                            )
+                            _processed_urls[url_hash] = str(file_record.file_id)
+                            if _mark_uploaded_file_for_reindex(
+                                str(file_record.file_id)
+                            ):
+                                logger.info(
+                                    "Marked changed web file as PENDING_REINDEX: url=%s, file_id=%s",
+                                    url,
+                                    file_record.file_id,
+                                )
+                            logger.info(
+                                "Updated existing web ingestion file from previous session: url=%s, file_id=%s",
+                                url,
+                                file_record.file_id,
+                            )
+                    else:
+                        # Recreate missing persistent file to keep record usable.
+                        existing_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(temp_file_path, existing_path)
+                        file_record = _upsert_uploaded_file_record(
+                            db_session,
+                            user_id=int(_user.id),
+                            filename=filename,
+                            storage_path=existing_path,
+                            mime_type="text/markdown",
+                            file_size=existing_path.stat().st_size,
+                        )
+                        _processed_urls[url_hash] = str(file_record.file_id)
 
-            # Ensure directory exists
-            persistent_file.parent.mkdir(parents=True, exist_ok=True)
+                    logger.info(
+                        f"Found existing UploadedFile record from previous session: "
+                        f"url={url}, file_id={existing_record.file_id}"
+                    )
+                    _processed_urls[url_hash] = str(existing_record.file_id)
+                    return FileHandlerResult(
+                        file_path=str(existing_record.storage_path),
+                        file_id=str(existing_record.file_id),
+                    )
 
-            try:
-                # Copy file to persistent location
-                shutil.copy2(temp_file_path, persistent_file)
-                logger.info(
-                    f"Copied web ingestion file from {temp_file_path} to {persistent_file}"
-                )
-
-                # Create UploadedFile record
-                file_record = _upsert_uploaded_file_record(
-                    db_session,
+                # Generate persistent file path
+                persistent_file = get_upload_path(
+                    filename,
                     user_id=int(_user.id),
-                    filename=filename,
-                    storage_path=persistent_file,
-                    mime_type="text/markdown",
-                    file_size=persistent_file.stat().st_size,
+                    collection=collection_name,
+                    collection_is_sanitized=True,
                 )
 
-                logger.info(
-                    f"Created UploadedFile record for web ingestion: file_id={file_record.file_id}, "
-                    f"filename={filename}, url={url}"
-                )
+                # Ensure directory exists
+                persistent_file.parent.mkdir(parents=True, exist_ok=True)
 
-                # Track this URL to prevent duplicates
-                _processed_urls[url_hash] = str(file_record.file_id)
+                try:
+                    # Copy file to persistent location
+                    shutil.copy2(temp_file_path, persistent_file)
+                    logger.info(
+                        f"Copied web ingestion file from {temp_file_path} to {persistent_file}"
+                    )
 
-                return FileHandlerResult(
-                    file_path=str(persistent_file),
-                    file_id=str(file_record.file_id),
-                )
-            except Exception:
-                # Clean up orphaned persistent file if upsert failed
-                if persistent_file.exists():
-                    try:
-                        persistent_file.unlink()
-                        logger.warning(
-                            f"Cleaned up orphaned persistent file due to upsert failure: {persistent_file}"
-                        )
-                    except Exception as cleanup_error:
-                        logger.warning(
-                            f"Failed to clean up orphaned persistent file {persistent_file}: {cleanup_error}"
-                        )
-                raise
+                    # Create UploadedFile record
+                    file_record = _upsert_uploaded_file_record(
+                        db_session,
+                        user_id=int(_user.id),
+                        filename=filename,
+                        storage_path=persistent_file,
+                        mime_type="text/markdown",
+                        file_size=persistent_file.stat().st_size,
+                    )
+
+                    logger.info(
+                        f"Created UploadedFile record for web ingestion: file_id={file_record.file_id}, "
+                        f"filename={filename}, url={url}"
+                    )
+
+                    # Track this URL to prevent duplicates
+                    _processed_urls[url_hash] = str(file_record.file_id)
+
+                    return FileHandlerResult(
+                        file_path=str(persistent_file),
+                        file_id=str(file_record.file_id),
+                    )
+                except Exception:
+                    # Clean up orphaned persistent file if upsert failed
+                    if persistent_file.exists():
+                        try:
+                            persistent_file.unlink()
+                            logger.warning(
+                                f"Cleaned up orphaned persistent file due to upsert failure: {persistent_file}"
+                            )
+                        except Exception as cleanup_error:
+                            logger.warning(
+                                f"Failed to clean up orphaned persistent file {persistent_file}: {cleanup_error}"
+                            )
+                    raise
 
         # Create a wrapper that creates a dedicated DB session for the executor thread
         # This avoids sharing the request thread's session across thread boundaries,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -7,8 +7,10 @@ import hashlib
 import json
 import logging
 import mimetypes
+import os
 import shutil
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
 
@@ -119,6 +121,72 @@ def _like_contains_pattern(value: str) -> str:
     return f"%{escaped}%"
 
 
+def cleanup_orphaned_temp_files(upload_dir: Optional[Path] = None) -> int:
+    """Clean up orphaned temporary files from interrupted atomic replacements.
+
+    Removes files matching patterns like:
+    - *.tmp-replace (old pattern)
+    - .*.tmp (new NamedTemporaryFile pattern)
+
+    Args:
+        upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
+
+    Returns:
+        Number of files cleaned up.
+    """
+    from ..config import get_uploads_dir
+
+    base_dir = upload_dir or get_uploads_dir()
+    if not base_dir.exists():
+        return 0
+
+    cleaned_count = 0
+    now = time.time()
+
+    # Walk through uploads directory and clean up temp files older than 1 hour
+    # to avoid deleting files that might still be in use
+    for root, dirs, files in os.walk(base_dir):
+        for filename in files:
+            file_path = Path(root) / filename
+
+            # Check for old temp file pattern (*.tmp-replace)
+            if filename.endswith(".tmp-replace"):
+                file_age = now - file_path.stat().st_mtime
+                if file_age > 3600:  # 1 hour
+                    try:
+                        file_path.unlink()
+                        cleaned_count += 1
+                        logger.debug("Cleaned up orphaned temp file: %s", file_path)
+                    except OSError as e:
+                        logger.warning(
+                            "Failed to clean up orphaned temp file %s: %s", file_path, e
+                        )
+
+            # Check for new temp file pattern (.*.tmp from NamedTemporaryFile)
+            # Pattern: filename.XXXXXX.tmp where X is random hex
+            if filename.endswith(".tmp") and "." in filename[:-4]:
+                # Verify it looks like our temp pattern (has multiple extensions)
+                parts = filename.split(".")
+                if len(parts) >= 3 and parts[-1] == "tmp":
+                    file_age = now - file_path.stat().st_mtime
+                    if file_age > 3600:  # 1 hour
+                        try:
+                            file_path.unlink()
+                            cleaned_count += 1
+                            logger.debug("Cleaned up orphaned temp file: %s", file_path)
+                        except OSError as e:
+                            logger.warning(
+                                "Failed to clean up orphaned temp file %s: %s",
+                                file_path,
+                                e,
+                            )
+
+    if cleaned_count > 0:
+        logger.info("Cleaned up %d orphaned temporary file(s)", cleaned_count)
+
+    return cleaned_count
+
+
 def _get_file_sha256(file_path: Path) -> str:
     """Compute SHA256 hash for a local file."""
     hash_obj = hashlib.sha256()
@@ -132,10 +200,32 @@ def _get_file_sha256(file_path: Path) -> str:
 
 
 def _atomic_replace_file(source_path: Path, target_path: Path) -> None:
-    """Atomically replace target file with source file content."""
-    temp_target = target_path.with_suffix(f"{target_path.suffix}.tmp-replace")
-    shutil.copy2(source_path, temp_target)
-    temp_target.replace(target_path)
+    """Atomically replace target file with source file content.
+
+    Uses a temporary file in the same directory as the target to ensure
+    atomic replacement via os.replace(). The temp file is automatically
+    cleaned up on success, and will be cleaned up by the OS on crash
+    (on most systems) or on next startup via cleanup logic.
+    """
+    import tempfile
+
+    # Ensure target directory exists
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create a temp file in the same directory as target (required for atomic replace)
+    # delete=False so we can use it for replace() and clean up manually
+    with tempfile.NamedTemporaryFile(
+        dir=target_path.parent,
+        prefix=f"{target_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+        # Copy to temp file first
+        shutil.copy2(source_path, tmp_path)
+
+    # Atomic replace - this is atomic on POSIX systems
+    tmp_path.replace(target_path)
 
 
 def _mark_uploaded_file_for_reindex(file_id: str) -> bool:
@@ -185,6 +275,94 @@ def _mark_uploaded_file_for_reindex(file_id: str) -> bool:
         return False
 
 
+def _refresh_existing_file_if_changed(
+    existing_record: Any,
+    temp_file_path: Path,
+    db_session: Session,
+    user_id: int,
+    url: str,
+    filename: str,
+    url_hash: str,
+    processed_urls: Dict[str, str],
+    context: str,
+) -> Optional[FileHandlerResult]:
+    """Refresh existing file if content has changed.
+
+    This function:
+    1. Compares file hashes to detect content changes
+    2. If changed, marks for reindex FIRST (before any file modification)
+    3. If mark succeeds, atomically replaces the file and updates DB record
+    4. If mark fails, returns existing file without refresh (stale but consistent)
+
+    Args:
+        existing_record: The UploadedFile record from database
+        temp_file_path: Path to the new temporary file
+        db_session: Database session for updates
+        user_id: User ID for record ownership
+        url: Source URL (for logging)
+        filename: Filename for the record
+        url_hash: Hash key for processed_urls cache
+        processed_urls: Cache dict to update with new file_id
+        context: Context string for logging (e.g., "in-memory cache", "cross-session")
+
+    Returns:
+        FileHandlerResult if operation completed (success or skipped),
+        None if file content is unchanged and caller should continue processing.
+    """
+    existing_path = Path(str(existing_record.storage_path))
+    if not existing_path.exists():
+        return None
+
+    old_hash = _get_file_sha256(existing_path)
+    new_hash = _get_file_sha256(temp_file_path)
+
+    if old_hash == new_hash:
+        # Content unchanged - return existing file
+        return FileHandlerResult(
+            file_path=str(existing_record.storage_path),
+            file_id=str(existing_record.file_id),
+        )
+
+    # Content changed - first try to mark for reindex BEFORE modifying file
+    if not _mark_uploaded_file_for_reindex(str(existing_record.file_id)):
+        logger.warning(
+            "Failed to mark file for reindex, skipping file refresh to avoid inconsistent state: "
+            "url=%s, file_id=%s, context=%s",
+            url,
+            existing_record.file_id,
+            context,
+        )
+        # Return existing file without refreshing (stale embeddings but consistent state)
+        return FileHandlerResult(
+            file_path=str(existing_record.storage_path),
+            file_id=str(existing_record.file_id),
+        )
+
+    # Mark succeeded - now atomically replace the file
+    _atomic_replace_file(temp_file_path, existing_path)
+    file_record = _upsert_uploaded_file_record(
+        db_session,
+        user_id=user_id,
+        filename=filename,
+        storage_path=existing_path,
+        mime_type="text/markdown",
+        file_size=existing_path.stat().st_size,
+    )
+    processed_urls[url_hash] = str(file_record.file_id)
+
+    logger.info(
+        "Marked changed web file as PENDING_REINDEX and refreshed content: url=%s, file_id=%s, context=%s",
+        url,
+        file_record.file_id,
+        context,
+    )
+
+    return FileHandlerResult(
+        file_path=str(existing_record.storage_path),
+        file_id=str(existing_record.file_id),
+    )
+
+
 class _WebFileLock:
     """Per-key in-process lock for web ingestion file operations."""
 
@@ -199,9 +377,9 @@ class _WebFileLock:
                 lock = threading.Lock()
                 _WEB_FILE_LOCKS[self._lock_key] = lock
             self._lock = lock
-            # Acquire the same lock object while still under guard to avoid
-            # any follow-up lookup race on the lock registry.
-            lock.acquire()
+        # Acquire the per-key lock outside the global guard to avoid
+        # blocking other threads from accessing the registry for different keys.
+        self._lock.acquire()
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
@@ -1379,38 +1557,19 @@ async def ingest_web(
                         .first()
                     )
                     if existing_record:
-                        existing_path = Path(str(existing_record.storage_path))
-                        if existing_path.exists():
-                            old_hash = _get_file_sha256(existing_path)
-                            new_hash = _get_file_sha256(temp_file_path)
-                            if old_hash != new_hash:
-                                _atomic_replace_file(temp_file_path, existing_path)
-                                file_record = _upsert_uploaded_file_record(
-                                    db_session,
-                                    user_id=int(_user.id),
-                                    filename=filename,
-                                    storage_path=existing_path,
-                                    mime_type="text/markdown",
-                                    file_size=existing_path.stat().st_size,
-                                )
-                                _processed_urls[url_hash] = str(file_record.file_id)
-                                if _mark_uploaded_file_for_reindex(
-                                    str(file_record.file_id)
-                                ):
-                                    logger.info(
-                                        "Marked changed web file as PENDING_REINDEX: url=%s, file_id=%s",
-                                        url,
-                                        file_record.file_id,
-                                    )
-                                logger.info(
-                                    "Refreshed web ingestion file due to content change: url=%s, file_id=%s",
-                                    url,
-                                    file_record.file_id,
-                                )
-                        return FileHandlerResult(
-                            file_path=str(existing_record.storage_path),
-                            file_id=str(existing_record.file_id),
+                        result = _refresh_existing_file_if_changed(
+                            existing_record=existing_record,
+                            temp_file_path=temp_file_path,
+                            db_session=db_session,
+                            user_id=int(_user.id),
+                            url=url,
+                            filename=filename,
+                            url_hash=url_hash,
+                            processed_urls=_processed_urls,
+                            context="in-memory cache",
                         )
+                        if result is not None:
+                            return result
                     # Cached file_id was deleted from DB, fall through to recreate
                     logger.warning(
                         f"Cached file_id {existing_file_id} not found in DB (record was deleted), "
@@ -1428,53 +1587,45 @@ async def ingest_web(
                 )
 
                 if existing_record:
-                    existing_path = Path(str(existing_record.storage_path))
-                    if existing_path.exists():
-                        old_hash = _get_file_sha256(existing_path)
-                        new_hash = _get_file_sha256(temp_file_path)
-                        if old_hash != new_hash:
-                            _atomic_replace_file(temp_file_path, existing_path)
-                            file_record = _upsert_uploaded_file_record(
-                                db_session,
-                                user_id=int(_user.id),
-                                filename=filename,
-                                storage_path=existing_path,
-                                mime_type="text/markdown",
-                                file_size=existing_path.stat().st_size,
-                            )
-                            _processed_urls[url_hash] = str(file_record.file_id)
-                            if _mark_uploaded_file_for_reindex(
-                                str(file_record.file_id)
-                            ):
-                                logger.info(
-                                    "Marked changed web file as PENDING_REINDEX: url=%s, file_id=%s",
-                                    url,
-                                    file_record.file_id,
-                                )
-                            logger.info(
-                                "Updated existing web ingestion file from previous session: url=%s, file_id=%s",
-                                url,
-                                file_record.file_id,
-                            )
-                    else:
-                        # Recreate missing persistent file to keep record usable.
-                        existing_path.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(temp_file_path, existing_path)
-                        file_record = _upsert_uploaded_file_record(
-                            db_session,
-                            user_id=int(_user.id),
-                            filename=filename,
-                            storage_path=existing_path,
-                            mime_type="text/markdown",
-                            file_size=existing_path.stat().st_size,
-                        )
-                        _processed_urls[url_hash] = str(file_record.file_id)
-
-                    logger.info(
-                        f"Found existing UploadedFile record from previous session: "
-                        f"url={url}, file_id={existing_record.file_id}"
+                    result = _refresh_existing_file_if_changed(
+                        existing_record=existing_record,
+                        temp_file_path=temp_file_path,
+                        db_session=db_session,
+                        user_id=int(_user.id),
+                        url=url,
+                        filename=filename,
+                        url_hash=url_hash,
+                        processed_urls=_processed_urls,
+                        context="cross-session",
                     )
-                    _processed_urls[url_hash] = str(existing_record.file_id)
+                    if result is not None:
+                        # File existed and was handled (either unchanged or refreshed)
+                        _processed_urls[url_hash] = str(existing_record.file_id)
+                        logger.info(
+                            "Found existing UploadedFile record from previous session: url=%s, file_id=%s",
+                            url,
+                            existing_record.file_id,
+                        )
+                        return result
+
+                    # result is None means file doesn't exist - recreate it
+                    existing_path = Path(str(existing_record.storage_path))
+                    existing_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(temp_file_path, existing_path)
+                    file_record = _upsert_uploaded_file_record(
+                        db_session,
+                        user_id=int(_user.id),
+                        filename=filename,
+                        storage_path=existing_path,
+                        mime_type="text/markdown",
+                        file_size=existing_path.stat().st_size,
+                    )
+                    _processed_urls[url_hash] = str(file_record.file_id)
+                    logger.info(
+                        "Recreated missing persistent file for existing UploadedFile record: url=%s, file_id=%s",
+                        url,
+                        file_record.file_id,
+                    )
                     return FileHandlerResult(
                         file_path=str(existing_record.storage_path),
                         file_id=str(existing_record.file_id),

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -452,8 +452,10 @@ async def startup_event() -> None:
 
     # Reconcile uploaded_files when auto migration is enabled.
     # Keep this under the same migration toggle for consistent startup behavior.
+    # Run in background after app starts serving to avoid blocking startup.
     if auto_migrate:
-        try:
+
+        async def run_uploaded_file_reconcile_background() -> None:
             from .models.database import get_session_local
             from .services.kb_file_service import reconcile_uploaded_files
 
@@ -472,10 +474,34 @@ async def startup_event() -> None:
                 finally:
                     db.close()
 
-            await asyncio.to_thread(_run_uploaded_file_reconcile)
+            try:
+                await asyncio.to_thread(_run_uploaded_file_reconcile)
+            except Exception as e:
+                logger.warning(
+                    "Uploaded files reconcile failed: %s",
+                    e,
+                )
+
+        # Start background task without awaiting
+        asyncio.create_task(run_uploaded_file_reconcile_background())
+        logger.info("Started background uploaded files reconcile task")
+
+        # Clean up orphaned temporary files from interrupted atomic replacements
+        try:
+            from .api.kb import cleanup_orphaned_temp_files
+
+            def _run_temp_file_cleanup() -> int:
+                return cleanup_orphaned_temp_files()
+
+            cleaned_count = await asyncio.to_thread(_run_temp_file_cleanup)
+            if cleaned_count > 0:
+                logger.info(
+                    "Startup cleanup: removed %d orphaned temporary file(s)",
+                    cleaned_count,
+                )
         except Exception as e:
             logger.warning(
-                "Uploaded files reconcile skipped due to error: %s",
+                "Temporary file cleanup skipped due to error: %s",
                 e,
             )
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -450,6 +450,35 @@ async def startup_event() -> None:
                 e,
             )
 
+    # Reconcile uploaded_files when auto migration is enabled.
+    # Keep this under the same migration toggle for consistent startup behavior.
+    if auto_migrate:
+        try:
+            from .models.database import get_session_local
+            from .services.kb_file_service import reconcile_uploaded_files
+
+            def _run_uploaded_file_reconcile() -> None:
+                session_local = get_session_local()
+                db = session_local()
+                try:
+                    result = reconcile_uploaded_files(
+                        db,
+                        user_id=-1,
+                        is_admin=True,
+                        stale_ttl_hours=24 * 7,
+                        delete_stale=True,
+                    )
+                    logger.info("Uploaded files reconcile completed: %s", result)
+                finally:
+                    db.close()
+
+            await asyncio.to_thread(_run_uploaded_file_reconcile)
+        except Exception as e:
+            logger.warning(
+                "Uploaded files reconcile skipped due to error: %s",
+                e,
+            )
+
     # Warmup sandbox manager
     from .sandbox_manager import get_sandbox_manager
 

--- a/src/xagent/web/services/kb_file_service.py
+++ b/src/xagent/web/services/kb_file_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -20,12 +21,57 @@ from ...core.tools.core.RAG_tools.utils.string_utils import (
     escape_lancedb_string,
 )
 from ...core.tools.core.RAG_tools.utils.user_permissions import UserPermissions
+from ...core.tools.core.RAG_tools.version_management.cascade_cleaner import (
+    cascade_delete,
+)
 from ...providers.vector_store.lancedb import get_connection_from_env
 from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)
 
 _FILE_STATUS_BATCH_SIZE = 200
+
+
+class _FileStatusCache:
+    """Simple TTL cache for file status aggregation results.
+
+    Caches status maps keyed by (user_id, file_ids_tuple) to avoid
+    repeated LanceDB queries for the same set of files within a short window.
+    """
+
+    def __init__(self, ttl_seconds: int = 5) -> None:
+        self._cache: Dict[
+            tuple[int, tuple[str, ...]], tuple[Dict[str, str], float]
+        ] = {}
+        self._ttl = ttl_seconds
+
+    def get(self, user_id: int, file_ids: List[str]) -> Optional[Dict[str, str]]:
+        key = (user_id, tuple(sorted(file_ids)))
+        if key in self._cache:
+            result, timestamp = self._cache[key]
+            if time.time() - timestamp < self._ttl:
+                return result
+            # Expired, remove
+            del self._cache[key]
+        return None
+
+    def put(self, user_id: int, file_ids: List[str], result: Dict[str, str]) -> None:
+        key = (user_id, tuple(sorted(file_ids)))
+        self._cache[key] = (result, time.time())
+
+    def invalidate_user(self, user_id: int) -> None:
+        """Remove all cached entries for a specific user."""
+        keys_to_delete = [k for k in self._cache if k[0] == user_id]
+        for key in keys_to_delete:
+            del self._cache[key]
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._cache.clear()
+
+
+# Global cache instance
+_file_status_cache = _FileStatusCache(ttl_seconds=5)
 
 
 def upsert_uploaded_file_record(
@@ -63,6 +109,10 @@ def upsert_uploaded_file_record(
         db.flush()
     db.commit()
     db.refresh(file_record)
+
+    # Invalidate cache for this user since file list may have changed
+    _file_status_cache.invalidate_user(user_id)
+
     return file_record
 
 
@@ -211,6 +261,10 @@ def delete_uploaded_file_if_orphaned(
 
     db.delete(file_record)
     db.flush()
+
+    # Invalidate cache for this user since file list changed
+    _file_status_cache.invalidate_user(user_id)
+
     return True
 
 
@@ -232,12 +286,30 @@ def aggregate_uploaded_file_statuses(
     file_ids: List[str],
     user_id: int,
     is_admin: bool,
+    use_cache: bool = True,
 ) -> Dict[str, str]:
-    """Aggregate file status by joining documents + ingestion status records."""
+    """Aggregate file status by joining documents + ingestion status records.
+
+    Args:
+        file_ids: List of file IDs to get status for
+        user_id: User ID for permission filtering
+        is_admin: Whether user has admin privileges
+        use_cache: Whether to use the in-memory cache (default: True)
+
+    Returns:
+        Dictionary mapping file_id to status (RUNNING, SUCCESS, FAILED, UNKNOWN)
+    """
     normalized_file_ids = sorted({file_id for file_id in file_ids if file_id})
     if not normalized_file_ids:
         return {}
 
+    # Check cache first
+    if use_cache:
+        cached_result = _file_status_cache.get(user_id, normalized_file_ids)
+        if cached_result is not None:
+            return cached_result
+
+    # Cache miss - compute from database
     conn = get_connection_from_env()
     ensure_documents_table(conn)
     documents_table = conn.open_table("documents")
@@ -307,6 +379,10 @@ def aggregate_uploaded_file_statuses(
             continue
         status_map[file_id] = "UNKNOWN"
 
+    # Store in cache for future requests
+    if use_cache:
+        _file_status_cache.put(user_id, normalized_file_ids, status_map)
+
     return status_map
 
 
@@ -343,7 +419,7 @@ def reconcile_uploaded_files(
         scanned += 1
         file_id = str(record.file_id)
         status = status_map.get(file_id, "UNKNOWN")
-        if status not in {"FAILED", "UNKNOWN"}:
+        if status not in {"FAILED", "UNKNOWN", "RUNNING"}:
             continue
 
         created_at = getattr(record, "created_at", None)
@@ -351,6 +427,14 @@ def reconcile_uploaded_files(
             created_at = created_at.replace(tzinfo=timezone.utc)
         if created_at is not None and created_at > cutoff:
             continue
+
+        # Log warning for RUNNING files as they may indicate crashed ingestion
+        if status == "RUNNING":
+            logger.warning(
+                "Found stale RUNNING file (possible crashed ingestion): file_id=%s, created_at=%s",
+                file_id,
+                created_at,
+            )
 
         stale_candidates += 1
         if not delete_stale:
@@ -381,19 +465,80 @@ def reconcile_uploaded_files(
                     )
                     continue
 
+        # Query documents table to get (collection, doc_id) pairs for cascade deletion
         try:
-            documents_table.delete(f"file_id = '{safe_file_id}'")
+            doc_rows = query_to_list(
+                documents_table.search()
+                .where(f"file_id = '{safe_file_id}'")
+                .select(["collection", "doc_id"])
+                .limit(-1)
+            )
         except Exception as exc:  # noqa: BLE001
             cleanup_errors += 1
             logger.error(
-                "Failed to delete documents rows for stale file_id=%s: %s",
+                "Failed to query documents for stale file_id=%s: %s",
                 file_id,
                 exc,
             )
             continue
 
+        # Cascade delete all related data for each (collection, doc_id) pair
+        # Note: We use cascade_delete for complete cleanup across all tables
+        # (parses, chunks, embeddings_*, main_pointers, ingestion_runs, documents)
+        cascade_deleted = 0
+        cascade_error = False
+        for row in doc_rows:
+            collection = str(row.get("collection") or "").strip()
+            doc_id = str(row.get("doc_id") or "").strip()
+            if not collection or not doc_id:
+                continue
+
+            try:
+                deleted_counts = cascade_delete(
+                    target="document",
+                    collection=collection,
+                    doc_id=doc_id,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    preview_only=False,
+                    confirm=True,
+                )
+                cascade_deleted += sum(int(v) for v in deleted_counts.values())
+                logger.info(
+                    "Cascade deleted %d rows for stale document: collection=%s, doc_id=%s, file_id=%s",
+                    sum(deleted_counts.values()),
+                    collection,
+                    doc_id,
+                    file_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                cascade_error = True
+                cleanup_errors += 1
+                logger.error(
+                    "Failed to cascade delete for stale document: collection=%s, doc_id=%s, file_id=%s: %s",
+                    collection,
+                    doc_id,
+                    file_id,
+                    exc,
+                )
+
+        # If cascade delete failed, skip deleting the UploadedFile record
+        # to maintain consistency (file record still references the documents)
+        if cascade_error:
+            logger.warning(
+                "Skipping UploadedFile deletion due to cascade delete errors: file_id=%s",
+                file_id,
+            )
+            continue
+
+        # Finally delete the UploadedFile record
         db.delete(record)
         deleted += 1
+        logger.info(
+            "Deleted stale UploadedFile record: file_id=%s (cascade deleted %d related rows)",
+            file_id,
+            cascade_deleted,
+        )
 
     if delete_stale and deleted > 0:
         db.commit()

--- a/src/xagent/web/services/kb_file_service.py
+++ b/src/xagent/web/services/kb_file_service.py
@@ -441,30 +441,6 @@ def reconcile_uploaded_files(
             continue
 
         safe_file_id = escape_lancedb_string(file_id)
-        file_path = Path(str(record.storage_path))
-        uploads_root = get_uploads_dir().resolve()
-        try:
-            resolved_path = file_path.resolve()
-            resolved_path.relative_to(uploads_root)
-        except ValueError:
-            logger.warning(
-                "Skipping stale file cleanup outside uploads root: %s",
-                file_path,
-            )
-        else:
-            if resolved_path.exists() and resolved_path.is_file():
-                try:
-                    resolved_path.unlink()
-                except OSError as exc:
-                    cleanup_errors += 1
-                    logger.error(
-                        "Failed to delete stale file %s for file_id=%s: %s",
-                        resolved_path,
-                        file_id,
-                        exc,
-                    )
-                    continue
-
         # Query documents table to get (collection, doc_id) pairs for cascade deletion
         try:
             doc_rows = query_to_list(
@@ -530,6 +506,31 @@ def reconcile_uploaded_files(
                 file_id,
             )
             continue
+
+        # After relational/vector cleanup succeeds, delete physical file.
+        file_path = Path(str(record.storage_path))
+        uploads_root = get_uploads_dir().resolve()
+        try:
+            resolved_path = file_path.resolve()
+            resolved_path.relative_to(uploads_root)
+        except ValueError:
+            logger.warning(
+                "Skipping stale file cleanup outside uploads root: %s",
+                file_path,
+            )
+        else:
+            if resolved_path.exists() and resolved_path.is_file():
+                try:
+                    resolved_path.unlink()
+                except OSError as exc:
+                    cleanup_errors += 1
+                    logger.error(
+                        "Failed to delete stale file %s for file_id=%s: %s",
+                        resolved_path,
+                        file_id,
+                        exc,
+                    )
+                    continue
 
         # Finally delete the UploadedFile record
         db.delete(record)

--- a/src/xagent/web/services/kb_file_service.py
+++ b/src/xagent/web/services/kb_file_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -11,16 +12,20 @@ from sqlalchemy.orm import Session
 
 from ...config import get_uploads_dir
 from ...core.tools.core.RAG_tools.LanceDB.schema_manager import ensure_documents_table
+from ...core.tools.core.RAG_tools.management.status import load_ingestion_status
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import query_to_list
 from ...core.tools.core.RAG_tools.utils.string_utils import (
     build_lancedb_filter_expression,
+    escape_lancedb_string,
 )
 from ...core.tools.core.RAG_tools.utils.user_permissions import UserPermissions
 from ...providers.vector_store.lancedb import get_connection_from_env
 from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)
+
+_FILE_STATUS_BATCH_SIZE = 200
 
 
 def upsert_uploaded_file_record(
@@ -207,3 +212,195 @@ def delete_uploaded_file_if_orphaned(
     db.delete(file_record)
     db.flush()
     return True
+
+
+def _build_file_id_in_filter(file_ids: List[str]) -> str:
+    escaped_ids = [f"'{escape_lancedb_string(file_id)}'" for file_id in file_ids]
+    return f"file_id IN ({', '.join(escaped_ids)})"
+
+
+def _combine_lancedb_filters(
+    base_filter: Optional[str], user_filter: Optional[str]
+) -> Optional[str]:
+    if base_filter and user_filter:
+        return f"({base_filter}) and ({user_filter})"
+    return base_filter or user_filter
+
+
+def aggregate_uploaded_file_statuses(
+    *,
+    file_ids: List[str],
+    user_id: int,
+    is_admin: bool,
+) -> Dict[str, str]:
+    """Aggregate file status by joining documents + ingestion status records."""
+    normalized_file_ids = sorted({file_id for file_id in file_ids if file_id})
+    if not normalized_file_ids:
+        return {}
+
+    conn = get_connection_from_env()
+    ensure_documents_table(conn)
+    documents_table = conn.open_table("documents")
+    user_filter = UserPermissions.get_user_filter(user_id, is_admin=is_admin)
+
+    doc_refs_by_file_id: Dict[str, List[tuple[str, str]]] = {
+        file_id: [] for file_id in normalized_file_ids
+    }
+    for offset in range(0, len(normalized_file_ids), _FILE_STATUS_BATCH_SIZE):
+        batch = normalized_file_ids[offset : offset + _FILE_STATUS_BATCH_SIZE]
+        base_filter = _build_file_id_in_filter(batch)
+        combined_filter = _combine_lancedb_filters(base_filter, user_filter)
+
+        query = documents_table.search()
+        if combined_filter:
+            query = query.where(combined_filter)
+        rows = query_to_list(
+            query.select(["file_id", "collection", "doc_id"]).limit(-1)
+        )
+        for row in rows:
+            file_id = str(row.get("file_id") or "").strip()
+            collection = str(row.get("collection") or "").strip()
+            doc_id = str(row.get("doc_id") or "").strip()
+            if file_id and collection and doc_id and file_id in doc_refs_by_file_id:
+                doc_refs_by_file_id[file_id].append((collection, doc_id))
+
+    collections = sorted(
+        {
+            collection
+            for doc_refs in doc_refs_by_file_id.values()
+            for collection, _ in doc_refs
+        }
+    )
+    status_by_doc: Dict[tuple[str, str], str] = {}
+    for collection in collections:
+        for entry in load_ingestion_status(
+            collection=collection,
+            user_id=user_id,
+            is_admin=is_admin,
+        ):
+            doc_id = str(entry.get("doc_id") or "").strip()
+            status = str(entry.get("status") or "").strip().lower()
+            if doc_id and status:
+                status_by_doc[(collection, doc_id)] = status
+
+    status_map: Dict[str, str] = {}
+    for file_id, doc_refs in doc_refs_by_file_id.items():
+        if not doc_refs:
+            status_map[file_id] = "UNKNOWN"
+            continue
+
+        statuses = [
+            status_by_doc.get((collection, doc_id), "")
+            for collection, doc_id in doc_refs
+        ]
+        if any(status == "running" for status in statuses):
+            status_map[file_id] = "RUNNING"
+            continue
+
+        has_failed = any(status == "failed" for status in statuses)
+        has_success = any(status == "success" for status in statuses)
+        if has_failed and not has_success:
+            status_map[file_id] = "FAILED"
+            continue
+        if has_success:
+            status_map[file_id] = "SUCCESS"
+            continue
+        status_map[file_id] = "UNKNOWN"
+
+    return status_map
+
+
+def reconcile_uploaded_files(
+    db: Session,
+    *,
+    user_id: int,
+    is_admin: bool,
+    stale_ttl_hours: int = 24 * 7,
+    delete_stale: bool = True,
+) -> Dict[str, int]:
+    """Reconcile uploaded files with document + ingestion status state."""
+    query = db.query(UploadedFile)
+    if not is_admin:
+        query = query.filter(UploadedFile.user_id == user_id)
+
+    uploaded_files = query.order_by(UploadedFile.created_at.asc()).all()
+    file_ids = [str(record.file_id) for record in uploaded_files if record.file_id]
+    status_map = aggregate_uploaded_file_statuses(
+        file_ids=file_ids,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=max(stale_ttl_hours, 1))
+    scanned = 0
+    deleted = 0
+    stale_candidates = 0
+    cleanup_errors = 0
+    conn = get_connection_from_env()
+    ensure_documents_table(conn)
+    documents_table = conn.open_table("documents")
+    for record in uploaded_files:
+        scanned += 1
+        file_id = str(record.file_id)
+        status = status_map.get(file_id, "UNKNOWN")
+        if status not in {"FAILED", "UNKNOWN"}:
+            continue
+
+        created_at = getattr(record, "created_at", None)
+        if created_at is not None and getattr(created_at, "tzinfo", None) is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        if created_at is not None and created_at > cutoff:
+            continue
+
+        stale_candidates += 1
+        if not delete_stale:
+            continue
+
+        safe_file_id = escape_lancedb_string(file_id)
+        file_path = Path(str(record.storage_path))
+        uploads_root = get_uploads_dir().resolve()
+        try:
+            resolved_path = file_path.resolve()
+            resolved_path.relative_to(uploads_root)
+        except ValueError:
+            logger.warning(
+                "Skipping stale file cleanup outside uploads root: %s",
+                file_path,
+            )
+        else:
+            if resolved_path.exists() and resolved_path.is_file():
+                try:
+                    resolved_path.unlink()
+                except OSError as exc:
+                    cleanup_errors += 1
+                    logger.error(
+                        "Failed to delete stale file %s for file_id=%s: %s",
+                        resolved_path,
+                        file_id,
+                        exc,
+                    )
+                    continue
+
+        try:
+            documents_table.delete(f"file_id = '{safe_file_id}'")
+        except Exception as exc:  # noqa: BLE001
+            cleanup_errors += 1
+            logger.error(
+                "Failed to delete documents rows for stale file_id=%s: %s",
+                file_id,
+                exc,
+            )
+            continue
+
+        db.delete(record)
+        deleted += 1
+
+    if delete_stale and deleted > 0:
+        db.commit()
+
+    return {
+        "scanned": scanned,
+        "stale_candidates": stale_candidates,
+        "deleted": deleted,
+        "cleanup_errors": cleanup_errors,
+    }

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -654,3 +654,493 @@ def test_cascade_delete_admin_vs_non_admin_user_filter_behavior(
     user_filter = table.delete.call_args[0][0]
     assert "collection == 'c_user'" in user_filter
     assert "user_id == 1" in user_filter
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_collection_open_table_error_uses_tenant_safe_fallback(
+    mock_get_conn: MagicMock,
+) -> None:
+    """When table introspection fails, collection delete should keep tenant scoping."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    conn.open_table.side_effect = RuntimeError("table unavailable")
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"documents": 0}
+
+        cascade_delete(
+            target="collection",
+            collection="c_err",
+            user_id=7,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    filt = predicates["documents"]
+    assert "collection == 'c_err'" in filt
+    assert "user_id == 7" in filt
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_open_table_error_uses_tenant_safe_fallback(
+    mock_get_conn: MagicMock,
+) -> None:
+    """When table introspection fails, document delete should keep tenant scoping."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    conn.open_table.side_effect = RuntimeError("table unavailable")
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"documents": 0}
+
+        cascade_delete(
+            target="document",
+            collection="c_err",
+            doc_id="d_err",
+            user_id=7,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    filt = predicates["documents"]
+    assert "collection == 'c_err'" in filt
+    assert "doc_id == 'd_err'" in filt
+    assert "user_id == 7" in filt
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_collection_open_table_error_without_user_id_denied(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Unauthenticated non-admin fallback should deny access on introspection error."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    conn.open_table.side_effect = RuntimeError("table unavailable")
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"documents": 0}
+
+        cascade_delete(
+            target="collection",
+            collection="c_err",
+            user_id=None,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    filt = predicates["documents"]
+    assert "collection == 'c_err'" in filt
+    assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_open_table_error_without_user_id_denied(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Unauthenticated non-admin document fallback should deny access."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    conn.open_table.side_effect = RuntimeError("table unavailable")
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"documents": 0}
+
+        cascade_delete(
+            target="document",
+            collection="c_err",
+            doc_id="d_err",
+            user_id=None,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    filt = predicates["documents"]
+    assert "collection == 'c_err'" in filt
+    assert "doc_id == 'd_err'" in filt
+    assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_schema_probe_error_keeps_legacy_compatible_filter(
+    mock_get_conn: MagicMock,
+) -> None:
+    """If schema.names probing fails, document delete should stay legacy-compatible."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    table = MagicMock()
+    schema = MagicMock()
+    # Simulate schema names probe failure in _table_has_column.
+    type(schema).names = property(
+        lambda _self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    table.schema = schema
+    conn.open_table.return_value = table
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"documents": 0}
+        cascade_delete(
+            target="document",
+            collection="c_probe",
+            doc_id="d_probe",
+            user_id=21,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    filt = predicates["documents"]
+    assert "collection == 'c_probe'" in filt
+    assert "doc_id == 'd_probe'" in filt
+    assert "user_id ==" not in filt
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_multitable_predicates_are_consistent(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Document delete should build consistent predicates across all target tables."""
+    conn = MagicMock()
+    conn.table_names.return_value = [
+        "documents",
+        "parses",
+        "chunks",
+        "main_pointers",
+        "ingestion_runs",
+        "embeddings_m1",
+    ]
+
+    table_map = {
+        "documents": _create_mock_table_with_columns(
+            ["collection", "doc_id", "user_id"]
+        ),
+        "parses": _create_mock_table_with_columns(["collection", "doc_id", "user_id"]),
+        "chunks": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "main_pointers": _create_mock_table_with_columns(["collection", "doc_id"]),
+        "ingestion_runs": _create_mock_table_with_columns(
+            ["collection", "doc_id", "status", "user_id"]
+        ),
+        "embeddings_m1": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+    }
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {}
+        cascade_delete(
+            target="document",
+            collection="c_multi",
+            doc_id="d_multi",
+            user_id=5,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+
+    # Tables with user_id column should have tenant filter.
+    for table_name in (
+        "documents",
+        "parses",
+        "chunks",
+        "ingestion_runs",
+        "embeddings_m1",
+    ):
+        filt = predicates[table_name]
+        assert "collection == 'c_multi'" in filt
+        assert "doc_id == 'd_multi'" in filt
+        assert "user_id == 5" in filt
+
+    # Legacy-compatible table without user_id should not have tenant filter appended.
+    pointers_filter = predicates["main_pointers"]
+    assert "collection == 'c_multi'" in pointers_filter
+    assert "doc_id == 'd_multi'" in pointers_filter
+    assert "user_id ==" not in pointers_filter
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_model_tag_only_builds_target_embeddings_predicate(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Document cascade with model_tag should only target the specified embeddings table."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["embeddings_m1", "embeddings_m2"]
+
+    queried_tables: list[str] = []
+
+    def mock_open_table(table_name: str) -> MagicMock:
+        queried_tables.append(table_name)
+        if table_name == "embeddings_m2":
+            raise AssertionError(
+                "embeddings_m2 should not be queried when model_tag='m1'"
+            )
+        return _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        )
+
+    conn.open_table.side_effect = mock_open_table
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {}
+        cascade_delete(
+            target="document",
+            collection="c_model",
+            doc_id="d_model",
+            user_id=8,
+            is_admin=False,
+            model_tag="m1",
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert "embeddings_m1" in predicates
+    assert "embeddings_m2" not in predicates
+    assert queried_tables == ["embeddings_m1"]
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_document_model_tag_probe_error_without_user_id_denied(
+    mock_get_conn: MagicMock,
+) -> None:
+    """If target embeddings table probing fails, unauthenticated fallback must deny access."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["embeddings_m1", "embeddings_m2"]
+
+    queried_tables: list[str] = []
+
+    def mock_open_table(table_name: str) -> MagicMock:
+        queried_tables.append(table_name)
+        if table_name == "embeddings_m1":
+            raise RuntimeError("embeddings_m1 unavailable")
+        return _create_mock_table_with_columns(["collection", "doc_id", "parse_hash"])
+
+    conn.open_table.side_effect = mock_open_table
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {}
+        cascade_delete(
+            target="document",
+            collection="c_model",
+            doc_id="d_model",
+            user_id=None,
+            is_admin=False,
+            model_tag="m1",
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert "embeddings_m1" in predicates
+    assert "embeddings_m2" not in predicates
+    filt = predicates["embeddings_m1"]
+    assert "collection == 'c_model'" in filt
+    assert "doc_id == 'd_model'" in filt
+    assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
+    assert queried_tables == ["embeddings_m1"]
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_confirm_delete_error_propagates(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Confirm mode should fail fast when table.delete raises an exception."""
+    conn = MagicMock()
+    conn.table_names.return_value = ["documents"]
+    table = _create_mock_table_with_columns(["collection", "doc_id", "user_id"])
+    table.count_rows.return_value = 1
+    table.delete.side_effect = RuntimeError("delete failed")
+    conn.open_table.return_value = table
+    mock_get_conn.return_value = conn
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        cascade_delete(
+            target="document",
+            collection="c_err",
+            doc_id="d_err",
+            user_id=1,
+            is_admin=False,
+            preview_only=False,
+            confirm=True,
+        )
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_preview_and_confirm_counts_match_for_model_tag(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Preview counts should match confirm counts in fixed-count model_tag scenario."""
+    conn = MagicMock()
+    conn.table_names.return_value = [
+        "documents",
+        "parses",
+        "chunks",
+        "main_pointers",
+        "ingestion_runs",
+        "embeddings_m1",
+        "embeddings_m2",
+    ]
+
+    table_map = {
+        "documents": _create_mock_table_with_columns(
+            ["collection", "doc_id", "user_id"]
+        ),
+        "parses": _create_mock_table_with_columns(["collection", "doc_id", "user_id"]),
+        "chunks": _create_mock_table_with_columns(["collection", "doc_id", "user_id"]),
+        "main_pointers": _create_mock_table_with_columns(["collection", "doc_id"]),
+        "ingestion_runs": _create_mock_table_with_columns(
+            ["collection", "doc_id", "status", "user_id"]
+        ),
+        "embeddings_m1": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "embeddings_m2": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+    }
+    table_map["documents"].count_rows.return_value = 1
+    table_map["parses"].count_rows.return_value = 2
+    table_map["chunks"].count_rows.return_value = 3
+    table_map["main_pointers"].count_rows.return_value = 4
+    table_map["ingestion_runs"].count_rows.return_value = 5
+    table_map["embeddings_m1"].count_rows.return_value = 6
+    table_map[
+        "embeddings_m2"
+    ].count_rows.return_value = 99  # must not be touched by model_tag
+
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    preview = cascade_delete(
+        target="document",
+        collection="c_sync",
+        doc_id="d_sync",
+        user_id=2,
+        is_admin=False,
+        model_tag="m1",
+        preview_only=True,
+        confirm=False,
+    )
+    confirm = cascade_delete(
+        target="document",
+        collection="c_sync",
+        doc_id="d_sync",
+        user_id=2,
+        is_admin=False,
+        model_tag="m1",
+        preview_only=False,
+        confirm=True,
+    )
+    assert preview == confirm
+    assert "embeddings_m2" not in preview
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_confirm_deletion_order_is_stable(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Confirm mode should delete tables in dependency-safe fixed order."""
+    conn = MagicMock()
+    conn.table_names.return_value = [
+        "documents",
+        "parses",
+        "chunks",
+        "main_pointers",
+        "ingestion_runs",
+        "embeddings_m1",
+    ]
+
+    delete_order: list[str] = []
+
+    def make_table(table_name: str) -> MagicMock:
+        table = _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        )
+        table.count_rows.return_value = 1
+
+        def _delete(_: str) -> None:
+            delete_order.append(table_name)
+
+        table.delete = _delete
+        return table
+
+    table_map = {name: make_table(name) for name in conn.table_names.return_value}
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    cascade_delete(
+        target="document",
+        collection="c_order",
+        doc_id="d_order",
+        user_id=3,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert delete_order == [
+        "embeddings_m1",
+        "chunks",
+        "parses",
+        "main_pointers",
+        "ingestion_runs",
+        "documents",
+    ]

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -896,7 +896,8 @@ async def test_startup_event_triggers_background_auto_migration(
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    assert len(created_tasks) == 1
+    # We expect 2 tasks: backfill migration + uploaded files reconcile
+    assert len(created_tasks) == 2
     assert migration_called["value"] is True
 
 
@@ -1001,5 +1002,6 @@ async def test_startup_event_no_task_when_no_table_needs_migration(
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    assert created_tasks == []
+    # We expect 1 task: uploaded files reconcile (even without migration needs)
+    assert len(created_tasks) == 1
     assert migration_called["value"] is False

--- a/tests/migrations/test_backfill_uploaded_file_links.py
+++ b/tests/migrations/test_backfill_uploaded_file_links.py
@@ -1,0 +1,224 @@
+"""Tests for documents.file_id backfill migration."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import lancedb
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+    ensure_documents_table,
+)
+from xagent.migrations.lancedb import backfill_uploaded_file_links
+from xagent.web.models.database import Base
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+
+
+@pytest.fixture
+def migration_env(monkeypatch: pytest.MonkeyPatch):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conn = lancedb.connect(temp_dir)
+        ensure_documents_table(conn)
+        docs_table = conn.open_table("documents")
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        SessionLocal = sessionmaker(bind=engine)
+
+        monkeypatch.setattr(
+            backfill_uploaded_file_links,
+            "get_session_local",
+            lambda: SessionLocal,
+        )
+        yield conn, docs_table, SessionLocal, Path(temp_dir)
+
+
+def _create_user(db: Session, user_id: int = 1) -> None:
+    user = User(
+        id=user_id,
+        username=f"user_{user_id}",
+        password_hash="hash",
+        is_admin=False,
+    )
+    db.add(user)
+    db.commit()
+
+
+def test_backfill_documents_file_links_matches_existing_uploaded_file(migration_env):
+    conn, docs_table, SessionLocal, base_dir = migration_env
+    source_file = base_dir / "user_1" / "kb" / "page.md"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("content", encoding="utf-8")
+
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-1",
+                "file_id": None,
+                "source_path": str(source_file),
+                "user_id": 1,
+            }
+        ]
+    )
+
+    db = SessionLocal()
+    _create_user(db, user_id=1)
+    uploaded = UploadedFile(
+        user_id=1,
+        filename=source_file.name,
+        storage_path=str(source_file),
+        mime_type="text/markdown",
+        file_size=source_file.stat().st_size,
+    )
+    db.add(uploaded)
+    db.commit()
+    db.close()
+
+    result = backfill_uploaded_file_links.backfill_documents_file_links(
+        dry_run=False,
+        conn=conn,
+    )
+
+    assert result["backfilled_by_match"] == 1
+    assert result["failures"] == 0
+
+
+def test_backfill_documents_file_links_creates_uploaded_file_when_missing(
+    migration_env,
+):
+    conn, docs_table, SessionLocal, base_dir = migration_env
+    source_file = base_dir / "user_1" / "kb" / "new_page.md"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("new-content", encoding="utf-8")
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-2",
+                "file_id": None,
+                "source_path": str(source_file),
+                "user_id": 1,
+            }
+        ]
+    )
+
+    db = SessionLocal()
+    _create_user(db, user_id=1)
+    db.close()
+
+    result = backfill_uploaded_file_links.backfill_documents_file_links(
+        dry_run=False,
+        conn=conn,
+    )
+
+    assert result["backfilled_by_create"] == 1
+    assert result["failures"] == 0
+
+    db = SessionLocal()
+    record = (
+        db.query(UploadedFile)
+        .filter(UploadedFile.storage_path == str(source_file))
+        .first()
+    )
+    assert record is not None
+    db.close()
+
+
+def test_backfill_documents_file_links_dry_run_keeps_documents_unchanged(migration_env):
+    conn, docs_table, SessionLocal, base_dir = migration_env
+    source_file = base_dir / "user_1" / "kb" / "dry_run.md"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("dry-run", encoding="utf-8")
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-3",
+                "file_id": None,
+                "source_path": str(source_file),
+                "user_id": 1,
+            }
+        ]
+    )
+
+    db = SessionLocal()
+    _create_user(db, user_id=1)
+    db.close()
+
+    result = backfill_uploaded_file_links.backfill_documents_file_links(
+        dry_run=True,
+        conn=conn,
+    )
+
+    assert result["backfilled_by_create"] == 1
+    assert result["failures"] == 0
+
+
+def test_backfill_documents_file_links_marks_unbackfillable(migration_env):
+    conn, docs_table, SessionLocal, _ = migration_env
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-4",
+                "file_id": None,
+                "source_path": "/tmp/not-exists-file.md",
+                "user_id": 1,
+            }
+        ]
+    )
+    db = SessionLocal()
+    _create_user(db, user_id=1)
+    db.close()
+
+    result = backfill_uploaded_file_links.backfill_documents_file_links(
+        dry_run=False,
+        conn=conn,
+    )
+
+    assert result["unbackfillable"] == 1
+    assert result["unbackfillable_samples"][0]["reason"] == "missing_file_on_disk"
+
+
+def test_backfill_all_releases_locks_when_backfill_raises(
+    migration_env, monkeypatch: pytest.MonkeyPatch
+):
+    conn, _, _, _ = migration_env
+
+    class _DummyLockFile:
+        def fileno(self) -> int:
+            return 0
+
+        def close(self) -> None:
+            return None
+
+    def _fake_backfill(*, dry_run: bool = False, batch_size: int = 500, conn=None):
+        raise RuntimeError("boom")
+
+    lock_file = _DummyLockFile()
+    release_calls: list[_DummyLockFile] = []
+
+    monkeypatch.setattr(
+        backfill_uploaded_file_links, "_acquire_file_lock", lambda: lock_file
+    )
+    monkeypatch.setattr(
+        backfill_uploaded_file_links,
+        "_release_file_lock",
+        lambda file_obj: release_calls.append(file_obj),
+    )
+    monkeypatch.setattr(
+        backfill_uploaded_file_links, "backfill_documents_file_links", _fake_backfill
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        backfill_uploaded_file_links.backfill_all(dry_run=False, batch_size=10)
+
+    assert release_calls == [lock_file]
+    assert backfill_uploaded_file_links._migration_lock.acquire(blocking=False)
+    backfill_uploaded_file_links._migration_lock.release()

--- a/tests/web/api/test_kb_web_ingestion_file_handler.py
+++ b/tests/web/api/test_kb_web_ingestion_file_handler.py
@@ -20,6 +20,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.web.api.kb import (
+    _WEB_FILE_LOCKS,
     _atomic_replace_file,
     _get_file_sha256,
     _mark_uploaded_file_for_reindex,
@@ -453,6 +454,15 @@ class TestWebFileRefreshHelpers:
             thread.join()
 
         assert peak_active_count == 1
+
+    def test_web_file_lock_registry_entry_is_released_after_use(self) -> None:
+        lock_key = "1:transient-url-hash"
+        _WEB_FILE_LOCKS.pop(lock_key, None)
+
+        with _WebFileLock(lock_key):
+            assert lock_key in _WEB_FILE_LOCKS
+
+        assert lock_key not in _WEB_FILE_LOCKS
 
     def test_cache_updates_with_upsert_returned_file_id(self) -> None:
         processed_urls: dict[str, str] = {"hash-key": "old-file-id"}

--- a/tests/web/api/test_kb_web_ingestion_file_handler.py
+++ b/tests/web/api/test_kb_web_ingestion_file_handler.py
@@ -9,6 +9,8 @@ This module tests the file handler callback used in web ingestion, which handles
 """
 
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -17,7 +19,13 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from xagent.web.api.kb import _upsert_uploaded_file_record
+from xagent.web.api.kb import (
+    _atomic_replace_file,
+    _get_file_sha256,
+    _mark_uploaded_file_for_reindex,
+    _upsert_uploaded_file_record,
+    _WebFileLock,
+)
 from xagent.web.models.database import Base
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -395,3 +403,114 @@ class TestHandleWebFile:
                 # Verify new record was created
                 assert new_record.file_id != nonexistent_file_id
                 assert new_record.filename == filename
+
+
+class TestWebFileRefreshHelpers:
+    """Test helper functions for stale content refresh."""
+
+    def test_get_file_sha256_changes_with_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = Path(temp_dir) / "sample.md"
+            file_path.write_text("old-content", encoding="utf-8")
+            old_hash = _get_file_sha256(file_path)
+
+            file_path.write_text("new-content", encoding="utf-8")
+            new_hash = _get_file_sha256(file_path)
+
+            assert old_hash != new_hash
+
+    def test_atomic_replace_file_overwrites_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "source.md"
+            target_path = Path(temp_dir) / "target.md"
+            source_path.write_text("new-value", encoding="utf-8")
+            target_path.write_text("old-value", encoding="utf-8")
+
+            _atomic_replace_file(source_path, target_path)
+
+            assert target_path.read_text(encoding="utf-8") == "new-value"
+
+    def test_web_file_lock_serializes_same_key(self) -> None:
+        lock_key = "1:same-url-hash"
+        active_count = 0
+        peak_active_count = 0
+        guard = threading.Lock()
+
+        def _worker() -> None:
+            nonlocal active_count, peak_active_count
+            with _WebFileLock(lock_key):
+                with guard:
+                    active_count += 1
+                    peak_active_count = max(peak_active_count, active_count)
+                time.sleep(0.05)
+                with guard:
+                    active_count -= 1
+
+        threads = [threading.Thread(target=_worker) for _ in range(6)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert peak_active_count == 1
+
+    def test_cache_updates_with_upsert_returned_file_id(self) -> None:
+        processed_urls: dict[str, str] = {"hash-key": "old-file-id"}
+
+        class _Record:
+            def __init__(self, file_id: str) -> None:
+                self.file_id = file_id
+
+        file_record = _Record("new-file-id")
+        processed_urls["hash-key"] = str(file_record.file_id)
+
+        assert processed_urls["hash-key"] == "new-file-id"
+
+    def test_mark_uploaded_file_for_reindex_clears_ingestion_runs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        deleted_filters: list[str] = []
+
+        class _FakeTable:
+            def search(self):
+                return self
+
+            def where(self, _expr: str):
+                return self
+
+            def select(self, _fields: list[str]):
+                return self
+
+            def limit(self, _value: int):
+                return self
+
+            def delete(self, expr: str) -> None:
+                deleted_filters.append(expr)
+
+        class _FakeConn:
+            def open_table(self, _name: str):
+                return _FakeTable()
+
+        monkeypatch.setattr(
+            "xagent.providers.vector_store.lancedb.get_connection_from_env",
+            lambda: _FakeConn(),
+        )
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.LanceDB.schema_manager.ensure_documents_table",
+            lambda _conn: None,
+        )
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.LanceDB.schema_manager.ensure_ingestion_runs_table",
+            lambda _conn: None,
+        )
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils.query_to_list",
+            lambda _query: [{"collection": "kb", "doc_id": "doc-1"}],
+        )
+
+        marked = _mark_uploaded_file_for_reindex("file-123")
+
+        assert marked is True
+        assert len(deleted_filters) == 1
+        assert "collection = 'kb'" in deleted_filters[0]
+        assert "doc_id = 'doc-1'" in deleted_filters[0]

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -340,6 +340,8 @@ class TestFileManagement:
         assert "total_count" in data
         assert isinstance(data["files"], list)
         assert isinstance(data["total_count"], int)
+        for item in data["files"]:
+            assert "ingestion_status" in item
 
     def test_list_files_with_collections(
         self, client, test_db, sample_files, temp_uploads_dir, auth_headers
@@ -370,6 +372,12 @@ class TestFileManagement:
                 found = True
                 assert f.get("file_id"), "list should return file_id"
                 assert collection_name in f.get("relative_path", "")
+                assert f.get("ingestion_status") in {
+                    "SUCCESS",
+                    "RUNNING",
+                    "UNKNOWN",
+                    "FAILED",
+                }
                 break
         assert found, (
             "File in collection directory should appear in list (file_id design)"

--- a/tests/web/test_kb_file_service_reconcile.py
+++ b/tests/web/test_kb_file_service_reconcile.py
@@ -1,0 +1,307 @@
+"""Tests for uploaded files reconciliation helpers."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import lancedb
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+    ensure_documents_table,
+)
+from xagent.core.tools.core.RAG_tools.management.status import write_ingestion_status
+from xagent.providers.vector_store.lancedb import get_connection_from_env
+from xagent.web.models.database import Base
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+from xagent.web.services.kb_file_service import (
+    aggregate_uploaded_file_statuses,
+    reconcile_uploaded_files,
+)
+
+
+@pytest.fixture
+def reconcile_env(monkeypatch: pytest.MonkeyPatch):
+    with (
+        tempfile.TemporaryDirectory() as lancedb_dir,
+        tempfile.TemporaryDirectory() as uploads_dir,
+    ):
+        monkeypatch.setenv("LANCEDB_DIR", lancedb_dir)
+        monkeypatch.setenv("XAGENT_UPLOADS_DIR", uploads_dir)
+
+        conn = lancedb.connect(lancedb_dir)
+        ensure_documents_table(conn)
+        docs_table = conn.open_table("documents")
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        SessionLocal = sessionmaker(bind=engine)
+        yield docs_table, SessionLocal, Path(uploads_dir)
+
+
+def _create_user(session_local: sessionmaker, user_id: int = 1) -> None:
+    db = session_local()
+    db.add(
+        User(
+            id=user_id,
+            username=f"user_{user_id}",
+            password_hash="hash",
+            is_admin=False,
+        )
+    )
+    db.commit()
+    db.close()
+
+
+def test_aggregate_uploaded_file_statuses_returns_expected_priority(reconcile_env):
+    docs_table, session_local, uploads_dir = reconcile_env
+    _create_user(session_local, user_id=1)
+
+    file_path = uploads_dir / "user_1" / "kb" / "a.md"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("content", encoding="utf-8")
+
+    db = session_local()
+    file_record = UploadedFile(
+        user_id=1,
+        filename="a.md",
+        storage_path=str(file_path),
+        mime_type="text/markdown",
+        file_size=file_path.stat().st_size,
+    )
+    db.add(file_record)
+    db.commit()
+    db.refresh(file_record)
+
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-agg",
+                "file_id": file_record.file_id,
+                "source_path": str(file_path),
+                "user_id": 1,
+            }
+        ]
+    )
+    write_ingestion_status(
+        "kb",
+        "doc-agg",
+        status="success",
+        message="done",
+        parse_hash="",
+        user_id=1,
+    )
+
+    status_map = aggregate_uploaded_file_statuses(
+        file_ids=[file_record.file_id],
+        user_id=1,
+        is_admin=False,
+    )
+    assert status_map[file_record.file_id] == "SUCCESS"
+    db.close()
+
+
+def test_reconcile_uploaded_files_deletes_stale_failed_and_unknown(reconcile_env):
+    docs_table, session_local, uploads_dir = reconcile_env
+    _create_user(session_local, user_id=1)
+    db = session_local()
+
+    failed_path = uploads_dir / "user_1" / "kb" / "failed.md"
+    failed_path.parent.mkdir(parents=True, exist_ok=True)
+    failed_path.write_text("failed", encoding="utf-8")
+
+    unknown_path = uploads_dir / "user_1" / "kb" / "unknown.md"
+    unknown_path.write_text("unknown", encoding="utf-8")
+
+    success_path = uploads_dir / "user_1" / "kb" / "success.md"
+    success_path.write_text("success", encoding="utf-8")
+
+    old_time = datetime.now(timezone.utc) - timedelta(days=10)
+
+    failed_file = UploadedFile(
+        user_id=1,
+        filename="failed.md",
+        storage_path=str(failed_path),
+        mime_type="text/markdown",
+        file_size=failed_path.stat().st_size,
+        created_at=old_time,
+    )
+    unknown_file = UploadedFile(
+        user_id=1,
+        filename="unknown.md",
+        storage_path=str(unknown_path),
+        mime_type="text/markdown",
+        file_size=unknown_path.stat().st_size,
+        created_at=old_time,
+    )
+    success_file = UploadedFile(
+        user_id=1,
+        filename="success.md",
+        storage_path=str(success_path),
+        mime_type="text/markdown",
+        file_size=success_path.stat().st_size,
+        created_at=old_time,
+    )
+    db.add_all([failed_file, unknown_file, success_file])
+    db.commit()
+    db.refresh(failed_file)
+    db.refresh(unknown_file)
+    db.refresh(success_file)
+
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-failed",
+                "file_id": failed_file.file_id,
+                "source_path": str(failed_path),
+                "user_id": 1,
+            },
+            {
+                "collection": "kb",
+                "doc_id": "doc-success",
+                "file_id": success_file.file_id,
+                "source_path": str(success_path),
+                "user_id": 1,
+            },
+        ]
+    )
+    write_ingestion_status(
+        "kb",
+        "doc-failed",
+        status="failed",
+        message="failed",
+        parse_hash="",
+        user_id=1,
+    )
+    write_ingestion_status(
+        "kb",
+        "doc-success",
+        status="success",
+        message="ok",
+        parse_hash="",
+        user_id=1,
+    )
+
+    result = reconcile_uploaded_files(
+        db,
+        user_id=1,
+        is_admin=False,
+        stale_ttl_hours=24,
+        delete_stale=True,
+    )
+
+    assert result["stale_candidates"] == 2
+    assert result["deleted"] == 2
+    assert result["cleanup_errors"] == 0
+    assert not failed_path.exists()
+    assert not unknown_path.exists()
+    assert success_path.exists()
+
+    remaining = db.query(UploadedFile).all()
+    assert len(remaining) == 1
+    assert remaining[0].file_id == success_file.file_id
+
+    refreshed_docs_table = get_connection_from_env().open_table("documents")
+    rows = refreshed_docs_table.search().where("collection == 'kb'").to_list()
+    row_by_doc_id = {str(row.get("doc_id")): row for row in rows}
+    assert "doc-failed" not in row_by_doc_id
+    assert "doc-success" in row_by_doc_id
+    db.close()
+
+
+def test_reconcile_uploaded_files_records_cleanup_error_when_documents_delete_fails(
+    reconcile_env, monkeypatch: pytest.MonkeyPatch
+):
+    docs_table, session_local, uploads_dir = reconcile_env
+    _create_user(session_local, user_id=1)
+    db = session_local()
+
+    failed_path = uploads_dir / "user_1" / "kb" / "failed-delete.md"
+    failed_path.parent.mkdir(parents=True, exist_ok=True)
+    failed_path.write_text("failed", encoding="utf-8")
+
+    old_time = datetime.now(timezone.utc) - timedelta(days=10)
+    failed_file = UploadedFile(
+        user_id=1,
+        filename="failed-delete.md",
+        storage_path=str(failed_path),
+        mime_type="text/markdown",
+        file_size=failed_path.stat().st_size,
+        created_at=old_time,
+    )
+    db.add(failed_file)
+    db.commit()
+    db.refresh(failed_file)
+
+    docs_table.add(
+        [
+            {
+                "collection": "kb",
+                "doc_id": "doc-delete-failed",
+                "file_id": failed_file.file_id,
+                "source_path": str(failed_path),
+                "user_id": 1,
+            }
+        ]
+    )
+    write_ingestion_status(
+        "kb",
+        "doc-delete-failed",
+        status="failed",
+        message="failed",
+        parse_hash="",
+        user_id=1,
+    )
+
+    real_conn = get_connection_from_env()
+    real_table = real_conn.open_table("documents")
+
+    class _DeleteFailingTable:
+        def delete(self, where: str) -> None:
+            if failed_file.file_id in where:
+                raise RuntimeError("delete failed")
+            real_table.delete(where)
+
+        def __getattr__(self, item: str):
+            return getattr(real_table, item)
+
+    class _DeleteFailingConn:
+        def open_table(self, name: str):
+            if name == "documents":
+                return _DeleteFailingTable()
+            return real_conn.open_table(name)
+
+    monkeypatch.setattr(
+        "xagent.web.services.kb_file_service.get_connection_from_env",
+        lambda: _DeleteFailingConn(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.kb_file_service.ensure_documents_table",
+        lambda _conn: None,
+    )
+
+    result = reconcile_uploaded_files(
+        db,
+        user_id=1,
+        is_admin=False,
+        stale_ttl_hours=24,
+        delete_stale=True,
+    )
+
+    assert result["cleanup_errors"] == 1
+    assert result["deleted"] == 0
+    assert not failed_path.exists()
+    still_exists = (
+        db.query(UploadedFile)
+        .filter(UploadedFile.file_id == failed_file.file_id)
+        .first()
+    )
+    assert still_exists is not None
+    db.close()

--- a/tests/web/test_kb_file_service_reconcile.py
+++ b/tests/web/test_kb_file_service_reconcile.py
@@ -303,7 +303,7 @@ def test_reconcile_uploaded_files_records_cleanup_error_when_documents_delete_fa
 
     assert result["cleanup_errors"] == 1
     assert result["deleted"] == 0
-    assert not failed_path.exists()
+    assert failed_path.exists()
     still_exists = (
         db.query(UploadedFile)
         .filter(UploadedFile.file_id == failed_file.file_id)

--- a/tests/web/test_kb_file_service_reconcile.py
+++ b/tests/web/test_kb_file_service_reconcile.py
@@ -278,6 +278,7 @@ def test_reconcile_uploaded_files_records_cleanup_error_when_documents_delete_fa
                 return _DeleteFailingTable()
             return real_conn.open_table(name)
 
+    # Mock kb_file_service's connection (used for querying documents)
     monkeypatch.setattr(
         "xagent.web.services.kb_file_service.get_connection_from_env",
         lambda: _DeleteFailingConn(),
@@ -285,6 +286,11 @@ def test_reconcile_uploaded_files_records_cleanup_error_when_documents_delete_fa
     monkeypatch.setattr(
         "xagent.web.services.kb_file_service.ensure_documents_table",
         lambda _conn: None,
+    )
+    # Mock cascade_cleaner's connection (used by cascade_delete)
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection",
+        lambda: _DeleteFailingConn(),
     )
 
     result = reconcile_uploaded_files(


### PR DESCRIPTION
Ensure web-ingested file refreshes safely update persisted content, maintain consistent file status and cleanup behavior across SQL/LanceDB, and add migrations plus tests to close gap regressions around locking, backfill, and reindex signaling.
FIX: #287 