### PR TITLE
fix: normalize react tool action types

### DIFF
--- a/src/xagent/core/agent/pattern/react.py
+++ b/src/xagent/core/agent/pattern/react.py
@@ -1577,18 +1577,18 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
             # Try to parse as JSON first
             try:
                 parsed = json.loads(response.strip())
-                if isinstance(parsed, dict):
-                    parsed = self._normalize_first_phase_action_dict(parsed)
-                    action = self._try_parse_action_from_dict(parsed, response.strip())
-                    if action:
-                        await log_llm_completion(
-                            parsed, action.type == "tool_call", action.reasoning
-                        )
-                        return action
-                    self._raise_invalid_first_phase_action(
-                        parsed,
-                        f"Failed to parse ReAct action from JSON type: {parsed.get('type')}",
+                parsed = self._select_first_phase_action_dict(parsed, response)
+                parsed = self._normalize_first_phase_action_dict(parsed)
+                action = self._try_parse_action_from_dict(parsed, response.strip())
+                if action:
+                    await log_llm_completion(
+                        parsed, action.type == "tool_call", action.reasoning
                     )
+                    return action
+                self._raise_invalid_first_phase_action(
+                    parsed,
+                    f"Failed to parse ReAct action from JSON type: {parsed.get('type')}",
+                )
             except json.JSONDecodeError:
                 # JSON parsing failed - might be multiple JSON objects
                 # Try to use json_repair to handle multiple JSON objects
@@ -1600,44 +1600,10 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                     else:
                         action_data = repaired
 
-                    # Handle when json_repair returns a list (multiple JSON objects)
-                    # gpt-5.4 in streaming mode often returns multiple JSONs even with response_format='json_object'
-                    # We take the first one as the intended action
-                    if isinstance(action_data, list):
-                        # Log all items for debugging
-                        for i, item in enumerate(action_data):
-                            if isinstance(item, dict):
-                                logger.warning(
-                                    f"First call: JSON object {i}: type={item.get('type', 'UNKNOWN')}, keys={list(item.keys())}"
-                                )
-                            else:
-                                logger.warning(
-                                    f"First call: JSON object {i}: {type(item).__name__}"
-                                )
-
-                        # Take the first JSON object
-                        if action_data and isinstance(action_data[0], dict):
-                            action_data = action_data[0]
-                            logger.info(
-                                f"First call: Selected first JSON object from multiple (type: {action_data.get('type', 'UNKNOWN')})"
-                            )
-                        else:
-                            # First item is not a dict, raise error
-                            raise PatternExecutionError(
-                                pattern_name="ReAct",
-                                message=f"LLM returned multiple JSON objects but the first one is not a valid dict (count: {len(action_data)})",
-                                context={
-                                    "json_object_count": len(action_data),
-                                    "first_object_type": type(action_data[0]).__name__
-                                    if action_data
-                                    else "none",
-                                    "response_preview": response[:500]
-                                    if response
-                                    else None,
-                                },
-                            )
-
-                    if isinstance(action_data, dict):
+                    if isinstance(action_data, (dict, list)):
+                        action_data = self._select_first_phase_action_dict(
+                            action_data, response
+                        )
                         action_data = self._normalize_first_phase_action_dict(
                             action_data
                         )
@@ -1860,6 +1826,38 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                 message=f"Failed to invoke tool via native calling: {str(e)}",
                 context={"error": str(e), "chat_kwargs": chat_kwargs},
             )
