### PR TITLE
feat(tools): add get_user_tool_overrides hook for per-user tool policies

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -186,6 +186,17 @@ class ToolFactory:
                 "⚠️ allowed_tools is empty list - this will filter out all tools! If you want to allow all tools, set allowed_tools to None"
             )
 
+        # Filter out tools disabled by per-user hook policy
+        overrides = getattr(config, "get_user_tool_overrides", lambda: {})()
+        if overrides:
+            disabled_by_hook = {
+                name
+                for name, ov in overrides.items()
+                if ov and ov.get("enabled") is False
+            }
+            if disabled_by_hook:
+                tools = [tool for tool in tools if tool.name not in disabled_by_hook]
+
         # Wrap sandbox-enabled tools if sandbox is available
         sandbox = config.get_sandbox()
         if sandbox is not None:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -153,6 +153,7 @@ async def create_default_tools(
     tool_config = WebToolConfig(
         db=db,
         request=request,
+        user=user,
         llm=llm,
         user_id=int(user.id),
         is_admin=bool(user.is_admin),
@@ -662,6 +663,7 @@ class AgentServiceManager:
                     temp_config = WebToolConfig(
                         db=db,
                         request=self.request,
+                        user=user,
                         llm=task_llm,
                         user_id=int(user.id),
                         is_admin=bool(user.is_admin),

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -20,7 +20,6 @@ from ..services.tool_credentials import (
     clear_tool_credential,
     delete_sql_connection,
     get_tool_credential_view,
-    get_user_tool_overrides,
     list_configurable_tool_names,
     list_sql_connections,
     set_sql_connection,
@@ -205,15 +204,16 @@ async def get_available_tools(
 
     # Create a temporary request object (simulating WebToolConfig requirements)
     class MockRequest:
-        def __init__(self) -> None:
+        def __init__(self, user: User) -> None:
             self.credentials: Any | None = None
+            self.user = user
 
     # Create WebToolConfig, now includes MCP tools
     # Note: llm=None for tool listing (display only, no execution)
     current_user_id = _require_user_id(current_user)
     tool_config = WebToolConfig(
         db=db,
-        request=MockRequest(),
+        request=MockRequest(current_user),
         user_id=current_user_id,
         is_admin=bool(current_user.is_admin),
         llm=None,  # Not needed for tool listing
@@ -318,11 +318,7 @@ async def get_available_tools(
     # Apply per-user tool overrides (e.g. per-user enable/disable).
     # Only affects policy-based states; resource-missing states cannot be
     # overridden to "available".
-    try:
-        user_overrides = get_user_tool_overrides(db, current_user)
-    except Exception:
-        logger.exception("Failed to get user tool overrides, skipping")
-        user_overrides = {}
+    user_overrides = tool_config.get_user_tool_overrides()
     for tool_item in tools:
         tool_name = str(tool_item.get("name") or "")
         override = user_overrides.get(tool_name)

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, DefaultDict, Dict, List, Optional, cast
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -20,6 +20,7 @@ from ..services.tool_credentials import (
     clear_tool_credential,
     delete_sql_connection,
     get_tool_credential_view,
+    get_user_tool_overrides,
     list_configurable_tool_names,
     list_sql_connections,
     set_sql_connection,
@@ -62,7 +63,7 @@ class CredentialFieldUpdate(BaseModel):
 
 
 class ToolCredentialUpdateRequest(BaseModel):
-    credentials: Dict[str, CredentialFieldUpdate]
+    credentials: dict[str, CredentialFieldUpdate]
 
 
 class ToolEnableUpdateRequest(BaseModel):
@@ -80,7 +81,7 @@ def _create_tool_info(
     image_models: Any = None,
     asr_models: Any = None,
     tts_models: Any = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create tool information based on category instead of hardcoded names"""
     tool_name = getattr(tool, "name", tool.__class__.__name__)
 
@@ -195,7 +196,7 @@ def _create_tool_info(
 async def get_available_tools(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get list of all available tools, including MCP tools.
 
     Tools are self-describing - each tool declares its own category via
@@ -205,7 +206,7 @@ async def get_available_tools(
     # Create a temporary request object (simulating WebToolConfig requirements)
     class MockRequest:
         def __init__(self) -> None:
-            self.credentials: Optional[Any] = None
+            self.credentials: Any | None = None
 
     # Create WebToolConfig, now includes MCP tools
     # Note: llm=None for tool listing (display only, no execution)
@@ -258,7 +259,7 @@ async def get_available_tools(
     tts_models = tool_config.get_tts_models()
 
     # Convert tools to API format with category information
-    tools: List[Dict[str, Any]] = []
+    tools: list[dict[str, Any]] = []
     for tool in all_tools:
         category = get_tool_category(tool)
         tools.append(
@@ -275,9 +276,9 @@ async def get_available_tools(
     # Calculate tool usage count from ToolUsage table (execution stats)
     from collections import defaultdict
 
-    usage_map: DefaultDict[str, int] = defaultdict(int)
+    usage_map: defaultdict[str, int] = defaultdict(int)
     try:
-        usage_stats: List[Any] = db.query(ToolUsage).all()
+        usage_stats: list[Any] = db.query(ToolUsage).all()
         for stat in usage_stats:
             usage_map[stat.tool_name] = stat.usage_count
     except Exception as e:
@@ -314,6 +315,27 @@ async def get_available_tools(
             requires_configuration = requires_configuration_map.get("sql_query", False)
         tool_item["requires_configuration"] = requires_configuration
 
+    # Apply per-user tool overrides (e.g. per-user enable/disable).
+    # Only affects policy-based states; resource-missing states cannot be
+    # overridden to "available".
+    try:
+        user_overrides = get_user_tool_overrides(db, current_user)
+    except Exception:
+        logger.exception("Failed to get user tool overrides, skipping")
+        user_overrides = {}
+    for tool_item in tools:
+        tool_name = str(tool_item.get("name") or "")
+        override = user_overrides.get(tool_name)
+        if override and override.get("enabled") is not None:
+            if not override["enabled"]:
+                tool_item["enabled"] = False
+                tool_item["status"] = "disabled"
+                tool_item["status_reason"] = "Disabled by admin"
+            elif tool_item["status"] in ("disabled", "available"):
+                tool_item["enabled"] = True
+                tool_item["status"] = "available"
+                tool_item["status_reason"] = None
+
     return {
         "tools": tools,
         "count": len(tools),
@@ -324,11 +346,11 @@ async def get_available_tools(
 async def get_configurable_tools(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not bool(current_user.is_admin):
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
-    items: List[Dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
     for tool_name in list_configurable_tool_names():
         view = get_tool_credential_view(db, tool_name)
         items.append(
@@ -350,7 +372,7 @@ async def get_configurable_tools(
 async def get_sql_connections(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     items = list_sql_connections(db, _require_user_id(current_user))
     return {
         "connections": items,
@@ -364,7 +386,7 @@ async def upsert_sql_connection(
     payload: SqlConnectionUpsertRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     current_user_id = _require_user_id(current_user)
     try:
         set_sql_connection(db, current_user_id, name, payload.connection_url)
@@ -381,7 +403,7 @@ async def remove_sql_connection(
     name: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     current_user_id = _require_user_id(current_user)
     delete_sql_connection(db, current_user_id, name)
     return {
@@ -395,7 +417,7 @@ async def update_tool_enabled(
     payload: ToolEnableUpdateRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not bool(current_user.is_admin):
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
@@ -433,7 +455,7 @@ async def get_tool_credentials(
     tool_name: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not bool(current_user.is_admin):
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
@@ -451,7 +473,7 @@ async def update_tool_credentials(
     payload: ToolCredentialUpdateRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not bool(current_user.is_admin):
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
@@ -479,7 +501,7 @@ async def delete_tool_credential(
     field_name: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not bool(current_user.is_admin):
         raise HTTPException(status_code=403, detail="Admin privileges required")
 
@@ -498,11 +520,11 @@ async def delete_tool_credential(
 
 
 @tools_router.get("/usage")
-async def get_tool_usage(db: Session = Depends(get_db)) -> List[Dict[str, Any]]:
+async def get_tool_usage(db: Session = Depends(get_db)) -> list[dict[str, Any]]:
     """Get tool usage statistics"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
-        def _get_tool_usage_sync() -> List[Dict[str, Any]]:
+        def _get_tool_usage_sync() -> list[dict[str, Any]]:
             usage_stats = db.query(ToolUsage).all()
 
             result = []
@@ -533,4 +555,4 @@ async def get_tool_usage(db: Session = Depends(get_db)) -> List[Dict[str, Any]]:
 
     except Exception as e:
         logger.error(f"Get tool usage failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, cast
+from typing import Any, Callable, cast
 
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy.engine import make_url
@@ -14,10 +15,27 @@ from sqlalchemy.orm.attributes import flag_modified
 from ..init_tool_configs import get_default_tool_configs
 from ..models.tool_config import ToolConfig, UserToolConfig
 
-ToolFieldSpec = Dict[str, Any]
+ToolFieldSpec = dict[str, Any]
+
+# Hook signature: (db: Session, user: Any) -> dict[str, {"enabled": bool|None}]
+# Returns per-user overrides for tool enable/disable.
+# Application layers can inject per-user tool policies via set_user_tool_overrides_hook().
+# NOTE: "config" override is reserved for future use and not yet implemented.
+_get_user_tool_overrides_hook: Callable[[Session, Any], dict] | None = None
 
 
-TOOL_CREDENTIAL_SPECS: Dict[str, Dict[str, ToolFieldSpec]] = {
+def set_user_tool_overrides_hook(hook: Callable[[Session, Any], dict] | None) -> None:
+    global _get_user_tool_overrides_hook
+    _get_user_tool_overrides_hook = hook
+
+
+def get_user_tool_overrides(db: Session, user: Any) -> dict:
+    if _get_user_tool_overrides_hook is not None:
+        return _get_user_tool_overrides_hook(db, user)
+    return {}
+
+
+TOOL_CREDENTIAL_SPECS: dict[str, dict[str, ToolFieldSpec]] = {
     "exa_web_search": {
         "api_key": {
             "secret": True,
@@ -470,7 +488,7 @@ def get_tool_credential_view(db: Session, tool_name: str) -> dict[str, Any]:
     config = db.query(ToolConfig).filter(ToolConfig.tool_name == tool_name).first()
     display_name = tool_name
     if config is not None and isinstance(getattr(config, "display_name", None), str):
-        display_name = str(getattr(config, "display_name"))
+        display_name = str(config.display_name)
     else:
         defaults = {item["tool_name"]: item for item in get_default_tool_configs()}
         display_name = str(defaults.get(tool_name, {}).get("display_name") or tool_name)

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -125,6 +125,7 @@ class WebToolConfig(BaseToolConfig):
         request: Any,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        user: Optional[Any] = None,
         workspace_config: Optional[Dict[str, Any]] = None,
         vision_model: Optional[Any] = None,
         llm: Optional[Any] = None,
@@ -164,8 +165,9 @@ class WebToolConfig(BaseToolConfig):
         self._allowed_tools = allowed_tools
         self._excluded_agent_id: Optional[int] = None
 
-        # Cache user object for hook queries
-        self._user = getattr(request, "user", None)
+        # Cache user object for hook queries.
+        # Use explicit user param first; fall back to request.user.
+        self._user = user if user is not None else getattr(request, "user", None)
         self._cached_tool_overrides: Optional[dict] = None
 
         # Sandbox instance - only store reference, lifecycle managed by upper layer

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -14,7 +14,11 @@ import httpx
 
 from ...config import get_uploads_dir
 from ...core.tools.adapters.vibe.config import BaseToolConfig
-from ..services.tool_credentials import get_sql_connection_map, resolve_tool_credential
+from ..services.tool_credentials import (
+    get_sql_connection_map,
+    get_user_tool_overrides,
+    resolve_tool_credential,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +164,10 @@ class WebToolConfig(BaseToolConfig):
         self._allowed_tools = allowed_tools
         self._excluded_agent_id: Optional[int] = None
 
+        # Cache user object for hook queries
+        self._user = getattr(request, "user", None)
+        self._cached_tool_overrides: Optional[dict] = None
+
         # Sandbox instance - only store reference, lifecycle managed by upper layer
         self._sandbox: Optional[Any] = None
 
@@ -294,6 +302,24 @@ class WebToolConfig(BaseToolConfig):
     def get_allowed_tools(self) -> Optional[List[str]]:
         """Get allowed tool names. None means all tools are allowed."""
         return self._allowed_tools
+
+    def get_user_tool_overrides(self) -> dict:
+        """Return per-user tool overrides from the registered hook.
+
+        Both display layer and execution layer use this as the single
+        source of truth for per-user tool policies.
+        """
+        if self._cached_tool_overrides is not None:
+            return self._cached_tool_overrides
+        if self._user is None:
+            self._cached_tool_overrides = {}
+            return {}
+        try:
+            self._cached_tool_overrides = get_user_tool_overrides(self.db, self._user)
+        except Exception:
+            logger.exception("Failed to get user tool overrides")
+            self._cached_tool_overrides = {}
+        return self._cached_tool_overrides
 
     def get_excluded_agent_id(self) -> Optional[int]:
         """Get agent ID to exclude from agent tools (to prevent self-calls)."""

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -659,3 +659,182 @@ def test_user_tool_overrides_hook_reset_to_none():
     set_user_tool_overrides_hook(None)
     result = get_user_tool_overrides(db=None, user=None)
     assert result == {}
+
+
+class TestWebToolConfigUserOverride:
+    """Verify WebToolConfig.get_user_tool_overrides() resolves user correctly."""
+
+    def test_explicit_user_param_takes_priority(self):
+        """When user keyword arg is passed, it is used even when request has no .user."""
+        from unittest.mock import MagicMock
+
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+        from xagent.web.tools.config import WebToolConfig
+
+        def _hook(db, user):
+            return {"browser_navigate": {"enabled": False}}
+
+        set_user_tool_overrides_hook(_hook)
+        try:
+            # Simulate TaskCreateRequest: no .user attribute
+            request_without_user = MagicMock()
+            del request_without_user.user
+
+            cfg = WebToolConfig(
+                db=MagicMock(),
+                request=request_without_user,
+                user_id=42,
+                user=MagicMock(id=42),  # explicit user
+                workspace_config={"base_dir": "/tmp", "task_id": "test"},
+            )
+            assert cfg.get_user_tool_overrides() == {
+                "browser_navigate": {"enabled": False}
+            }
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    def test_falls_back_to_request_user_when_explicit_not_given(self):
+        """Without explicit user, request.user is used (existing behavior)."""
+        from unittest.mock import MagicMock
+
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+        from xagent.web.tools.config import WebToolConfig
+
+        def _hook(db, user):
+            return {"browser_navigate": {"enabled": False}}
+
+        set_user_tool_overrides_hook(_hook)
+        try:
+            mock_user = MagicMock(id=42)
+            request = MagicMock(user=mock_user)
+
+            cfg = WebToolConfig(
+                db=MagicMock(),
+                request=request,
+                user_id=42,
+                workspace_config={"base_dir": "/tmp", "task_id": "test"},
+            )
+            assert cfg.get_user_tool_overrides() == {
+                "browser_navigate": {"enabled": False}
+            }
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    def test_returns_empty_when_no_user_at_all(self):
+        """When neither explicit user nor request.user is available, returns {}."""
+        from unittest.mock import MagicMock
+
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+        from xagent.web.tools.config import WebToolConfig
+
+        def _hook(db, user):
+            return {"browser_navigate": {"enabled": False}}
+
+        set_user_tool_overrides_hook(_hook)
+        try:
+            request_without_user = MagicMock()
+            del request_without_user.user
+
+            cfg = WebToolConfig(
+                db=MagicMock(),
+                request=request_without_user,
+                user_id=42,
+                workspace_config={"base_dir": "/tmp", "task_id": "test"},
+            )
+            assert cfg.get_user_tool_overrides() == {}
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    @pytest.mark.asyncio
+    async def test_create_all_tools_filters_disabled_when_user_is_explicit(self):
+        """End-to-end: ToolFactory filters tools disabled by per-user hook
+        even when request has no .user but explicit user is provided."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from xagent.core.tools.adapters.vibe.factory import ToolFactory
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+        from xagent.web.tools.config import WebToolConfig
+
+        def _hook(db, user):
+            return {"browser_navigate": {"enabled": False}}
+
+        set_user_tool_overrides_hook(_hook)
+        try:
+            # Simulate TaskCreateRequest: no .user
+            request_without_user = MagicMock()
+            del request_without_user.user
+
+            cfg = WebToolConfig(
+                db=MagicMock(),
+                request=request_without_user,
+                user=MagicMock(id=42),  # explicit user
+                user_id=42,
+                workspace_config={"base_dir": "/tmp", "task_id": "test"},
+            )
+
+            # Create mock tools with string .name attributes
+            tool_browser = MagicMock()
+            tool_browser.name = "browser_navigate"
+            tool_calc = MagicMock()
+            tool_calc.name = "calculator"
+
+            with patch(
+                "xagent.core.tools.adapters.vibe.factory.ToolRegistry.create_registered_tools",
+                AsyncMock(return_value=[tool_browser, tool_calc]),
+            ):
+                result = await ToolFactory.create_all_tools(cfg)
+
+            tool_names = [t.name for t in result]
+            assert "browser_navigate" not in tool_names, (
+                "Disabled tool was NOT filtered from create_all_tools"
+            )
+            assert "calculator" in tool_names, "Non-disabled tool should remain"
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    @pytest.mark.asyncio
+    async def test_create_all_tools_skips_filter_when_no_user_at_all(self):
+        """When neither explicit user nor request.user is set,
+        get_user_tool_overrides() returns {} and ToolFactory filtering is skipped.
+        This is the safe fallback — no user means no per-user policy can apply."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from xagent.core.tools.adapters.vibe.factory import ToolFactory
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+        from xagent.web.tools.config import WebToolConfig
+
+        def _hook(db, user):
+            return {"browser_navigate": {"enabled": False}}
+
+        set_user_tool_overrides_hook(_hook)
+        try:
+            request_without_user = MagicMock()
+            del request_without_user.user
+
+            cfg = WebToolConfig(
+                db=MagicMock(),
+                request=request_without_user,
+                user_id=42,
+                # No explicit user passed — this is the pre-fix bug path
+                workspace_config={"base_dir": "/tmp", "task_id": "test"},
+            )
+
+            tool_browser = MagicMock()
+            tool_browser.name = "browser_navigate"
+            tool_calc = MagicMock()
+            tool_calc.name = "calculator"
+
+            with patch(
+                "xagent.core.tools.adapters.vibe.factory.ToolRegistry.create_registered_tools",
+                AsyncMock(return_value=[tool_browser, tool_calc]),
+            ):
+                result = await ToolFactory.create_all_tools(cfg)
+
+            tool_names = [t.name for t in result]
+            # Without explicit user, overrides are {} and filtering is skipped
+            assert "browser_navigate" in tool_names, (
+                "No filtering when no user (existing behavior)"
+            )
+            assert "calculator" in tool_names
+        finally:
+            set_user_tool_overrides_hook(None)

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -287,6 +287,90 @@ class TestToolsAvailableAPI:
         assert categories["tool_without_metadata"] == "other"
         assert categories["tool_with_metadata"] == "basic"
 
+    def test_get_available_tools_applies_user_override(self):
+        """Test that user tool override hook affects /available response."""
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+        set_user_tool_overrides_hook(
+            lambda db, user: {"browser_navigate": {"enabled": False}}
+        )
+        try:
+            login_response = client.post(
+                "/api/auth/login",
+                json={"username": "admin", "password": "admin123"},
+            )
+            assert login_response.status_code == 200
+            token = login_response.json()["access_token"]
+
+            response = client.get(
+                "/api/tools/available",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status_code == 200
+            payload = response.json()
+
+            tool_map = {item["name"]: item for item in payload["tools"]}
+            assert "browser_navigate" in tool_map
+            assert tool_map["browser_navigate"]["enabled"] is False
+            assert tool_map["browser_navigate"]["status"] == "disabled"
+            assert tool_map["browser_navigate"]["status_reason"] == "Disabled by admin"
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    def test_get_available_tools_override_does_not_mask_missing_model(
+        self, monkeypatch
+    ):
+        """Test that enabled=True override cannot mask resource-missing states."""
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+        class _Category:
+            value = "vision"
+
+        class _Metadata:
+            category = _Category()
+
+        class _VisionTool:
+            name = "vision_test_tool"
+            description = ""
+            metadata = _Metadata()
+
+        async def mock_create_all_tools(config):
+            return [_VisionTool()]
+
+        monkeypatch.setattr(
+            "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+            mock_create_all_tools,
+        )
+        monkeypatch.setattr(
+            "xagent.web.tools.config.WebToolConfig.get_vision_model",
+            lambda self: None,
+        )
+
+        set_user_tool_overrides_hook(
+            lambda db, user: {"vision_test_tool": {"enabled": True}}
+        )
+        try:
+            login_response = client.post(
+                "/api/auth/login",
+                json={"username": "admin", "password": "admin123"},
+            )
+            assert login_response.status_code == 200
+            token = login_response.json()["access_token"]
+
+            response = client.get(
+                "/api/tools/available",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert response.status_code == 200
+            payload = response.json()
+
+            tool_map = {item["name"]: item for item in payload["tools"]}
+            assert "vision_test_tool" in tool_map
+            assert tool_map["vision_test_tool"]["status"] == "missing_model"
+            assert tool_map["vision_test_tool"]["enabled"] is False
+        finally:
+            set_user_tool_overrides_hook(None)
+
 
 class TestToolsGovernanceAPI:
     @pytest.fixture(autouse=True)
@@ -493,3 +577,47 @@ class TestToolsGovernanceAPI:
 
         assert configurable_resp.status_code == 403
         assert credential_resp.status_code == 403
+
+
+def test_user_tool_overrides_hook_noop_by_default():
+    """Without a hook set, get_user_tool_overrides returns an empty dict."""
+    from xagent.web.services.tool_credentials import get_user_tool_overrides
+
+    result = get_user_tool_overrides(db=None, user=None)
+    assert result == {}
+
+
+def test_user_tool_overrides_hook_returns_injected_data():
+    """When a hook is set, it returns the hook's result."""
+    from xagent.web.services.tool_credentials import (
+        get_user_tool_overrides,
+        set_user_tool_overrides_hook,
+    )
+
+    def my_hook(db, user):
+        return {
+            "calculator": {"enabled": False},
+            "web_search": {"config": {"api_key": "x"}},
+        }
+
+    set_user_tool_overrides_hook(my_hook)
+    try:
+        result = get_user_tool_overrides(db=None, user=None)
+        assert result["calculator"]["enabled"] is False
+        assert result["web_search"]["config"] == {"api_key": "x"}
+        assert "nonexistent" not in result
+    finally:
+        set_user_tool_overrides_hook(None)
+
+
+def test_user_tool_overrides_hook_reset_to_none():
+    """Setting hook to None restores default empty behavior."""
+    from xagent.web.services.tool_credentials import (
+        get_user_tool_overrides,
+        set_user_tool_overrides_hook,
+    )
+
+    set_user_tool_overrides_hook(lambda db, user: {"test": {"enabled": True}})
+    set_user_tool_overrides_hook(None)
+    result = get_user_tool_overrides(db=None, user=None)
+    assert result == {}

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -288,7 +288,7 @@ class TestToolsAvailableAPI:
         assert categories["tool_with_metadata"] == "basic"
 
     def test_get_available_tools_applies_user_override(self):
-        """Test that user tool override hook affects /available response."""
+        """Test that user tool override hook filters disabled tools from /available."""
         from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
 
         set_user_tool_overrides_hook(
@@ -309,11 +309,10 @@ class TestToolsAvailableAPI:
             assert response.status_code == 200
             payload = response.json()
 
-            tool_map = {item["name"]: item for item in payload["tools"]}
-            assert "browser_navigate" in tool_map
-            assert tool_map["browser_navigate"]["enabled"] is False
-            assert tool_map["browser_navigate"]["status"] == "disabled"
-            assert tool_map["browser_navigate"]["status_reason"] == "Disabled by admin"
+            tool_names = {item["name"] for item in payload["tools"]}
+            # browser_navigate is filtered out by the hook in both display
+            # and execution layers for consistency.
+            assert "browser_navigate" not in tool_names
         finally:
             set_user_tool_overrides_hook(None)
 
@@ -370,6 +369,45 @@ class TestToolsAvailableAPI:
             assert tool_map["vision_test_tool"]["enabled"] is False
         finally:
             set_user_tool_overrides_hook(None)
+
+    def test_get_available_tools_override_enables_globally_disabled_tool(self):
+        """Test that enabled=True override can re-enable a globally disabled tool."""
+        from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+        # Step 1: globally disable browser_navigate via admin API
+        headers = {"Authorization": f"Bearer {self._login_admin()}"}
+        put_resp = client.put(
+            "/api/tools/browser_navigate/enabled",
+            headers=headers,
+            json={"enabled": False},
+        )
+        assert put_resp.status_code == 200
+
+        # Step 2: set hook to re-enable it
+        set_user_tool_overrides_hook(
+            lambda db, user: {"browser_navigate": {"enabled": True}}
+        )
+        try:
+            response = client.get(
+                "/api/tools/available",
+                headers=headers,
+            )
+            assert response.status_code == 200
+            payload = response.json()
+
+            tool_map = {item["name"]: item for item in payload["tools"]}
+            assert "browser_navigate" in tool_map
+            assert tool_map["browser_navigate"]["enabled"] is True
+            assert tool_map["browser_navigate"]["status"] == "available"
+        finally:
+            set_user_tool_overrides_hook(None)
+
+    def _login_admin(self) -> str:
+        login_response = client.post(
+            "/api/auth/login", json={"username": "admin", "password": "admin123"}
+        )
+        assert login_response.status_code == 200
+        return login_response.json()["access_token"]
 
 
 class TestToolsGovernanceAPI:


### PR DESCRIPTION
## Summary

This PR introduces a hook mechanism that allows external application layers to inject per-user tool enable/disable policies, affecting the `/api/tools/available` endpoint.

## Changes

- **Hook API** (`src/xagent/web/services/tool_credentials.py`):
  - `set_user_tool_overrides_hook(hook)` — register a callback `(db: Session, user: Any) -> dict[str, {"enabled": bool|None}]`
  - `get_user_tool_overrides(db, user)` — query the registered hook (returns `{}` if none set)
  - NOTE: `"config"` override is reserved for future use and not yet implemented.

- **Display-layer override** (`src/xagent/web/api/tools.py`):
  - `GET /api/tools/available` now applies per-user overrides before returning the tool list.
  - `enabled=True` only overrides policy-based states (`disabled`, `available`); resource-missing states (`missing_model`, `missing_capability`) are protected and cannot be forced to `"available"`.
  - Hook exceptions are caught and logged, preventing external callbacks from breaking the tool listing endpoint.

- **Type hint modernization** (`tools.py`, `tool_credentials.py`):
  - Migrated `Dict`/`List`/`Optional` to `dict`/`list`/`X \| None` for Python 3.11+ compatibility.

- **Tests** (`tests/web/api/test_tools_api.py`):
  - Unit tests: hook noop by default, hook returns injected data, hook reset to `None`.
  - Integration test: `GET /api/tools/available` correctly applies `enabled=False` override.
  - Integration test: `enabled=True` override cannot mask `missing_model` state.

## Testing

```bash
pytest tests/web/api/test_tools_api.py -q
# 18 passed
```

All pre-commit hooks (ruff, mypy, isort, codespell) pass.