### PR TITLE
fix(RAG_tools): handle LanceDB concurrent transaction conflicts in _create_table

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/LanceDB/schema_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/LanceDB/schema_manager.py
@@ -97,7 +97,14 @@ def _create_table(conn: DBConnection, name: str, schema: object | None = None) -
     except Exception as e:
         # Concurrent creators may race between existence check and create_table.
         # Treat "already exists" as benign to keep ensure_* idempotent.
-        if "already exists" in str(e).lower():
+        msg = str(e).lower()
+        if "already exists" in msg:
+            return
+        # LanceDB can throw concurrent transaction conflicts under multi-threaded
+        # load (e.g. "Incompatible transaction: This Overwrite transaction is
+        # incompatible with concurrent transaction ...").  If the table now
+        # exists the race was benign; re-raise only if it genuinely failed.
+        if "incompatible transaction" in msg and _table_exists(conn, name):
             return
         raise
 


### PR DESCRIPTION
## Summary

Fixes a flaky test failure caused by LanceDB concurrent transaction conflicts when multiple threads simultaneously call `ensure_collection_metadata_table()`.

## Problem

`test_concurrent_ensure_collection_metadata_table_is_safe` fails intermittently with:

```
RuntimeError: lance error: Incompatible transaction: This Overwrite transaction
is incompatible with concurrent transaction Overwrite at version 2.
```

The existing `_create_table()` only catches `"already exists"` errors, but LanceDB can throw a different message (`"incompatible transaction"`) under multi-threaded load when multiple threads race to create the same table.

## Fix

Extended the exception handler in `_create_table()` to also treat `"incompatible transaction"` as benign **if the table now exists** (i.e. another thread won the race). If the table does not exist after the exception, the error is still re-raised as before.

## Testing

- `pytest tests/core/tools/core/RAG_tools/LanceDB/test_schema_migration.py::test_concurrent_ensure_collection_metadata_table_is_safe -xvs` passes locally.