+
+    def _select_first_phase_action_dict(self, action_data: Any, response: str) -> dict:
+        """Return the first action dict from first-phase parsed JSON."""
+        if isinstance(action_data, dict):
+            return action_data
+
+        if isinstance(action_data, list):
+            for i, item in enumerate(action_data):
+                if isinstance(item, dict):
+                    logger.info(
+                        f"First call: Selected JSON object {i} from list (type: {item.get('type', 'UNKNOWN')})"
+                    )
+                    return item
+
+                logger.warning(
+                    f"First call: Skipping non-dict JSON list item {i}: {type(item).__name__}"
+                )
+
+            raise PatternExecutionError(
+                pattern_name="ReAct",
+                message="No ReAct action object found in JSON array",
+                context={
+                    "json_object_count": len(action_data),
+                    "response_preview": response[:500] if response else None,
+                },
+            )
+
+        raise PatternExecutionError(
+            pattern_name="ReAct",
+            message=f"Expected ReAct action JSON object, got {type(action_data).__name__}",
+            context={"response_preview": response[:500] if response else None},
+        )
 
     def _normalize_first_phase_action_dict(self, data: dict) -> dict:
         """Normalize first-phase action JSON before parsing it as an Action.

--- a/src/xagent/core/agent/pattern/react.py
+++ b/src/xagent/core/agent/pattern/react.py
@@ -1862,26 +1862,43 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
     def _normalize_first_phase_action_dict(self, data: dict) -> dict:
         """Normalize first-phase action JSON before parsing it as an Action.
 
