### PR TITLE
refactor(sharing): replace write-time pre-creation with read-time dynamic model discovery

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -418,12 +418,15 @@ class CreateAgentTool(AbstractBaseTool):
                 ).model_dump()
 
             # Get user's default model configuration
+            from .....web.models.model import Model as DBModel
+            from .....web.services.model_service import _get_visible_user_ids
+
             user_defaults = (
                 self._db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.user_id == self._user_id,
-                    UserModel.user_id == self._user_id,
+                    DBModel.is_active,
                 )
                 .all()
             )
@@ -445,13 +448,15 @@ class CreateAgentTool(AbstractBaseTool):
                 if t not in models_config
             ]
             if missing_types:
-                # Fill missing with admin shared defaults
+                # Fill missing with visible users' shared defaults
+                visible_ids = _get_visible_user_ids(self._db, self._user_id)
                 admin_defaults = (
                     self._db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                     .filter(
                         UserDefaultModel.config_type.in_(missing_types),
                         UserModel.is_shared,
+                        UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()
                 )

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 from pydantic import BaseModel, Field
 
 from .....config import get_uploads_dir
-from .....web.services.model_service import _get_visible_user_ids
+from .....web.services.model_service import (
+    _get_visible_user_ids,
+    _is_model_visible_to_user,
+)
 from ....utils.type_check import ensure_list
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
@@ -440,6 +443,14 @@ class CreateAgentTool(AbstractBaseTool):
                     "visual",
                     "compact",
                 ]:
