### PR TITLE
fix: move ask_user_tool category to basic

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/ask_user_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/ask_user_tool.py
@@ -73,7 +73,7 @@ class AskUserQuestionTool(AbstractBaseTool):
     recognizes and renders as a ClarificationForm.
     """
 
-    category: ToolCategory = ToolCategory.AGENT
+    category: ToolCategory = ToolCategory.BASIC
 
     def __init__(
         self,


### PR DESCRIPTION
fix `ask_user_tool` missing in current templates and cause execution error:
<img width="847" height="123" alt="Screenshot 2026-05-08 at 14 50 28" src="https://github.com/user-attachments/assets/aa362a3f-cbdc-4f73-94bd-77aa5a35413a" />