-        The first ReAct LLM call should use ``type="tool_call"`` for any tool
-        intent. Some models put the concrete tool name in ``type`` instead.
-        Treat registered tool names as tool-call decisions; reject other
-        unknown types so they are not leaked as final answers.
+        The first ReAct LLM call should normally return ``type="tool_call"``
+        or ``type="final_answer"``. This also accepts the frontend
+        ``type="chat"`` payload emitted after ``ask_user_question`` and wraps
+        it as a final answer so the caller can extract ``chat_response``.
+
+        Some models put a concrete tool name, such as ``ask_user_question``,
+        in ``type`` instead of using ``tool_call``. Any other string type is
+        treated as that kind of tool-call decision; non-string or missing
+        action types are rejected so they trigger the ReAct retry path.
         """
         action_type = data.get("type")
         if action_type in ("tool_call", "final_answer"):
             return data
 
-        registered_tools = set(self.tool_registry.list_tools())
-        if isinstance(action_type, str) and action_type in registered_tools:
+        if action_type == "chat":
+            chat_response = data.get("chat")
+            if isinstance(chat_response, dict):
+                return {
+                    "type": "final_answer",
+                    "reasoning": "LLM provided a structured chat response",
+                    "answer": json.dumps(data, ensure_ascii=False),
+                    "success": True,
+                    "error": None,
+                }
+
+            self._raise_invalid_first_phase_action(
+                data,
+                "Invalid ReAct chat response: expected a 'chat' object",
+            )
+
+        if isinstance(action_type, str):
             normalized = dict(data)
             normalized["type"] = "tool_call"
-            normalized["intended_tool_name"] = action_type
             return normalized
 
         self._raise_invalid_first_phase_action(
-            data,
-            f"Invalid ReAct action type: {action_type}",
-            available_tools=registered_tools,
+            data, f"Invalid ReAct action type: {action_type}"
         )
 
         # fix mypy false positive
@@ -1891,18 +1908,10 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
         self,
         data: dict,
         message: str,
-        available_tools: Optional[set[str]] = None,
     ) -> None:
         """Raise when parsed first-phase JSON is not a usable ReAct action."""
-        tool_names = (
-            sorted(available_tools)
-            if available_tools is not None
-            else sorted(self.tool_registry.list_tools())
-        )
         raise PatternExecutionError(
-            pattern_name="ReAct",
-            message=message,
-            context={"response": data, "available_tools": tool_names},
+            pattern_name="ReAct", message=message, context={"response": data}
         )
 
     def _try_parse_action_from_dict(

--- a/src/xagent/core/agent/pattern/react.py
+++ b/src/xagent/core/agent/pattern/react.py
@@ -1578,16 +1578,17 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
             try:
                 parsed = json.loads(response.strip())
                 if isinstance(parsed, dict):
+                    parsed = self._normalize_first_phase_action_dict(parsed)
                     action = self._try_parse_action_from_dict(parsed, response.strip())
                     if action:
                         await log_llm_completion(
                             parsed, action.type == "tool_call", action.reasoning
                         )
                         return action
-                    else:
-                        logger.warning(
-                            f"First call: Parsed JSON but unknown type: {parsed.get('type')}"
-                        )
+                    self._raise_invalid_first_phase_action(
+                        parsed,
+                        f"Failed to parse ReAct action from JSON type: {parsed.get('type')}",
+                    )
             except json.JSONDecodeError:
                 # JSON parsing failed - might be multiple JSON objects
                 # Try to use json_repair to handle multiple JSON objects
@@ -1637,6 +1638,9 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                             )
 
                     if isinstance(action_data, dict):
+                        action_data = self._normalize_first_phase_action_dict(
+                            action_data
+                        )
                         action = self._try_parse_action_from_dict(
                             action_data, response.strip()
                         )
@@ -1647,6 +1651,10 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                                 action.reasoning,
                             )
                             return action
+                        self._raise_invalid_first_phase_action(
+                            action_data,
+                            f"Failed to parse ReAct action from JSON type: {action_data.get('type')}",
+                        )
                 except Exception as repair_error:
                     # Re-raise PatternExecutionError as it's not a repair failure
                     if isinstance(repair_error, PatternExecutionError):
@@ -1852,6 +1860,52 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                 message=f"Failed to invoke tool via native calling: {str(e)}",
                 context={"error": str(e), "chat_kwargs": chat_kwargs},
             )
+
+    def _normalize_first_phase_action_dict(self, data: dict) -> dict:
+        """Normalize first-phase action JSON before parsing it as an Action.
+
+        The first ReAct LLM call should use ``type="tool_call"`` for any tool
+        intent. Some models put the concrete tool name in ``type`` instead.
+        Treat registered tool names as tool-call decisions; reject other
+        unknown types so they are not leaked as final answers.
+        """
+        action_type = data.get("type")
+        if action_type in ("tool_call", "final_answer"):
+            return data
+
+        registered_tools = set(self.tool_registry.list_tools())
+        if isinstance(action_type, str) and action_type in registered_tools:
+            normalized = dict(data)
+            normalized["type"] = "tool_call"
+            normalized["intended_tool_name"] = action_type
+            return normalized
+
+        self._raise_invalid_first_phase_action(
+            data,
+            f"Invalid ReAct action type: {action_type}",
+            available_tools=registered_tools,
+        )
+
+        # fix mypy false positive
+        return data
+
+    def _raise_invalid_first_phase_action(
+        self,
+        data: dict,
+        message: str,
+        available_tools: Optional[set[str]] = None,
+    ) -> None:
+        """Raise when parsed first-phase JSON is not a usable ReAct action."""
+        tool_names = (
+            sorted(available_tools)
+            if available_tools is not None
+            else sorted(self.tool_registry.list_tools())
+        )
+        raise PatternExecutionError(
+            pattern_name="ReAct",
+            message=message,
+            context={"response": data, "available_tools": tool_names},
+        )
 
     def _try_parse_action_from_dict(
         self, data: dict, answer_fallback: str = ""

--- a/tests/core/agent/pattern/test_react.py
+++ b/tests/core/agent/pattern/test_react.py
@@ -318,10 +318,10 @@ async def test_react_normalizes_registered_tool_name_action_type():
 
 
 @pytest.mark.asyncio
-async def test_react_raises_for_unknown_action_type():
-    """Unknown first-phase JSON types should raise instead of becoming final text."""
+async def test_react_raises_for_non_string_action_type():
+    """Non-string first-phase JSON types should raise instead of becoming final text."""
     responses = [
-        '{"type": "clarification", "reasoning": "Need more information"}',
+        '{"type": 123, "reasoning": "Need more information"}',
     ]
 
     llm = MockReActLLM(responses)
@@ -423,6 +423,66 @@ async def test_react_raises_when_action_array_has_no_dict():
     with pytest.raises(PatternExecutionError, match="No ReAct action object found"):
         await pattern._get_action_from_llm(
             [{"role": "user", "content": "Create an FAQ agent"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_react_extracts_direct_chat_response_payload():
+    """A valid frontend chat payload should complete as chat_response."""
+    chat_payload = {
+        "type": "chat",
+        "chat": {
+            "message": "Please provide a Sansri Enterprise FAQ source.",
+            "interactions": [
+                {
+                    "type": "action_cards",
+                    "field": "knowledge_source",
+                    "label": "Add knowledge source",
+                    "options": [
+                        {
+                            "label": "Import Website",
+                            "value": "url",
+                            "action_type": "input_url",
+                        },
+                        {
+                            "label": "Upload File",
+                            "value": "upload",
+                            "action_type": "upload",
+                        },
+                    ],
+                }
+            ],
+        },
+    }
+    responses = [json.dumps(chat_payload)]
+
+    llm = MockReActLLM(responses)
+    memory = DummyMemoryStore()
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    result = await pattern.run(
+        task="Create a Sansri Enterprise FAQ bot",
+        memory=memory,
+        tools=[],
+        context=AgentContext(),
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "Please provide a Sansri Enterprise FAQ source."
+    assert result["chat_response"] == chat_payload["chat"]
+
+
+@pytest.mark.asyncio
+async def test_react_raises_for_invalid_chat_payload():
+    """A chat type without chat response data is not a usable ReAct action."""
+    responses = ['{"type": "chat", "reasoning": "Need user input"}']
+
+    llm = MockReActLLM(responses)
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    with pytest.raises(PatternExecutionError, match="Invalid ReAct chat response"):
+        await pattern._get_action_from_llm(
+            [{"role": "user", "content": "Create a Sansri Enterprise FAQ bot"}]
         )
 
 

--- a/tests/core/agent/pattern/test_react.py
+++ b/tests/core/agent/pattern/test_react.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from xagent.core.agent.context import AgentContext
+from xagent.core.agent.exceptions import PatternExecutionError
 from xagent.core.agent.pattern.react import ReActPattern
 from xagent.core.memory.base import MemoryResponse, MemoryStore
 from xagent.core.model.chat.basic.base import BaseLLM
@@ -282,6 +283,69 @@ async def test_react_native_tool_call_includes_decision_reasoning():
     second_call_prompt = second_call_messages[-1]["content"]
     assert "Your prior decision/reasoning for this tool call was" in second_call_prompt
     assert decision_reasoning in second_call_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_normalizes_registered_tool_name_action_type():
+    """A first-phase type matching a tool name should become a tool_call decision."""
+    responses = [
+        '{"type": "calculator", "reasoning": "I need to calculate using the calculator tool"}',
+        '{"type": "tool_call", "reasoning": "Calling calculator", "tool_name": "calculator", "tool_args": {"expression": "2+2"}}',
+        '{"type": "final_answer", "reasoning": "The calculation is complete", "answer": "The result is 4", "success": true, "error": null}',
+    ]
+
+    llm = MockReActLLM(responses)
+    memory = DummyMemoryStore()
+    tools = [MockCalculatorTool()]
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    result = await pattern.run(
+        task="Calculate 2+2",
+        memory=memory,
+        tools=tools,
+        context=AgentContext(),
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "The result is 4"
+    assert len(llm.calls) >= 2
+    second_call_prompt = llm.calls[1]["messages"][-1]["content"]
+    assert "I need to calculate using the calculator tool" in second_call_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_raises_for_unknown_action_type():
+    """Unknown first-phase JSON types should raise instead of becoming final text."""
+    responses = [
+        '{"type": "clarification", "reasoning": "Need more information"}',
+    ]
+
+    llm = MockReActLLM(responses)
+    pattern = ReActPattern(llm, max_iterations=3)
+    pattern.tool_registry.register_all([MockCalculatorTool()])
+
+    with pytest.raises(PatternExecutionError, match="Invalid ReAct action type"):
+        await pattern._get_action_from_llm(
+            [{"role": "user", "content": "Create an FAQ agent"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_react_raises_when_parsed_json_does_not_create_action(monkeypatch):
+    """Parsed first-phase JSON should not fall back to final text if action parsing fails."""
+    responses = [
+        '{"type": "final_answer", "reasoning": "Done", "answer": "Done"}',
+    ]
+
+    llm = MockReActLLM(responses)
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    monkeypatch.setattr(pattern, "_try_parse_action_from_dict", lambda *_args: None)
+
+    with pytest.raises(PatternExecutionError, match="Failed to parse ReAct action"):
+        await pattern._get_action_from_llm(
+            [{"role": "user", "content": "Complete the task"}]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/pattern/test_react.py
+++ b/tests/core/agent/pattern/test_react.py
@@ -73,7 +73,11 @@ class MockReActLLM(BaseLLM):
         # Check if this is a native tool call request. The ReAct pattern's first
         # call returns JSON text; only the second call passes tools and should
         # produce native tool_calls.
-        if response_json.get("type") == "tool_call" and kwargs.get("tools"):
+        if (
+            isinstance(response_json, dict)
+            and response_json.get("type") == "tool_call"
+            and kwargs.get("tools")
+        ):
             # Return native tool call format
             tool_name = response_json.get("tool_name", "")
             tool_args = response_json.get("tool_args", {})
@@ -345,6 +349,80 @@ async def test_react_raises_when_parsed_json_does_not_create_action(monkeypatch)
     with pytest.raises(PatternExecutionError, match="Failed to parse ReAct action"):
         await pattern._get_action_from_llm(
             [{"role": "user", "content": "Complete the task"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_react_accepts_single_item_action_array():
+    """A JSON array containing one action dict should be parsed as that action."""
+    responses = [
+        '[{"type": "tool_call", "reasoning": "I need to calculate using a tool"}]',
+        '{"type": "tool_call", "reasoning": "Calling calculator", "tool_name": "calculator", "tool_args": {"expression": "2+2"}}',
+        '{"type": "final_answer", "reasoning": "The calculation is complete", "answer": "The result is 4", "success": true, "error": null}',
+    ]
+
+    llm = MockReActLLM(responses)
+    memory = DummyMemoryStore()
+    tools = [MockCalculatorTool()]
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    result = await pattern.run(
+        task="Calculate 2+2",
+        memory=memory,
+        tools=tools,
+        context=AgentContext(),
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "The result is 4"
+
+
+@pytest.mark.asyncio
+async def test_react_normalizes_registered_tool_name_action_type_in_array():
+    """A tool-name type inside a JSON action array should normalize to tool_call."""
+    responses = [
+        '[{"type": "calculator", "reasoning": "I need the calculator tool"}]',
+        '{"type": "tool_call", "reasoning": "Calling calculator", "tool_name": "calculator", "tool_args": {"expression": "3+3"}}',
+        '{"type": "final_answer", "reasoning": "The calculation is complete", "answer": "The result is 6", "success": true, "error": null}',
+    ]
+
+    llm = MockReActLLM(responses)
+    memory = DummyMemoryStore()
+    tools = [MockCalculatorTool()]
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    result = await pattern.run(
+        task="Calculate 3+3",
+        memory=memory,
+        tools=tools,
+        context=AgentContext(),
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "The result is 6"
+
+
+@pytest.mark.asyncio
+async def test_react_raises_for_empty_action_array():
+    """An empty first-phase JSON array should raise instead of becoming final text."""
+    llm = MockReActLLM(["[]"])
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    with pytest.raises(PatternExecutionError, match="No ReAct action object found"):
+        await pattern._get_action_from_llm(
+            [{"role": "user", "content": "Create an FAQ agent"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_react_raises_when_action_array_has_no_dict():
+    """A first-phase JSON array without any dict item should raise."""
+    llm = MockReActLLM(['["tool_call"]'])
+    pattern = ReActPattern(llm, max_iterations=3)
+
+    with pytest.raises(PatternExecutionError, match="No ReAct action object found"):
+        await pattern._get_action_from_llm(
+            [{"role": "user", "content": "Create an FAQ agent"}]
         )
 
 


### PR DESCRIPTION
## Changes
- raise an error directly if the content is already a JSON and cannot be parsed (other than falling back to final answer)
- try to repair the JSON if the model fill the `type` field with tool name
- normalize array into single dict for both path