### PR TITLE
perf(RAG): optimize fd usage and add table cache for KB list operations

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -647,7 +647,8 @@ async def rebuild_collection_metadata() -> None:
     from . import collections
 
     # Get all existing collections (use is_admin=True to bypass user filtering)
-    result = await collections.list_collections(is_admin=True)
+    # force_realtime=True to avoid reading stale metadata cache.
+    result = await collections.list_collections(is_admin=True, force_realtime=True)
 
     if result.status != "success":
         logger.error(f"Failed to list collections: {result.message}")

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -506,7 +506,7 @@ async def _load_collection_ingestion_configs(
 
 
 async def list_collections(
-    user_id: Optional[int] = None, is_admin: bool = False
+    user_id: Optional[int] = None, is_admin: bool = False, force_realtime: bool = False
 ) -> ListCollectionsResult:
     """List all knowledge base collections along with aggregated statistics.
 
@@ -527,12 +527,7 @@ async def list_collections(
     warnings: List[str] = []
 
     try:
-        # Use storage abstraction for aggregation
         vector_store = get_vector_index_store()
-        stats: Dict[str, Dict[str, int]] = vector_store.aggregate_collection_stats(
-            user_id=user_id,
-            is_admin=is_admin,
-        )
 
         document_names: Dict[str, Set[str]] = defaultdict(set)
         owners: Dict[str, Set[int]] = defaultdict(set)
@@ -583,68 +578,141 @@ async def list_collections(
                 )
             )
 
-        def _collect_document_names() -> None:
-            for batch in vector_store.iter_batches(
-                table_name="documents",
-                columns=[
-                    "collection",
-                    "source_path",
-                    "doc_id",
-                    "file_id",
-                    "user_id",
-                ],
+        # Step 1: Scan documents table once to get collection list,
+        # document names, and owners (real-time, user-filtered).
+        for batch in vector_store.iter_batches(
+            table_name="documents",
+            columns=[
+                "collection",
+                "source_path",
+                "doc_id",
+                "file_id",
+                "user_id",
+            ],
+            user_id=user_id,
+            is_admin=is_admin,
+        ):
+            collection_idx = batch.schema.get_field_index("collection")
+            source_idx = batch.schema.get_field_index("source_path")
+            doc_id_idx = batch.schema.get_field_index("doc_id")
+            file_id_idx = batch.schema.get_field_index("file_id")
+            user_idx = batch.schema.get_field_index("user_id")
+            if collection_idx == -1:
+                continue
+            collection_array = batch.column(collection_idx)
+            source_array = (
+                batch.column(source_idx)
+                if source_idx != -1
+                else pa.array([None] * batch.num_rows)
+            )
+            doc_id_array = (
+                batch.column(doc_id_idx)
+                if doc_id_idx != -1
+                else pa.array([None] * batch.num_rows)
+            )
+            file_id_array = (
+                batch.column(file_id_idx)
+                if file_id_idx != -1
+                else pa.array([None] * batch.num_rows)
+            )
+            user_array = (
+                batch.column(user_idx)
+                if user_idx != -1
+                else pa.array([None] * batch.num_rows)
+            )
+            for idx in range(batch.num_rows):
+                collection_raw = collection_array[idx].as_py()
+                if not collection_raw:
+                    continue
+                collection_key = str(collection_raw)
+                _add_document_entry(
+                    collection_key,
+                    source_array[idx].as_py(),
+                    doc_id_array[idx].as_py(),
+                    file_id_array[idx].as_py(),
+                )
+                user_val = user_array[idx].as_py()
+                if user_val is not None:
+                    try:
+                        owners[collection_key].add(int(user_val))
+                    except (TypeError, ValueError):
+                        pass
+
+        collection_keys = sorted(document_names.keys())
+
+        # Step 2: Get stats. Try metadata cache first; fallback to realtime scan.
+        stats: Dict[str, Dict[str, int]] = {}
+        if not force_realtime:
+            try:
+                from ..storage.factory import get_metadata_store
+
+                metadata_store = get_metadata_store()
+                cached = await metadata_store.list_collections()
+                for info in cached:
+                    if info.name in collection_keys or is_admin:
+                        stats[info.name] = {
+                            "documents": info.documents,
+                            "parses": info.parses,
+                            "chunks": info.chunks,
+                            "embeddings": info.embeddings,
+                        }
+            except Exception as exc:
+                logger.debug(
+                    "Metadata cache unavailable, falling back to realtime: %s", exc
+                )
+
+        # Fallback to realtime aggregation for missing collections or cache failure
+        used_realtime = False
+        if (
+            force_realtime
+            or not stats
+            or any(key not in stats for key in collection_keys)
+        ):
+            used_realtime = True
+            realtime_stats = vector_store.aggregate_collection_stats(
                 user_id=user_id,
                 is_admin=is_admin,
-            ):
-                collection_idx = batch.schema.get_field_index("collection")
-                source_idx = batch.schema.get_field_index("source_path")
-                doc_id_idx = batch.schema.get_field_index("doc_id")
-                file_id_idx = batch.schema.get_field_index("file_id")
-                user_idx = batch.schema.get_field_index("user_id")
-                if collection_idx == -1:
-                    continue
-                collection_array = batch.column(collection_idx)
-                source_array = (
-                    batch.column(source_idx)
-                    if source_idx != -1
-                    else pa.array([None] * batch.num_rows)
-                )
-                doc_id_array = (
-                    batch.column(doc_id_idx)
-                    if doc_id_idx != -1
-                    else pa.array([None] * batch.num_rows)
-                )
-                file_id_array = (
-                    batch.column(file_id_idx)
-                    if file_id_idx != -1
-                    else pa.array([None] * batch.num_rows)
-                )
-                user_array = (
-                    batch.column(user_idx)
-                    if user_idx != -1
-                    else pa.array([None] * batch.num_rows)
-                )
-                for idx in range(batch.num_rows):
-                    collection_raw = collection_array[idx].as_py()
-                    if not collection_raw:
-                        continue
-                    collection_key = str(collection_raw)
-                    _add_document_entry(
-                        collection_key,
-                        source_array[idx].as_py(),
-                        doc_id_array[idx].as_py(),
-                        file_id_array[idx].as_py(),
+            )
+            for key in collection_keys:
+                if key not in stats:
+                    stats[key] = realtime_stats.get(
+                        key,
+                        {
+                            "documents": 0,
+                            "parses": 0,
+                            "chunks": 0,
+                            "embeddings": 0,
+                        },
                     )
-                    user_val = user_array[idx].as_py()
-                    if user_val is not None:
-                        try:
-                            owners[collection_key].add(int(user_val))
-                        except (TypeError, ValueError):
-                            pass
 
-        _collect_document_names()
+        # Async write stats back to metadata cache for next request
+        if used_realtime:
+            try:
+                from ..storage.factory import get_metadata_store
 
-        collection_keys = sorted(stats.keys() | document_names.keys())
+                metadata_store = get_metadata_store()
+                for collection in collection_keys:
+                    info = CollectionInfo(
+                        name=collection,
+                        documents=stats[collection]["documents"],
+                        parses=stats[collection]["parses"],
+                        chunks=stats[collection]["chunks"],
+                        embeddings=stats[collection]["embeddings"],
+                        processed_documents=stats[collection]["parses"],
+                        document_names=sorted(document_names.get(collection, set())),
+                        document_metadata=sorted(
+                            document_metadata.get(collection, []),
+                            key=lambda item: (
+                                item.filename,
+                                item.file_id or "",
+                                item.doc_id or "",
+                            ),
+                        ),
+                        owners=sorted(owners.get(collection, set())),
+                    )
+                    await metadata_store.save_collection(info)
+            except Exception as exc:
+                logger.debug("Failed to cache collection metadata: %s", exc)
 
         # Load configs for collections (admin sees cross-tenant configs)
         collection_configs: Dict[str, IngestionConfig] = {}

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -307,6 +307,14 @@ class MetadataStore(ABC):
         """Create or update collection metadata."""
 
     @abstractmethod
+    async def delete_collection(self, collection_name: str) -> None:
+        """Delete collection metadata entry."""
+
+    @abstractmethod
+    async def list_collections(self) -> Sequence[CollectionInfo]:
+        """List all collections from metadata table."""
+
+    @abstractmethod
     async def ensure_collection_metadata_table(self) -> None:
         """Ensure control-plane metadata table exists."""
 

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, cast
 
@@ -66,6 +66,33 @@ class LanceDBMetadataStore(MetadataStore):
             return CollectionInfo.from_storage(data)
         finally:
             _safe_close_table(table)
+
+    async def list_collections(self) -> list[CollectionInfo]:
+        """List all collections from metadata table."""
+        conn = await self._get_connection()
+        await self.ensure_collection_metadata_table()
+
+        try:
+            table = conn.open_table("collection_metadata")
+            result = table.search().to_arrow()
+            if len(result) == 0:
+                return []
+            return [CollectionInfo.from_storage(row) for row in result.to_pylist()]
+        except Exception as exc:
+            logger.debug("Failed to list collections from metadata: %s", exc)
+            return []
+
+    async def delete_collection(self, collection_name: str) -> None:
+        """Delete a collection entry from metadata table."""
+        conn = await self._get_connection()
+        await self.ensure_collection_metadata_table()
+
+        try:
+            table = conn.open_table("collection_metadata")
+            safe_name = escape_lancedb_string(collection_name)
+            table.delete(f"name = '{safe_name}'")
+        except Exception as exc:
+            logger.debug("Failed to delete collection metadata: %s", exc)
 
     async def save_collection(self, collection: CollectionInfo) -> None:
         from ..LanceDB.schema_manager import _safe_close_table
@@ -271,15 +298,37 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     Both sync and async methods return native Arrow format for efficient zero-copy operations.
     """
 
+    _TABLE_CACHE_MAXSIZE = 64
+
     def __init__(self) -> None:
         self._conn: Optional[DBConnection] = None
         self._async_conn: Optional[Any] = None  # AsyncConnection
         self._async_lock = asyncio.Lock()  # Protect async connection initialization
+        self._table_cache: OrderedDict[str, Any] = OrderedDict()
 
     def _get_connection(self) -> DBConnection:
         if self._conn is None:
             self._conn = get_connection_from_env()
         return self._conn
+
+    def _get_table(self, table_name: str) -> Any:
+        """Get cached table handle to avoid repeated open_table()."""
+        cached = self._table_cache.get(table_name)
+        if cached is not None:
+            self._table_cache.move_to_end(table_name)
+            return cached
+        table = self._get_connection().open_table(table_name)
+        self._table_cache[table_name] = table
+        if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
+            self._table_cache.popitem(last=False)
+        return table
+
+    def invalidate_table_cache(self, table_name: str | None = None) -> None:
+        """Clear table cache after drop/delete to avoid stale handles."""
+        if table_name is None:
+            self._table_cache.clear()
+        else:
+            self._table_cache.pop(table_name, None)
 
     async def _get_async_connection(self) -> Any:
         """Get or create async LanceDB connection with thread-safe initialization."""
@@ -551,7 +600,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         for table_name in ["documents", "parses", "chunks"]:
             table = None
             try:
-                table = conn.open_table(table_name)
+                table = self._get_table(table_name)
                 original_count = table.count_rows()
                 table.delete(f"collection = '{safe_collection}'")
                 deleted_count = original_count - table.count_rows()
@@ -568,7 +617,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 continue
             table = None
             try:
-                table = conn.open_table(table_name)
+                table = self._get_table(table_name)
                 original_count = table.count_rows()
                 table.delete(f"collection = '{safe_collection}'")
                 deleted_count = original_count - table.count_rows()
@@ -579,7 +628,52 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             finally:
                 _safe_close_table(table)
 
+        self.invalidate_table_cache()
         return deleted_counts
+
+    def _count_collections_fast(
+        self,
+        table_name: str,
+        stat_key: str,
+        stats: Dict[str, Dict[str, int]],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Count records per collection using PyArrow C++ value_counts.
+
+        Avoids iter_batches overhead and Python-level row iteration.
+        """
+        try:
+            table = self._get_table(table_name)
+            combined_filter = UserPermissions.get_user_filter(user_id, is_admin)
+
+            if combined_filter:
+                arrow_table = (
+                    table.search()
+                    .where(combined_filter)
+                    .select(["collection"])
+                    .limit(None)
+                    .to_arrow()
+                )
+            else:
+                arrow_table = (
+                    table.search().select(["collection"]).limit(None).to_arrow()
+                )
+
+            if arrow_table.num_rows == 0:
+                return
+
+            counts = arrow_table.column("collection").value_counts()
+            for collection, count in zip(counts.field(0), counts.field(1)):
+                c = str(collection.as_py())
+                if c:
+                    stats.setdefault(
+                        c,
+                        {"documents": 0, "parses": 0, "chunks": 0, "embeddings": 0},
+                    )
+                    stats[c][stat_key] = count.as_py()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to fast-count table '%s': %s", table_name, exc)
 
     def aggregate_collection_stats(
         self,
@@ -601,46 +695,18 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         ensure_parses_table(conn)
         ensure_chunks_table(conn)
 
-        def _count_table(table_name: str, stat_key: str) -> None:
-            """Count records per collection using batched streaming to avoid OOM."""
-            try:
-                # Use iter_batches for memory-efficient streaming with default batch_size=1000
-                for batch in self.iter_batches(
-                    table_name=table_name,
-                    columns=["collection"],  # Only need collection column
-                    user_id=user_id,
-                    is_admin=is_admin,
-                ):
-                    # Extract collection column from PyArrow RecordBatch
-                    collection_idx = batch.schema.get_field_index("collection")
-                    if collection_idx == -1:
-                        continue
-
-                    collection_array = batch.column(collection_idx)
-                    for i in range(batch.num_rows):
-                        collection = str(collection_array[i].as_py())
-                        if collection:
-                            if collection not in stats:
-                                stats[collection] = {
-                                    "documents": 0,
-                                    "parses": 0,
-                                    "chunks": 0,
-                                    "embeddings": 0,
-                                }
-                            stats[collection][stat_key] += 1
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("Failed to count table '%s': %s", table_name, exc)
-
         # Count documents, parses, and chunks
-        _count_table("documents", "documents")
-        _count_table("parses", "parses")
-        _count_table("chunks", "chunks")
+        self._count_collections_fast("documents", "documents", stats, user_id, is_admin)
+        self._count_collections_fast("parses", "parses", stats, user_id, is_admin)
+        self._count_collections_fast("chunks", "chunks", stats, user_id, is_admin)
 
         # Count embeddings from all embeddings_* tables
         for table_name in self.list_table_names():
             if not table_name.startswith("embeddings_"):
                 continue
-            _count_table(table_name, "embeddings")
+            self._count_collections_fast(
+                table_name, "embeddings", stats, user_id, is_admin
+            )
 
         return stats
 
@@ -1007,7 +1073,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         table = None
         try:
-            table = conn.open_table(table_name)
+            table = self._get_table(table_name)
         except Exception as exc:
             logger.debug("Unable to open table '%s': %s", table_name, exc)
             return
@@ -1112,10 +1178,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         from ..core.exceptions import DatabaseOperationError
         from ..LanceDB.schema_manager import _safe_close_table
 
-        conn = self._get_connection()
-
         try:
-            table = conn.open_table(table_name)
+            table = self._get_table(table_name)
         except Exception as exc:
             raise DatabaseOperationError(
                 f"Failed to open table '{table_name}': {exc}"

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -313,6 +313,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
     def _get_table(self, table_name: str) -> Any:
         """Get cached table handle to avoid repeated open_table()."""
+        from ..LanceDB.schema_manager import _safe_close_table
+
         cached = self._table_cache.get(table_name)
         if cached is not None:
             self._table_cache.move_to_end(table_name)
@@ -320,15 +322,25 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         table = self._get_connection().open_table(table_name)
         self._table_cache[table_name] = table
         if len(self._table_cache) > self._TABLE_CACHE_MAXSIZE:
-            self._table_cache.popitem(last=False)
+            _evicted_name, _evicted_table = self._table_cache.popitem(last=False)
+            _safe_close_table(_evicted_table)
         return table
 
     def invalidate_table_cache(self, table_name: str | None = None) -> None:
-        """Clear table cache after drop/delete to avoid stale handles."""
+        """Clear table cache after drop/delete to avoid stale handles.
+
+        Cached handles are closed before removal so underlying file
+        descriptors are released promptly.
+        """
+        from ..LanceDB.schema_manager import _safe_close_table
+
         if table_name is None:
+            for _name, _table in list(self._table_cache.items()):
+                _safe_close_table(_table)
             self._table_cache.clear()
         else:
-            self._table_cache.pop(table_name, None)
+            _table = self._table_cache.pop(table_name, None)
+            _safe_close_table(_table)
 
     async def _get_async_connection(self) -> Any:
         """Get or create async LanceDB connection with thread-safe initialization."""
@@ -581,7 +593,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
     ) -> Dict[str, int]:
         """Delete all data for a collection from vector-side tables."""
         from ..LanceDB.schema_manager import (
-            _safe_close_table,
             ensure_chunks_table,
             ensure_documents_table,
             ensure_parses_table,
@@ -596,9 +607,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         ensure_parses_table(conn)
         ensure_chunks_table(conn)
 
-        # Delete from core tables
+        # Delete from core tables (use cached handles; do NOT close them)
         for table_name in ["documents", "parses", "chunks"]:
-            table = None
             try:
                 table = self._get_table(table_name)
                 original_count = table.count_rows()
@@ -608,14 +618,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                     deleted_counts[table_name] = deleted_count
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Failed to delete from '%s': %s", table_name, exc)
-            finally:
-                _safe_close_table(table)
 
-        # Delete embeddings data
+        # Delete embeddings data (use cached handles; do NOT close them)
         for table_name in self.list_table_names():
             if not table_name.startswith("embeddings_"):
                 continue
-            table = None
             try:
                 table = self._get_table(table_name)
                 original_count = table.count_rows()
@@ -625,9 +632,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                     deleted_counts[table_name] = deleted_count
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Failed to delete from '%s': %s", table_name, exc)
-            finally:
-                _safe_close_table(table)
 
+        # Clear cache so subsequent reads see the deletion and fd is released
         self.invalidate_table_cache()
         return deleted_counts
 
@@ -1055,7 +1061,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         Yields backend-specific batch objects (e.g., PyArrow RecordBatch).
         """
         from ..LanceDB.schema_manager import (
-            _safe_close_table,
             ensure_chunks_table,
             ensure_documents_table,
             ensure_parses_table,
@@ -1106,62 +1111,59 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 return pa.RecordBatch.from_arrays([], [])
             return pa.RecordBatch.from_arrays(arrays, names)
 
+        # Preferred path: streaming batches directly from LanceDB
         try:
-            # Preferred path: streaming batches directly from LanceDB
+            if combined_filter:
+                for raw_batch in table.to_batches(
+                    filter=combined_filter, batch_size=batch_size
+                ):
+                    batch = raw_batch
+                    if columns is not None:
+                        batch = _select_columns(batch, columns)
+                    if batch.num_rows > 0:
+                        yield batch
+            else:
+                for raw_batch in table.to_batches(batch_size=batch_size):
+                    batch = raw_batch
+                    if columns is not None:
+                        batch = _select_columns(batch, columns)
+                    if batch.num_rows > 0:
+                        yield batch
+            return
+        except Exception as exc:
+            logger.debug(
+                "Batch streaming unavailable for table '%s': %s", table_name, exc
+            )
+
+        # Arrow fallback: materialize table as Arrow then iterate
+        try:
+            # Note: LanceDB's to_arrow() doesn't accept filter parameter
+            # Use search().where().to_arrow() instead
+            if combined_filter:
+                arrow_table = table.search().where(combined_filter).to_arrow()
+            else:
+                arrow_table = table.to_arrow()
+        except Exception as exc:
+            logger.debug(
+                "Unable to read table '%s' via to_arrow(): %s", table_name, exc
+            )
+            return
+
+        if columns is not None:
             try:
-                if combined_filter:
-                    for raw_batch in table.to_batches(
-                        filter=combined_filter, batch_size=batch_size
-                    ):
-                        batch = raw_batch
-                        if columns is not None:
-                            batch = _select_columns(batch, columns)
-                        if batch.num_rows > 0:
-                            yield batch
-                else:
-                    for raw_batch in table.to_batches(batch_size=batch_size):
-                        batch = raw_batch
-                        if columns is not None:
-                            batch = _select_columns(batch, columns)
-                        if batch.num_rows > 0:
-                            yield batch
-                return
+                arrow_table = arrow_table.select(columns)
             except Exception as exc:
                 logger.debug(
-                    "Batch streaming unavailable for table '%s': %s", table_name, exc
-                )
-
-            # Arrow fallback: materialize table as Arrow then iterate
-            try:
-                # Note: LanceDB's to_arrow() doesn't accept filter parameter
-                # Use search().where().to_arrow() instead
-                if combined_filter:
-                    arrow_table = table.search().where(combined_filter).to_arrow()
-                else:
-                    arrow_table = table.to_arrow()
-            except Exception as exc:
-                logger.debug(
-                    "Unable to read table '%s' via to_arrow(): %s", table_name, exc
+                    "Table '%s' missing expected columns %s: %s",
+                    table_name,
+                    columns,
+                    exc,
                 )
                 return
 
-            if columns is not None:
-                try:
-                    arrow_table = arrow_table.select(columns)
-                except Exception as exc:
-                    logger.debug(
-                        "Table '%s' missing expected columns %s: %s",
-                        table_name,
-                        columns,
-                        exc,
-                    )
-                    return
-
-            for batch in arrow_table.to_batches(max_chunksize=batch_size):
-                if batch.num_rows > 0:
-                    yield batch
-        finally:
-            _safe_close_table(table)
+        for batch in arrow_table.to_batches(max_chunksize=batch_size):
+            if batch.num_rows > 0:
+                yield batch
 
     def count_rows(
         self,
@@ -1176,7 +1178,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             DatabaseOperationError: If table cannot be opened or count fails.
         """
         from ..core.exceptions import DatabaseOperationError
-        from ..LanceDB.schema_manager import _safe_close_table
 
         try:
             table = self._get_table(table_name)
@@ -1206,8 +1207,6 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             raise DatabaseOperationError(
                 f"Failed to count rows in table '{table_name}': {exc}"
             ) from exc
-        finally:
-            _safe_close_table(table)
 
     def aggregate_document_counts(
         self,
@@ -1288,6 +1287,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             ).when_matched_update_all().when_not_matched_insert_all().execute(records)
         finally:
             _safe_close_table(table)
+        self.invalidate_table_cache("documents")
 
     def upsert_parses(self, records: List[Dict[str, Any]]) -> None:
         """Upsert parse records to LanceDB.
@@ -1312,6 +1312,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             ).when_matched_update_all().when_not_matched_insert_all().execute(records)
         finally:
             _safe_close_table(table)
+        self.invalidate_table_cache("parses")
 
     def upsert_chunks(self, records: List[Dict[str, Any]]) -> None:
         """Upsert chunk records to LanceDB.
@@ -1336,6 +1337,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             ).when_matched_update_all().when_not_matched_insert_all().execute(records)
         finally:
             _safe_close_table(table)
+        self.invalidate_table_cache("chunks")
 
     def upsert_embeddings(self, model_tag: str, records: List[Dict[str, Any]]) -> None:
         """Upsert embedding records to LanceDB with fallback pattern.
@@ -1409,6 +1411,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 raise
         finally:
             _safe_close_table(table)
+        self.invalidate_table_cache(table_name)
 
     # --- Sync search methods (Phase 1A Option C) ---
 

--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -331,6 +331,7 @@ class _SandboxControl:
     new_operations_paused: bool = False
     deleted: bool = False
     file_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    exec_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     cond: asyncio.Condition = field(default_factory=asyncio.Condition)
 
     async def acquire_operation(self) -> None:
@@ -473,9 +474,14 @@ class DockerSandbox(Sandbox):
         *args: str,
         env: Optional[dict[str, str]] = None,
     ) -> ExecResult:
-        """Execute a shell command inside the sandbox."""
+        """Execute a shell command inside the sandbox.
+
+        Exec calls are serialized per sandbox to avoid Docker SDK stream
+        corruption when concurrent execs read from the same container socket.
+        """
         async with self._control.operation():
-            return await self._exec_in_container(command, *args, env=env)
+            async with self._control.exec_lock:
+                return await self._exec_in_container(command, *args, env=env)
 
     async def run_code(
         self,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1746,12 +1746,21 @@ async def delete_collection_api(
     Raises:
         HTTPException: If physical deletion fails (prevents database deletion)
     """
-    return _perform_kb_collection_delete(
+    result = _perform_kb_collection_delete(
         collection_name,
         int(_user.id),
         bool(_user.is_admin),
         db,
     )
+    if result.status in ("success", "partial_success"):
+        try:
+            from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+            metadata_store = get_metadata_store()
+            await metadata_store.delete_collection(collection_name)
+        except Exception as exc:
+            logger.debug("Failed to delete collection metadata: %s", exc)
+    return result
 
 
 @kb_router.post(
@@ -1795,6 +1804,15 @@ async def batch_delete_collections_api(
                 result = _perform_kb_collection_delete(name, user_id, is_admin, db)
                 if result.status in ("success", "partial_success"):
                     deleted.append(name)
+                    try:
+                        from ...core.tools.core.RAG_tools.storage.factory import (
+                            get_metadata_store,
+                        )
+
+                        metadata_store = get_metadata_store()
+                        await metadata_store.delete_collection(name)
+                    except Exception as exc:
+                        logger.debug("Failed to delete collection metadata: %s", exc)
                 else:
                     failed.append(
                         BatchDeleteFailureItem(

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -476,11 +476,16 @@ async def startup_event() -> None:
             except Exception as e:
                 logger.warning("Collection metadata rebuild failed: %s", e)
 
-    asyncio.create_task(run_metadata_rebuild_background())
-    logger.info(
-        "Started background collection metadata rebuild task (interval=%sh)",
-        os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"),
-    )
+    if not os.getenv("PYTEST_CURRENT_TEST"):
+        app.state.metadata_rebuild_task = asyncio.create_task(
+            run_metadata_rebuild_background()
+        )
+        logger.info(
+            "Started background collection metadata rebuild task (interval=%sh)",
+            os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"),
+        )
+    else:
+        logger.info("Skipping background metadata rebuild (test environment)")
 
     # Warmup sandbox manager
     from .sandbox_manager import get_sandbox_manager
@@ -523,6 +528,14 @@ async def shutdown_event() -> None:
         with suppress(asyncio.CancelledError):
             await _migration_task
     _migration_task = None
+
+    # Cancel metadata rebuild background task
+    if hasattr(app.state, "metadata_rebuild_task"):
+        task = app.state.metadata_rebuild_task
+        if task and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
 
     # Shutdown Telegram channel if enabled
     try:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -458,6 +458,30 @@ async def startup_event() -> None:
                 e,
             )
 
+    # Periodic collection metadata rebuild to keep cache in sync
+    async def run_metadata_rebuild_background() -> None:
+        import os
+
+        interval_hours = float(os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"))
+        interval_seconds = interval_hours * 3600
+        while True:
+            try:
+                await asyncio.sleep(interval_seconds)
+                from xagent.core.tools.core.RAG_tools.management.collection_manager import (
+                    rebuild_collection_metadata,
+                )
+
+                await rebuild_collection_metadata()
+                logger.info("Periodic collection metadata rebuild completed")
+            except Exception as e:
+                logger.warning("Collection metadata rebuild failed: %s", e)
+
+    asyncio.create_task(run_metadata_rebuild_background())
+    logger.info(
+        "Started background collection metadata rebuild task (interval=%sh)",
+        os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"),
+    )
+
     # Warmup sandbox manager
     from .sandbox_manager import get_sandbox_manager
 

--- a/tests/core/tools/core/RAG_tools/LanceDB/test_schema_manager.py
+++ b/tests/core/tools/core/RAG_tools/LanceDB/test_schema_manager.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 
 from xagent.core.tools.core.RAG_tools.LanceDB.model_tag_utils import to_model_tag
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+    _table_exists,
     check_table_needs_migration,
     ensure_chunks_table,
     ensure_documents_table,
@@ -470,3 +471,64 @@ def test_backfill_user_id_uses_batched_updates(tmp_path: Path, monkeypatch) -> N
 
     # 120 rows, chunk size 50 => 3 batched updates expected for a single group.
     assert update_calls["count"] == 3
+
+
+# --- _table_exists Tests ---
+
+
+def test_table_exists_uses_list_table_names_not_open_table(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """_table_exists should use list_table_names() instead of open_table().
+
+    This verifies the fix that avoids opening file descriptors on every
+    table existence check. list_table_names() is a metadata-only operation.
+    """
+    from unittest.mock import patch
+
+    db_dir = tmp_path / "db"
+    monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+    conn = get_vector_store_raw_connection()
+
+    # Create a real table
+    ensure_documents_table(conn)
+
+    # Verify _table_exists returns True for existing table
+    assert _table_exists(conn, "documents") is True
+
+    # Verify _table_exists returns False for non-existent table
+    assert _table_exists(conn, "nonexistent") is False
+
+    # Verify open_table is NOT called during _table_exists
+    with patch.object(conn, "open_table", wraps=conn.open_table) as spy:
+        _table_exists(conn, "documents")
+        spy.assert_not_called()
+
+
+def test_table_exists_with_embeddings_table(tmp_path: Path, monkeypatch) -> None:
+    """_table_exists should work correctly with embeddings tables."""
+    db_dir = tmp_path / "db"
+    monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+
+    conn = get_vector_store_raw_connection()
+    model_tag = to_model_tag("test-model-v1")
+    table_name = f"embeddings_{model_tag}"
+
+    # Table doesn't exist yet
+    assert _table_exists(conn, table_name) is False
+
+    # Create the table
+    ensure_embeddings_table(conn, model_tag, vector_dim=128)
+
+    # Now it exists
+    assert _table_exists(conn, table_name) is True
+
+
+def test_table_exists_empty_database(tmp_path: Path, monkeypatch) -> None:
+    """_table_exists should return False for all tables on empty database."""
+    db_dir = tmp_path / "db"
+    monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+    conn = get_vector_store_raw_connection()
+
+    for name in ["documents", "parses", "chunks", "embeddings_any"]:
+        assert _table_exists(conn, name) is False

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -437,3 +437,141 @@ def test_e2e_register_and_list_documents_with_legacy_empty_string_file_id(
     assert list_result.status == "success"
     listed_ids = {doc.doc_id for doc in list_result.documents}
     assert reg_result["doc_id"] in listed_ids
+
+
+# --- list_collections force_realtime Tests ---
+
+
+@pytest.mark.asyncio
+async def test_list_collections_force_realtime_bypasses_cache(
+    temp_lancedb_dir: str,
+) -> None:
+    """force_realtime=True should skip metadata cache and use realtime aggregation."""
+    now = datetime.now(timezone.utc)
+    collection = "realtime_test"
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-1",
+                "source_path": "/path/doc.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-1",
+                "uploaded_at": now,
+                "title": "Doc",
+                "language": "en",
+            }
+        ]
+    )
+
+    result = await list_collections(user_id=None, is_admin=True, force_realtime=True)
+
+    assert result.status == "success"
+    assert result.total_count == 1
+    assert result.collections[0].name == collection
+    assert result.collections[0].documents == 1
+
+
+@pytest.mark.asyncio
+async def test_list_collections_cache_filled_by_subsequent_call(
+    temp_lancedb_dir: str,
+) -> None:
+    """After a force_realtime call fills the cache, subsequent call should use it."""
+    now = datetime.now(timezone.utc)
+    collection = "cache_fill_test"
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-1",
+                "source_path": "/path/doc.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-1",
+                "uploaded_at": now,
+                "title": "Doc",
+                "language": "en",
+            }
+        ]
+    )
+
+    # First call with force_realtime fills the metadata cache
+    result1 = await list_collections(user_id=None, is_admin=True, force_realtime=True)
+    assert result1.status == "success"
+    assert result1.total_count == 1
+
+    # Second normal call should hit the cache
+    result2 = await list_collections(user_id=None, is_admin=True)
+    assert result2.status == "success"
+    assert result2.total_count == 1
+    assert result2.collections[0].name == collection
+    assert result2.collections[0].documents == 1
+
+
+@pytest.mark.asyncio
+async def test_list_collections_cache_miss_uses_realtime(
+    temp_lancedb_dir: str,
+) -> None:
+    """When metadata cache misses (no cached data), list_collections falls back to realtime aggregation."""
+    collection = "miss_test"
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-1",
+                "source_path": "/path/doc.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-1",
+                "uploaded_at": datetime.now(timezone.utc),
+                "title": "Doc",
+                "language": "en",
+            }
+        ]
+    )
+
+    # No prior cache population — should fallback to realtime successfully
+    result = await list_collections(user_id=None, is_admin=True)
+    assert result.status == "success"
+    assert result.total_count >= 1
+
+    names = [c.name for c in result.collections]
+    assert collection in names
+
+
+# --- delete_collection metadata cleanup Tests ---
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_clears_metadata_cache(temp_lancedb_dir: str) -> None:
+    """After deleting a collection, metadata cache should not return it."""
+    now = datetime.now(timezone.utc)
+    collection = "to_delete_test"
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-1",
+                "source_path": "/path/doc.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-1",
+                "uploaded_at": now,
+                "title": "Doc",
+                "language": "en",
+            }
+        ]
+    )
+
+    # Populate metadata cache first
+    await list_collections(user_id=None, is_admin=True, force_realtime=True)
+
+    # Delete the collection
+    del_result = delete_collection(collection, user_id=None, is_admin=True)
+    assert del_result.status == "success"
+
+    # Metadata cache should no longer include the deleted collection
+    result = await list_collections(user_id=None, is_admin=True)
+    remaining = [c.name for c in result.collections]
+    assert collection not in remaining

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -1852,3 +1852,417 @@ async def test_get_vector_dimension_async_delegates_to_sync(
     dimension = await store.get_vector_dimension_async("embeddings_async_test")
 
     assert dimension == 768
+
+
+# --- _get_table cache Tests ---
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_get_table_cache_miss_calls_open_table(mock_get_connection: Mock) -> None:
+    """_get_table should call open_table on cache miss."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    table = store._get_table("documents")
+
+    assert table is mock_table
+    mock_conn.open_table.assert_called_once_with("documents")
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_get_table_cache_hit_skips_open_table(mock_get_connection: Mock) -> None:
+    """_get_table should not call open_table on cache hit."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    first = store._get_table("documents")
+    second = store._get_table("documents")
+
+    assert first is second is mock_table
+    mock_conn.open_table.assert_called_once()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_get_table_cache_multiple_tables(mock_get_connection: Mock) -> None:
+    """_get_table should cache multiple different tables independently."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_docs = Mock()
+    mock_parses = Mock()
+    mock_conn.open_table.side_effect = [mock_docs, mock_parses]
+
+    store = LanceDBVectorIndexStore()
+    docs = store._get_table("documents")
+    parses = store._get_table("parses")
+
+    assert docs is mock_docs
+    assert parses is mock_parses
+    assert mock_conn.open_table.call_count == 2
+    assert store._get_table("documents") is mock_docs  # still cached
+    assert mock_conn.open_table.call_count == 2  # no additional call
+
+
+# --- invalidate_table_cache Tests ---
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_invalidate_cache_all_clears_everything(
+    mock_get_connection: Mock,
+) -> None:
+    """invalidate_table_cache() should clear the entire cache when no arg given."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.side_effect = [Mock(), Mock(), Mock()]
+
+    store = LanceDBVectorIndexStore()
+    store._get_table("documents")
+    store._get_table("parses")
+    assert len(store._table_cache) == 2
+
+    store.invalidate_table_cache()
+    assert len(store._table_cache) == 0
+
+    # Subsequent access re-opens
+    store._get_table("documents")
+    assert mock_conn.open_table.call_count == 3  # 2 initial + 1 re-open
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_invalidate_cache_by_name_only_removes_one(
+    mock_get_connection: Mock,
+) -> None:
+    """invalidate_table_cache('name') should only remove that entry."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.side_effect = [Mock(), Mock(), Mock()]
+
+    store = LanceDBVectorIndexStore()
+    store._get_table("documents")
+    store._get_table("parses")
+    assert len(store._table_cache) == 2
+
+    store.invalidate_table_cache("documents")
+    assert len(store._table_cache) == 1
+    assert "documents" not in store._table_cache
+    assert "parses" in store._table_cache
+
+    # Re-access evicted table
+    store._get_table("documents")
+    assert mock_conn.open_table.call_count == 3
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_invalidate_cache_unknown_name_noop(mock_get_connection: Mock) -> None:
+    """invalidate_table_cache('unknown') should not raise or affect cache."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = Mock()
+
+    store = LanceDBVectorIndexStore()
+    store._get_table("documents")
+    assert len(store._table_cache) == 1
+
+    store.invalidate_table_cache("nonexistent")
+    assert len(store._table_cache) == 1
+
+
+# --- LRU Eviction Tests ---
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_lru_eviction_at_maxsize(mock_get_connection: Mock) -> None:
+    """Cache should evict oldest entry when exceeding _TABLE_CACHE_MAXSIZE (64)."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = Mock()
+
+    store = LanceDBVectorIndexStore()
+    maxsize = store._TABLE_CACHE_MAXSIZE
+
+    # Fill cache to exactly maxsize
+    for i in range(maxsize):
+        store._get_table(f"table_{i}")
+    assert len(store._table_cache) == maxsize
+
+    # Insert one more — oldest should be evicted
+    store._get_table("overflow_table")
+    assert len(store._table_cache) == maxsize
+    assert "table_0" not in store._table_cache
+    assert "overflow_table" in store._table_cache
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_lru_access_refreshes_position(mock_get_connection: Mock) -> None:
+    """Accessing a cached table should move it to the end (most-recently-used)."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_conn.open_table.return_value = Mock()
+
+    store = LanceDBVectorIndexStore()
+    maxsize = store._TABLE_CACHE_MAXSIZE
+
+    # Fill cache, with table_0 first
+    for i in range(maxsize):
+        store._get_table(f"table_{i}")
+
+    # Access table_0 — should move to MRU end
+    store._get_table("table_0")
+
+    # Insert one more — table_1 (now the oldest) should be evicted, not table_0
+    store._get_table("overflow_table")
+    assert len(store._table_cache) == maxsize
+    assert "table_0" in store._table_cache  # still alive (was refreshed)
+    assert "table_1" not in store._table_cache  # became oldest and evicted
+
+
+# --- _count_collections_fast / aggregate_collection_stats Tests ---
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_aggregate_collection_stats_basic(mock_get_connection: Mock) -> None:
+    """aggregate_collection_stats should return per-collection counts."""
+    import pyarrow as pa
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    # Build Arrow tables for documents, parses, chunks
+    docs_tbl = pa.table({"collection": ["col_a", "col_a", "col_b"]})
+    parses_tbl = pa.table({"collection": ["col_a"]})
+    chunks_tbl = pa.table({"collection": ["col_a", "col_a", "col_b", "col_b"]})
+
+    # Mock open_table to return different Arrow tables based on table name
+    def mock_search(table_name):
+        mock_result = Mock()
+        # Set up search().where().select().limit().to_arrow() chain
+        mock_chain = Mock()
+        if table_name == "documents":
+            mock_chain.to_arrow.return_value = docs_tbl
+        elif table_name == "parses":
+            mock_chain.to_arrow.return_value = parses_tbl
+        elif table_name == "chunks":
+            mock_chain.to_arrow.return_value = chunks_tbl
+        else:
+            mock_chain.to_arrow.return_value = pa.table({"collection": []})
+        mock_result.search.return_value = mock_chain
+        return mock_result
+
+    mock_table = Mock()
+    mock_table.search = Mock()
+    mock_conn.open_table.return_value = mock_table
+
+    # Patch the search().where().select().limit().to_arrow() chain for each table
+    def build_chains(table_name):
+        if table_name == "documents":
+            tbl = docs_tbl
+        elif table_name == "parses":
+            tbl = parses_tbl
+        elif table_name == "chunks":
+            tbl = chunks_tbl
+        else:
+            tbl = pa.table({"collection": []})
+        chain = Mock()
+        chain.select.return_value = chain
+        chain.where.return_value = chain
+        chain.limit.return_value = chain
+        chain.to_arrow.return_value = tbl
+        return chain
+
+    chains = {}
+    for name in ["documents", "parses", "chunks"]:
+        chains[name] = build_chains(name)
+
+    # The table is cached; the _get_table returns the mock_table,
+    # and the code calls mock_table.search() to start the chain
+    mock_table.search.side_effect = (
+        lambda: chains.get(
+            # Figure out which table name from the cache — use a side effect approach
+            # Since _get_table caches by name, we need a smarter mock
+        )
+    )
+
+    # Update: simplify — just use MagicMock with per-table chains
+    mock_conn.open_table.side_effect = lambda name: _make_mock_for(name)
+
+    def _make_mock_for(name):
+        t = Mock()
+        t.search.return_value = chains[name]
+        return t
+
+    store = LanceDBVectorIndexStore()
+    # Prime cache with mock tables
+    for name in ["documents", "parses", "chunks"]:
+        store._table_cache[name] = _make_mock_for(name)
+
+    # Mock list_table_names to return no extra embeddings tables
+    store.list_table_names = Mock(return_value=[])
+
+    stats = store.aggregate_collection_stats(user_id=None, is_admin=True)
+
+    assert "col_a" in stats
+    assert "col_b" in stats
+    assert stats["col_a"]["documents"] == 2
+    assert stats["col_a"]["parses"] == 1
+    assert stats["col_a"]["chunks"] == 2
+    assert stats["col_b"]["documents"] == 1
+    assert stats["col_b"]["parses"] == 0
+    assert stats["col_b"]["chunks"] == 2
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_count_collections_fast_with_user_filter(mock_get_connection: Mock) -> None:
+    """_count_collections_fast should apply user_id filter when not admin."""
+    import pyarrow as pa
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    tbl = pa.table(
+        {
+            "collection": ["col_a", "col_a", "col_b"],
+            "user_id": [1, 2, 3],
+        }
+    )
+
+    chain = Mock()
+    chain.select.return_value = chain
+    chain.where.return_value = chain
+    chain.limit.return_value = chain
+    chain.to_arrow.return_value = tbl
+
+    mock_table = Mock()
+    mock_table.search.return_value = chain
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    store._table_cache["documents"] = mock_table
+
+    stats: dict = {}
+    store._count_collections_fast(
+        "documents", "documents", stats, user_id=1, is_admin=False
+    )
+
+    # Verify that the where filter was applied
+    chain.where.assert_called_once()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_count_collections_fast_admin_no_filter(mock_get_connection: Mock) -> None:
+    """_count_collections_fast should not apply user filter when is_admin=True."""
+    import pyarrow as pa
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    tbl = pa.table(
+        {
+            "collection": ["col_a", "col_a", "col_b"],
+            "user_id": [1, 2, 3],
+        }
+    )
+
+    chain = Mock()
+    chain.select.return_value = chain
+    chain.where.return_value = chain
+    chain.limit.return_value = chain
+    chain.to_arrow.return_value = tbl
+
+    mock_table = Mock()
+    mock_table.search.return_value = chain
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    store._table_cache["documents"] = mock_table
+
+    stats: dict = {}
+    store._count_collections_fast(
+        "documents", "documents", stats, user_id=None, is_admin=True
+    )
+
+    # For admin, the where filter should NOT be called (get_user_filter returns "")
+    chain.where.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_count_collections_fast_empty_table(mock_get_connection: Mock) -> None:
+    """_count_collections_fast should handle empty Arrow table gracefully."""
+    import pyarrow as pa
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    empty_tbl = pa.table({"collection": pa.array([], type=pa.string())})
+
+    chain = Mock()
+    chain.select.return_value = chain
+    chain.where.return_value = chain
+    chain.limit.return_value = chain
+    chain.to_arrow.return_value = empty_tbl
+
+    mock_table = Mock()
+    mock_table.search.return_value = chain
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    store._table_cache["documents"] = mock_table
+
+    stats: dict = {}
+    store._count_collections_fast(
+        "documents", "documents", stats, user_id=None, is_admin=True
+    )
+
+    # Empty table should produce no stats entries
+    assert stats == {}
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_count_collections_fast_error_graceful(mock_get_connection: Mock) -> None:
+    """_count_collections_fast should not raise on error, just log debug."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    mock_table = Mock()
+    mock_table.search.side_effect = Exception("LanceDB read error")
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    store._table_cache["documents"] = mock_table
+
+    stats: dict = {}
+    # Should not raise
+    store._count_collections_fast(
+        "documents", "documents", stats, user_id=None, is_admin=True
+    )
+    assert stats == {}

--- a/tests/web/api/test_kb_exception_decorator.py
+++ b/tests/web/api/test_kb_exception_decorator.py
@@ -94,3 +94,154 @@ async def test_handle_kb_exceptions_maps_unknown_errors_to_500() -> None:
     assert exc_info.value.status_code == 500
     assert isinstance(exc_info.value.detail, str)
     assert exc_info.value.detail.startswith("服务器内部错误:")
+
+
+# --- delete_collection_api metadata cleanup Tests ---
+
+_FACTORY_PATH = "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_api_cleans_metadata_cache() -> None:
+    """After successful deletion, metadata_store.delete_collection() should be called."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from xagent.web.api.kb import delete_collection_api
+    from xagent.web.models.user import User
+
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 1
+    mock_user.is_admin = True
+    mock_db = MagicMock()
+
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock()
+
+    _fake_delete_result = MagicMock()
+    _fake_delete_result.status = "success"
+    _fake_delete_result.affected_documents = 1
+    _fake_delete_result.deleted_counts = {"documents": 1}
+
+    with (
+        patch("xagent.web.api.kb.delete_collection_physical_dir"),
+        patch(
+            "xagent.web.api.kb.get_vector_index_store",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_collection",
+            return_value=_fake_delete_result,
+        ),
+        patch(
+            "xagent.web.api.kb.delete_collection_uploaded_files",
+            return_value=None,
+        ),
+        patch(
+            _FACTORY_PATH,
+            return_value=mock_metadata_store,
+        ),
+    ):
+        await delete_collection_api(
+            collection_name="test_collection_abc",
+            _user=mock_user,
+            db=mock_db,
+        )
+
+    mock_metadata_store.delete_collection.assert_awaited_once_with(
+        "test_collection_abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_api_metadata_error_not_fatal() -> None:
+    """If metadata_store.delete_collection() fails, the API should still return success."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from xagent.web.api.kb import delete_collection_api
+    from xagent.web.models.user import User
+
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 1
+    mock_user.is_admin = True
+    mock_db = MagicMock()
+
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(
+        side_effect=RuntimeError("metadata store unreachable")
+    )
+
+    _fake_delete_result = MagicMock()
+    _fake_delete_result.status = "success"
+    _fake_delete_result.affected_documents = 1
+    _fake_delete_result.deleted_counts = {"documents": 1}
+
+    with (
+        patch("xagent.web.api.kb.delete_collection_physical_dir"),
+        patch(
+            "xagent.web.api.kb.get_vector_index_store",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_collection",
+            return_value=_fake_delete_result,
+        ),
+        patch(
+            "xagent.web.api.kb.delete_collection_uploaded_files",
+            return_value=None,
+        ),
+        patch(
+            _FACTORY_PATH,
+            return_value=mock_metadata_store,
+        ),
+    ):
+        result = await delete_collection_api(
+            collection_name="test_collection",
+            _user=mock_user,
+            db=mock_db,
+        )
+
+    # Should not raise — error is logged but swallowed
+    assert result.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_api_failed_no_metadata_cleanup() -> None:
+    """If deletion fails (not success/partial_success), metadata should NOT be cleaned."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from xagent.web.api.kb import delete_collection_api
+    from xagent.web.models.user import User
+
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 1
+    mock_user.is_admin = True
+    mock_db = MagicMock()
+
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock()
+
+    class _FakeErrorResult:
+        status = "error"
+        affected_documents = 0
+        deleted_counts = {}
+        physical_cleanup = {}
+        uploaded_file_cleanup = None
+        uploads_cleanup = {}
+
+    with (
+        patch(
+            "xagent.web.api.kb._perform_kb_collection_delete",
+            return_value=_FakeErrorResult(),
+        ),
+        patch(
+            _FACTORY_PATH,
+            return_value=mock_metadata_store,
+        ),
+    ):
+        await delete_collection_api(
+            collection_name="test_collection",
+            _user=mock_user,
+            db=mock_db,
+        )
+
+    mock_metadata_store.delete_collection.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Replace `open_table()` with `list_table_names()` in `_table_exists` to avoid opening file descriptors on every table existence check
- Add LRU table cache (max 64 entries) to `LanceDBVectorIndexStore` to avoid repeated `open_table()` calls
- Use PyArrow C++ `value_counts` for collection stats aggregation instead of per-row Python iteration
- Merge double documents table scan in `list_collections` into single pass
- Add metadata cache (`collection_metadata` table) with periodic background rebuild
- Fix critical bug: replace non-existent `table.to_batches()` with `table.search().to_arrow()` in `_count_collections_fast`
- Add 23 tests covering all new code paths

## Test plan

- [x] All 99 tests pass across 4 modified test files
- [x] Pre-commit: ruff check, ruff format, mypy, isort, codespell pass
- [x] `aggregate_collection_stats` returns correct per-collection counts (user-filtered and admin)
- [x] Table cache hit/miss, LRU eviction, and invalidation behave correctly
- [x] Metadata cache read/write path and `force_realtime` bypass work
- [x] KB collection deletion cleans up metadata cache
- [x] `_table_exists` uses `list_table_names` and never calls `open_table`