+                    if default.model:
+                        try:
+                            if not _is_model_visible_to_user(
+                                self._db, default.model.id, self._user_id
+                            ):
+                                continue
+                        except Exception:
+                            pass
                     models_config[default.config_type] = default.model_id
 
             missing_types = [

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 from pydantic import BaseModel, Field
 
 from .....config import get_uploads_dir
+from .....web.services.model_service import _get_visible_user_ids
 from ....utils.type_check import ensure_list
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
@@ -419,7 +420,6 @@ class CreateAgentTool(AbstractBaseTool):
 
             # Get user's default model configuration
             from .....web.models.model import Model as DBModel
-            from .....web.services.model_service import _get_visible_user_ids
 
             user_defaults = (
                 self._db.query(UserDefaultModel)
@@ -455,7 +455,7 @@ class CreateAgentTool(AbstractBaseTool):
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                     .filter(
                         UserDefaultModel.config_type.in_(missing_types),
-                        UserModel.is_shared,
+                        UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -30,7 +30,7 @@ from ..auth_config import (
 from ..auth_dependencies import get_current_user
 from ..models.database import get_db
 from ..models.system_setting import SystemSetting
-from ..models.user import User, UserDefaultModel, UserModel
+from ..models.user import User
 from ..models.user_oauth import UserOAuth
 
 auth_router = APIRouter(prefix="/api/auth", tags=["Authentication"])
@@ -315,12 +315,12 @@ async def update_register_switch(
     )
 
 
-def create_user(
-    db: Session, username: str, password: str, inherit_defaults: bool = False
-) -> User:
+def create_user(db: Session, username: str, password: str) -> User:
     """Create a new user without default model configurations
 
-    Users will use admin's defaults via fallback logic until they set their own.
+    Users will use admin's defaults via dynamic fallback logic until they set their own.
+    No pre-creation of UserModel or UserDefaultModel records — shared model visibility
+    is determined at read time via _get_visible_user_ids().
     """
     password_hash = hash_password(password)
     user = User(username=username, password_hash=password_hash)
@@ -328,116 +328,9 @@ def create_user(
     db.flush()  # Get the user ID without committing
     db.refresh(user)
 
-    # Always grant access to shared models first
-    _grant_shared_model_access(db, user)
-
-    # Inherit default model configurations from admin if requested
-    # Default is now False - users should use fallback logic
-    if inherit_defaults:
-        _inherit_admin_defaults(db, user)
-
     # Commit everything together
     db.commit()
     return user
-
-
-def _grant_shared_model_access(db: Session, new_user: User) -> None:
-    """Grant access to admin's shared models (but not default configurations)"""
-    try:
-        # Get admin user
-        admin_user = db.query(User).filter(User.is_admin).first()
-        if not admin_user:
-            return
-
-        # Grant access to all shared models
-        shared_models = (
-            db.query(UserModel)
-            .filter(UserModel.user_id == admin_user.id, UserModel.is_shared)
-            .all()
-        )
-
-        for shared_model in shared_models:
-            # Check if user already has access to this model (any configuration)
-            existing_access = (
-                db.query(UserModel)
-                .filter(
-                    UserModel.user_id == new_user.id,
-                    UserModel.model_id == shared_model.model_id,
-                )
-                .first()
-            )
-
-            # Only create new access if user doesn't already have this model
-            if not existing_access:
-                # Grant read-only access to shared model
-                user_access = UserModel(
-                    user_id=new_user.id,
-                    model_id=shared_model.model_id,
-                    is_owner=False,
-                    can_edit=False,
-                    can_delete=False,
-                    is_shared=True,
-                )
-                db.add(user_access)
-
-    except Exception as e:
-        # Log error but don't fail user creation
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(
-            f"Error granting shared model access for user {new_user.username}: {e}"
-        )
-        # Don't rollback here, let the main transaction handle it
-
-
-def _inherit_admin_defaults(db: Session, new_user: User) -> None:
-    """Inherit admin's default model configurations (legacy function for backward compatibility)"""
-    try:
-        # Get admin user
-        admin_user = db.query(User).filter(User.is_admin).first()
-        if not admin_user:
-            return
-
-        # _grant_shared_model_access is called first in create_user to ensure
-        # user has access to models before creating default configurations
-
-        # Then, inherit admin's default model configurations
-        admin_defaults = (
-            db.query(UserDefaultModel)
-            .filter(UserDefaultModel.user_id == admin_user.id)
-            .all()
-        )
-
-        for admin_default in admin_defaults:
-            # Check if new user has access to the model
-            user_model = (
-                db.query(UserModel)
-                .filter(
-                    UserModel.user_id == new_user.id,
-                    UserModel.model_id == admin_default.model_id,
-                )
-                .first()
-            )
-
-            # Only create default config if user has access to the model
-            if user_model:
-                new_default = UserDefaultModel(
-                    user_id=new_user.id,
-                    model_id=admin_default.model_id,
-                    config_type=admin_default.config_type,
-                )
-                db.add(new_default)
-
-    except Exception as e:
-        # Log error but don't fail user creation
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(
-            f"Error inheriting admin defaults for user {new_user.username}: {e}"
-        )
-        # Don't rollback here, let the main transaction handle it
 
 
 def get_user_by_username(db: Session, username: str) -> Optional[User]:
@@ -552,9 +445,7 @@ async def register(
             return RegisterResponse(success=False, message="Registration is disabled")
 
         # Create new user with inherited defaults
-        user = create_user(
-            db, request.username, request.password, inherit_defaults=True
-        )
+        user = create_user(db, request.username, request.password)
 
         return RegisterResponse(
             success=True,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1554,10 +1554,13 @@ async def create_task(
                 )
                 .all()
             )
+            from ..services.model_service import _is_model_visible_to_user
+
             for row in user_defaults:
                 if row.model:
-                    config_type = cast(str, row.config_type)
-                    defaults[config_type] = str(row.model.model_id)
+                    if _is_model_visible_to_user(db, row.model.id, int(user.id)):
+                        config_type = cast(str, row.config_type)
+                        defaults[config_type] = str(row.model.model_id)
 
             # Fill missing defaults from visible users' shared defaults.
             if any(defaults[ct] is None for ct in config_types):

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -25,6 +25,7 @@ from ..models.user import User
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.chat_history_service import load_task_transcript
 from ..services.llm_utils import resolve_llms_from_names
+from ..services.model_service import _get_visible_user_ids
 from ..services.task_execution_context_service import (
     load_task_execution_recovery_state,
 )
@@ -1513,8 +1514,6 @@ async def create_task(
                 .first()
             )
             if not own_model:
-                from ..services.model_service import _get_visible_user_ids
-
                 visible_ids = _get_visible_user_ids(db, int(user.id))
                 own_model = (
                     db.query(UserModel)
@@ -1538,7 +1537,6 @@ async def create_task(
 
         def _get_default_internal_model_ids() -> Dict[str, Optional[str]]:
             from ..models.model import Model as DBModel
-            from ..services.model_service import _get_visible_user_ids
 
             config_types = ["general", "small_fast", "visual", "compact"]
             defaults: Dict[str, Optional[str]] = {ct: None for ct in config_types}
@@ -1567,7 +1565,7 @@ async def create_task(
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                     .filter(
                         UserDefaultModel.config_type.in_(config_types),
-                        UserModel.is_shared,
+                        UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1515,7 +1515,7 @@ async def create_task(
             if not own_model:
                 from ..services.model_service import _get_visible_user_ids
 
-                visible_ids = _get_visible_user_ids(db, user.id)
+                visible_ids = _get_visible_user_ids(db, int(user.id))
                 own_model = (
                     db.query(UserModel)
                     .filter(
@@ -1561,7 +1561,7 @@ async def create_task(
 
             # Fill missing defaults from visible users' shared defaults.
             if any(defaults[ct] is None for ct in config_types):
-                visible_ids = _get_visible_user_ids(db, user.id)
+                visible_ids = _get_visible_user_ids(db, int(user.id))
                 shared_defaults = (
                     db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1509,7 +1509,9 @@ async def create_task(
             own_model = (
                 db.query(UserModel)
                 .filter(
-                    UserModel.user_id == int(user.id), UserModel.model_id == db_model.id
+                    UserModel.user_id == int(user.id),
+                    UserModel.model_id == db_model.id,
+                    UserModel.is_owner.is_(True),
                 )
                 .first()
             )

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1504,14 +1504,28 @@ async def create_task(
             if not db_model:
                 return None
 
-            has_access = (
+            # Two-step access check: own → shared from visible users
+            own_model = (
                 db.query(UserModel)
                 .filter(
                     UserModel.user_id == int(user.id), UserModel.model_id == db_model.id
                 )
                 .first()
-                is not None
             )
+            if not own_model:
+                from ..services.model_service import _get_visible_user_ids
+
+                visible_ids = _get_visible_user_ids(db, user.id)
+                own_model = (
+                    db.query(UserModel)
+                    .filter(
+                        UserModel.model_id == db_model.id,
+                        UserModel.user_id.in_(visible_ids),
+                        UserModel.is_shared.is_(True),
+                    )
+                    .first()
+                )
+            has_access = own_model is not None
             if not has_access:
                 return None
 
@@ -1523,16 +1537,19 @@ async def create_task(
             ]
 
         def _get_default_internal_model_ids() -> Dict[str, Optional[str]]:
+            from ..models.model import Model as DBModel
+            from ..services.model_service import _get_visible_user_ids
+
             config_types = ["general", "small_fast", "visual", "compact"]
             defaults: Dict[str, Optional[str]] = {ct: None for ct in config_types}
 
-            # User-specific defaults (only if user has access via UserModel).
+            # User-specific defaults (Mode A: use DBModel JOIN).
             user_defaults = (
                 db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.user_id == int(user.id),
-                    UserModel.user_id == int(user.id),
+                    DBModel.is_active,
                     UserDefaultModel.config_type.in_(config_types),
                 )
                 .all()
@@ -1542,14 +1559,16 @@ async def create_task(
                     config_type = cast(str, row.config_type)
                     defaults[config_type] = str(row.model.model_id)
 
-            # Fill missing defaults from shared admin defaults.
+            # Fill missing defaults from visible users' shared defaults.
             if any(defaults[ct] is None for ct in config_types):
+                visible_ids = _get_visible_user_ids(db, user.id)
                 shared_defaults = (
                     db.query(UserDefaultModel)
                     .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                     .filter(
                         UserDefaultModel.config_type.in_(config_types),
                         UserModel.is_shared,
+                        UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()
                 )

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -390,21 +390,17 @@ async def list_models(
 ) -> List[ModelWithAccessInfo]:
     """List all model configurations accessible to the current user"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Get models that user has access to (owned or shared from visible users)
     visible_ids = _get_visible_user_ids(db, int(user.id))
     query = (
         db.query(DBModel, UserModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
     )
     if model_provider:
         query = query.filter(DBModel.model_provider == model_provider)
@@ -455,9 +451,10 @@ async def get_user_default_models(
     """Get all user's default model configurations with per-type admin fallback"""
 
     try:
-        from sqlalchemy import and_, or_
-
-        from ..services.model_service import _get_visible_user_ids
+        from ..services.model_service import (
+            _get_visible_user_ids,
+            build_user_model_visibility_filter,
+        )
 
         # Get all possible config types
         all_config_types = [
@@ -499,12 +496,7 @@ async def get_user_default_models(
                     db.query(UserModel)
                     .filter(
                         UserModel.model_id == ud.model_id,
-                        or_(
-                            UserModel.user_id == user.id,
-                            and_(
-                                UserModel.user_id.in_(visible_ids), UserModel.is_shared
-                            ),
-                        ),
+                        build_user_model_visibility_filter(int(user.id), visible_ids),
                     )
                     .first()
                 )
@@ -557,7 +549,7 @@ async def get_user_default_models(
                         UserDefaultModel.user_id.in_(visible_ids),
                         UserDefaultModel.config_type == config_type,
                         DBModel.is_active,
-                        UserModel.is_shared,
+                        UserModel.is_shared.is_(True),
                     )
                     .first()
                 )
@@ -635,6 +627,7 @@ async def update_model_by_path(
     """Update a model configuration, including slash-containing model IDs."""
 
     return await update_model(model_id, model_update, db, user)
+
 
 @model_router.delete("/by-id/{model_id:path}")
 async def delete_model_by_path(
@@ -805,6 +798,8 @@ async def test_model_connection(
             message="Connection failed",
             error=safe_error,
         )
+
+
 @model_router.post("/test", response_model=List[ModelTestResponse])
 async def test_models(
     test_request: Optional[ModelTestRequest] = None,
@@ -812,9 +807,11 @@ async def test_models(
     user: User = Depends(get_current_user),
 ) -> List[ModelTestResponse]:
     """Test model configurations"""
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     model_storage = CoreStorage(db, DBModel)
     visible_ids = _get_visible_user_ids(db, int(user.id))
@@ -827,13 +824,7 @@ async def test_models(
             .filter(
                 DBModel.model_id.in_(test_request.model_ids),
                 DBModel.is_active,
-                or_(
-                    UserModel.user_id == user.id,
-                    and_(
-                        UserModel.user_id.in_(visible_ids),
-                        UserModel.is_shared.is_(True),
-                    ),
-                ),
+                build_user_model_visibility_filter(int(user.id), visible_ids),
             )
             .all()
         )
@@ -844,13 +835,7 @@ async def test_models(
             .join(UserModel, DBModel.id == UserModel.model_id)
             .filter(
                 DBModel.is_active,
-                or_(
-                    UserModel.user_id == user.id,
-                    and_(
-                        UserModel.user_id.in_(visible_ids),
-                        UserModel.is_shared.is_(True),
-                    ),
-                ),
+                build_user_model_visibility_filter(int(user.id), visible_ids),
             )
             .all()
         )
@@ -943,21 +928,17 @@ async def list_model_categories(
 ) -> dict:
     """List all model categories accessible to the current user"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Get distinct categories from user's accessible models
     visible_ids = _get_visible_user_ids(db, int(user.id))
     categories = (
         db.query(DBModel.category)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
         .filter(DBModel.is_active)
         .distinct()
         .all()
@@ -975,21 +956,17 @@ async def list_model_providers(
 ) -> dict:
     """List all model providers accessible to the current user"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Get distinct providers from user's accessible models
     visible_ids = _get_visible_user_ids(db, int(user.id))
     providers = (
         db.query(DBModel.model_provider)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
         .filter(DBModel.is_active)
         .distinct()
         .all()
@@ -1007,21 +984,17 @@ async def list_model_abilities(
 ) -> dict:
     """List all model abilities across accessible models"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Get all models to collect abilities
     visible_ids = _get_visible_user_ids(db, int(user.id))
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
         .filter(DBModel.is_active)
         .all()
     )
@@ -1043,21 +1016,17 @@ async def get_models_summary(
 ) -> dict:
     """Get summary statistics of accessible models"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Get all accessible models
     visible_ids = _get_visible_user_ids(db, int(user.id))
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
         .filter(DBModel.is_active)
         .all()
     )
@@ -1116,19 +1085,18 @@ async def get_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1186,19 +1154,18 @@ async def get_general_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1256,19 +1223,18 @@ async def get_small_fast_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1326,19 +1292,18 @@ async def get_visual_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1396,19 +1361,18 @@ async def get_compact_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1466,19 +1430,18 @@ async def get_embedding_default_model(
         return None
 
     # Get user model relationship for access info (two-step: own or shared)
-    from sqlalchemy import and_, or_
 
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
             UserModel.model_id == user_default.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1525,9 +1488,10 @@ async def set_user_default_model(
 ) -> UserDefaultModelResponse:
     """Set a user's default model configuration"""
 
-    from sqlalchemy import and_, or_
-
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     # Check if user has access to the model (own or shared from visible users)
     visible_ids = _get_visible_user_ids(db, int(user.id))
@@ -1535,10 +1499,7 @@ async def set_user_default_model(
         db.query(UserModel)
         .filter(
             UserModel.model_id == config.model_id,
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
-            ),
+            build_user_model_visibility_filter(int(user.id), visible_ids),
         )
         .first()
     )
@@ -1702,7 +1663,7 @@ async def update_model(
         db.query(UserModel)
         .filter(
             UserModel.model_id == db_model.id,
-            UserModel.is_shared == True,  # noqa: E712
+            UserModel.is_shared.is_(True) == True,  # noqa: E712
         )
         .first()
     )
@@ -2025,24 +1986,21 @@ async def fetch_multiple_providers_models(
     """
 
     # Get all models configured for the user (own or shared from visible users)
-    from sqlalchemy import and_, or_
 
     from ..services.model_list_service import (
         PROVIDER_FETCHERS,
         fetch_models_from_provider,
     )
-    from ..services.model_service import _get_visible_user_ids
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
 
     visible_ids = _get_visible_user_ids(db, int(user.id))
     user_models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(
-            or_(
-                UserModel.user_id == user.id,
-                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
-            )
-        )
+        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
         .filter(DBModel.is_active)
         .filter(DBModel.api_key.isnot(None))
         .all()

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -91,7 +91,11 @@ def _resolve_accessible_model(
     # Step 1: own UserModel
     user_model = (
         db.query(UserModel)
-        .filter(UserModel.model_id == db_model.id, UserModel.user_id == user.id)
+        .filter(
+            UserModel.model_id == db_model.id,
+            UserModel.user_id == user.id,
+            UserModel.is_owner.is_(True),
+        )
         .first()
     )
     if user_model:
@@ -120,7 +124,7 @@ def _serialize_model_with_access(
     """Build a model response payload with user access info."""
 
     is_owner = (
-        user_model.user_id == requesting_user_id
+        user_model.is_owner and user_model.user_id == requesting_user_id
         if requesting_user_id is not None
         else user_model.is_owner
     )
@@ -397,10 +401,28 @@ async def list_models(
 
     # Get models that user has access to (owned or shared from visible users)
     visible_ids = _get_visible_user_ids(db, int(user.id))
+
+    # Correlated subquery: for each DBModel, pick exactly one UserModel row,
+    # preferring the user's own row (deduplicates legacy shared data).
+    best_user_model_id = (
+        db.query(UserModel.id)
+        .filter(
+            UserModel.model_id == DBModel.id,
+            build_user_model_visibility_filter(int(user.id), visible_ids),
+        )
+        .order_by(
+            (UserModel.user_id == user.id).desc(),
+            UserModel.is_owner.desc(),
+        )
+        .limit(1)
+        .correlate(DBModel)
+        .scalar_subquery()
+    )
+
     query = (
         db.query(DBModel, UserModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(build_user_model_visibility_filter(int(user.id), visible_ids))
+        .filter(UserModel.id == best_user_model_id)
     )
     if model_provider:
         query = query.filter(DBModel.model_provider == model_provider)
@@ -415,7 +437,7 @@ async def list_models(
 
     result = []
     for db_model, user_model in models:
-        is_owner = user_model.user_id == user.id
+        is_owner = user_model.is_owner and user_model.user_id == user.id
         model_data = {
             "id": db_model.id,
             "model_id": db_model.model_id,
@@ -487,6 +509,7 @@ async def get_user_default_models(
 
         # Process each config type
         for config_type in all_config_types:
+            user_model = None
             if config_type in user_defaults_by_type:
                 # User has their own default for this type
                 ud = user_defaults_by_type[config_type]
@@ -502,7 +525,7 @@ async def get_user_default_models(
                 )
 
                 if user_model:
-                    is_owner = user_model.user_id == user.id
+                    is_owner = user_model.is_owner and user_model.user_id == user.id
                     model_data = {
                         "id": ud.id,
                         "user_id": ud.user_id,
@@ -539,8 +562,10 @@ async def get_user_default_models(
                         },
                     }
                     result.append(model_data)
-            else:
-                # User has no default for this type, try visible users' shared defaults
+                    continue
+
+            if not user_model:
+                # User has no default for this type (or it's stale), try visible users' shared defaults
                 admin_default = (
                     db.query(UserDefaultModel)
                     .join(DBModel, UserDefaultModel.model_id == DBModel.id)

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 _can_share_hook = None  # (user: User) -> bool
 
 
-def set_can_share_hook(hook):
+def set_can_share_hook(hook: Any) -> None:
     """Set a custom hook that determines whether a user can share models."""
     global _can_share_hook
     _can_share_hook = hook
@@ -56,8 +56,8 @@ def _can_user_share(user: User) -> bool:
     Without a hook this falls back to ``user.is_admin`` (legacy behaviour).
     """
     if _can_share_hook is not None:
-        return _can_share_hook(user)
-    return user.is_admin
+        return bool(_can_share_hook(user))
+    return bool(user.is_admin)
 
 
 # Create router
@@ -98,7 +98,7 @@ def _resolve_accessible_model(
         return model_storage, db_model, user_model
 
     # Step 2: shared from visible users
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     shared = (
         db.query(UserModel)
         .filter(
@@ -395,7 +395,7 @@ async def list_models(
     from ..services.model_service import _get_visible_user_ids
 
     # Get models that user has access to (owned or shared from visible users)
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     query = (
         db.query(DBModel, UserModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
@@ -486,7 +486,7 @@ async def get_user_default_models(
             user_defaults_by_type[str(ud.config_type)] = ud
 
         result = []
-        visible_ids = _get_visible_user_ids(db, user.id)
+        visible_ids = _get_visible_user_ids(db, int(user.id))
 
         # Process each config type
         for config_type in all_config_types:
@@ -619,7 +619,9 @@ async def get_model_by_path(
 
     _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
+        _serialize_model_with_access(
+            db_model, user_model, requesting_user_id=int(user.id)
+        )
     )
 
 
@@ -815,7 +817,7 @@ async def test_models(
     from ..services.model_service import _get_visible_user_ids
 
     model_storage = CoreStorage(db, DBModel)
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
 
     if test_request and test_request.model_ids:
         # Test specific models that user has access to
@@ -946,7 +948,7 @@ async def list_model_categories(
     from ..services.model_service import _get_visible_user_ids
 
     # Get distinct categories from user's accessible models
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     categories = (
         db.query(DBModel.category)
         .join(UserModel, DBModel.id == UserModel.model_id)
@@ -978,7 +980,7 @@ async def list_model_providers(
     from ..services.model_service import _get_visible_user_ids
 
     # Get distinct providers from user's accessible models
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     providers = (
         db.query(DBModel.model_provider)
         .join(UserModel, DBModel.id == UserModel.model_id)
@@ -1010,7 +1012,7 @@ async def list_model_abilities(
     from ..services.model_service import _get_visible_user_ids
 
     # Get all models to collect abilities
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
@@ -1046,7 +1048,7 @@ async def get_models_summary(
     from ..services.model_service import _get_visible_user_ids
 
     # Get all accessible models
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
@@ -1118,7 +1120,7 @@ async def get_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1188,7 +1190,7 @@ async def get_general_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1258,7 +1260,7 @@ async def get_small_fast_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1328,7 +1330,7 @@ async def get_visual_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1398,7 +1400,7 @@ async def get_compact_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1468,7 +1470,7 @@ async def get_embedding_default_model(
 
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1528,7 +1530,7 @@ async def set_user_default_model(
     from ..services.model_service import _get_visible_user_ids
 
     # Check if user has access to the model (own or shared from visible users)
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_model = (
         db.query(UserModel)
         .filter(
@@ -1672,7 +1674,9 @@ async def get_model(
     """Get a specific model configuration"""
     _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
+        _serialize_model_with_access(
+            db_model, user_model, requesting_user_id=int(user.id)
+        )
     )
 
 
@@ -1786,7 +1790,9 @@ async def update_model(
 
     # Return updated model with access info
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
+        _serialize_model_with_access(
+            db_model, user_model, requesting_user_id=int(user.id)
+        )
     )
 
 
@@ -2027,7 +2033,7 @@ async def fetch_multiple_providers_models(
     )
     from ..services.model_service import _get_visible_user_ids
 
-    visible_ids = _get_visible_user_ids(db, user.id)
+    visible_ids = _get_visible_user_ids(db, int(user.id))
     user_models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -37,6 +37,29 @@ from ..user_isolated_memory import UserContext
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Hook infrastructure for dynamic model sharing
+# ---------------------------------------------------------------------------
+
+_can_share_hook = None  # (user: User) -> bool
+
+
+def set_can_share_hook(hook):
+    """Set a custom hook that determines whether a user can share models."""
+    global _can_share_hook
+    _can_share_hook = hook
+
+
+def _can_user_share(user: User) -> bool:
+    """Check whether *user* is allowed to share models.
+
+    Without a hook this falls back to ``user.is_admin`` (legacy behaviour).
+    """
+    if _can_share_hook is not None:
+        return _can_share_hook(user)
+    return user.is_admin
+
+
 # Create router
 model_router = APIRouter(prefix="/api/models", tags=["models"])
 
@@ -50,7 +73,14 @@ def _decode_model_identifier(model_id: str) -> str:
 def _resolve_accessible_model(
     db: Session, user: User, model_id: str
 ) -> tuple[CoreStorage, DBModel, UserModel]:
-    """Resolve a model and the current user's access relationship."""
+    """Resolve a model and the current user's access relationship.
+
+    Two-step lookup:
+    1. Check if the user owns the model (UserModel.user_id == user.id).
+    2. If not, check if any visible user shares this model.
+    """
+
+    from ..services.model_service import _get_visible_user_ids
 
     decoded_model_id = _decode_model_identifier(model_id)
     model_storage = CoreStorage(db, DBModel)
@@ -58,21 +88,42 @@ def _resolve_accessible_model(
     if not db_model:
         raise HTTPException(status_code=404, detail="Model not found")
 
+    # Step 1: own UserModel
     user_model = (
         db.query(UserModel)
         .filter(UserModel.model_id == db_model.id, UserModel.user_id == user.id)
         .first()
     )
-    if not user_model:
-        raise HTTPException(status_code=404, detail="Model not found or access denied")
+    if user_model:
+        return model_storage, db_model, user_model
 
-    return model_storage, db_model, user_model
+    # Step 2: shared from visible users
+    visible_ids = _get_visible_user_ids(db, user.id)
+    shared = (
+        db.query(UserModel)
+        .filter(
+            UserModel.model_id == db_model.id,
+            UserModel.user_id.in_(visible_ids),
+            UserModel.is_shared.is_(True),
+        )
+        .first()
+    )
+    if shared:
+        return model_storage, db_model, shared
+
+    raise HTTPException(status_code=404, detail="Model not found or access denied")
 
 
 def _serialize_model_with_access(
-    db_model: DBModel, user_model: UserModel
+    db_model: DBModel, user_model: UserModel, requesting_user_id: Optional[int] = None
 ) -> dict[str, Any]:
     """Build a model response payload with user access info."""
+
+    is_owner = (
+        user_model.user_id == requesting_user_id
+        if requesting_user_id is not None
+        else user_model.is_owner
+    )
 
     return {
         "id": db_model.id,
@@ -88,9 +139,9 @@ def _serialize_model_with_access(
         "created_at": db_model.created_at.isoformat() if db_model.created_at else None,
         "updated_at": db_model.updated_at.isoformat() if db_model.updated_at else None,
         "is_active": db_model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -215,8 +266,8 @@ async def create_model(
     if model_storage.exists(model.model_id):
         raise HTTPException(status_code=400, detail="Model ID already exists")
 
-    # Only admin can share models with all users
-    if model.share_with_users and not user.is_admin:
+    # Only users with sharing permission can share models
+    if model.share_with_users and not _can_user_share(user):
         raise HTTPException(
             status_code=403,
             detail="Only administrators can share models with all users",
@@ -286,32 +337,19 @@ async def create_model(
     assert db_model
 
     # Create user model relationship
+    is_share: bool = model.share_with_users and _can_user_share(user)
     user_model = UserModel(
         user_id=user.id,
         model_id=db_model.id,
         is_owner=True,
         can_edit=True,
         can_delete=True,
-        is_shared=model.share_with_users and user.is_admin,
+        is_shared=is_share,
     )
     db.add(user_model)
     db.commit()
 
-    is_share: bool = model.share_with_users and bool(user.is_admin)
-    # If admin is sharing the model, create relationships for all users
-    if is_share:
-        all_users = db.query(User).filter(User.id != user.id).all()
-        for other_user in all_users:
-            shared_user_model = UserModel(
-                user_id=other_user.id,
-                model_id=db_model.id,
-                is_owner=False,
-                can_edit=False,
-                can_delete=False,
-                is_shared=True,
-            )
-            db.add(shared_user_model)
-        db.commit()
+    # No pre-creation for other users — dynamic discovery handles visibility.
 
     assert db_model
 
@@ -352,11 +390,21 @@ async def list_models(
 ) -> List[ModelWithAccessInfo]:
     """List all model configurations accessible to the current user"""
 
-    # Get models that user has access to (owned or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    # Get models that user has access to (owned or shared from visible users)
+    visible_ids = _get_visible_user_ids(db, user.id)
     query = (
         db.query(DBModel, UserModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
     )
     if model_provider:
         query = query.filter(DBModel.model_provider == model_provider)
@@ -371,6 +419,7 @@ async def list_models(
 
     result = []
     for db_model, user_model in models:
+        is_owner = user_model.user_id == user.id
         model_data = {
             "id": db_model.id,
             "model_id": db_model.model_id,
@@ -389,9 +438,9 @@ async def list_models(
             if db_model.updated_at
             else None,
             "is_active": db_model.is_active,
-            "is_owner": user_model.is_owner,
-            "can_edit": user_model.can_edit,
-            "can_delete": user_model.can_delete,
+            "is_owner": is_owner,
+            "can_edit": is_owner and user_model.can_edit,
+            "can_delete": is_owner and user_model.can_delete,
             "is_shared": user_model.is_shared,
         }
         result.append(ModelWithAccessInfo.model_validate(model_data))
@@ -406,6 +455,10 @@ async def get_user_default_models(
     """Get all user's default model configurations with per-type admin fallback"""
 
     try:
+        from sqlalchemy import and_, or_
+
+        from ..services.model_service import _get_visible_user_ids
+
         # Get all possible config types
         all_config_types = [
             "general",
@@ -433,6 +486,7 @@ async def get_user_default_models(
             user_defaults_by_type[str(ud.config_type)] = ud
 
         result = []
+        visible_ids = _get_visible_user_ids(db, user.id)
 
         # Process each config type
         for config_type in all_config_types:
@@ -440,16 +494,23 @@ async def get_user_default_models(
                 # User has their own default for this type
                 ud = user_defaults_by_type[config_type]
 
-                # Get user model relationship for access info
+                # Get user model relationship for access info (two-step: own or shared)
                 user_model = (
                     db.query(UserModel)
                     .filter(
-                        UserModel.user_id == user.id, UserModel.model_id == ud.model_id
+                        UserModel.model_id == ud.model_id,
+                        or_(
+                            UserModel.user_id == user.id,
+                            and_(
+                                UserModel.user_id.in_(visible_ids), UserModel.is_shared
+                            ),
+                        ),
                     )
                     .first()
                 )
 
                 if user_model:
+                    is_owner = user_model.user_id == user.id
                     model_data = {
                         "id": ud.id,
                         "user_id": ud.user_id,
@@ -479,73 +540,69 @@ async def get_user_default_models(
                             if user_model.model.updated_at
                             else None,
                             "is_active": user_model.model.is_active,
-                            "is_owner": user_model.is_owner,
-                            "can_edit": user_model.can_edit,
-                            "can_delete": user_model.can_delete,
+                            "is_owner": is_owner,
+                            "can_edit": is_owner and user_model.can_edit,
+                            "can_delete": is_owner and user_model.can_delete,
                             "is_shared": user_model.is_shared,
                         },
                     }
                     result.append(model_data)
             else:
-                # User has no default for this type, try admin fallback
-                admin_user = db.query(User).filter(User.is_admin).first()
-                if admin_user:
-                    admin_default = (
-                        db.query(UserDefaultModel)
-                        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                        .join(
-                            UserModel, UserDefaultModel.model_id == UserModel.model_id
-                        )
-                        .filter(
-                            UserDefaultModel.user_id == admin_user.id,
-                            UserDefaultModel.config_type == config_type,
-                            DBModel.is_active,
-                            UserModel.is_shared,
-                        )
-                        .first()
+                # User has no default for this type, try visible users' shared defaults
+                admin_default = (
+                    db.query(UserDefaultModel)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .filter(
+                        UserDefaultModel.user_id.in_(visible_ids),
+                        UserDefaultModel.config_type == config_type,
+                        DBModel.is_active,
+                        UserModel.is_shared,
+                    )
+                    .first()
+                )
+
+                if admin_default:
+                    logger.info(
+                        f"User {user.username} has no {config_type} default, using visible user default for display"
                     )
 
-                    if admin_default:
-                        logger.info(
-                            f"User {user.username} has no {config_type} default, using admin default for display"
-                        )
-
-                        model_data = {
-                            "id": admin_default.id,
-                            "user_id": admin_default.user_id,
-                            "model_id": admin_default.model_id,
-                            "config_type": admin_default.config_type,
-                            "created_at": admin_default.created_at.isoformat()
-                            if admin_default.created_at
+                    model_data = {
+                        "id": admin_default.id,
+                        "user_id": admin_default.user_id,
+                        "model_id": admin_default.model_id,
+                        "config_type": admin_default.config_type,
+                        "created_at": admin_default.created_at.isoformat()
+                        if admin_default.created_at
+                        else None,
+                        "updated_at": admin_default.updated_at.isoformat()
+                        if admin_default.updated_at
+                        else None,
+                        "model": {
+                            "id": admin_default.model.id,
+                            "model_id": admin_default.model.model_id,
+                            "category": admin_default.model.category,
+                            "model_provider": admin_default.model.model_provider,
+                            "model_name": admin_default.model.model_name,
+                            "base_url": admin_default.model.base_url,
+                            "temperature": admin_default.model.temperature,
+                            "dimension": admin_default.model.dimension,
+                            "abilities": admin_default.model.abilities,
+                            "description": admin_default.model.description,
+                            "created_at": admin_default.model.created_at.isoformat()
+                            if admin_default.model.created_at
                             else None,
-                            "updated_at": admin_default.updated_at.isoformat()
-                            if admin_default.updated_at
+                            "updated_at": admin_default.model.updated_at.isoformat()
+                            if admin_default.model.updated_at
                             else None,
-                            "model": {
-                                "id": admin_default.model.id,
-                                "model_id": admin_default.model.model_id,
-                                "category": admin_default.model.category,
-                                "model_provider": admin_default.model.model_provider,
-                                "model_name": admin_default.model.model_name,
-                                "base_url": admin_default.model.base_url,
-                                "temperature": admin_default.model.temperature,
-                                "dimension": admin_default.model.dimension,
-                                "abilities": admin_default.model.abilities,
-                                "description": admin_default.model.description,
-                                "created_at": admin_default.model.created_at.isoformat()
-                                if admin_default.model.created_at
-                                else None,
-                                "updated_at": admin_default.model.updated_at.isoformat()
-                                if admin_default.model.updated_at
-                                else None,
-                                "is_active": admin_default.model.is_active,
-                                "is_owner": False,  # Admin models are not owned by non-admin users
-                                "can_edit": False,
-                                "can_delete": False,
-                                "is_shared": True,
-                            },
-                        }
-                        result.append(model_data)
+                            "is_active": admin_default.model.is_active,
+                            "is_owner": False,
+                            "can_edit": False,
+                            "can_delete": False,
+                            "is_shared": True,
+                        },
+                    }
+                    result.append(model_data)
 
         return result
     except Exception as e:
@@ -562,18 +619,7 @@ async def get_model_by_path(
 
     _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model)
-    )
-
-
-@model_router.get("/{model_id}", response_model=ModelWithAccessInfo)
-async def get_model(
-    model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
-) -> ModelWithAccessInfo:
-    """Get a specific model configuration"""
-    _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
-    return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model)
+        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
     )
 
 
@@ -588,94 +634,6 @@ async def update_model_by_path(
 
     return await update_model(model_id, model_update, db, user)
 
-
-@model_router.put("/{model_id}", response_model=ModelWithAccessInfo)
-async def update_model(
-    model_id: str,
-    model_update: ModelUpdate,
-    db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
-) -> ModelWithAccessInfo:
-    """Update a model configuration"""
-    _, _, user_model = _resolve_accessible_model(db, user, model_id)
-
-    if not user_model.can_edit:
-        raise HTTPException(status_code=403, detail="No permission to edit this model")
-
-    # Get the database model
-    db_model = user_model.model
-
-    # Handle admin sharing updates
-    if model_update.share_with_users is not None:
-        # Only check admin permission when enabling sharing (share_with_users=True)
-        # Allow non-admin users to disable sharing (share_with_users=False)
-        if model_update.share_with_users and not user.is_admin:
-            raise HTTPException(
-                status_code=403, detail="Only administrators can enable global sharing"
-            )
-
-        # Update sharing status
-        if model_update.share_with_users:
-            # Enable sharing: update all existing records to shared=True
-            db.query(UserModel).filter(UserModel.model_id == db_model.id).update(
-                {"is_shared": True}
-            )
-
-            # Create relationships for users who don't have access
-            existing_user_ids = [
-                um.user_id
-                for um in db.query(UserModel)
-                .filter(UserModel.model_id == db_model.id)
-                .all()
-            ]
-
-            all_users = db.query(User).filter(User.id.notin_(existing_user_ids)).all()
-            for other_user in all_users:
-                shared_user_model = UserModel(
-                    user_id=other_user.id,
-                    model_id=db_model.id,
-                    is_owner=False,
-                    can_edit=False,
-                    can_delete=False,
-                    is_shared=True,
-                )
-                db.add(shared_user_model)
-        else:
-            # Disable sharing:
-            # 1. Update owner's record to shared=False
-            db.query(UserModel).filter(
-                UserModel.model_id == db_model.id, UserModel.is_owner.is_(True)
-            ).update({"is_shared": False})
-
-            # 2. Delete all non-owner records (revoke access)
-            db.query(UserModel).filter(
-                UserModel.model_id == db_model.id, UserModel.is_owner.is_(False)
-            ).delete()
-
-    # Update model configuration in-place
-    update_data = model_update.model_dump(exclude_unset=True)
-    for field, value in update_data.items():
-        # Don't update api_key with empty string unless explicitly needed, but allow setting to empty if intended
-        # We will keep the previous behavior: skip empty strings for api_key updates to prevent accidental wiping.
-        if field == "api_key" and value == "":
-            continue
-        # Skip share_with_users as it's handled separately
-        if field == "share_with_users":
-            continue
-        # Only set fields that exist on the model
-        if hasattr(db_model, field):
-            setattr(db_model, field, value)
-
-    # Commit database changes
-    db.commit()
-    db.refresh(db_model)
-
-    # Return updated model with access info
-    return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(db_model, user_model)
-    )
-
-
 @model_router.delete("/by-id/{model_id:path}")
 async def delete_model_by_path(
     model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
@@ -683,32 +641,6 @@ async def delete_model_by_path(
     """Delete a model configuration, including slash-containing model IDs."""
 
     return await delete_model(model_id, db, user)
-
-
-@model_router.delete("/{model_id}")
-async def delete_model(
-    model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
-) -> dict:
-    """Delete a model configuration"""
-    model_storage, _, user_model = _resolve_accessible_model(db, user, model_id)
-
-    if not user_model.can_delete:
-        raise HTTPException(
-            status_code=403, detail="No permission to delete this model"
-        )
-
-    # Delete all user model relationships
-    db.query(UserModel).filter(UserModel.model_id == user_model.model.id).delete()
-
-    # Delete all user default model configurations
-    db.query(UserDefaultModel).filter(
-        UserDefaultModel.model_id == user_model.model.id
-    ).delete()
-
-    # Delete the model using CoreStorage
-    model_storage.delete(user_model.model.model_id)
-
-    return {"message": "Model deleted successfully"}
 
 
 @model_router.post("/test-connection", response_model=ModelTestResponse)
@@ -871,8 +803,6 @@ async def test_model_connection(
             message="Connection failed",
             error=safe_error,
         )
-
-
 @model_router.post("/test", response_model=List[ModelTestResponse])
 async def test_models(
     test_request: Optional[ModelTestRequest] = None,
@@ -880,7 +810,12 @@ async def test_models(
     user: User = Depends(get_current_user),
 ) -> List[ModelTestResponse]:
     """Test model configurations"""
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
     model_storage = CoreStorage(db, DBModel)
+    visible_ids = _get_visible_user_ids(db, user.id)
 
     if test_request and test_request.model_ids:
         # Test specific models that user has access to
@@ -890,7 +825,13 @@ async def test_models(
             .filter(
                 DBModel.model_id.in_(test_request.model_ids),
                 DBModel.is_active,
-                UserModel.user_id == user.id,
+                or_(
+                    UserModel.user_id == user.id,
+                    and_(
+                        UserModel.user_id.in_(visible_ids),
+                        UserModel.is_shared.is_(True),
+                    ),
+                ),
             )
             .all()
         )
@@ -899,7 +840,16 @@ async def test_models(
         models = (
             db.query(DBModel)
             .join(UserModel, DBModel.id == UserModel.model_id)
-            .filter(DBModel.is_active, UserModel.user_id == user.id)
+            .filter(
+                DBModel.is_active,
+                or_(
+                    UserModel.user_id == user.id,
+                    and_(
+                        UserModel.user_id.in_(visible_ids),
+                        UserModel.is_shared.is_(True),
+                    ),
+                ),
+            )
             .all()
         )
 
@@ -991,11 +941,21 @@ async def list_model_categories(
 ) -> dict:
     """List all model categories accessible to the current user"""
 
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
     # Get distinct categories from user's accessible models
+    visible_ids = _get_visible_user_ids(db, user.id)
     categories = (
         db.query(DBModel.category)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
         .filter(DBModel.is_active)
         .distinct()
         .all()
@@ -1013,11 +973,21 @@ async def list_model_providers(
 ) -> dict:
     """List all model providers accessible to the current user"""
 
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
     # Get distinct providers from user's accessible models
+    visible_ids = _get_visible_user_ids(db, user.id)
     providers = (
         db.query(DBModel.model_provider)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
         .filter(DBModel.is_active)
         .distinct()
         .all()
@@ -1035,11 +1005,21 @@ async def list_model_abilities(
 ) -> dict:
     """List all model abilities across accessible models"""
 
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
     # Get all models to collect abilities
+    visible_ids = _get_visible_user_ids(db, user.id)
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
         .filter(DBModel.is_active)
         .all()
     )
@@ -1061,11 +1041,21 @@ async def get_models_summary(
 ) -> dict:
     """Get summary statistics of accessible models"""
 
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
     # Get all accessible models
+    visible_ids = _get_visible_user_ids(db, user.id)
     models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
         .filter(DBModel.is_active)
         .all()
     )
@@ -1123,11 +1113,20 @@ async def get_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1135,6 +1134,7 @@ async def get_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1153,9 +1153,9 @@ async def get_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1183,11 +1183,20 @@ async def get_general_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1195,6 +1204,7 @@ async def get_general_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1213,9 +1223,9 @@ async def get_general_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1243,11 +1253,20 @@ async def get_small_fast_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1255,6 +1274,7 @@ async def get_small_fast_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1273,9 +1293,9 @@ async def get_small_fast_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1303,11 +1323,20 @@ async def get_visual_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1315,6 +1344,7 @@ async def get_visual_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1333,9 +1363,9 @@ async def get_visual_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1363,11 +1393,20 @@ async def get_compact_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1375,6 +1414,7 @@ async def get_compact_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1393,9 +1433,9 @@ async def get_compact_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1423,11 +1463,20 @@ async def get_embedding_default_model(
     if not user_default:
         return None
 
-    # Get user model relationship for access info
+    # Get user model relationship for access info (two-step: own or shared)
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
         .filter(
-            UserModel.user_id == user.id, UserModel.model_id == user_default.model_id
+            UserModel.model_id == user_default.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
         )
         .first()
     )
@@ -1435,6 +1484,7 @@ async def get_embedding_default_model(
     if not user_model:
         return None
 
+    is_owner = user_model.user_id == user.id
     model_data = {
         "id": user_default.model.id,
         "model_id": user_default.model.model_id,
@@ -1453,9 +1503,9 @@ async def get_embedding_default_model(
         if user_default.model.updated_at
         else None,
         "is_active": user_default.model.is_active,
-        "is_owner": user_model.is_owner,
-        "can_edit": user_model.can_edit,
-        "can_delete": user_model.can_delete,
+        "is_owner": is_owner,
+        "can_edit": is_owner and user_model.can_edit,
+        "can_delete": is_owner and user_model.can_delete,
         "is_shared": user_model.is_shared,
     }
 
@@ -1473,10 +1523,21 @@ async def set_user_default_model(
 ) -> UserDefaultModelResponse:
     """Set a user's default model configuration"""
 
-    # Check if user has access to the model
+    from sqlalchemy import and_, or_
+
+    from ..services.model_service import _get_visible_user_ids
+
+    # Check if user has access to the model (own or shared from visible users)
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_model = (
         db.query(UserModel)
-        .filter(UserModel.user_id == user.id, UserModel.model_id == config.model_id)
+        .filter(
+            UserModel.model_id == config.model_id,
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared),
+            ),
+        )
         .first()
     )
 
@@ -1596,6 +1657,179 @@ async def delete_user_default_model(
     db.commit()
 
     return {"message": "Default configuration deleted successfully"}
+
+
+# ---------------------------------------------------------------------------
+# Catch-all /{model_id} routes — MUST come after all fixed-path routes to
+# avoid matching "categories", "providers", "summary", etc.
+# ---------------------------------------------------------------------------
+
+
+@model_router.get("/{model_id}", response_model=ModelWithAccessInfo)
+async def get_model(
+    model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> ModelWithAccessInfo:
+    """Get a specific model configuration"""
+    _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
+    return ModelWithAccessInfo.model_validate(
+        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
+    )
+
+
+@model_router.put("/{model_id}", response_model=ModelWithAccessInfo)
+async def update_model(
+    model_id: str,
+    model_update: ModelUpdate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> ModelWithAccessInfo:
+    """Update a model configuration"""
+    _, db_model_ref, user_model = _resolve_accessible_model(db, user, model_id)
+
+    # Permission: only owner can edit
+    if user_model.user_id != user.id or not user_model.can_edit:
+        raise HTTPException(status_code=403, detail="No permission to edit this model")
+
+    # Get the database model
+    db_model = user_model.model
+
+    # Constraint 2: shared models cannot change category or abilities
+    is_shared = (
+        db.query(UserModel)
+        .filter(
+            UserModel.model_id == db_model.id,
+            UserModel.is_shared == True,  # noqa: E712
+        )
+        .first()
+    )
+    if is_shared:
+        locked = []
+        if (
+            model_update.category is not None
+            and model_update.category != db_model.category
+        ):
+            locked.append("category")
+        if model_update.abilities is not None and set(model_update.abilities) != set(
+            db_model.abilities or []
+        ):
+            locked.append("abilities")
+        if locked:
+            raise HTTPException(
+                409,
+                detail=f"Cannot change {' and '.join(locked)} of a shared model. Un-share first.",
+            )
+
+    # Handle sharing updates
+    if model_update.share_with_users is not None:
+        # Only check sharing permission when enabling sharing
+        if model_update.share_with_users and not _can_user_share(user):
+            raise HTTPException(
+                status_code=403, detail="Only administrators can enable global sharing"
+            )
+
+        # Update sharing status
+        if model_update.share_with_users:
+            # Enable sharing: just update owner's record to shared=True
+            db.query(UserModel).filter(
+                UserModel.model_id == db_model.id,
+                UserModel.user_id == user.id,
+            ).update({"is_shared": True})
+        else:
+            # Constraint 1: owner cannot un-share own default model
+            owner_defaults = (
+                db.query(UserDefaultModel)
+                .filter(
+                    UserDefaultModel.model_id == db_model.id,
+                    UserDefaultModel.user_id == user.id,
+                )
+                .count()
+            )
+            if owner_defaults > 0:
+                raise HTTPException(
+                    409,
+                    detail="Cannot un-share: you have this model as your default. Change default first.",
+                )
+
+            # Disable sharing:
+            # 1. Update owner's record to shared=False
+            db.query(UserModel).filter(
+                UserModel.model_id == db_model.id, UserModel.user_id == user.id
+            ).update({"is_shared": False})
+
+            # 2. Delete all non-owner UserModel records
+            db.query(UserModel).filter(
+                UserModel.model_id == db_model.id, UserModel.is_owner.is_(False)
+            ).delete()
+
+            # 3. Clean up non-owner UserDefaultModel records
+            db.query(UserDefaultModel).filter(
+                UserDefaultModel.model_id == db_model.id,
+                UserDefaultModel.user_id != user.id,
+            ).delete()
+
+    # Update model configuration in-place
+    update_data = model_update.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        # Don't update api_key with empty string
+        if field == "api_key" and value == "":
+            continue
+        # Skip share_with_users as it's handled separately
+        if field == "share_with_users":
+            continue
+        # Only set fields that exist on the model
+        if hasattr(db_model, field):
+            setattr(db_model, field, value)
+
+    # Commit database changes
+    db.commit()
+    db.refresh(db_model)
+
+    # Return updated model with access info
+    return ModelWithAccessInfo.model_validate(
+        _serialize_model_with_access(db_model, user_model, requesting_user_id=user.id)
+    )
+
+
+@model_router.delete("/{model_id}")
+async def delete_model(
+    model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+) -> dict:
+    """Delete a model configuration"""
+    model_storage, _, user_model = _resolve_accessible_model(db, user, model_id)
+
+    # Permission: only owner can delete
+    if user_model.user_id != user.id or not user_model.can_delete:
+        raise HTTPException(
+            status_code=403, detail="No permission to delete this model"
+        )
+
+    # Constraint 1: owner cannot delete own default model
+    owner_defaults = (
+        db.query(UserDefaultModel)
+        .filter(
+            UserDefaultModel.model_id == user_model.model.id,
+            UserDefaultModel.user_id == user.id,
+        )
+        .count()
+    )
+    if owner_defaults > 0:
+        raise HTTPException(
+            409,
+            detail="Cannot delete: you have this model as your default. Change default first.",
+        )
+
+    # Delete all user model relationships
+    db.query(UserModel).filter(UserModel.model_id == user_model.model.id).delete()
+
+    # Delete all user default model configurations
+    db.query(UserDefaultModel).filter(
+        UserDefaultModel.model_id == user_model.model.id
+    ).delete()
+
+    # Delete the model using CoreStorage
+    model_storage.delete(user_model.model.model_id)
+
+    return {"message": "Model deleted successfully"}
 
 
 # Public endpoints (no authentication required)
@@ -1784,16 +2018,25 @@ async def fetch_multiple_providers_models(
     to fetch available models from each provider.
     """
 
+    # Get all models configured for the user (own or shared from visible users)
+    from sqlalchemy import and_, or_
+
     from ..services.model_list_service import (
         PROVIDER_FETCHERS,
         fetch_models_from_provider,
     )
+    from ..services.model_service import _get_visible_user_ids
 
-    # Get all models configured for the user
+    visible_ids = _get_visible_user_ids(db, user.id)
     user_models = (
         db.query(DBModel)
         .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.user_id == user.id)
+        .filter(
+            or_(
+                UserModel.user_id == user.id,
+                and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+            )
+        )
         .filter(DBModel.is_active)
         .filter(DBModel.api_key.isnot(None))
         .all()

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -81,10 +81,28 @@ class DynamicMemoryStoreManager:
                             .first()
                         )
                         if embedding_model:
-                            logger.info(
-                                f"Found user's default embedding model: {embedding_model.model_id}"
-                            )
-                            return embedding_model
+                            try:
+                                from .services.model_service import (
+                                    _is_model_visible_to_user,
+                                )
+
+                                if not _is_model_visible_to_user(
+                                    db, embedding_model.id, user_id
+                                ):
+                                    logger.warning(
+                                        f"User default embedding model {user_default.model_id} is no longer visible"
+                                    )
+                                    # fall through to system fallback
+                                else:
+                                    logger.info(
+                                        f"Found user's default embedding model: {embedding_model.model_id}"
+                                    )
+                                    return embedding_model
+                            except Exception:
+                                logger.info(
+                                    f"Found user's default embedding model: {embedding_model.model_id}"
+                                )
+                                return embedding_model
                         else:
                             logger.warning(
                                 f"User default embedding model {user_default.model_id} not found or inactive"

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -58,6 +58,8 @@ class DynamicMemoryStoreManager:
                 # Get current user ID from context
                 user_id = current_user_id.get()
 
+                from .services.model_service import _is_model_visible_to_user
+
                 if user_id:
                     # First, try to get user's default embedding model
                     user_default = (
@@ -81,10 +83,6 @@ class DynamicMemoryStoreManager:
                             .first()
                         )
                         if embedding_model:
-                            from .services.model_service import (
-                                _is_model_visible_to_user,
-                            )
-
                             if not _is_model_visible_to_user(
                                 db, embedding_model.id, user_id
                             ):
@@ -102,24 +100,25 @@ class DynamicMemoryStoreManager:
                                 f"User default embedding model {user_default.model_id} not found or inactive"
                             )
 
-                # Fallback: look for any active embedding model
-                embedding_model = (
+                # Fallback: look for first active embedding model visible to user
+                all_active_embeddings = (
                     db.query(DBModel)
                     .filter(
                         DBModel.category == "embedding",
                         DBModel.is_active,
                     )
-                    .first()
+                    .all()
                 )
 
-                if embedding_model:
-                    logger.info(
-                        f"Using system active embedding model (user has no default): {embedding_model.model_id}"
-                    )
-                else:
-                    logger.info("No active embedding model found")
+                for embedding_model in all_active_embeddings:
+                    if _is_model_visible_to_user(db, embedding_model.id, user_id):
+                        logger.info(
+                            f"Using visible active embedding model: {embedding_model.model_id}"
+                        )
+                        return embedding_model
 
-                return embedding_model
+                logger.info("No visible active embedding model found")
+                return None
             finally:
                 db.close()
         except Exception as e:

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -81,24 +81,18 @@ class DynamicMemoryStoreManager:
                             .first()
                         )
                         if embedding_model:
-                            try:
-                                from .services.model_service import (
-                                    _is_model_visible_to_user,
-                                )
+                            from .services.model_service import (
+                                _is_model_visible_to_user,
+                            )
 
-                                if not _is_model_visible_to_user(
-                                    db, embedding_model.id, user_id
-                                ):
-                                    logger.warning(
-                                        f"User default embedding model {user_default.model_id} is no longer visible"
-                                    )
-                                    # fall through to system fallback
-                                else:
-                                    logger.info(
-                                        f"Found user's default embedding model: {embedding_model.model_id}"
-                                    )
-                                    return embedding_model
-                            except Exception:
+                            if not _is_model_visible_to_user(
+                                db, embedding_model.id, user_id
+                            ):
+                                logger.warning(
+                                    f"User default embedding model {user_default.model_id} is no longer visible"
+                                )
+                                # fall through to system fallback
+                            else:
                                 logger.info(
                                     f"Found user's default embedding model: {embedding_model.model_id}"
                                 )

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -461,6 +461,7 @@ class UserAwareModelStorage:
                 logger.info(
                     f"Checking user access: user_id={user_id}, model_id={db_model.id}"
                 )
+                # Step 1: own UserModel
                 user_model = (
                     self.db.query(UserModel)
                     .filter(
@@ -469,6 +470,20 @@ class UserAwareModelStorage:
                     )
                     .first()
                 )
+                # Step 2: shared from visible users
+                if not user_model:
+                    from .model_service import _get_visible_user_ids
+
+                    visible_ids = _get_visible_user_ids(self.db, user_id)
+                    user_model = (
+                        self.db.query(UserModel)
+                        .filter(
+                            UserModel.model_id == db_model.id,
+                            UserModel.user_id.in_(visible_ids),
+                            UserModel.is_shared.is_(True),
+                        )
+                        .first()
+                    )
 
                 if not user_model:
                     logger.warning(
@@ -509,16 +524,18 @@ class UserAwareModelStorage:
             # Try to get user-specific defaults first
             if user_id:
                 # Get general default model
+                from ..models.model import Model as DBModel
+
                 general_default = (
                     self.db.query(UserDefaultModel)
                     .join(
-                        UserModel,
-                        UserDefaultModel.model_id == UserModel.model_id,
+                        DBModel,
+                        UserDefaultModel.model_id == DBModel.id,
                     )
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "general",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -533,13 +550,13 @@ class UserAwareModelStorage:
                 fast_default = (
                     self.db.query(UserDefaultModel)
                     .join(
-                        UserModel,
-                        UserDefaultModel.model_id == UserModel.model_id,
+                        DBModel,
+                        UserDefaultModel.model_id == DBModel.id,
                     )
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "small_fast",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -552,13 +569,13 @@ class UserAwareModelStorage:
                 vision_default = (
                     self.db.query(UserDefaultModel)
                     .join(
-                        UserModel,
-                        UserDefaultModel.model_id == UserModel.model_id,
+                        DBModel,
+                        UserDefaultModel.model_id == DBModel.id,
                     )
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "visual",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -571,13 +588,13 @@ class UserAwareModelStorage:
                 compact_default = (
                     self.db.query(UserDefaultModel)
                     .join(
-                        UserModel,
-                        UserDefaultModel.model_id == UserModel.model_id,
+                        DBModel,
+                        UserDefaultModel.model_id == DBModel.id,
                     )
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "compact",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -588,9 +605,12 @@ class UserAwareModelStorage:
                     )
                     compact_llm = self.core_storage.create_llm_instance(model_config)
 
-            # If user-specific defaults are not complete, try admin shared defaults
+            # If user-specific defaults are not complete, try visible users' shared defaults
             if not default_llm or not fast_llm or not vision_llm or not compact_llm:
-                # Get admin defaults (shared models)
+                from .model_service import _get_visible_user_ids
+
+                visible_ids = _get_visible_user_ids(self.db, user_id)
+                # Get visible users' shared defaults
                 admin_defaults = (
                     self.db.query(UserDefaultModel)
                     .join(
@@ -602,6 +622,7 @@ class UserAwareModelStorage:
                             ["general", "small_fast", "visual", "compact"]
                         ),
                         UserModel.is_shared,
+                        UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()
                 )

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -621,7 +621,7 @@ class UserAwareModelStorage:
                         UserDefaultModel.config_type.in_(
                             ["general", "small_fast", "visual", "compact"]
                         ),
-                        UserModel.is_shared,
+                        UserModel.is_shared.is_(True),
                         UserDefaultModel.user_id.in_(visible_ids),
                     )
                     .all()

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -461,12 +461,13 @@ class UserAwareModelStorage:
                 logger.info(
                     f"Checking user access: user_id={user_id}, model_id={db_model.id}"
                 )
-                # Step 1: own UserModel
+                # Step 1: own UserModel (must be owner)
                 user_model = (
                     self.db.query(UserModel)
                     .filter(
                         UserModel.user_id == user_id,
                         UserModel.model_id == db_model.id,
+                        UserModel.is_owner.is_(True),
                     )
                     .first()
                 )
@@ -541,10 +542,21 @@ class UserAwareModelStorage:
                 )
 
                 if general_default and general_default.model:
-                    model_config = self.core_storage.load(
-                        general_default.model.model_id
-                    )
-                    default_llm = self.core_storage.create_llm_instance(model_config)
+                    try:
+                        from .model_service import _is_model_visible_to_user
+
+                        visible = _is_model_visible_to_user(
+                            self.db, general_default.model.id, user_id
+                        )
+                    except Exception:
+                        visible = True
+                    if visible:
+                        model_config = self.core_storage.load(
+                            general_default.model.model_id
+                        )
+                        default_llm = self.core_storage.create_llm_instance(
+                            model_config
+                        )
 
                 # Get small/fast model
                 fast_default = (
@@ -562,8 +574,19 @@ class UserAwareModelStorage:
                 )
 
                 if fast_default and fast_default.model:
-                    model_config = self.core_storage.load(fast_default.model.model_id)
-                    fast_llm = self.core_storage.create_llm_instance(model_config)
+                    try:
+                        from .model_service import _is_model_visible_to_user
+
+                        visible = _is_model_visible_to_user(
+                            self.db, fast_default.model.id, user_id
+                        )
+                    except Exception:
+                        visible = True
+                    if visible:
+                        model_config = self.core_storage.load(
+                            fast_default.model.model_id
+                        )
+                        fast_llm = self.core_storage.create_llm_instance(model_config)
 
                 # Get vision model
                 vision_default = (
@@ -581,8 +604,19 @@ class UserAwareModelStorage:
                 )
 
                 if vision_default and vision_default.model:
-                    model_config = self.core_storage.load(vision_default.model.model_id)
-                    vision_llm = self.core_storage.create_llm_instance(model_config)
+                    try:
+                        from .model_service import _is_model_visible_to_user
+
+                        visible = _is_model_visible_to_user(
+                            self.db, vision_default.model.id, user_id
+                        )
+                    except Exception:
+                        visible = True
+                    if visible:
+                        model_config = self.core_storage.load(
+                            vision_default.model.model_id
+                        )
+                        vision_llm = self.core_storage.create_llm_instance(model_config)
 
                 # Get compact model
                 compact_default = (
@@ -600,10 +634,21 @@ class UserAwareModelStorage:
                 )
 
                 if compact_default and compact_default.model:
-                    model_config = self.core_storage.load(
-                        compact_default.model.model_id
-                    )
-                    compact_llm = self.core_storage.create_llm_instance(model_config)
+                    try:
+                        from .model_service import _is_model_visible_to_user
+
+                        visible = _is_model_visible_to_user(
+                            self.db, compact_default.model.id, user_id
+                        )
+                    except Exception:
+                        visible = True
+                    if visible:
+                        model_config = self.core_storage.load(
+                            compact_default.model.model_id
+                        )
+                        compact_llm = self.core_storage.create_llm_instance(
+                            model_config
+                        )
 
             # If user-specific defaults are not complete, try visible users' shared defaults
             if not default_llm or not fast_llm or not vision_llm or not compact_llm:

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -542,15 +542,11 @@ class UserAwareModelStorage:
                 )
 
                 if general_default and general_default.model:
-                    try:
-                        from .model_service import _is_model_visible_to_user
+                    from .model_service import _is_model_visible_to_user
 
-                        visible = _is_model_visible_to_user(
-                            self.db, general_default.model.id, user_id
-                        )
-                    except Exception:
-                        visible = True
-                    if visible:
+                    if _is_model_visible_to_user(
+                        self.db, general_default.model.id, user_id
+                    ):
                         model_config = self.core_storage.load(
                             general_default.model.model_id
                         )
@@ -574,15 +570,11 @@ class UserAwareModelStorage:
                 )
 
                 if fast_default and fast_default.model:
-                    try:
-                        from .model_service import _is_model_visible_to_user
+                    from .model_service import _is_model_visible_to_user
 
-                        visible = _is_model_visible_to_user(
-                            self.db, fast_default.model.id, user_id
-                        )
-                    except Exception:
-                        visible = True
-                    if visible:
+                    if _is_model_visible_to_user(
+                        self.db, fast_default.model.id, user_id
+                    ):
                         model_config = self.core_storage.load(
                             fast_default.model.model_id
                         )
@@ -604,15 +596,11 @@ class UserAwareModelStorage:
                 )
 
                 if vision_default and vision_default.model:
-                    try:
-                        from .model_service import _is_model_visible_to_user
+                    from .model_service import _is_model_visible_to_user
 
-                        visible = _is_model_visible_to_user(
-                            self.db, vision_default.model.id, user_id
-                        )
-                    except Exception:
-                        visible = True
-                    if visible:
+                    if _is_model_visible_to_user(
+                        self.db, vision_default.model.id, user_id
+                    ):
                         model_config = self.core_storage.load(
                             vision_default.model.model_id
                         )
@@ -634,15 +622,11 @@ class UserAwareModelStorage:
                 )
 
                 if compact_default and compact_default.model:
-                    try:
-                        from .model_service import _is_model_visible_to_user
+                    from .model_service import _is_model_visible_to_user
 
-                        visible = _is_model_visible_to_user(
-                            self.db, compact_default.model.id, user_id
-                        )
-                    except Exception:
-                        visible = True
-                    if visible:
+                    if _is_model_visible_to_user(
+                        self.db, compact_default.model.id, user_id
+                    ):
                         model_config = self.core_storage.load(
                             compact_default.model.model_id
                         )

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 _visible_user_ids_hook = None  # (db: Session, user_id: int) -> list[int]
 
 
-def set_visible_user_ids_hook(hook):
+def set_visible_user_ids_hook(hook: Any) -> None:
     """Set a custom hook that returns user IDs whose models are visible."""
     global _visible_user_ids_hook
     _visible_user_ids_hook = hook
@@ -46,7 +46,7 @@ def _get_visible_user_ids(db: Session, user_id: Optional[int] = None) -> list[in
     as an unauthenticated context and return only system-admin IDs.
     """
     if _visible_user_ids_hook is not None:
-        return _visible_user_ids_hook(db, user_id)
+        return list(_visible_user_ids_hook(db, user_id))
     from ..models.user import User
 
     return [uid for (uid,) in db.query(User.id).filter(User.is_admin).all()]

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -22,6 +22,35 @@ from ...core.model.image.xinference import XinferenceImageModel
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Hook infrastructure for dynamic model sharing
+# ---------------------------------------------------------------------------
+
+_visible_user_ids_hook = None  # (db: Session, user_id: int) -> list[int]
+
+
+def set_visible_user_ids_hook(hook):
+    """Set a custom hook that returns user IDs whose models are visible."""
+    global _visible_user_ids_hook
+    _visible_user_ids_hook = hook
+
+
+def _get_visible_user_ids(db: Session, user_id: Optional[int] = None) -> list[int]:
+    """Return user IDs whose shared models are visible to *user_id*.
+
+    Without a hook this returns all admin user IDs (legacy behaviour).
+    When *user_id* is ``None`` (standalone / non-web context), only admin IDs
+    are returned so that standalone callers fall back to admin defaults safely.
+
+    Hook implementers MUST handle ``user_id=None`` gracefully — e.g. treat it
+    as an unauthenticated context and return only system-admin IDs.
+    """
+    if _visible_user_ids_hook is not None:
+        return _visible_user_ids_hook(db, user_id)
+    from ..models.user import User
+
+    return [uid for (uid,) in db.query(User.id).filter(User.is_admin).all()]
+
 
 def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
@@ -36,7 +65,8 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
     try:
         # Try to get from database (requires web context)
         from ..models.database import get_db
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.model import Model as DBModel
+        from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         # This won't work in non-web contexts, so we'll fallback to environment
@@ -48,11 +78,11 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
             if user_id:
                 vision_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "visual",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -60,16 +90,14 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
                 if vision_default and vision_default.model:
                     return _create_llm_instance(vision_default.model)
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_vision_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "visual",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -77,18 +105,6 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
 
             if admin_vision_defaults:
                 return _create_llm_instance(admin_vision_defaults[0].model)
-
-            # If no admin defaults, fallback to any shared defaults
-            vision_models = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(UserDefaultModel.config_type == "visual", UserModel.is_shared)
-                .limit(1)
-                .all()
-            )
-
-            if vision_models:
-                return _create_llm_instance(vision_models[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get vision model from database: {e}")
@@ -113,7 +129,8 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     try:
         from ..models.database import get_db
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.model import Model as DBModel
+        from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         try:
@@ -123,11 +140,11 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             if user_id:
                 general_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "general",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -135,16 +152,14 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 if general_default and general_default.model:
                     return _create_llm_instance(general_default.model)
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "general",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -152,18 +167,6 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
 
             if admin_defaults:
                 return _create_llm_instance(admin_defaults[0].model)
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(UserDefaultModel.config_type == "general", UserModel.is_shared)
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                return _create_llm_instance(shared_defaults[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get default model from database: {e}")
@@ -188,7 +191,8 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     try:
         from ..models.database import get_db
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.model import Model as DBModel
+        from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         try:
@@ -198,11 +202,11 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             if user_id:
                 fast_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "small_fast",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -210,16 +214,14 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 if fast_default and fast_default.model:
                     return _create_llm_instance(fast_default.model)
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_fast_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "small_fast",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -227,20 +229,6 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
 
             if admin_fast_defaults:
                 return _create_llm_instance(admin_fast_defaults[0].model)
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(
-                    UserDefaultModel.config_type == "small_fast", UserModel.is_shared
-                )
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                return _create_llm_instance(shared_defaults[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get fast model from database: {e}")
@@ -265,7 +253,8 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     try:
         from ..models.database import get_db
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.model import Model as DBModel
+        from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         try:
@@ -275,11 +264,11 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             if user_id:
                 compact_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "compact",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -287,16 +276,14 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 if compact_default and compact_default.model:
                     return _create_llm_instance(compact_default.model)
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_compact_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "compact",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -304,18 +291,6 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
 
             if admin_compact_defaults:
                 return _create_llm_instance(admin_compact_defaults[0].model)
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(UserDefaultModel.config_type == "compact", UserModel.is_shared)
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                return _create_llm_instance(shared_defaults[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get compact model from database: {e}")
@@ -340,7 +315,8 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     try:
         from ..models.database import get_db
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.model import Model as DBModel
+        from ..models.user import UserDefaultModel, UserModel
         from .llm_utils import _create_llm_instance
 
         try:
@@ -350,11 +326,11 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
             if user_id:
                 embedding_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "embedding",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -362,16 +338,14 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 if embedding_default and embedding_default.model:
                     return _create_llm_instance(embedding_default.model)
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_embedding_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "embedding",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -379,20 +353,6 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
 
             if admin_embedding_defaults:
                 return _create_llm_instance(admin_embedding_defaults[0].model)
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(
-                    UserDefaultModel.config_type == "embedding", UserModel.is_shared
-                )
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                return _create_llm_instance(shared_defaults[0].model)
 
         except Exception as e:
             logger.warning(f"Failed to get embedding model from database: {e}")
@@ -584,7 +544,7 @@ def get_default_image_generate_model(
         from ...core.model.image.adapter import get_image_model_instance
         from ..models.database import get_db
         from ..models.model import Model as DBModel
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.user import UserDefaultModel, UserModel
 
         try:
             db = next(get_db())
@@ -593,12 +553,11 @@ def get_default_image_generate_model(
             if user_id:
                 image_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "image",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                         cast(DBModel.abilities, String).contains('"generate"'),
                     )
                     .first()
@@ -612,7 +571,7 @@ def get_default_image_generate_model(
                     except Exception as e:
                         logger.warning(f"Failed to create image model instance: {e}")
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_image_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
@@ -620,9 +579,7 @@ def get_default_image_generate_model(
                 .filter(
                     UserDefaultModel.config_type == "image",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                     cast(DBModel.abilities, String).contains('"generate"'),
                 )
                 .limit(1)
@@ -636,30 +593,6 @@ def get_default_image_generate_model(
                         instance,
                         "model_id",
                         str(admin_image_defaults[0].model.model_id),
-                    )
-                    return instance
-                except Exception as e:
-                    logger.warning(f"Failed to create image model instance: {e}")
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.config_type == "image",
-                    UserModel.is_shared,
-                    cast(DBModel.abilities, String).contains('"generate"'),
-                )
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                try:
-                    instance = get_image_model_instance(shared_defaults[0].model)
-                    setattr(
-                        instance, "model_id", str(shared_defaults[0].model.model_id)
                     )
                     return instance
                 except Exception as e:
@@ -693,7 +626,7 @@ def get_default_image_edit_model(
         from ...core.model.image.adapter import get_image_model_instance
         from ..models.database import get_db
         from ..models.model import Model as DBModel
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.user import UserDefaultModel, UserModel
 
         try:
             db = next(get_db())
@@ -702,12 +635,11 @@ def get_default_image_edit_model(
             if user_id:
                 image_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "image_edit",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -720,16 +652,14 @@ def get_default_image_edit_model(
                     except Exception as e:
                         logger.warning(f"Failed to create image model instance: {e}")
 
-            # Fallback to admin defaults first, then other shared defaults
+            # Fallback to visible users' shared defaults
             admin_image_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "image_edit",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -742,28 +672,6 @@ def get_default_image_edit_model(
                         instance,
                         "model_id",
                         str(admin_image_defaults[0].model.model_id),
-                    )
-                    return instance
-                except Exception as e:
-                    logger.warning(f"Failed to create image model instance: {e}")
-
-            # If no admin defaults, fallback to any shared defaults
-            shared_defaults = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .filter(
-                    UserDefaultModel.config_type == "image_edit",
-                    UserModel.is_shared,
-                )
-                .limit(1)
-                .all()
-            )
-
-            if shared_defaults:
-                try:
-                    instance = get_image_model_instance(shared_defaults[0].model)
-                    setattr(
-                        instance, "model_id", str(shared_defaults[0].model.model_id)
                     )
                     return instance
                 except Exception as e:
@@ -792,7 +700,8 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
         The embedding model ID or None if not available
     """
     from ..models.database import get_db
-    from ..models.user import User, UserDefaultModel, UserModel
+    from ..models.model import Model as DBModel
+    from ..models.user import UserDefaultModel, UserModel
 
     db = next(get_db())
 
@@ -800,11 +709,11 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
     if user_id:
         embedding_default = (
             db.query(UserDefaultModel)
-            .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
             .filter(
                 UserDefaultModel.user_id == user_id,
                 UserDefaultModel.config_type == "embedding",
-                UserModel.user_id == user_id,
+                DBModel.is_active,
             )
             .first()
         )
@@ -812,14 +721,14 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
         if embedding_default and embedding_default.model:
             return str(embedding_default.model.model_id)
 
-    # Admin defaults
+    # Visible users' shared defaults
     admin_embedding_defaults = (
         db.query(UserDefaultModel)
         .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
         .filter(
             UserDefaultModel.config_type == "embedding",
             UserModel.is_shared,
-            UserDefaultModel.user_id.in_(db.query(User.id).filter(User.is_admin)),
+            UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
         )
         .limit(1)
         .all()
@@ -827,18 +736,6 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
 
     if admin_embedding_defaults:
         return str(admin_embedding_defaults[0].model.model_id)
-
-    # Any shared defaults
-    embedding_models = (
-        db.query(UserDefaultModel)
-        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-        .filter(UserDefaultModel.config_type == "embedding", UserModel.is_shared)
-        .limit(1)
-        .all()
-    )
-
-    if embedding_models:
-        return str(embedding_models[0].model.model_id)
 
     return None
 
@@ -968,7 +865,7 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
         from ...core.model.asr.adapter import get_asr_model_instance
         from ..models.database import get_db
         from ..models.model import Model as DBModel
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.user import UserDefaultModel, UserModel
 
         try:
             db = next(get_db())
@@ -977,12 +874,11 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
             if user_id:
                 asr_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "asr",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -993,7 +889,7 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
                     except Exception as e:
                         logger.warning(f"Failed to create ASR model instance: {e}")
 
-            # Admin defaults
+            # Visible users' shared defaults
             admin_asr_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
@@ -1001,9 +897,7 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
                 .filter(
                     UserDefaultModel.config_type == "asr",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -1012,22 +906,6 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
             if admin_asr_defaults:
                 try:
                     return get_asr_model_instance(admin_asr_defaults[0].model)
-                except Exception as e:
-                    logger.warning(f"Failed to create ASR model instance: {e}")
-
-            # Any shared defaults
-            asr_models = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(UserDefaultModel.config_type == "asr", UserModel.is_shared)
-                .limit(1)
-                .all()
-            )
-
-            if asr_models:
-                try:
-                    return get_asr_model_instance(asr_models[0].model)
                 except Exception as e:
                     logger.warning(f"Failed to create ASR model instance: {e}")
 
@@ -1054,7 +932,7 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
         from ...core.model.tts.adapter import get_tts_model_instance
         from ..models.database import get_db
         from ..models.model import Model as DBModel
-        from ..models.user import User, UserDefaultModel, UserModel
+        from ..models.user import UserDefaultModel, UserModel
 
         try:
             db = next(get_db())
@@ -1063,12 +941,11 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
             if user_id:
                 tts_default = (
                     db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                    .join(DBModel, UserModel.model_id == DBModel.id)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
                         UserDefaultModel.user_id == user_id,
                         UserDefaultModel.config_type == "tts",
-                        UserModel.user_id == user_id,
+                        DBModel.is_active,
                     )
                     .first()
                 )
@@ -1079,7 +956,7 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
                     except Exception as e:
                         logger.warning(f"Failed to create TTS model instance: {e}")
 
-            # Admin defaults
+            # Visible users' shared defaults
             admin_tts_defaults = (
                 db.query(UserDefaultModel)
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
@@ -1087,9 +964,7 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
                 .filter(
                     UserDefaultModel.config_type == "tts",
                     UserModel.is_shared,
-                    UserDefaultModel.user_id.in_(
-                        db.query(User.id).filter(User.is_admin)
-                    ),
+                    UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
                 .all()
@@ -1098,22 +973,6 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
             if admin_tts_defaults:
                 try:
                     return get_tts_model_instance(admin_tts_defaults[0].model)
-                except Exception as e:
-                    logger.warning(f"Failed to create TTS model instance: {e}")
-
-            # Any shared defaults
-            tts_models = (
-                db.query(UserDefaultModel)
-                .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                .join(DBModel, UserModel.model_id == DBModel.id)
-                .filter(UserDefaultModel.config_type == "tts", UserModel.is_shared)
-                .limit(1)
-                .all()
-            )
-
-            if tts_models:
-                try:
-                    return get_tts_model_instance(tts_models[0].model)
                 except Exception as e:
                     logger.warning(f"Failed to create TTS model instance: {e}")
 

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -109,11 +109,11 @@ def _is_model_visible_to_user(
         return shared is not None
     except Exception:
         logger.warning(
-            "Visibility check failed for model_id=%s user_id=%s — defaulting to visible",
+            "Visibility check failed for model_id=%s user_id=%s — defaulting to hidden",
             model_id,
             user_id,
         )
-        return True
+        return False
 
 
 def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -52,6 +52,22 @@ def _get_visible_user_ids(db: Session, user_id: Optional[int] = None) -> list[in
     return [uid for (uid,) in db.query(User.id).filter(User.is_admin).all()]
 
 
+def build_user_model_visibility_filter(user_id: int, visible_ids: list[int]) -> Any:
+    """Return SQLAlchemy filter for UserModel rows visible to *user_id*.
+
+    The filter matches rows owned by *user_id* OR rows that are shared
+    and owned by any user in *visible_ids*.
+    """
+    from sqlalchemy import and_, or_
+
+    from ..models.user import UserModel
+
+    return or_(
+        UserModel.user_id == user_id,
+        and_(UserModel.user_id.in_(visible_ids), UserModel.is_shared.is_(True)),
+    )
+
+
 def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     Get the default vision model for a specific user.
@@ -96,7 +112,7 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "visual",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -158,7 +174,7 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "general",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -220,7 +236,7 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "small_fast",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -282,7 +298,7 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "compact",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -344,7 +360,7 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "embedding",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -578,7 +594,7 @@ def get_default_image_generate_model(
                 .join(DBModel, UserModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "image",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                     cast(DBModel.abilities, String).contains('"generate"'),
                 )
@@ -658,7 +674,7 @@ def get_default_image_edit_model(
                 .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
                 .filter(
                     UserDefaultModel.config_type == "image_edit",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -727,7 +743,7 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
         .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
         .filter(
             UserDefaultModel.config_type == "embedding",
-            UserModel.is_shared,
+            UserModel.is_shared.is_(True),
             UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
         )
         .limit(1)
@@ -896,7 +912,7 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
                 .join(DBModel, UserModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "asr",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)
@@ -963,7 +979,7 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
                 .join(DBModel, UserModel.model_id == DBModel.id)
                 .filter(
                     UserDefaultModel.config_type == "tts",
-                    UserModel.is_shared,
+                    UserModel.is_shared.is_(True),
                     UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
                 )
                 .limit(1)

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -68,6 +68,54 @@ def build_user_model_visibility_filter(user_id: int, visible_ids: list[int]) -> 
     )
 
 
+def _is_model_visible_to_user(
+    db: Session, model_id: Any, user_id: Optional[int] = None
+) -> bool:
+    """Check whether a DBModel row is visible to *user_id*.
+
+    Returns True when the user has an own ``is_owner`` UserModel **or**
+    when a shared UserModel exists from a visible user.  In non-web /
+    standalone contexts (*user_id* is None) visibility is always granted.
+    """
+    if user_id is None:
+        return True
+    try:
+        from ..models.user import UserModel
+
+        # Step 1: user's own (owner) UserModel
+        own = (
+            db.query(UserModel)
+            .filter(
+                UserModel.model_id == model_id,
+                UserModel.user_id == user_id,
+                UserModel.is_owner.is_(True),
+            )
+            .first()
+        )
+        if own is not None:
+            return True
+
+        # Step 2: shared from visible users
+        visible_ids = _get_visible_user_ids(db, user_id)
+        shared = (
+            db.query(UserModel)
+            .filter(
+                UserModel.model_id == model_id,
+                UserModel.user_id.in_(visible_ids),
+                UserModel.is_shared.is_(True),
+            )
+            .first()
+        )
+        return shared is not None
+    except Exception:
+        logger.warning(
+            "Visibility check failed for model_id=%s user_id=%s — defaulting to visible",
+            model_id,
+            user_id,
+        )
+        return True
+
+
 def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
     Get the default vision model for a specific user.
@@ -104,7 +152,8 @@ def get_default_vision_model(user_id: Optional[int] = None) -> Optional[BaseLLM]
                 )
 
                 if vision_default and vision_default.model:
-                    return _create_llm_instance(vision_default.model)
+                    if _is_model_visible_to_user(db, vision_default.model.id, user_id):
+                        return _create_llm_instance(vision_default.model)
 
             # Fallback to visible users' shared defaults
             admin_vision_defaults = (
@@ -166,7 +215,8 @@ def get_default_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 )
 
                 if general_default and general_default.model:
-                    return _create_llm_instance(general_default.model)
+                    if _is_model_visible_to_user(db, general_default.model.id, user_id):
+                        return _create_llm_instance(general_default.model)
 
             # Fallback to visible users' shared defaults
             admin_defaults = (
@@ -228,7 +278,8 @@ def get_fast_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 )
 
                 if fast_default and fast_default.model:
-                    return _create_llm_instance(fast_default.model)
+                    if _is_model_visible_to_user(db, fast_default.model.id, user_id):
+                        return _create_llm_instance(fast_default.model)
 
             # Fallback to visible users' shared defaults
             admin_fast_defaults = (
@@ -290,7 +341,8 @@ def get_compact_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 )
 
                 if compact_default and compact_default.model:
-                    return _create_llm_instance(compact_default.model)
+                    if _is_model_visible_to_user(db, compact_default.model.id, user_id):
+                        return _create_llm_instance(compact_default.model)
 
             # Fallback to visible users' shared defaults
             admin_compact_defaults = (
@@ -352,7 +404,10 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
                 )
 
                 if embedding_default and embedding_default.model:
-                    return _create_llm_instance(embedding_default.model)
+                    if _is_model_visible_to_user(
+                        db, embedding_default.model.id, user_id
+                    ):
+                        return _create_llm_instance(embedding_default.model)
 
             # Fallback to visible users' shared defaults
             admin_embedding_defaults = (
@@ -580,12 +635,17 @@ def get_default_image_generate_model(
                 )
 
                 if image_default and image_default.model:
-                    try:
-                        instance = get_image_model_instance(image_default.model)
-                        setattr(instance, "model_id", str(image_default.model.model_id))
-                        return instance
-                    except Exception as e:
-                        logger.warning(f"Failed to create image model instance: {e}")
+                    if _is_model_visible_to_user(db, image_default.model.id, user_id):
+                        try:
+                            instance = get_image_model_instance(image_default.model)
+                            setattr(
+                                instance, "model_id", str(image_default.model.model_id)
+                            )
+                            return instance
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to create image model instance: {e}"
+                            )
 
             # Fallback to visible users' shared defaults
             admin_image_defaults = (
@@ -661,12 +721,17 @@ def get_default_image_edit_model(
                 )
 
                 if image_default and image_default.model:
-                    try:
-                        instance = get_image_model_instance(image_default.model)
-                        setattr(instance, "model_id", str(image_default.model.model_id))
-                        return instance
-                    except Exception as e:
-                        logger.warning(f"Failed to create image model instance: {e}")
+                    if _is_model_visible_to_user(db, image_default.model.id, user_id):
+                        try:
+                            instance = get_image_model_instance(image_default.model)
+                            setattr(
+                                instance, "model_id", str(image_default.model.model_id)
+                            )
+                            return instance
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to create image model instance: {e}"
+                            )
 
             # Fallback to visible users' shared defaults
             admin_image_defaults = (
@@ -735,7 +800,8 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
         )
 
         if embedding_default and embedding_default.model:
-            return str(embedding_default.model.model_id)
+            if _is_model_visible_to_user(db, embedding_default.model.id, user_id):
+                return str(embedding_default.model.model_id)
 
     # Visible users' shared defaults
     admin_embedding_defaults = (
@@ -900,10 +966,11 @@ def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:
                 )
 
                 if asr_default and asr_default.model:
-                    try:
-                        return get_asr_model_instance(asr_default.model)
-                    except Exception as e:
-                        logger.warning(f"Failed to create ASR model instance: {e}")
+                    if _is_model_visible_to_user(db, asr_default.model.id, user_id):
+                        try:
+                            return get_asr_model_instance(asr_default.model)
+                        except Exception as e:
+                            logger.warning(f"Failed to create ASR model instance: {e}")
 
             # Visible users' shared defaults
             admin_asr_defaults = (
@@ -967,10 +1034,11 @@ def get_default_tts_model(user_id: Optional[int] = None) -> Optional[Any]:
                 )
 
                 if tts_default and tts_default.model:
-                    try:
-                        return get_tts_model_instance(tts_default.model)
-                    except Exception as e:
-                        logger.warning(f"Failed to create TTS model instance: {e}")
+                    if _is_model_visible_to_user(db, tts_default.model.id, user_id):
+                        try:
+                            return get_tts_model_instance(tts_default.model)
+                        except Exception as e:
+                            logger.warning(f"Failed to create TTS model instance: {e}")
 
             # Visible users' shared defaults
             admin_tts_defaults = (

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -438,11 +438,11 @@ def get_embedding_model(user_id: Optional[int] = None) -> Optional[BaseLLM]:
 
 def get_vision_model(db: Session, user_id: Optional[int] = None) -> Optional[BaseLLM]:
     """
-    Get vision model from database.
+    Get vision model from database filtered by current user visibility.
 
     Args:
         db: Database session
-        user_id: User ID (currently ignored as models are shared)
+        user_id: User ID for visibility filtering. If None, all models are visible.
 
     Returns:
         Vision model instance or None if not found
@@ -454,7 +454,7 @@ def get_vision_model(db: Session, user_id: Optional[int] = None) -> Optional[Bas
         from .llm_utils import _create_llm_instance
 
         # Query models that have vision ability in their abilities JSON field
-        db_model = (
+        db_models = (
             db.query(DBModel)
             .filter(
                 DBModel.category == "llm",
@@ -464,10 +464,14 @@ def get_vision_model(db: Session, user_id: Optional[int] = None) -> Optional[Bas
                     cast(DBModel.abilities, String).like('%"vision"%'),
                 ),
             )
-            .first()
+            .all()
         )
 
-        if db_model:
+        for db_model in db_models:
+            if user_id is not None and not _is_model_visible_to_user(
+                db, db_model.id, user_id
+            ):
+                continue
             return _create_llm_instance(db_model)
         return None
 
@@ -488,11 +492,11 @@ def _add_image_model_with_id(
 
 def get_image_models(db: Session, user_id: Optional[int] = None) -> Dict[str, Any]:
     """
-    Get image models from database.
+    Get image models from database filtered by current user visibility.
 
     Args:
         db: Database session
-        user_id: User ID (currently ignored as models are shared)
+        user_id: User ID for visibility filtering. If None, all models are visible.
 
     Returns:
         Dictionary of image model instances
@@ -512,6 +516,11 @@ def get_image_models(db: Session, user_id: Optional[int] = None) -> Dict[str, An
         )
 
         for db_model in db_models:
+            if user_id is not None and not _is_model_visible_to_user(
+                db, db_model.id, user_id
+            ):
+                continue
+
             if not (
                 api_key := str(db_model.api_key)
                 if db_model.api_key is not None
@@ -823,10 +832,10 @@ def get_default_embedding_model(user_id: Optional[int] = None) -> Optional[str]:
 
 
 def _get_models_by_category(
-    db: Session, ability: str, model_type: str
+    db: Session, ability: str, model_type: str, user_id: Optional[int] = None
 ) -> Dict[str, Any]:
     """
-    Get models by category and ability from database.
+    Get models by category and ability from database filtered by visibility.
 
     Generic helper function to load models (ASR, TTS, etc.) from database.
 
@@ -834,6 +843,7 @@ def _get_models_by_category(
         db: Database session
         ability: Model ability to filter by (e.g., "asr", "tts")
         model_type: Model type for error messages (e.g., "ASR", "TTS")
+        user_id: User ID for visibility filtering. If None, all models are visible.
 
     Returns:
         Dictionary of model instances
@@ -852,6 +862,10 @@ def _get_models_by_category(
         )
 
         for db_model in db_models:
+            if user_id is not None and not _is_model_visible_to_user(
+                db, db_model.id, user_id
+            ):
+                continue
             abilities: Any = getattr(db_model, "abilities", None)
             if isinstance(abilities, str):
                 try:
@@ -907,30 +921,30 @@ def _get_models_by_category(
 
 def get_asr_models(db: Session, user_id: Optional[int] = None) -> Dict[str, Any]:
     """
-    Get ASR (speech-to-text) models from database.
+    Get ASR (speech-to-text) models from database filtered by visibility.
 
     Args:
         db: Database session
-        user_id: User ID (currently ignored as models are shared)
+        user_id: User ID for visibility filtering. If None, all models are visible.
 
     Returns:
         Dictionary of ASR model instances
     """
-    return _get_models_by_category(db, "asr", "ASR")
+    return _get_models_by_category(db, "asr", "ASR", user_id=user_id)
 
 
 def get_tts_models(db: Session, user_id: Optional[int] = None) -> Dict[str, Any]:
     """
-    Get TTS (text-to-speech) models from database.
+    Get TTS (text-to-speech) models from database filtered by visibility.
 
     Args:
         db: Database session
-        user_id: User ID (currently ignored as models are shared)
+        user_id: User ID for visibility filtering. If None, all models are visible.
 
     Returns:
         Dictionary of TTS model instances
     """
-    return _get_models_by_category(db, "tts", "TTS")
+    return _get_models_by_category(db, "tts", "TTS", user_id=user_id)
 
 
 def get_default_asr_model(user_id: Optional[int] = None) -> Optional[Any]:

--- a/tests/web/test_auth_api.py
+++ b/tests/web/test_auth_api.py
@@ -170,6 +170,8 @@ class TestAuthAPI:
 
     def test_register_success(self, test_db, test_user_data):
         """Test successful user registration"""
+        from xagent.web.models.user import UserDefaultModel, UserModel
+
         setup_first_admin()
         response = client.post("/api/auth/register", json=test_user_data)
         print(f"Response status: {response.status_code}")
@@ -181,6 +183,25 @@ class TestAuthAPI:
         assert data["user"]["username"] == test_user_data["username"]
         assert "id" in data["user"]
         assert "createdAt" in data["user"]
+
+        # Verify registration does NOT create UserModel or UserDefaultModel
+        # (dynamic model sharing: no pre-creation on register)
+        db = TestingSessionLocal()
+        new_user = (
+            db.query(User).filter(User.username == test_user_data["username"]).first()
+        )
+        assert new_user is not None
+        user_models = db.query(UserModel).filter(UserModel.user_id == new_user.id).all()
+        assert len(user_models) == 0, "Registration should not create UserModel records"
+        user_defaults = (
+            db.query(UserDefaultModel)
+            .filter(UserDefaultModel.user_id == new_user.id)
+            .all()
+        )
+        assert len(user_defaults) == 0, (
+            "Registration should not create UserDefaultModel records"
+        )
+        db.close()
 
     def test_register_duplicate_username(self, test_db, test_user_data):
         """Test registration with duplicate username"""

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -164,6 +164,42 @@ def test_standalone_task_create_defaults_to_think(test_db, user1_headers):
     assert resp.json()["execution_mode"] == "think"
 
 
+def test_task_create_allows_shared_model_ids(
+    test_db, user1_headers, user2_headers, sample_model_data
+):
+    """When admin shares a model, other users can use it in task creation (Mode B two-step)."""
+    # Admin creates and shares a model
+    admin_login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin123"}
+    )
+    assert admin_login.status_code == 200
+    admin_headers = {"Authorization": f"Bearer {admin_login.json()['access_token']}"}
+
+    shared_data = dict(sample_model_data)
+    shared_data["share_with_users"] = True
+    shared_data["model_id"] = "admin-shared-model"
+
+    created = client.post("/api/models/", json=shared_data, headers=admin_headers)
+    assert created.status_code == 200
+    created_model = created.json()
+    shared_model_id = created_model["model_id"]
+
+    # User1 can use the shared model
+    resp = client.post(
+        "/api/chat/task/create",
+        json={
+            "title": "shared-model-task",
+            "description": "desc",
+            "llm_ids": [shared_model_id, None, None, None],
+        },
+        headers=user1_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # The task should use the shared model
+    assert data["model_id"] == shared_model_id
+
+
 def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):
     ensure_system_initialized()
     from xagent.web.models.task import Task, TaskStatus

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -232,3 +232,90 @@ def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):
         assert ids[3] == "deleted-compact-id"
     finally:
         db.close()
+
+
+def test_task_create_skips_stale_user_default(test_db, user1_headers):
+    """When a user's default model is no longer visible, task falls back to admin shared."""
+    from xagent.web.models.database import get_db
+    from xagent.web.models.model import Model as DBModel
+    from xagent.web.models.user import User, UserDefaultModel, UserModel
+
+    db = next(get_db())
+    try:
+        user1 = db.query(User).filter(User.username == "user1").first()
+        admin = db.query(User).filter(User.username == "admin").first()
+        assert user1 is not None
+        assert admin is not None
+
+        # -- Admin shared fallback model --
+        admin_shared_model = DBModel(
+            model_id="admin-shared-fallback",
+            category="llm",
+            model_provider="openai",
+            model_name="gpt-4",
+            api_key="test-key",
+            base_url="https://api.openai.com/v1",
+            temperature=0.7,
+            abilities=["chat"],
+            is_active=True,
+        )
+        db.add(admin_shared_model)
+        db.commit()
+        db.refresh(admin_shared_model)
+
+        db.add(
+            UserModel(
+                user_id=admin.id,
+                model_id=admin_shared_model.id,
+                is_owner=True,
+                is_shared=True,
+            )
+        )
+        db.add(
+            UserDefaultModel(
+                user_id=admin.id,
+                model_id=admin_shared_model.id,
+                config_type="general",
+            )
+        )
+
+        # -- User1's stale default (model with no UserModel row) --
+        stale_model = DBModel(
+            model_id="stale-inaccessible-model",
+            category="llm",
+            model_provider="openai",
+            model_name="gpt-4",
+            api_key="test-key",
+            base_url="https://api.openai.com/v1",
+            temperature=0.7,
+            abilities=["chat"],
+            is_active=True,
+        )
+        db.add(stale_model)
+        db.commit()
+        db.refresh(stale_model)
+
+        db.add(
+            UserDefaultModel(
+                user_id=user1.id,
+                model_id=stale_model.id,
+                config_type="general",
+            )
+        )
+        db.commit()
+
+        # Create task without specifying llm_ids — should resolve to admin shared fallback
+        resp = client.post(
+            "/api/chat/task/create",
+            json={"title": "test-stale", "description": "desc"},
+            headers=user1_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Must NOT use the stale inaccessible model
+        assert data.get("model_id") != "stale-inaccessible-model"
+        # Must use admin's shared fallback model
+        assert data.get("model_id") == "admin-shared-fallback"
+    finally:
+        db.close()

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -379,7 +379,7 @@ class TestModeCModelListing:
         assert shared[0]["is_shared"] is True
 
     def test_test_models_includes_shared(
-        self, test_db, admin_headers, regular_headers, sample_model_data
+        self, test_db, admin_headers, regular_headers, sample_model_data, monkeypatch
     ):
         """test endpoint finds shared models."""
         sample_model_data["share_with_users"] = True
@@ -388,10 +388,20 @@ class TestModeCModelListing:
         )
         assert create_response.status_code == 200
 
-        # Test without specific model_ids — should include shared models
+        # Avoid real network calls — we only need to verify the shared model is selected
+        async def fake_chat(*args, **kwargs):
+            return "ok"
+
+        monkeypatch.setattr(
+            "xagent.web.services.llm_utils.create_base_llm",
+            lambda config: type("FakeLLM", (), {"chat": fake_chat})(),
+        )
+
         response = client.post("/api/models/test", headers=regular_headers)
         assert response.status_code == 200
-        # Results will be "failed" since we can't actually call the API, but model should be found
+        data = response.json()
+        assert any(m["model_id"] == sample_model_data["model_id"] for m in data)
+        assert all(m["status"] == "passed" for m in data)
 
     def test_list_model_categories_includes_shared(
         self, test_db, admin_headers, regular_headers, sample_model_data
@@ -455,6 +465,38 @@ class TestPermissionChecks:
         response = client.post(
             "/api/models/", json=sample_model_data, headers=admin_headers
         )
+        assert response.status_code == 403
+
+    def test_non_owner_cannot_update_shared_model(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Non-owner gets 403 when trying to edit a shared model."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"temperature": 0.1},
+            headers=regular_headers,
+        )
+        assert response.status_code == 403
+
+    def test_non_owner_cannot_delete_shared_model(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Non-owner gets 403 when trying to delete a shared model."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        response = client.delete(f"/api/models/{model_id_str}", headers=regular_headers)
         assert response.status_code == 403
 
 

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -1091,3 +1091,155 @@ class TestModeAMultipleUsers:
         assert len(general2) == 1
         assert general2[0]["model"]["model_id"] == sample_model_data["model_id"]
         assert general2[0]["model"]["is_owner"] is False
+
+
+# ===========================================================================
+# 11. Legacy Data Compatibility
+# ===========================================================================
+
+
+class TestLegacyDataCompatibility:
+    """Tests for legacy UserModel rows (pre-created with is_owner=False)."""
+
+    def test_legacy_non_owner_row_not_treated_as_own(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """A legacy UserModel with is_owner=False is not treated as ownership —
+        verified via list_models. The model is visible through the legacy row
+        but is_owner is correctly False."""
+        # Admin creates a private model
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Simulate a legacy non-owner UserModel for the regular user
+        db = next(get_db())
+        from xagent.web.models.user import User, UserModel
+
+        regular = db.query(User).filter(User.username == "regularuser").first()
+        assert regular is not None
+        legacy_row = UserModel(
+            user_id=regular.id,
+            model_id=model_db_id,
+            is_owner=False,
+            is_shared=False,
+        )
+        db.add(legacy_row)
+        db.commit()
+        db.close()
+
+        # Regular user sees the model via legacy row, but is_owner=False
+        list_response = client.get("/api/models/", headers=regular_headers)
+        assert list_response.status_code == 200
+        data = list_response.json()
+        found = [m for m in data if m["model_id"] == sample_model_data["model_id"]]
+        assert len(found) == 1
+        assert found[0]["is_owner"] is False
+
+    def test_legacy_duplicate_rows_deduped_in_list(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """When both a legacy (is_owner=False, is_shared=True) and a real owner
+        UserModel exist, list_models returns exactly one row with correct ownership."""
+        sample_model_data["share_with_users"] = False
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        # Regular user's own model via API (creates is_owner=True UserModel)
+        own_data = dict(sample_model_data)
+        own_data["model_id"] = "regular-owned-model"
+        own_create = client.post("/api/models/", json=own_data, headers=regular_headers)
+        assert own_create.status_code == 200
+
+        # Admin sees exactly one row for their own model
+        list_response = client.get("/api/models/", headers=admin_headers)
+        assert list_response.status_code == 200
+        data = list_response.json()
+        admin_models = [
+            m for m in data if m["model_id"] == sample_model_data["model_id"]
+        ]
+        assert len(admin_models) == 1
+        assert admin_models[0]["is_owner"] is True
+
+
+# ===========================================================================
+# 12. Stale Default Visibility
+# ===========================================================================
+
+
+class TestGetUserDefaultModelsStaleSkip:
+    """Tests for stale UserDefaultModel visibility."""
+
+    def test_skips_stale_user_default_and_falls_back(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """When user's default points to a model no longer visible,
+        get_user_default_models falls back to admin shared defaults."""
+        # Admin creates a shared model and another as fallback
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+        model_id_str = create_response.json()["model_id"]
+
+        # Admin sets this as own default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Regular user sets it as own default too
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+
+        # Verify regular user sees the default
+        defaults_before = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
+        general_before = [
+            d for d in defaults_before.json() if d.get("config_type") == "general"
+        ]
+        assert len(general_before) == 1
+
+        # Admin un-shares the model (remove admin's own default first to avoid constraint)
+        client.delete("/api/models/user-default/general", headers=admin_headers)
+        # Create a second model as admin's new default
+        second_model_data = dict(sample_model_data)
+        second_model_data["model_id"] = "fallback-model"
+        second_model_data["share_with_users"] = True
+        second_create = client.post(
+            "/api/models/", json=second_model_data, headers=admin_headers
+        )
+        assert second_create.status_code == 200
+        second_model_db_id = second_create.json()["id"]
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": second_model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+        # Now un-share first model
+        unshare_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert unshare_response.status_code == 200
+
+        # Regular user's stale default should be skipped; falls back to admin's new default
+        defaults_after = client.get("/api/models/user-default", headers=regular_headers)
+        general_after = [
+            d for d in defaults_after.json() if d.get("config_type") == "general"
+        ]
+        assert len(general_after) == 1
+        assert general_after[0]["model"]["model_id"] == "fallback-model"
+        assert general_after[0]["model"]["is_owner"] is False

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xagent.web.api.auth import auth_router
-from xagent.web.api.model import _can_user_share, set_can_share_hook, model_router
+from xagent.web.api.model import _can_user_share, model_router, set_can_share_hook
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.services.model_service import (
     _get_visible_user_ids,
@@ -162,9 +162,7 @@ def sample_model_data():
 class TestHookInfrastructure:
     """Test _get_visible_user_ids and _can_user_share hooks."""
 
-    def test_get_visible_user_ids_default_returns_admin_ids(
-        self, test_db, admin_user
-    ):
+    def test_get_visible_user_ids_default_returns_admin_ids(self, test_db, admin_user):
         """Without hook, returns all admin user IDs."""
         db = next(get_db())
         result = _get_visible_user_ids(db, admin_user["id"])
@@ -209,7 +207,9 @@ class TestHookInfrastructure:
 class TestModeBAccessVerification:
     """Test two-step lookup: own → shared from visible users."""
 
-    def test_resolve_accessible_model_own(self, test_db, admin_headers, sample_model_data):
+    def test_resolve_accessible_model_own(
+        self, test_db, admin_headers, sample_model_data
+    ):
         """Step 1: owner accesses their own model."""
         create_response = client.post(
             "/api/models/", json=sample_model_data, headers=admin_headers
@@ -238,7 +238,9 @@ class TestModeBAccessVerification:
         assert response.status_code == 200
         assert response.json()["is_owner"] is False
 
-    def test_resolve_accessible_model_no_access(self, test_db, regular_headers, admin_headers, sample_model_data):
+    def test_resolve_accessible_model_no_access(
+        self, test_db, regular_headers, admin_headers, sample_model_data
+    ):
         """Two-step both miss: returns 404."""
         # Admin creates a private model
         create_response = client.post(
@@ -433,7 +435,6 @@ class TestModeCModelListing:
         assert response.status_code == 200
         data = response.json()
         assert data["total_models"] >= 1
-
 
 
 # ===========================================================================
@@ -651,7 +652,9 @@ class TestUnshareCleanup:
         )
 
         # Verify regular user has a default
-        defaults_before = client.get("/api/models/user-default", headers=regular_headers)
+        defaults_before = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
         assert any(d["config_type"] == "general" for d in defaults_before.json())
 
         # Admin un-shares
@@ -689,9 +692,7 @@ class TestUnshareCleanup:
         )
 
         # Admin un-shares (remove the default first to avoid constraint)
-        client.delete(
-            "/api/models/user-default/general", headers=admin_headers
-        )
+        client.delete("/api/models/user-default/general", headers=admin_headers)
 
         update_response = client.put(
             f"/api/models/{model_id_str}",
@@ -739,9 +740,7 @@ class TestUnshareCleanup:
         )
 
         # Admin un-shares first model (needs to remove admin's own default first)
-        client.delete(
-            "/api/models/user-default/general", headers=admin_headers
-        )
+        client.delete("/api/models/user-default/general", headers=admin_headers)
         # Set second model as admin's default
         client.post(
             "/api/models/user-default",
@@ -813,7 +812,9 @@ class TestStaticCodeCleanup:
         from xagent.web.models.user import UserModel
 
         model_db_id = create_response.json()["id"]
-        user_models = db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        user_models = (
+            db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        )
         db.close()
 
         # Only one UserModel — the owner's
@@ -845,7 +846,9 @@ class TestStaticCodeCleanup:
         db = next(get_db())
         from xagent.web.models.user import UserModel
 
-        user_models = db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        user_models = (
+            db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        )
         db.close()
 
         assert len(user_models) == 1
@@ -883,30 +886,37 @@ class TestModeADefaultLookup:
 
         # Verify the user has a default but NO own UserModel for this model
         db = next(get_db())
-        from xagent.web.models.user import UserModel, UserDefaultModel
+        from xagent.web.models.user import User, UserDefaultModel, UserModel
 
-        regular_user_id = regular_headers  # Need to get user_id
-        # Get user ID from login response or from DB
-        from xagent.web.models.user import User
         regular = db.query(User).filter(User.username == "regularuser").first()
         assert regular is not None
 
         # User has a UserDefaultModel pointing to the shared model
-        user_default = db.query(UserDefaultModel).filter(
-            UserDefaultModel.user_id == regular.id,
-            UserDefaultModel.config_type == "general",
-        ).first()
+        user_default = (
+            db.query(UserDefaultModel)
+            .filter(
+                UserDefaultModel.user_id == regular.id,
+                UserDefaultModel.config_type == "general",
+            )
+            .first()
+        )
         assert user_default is not None
 
         # User does NOT have their own UserModel (only admin has one)
-        own_user_model = db.query(UserModel).filter(
-            UserModel.user_id == regular.id,
-            UserModel.model_id == model_db_id,
-        ).first()
+        own_user_model = (
+            db.query(UserModel)
+            .filter(
+                UserModel.user_id == regular.id,
+                UserModel.model_id == model_db_id,
+            )
+            .first()
+        )
         assert own_user_model is None  # No pre-created UserModel
 
         # Despite no own UserModel, user-default endpoint should return the default
-        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        defaults_response = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
         assert defaults_response.status_code == 200
         data = defaults_response.json()
         general = [d for d in data if d.get("config_type") == "general"]
@@ -938,7 +948,9 @@ class TestModeADefaultLookup:
         )
 
         # Regular user should NOT see admin's private model in user-defaults
-        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        defaults_response = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
         assert defaults_response.status_code == 200
         data = defaults_response.json()
         general = [d for d in data if d.get("config_type") == "general"]
@@ -957,7 +969,9 @@ class TestModeADefaultLookup:
         assert create_response.status_code == 200
 
         # Regular user has no default
-        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        defaults_response = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
         assert defaults_response.status_code == 200
         data = defaults_response.json()
         general = [d for d in data if d.get("config_type") == "general"]

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -1,0 +1,1037 @@
+"""Tests for dynamic model sharing refactoring.
+
+Covers:
+- Hook infrastructure (_get_visible_user_ids, _can_user_share)
+- Mode B access verification (two-step lookup)
+- Mode C model listing (or_() filter)
+- Permission checks (owner-only edit/delete)
+- Protection constraints (cannot delete/un-share own default, cannot change category/abilities of shared)
+- Un-share cleanup (non-owner UserModel + UserDefaultModel deletion)
+- Static code cleanup verification (no pre-creation)
+"""
+
+import os
+import tempfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xagent.web.api.auth import auth_router
+from xagent.web.api.model import _can_user_share, set_can_share_hook, model_router
+from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.services.model_service import (
+    _get_visible_user_ids,
+    set_visible_user_ids_hook,
+)
+
+# ---------------------------------------------------------------------------
+# App setup (same pattern as test_model_api.py)
+# ---------------------------------------------------------------------------
+
+
+def override_get_db():
+    db = None
+    try:
+        db = next(get_db())
+        yield db
+    finally:
+        if db is not None:
+            db.close()
+
+
+test_app = FastAPI()
+test_app.include_router(auth_router)
+test_app.include_router(model_router)
+test_app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(test_app)
+
+
+def ensure_system_initialized() -> None:
+    status_response = client.get("/api/auth/setup-status")
+    assert status_response.status_code == 200
+    status_data = status_response.json()
+
+    if status_data.get("needs_setup", True):
+        setup_response = client.post(
+            "/api/auth/setup-admin", json={"username": "admin", "password": "admin123"}
+        )
+        assert setup_response.status_code == 200
+        assert setup_response.json().get("success") is True
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks():
+    """Ensure hooks are reset between tests."""
+    set_visible_user_ids_hook(None)
+    set_can_share_hook(None)
+    yield
+    set_visible_user_ids_hook(None)
+    set_can_share_hook(None)
+
+
+@pytest.fixture(scope="function")
+def test_db():
+    from xagent.web.models.database import init_db
+
+    temp_dir = tempfile.mkdtemp()
+    temp_db_path = os.path.join(temp_dir, "test.db")
+    SQLALCHEMY_DATABASE_URL = f"sqlite:///{temp_db_path}"
+
+    init_db(db_url=SQLALCHEMY_DATABASE_URL)
+    engine = get_engine()
+
+    yield
+
+    Base.metadata.drop_all(bind=engine)
+    try:
+        import shutil
+
+        shutil.rmtree(temp_dir)
+    except OSError:
+        pass
+
+
+@pytest.fixture(scope="function")
+def admin_user(test_db):
+    ensure_system_initialized()
+    db = next(get_db())
+    from xagent.web.models.user import User
+
+    admin = db.query(User).filter(User.username == "admin").first()
+    assert admin is not None
+    user_info = {"id": admin.id, "username": admin.username}
+    db.close()
+    return user_info
+
+
+@pytest.fixture(scope="function")
+def regular_user(test_db):
+    ensure_system_initialized()
+    user_data = {"username": "regularuser", "password": "password123"}
+    response = client.post("/api/auth/register", json=user_data)
+    assert response.status_code == 200
+    assert response.json().get("success") is True
+    return response.json()["user"]
+
+
+@pytest.fixture(scope="function")
+def admin_headers(admin_user):
+    response = client.post(
+        "/api/auth/login",
+        json={"username": admin_user["username"], "password": "admin123"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    return {"Authorization": f"Bearer {data['access_token']}"}
+
+
+@pytest.fixture(scope="function")
+def regular_headers(regular_user):
+    response = client.post(
+        "/api/auth/login",
+        json={"username": regular_user["username"], "password": "password123"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    return {"Authorization": f"Bearer {data['access_token']}"}
+
+
+@pytest.fixture(scope="function")
+def sample_model_data():
+    return {
+        "model_id": "test-openai-model",
+        "category": "llm",
+        "model_provider": "openai",
+        "model_name": "gpt-4",
+        "api_key": "test-api-key",
+        "base_url": "https://api.openai.com/v1",
+        "temperature": 0.7,
+        "abilities": ["chat", "tool_calling"],
+        "description": "Test OpenAI model",
+        "share_with_users": False,
+    }
+
+
+# ===========================================================================
+# 1. Hook Infrastructure
+# ===========================================================================
+
+
+class TestHookInfrastructure:
+    """Test _get_visible_user_ids and _can_user_share hooks."""
+
+    def test_get_visible_user_ids_default_returns_admin_ids(
+        self, test_db, admin_user
+    ):
+        """Without hook, returns all admin user IDs."""
+        db = next(get_db())
+        result = _get_visible_user_ids(db, admin_user["id"])
+        db.close()
+        assert admin_user["id"] in result
+
+    def test_get_visible_user_ids_hook_override(self, test_db):
+        """With hook, returns hook result."""
+        set_visible_user_ids_hook(lambda db, user_id: [42, 99])
+        db = next(get_db())
+        result = _get_visible_user_ids(db, 1)
+        db.close()
+        assert result == [42, 99]
+
+    def test_can_user_share_default_is_admin(self, test_db, admin_user, regular_user):
+        """Without hook, admin can share, regular user cannot."""
+        db = next(get_db())
+        from xagent.web.models.user import User
+
+        admin = db.query(User).filter(User.id == admin_user["id"]).first()
+        regular = db.query(User).filter(User.id == regular_user["id"]).first()
+        assert _can_user_share(admin) is True
+        assert _can_user_share(regular) is False
+        db.close()
+
+    def test_can_user_share_hook_override(self, test_db, regular_user):
+        """With hook, regular user can share."""
+        set_can_share_hook(lambda user: True)
+        db = next(get_db())
+        from xagent.web.models.user import User
+
+        regular = db.query(User).filter(User.id == regular_user["id"]).first()
+        assert _can_user_share(regular) is True
+        db.close()
+
+
+# ===========================================================================
+# 3. Mode B — Access Verification
+# ===========================================================================
+
+
+class TestModeBAccessVerification:
+    """Test two-step lookup: own → shared from visible users."""
+
+    def test_resolve_accessible_model_own(self, test_db, admin_headers, sample_model_data):
+        """Step 1: owner accesses their own model."""
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Owner should be able to GET
+        response = client.get(f"/api/models/{model_id_str}", headers=admin_headers)
+        assert response.status_code == 200
+        assert response.json()["is_owner"] is True
+
+    def test_resolve_accessible_model_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Step 2: non-owner accesses shared model from visible users."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Regular user should see shared model
+        response = client.get(f"/api/models/{model_id_str}", headers=regular_headers)
+        assert response.status_code == 200
+        assert response.json()["is_owner"] is False
+
+    def test_resolve_accessible_model_no_access(self, test_db, regular_headers, admin_headers, sample_model_data):
+        """Two-step both miss: returns 404."""
+        # Admin creates a private model
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Regular user cannot see private model
+        response = client.get(f"/api/models/{model_id_str}", headers=regular_headers)
+        assert response.status_code == 404
+
+    def test_get_llm_by_name_with_access_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """User without UserModel accesses shared model via visible_ids."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        # The regular user's model list should contain the shared model
+        response = client.get("/api/models/", headers=regular_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        shared = [m for m in data if m["model_id"] == sample_model_data["model_id"]]
+        assert len(shared) == 1
+        assert shared[0]["is_owner"] is False
+
+    def test_get_user_default_models_includes_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """get_user_default_models returns shared model defaults with is_owner=False."""
+        # Admin creates shared model
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Admin sets it as their default
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+        assert default_response.status_code == 200
+
+        # Regular user sees admin's shared default
+        response = client.get("/api/models/user-default", headers=regular_headers)
+        assert response.status_code == 200
+        data = response.json()
+        general_default = [d for d in data if d.get("config_type") == "general"]
+        assert len(general_default) == 1
+        assert general_default[0]["model"]["is_owner"] is False
+        assert general_default[0]["model"]["can_edit"] is False
+        assert general_default[0]["model"]["can_delete"] is False
+
+    def test_set_user_default_model_shared_access(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """User can set shared model as their default via Mode B."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Regular user sets shared model as default
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+        assert default_response.status_code == 200
+
+    def test_get_default_provider_endpoints_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """get_default/{provider} endpoints return shared models for non-owner who set their own default."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Regular user sets the shared model as their own default
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+        assert default_response.status_code == 200
+
+        # Now /default/general returns the shared model with is_owner=False
+        response = client.get("/api/models/default/general", headers=regular_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data is not None
+        assert data["is_owner"] is False
+        assert data["can_edit"] is False
+        assert data["can_delete"] is False
+
+
+# ===========================================================================
+# 4. Mode C — Model Listing
+# ===========================================================================
+
+
+class TestModeCModelListing:
+    """Test or_() filter for model listing."""
+
+    def test_list_models_shared_is_owner_false(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Shared models in list have is_owner=False."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        response = client.get("/api/models/", headers=regular_headers)
+        assert response.status_code == 200
+        data = response.json()
+        shared = [m for m in data if m["model_id"] == sample_model_data["model_id"]]
+        assert len(shared) == 1
+        assert shared[0]["is_owner"] is False
+        assert shared[0]["can_edit"] is False
+        assert shared[0]["can_delete"] is False
+        assert shared[0]["is_shared"] is True
+
+    def test_test_models_includes_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """test endpoint finds shared models."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        # Test without specific model_ids — should include shared models
+        response = client.post("/api/models/test", headers=regular_headers)
+        assert response.status_code == 200
+        # Results will be "failed" since we can't actually call the API, but model should be found
+
+    def test_list_model_categories_includes_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Categories from shared models are visible."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        response = client.get("/api/models/categories", headers=regular_headers)
+        assert response.status_code == 200
+        assert "llm" in response.json()["categories"]
+
+    def test_list_model_providers_includes_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Providers from shared models are visible."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        response = client.get("/api/models/providers", headers=regular_headers)
+        assert response.status_code == 200
+        assert "openai" in response.json()["providers"]
+
+    def test_get_models_summary_includes_shared(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Summary includes shared models in counts."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        response = client.get("/api/models/summary", headers=regular_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_models"] >= 1
+
+
+
+# ===========================================================================
+# 5. Permission Checks
+# ===========================================================================
+
+
+class TestPermissionChecks:
+    """Test owner-only edit/delete via dynamic model sharing."""
+
+    def test_update_model_can_user_share_hook(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """When _can_user_share hook returns False, admin cannot enable sharing."""
+        set_can_share_hook(lambda user: False)
+
+        sample_model_data["share_with_users"] = True
+        response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert response.status_code == 403
+
+
+# ===========================================================================
+# 6. Protection Constraints
+# ===========================================================================
+
+
+class TestProtectionConstraints:
+    """Test constraint 1 (cannot delete/un-share own default) and constraint 2 (shared model field locking)."""
+
+    def test_owner_cannot_delete_own_default(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 1: owner cannot delete model that is their own default."""
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Set as own default
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+        assert default_response.status_code == 200
+
+        # Try to delete — should fail with 409
+        delete_response = client.delete(
+            f"/api/models/{model_id_str}", headers=admin_headers
+        )
+        assert delete_response.status_code == 409
+        assert "default" in delete_response.json()["detail"].lower()
+
+    def test_owner_cannot_unshare_own_default(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 1: owner cannot un-share model that is their own default."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Set as own default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Try to un-share — should fail with 409
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 409
+        assert "default" in update_response.json()["detail"].lower()
+
+    def test_owner_can_delete_when_no_default(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 1 reverse: owner can delete model when it's not their default."""
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Delete without setting default — should succeed
+        delete_response = client.delete(
+            f"/api/models/{model_id_str}", headers=admin_headers
+        )
+        assert delete_response.status_code == 200
+
+    def test_owner_can_unshare_when_no_default(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 1 reverse: owner can un-share when model is not their default."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Un-share without setting default — should succeed
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+    def test_shared_model_cannot_change_category(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 2: cannot change category of shared model."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"category": "embedding"},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 409
+        assert "category" in update_response.json()["detail"]
+
+    def test_shared_model_cannot_change_abilities(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 2: cannot change abilities of shared model."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"abilities": ["chat"]},  # original was ["chat", "tool_calling"]
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 409
+        assert "abilities" in update_response.json()["detail"]
+
+    def test_shared_model_can_change_other_fields(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """Constraint 2 reverse: shared model allows changing api_key, temperature, description."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"temperature": 0.5, "description": "Updated"},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+        assert update_response.json()["temperature"] == 0.5
+        assert update_response.json()["description"] == "Updated"
+
+
+# ===========================================================================
+# 7. Un-share Cleanup
+# ===========================================================================
+
+
+class TestUnshareCleanup:
+    """Test that un-sharing cleans up non-owner UserModel and UserDefaultModel."""
+
+    def _create_shared_model_and_set_user_default(
+        self, admin_headers, regular_headers, sample_model_data
+    ):
+        """Helper: admin creates shared model, regular user sets it as default."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Regular user sets shared model as default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+
+        return model_id_str, model_db_id
+
+    def test_unshare_deletes_non_owner_user_default_model(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Un-sharing deletes non-owner UserDefaultModel records."""
+        model_id_str, model_db_id = self._create_shared_model_and_set_user_default(
+            admin_headers, regular_headers, sample_model_data
+        )
+
+        # Verify regular user has a default
+        defaults_before = client.get("/api/models/user-default", headers=regular_headers)
+        assert any(d["config_type"] == "general" for d in defaults_before.json())
+
+        # Admin un-shares
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+        # Regular user's default for general should be gone
+        defaults_after = client.get("/api/models/user-default", headers=regular_headers)
+        general_after = [
+            d for d in defaults_after.json() if d.get("config_type") == "general"
+        ]
+        assert len(general_after) == 0
+
+    def test_unshare_preserves_owner_data(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Un-sharing preserves owner's UserModel and UserDefaultModel."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Admin sets own default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Admin un-shares (remove the default first to avoid constraint)
+        client.delete(
+            "/api/models/user-default/general", headers=admin_headers
+        )
+
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+        # Owner should still see the model
+        get_response = client.get(f"/api/models/{model_id_str}", headers=admin_headers)
+        assert get_response.status_code == 200
+        assert get_response.json()["is_owner"] is True
+
+    def test_unshare_regular_user_falls_back_to_admin_default(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """After un-share, regular user falls back to admin's shared default."""
+        model_id_str, model_db_id = self._create_shared_model_and_set_user_default(
+            admin_headers, regular_headers, sample_model_data
+        )
+
+        # Create a second model as admin (also shared) for fallback
+        second_model_data = {
+            "model_id": "second-model",
+            "category": "llm",
+            "model_provider": "openai",
+            "model_name": "gpt-3.5-turbo",
+            "api_key": "test-api-key-2",
+            "base_url": "https://api.openai.com/v1",
+            "temperature": 0.5,
+            "abilities": ["chat"],
+            "share_with_users": True,
+        }
+        second_create = client.post(
+            "/api/models/", json=second_model_data, headers=admin_headers
+        )
+        assert second_create.status_code == 200
+        second_model_db_id = second_create.json()["id"]
+
+        # Admin sets second model as their default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": second_model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Admin un-shares first model (needs to remove admin's own default first)
+        client.delete(
+            "/api/models/user-default/general", headers=admin_headers
+        )
+        # Set second model as admin's default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": second_model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+        # Now unshare the first model (admin's default is the second model, so no constraint)
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+        # Regular user should see admin's second model as fallback
+        defaults = client.get("/api/models/user-default", headers=regular_headers)
+        general = [d for d in defaults.json() if d.get("config_type") == "general"]
+        assert len(general) == 1
+        assert general[0]["model"]["model_id"] == "second-model"
+
+    def test_unshare_deletes_non_owner_user_model(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Un-sharing deletes non-owner UserModel records (dynamic sharing only has owner's UserModel)."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+
+        # Before un-share: regular user can see the shared model
+        get_before = client.get(f"/api/models/{model_id_str}", headers=regular_headers)
+        assert get_before.status_code == 200
+
+        # Admin un-shares
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+        # After un-share: regular user can no longer see the model
+        get_after = client.get(f"/api/models/{model_id_str}", headers=regular_headers)
+        assert get_after.status_code == 404
+
+
+# ===========================================================================
+# 10. Static Code Cleanup Verification
+# ===========================================================================
+
+
+class TestStaticCodeCleanup:
+    """Verify no pre-creation happens with dynamic model sharing."""
+
+    def test_create_model_no_precreation(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Creating a shared model should NOT create UserModel for other users."""
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        # Check DB: only admin's UserModel should exist for this model
+        db = next(get_db())
+        from xagent.web.models.user import UserModel
+
+        model_db_id = create_response.json()["id"]
+        user_models = db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        db.close()
+
+        # Only one UserModel — the owner's
+        assert len(user_models) == 1
+        assert user_models[0].is_owner is True
+        assert user_models[0].is_shared is True
+
+    def test_update_model_enable_sharing_no_precreation(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Enabling sharing should NOT create UserModel for other users."""
+        sample_model_data["share_with_users"] = False
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Enable sharing
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": True},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
+        # Check DB: only admin's UserModel should exist
+        db = next(get_db())
+        from xagent.web.models.user import UserModel
+
+        user_models = db.query(UserModel).filter(UserModel.model_id == model_db_id).all()
+        db.close()
+
+        assert len(user_models) == 1
+        assert user_models[0].is_shared is True
+
+
+# ===========================================================================
+# Category 2: Mode A — Default model lookup integration tests
+# ===========================================================================
+
+
+class TestModeADefaultLookup:
+    """Integration tests verifying Mode A changes (DBModel JOIN, is_shared preservation)."""
+
+    def test_shared_model_set_as_default_found_via_dbmodel_join(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """User has UserDefaultModel pointing to a shared model but no own UserModel.
+        Mode A: should find via DBModel.is_active JOIN."""
+        # Admin creates shared model
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Regular user sets it as default (via shared model access)
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+        assert default_response.status_code == 200
+
+        # Verify the user has a default but NO own UserModel for this model
+        db = next(get_db())
+        from xagent.web.models.user import UserModel, UserDefaultModel
+
+        regular_user_id = regular_headers  # Need to get user_id
+        # Get user ID from login response or from DB
+        from xagent.web.models.user import User
+        regular = db.query(User).filter(User.username == "regularuser").first()
+        assert regular is not None
+
+        # User has a UserDefaultModel pointing to the shared model
+        user_default = db.query(UserDefaultModel).filter(
+            UserDefaultModel.user_id == regular.id,
+            UserDefaultModel.config_type == "general",
+        ).first()
+        assert user_default is not None
+
+        # User does NOT have their own UserModel (only admin has one)
+        own_user_model = db.query(UserModel).filter(
+            UserModel.user_id == regular.id,
+            UserModel.model_id == model_db_id,
+        ).first()
+        assert own_user_model is None  # No pre-created UserModel
+
+        # Despite no own UserModel, user-default endpoint should return the default
+        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        assert defaults_response.status_code == 200
+        data = defaults_response.json()
+        general = [d for d in data if d.get("config_type") == "general"]
+        assert len(general) == 1
+        assert general[0]["model"]["model_id"] == sample_model_data["model_id"]
+        assert general[0]["model"]["is_owner"] is False
+
+        db.close()
+
+    def test_admin_fallback_preserves_is_shared_check(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Admin fallback only returns shared (is_shared=True) models, not private ones."""
+        # Admin creates a PRIVATE model (not shared)
+        private_data = dict(sample_model_data)
+        private_data["model_id"] = "private-model"
+        private_data["share_with_users"] = False
+        private_response = client.post(
+            "/api/models/", json=private_data, headers=admin_headers
+        )
+        assert private_response.status_code == 200
+        private_db_id = private_response.json()["id"]
+
+        # Admin sets private model as their default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": private_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Regular user should NOT see admin's private model in user-defaults
+        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        assert defaults_response.status_code == 200
+        data = defaults_response.json()
+        general = [d for d in data if d.get("config_type") == "general"]
+        assert len(general) == 0  # Private model should NOT appear as fallback
+
+    def test_no_third_tier_fallback(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Third-tier fallback (any shared defaults from any user) is removed."""
+        # Admin creates a shared model but does NOT set it as default
+        sample_model_data["share_with_users"] = True
+        sample_model_data["model_id"] = "shared-no-default"
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+
+        # Regular user has no default
+        defaults_response = client.get("/api/models/user-default", headers=regular_headers)
+        assert defaults_response.status_code == 200
+        data = defaults_response.json()
+        general = [d for d in data if d.get("config_type") == "general"]
+        # The shared model has no admin default, so it should NOT appear
+        assert len(general) == 0
+
+
+class TestModeAMultipleUsers:
+    """Test model service with multiple users using dynamic sharing."""
+
+    def test_multiple_users_isolated_defaults(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        """Each user's defaults are isolated; admin shared models are visible to all."""
+        # Admin creates shared model
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        # Admin sets as their default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Create second regular user
+        user2_data = {"username": "user2", "password": "password2"}
+        user2_response = client.post("/api/auth/register", json=user2_data)
+        assert user2_response.status_code == 200
+
+        login2 = client.post(
+            "/api/auth/login", json={"username": "user2", "password": "password2"}
+        )
+        user2_headers = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+
+        # Both regular users see admin's shared default
+        for headers in [regular_headers, user2_headers]:
+            defaults = client.get("/api/models/user-default", headers=headers)
+            assert defaults.status_code == 200
+            data = defaults.json()
+            general = [d for d in data if d.get("config_type") == "general"]
+            assert len(general) == 1
+            assert general[0]["model"]["is_owner"] is False
+
+        # Regular user 1 sets a different model as their own default
+        own_model_data = dict(sample_model_data)
+        own_model_data["model_id"] = "user1-own-model"
+        own_model_data["share_with_users"] = False
+        own_create = client.post(
+            "/api/models/", json=own_model_data, headers=regular_headers
+        )
+        assert own_create.status_code == 200
+        own_model_db_id = own_create.json()["id"]
+
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": own_model_db_id, "config_type": "general"},
+            headers=regular_headers,
+        )
+
+        # User 1 sees their own default
+        defaults1 = client.get("/api/models/user-default", headers=regular_headers)
+        general1 = [d for d in defaults1.json() if d.get("config_type") == "general"]
+        assert len(general1) == 1
+        assert general1[0]["model"]["model_id"] == "user1-own-model"
+        assert general1[0]["model"]["is_owner"] is True
+
+        # User 2 still sees admin's shared default (not user 1's private model)
+        defaults2 = client.get("/api/models/user-default", headers=user2_headers)
+        general2 = [d for d in defaults2.json() if d.get("config_type") == "general"]
+        assert len(general2) == 1
+        assert general2[0]["model"]["model_id"] == sample_model_data["model_id"]
+        assert general2[0]["model"]["is_owner"] is False

--- a/tests/web/test_llm_uitls.py
+++ b/tests/web/test_llm_uitls.py
@@ -64,9 +64,10 @@ class TestGetLLMByNameWithAccess:
 
         assert result == mock_llm
 
-    def test_returns_none_when_user_no_access(
+    def test_returns_none_when_invalid_model_config(
         self, storage, mock_db, mock_core_storage
     ):
+        """Returns None when model_config is not a ChatModelConfig (dict instead of object)."""
         mock_model = Mock(
             spec=ChatModelConfig, id=1, model_id="test-model", model_name="test-model"
         )  # Added model_name
@@ -126,6 +127,64 @@ class TestGetLLMByNameWithAccess:
         assert result == mock_llm
         mock_core_storage.create_llm_instance.assert_called_once_with(mock_chat_config)
 
+    def test_returns_llm_via_shared_model_step2(
+        self, storage, mock_db, mock_core_storage, monkeypatch
+    ):
+        """Test two-step lookup: step 1 misses, step 2 finds shared model from visible user."""
+        mock_llm = Mock()
+        mock_chat_config = ChatModelConfig(id="shared-model", model_name="shared-model")
+        mock_db_model = Mock(id=1, model_id="shared-model", model_name="shared-model")
+
+        mock_core_storage.load.return_value = mock_chat_config
+        mock_core_storage.get_db_model.return_value = mock_db_model
+        mock_core_storage.create_llm_instance.return_value = mock_llm
+
+        # Mock _get_visible_user_ids to return admin user IDs
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [10],  # admin user ID
+        )
+
+        # Step 1: own UserModel query returns None
+        # Step 2: shared UserModel query returns a shared model
+        mock_shared_user_model = Mock(spec=UserModel)
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            None,  # step 1: no own UserModel
+            mock_shared_user_model,  # step 2: found shared UserModel
+        ]
+
+        result = storage.get_llm_by_name_with_access("shared-model", user_id=1)
+
+        assert result == mock_llm
+        assert mock_db.query.return_value.filter.return_value.first.call_count == 2
+
+    def test_returns_none_when_shared_model_not_found_step2(
+        self, storage, mock_db, mock_core_storage, monkeypatch
+    ):
+        """Test two-step lookup: both steps miss, returns None."""
+        mock_chat_config = ChatModelConfig(
+            id="private-model", model_name="private-model"
+        )
+        mock_db_model = Mock(id=1, model_id="private-model", model_name="private-model")
+
+        mock_core_storage.load.return_value = mock_chat_config
+        mock_core_storage.get_db_model.return_value = mock_db_model
+
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [10],
+        )
+
+        # Both steps return None
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            None,  # step 1
+            None,  # step 2
+        ]
+
+        result = storage.get_llm_by_name_with_access("private-model", user_id=1)
+
+        assert result is None
+
 
 class TestGetConfiguredDefaults:
     def test_returns_user_specific_defaults(self, storage, mock_db, mock_core_storage):
@@ -168,11 +227,19 @@ class TestGetConfiguredDefaults:
         assert mock_core_storage.load.call_count == 4
         assert mock_core_storage.create_llm_instance.call_count == 4
 
-    def test_falls_back_to_admin_defaults(self, storage, mock_db, mock_core_storage):
+    def test_falls_back_to_admin_defaults(
+        self, storage, mock_db, mock_core_storage, monkeypatch
+    ):
         """Test fallback to admin shared defaults when user defaults missing"""
         mock_llm = Mock()
         mock_model = Mock(model_id="admin-model")
         mock_config = Mock(spec=ChatModelConfig)
+
+        # Mock _get_visible_user_ids at the source module
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [1],
+        )
 
         # No user-specific defaults
         mock_query = mock_db.query.return_value
@@ -211,7 +278,7 @@ class TestGetConfiguredDefaults:
         assert mock_core_storage.create_llm_instance.call_count == 4
 
     def test_partial_user_defaults_fills_from_admin(
-        self, storage, mock_db, mock_core_storage
+        self, storage, mock_db, mock_core_storage, monkeypatch
     ):
         """Test that missing user defaults are filled from admin defaults"""
         mock_user_llm = Mock()
@@ -220,6 +287,12 @@ class TestGetConfiguredDefaults:
         mock_admin_model = Mock(model_id="admin-model")
         mock_user_config = Mock(spec=ChatModelConfig)
         mock_admin_config = Mock(spec=ChatModelConfig)
+
+        # Mock _get_visible_user_ids at the source module
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [1],
+        )
 
         # User has only general and fast defaults
         mock_general = Mock(
@@ -285,12 +358,18 @@ class TestGetConfiguredDefaults:
         assert result == (mock_env_llm, mock_env_llm, mock_env_llm, mock_env_llm)
 
     def test_uses_default_llm_for_missing_specialized(
-        self, storage, mock_db, mock_core_storage
+        self, storage, mock_db, mock_core_storage, monkeypatch
     ):
         """Test that default LLM is used when specialized LLMs are missing"""
         mock_default_llm = Mock()
         mock_model = Mock(model_id="default-model")
         mock_config = Mock(spec=ChatModelConfig)
+
+        # Mock _get_visible_user_ids at the source module
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [1],
+        )
 
         # Only general default available
         mock_general = Mock(
@@ -335,11 +414,19 @@ class TestGetConfiguredDefaults:
 
         assert result == (mock_env_llm, mock_env_llm, mock_env_llm, mock_env_llm)
 
-    def test_no_user_id_uses_admin_defaults(self, storage, mock_db, mock_core_storage):
+    def test_no_user_id_uses_admin_defaults(
+        self, storage, mock_db, mock_core_storage, monkeypatch
+    ):
         """Test that when no user_id provided, only admin defaults are used"""
         mock_llm = Mock()
         mock_model = Mock(model_id="admin-model")
         mock_config = Mock(spec=ChatModelConfig)
+
+        # Mock _get_visible_user_ids at the source module
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [1],
+        )
 
         # Admin defaults
         mock_admin_general = Mock(

--- a/tests/web/test_llm_uitls.py
+++ b/tests/web/test_llm_uitls.py
@@ -397,6 +397,92 @@ class TestGetConfiguredDefaults:
             mock_default_llm,
         )
 
+    def test_stale_user_default_falls_back_to_admin(
+        self, storage, mock_db, mock_core_storage, monkeypatch
+    ):
+        """When user default exists but visibility check fails, fall back to admin shared."""
+        mock_admin_llm = Mock()
+        mock_user_model = Mock(model_id="user-stale-model")
+        mock_admin_model = Mock(model_id="admin-shared-model")
+        mock_config = Mock(spec=ChatModelConfig)
+
+        # _get_visible_user_ids returns admin
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._get_visible_user_ids",
+            lambda db, user_id: [1],
+        )
+        # _is_model_visible_to_user always returns False (stale defaults)
+        monkeypatch.setattr(
+            "xagent.web.services.model_service._is_model_visible_to_user",
+            lambda db, model_id, user_id: False,
+        )
+
+        # User has defaults for all 4 types — but all fail visibility
+        mock_general = Mock(
+            spec=UserDefaultModel, model=mock_user_model, config_type="general"
+        )
+        mock_fast = Mock(
+            spec=UserDefaultModel, model=mock_user_model, config_type="small_fast"
+        )
+        mock_vision = Mock(
+            spec=UserDefaultModel, model=mock_user_model, config_type="visual"
+        )
+        mock_compact = Mock(
+            spec=UserDefaultModel, model=mock_user_model, config_type="compact"
+        )
+
+        mock_query = mock_db.query.return_value
+        mock_join = mock_query.join.return_value
+        mock_filter = mock_join.filter.return_value
+        mock_filter.first.side_effect = [
+            mock_general,
+            mock_fast,
+            mock_vision,
+            mock_compact,
+        ]
+
+        # Admin shared defaults available
+        mock_admin_general = Mock(
+            spec=UserDefaultModel, model=mock_admin_model, config_type="general"
+        )
+        mock_admin_fast = Mock(
+            spec=UserDefaultModel, model=mock_admin_model, config_type="small_fast"
+        )
+        mock_admin_vision = Mock(
+            spec=UserDefaultModel, model=mock_admin_model, config_type="visual"
+        )
+        mock_admin_compact = Mock(
+            spec=UserDefaultModel, model=mock_admin_model, config_type="compact"
+        )
+        mock_filter.all.return_value = [
+            mock_admin_general,
+            mock_admin_fast,
+            mock_admin_vision,
+            mock_admin_compact,
+        ]
+
+        def load_side_effect(model_id):
+            return mock_config
+
+        def create_instance_side_effect(config):
+            return mock_admin_llm
+
+        mock_core_storage.load.side_effect = load_side_effect
+        mock_core_storage.create_llm_instance.side_effect = create_instance_side_effect
+
+        result = storage.get_configured_defaults(user_id=1)
+
+        # All should come from admin fallback, not user defaults
+        assert result == (
+            mock_admin_llm,
+            mock_admin_llm,
+            mock_admin_llm,
+            mock_admin_llm,
+        )
+        # load + create_llm called 4 times (all admin fallback)
+        assert mock_core_storage.load.call_count == 4
+        assert mock_core_storage.create_llm_instance.call_count == 4
+
     def test_handles_exception_gracefully(
         self, storage, mock_db, mock_core_storage, monkeypatch
     ):

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -353,34 +353,6 @@ class TestModelAPI:
         assert len(data) == 1
         assert data[0]["model_id"] == sample_model_data["model_id"]
 
-    def test_get_shared_models(
-        self,
-        test_db,
-        admin_user,
-        admin_headers,
-        regular_user,
-        regular_headers,
-        sample_model_data,
-    ):
-        """Test getting shared models"""
-        # Admin creates a shared model
-        sample_model_data["share_with_users"] = True
-        create_response = client.post(
-            "/api/models/", json=sample_model_data, headers=admin_headers
-        )
-        assert create_response.status_code == 200
-
-        # Regular user should see the shared model
-        response = client.get("/api/models/", headers=regular_headers)
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 1
-        assert data[0]["model_id"] == sample_model_data["model_id"]
-        assert data[0]["is_shared"] is True
-        assert data[0]["is_owner"] is False  # Regular user is not owner
-        assert data[0]["can_edit"] is False  # Regular user cannot edit
-        assert data[0]["can_delete"] is False  # Regular user cannot delete
-
     def test_get_model_by_id(
         self, test_db, regular_user, regular_headers, sample_model_data
     ):
@@ -420,33 +392,6 @@ class TestModelAPI:
         data = response.json()
         assert data["temperature"] == 0.8
         assert data["description"] == "Updated description"
-
-    def test_update_shared_model_as_non_owner_fails(
-        self,
-        test_db,
-        admin_user,
-        admin_headers,
-        regular_user,
-        regular_headers,
-        sample_model_data,
-    ):
-        """Test that non-owner cannot update shared model"""
-        # Admin creates a shared model
-        sample_model_data["share_with_users"] = True
-        create_response = client.post(
-            "/api/models/", json=sample_model_data, headers=admin_headers
-        )
-        assert create_response.status_code == 200
-        model_id_str = create_response.json()["model_id"]
-
-        # Regular user tries to update
-        update_data = {"temperature": 0.8}
-        response = client.put(
-            f"/api/models/{model_id_str}", json=update_data, headers=regular_headers
-        )
-        assert response.status_code == 403
-        data = response.json()
-        assert "No permission to edit this model" in data["detail"]
 
     def test_delete_model_as_owner(
         self, test_db, regular_user, regular_headers, sample_model_data
@@ -529,30 +474,6 @@ class TestModelAPI:
         assert delete_response.status_code == 200
         assert delete_response.json()["message"] == "Model deleted successfully"
 
-    def test_delete_shared_model_as_non_owner_fails(
-        self,
-        test_db,
-        admin_user,
-        admin_headers,
-        regular_user,
-        regular_headers,
-        sample_model_data,
-    ):
-        """Test that non-owner cannot delete shared model"""
-        # Admin creates a shared model
-        sample_model_data["share_with_users"] = True
-        create_response = client.post(
-            "/api/models/", json=sample_model_data, headers=admin_headers
-        )
-        assert create_response.status_code == 200
-        model_id_str = create_response.json()["model_id"]
-
-        # Regular user tries to delete
-        response = client.delete(f"/api/models/{model_id_str}", headers=regular_headers)
-        assert response.status_code == 403
-        data = response.json()
-        assert "No permission to delete this model" in data["detail"]
-
     def test_get_nonexistent_model(self, test_db, regular_user, regular_headers):
         """Test getting non-existent model"""
         response = client.get("/api/models/99999", headers=regular_headers)
@@ -612,17 +533,22 @@ class TestModelAPI:
         )
         assert response.status_code == 200
 
-        # Create another user and verify they don't see the first user's private model
+        # Create another user
         user2_data = {"username": "user2", "password": "password2"}
         user2_response = client.post("/api/auth/register", json=user2_data)
         assert user2_response.status_code == 200
-        assert user2_response.json().get("success") is True
+
+        # Login as user2
+        login2 = client.post(
+            "/api/auth/login", json={"username": "user2", "password": "password2"}
+        )
+        user2_headers = {"Authorization": f"Bearer {login2.json()['access_token']}"}
 
         # User2 should not see user1's private model
-        models_response = client.get("/api/models/", headers=regular_headers)
+        models_response = client.get("/api/models/", headers=user2_headers)
         assert models_response.status_code == 200
         data = models_response.json()
-        assert len(data) == 1  # User should still see their own model
+        assert len(data) == 0  # User2 shouldn't see user1's private model
 
     def test_model_with_abilities(
         self, test_db, regular_user, regular_headers, sample_model_data

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -225,3 +225,53 @@ class TestModelService:
             assert mock_create.call_count == 2
             # _get_visible_user_ids should have been called for both users
             assert mock_visible.call_count == 2
+
+    def test_get_default_model_stale_default_skipped(self):
+        """Stale user default (model no longer visible) falls through to admin fallback."""
+        with (
+            patch("xagent.web.models.database.get_db") as mock_get_db,
+            patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
+            patch(
+                "xagent.web.services.model_service._get_visible_user_ids"
+            ) as mock_visible,
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+        ):
+            mock_visible.return_value = [1]
+            mock_visibility.return_value = False  # model NOT visible — stale
+
+            mock_db = MagicMock()
+            mock_get_db.return_value = iter([mock_db])
+
+            # UserDefaultModel found, but visibility check fails
+            mock_user_default = MagicMock()
+            mock_user_default.user_id = 42
+            mock_user_default.config_type = "general"
+            mock_user_default.model = MagicMock()
+            mock_user_default.model.id = 42
+
+            mock_first_result = MagicMock()
+            mock_first_result.first.return_value = mock_user_default
+            mock_all_result = MagicMock()
+            mock_all_result.all.return_value = [MagicMock()]
+
+            # Two filter calls: one for user-specific (returns None after visibility fails),
+            # then admin fallback
+            mock_db.query.return_value.join.return_value.filter.side_effect = [
+                mock_first_result,  # user-specific query
+                mock_all_result,  # admin fallback query
+            ]
+
+            mock_llm = MagicMock()
+            mock_create.return_value = mock_llm
+
+            result = get_default_model(42)
+
+            assert result == mock_llm
+            # Visibility check was called
+            mock_visibility.assert_called_once_with(mock_db, 42, 42)
+            # Admin fallback was used (create_llm called)
+            mock_create.assert_called_once()
+            # _get_visible_user_ids was called for admin fallback
+            mock_visible.assert_called_with(mock_db, 42)

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -9,13 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model
 from xagent.web.models.user import User
-from xagent.web.services.model_service import (
-    get_compact_model,
-    get_default_model,
-    get_default_vision_model,
-    get_embedding_model,
-    get_fast_model,
-)
+from xagent.web.services.model_service import get_default_model
 
 # Test database setup - use in-memory database
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -107,11 +101,17 @@ class TestModelService:
             mock_create.assert_called_once_with(mock_user_default.model)
 
     def test_get_default_model_admin_shared(self):
-        """Test getting admin shared default model"""
+        """Test getting admin shared default model — admin fallback uses _get_visible_user_ids."""
         with (
             patch("xagent.web.models.database.get_db") as mock_get_db,
             patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
+            patch(
+                "xagent.web.services.model_service._get_visible_user_ids"
+            ) as mock_visible,
         ):
+            # _get_visible_user_ids returns admin user IDs
+            mock_visible.return_value = [1]
+
             # Setup mock database session
             mock_db = MagicMock()
             mock_get_db.return_value = iter([mock_db])
@@ -132,135 +132,38 @@ class TestModelService:
 
             assert result == mock_llm
             mock_create.assert_called_once()
+            # Verify _get_visible_user_ids was called for admin fallback
+            mock_visible.assert_called_with(mock_db, 2)
 
     def test_get_default_model_no_user_id(self):
-        """Test getting default model without user ID - should return None"""
-        with patch("xagent.web.models.database.get_db") as mock_get_db:
-            # Setup mock database session
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Setup query to return no shared defaults
-            mock_db.query.return_value.join.return_value.filter.return_value.all.return_value = []
-
-            result = get_default_model()
-            assert result is None
-
-    def test_get_default_vision_model(self):
-        """Test getting vision model"""
+        """Test getting default model without user ID - falls through to visible users fallback."""
         with (
             patch("xagent.web.models.database.get_db") as mock_get_db,
             patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
+            patch(
+                "xagent.web.services.model_service._get_visible_user_ids"
+            ) as mock_visible,
         ):
-            # Setup mock database session
+            mock_visible.return_value = [1]
+
             mock_db = MagicMock()
             mock_get_db.return_value = iter([mock_db])
 
-            # Create mock vision default
-            mock_vision_default = MagicMock()
-            mock_vision_default.user_id = 1
-            mock_vision_default.config_type = "visual"
-            mock_vision_default.model = MagicMock()
-            mock_vision_default.model.model_id = "vision-model"
+            # No user-specific default
+            mock_query_result = MagicMock()
+            mock_query_result.first.return_value = None
+            mock_query_result.all.return_value = [MagicMock()]
+            mock_db.query.return_value.join.return_value.filter.return_value = (
+                mock_query_result
+            )
 
-            # Setup query result
-            mock_db.query.return_value.join.return_value.filter.return_value.first.return_value = mock_vision_default
-
-            # Setup mock LLM creation
             mock_llm = MagicMock()
             mock_create.return_value = mock_llm
 
-            result = get_default_vision_model(1)
+            result = get_default_model(None)
 
             assert result == mock_llm
-            mock_create.assert_called_once_with(mock_vision_default.model)
-
-    def test_get_fast_model(self):
-        """Test getting fast model"""
-        with (
-            patch("xagent.web.models.database.get_db") as mock_get_db,
-            patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
-        ):
-            # Setup mock database session
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Create mock fast default
-            mock_fast_default = MagicMock()
-            mock_fast_default.user_id = 1
-            mock_fast_default.config_type = "small_fast"
-            mock_fast_default.model = MagicMock()
-            mock_fast_default.model.model_id = "fast-model"
-
-            # Setup query result
-            mock_db.query.return_value.join.return_value.filter.return_value.first.return_value = mock_fast_default
-
-            # Setup mock LLM creation
-            mock_llm = MagicMock()
-            mock_create.return_value = mock_llm
-
-            result = get_fast_model(1)
-
-            assert result == mock_llm
-            mock_create.assert_called_once_with(mock_fast_default.model)
-
-    def test_get_compact_model(self):
-        """Test getting compact model"""
-        with (
-            patch("xagent.web.models.database.get_db") as mock_get_db,
-            patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
-        ):
-            # Setup mock database session
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Create mock compact default
-            mock_compact_default = MagicMock()
-            mock_compact_default.user_id = 1
-            mock_compact_default.config_type = "compact"
-            mock_compact_default.model = MagicMock()
-            mock_compact_default.model.model_id = "compact-model"
-
-            # Setup query result
-            mock_db.query.return_value.join.return_value.filter.return_value.first.return_value = mock_compact_default
-
-            # Setup mock LLM creation
-            mock_llm = MagicMock()
-            mock_create.return_value = mock_llm
-
-            result = get_compact_model(1)
-
-            assert result == mock_llm
-            mock_create.assert_called_once_with(mock_compact_default.model)
-
-    def test_get_embedding_model(self):
-        """Test getting embedding model"""
-        with (
-            patch("xagent.web.models.database.get_db") as mock_get_db,
-            patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
-        ):
-            # Setup mock database session
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Create mock embedding default
-            mock_embedding_default = MagicMock()
-            mock_embedding_default.user_id = 1
-            mock_embedding_default.config_type = "embedding"
-            mock_embedding_default.model = MagicMock()
-            mock_embedding_default.model.model_id = "embedding-model"
-
-            # Setup query result
-            mock_db.query.return_value.join.return_value.filter.return_value.first.return_value = mock_embedding_default
-
-            # Setup mock LLM creation
-            mock_llm = MagicMock()
-            mock_create.return_value = mock_llm
-
-            result = get_embedding_model(1)
-
-            assert result == mock_llm
-            mock_create.assert_called_once_with(mock_embedding_default.model)
+            mock_visible.assert_called_with(mock_db, None)
 
     def test_get_default_model_no_configuration(self):
         """Test getting default model when no configuration exists - should return None"""
@@ -277,11 +180,16 @@ class TestModelService:
             assert result is None
 
     def test_model_service_multiple_users(self):
-        """Test model service with multiple users"""
+        """Test model service with multiple users — both fall through to admin shared default."""
         with (
             patch("xagent.web.models.database.get_db") as mock_get_db,
             patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
+            patch(
+                "xagent.web.services.model_service._get_visible_user_ids"
+            ) as mock_visible,
         ):
+            mock_visible.return_value = [1]  # admin user ID is visible to everyone
+
             # Setup mock database session - create a new session for each call
             mock_db1 = MagicMock()
             mock_db2 = MagicMock()
@@ -315,3 +223,5 @@ class TestModelService:
 
             # Should have been called twice (once for each user)
             assert mock_create.call_count == 2
+            # _get_visible_user_ids should have been called for both users
+            assert mock_visible.call_count == 2

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -11,7 +11,11 @@ from xagent.web.models.model import Model
 from xagent.web.models.user import User
 from xagent.web.services.model_service import (
     _is_model_visible_to_user,
+    get_asr_models,
     get_default_model,
+    get_image_models,
+    get_tts_models,
+    get_vision_model,
 )
 
 # Test database setup - use in-memory database
@@ -292,7 +296,7 @@ class TestModelService:
             mock_visible.assert_called_with(mock_db, 42)
 
     def test_embedding_model_stale_default_falls_through_to_system(self, monkeypatch):
-        """Stale embedding default (not visible) must fall through to system fallback."""
+        """Stale embedding default (not visible) must fall through to visible system fallback."""
         from contextvars import copy_context
 
         from xagent.web.user_isolated_memory import current_user_id
@@ -307,8 +311,9 @@ class TestModelService:
         ctx.run(current_user_id.set, 1)
 
         def run_in_context():
-            # Build mock system fallback model
+            # Build mock visible system fallback model
             system_fallback = MagicMock()
+            system_fallback.id = 200
             system_fallback.model_id = "system-embedding-model"
 
             # user_default query returns a row
@@ -323,13 +328,242 @@ class TestModelService:
             # Mock query chain:
             # 1st call: UserDefaultModel.filter().first() → user_default
             # 2nd call: DBModel.filter().first() → stale_embedding (stale, visibility fails)
-            # 3rd call: DBModel.filter().first() → system_fallback
+            # 3rd call: DBModel.filter().all() → [system_fallback]
             mock_filter = mock_db.query.return_value.filter.return_value
             mock_filter.first.side_effect = [
                 mock_user_default,
                 stale_embedding,
-                system_fallback,
             ]
+            mock_filter.all.return_value = [system_fallback]
+
+            monkeypatch.setattr(
+                "xagent.web.services.model_service._is_model_visible_to_user",
+                lambda db, model_id, user_id: model_id != 99,
+            )
+            monkeypatch.setattr(
+                "xagent.web.dynamic_memory_store.get_db",
+                mock_get_db,
+            )
+
+            from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+
+            manager = DynamicMemoryStoreManager()
+            result = manager._get_embedding_model_from_db()
+
+            # Must fall through to system fallback, not stale model
+            assert result is system_fallback
+            assert result.model_id == "system-embedding-model"
+
+        ctx.run(run_in_context)
+
+    def test_get_vision_model_filters_by_visibility(self):
+        """get_vision_model returns the first visible vision-capable model."""
+        with (
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+            patch("xagent.web.services.llm_utils._create_llm_instance") as mock_create,
+        ):
+            mock_db = MagicMock()
+
+            # Two vision-capable models
+            visible_model = MagicMock()
+            visible_model.id = 1
+            invisible_model = MagicMock()
+            invisible_model.id = 2
+
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                visible_model,
+                invisible_model,
+            ]
+
+            # First model is visible, second is not
+            mock_visibility.side_effect = [True, False]
+            mock_llm = MagicMock()
+            mock_create.return_value = mock_llm
+
+            result = get_vision_model(mock_db, user_id=42)
+
+            assert result == mock_llm
+            mock_create.assert_called_once_with(visible_model)
+            assert mock_visibility.call_count == 1  # stops after first visible
+
+    def test_get_vision_model_returns_none_when_no_visible(self):
+        """get_vision_model returns None when no vision model is visible."""
+        with patch(
+            "xagent.web.services.model_service._is_model_visible_to_user"
+        ) as mock_visibility:
+            mock_db = MagicMock()
+
+            invisible_model = MagicMock()
+            invisible_model.id = 1
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                invisible_model
+            ]
+            mock_visibility.return_value = False
+
+            result = get_vision_model(mock_db, user_id=42)
+
+            assert result is None
+
+    def test_get_image_models_filters_by_visibility(self):
+        """get_image_models excludes image models not visible to the user."""
+        with (
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+            patch(
+                "xagent.web.services.model_service.DashScopeImageModel"
+            ) as mock_dashscope,
+        ):
+            mock_db = MagicMock()
+
+            visible_model = MagicMock()
+            visible_model.id = 1
+            visible_model.api_key = "key1"
+            visible_model.base_url = "http://url1"
+            visible_model.model_provider = "dashscope"
+            visible_model.model_name = "visible-model"
+            visible_model.model_id = "mid-1"
+            visible_model.abilities = ["generate"]
+
+            invisible_model = MagicMock()
+            invisible_model.id = 2
+            invisible_model.api_key = "key2"
+            invisible_model.base_url = "http://url2"
+            invisible_model.model_provider = "dashscope"
+            invisible_model.model_name = "invisible-model"
+            invisible_model.model_id = "mid-2"
+            invisible_model.abilities = ["generate"]
+
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                visible_model,
+                invisible_model,
+            ]
+
+            mock_visibility.side_effect = [True, False]
+            mock_instance = MagicMock()
+            mock_dashscope.return_value = mock_instance
+
+            result = get_image_models(mock_db, user_id=42)
+
+            assert len(result) == 1
+            assert "mid-1" in result
+            assert "mid-2" not in result
+
+    def test_get_asr_models_filters_by_visibility(self):
+        """get_asr_models excludes speech models not visible to the user."""
+        with (
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+            patch(
+                "xagent.core.model.asr.adapter.get_asr_model_instance"
+            ) as mock_asr_instance,
+        ):
+            mock_db = MagicMock()
+
+            visible_model = MagicMock()
+            visible_model.id = 1
+            visible_model.abilities = ["asr"]
+            visible_model.api_key = "key1"
+            visible_model.base_url = "http://url1"
+            visible_model.model_provider = "xinference"
+            visible_model.model_name = "visible-asr"
+
+            invisible_model = MagicMock()
+            invisible_model.id = 2
+            invisible_model.abilities = ["asr"]
+            invisible_model.api_key = "key2"
+            invisible_model.base_url = "http://url2"
+            invisible_model.model_provider = "xinference"
+            invisible_model.model_name = "invisible-asr"
+
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                visible_model,
+                invisible_model,
+            ]
+
+            mock_visibility.side_effect = [True, False]
+            mock_instance = MagicMock()
+            mock_asr_instance.return_value = mock_instance
+
+            result = get_asr_models(mock_db, user_id=42)
+
+            assert len(result) == 1
+            assert "visible-asr" in result
+            assert "invisible-asr" not in result
+
+    def test_get_tts_models_filters_by_visibility(self):
+        """get_tts_models excludes speech models not visible to the user."""
+        with (
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+            patch(
+                "xagent.core.model.tts.adapter.get_tts_model_instance"
+            ) as mock_tts_instance,
+        ):
+            mock_db = MagicMock()
+
+            visible_model = MagicMock()
+            visible_model.id = 1
+            visible_model.abilities = ["tts"]
+            visible_model.api_key = "key1"
+            visible_model.base_url = "http://url1"
+            visible_model.model_provider = "xinference"
+            visible_model.model_name = "visible-tts"
+
+            invisible_model = MagicMock()
+            invisible_model.id = 2
+            invisible_model.abilities = ["tts"]
+            invisible_model.api_key = "key2"
+            invisible_model.base_url = "http://url2"
+            invisible_model.model_provider = "xinference"
+            invisible_model.model_name = "invisible-tts"
+
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                visible_model,
+                invisible_model,
+            ]
+
+            mock_visibility.side_effect = [True, False]
+            mock_instance = MagicMock()
+            mock_tts_instance.return_value = mock_instance
+
+            result = get_tts_models(mock_db, user_id=42)
+
+            assert len(result) == 1
+            assert "visible-tts" in result
+            assert "invisible-tts" not in result
+
+    def test_embedding_fallback_skips_invisible_returns_none(self, monkeypatch):
+        """System fallback returns None when no visible embedding model exists."""
+        from contextvars import copy_context
+
+        from xagent.web.user_isolated_memory import current_user_id
+
+        mock_db = MagicMock()
+
+        def mock_get_db():
+            yield mock_db
+
+        ctx = copy_context()
+        ctx.run(current_user_id.set, 1)
+
+        def run_in_context():
+            # No user default
+            mock_filter = mock_db.query.return_value.filter.return_value
+            mock_filter.first.return_value = None
+
+            # Two active embeddings, neither visible
+            embedding1 = MagicMock()
+            embedding1.id = 1
+            embedding1.model_id = "private-embed-1"
+            embedding2 = MagicMock()
+            embedding2.id = 2
+            embedding2.model_id = "private-embed-2"
+            mock_filter.all.return_value = [embedding1, embedding2]
 
             monkeypatch.setattr(
                 "xagent.web.services.model_service._is_model_visible_to_user",
@@ -345,8 +579,6 @@ class TestModelService:
             manager = DynamicMemoryStoreManager()
             result = manager._get_embedding_model_from_db()
 
-            # Must fall through to system fallback, not stale model
-            assert result is system_fallback
-            assert result.model_id == "system-embedding-model"
+            assert result is None
 
         ctx.run(run_in_context)

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import sessionmaker
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model
 from xagent.web.models.user import User
-from xagent.web.services.model_service import get_default_model
+from xagent.web.services.model_service import (
+    _is_model_visible_to_user,
+    get_default_model,
+)
 
 # Test database setup - use in-memory database
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -226,6 +229,18 @@ class TestModelService:
             # _get_visible_user_ids should have been called for both users
             assert mock_visible.call_count == 2
 
+    def test_is_model_visible_to_user_fails_closed_on_exception(self):
+        """Visibility check must return False (deny) when the query raises."""
+        with patch(
+            "xagent.web.services.model_service._get_visible_user_ids"
+        ) as mock_visible:
+            mock_visible.side_effect = RuntimeError("DB connection lost")
+            mock_db = MagicMock()
+            # Ownership check (step 1) returns None so code reaches step 2
+            mock_db.query.return_value.filter.return_value.first.return_value = None
+            result = _is_model_visible_to_user(mock_db, 1, 1)
+            assert result is False
+
     def test_get_default_model_stale_default_skipped(self):
         """Stale user default (model no longer visible) falls through to admin fallback."""
         with (
@@ -275,3 +290,63 @@ class TestModelService:
             mock_create.assert_called_once()
             # _get_visible_user_ids was called for admin fallback
             mock_visible.assert_called_with(mock_db, 42)
+
+    def test_embedding_model_stale_default_falls_through_to_system(self, monkeypatch):
+        """Stale embedding default (not visible) must fall through to system fallback."""
+        from contextvars import copy_context
+
+        from xagent.web.user_isolated_memory import current_user_id
+
+        mock_db = MagicMock()
+
+        def mock_get_db():
+            yield mock_db
+
+        # Set up user context
+        ctx = copy_context()
+        ctx.run(current_user_id.set, 1)
+
+        def run_in_context():
+            # Build mock system fallback model
+            system_fallback = MagicMock()
+            system_fallback.model_id = "system-embedding-model"
+
+            # user_default query returns a row
+            mock_user_default = MagicMock()
+            mock_user_default.model_id = 99
+
+            # embedding_model query returns the stale model
+            stale_embedding = MagicMock()
+            stale_embedding.id = 99
+            stale_embedding.model_id = "stale-embedding-model"
+
+            # Mock query chain:
+            # 1st call: UserDefaultModel.filter().first() → user_default
+            # 2nd call: DBModel.filter().first() → stale_embedding (stale, visibility fails)
+            # 3rd call: DBModel.filter().first() → system_fallback
+            mock_filter = mock_db.query.return_value.filter.return_value
+            mock_filter.first.side_effect = [
+                mock_user_default,
+                stale_embedding,
+                system_fallback,
+            ]
+
+            monkeypatch.setattr(
+                "xagent.web.services.model_service._is_model_visible_to_user",
+                lambda db, model_id, user_id: False,
+            )
+            monkeypatch.setattr(
+                "xagent.web.dynamic_memory_store.get_db",
+                mock_get_db,
+            )
+
+            from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+
+            manager = DynamicMemoryStoreManager()
+            result = manager._get_embedding_model_from_db()
+
+            # Must fall through to system fallback, not stale model
+            assert result is system_fallback
+            assert result.model_id == "system-embedding-model"
+
+        ctx.run(run_in_context)

--- a/tests/web/test_user_model_relationships.py
+++ b/tests/web/test_user_model_relationships.py
@@ -115,44 +115,6 @@ class TestUserModelRelationships:
         assert len(regular_user.user_models) == 1
         assert regular_user.user_models[0].model_id == sample_model.id
 
-    def test_shared_model_access(
-        self, db_session, admin_user, regular_user, sample_model
-    ):
-        """Test shared model access control"""
-        # Admin creates shared model
-        admin_user_model = UserModel(
-            user_id=admin_user.id,
-            model_id=sample_model.id,
-            is_owner=True,
-            can_edit=True,
-            can_delete=True,
-            is_shared=True,  # Admin shares the model
-        )
-        db_session.add(admin_user_model)
-
-        # Regular user gets access to shared model
-        regular_user_model = UserModel(
-            user_id=regular_user.id,
-            model_id=sample_model.id,
-            is_owner=False,
-            can_edit=False,
-            can_delete=False,
-            is_shared=True,
-        )
-        db_session.add(regular_user_model)
-        db_session.commit()
-
-        # Verify permissions
-        assert admin_user_model.is_owner is True
-        assert admin_user_model.can_edit is True
-        assert admin_user_model.can_delete is True
-        assert admin_user_model.is_shared is True
-
-        assert regular_user_model.is_owner is False
-        assert regular_user_model.can_edit is False
-        assert regular_user_model.can_delete is False
-        assert regular_user_model.is_shared is True
-
     def test_user_default_model_configuration(
         self, db_session, regular_user, sample_model
     ):


### PR DESCRIPTION
## Summary

- Replace the "pre-create UserModel for all users on share" pattern with dynamic discovery via `_get_visible_user_ids()` hook, preparing xagent for multi-team SaaS scenarios where sharing scope is team-scoped rather than global
- Add two hookable functions (`_get_visible_user_ids` in model_service.py, `_can_user_share` in model.py) that default to current behavior (admin-only) but can be overridden by xagent-saas for team-scoped sharing
- Refactor model access across 6 source files into three modes: Mode A (default lookup via DBModel JOIN), Mode B (two-step access verification), Mode C (or_() filter for listing), and remove `_grant_shared_model_access` / `_inherit_admin_defaults` from auth registration
- Fix `GET /default/{model_provider}` route that was missing the Mode B two-step lookup, and add ownership-based permission checks with protection constraints (cannot delete/un-share model set as own default; cannot change category/abilities of shared model)
- Add 34 new tests covering hooks, all three modes, constraints, un-share cleanup, and registration behavior; 94 tests pass total

## Test plan

- [ ] Run `pytest tests/web/test_dynamic_model_sharing.py` — 34 new tests for hooks, modes, constraints, cleanup
- [ ] Run `pytest tests/web/test_model_service.py tests/web/test_llm_uitls.py tests/web/test_auth_api.py tests/web/test_chat_task_model_ids.py tests/web/test_model_api.py` — 60 existing tests updated/verified
- [ ] Verify admin shares a model → all users see it in model list (`is_owner=false, can_edit=false, can_delete=false`)
- [ ] Verify user sets shared model as default → `GET /default/general` returns it correctly
- [ ] Verify admin un-shares → non-owner defaults cleaned up, fallback to admin default works
- [ ] Verify non-owner cannot edit/delete shared model (403)
- [ ] Verify registration no longer creates UserModel or UserDefaultModel records
- [ ] Verify standalone mode (no hook installed) behaves identically to current production