### PR TITLE
fix(sandbox): replace exec_run with get_archive for file existence check

### DIFF
--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -315,8 +315,11 @@ def _extract_single_file_from_tar(
 
 def _archive_path_exists(container: Container, remote_path: str) -> bool:
     """Check file existence."""
-    result = container.exec_run(["test", "-e", remote_path], stdout=False, stderr=False)
-    return cast(int, result.exit_code) == 0
+    try:
+        container.get_archive(remote_path)
+        return True
+    except NotFound:
+        return False
 
 
 @dataclass


### PR DESCRIPTION
## Problem
`tests/sandbox/test_docker_sandbox.py::TestDockerSandbox::test_upload_download` intermittently fails with:
```
AssertionError: Should raise FileExistsError
```

## Root Cause
`_archive_path_exists` used `container.exec_run(["test", "-e", remote_path])` to check file existence before `upload_file` / `write_file`. Docker exec is a separate process path from the archive API used for file I/O, and can occasionally return stale or incorrect exit codes—especially in overlayfs-backed containers immediately after a `put_archive` write.

## Fix
Replace `exec_run` with `container.get_archive(remote_path)` inside a `try/except NotFound` block. This uses the same Docker API path as `read_file`, eliminating the flaky exec-based check.

## Test
Pre-commit passes on the modified file.