### PR TITLE
feat(web-crawler): browser TLS impersonation with fallback chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "uvicorn >= 0.35.0",
   "websockets>=15.0.1",
   "httpx >= 0.27.2",
+  "curl_cffi >= 0.7.0",  # Browser TLS fingerprint impersonation for web crawler
   "rich >= 14.0.0",
   "prompt_toolkit >= 3.0.0",
   "langfuse >= 3.2.1, < 5.0.0",  # Compatible with both v3 and v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   "uvicorn >= 0.35.0",
   "websockets>=15.0.1",
   "httpx >= 0.27.2",
-  "curl_cffi >= 0.7.0",  # Browser TLS fingerprint impersonation for web crawler
   "rich >= 14.0.0",
   "prompt_toolkit >= 3.0.0",
   "langfuse >= 3.2.1, < 5.0.0",  # Compatible with both v3 and v4
@@ -100,6 +99,9 @@ duckdb = ["duckdb>=1.0.0,<2.0", "duckdb-engine>=0.10.0,<1.0"]
 # Browser automation
 browser = ["playwright>=1.40.0"]
 
+# Browser TLS fingerprint impersonation for WAF-sensitive web crawling
+waf-crawl = ["curl_cffi>=0.14.0"]
+
 # Alternative vector databases (optional alternatives to LanceDB)
 chromadb = ["chromadb"]
 milvus = ["pymilvus>=2.6.9,<3.0.0"]
@@ -117,8 +119,9 @@ all = [
   "docling>=2.68.0",
   "psycopg2-binary>=2.9.0",
   "playwright>=1.40.0",
+  "curl_cffi>=0.14.0",
   "chromadb",
-  "pymilvus>=2.6.9,<3.0.0"
+  "pymilvus>=2.6.9,<3.0.0",
 ]
 
 [dependency-groups]

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1737,7 +1737,7 @@ class WebCrawlConfig(BaseModel):
             "User-Agent for HTTP requests. "
             "ONLY applied when tls_impersonate is None -- the crawler then "
             "uses plain httpx with this UA. "
-            "When tls_impersonate is set (e.g. 'auto', the default), "
+            "When tls_impersonate is set (e.g. 'auto'), "
             "curl_cffi controls headers to keep TLS fingerprint and HTTP "
             "UA consistent; overriding the UA here would create a "
             "fingerprint mismatch that defeats WAF bypass and is therefore "
@@ -1745,14 +1745,16 @@ class WebCrawlConfig(BaseModel):
         ),
     )
     tls_impersonate: Optional[str] = Field(
-        default="auto",
+        default=None,
         description=(
             "TLS fingerprint to impersonate via curl_cffi. "
-            "Pass None to disable (uses plain httpx -- fastest, but no WAF bypass). "
-            "Pass 'auto' (default) to try a built-in fallback chain in order "
-            "until one succeeds. "
+            "Defaults to None (plain httpx -- fastest, but no WAF bypass). "
+            "Pass 'auto' to try a built-in fallback chain in order until one "
+            "succeeds. "
             "Pass a specific impersonate spec (e.g. 'safari17_0', 'chrome120') "
             "to lock to that fingerprint without fallback. "
+            "Install the waf-crawl extra to enable curl_cffi-backed "
+            "impersonation. "
             "See https://github.com/yifeikong/curl_cffi for valid specs."
         ),
     )

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1728,8 +1728,33 @@ class WebCrawlConfig(BaseModel):
 
     # Other configuration
     user_agent: Optional[str] = Field(
-        default="Mozilla/5.0 (xagent WebCrawler/1.0)",
-        description="User-Agent string for HTTP requests",
+        default=(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/130.0.0.0 Safari/537.36"
+        ),
+        description=(
+            "User-Agent for HTTP requests. "
+            "ONLY applied when tls_impersonate is None -- the crawler then "
+            "uses plain httpx with this UA. "
+            "When tls_impersonate is set (e.g. 'auto', the default), "
+            "curl_cffi controls headers to keep TLS fingerprint and HTTP "
+            "UA consistent; overriding the UA here would create a "
+            "fingerprint mismatch that defeats WAF bypass and is therefore "
+            "IGNORED on that path."
+        ),
+    )
+    tls_impersonate: Optional[str] = Field(
+        default="auto",
+        description=(
+            "TLS fingerprint to impersonate via curl_cffi. "
+            "Pass None to disable (uses plain httpx -- fastest, but no WAF bypass). "
+            "Pass 'auto' (default) to try a built-in fallback chain in order "
+            "until one succeeds. "
+            "Pass a specific impersonate spec (e.g. 'safari17_0', 'chrome120') "
+            "to lock to that fingerprint without fallback. "
+            "See https://github.com/yifeikong/curl_cffi for valid specs."
+        ),
     )
     timeout: int = Field(
         default=30,

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -192,9 +192,7 @@ class WebCrawler:
         if config.tls_impersonate is None:
             self._policy_user_agent: str = config.user_agent or _DEFAULT_USER_AGENT
         else:
-            first_fp = next(
-                (fp for fp in self._tls_chain if fp is not None), None
-            )
+            first_fp = next((fp for fp in self._tls_chain if fp is not None), None)
             self._policy_user_agent = (
                 _IMPERSONATE_TO_UA.get(first_fp, "*") if first_fp else "*"
             )

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -521,9 +521,17 @@ class WebCrawler:
                 logger.debug("Crawling %s (depth: %s)", url, depth)
 
                 # Fetch page (with TLS fingerprint fallback chain)
-                response, _ = await self._fetch_with_fallback(sessions, url)
+                response, fingerprint_used = await self._fetch_with_fallback(
+                    sessions, url
+                )
                 if response is None:
                     error_msg = "All TLS fingerprints raised exceptions"
+                    logger.error("Failed to crawl %s: %s", url, error_msg)
+                    self.failed_urls[url] = error_msg
+                    return None, set()
+
+                if fingerprint_used is None and 200 <= response.status_code < 300:
+                    error_msg = "TLS fallback exhausted with challenge page"
                     logger.error("Failed to crawl %s: %s", url, error_msg)
                     self.failed_urls[url] = error_msg
                     return None, set()

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -288,13 +288,9 @@ class WebCrawler:
                 self._tls_chain contains None. curl_cffi sessions get no
                 explicit headers -- their impersonate spec sets them.
         """
-        # Imported lazily so that environments which never use TLS
-        # impersonation don't pay the curl_cffi C-extension import cost
-        # at module load.
-        from curl_cffi.requests import AsyncSession as CffiSession
-
         async with AsyncExitStack() as stack:
             sessions: Dict[Optional[str], Any] = {}
+            cffi_session_cls: Any = None
             for fp in self._tls_chain:
                 if fp is None:
                     sess: Any = httpx.AsyncClient(
@@ -302,7 +298,13 @@ class WebCrawler:
                         timeout=self.config.timeout,
                     )
                 else:
-                    sess = CffiSession(
+                    if cffi_session_cls is None:
+                        # Imported lazily so environments using the default
+                        # httpx path do not need the optional waf-crawl extra.
+                        from curl_cffi.requests import AsyncSession as CffiSession
+
+                        cffi_session_cls = CffiSession
+                    sess = cffi_session_cls(
                         impersonate=fp,
                         timeout=self.config.timeout,
                     )

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -4,8 +4,9 @@ import asyncio
 import logging
 import time
 from collections import deque
+from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timezone
-from typing import Callable, Dict, List, Optional, Set
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
 
 import httpx
 
@@ -15,6 +16,118 @@ from .link_extractor import LinkExtractor
 from .url_filter import URLFilter
 
 logger = logging.getLogger(__name__)
+
+# Default fallback chain when WebCrawlConfig.tls_impersonate == "auto".
+#
+# Picks are based on a production-faithful matrix run on 2026-05-08
+# from a single Aliyun outbound IP, against 9 sites (Cloudflare /
+# Akamai / AWS-WAF / Imperva / Alibaba) with NO custom headers passed
+# to curl_cffi (so the impersonate spec owns UA / Accept / Sec-Fetch
+# headers consistently with its TLS fingerprint -- mirroring this
+# crawler's actual call shape). Of the seven specs probed, four
+# returned real content on 9/9 sites: chrome116, chrome110,
+# safari17_0, safari15_5. chrome131/124/120 were challenge/blocked on
+# detrack.com and medium.com; chrome120 in particular looked OK in an
+# earlier run that mixed a Chrome 130 UA on top of curl_cffi's TLS,
+# but failed once the test was made consistent with production.
+#
+# Why this specific triple:
+#   - chrome116:   Chrome family, recent enough to look mainstream,
+#                  not yet on Cloudflare's "frequently-abused" list.
+#   - safari17_0:  Different TLS stack (WebKit) -- if Cloudflare adds
+#                  Chrome-family blocks, Safari is unlikely to share
+#                  the same JA3/JA4 signature.
+#   - safari15_5:  Older Safari, same family as safari17_0 but with
+#                  a distinct fingerprint; the third backup if both
+#                  primary picks ever get added to a blocklist.
+#
+# Caveats: (1) results from a single IP/ASN do not generalize -- a
+# different network may see different blocks. (2) WAF rules drift;
+# if INFO logs start showing fallback hits dominated by chain[2],
+# revisit this list.
+_TLS_AUTO_CHAIN: Tuple[str, ...] = ("chrome116", "safari17_0", "safari15_5")
+
+# HTTP statuses where retrying the request with a different TLS fingerprint
+# has a chance of success. Statuses NOT in this set (e.g. 404, 401, 500)
+# almost always indicate a content-side problem that won't change between
+# fingerprints; retrying just wastes the rest of the chain and writes
+# misleading "TLS fallback exhausted" log lines for ordinary errors.
+_WAF_RETRY_STATUSES: frozenset = frozenset(
+    {403, 429, 503, 520, 521, 522, 523, 524, 525, 526}
+)
+
+# Heuristic markers for a Cloudflare / similar JS challenge wrapper page.
+# These pages return HTTP 200 but the body is a "Just a moment..." stub --
+# accepting them as successful crawls would pollute the KB with garbage.
+_CHALLENGE_PAGE_MARKERS: Tuple[str, ...] = (
+    "checking your browser",
+    "cf-challenge",
+    "just a moment",
+    "cf-please-wait",
+    "needs to review the security",
+)
+
+
+def _looks_like_challenge_page(body: str) -> bool:
+    """Heuristic: does this 200 response look like a JS challenge wrapper?"""
+    if not body:
+        return False
+    lowered = body[:3000].lower()
+    return any(marker in lowered for marker in _CHALLENGE_PAGE_MARKERS)
+
+
+# Default User-Agent used when tls_impersonate is None and the user has
+# not overridden config.user_agent.
+_DEFAULT_USER_AGENT: str = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/130.0.0.0 Safari/537.36"
+)
+
+# Mapping from a curl_cffi impersonate spec to the User-Agent that spec
+# actually puts on the wire. We need this for policy code (robots.txt)
+# which has to reason about the identity we are presenting -- since
+# curl_cffi sets the UA itself based on the impersonate spec, the
+# crawler does not have a direct way to read it back. Specs not in this
+# table fall back to "*" for robots.txt purposes (which matches catch-all
+# rules and is the safe conservative choice).
+_IMPERSONATE_TO_UA: Dict[str, str] = {
+    "chrome110": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/110.0.0.0 Safari/537.36"
+    ),
+    "chrome116": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/116.0.0.0 Safari/537.36"
+    ),
+    "chrome120": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "chrome124": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "chrome131": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "safari15_5": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+        "Version/15.5 Safari/605.1.15"
+    ),
+    "safari17_0": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+        "Version/17.0 Safari/605.1.15"
+    ),
+}
 
 
 class WebCrawler:
@@ -59,6 +172,33 @@ class WebCrawler:
         self.total_urls_found = 0
         self.start_time: Optional[float] = None
 
+        # Resolve the TLS-fingerprint sequence to use for fetches.
+        # Element type is Optional[str]: None means "use httpx, no impersonation".
+        if config.tls_impersonate is None:
+            self._tls_chain: Tuple[Optional[str], ...] = (None,)
+        elif config.tls_impersonate == "auto":
+            self._tls_chain = _TLS_AUTO_CHAIN
+        else:
+            self._tls_chain = (config.tls_impersonate,)
+
+        # Effective User-Agent for policy decisions (robots.txt, etc.).
+        # When tls_impersonate is None we send config.user_agent on the
+        # wire, so policy must reason about that string. When tls_impersonate
+        # is set, curl_cffi controls the UA based on the impersonate spec --
+        # config.user_agent is intentionally ignored in that path to keep
+        # TLS fingerprint and HTTP UA consistent. For policy we use the
+        # mapped UA of the *first* fingerprint in the chain, falling back
+        # to "*" if the spec is unknown to us.
+        if config.tls_impersonate is None:
+            self._policy_user_agent: str = config.user_agent or _DEFAULT_USER_AGENT
+        else:
+            first_fp = next(
+                (fp for fp in self._tls_chain if fp is not None), None
+            )
+            self._policy_user_agent = (
+                _IMPERSONATE_TO_UA.get(first_fp, "*") if first_fp else "*"
+            )
+
     async def crawl(self) -> List[CrawlResult]:
         """Start crawling from the configured start URL.
 
@@ -74,14 +214,33 @@ class WebCrawler:
 
         logger.info("Starting crawl from %s", self.config.start_url)
 
-        # Create HTTP client
-        user_agent = self.config.user_agent or "Mozilla/5.0 (xagent WebCrawler/1.0)"
-        headers = {"User-Agent": user_agent}
-        async with httpx.AsyncClient(
-            headers=headers,
-            timeout=self.config.timeout,
-        ) as client:
-            await self._crawl_loop(client)
+        # When tls_impersonate is None we use plain httpx; in that path we
+        # need to manually compose a browser-like header set so the request
+        # doesn't look obviously bot-shaped. When tls_impersonate is set,
+        # curl_cffi owns headers (matching its TLS impersonation), and we
+        # MUST NOT inject our own UA/headers -- doing so creates a TLS-vs-
+        # HTTP-fingerprint mismatch which is exactly what WAFs catch.
+        httpx_headers: Optional[Dict[str, str]] = None
+        if None in self._tls_chain:
+            user_agent = self.config.user_agent or _DEFAULT_USER_AGENT
+            httpx_headers = {
+                "User-Agent": user_agent,
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,*/*;q=0.8"
+                ),
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "none",
+                "Sec-Fetch-User": "?1",
+                "Upgrade-Insecure-Requests": "1",
+                "DNT": "1",
+            }
+
+        async with self._open_sessions(httpx_headers) as sessions:
+            await self._crawl_loop(sessions)
 
         elapsed = time.time() - self.start_time
         logger.info(
@@ -93,11 +252,156 @@ class WebCrawler:
 
         return self.crawl_results
 
-    async def _crawl_loop(self, client: httpx.AsyncClient) -> None:
+    @asynccontextmanager
+    async def _open_sessions(
+        self, httpx_headers: Optional[Dict[str, str]]
+    ) -> AsyncIterator[Dict[Optional[str], Any]]:
+        """Open one HTTP session per fingerprint in self._tls_chain.
+
+        Pre-opening sessions matters because curl_cffi.AsyncSession setup
+        isn't free (it initializes a TLS context that mimics a specific
+        browser); we reuse the same session across all pages of the crawl.
+
+        Yields a dict keyed by Optional[str]: the same key used in
+        self._tls_chain. None -> httpx.AsyncClient; "chromeXX"/"safariXX"
+        -> curl_cffi.requests.AsyncSession. Cleanup is delegated to
+        AsyncExitStack so exception context propagates correctly.
+
+        Args:
+            httpx_headers: Header dict for the httpx client. Only used when
+                self._tls_chain contains None. curl_cffi sessions get no
+                explicit headers -- their impersonate spec sets them.
+        """
+        # Imported lazily so that environments which never use TLS
+        # impersonation don't pay the curl_cffi C-extension import cost
+        # at module load.
+        from curl_cffi.requests import AsyncSession as CffiSession
+
+        async with AsyncExitStack() as stack:
+            sessions: Dict[Optional[str], Any] = {}
+            for fp in self._tls_chain:
+                if fp is None:
+                    sess: Any = httpx.AsyncClient(
+                        headers=httpx_headers or {},
+                        timeout=self.config.timeout,
+                    )
+                else:
+                    sess = CffiSession(
+                        impersonate=fp,
+                        timeout=self.config.timeout,
+                    )
+                sessions[fp] = await stack.enter_async_context(sess)
+            yield sessions
+
+    async def _fetch_with_fallback(
+        self,
+        sessions: Dict[Optional[str], Any],
+        url: str,
+    ) -> Tuple[Optional[Any], Optional[str]]:
+        """Fetch a URL by trying each TLS fingerprint in self._tls_chain.
+
+        Behavior on each response status:
+
+          * 2xx + body looks like real content
+              -> return (response, fp_used).
+          * 2xx + body looks like a JS challenge wrapper
+              (Cloudflare "Just a moment...", etc.)
+              -> treat as a WAF block, advance to the next fingerprint.
+          * Status in _WAF_RETRY_STATUSES (403, 429, 503, 520-526)
+              -> advance to next fingerprint.
+          * Any other non-2xx (404, 401, 500, ...)
+              -> return immediately. The error is content-side and
+                 won't change with a different TLS fingerprint;
+                 retrying just wastes the rest of the chain.
+
+        Returns:
+            (response, fingerprint_used) on first real 2xx success.
+            (last_response, None) if the chain was exhausted or returned
+                fast on a non-WAF non-2xx -- fingerprint_used=None signals
+                "this response is a failure, not a success".
+            (None, None) only if every attempt raised an exception.
+        """
+        last_response = None
+        last_status: Optional[int] = None
+
+        for i, fp in enumerate(self._tls_chain):
+            sess = sessions[fp]
+            fp_label = fp or "httpx"
+            try:
+                # curl_cffi uses 'allow_redirects', httpx uses 'follow_redirects'.
+                # Custom headers are NOT passed: httpx's are baked into the
+                # session, curl_cffi's are owned by the impersonate spec.
+                if fp is None:
+                    response = await sess.get(url, follow_redirects=True)
+                else:
+                    response = await sess.get(url, allow_redirects=True)
+
+                if 200 <= response.status_code < 300:
+                    body_preview = response.text or ""
+                    if _looks_like_challenge_page(body_preview):
+                        last_response = response
+                        last_status = response.status_code
+                        logger.debug(
+                            "TLS fp=%s got 200 challenge page for %s, trying next",
+                            fp_label,
+                            url,
+                        )
+                        continue
+                    if i > 0:
+                        logger.info(
+                            "TLS fallback hit: url=%s fp=%s pos=%d/%d",
+                            url,
+                            fp_label,
+                            i + 1,
+                            len(self._tls_chain),
+                        )
+                    return response, fp_label
+
+                if response.status_code in _WAF_RETRY_STATUSES:
+                    last_response = response
+                    last_status = response.status_code
+                    logger.debug(
+                        "TLS fp=%s returned %d (WAF-like) for %s, trying next",
+                        fp_label,
+                        response.status_code,
+                        url,
+                    )
+                    continue
+
+                # Non-WAF non-2xx (e.g. 404, 500): fail fast. Trying more
+                # TLS fingerprints can't recover content-side errors.
+                logger.debug(
+                    "TLS fp=%s returned %d for %s (not WAF-like), failing fast",
+                    fp_label,
+                    response.status_code,
+                    url,
+                )
+                return response, None
+            except Exception as e:
+                logger.debug(
+                    "TLS fp=%s raised %s for %s, trying next",
+                    fp_label,
+                    type(e).__name__,
+                    url,
+                )
+
+        if last_response is not None:
+            logger.warning(
+                "TLS fallback exhausted: url=%s last_status=%s chain=%s",
+                url,
+                last_status,
+                [f or "httpx" for f in self._tls_chain],
+            )
+            return last_response, None
+
+        return None, None
+
+    async def _crawl_loop(self, sessions: Dict[Optional[str], Any]) -> None:
         """Main crawl loop with concurrency control.
 
         Args:
-            client: HTTP client
+            sessions: Dict mapping fingerprint -> open HTTP session.
+                Keyed by Optional[str] same as self._tls_chain entries.
         """
         # Create semaphore for concurrency control
         semaphore = asyncio.Semaphore(self.config.concurrent_requests)
@@ -132,7 +436,7 @@ class WebCrawler:
                 self.visited_urls.add(url)
 
                 # Create crawl task
-                task = self._crawl_page(client, url, depth, semaphore)
+                task = self._crawl_page(sessions, url, depth, semaphore)
                 tasks.append(task)
 
             # Execute batch
@@ -169,7 +473,7 @@ class WebCrawler:
 
     async def _crawl_page(
         self,
-        client: httpx.AsyncClient,
+        sessions: Dict[Optional[str], Any],
         url: str,
         depth: int,
         semaphore: asyncio.Semaphore,
@@ -177,7 +481,7 @@ class WebCrawler:
         """Crawl a single page.
 
         Args:
-            client: HTTP client
+            sessions: Dict mapping fingerprint -> open HTTP session.
             url: URL to crawl
             depth: Current depth
             semaphore: Concurrency control semaphore
@@ -189,9 +493,22 @@ class WebCrawler:
             try:
                 logger.debug("Crawling %s (depth: %s)", url, depth)
 
-                # Fetch page
-                response = await client.get(url, follow_redirects=True)
-                response.raise_for_status()
+                # Fetch page (with TLS fingerprint fallback chain)
+                response, _ = await self._fetch_with_fallback(sessions, url)
+                if response is None:
+                    error_msg = "All TLS fingerprints raised exceptions"
+                    logger.error("Failed to crawl %s: %s", url, error_msg)
+                    self.failed_urls[url] = error_msg
+                    return None, set()
+
+                # Explicit status check is library-agnostic (works for both
+                # httpx and curl_cffi response objects, which raise different
+                # exception types from raise_for_status()).
+                if not 200 <= response.status_code < 300:
+                    error_msg = f"HTTP {response.status_code}"
+                    logger.error("Failed to crawl %s: %s", url, error_msg)
+                    self.failed_urls[url] = error_msg
+                    return None, set()
 
                 html = response.text
 
@@ -208,11 +525,12 @@ class WebCrawler:
                 # Extract links
                 links = self.link_extractor.extract_links(html, url)
 
-                # Filter links
+                # Filter links. Use the *effective* UA we send on the wire,
+                # not raw config.user_agent, so robots.txt decisions are
+                # consistent with what the WAF actually sees.
                 valid_links = set()
-                user_agent = self.config.user_agent or "*"
                 for link in links:
-                    if self.url_filter.should_crawl(link, user_agent):
+                    if self.url_filter.should_crawl(link, self._policy_user_agent):
                         valid_links.add(link)
 
                 self.total_urls_found += len(links)
@@ -239,19 +557,10 @@ class WebCrawler:
 
                 return result, valid_links
 
-            except httpx.HTTPStatusError as e:
-                error_msg = f"HTTP {e.response.status_code}"
-                logger.error("Failed to crawl %s: %s", url, error_msg)
-                self.failed_urls[url] = error_msg
-                return None, set()
-
-            except httpx.RequestError as e:
-                error_msg = f"Request error: {str(e)}"
-                logger.error("Failed to crawl %s: %s", url, error_msg)
-                self.failed_urls[url] = error_msg
-                return None, set()
-
             except Exception as e:
+                # Network/protocol errors are already swallowed inside
+                # _fetch_with_fallback; this catches errors from text decode,
+                # content cleaning, link extraction etc.
                 error_msg = f"Unexpected error: {str(e)}"
                 logger.error("Failed to crawl %s: %s", url, error_msg)
                 self.failed_urls[url] = error_msg

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -1,6 +1,7 @@
 """Core web crawler implementation."""
 
 import asyncio
+import importlib
 import logging
 import time
 from collections import deque
@@ -74,6 +75,21 @@ def _looks_like_challenge_page(body: str) -> bool:
         return False
     lowered = body[:3000].lower()
     return any(marker in lowered for marker in _CHALLENGE_PAGE_MARKERS)
+
+
+def _ensure_curl_cffi_available() -> None:
+    """Validate optional curl_cffi dependency before starting async crawl work."""
+    try:
+        importlib.import_module("curl_cffi.requests")
+    except ModuleNotFoundError as e:
+        if e.name and e.name.startswith("curl_cffi"):
+            raise ImportError(
+                "WebCrawlConfig.tls_impersonate requires the optional "
+                "curl_cffi dependency. Install it with `pip install "
+                "'xagent[waf-crawl]'` or set tls_impersonate=None to use "
+                "plain httpx."
+            ) from e
+        raise
 
 
 # Default User-Agent used when tls_impersonate is None and the user has
@@ -177,8 +193,10 @@ class WebCrawler:
         if config.tls_impersonate is None:
             self._tls_chain: Tuple[Optional[str], ...] = (None,)
         elif config.tls_impersonate == "auto":
+            _ensure_curl_cffi_available()
             self._tls_chain = _TLS_AUTO_CHAIN
         else:
+            _ensure_curl_cffi_available()
             self._tls_chain = (config.tls_impersonate,)
 
         # Effective User-Agent for policy decisions (robots.txt, etc.).
@@ -321,6 +339,7 @@ class WebCrawler:
         """
         last_response = None
         last_status: Optional[int] = None
+        exception_log: List[str] = []
 
         for i, fp in enumerate(self._tls_chain):
             sess = sessions[fp]
@@ -376,6 +395,7 @@ class WebCrawler:
                 )
                 return response, None
             except Exception as e:
+                exception_log.append(f"{fp_label}:{type(e).__name__}: {e}")
                 logger.debug(
                     "TLS fp=%s raised %s for %s, trying next",
                     fp_label,
@@ -391,6 +411,13 @@ class WebCrawler:
                 [f or "httpx" for f in self._tls_chain],
             )
             return last_response, None
+
+        if exception_log:
+            logger.warning(
+                "All TLS fingerprints failed for url=%s exceptions=%s",
+                url,
+                exception_log,
+            )
 
         return None, None
 

--- a/stubs/curl_cffi/__init__.pyi
+++ b/stubs/curl_cffi/__init__.pyi
@@ -1,0 +1,1 @@
+"""Minimal stubs for curl_cffi used by the web crawler."""

--- a/stubs/curl_cffi/requests.pyi
+++ b/stubs/curl_cffi/requests.pyi
@@ -1,8 +1,11 @@
-from typing import Any
+from typing import Any, Mapping
 
 class Response:
+    content: bytes
+    headers: Mapping[str, str]
     status_code: int
     text: str
+    url: str
 
 class AsyncSession:
     def __init__(

--- a/stubs/curl_cffi/requests.pyi
+++ b/stubs/curl_cffi/requests.pyi
@@ -1,0 +1,17 @@
+from typing import Any
+
+class Response:
+    status_code: int
+    text: str
+
+class AsyncSession:
+    def __init__(
+        self,
+        *,
+        impersonate: str | None = ...,
+        timeout: float | int | None = ...,
+        **kwargs: Any,
+    ) -> None: ...
+    async def __aenter__(self) -> "AsyncSession": ...
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None: ...
+    async def get(self, url: str, **kwargs: Any) -> Response: ...

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -315,6 +315,7 @@ class TestWebCrawler:
             call_log: list to append the impersonate spec on every .get()
             response_for: callable(impersonate) -> MagicMock response
         """
+
         def make_session(impersonate=None, **kwargs):
             sess = AsyncMock()
             sess.__aenter__ = AsyncMock(return_value=sess)

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -14,13 +14,19 @@ class TestWebCrawler:
 
     @pytest.fixture
     def crawl_config(self):
-        """Create a test crawl configuration."""
+        """Create a test crawl configuration.
+
+        tls_impersonate=None makes existing tests run on the httpx path,
+        so they keep mocking httpx.AsyncClient (TLS-impersonation-specific
+        behavior is covered separately below).
+        """
         return WebCrawlConfig(
             start_url="https://example.com",
             max_pages=5,
             max_depth=2,
             concurrent_requests=2,
             request_delay=0,
+            tls_impersonate=None,
         )
 
     @pytest.fixture
@@ -113,6 +119,7 @@ class TestWebCrawler:
             max_depth=3,
             concurrent_requests=1,
             request_delay=0,
+            tls_impersonate=None,
         )
 
         mock_response = MagicMock()
@@ -141,6 +148,7 @@ class TestWebCrawler:
             max_depth=1,  # Limit depth to 1
             concurrent_requests=1,
             request_delay=0,
+            tls_impersonate=None,
         )
 
         mock_response = MagicMock()
@@ -230,6 +238,7 @@ class TestWebCrawler:
             same_domain_only=True,
             concurrent_requests=1,
             request_delay=0,
+            tls_impersonate=None,
         )
 
         mock_response = MagicMock()
@@ -297,3 +306,179 @@ class TestWebCrawler:
 
         # Progress callback should have been called
         assert len(progress_updates) > 0
+
+    @staticmethod
+    def _make_cffi_session_factory(call_log, response_for):
+        """Return a side_effect that builds a fresh AsyncMock per call.
+
+        Args:
+            call_log: list to append the impersonate spec on every .get()
+            response_for: callable(impersonate) -> MagicMock response
+        """
+        def make_session(impersonate=None, **kwargs):
+            sess = AsyncMock()
+            sess.__aenter__ = AsyncMock(return_value=sess)
+            sess.__aexit__ = AsyncMock(return_value=None)
+
+            async def get(url, **kw):
+                call_log.append(impersonate)
+                return response_for(impersonate)
+
+            sess.get = AsyncMock(side_effect=get)
+            return sess
+
+        return make_session
+
+    @pytest.mark.asyncio
+    async def test_tls_fallback_chain_advances_on_waf_block(self, sample_html):
+        """When chain[0] returns 403 and chain[1] returns 200, the second
+        fingerprint must be used and the page must succeed. httpx must
+        not be touched at all on the auto path.
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+
+        call_log = []
+
+        def response_for(impersonate):
+            resp = MagicMock()
+            if impersonate == "chrome116":
+                resp.status_code = 403
+                resp.text = "blocked"
+            else:
+                resp.status_code = 200
+                resp.text = sample_html
+            return resp
+
+        with (
+            patch(
+                "curl_cffi.requests.AsyncSession",
+                side_effect=self._make_cffi_session_factory(call_log, response_for),
+            ) as p_cffi,
+            patch("httpx.AsyncClient") as p_httpx,
+        ):
+            crawler = WebCrawler(config)
+            results = await crawler.crawl()
+
+        # Three sessions opened (one per fingerprint), httpx not used at all
+        assert p_cffi.call_count == 3
+        p_httpx.assert_not_called()
+        # First two fingerprints tried in order; chain[1] succeeded
+        assert call_log[0] == "chrome116"
+        assert call_log[1] == "safari17_0"
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+    @pytest.mark.asyncio
+    async def test_tls_impersonate_none_uses_httpx_only(self, sample_html):
+        """When tls_impersonate=None, curl_cffi must NEVER be touched."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client) as p_httpx,
+            patch("curl_cffi.requests.AsyncSession") as p_cffi,
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        p_httpx.assert_called()
+        p_cffi.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_404_does_not_trigger_fallback_chain(self):
+        """Ordinary HTTP errors (404, 401, 500) must fail fast.
+
+        Only WAF-like statuses (403, 429, 503...) should advance the
+        fallback chain. Otherwise we'd 3x the cost of every dead link
+        and write misleading "TLS fallback exhausted" warnings for
+        ordinary content errors.
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+
+        call_log = []
+
+        def response_for(impersonate):
+            resp = MagicMock()
+            resp.status_code = 404
+            resp.text = "<html><body>not found</body></html>"
+            return resp
+
+        with patch(
+            "curl_cffi.requests.AsyncSession",
+            side_effect=self._make_cffi_session_factory(call_log, response_for),
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        # Only the first fingerprint should have been tried
+        assert call_log == ["chrome116"]
+        # And it's recorded as failed
+        assert "https://example.com" in crawler.failed_urls
+        assert "404" in crawler.failed_urls["https://example.com"]
+
+    @pytest.mark.asyncio
+    async def test_challenge_page_advances_chain(self, sample_html):
+        """A 200 response that's actually a CF JS challenge wrapper must
+        be treated like a WAF block (advance to next fingerprint), not
+        accepted as content -- otherwise the KB gets polluted with
+        "Just a moment..." stub pages.
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+
+        challenge_body = (
+            "<!DOCTYPE html><html><head><title>Just a moment...</title>"
+            "</head><body>Checking your browser before accessing the "
+            "site. cf-challenge in progress.</body></html>"
+        )
+        call_log = []
+
+        def response_for(impersonate):
+            resp = MagicMock()
+            resp.status_code = 200
+            if impersonate == "chrome116":
+                resp.text = challenge_body
+            else:
+                resp.text = sample_html
+            return resp
+
+        with patch(
+            "curl_cffi.requests.AsyncSession",
+            side_effect=self._make_cffi_session_factory(call_log, response_for),
+        ):
+            crawler = WebCrawler(config)
+            results = await crawler.crawl()
+
+        # chain[0] returned a 200 challenge -> fallback to chain[1]
+        assert call_log[0] == "chrome116"
+        assert call_log[1] == "safari17_0"
+        assert len(results) == 1
+        assert results[0].status == "success"

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -522,6 +522,45 @@ class TestWebCrawler:
         assert results[0].status == "success"
 
     @pytest.mark.asyncio
+    async def test_exhausted_challenge_pages_fail_crawl(self, monkeypatch):
+        """If every fingerprint returns a 200 challenge wrapper, fail the URL."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+
+        challenge_body = (
+            "<!DOCTYPE html><html><head><title>Just a moment...</title>"
+            "</head><body>Checking your browser before accessing the "
+            "site. cf-challenge in progress.</body></html>"
+        )
+        call_log = []
+        cffi_requests = self._install_fake_cffi(monkeypatch)
+
+        def response_for(impersonate):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.text = challenge_body
+            return resp
+
+        with patch.object(
+            cffi_requests,
+            "AsyncSession",
+            side_effect=self._make_cffi_session_factory(call_log, response_for),
+        ):
+            crawler = WebCrawler(config)
+            results = await crawler.crawl()
+
+        assert call_log == ["chrome116", "safari17_0", "safari15_5"]
+        assert results == []
+        assert "https://example.com" in crawler.failed_urls
+        assert crawler.failed_urls["https://example.com"] == (
+            "TLS fallback exhausted with challenge page"
+        )
+
+    @pytest.mark.asyncio
     async def test_tls_exception_chain_logs_warning(self, monkeypatch, caplog):
         """If every fingerprint raises, operators should get a warning summary."""
         config = WebCrawlConfig(

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -71,7 +71,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -99,7 +98,6 @@ class TestWebCrawler:
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.text = responses.get(url, "")
-            mock_resp.raise_for_status = MagicMock()
             return mock_resp
 
         mock_client = AsyncMock()
@@ -134,7 +132,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -163,7 +160,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -184,9 +180,7 @@ class TestWebCrawler:
         # Mock HTTP error response
         mock_response = MagicMock()
         mock_response.status_code = 404
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "Not Found", request=MagicMock(), response=mock_response
-        )
+        mock_response.text = "<html><body>Not Found</body></html>"
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -223,7 +217,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = "<html><body>Hi</body></html>"
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -253,7 +246,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -273,7 +265,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -302,7 +293,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
@@ -411,7 +401,6 @@ class TestWebCrawler:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = sample_html
-        mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -1,5 +1,8 @@
 """Unit tests for web crawler."""
 
+import logging
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -54,6 +57,12 @@ class TestWebCrawler:
         assert len(crawler.visited_urls) == 0
         assert len(crawler.pending_urls) == 0
         assert len(crawler.crawl_results) == 0
+
+    def test_default_tls_impersonate_uses_httpx(self):
+        """Unmodified configs should stay on the plain httpx path by default."""
+        config = WebCrawlConfig(start_url="https://example.com")
+
+        assert config.tls_impersonate is None
 
     @pytest.mark.asyncio
     async def test_crawl_single_page(self, crawl_config, sample_html):
@@ -330,8 +339,21 @@ class TestWebCrawler:
 
         return make_session
 
+    @staticmethod
+    def _install_fake_cffi(monkeypatch):
+        """Install fake curl_cffi modules so optional-dependency tests stay hermetic."""
+        cffi_module = types.ModuleType("curl_cffi")
+        requests_module = types.ModuleType("curl_cffi.requests")
+        requests_module.AsyncSession = MagicMock()
+        cffi_module.requests = requests_module
+        monkeypatch.setitem(sys.modules, "curl_cffi", cffi_module)
+        monkeypatch.setitem(sys.modules, "curl_cffi.requests", requests_module)
+        return requests_module
+
     @pytest.mark.asyncio
-    async def test_tls_fallback_chain_advances_on_waf_block(self, sample_html):
+    async def test_tls_fallback_chain_advances_on_waf_block(
+        self, sample_html, monkeypatch
+    ):
         """When chain[0] returns 403 and chain[1] returns 200, the second
         fingerprint must be used and the page must succeed. httpx must
         not be touched at all on the auto path.
@@ -344,6 +366,7 @@ class TestWebCrawler:
         )
 
         call_log = []
+        cffi_requests = self._install_fake_cffi(monkeypatch)
 
         def response_for(impersonate):
             resp = MagicMock()
@@ -356,8 +379,9 @@ class TestWebCrawler:
             return resp
 
         with (
-            patch(
-                "curl_cffi.requests.AsyncSession",
+            patch.object(
+                cffi_requests,
+                "AsyncSession",
                 side_effect=self._make_cffi_session_factory(call_log, response_for),
             ) as p_cffi,
             patch("httpx.AsyncClient") as p_httpx,
@@ -396,16 +420,36 @@ class TestWebCrawler:
 
         with (
             patch("httpx.AsyncClient", return_value=mock_client) as p_httpx,
-            patch("curl_cffi.requests.AsyncSession") as p_cffi,
+            patch(
+                "importlib.import_module",
+                side_effect=AssertionError("curl_cffi should not be imported"),
+            ) as p_import,
         ):
             crawler = WebCrawler(config)
             await crawler.crawl()
 
         p_httpx.assert_called()
-        p_cffi.assert_not_called()
+        p_import.assert_not_called()
+
+    def test_tls_impersonate_requires_waf_crawl_extra(self):
+        """Opt-in TLS impersonation should fail early when curl_cffi is absent."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+        error = ModuleNotFoundError("No module named 'curl_cffi'")
+        error.name = "curl_cffi"
+
+        with (
+            patch("importlib.import_module", side_effect=error),
+            pytest.raises(ImportError, match="waf-crawl"),
+        ):
+            WebCrawler(config)
 
     @pytest.mark.asyncio
-    async def test_404_does_not_trigger_fallback_chain(self):
+    async def test_404_does_not_trigger_fallback_chain(self, monkeypatch):
         """Ordinary HTTP errors (404, 401, 500) must fail fast.
 
         Only WAF-like statuses (403, 429, 503...) should advance the
@@ -421,6 +465,7 @@ class TestWebCrawler:
         )
 
         call_log = []
+        cffi_requests = self._install_fake_cffi(monkeypatch)
 
         def response_for(impersonate):
             resp = MagicMock()
@@ -428,8 +473,9 @@ class TestWebCrawler:
             resp.text = "<html><body>not found</body></html>"
             return resp
 
-        with patch(
-            "curl_cffi.requests.AsyncSession",
+        with patch.object(
+            cffi_requests,
+            "AsyncSession",
             side_effect=self._make_cffi_session_factory(call_log, response_for),
         ):
             crawler = WebCrawler(config)
@@ -442,7 +488,7 @@ class TestWebCrawler:
         assert "404" in crawler.failed_urls["https://example.com"]
 
     @pytest.mark.asyncio
-    async def test_challenge_page_advances_chain(self, sample_html):
+    async def test_challenge_page_advances_chain(self, sample_html, monkeypatch):
         """A 200 response that's actually a CF JS challenge wrapper must
         be treated like a WAF block (advance to next fingerprint), not
         accepted as content -- otherwise the KB gets polluted with
@@ -461,6 +507,7 @@ class TestWebCrawler:
             "site. cf-challenge in progress.</body></html>"
         )
         call_log = []
+        cffi_requests = self._install_fake_cffi(monkeypatch)
 
         def response_for(impersonate):
             resp = MagicMock()
@@ -471,8 +518,9 @@ class TestWebCrawler:
                 resp.text = sample_html
             return resp
 
-        with patch(
-            "curl_cffi.requests.AsyncSession",
+        with patch.object(
+            cffi_requests,
+            "AsyncSession",
             side_effect=self._make_cffi_session_factory(call_log, response_for),
         ):
             crawler = WebCrawler(config)
@@ -483,3 +531,32 @@ class TestWebCrawler:
         assert call_log[1] == "safari17_0"
         assert len(results) == 1
         assert results[0].status == "success"
+
+    @pytest.mark.asyncio
+    async def test_tls_exception_chain_logs_warning(self, monkeypatch, caplog):
+        """If every fingerprint raises, operators should get a warning summary."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            request_delay=0,
+            tls_impersonate="auto",
+        )
+        cffi_requests = self._install_fake_cffi(monkeypatch)
+
+        def make_session(impersonate=None, **kwargs):
+            sess = AsyncMock()
+            sess.__aenter__ = AsyncMock(return_value=sess)
+            sess.__aexit__ = AsyncMock(return_value=None)
+            sess.get = AsyncMock(side_effect=TimeoutError(f"{impersonate} timed out"))
+            return sess
+
+        with (
+            patch.object(cffi_requests, "AsyncSession", side_effect=make_session),
+            caplog.at_level(logging.WARNING),
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert "All TLS fingerprints failed" in caplog.text
+        assert "chrome116:TimeoutError" in caplog.text
+        assert "https://example.com" in crawler.failed_urls


### PR DESCRIPTION
## Summary

Crawling Cloudflare-fronted sites (saw it on detrack.com, also reproduced on medium.com) can return HTTP 403 even though robots.txt is permissive. The block is at the TLS layer, not HTTP -- the WAF decides from the ClientHello fingerprint before any header is read. Verified by sending a full browser-style header set from the same outbound IP and still getting 403.

This adds opt-in browser TLS fingerprint impersonation via `curl_cffi`, which produces a TLS handshake matching real Chrome / Safari versions. It also adds a built-in fallback chain because WAFs are now fingerprint-blocking the popular impersonation versions:

```
auto chain: chrome116 -> safari17_0 -> safari15_5
```

The picks come from a matrix run on the affected deployment (single outbound IP, 9 sites covering Cloudflare / Akamai / AWS-WAF / Imperva / Alibaba). All three got real content on every site; chrome131 / chrome124 / chrome120 / plain-httpx were 7/9 (blocked or challenged on detrack.com and medium.com).

> Methodology note: my first matrix run had a bug -- it passed a Chrome 130 UA on top of curl_cffi's TLS, which made `chrome120` look 9/9. That combination isn't what the production code uses. Once the test was aligned with the actual call shape (no header injection -- let the impersonate spec own headers), `chrome120` dropped to 7/9 and got swapped for `safari15_5` in the fallback chain.

## Behavior

`WebCrawlConfig.tls_impersonate`:
- `None` *(default)* -- plain httpx, no optional dependency required
- `"auto"` -- try the fallback chain, return first 2xx with real content
- specific spec like `"safari17_0"` -- lock to one fingerprint, no fallback

`curl_cffi` is optional. Install the extra when TLS impersonation is needed:

```bash
pip install "xagent[waf-crawl]"
```

When `tls_impersonate` is non-`None`, `WebCrawler.__init__` validates that `curl_cffi` is available and raises a clear install message if the extra is missing.

The fallback only triggers on actual block symptoms:

| Status | Action |
|---|---|
| 2xx + real content | success |
| 2xx + JS challenge wrapper ("Just a moment...") | advance chain |
| 403 / 429 / 503 / 520-526 | advance chain |
| Any other 4xx/5xx (404, 500...) | fail fast -- next fingerprint won't help |

When `tls_impersonate` is non-`None`, `curl_cffi` owns request headers; `config.user_agent` is intentionally ignored on that path. Mixing a custom UA into curl_cffi's TLS recreates the exact UA-vs-TLS inconsistency WAFs detect (and is what made the original test misleading). robots.txt checks use the impersonate spec's effective UA so policy stays consistent with what we actually send on the wire.

Sessions for every fingerprint in the chain are pre-opened via `AsyncExitStack` (curl_cffi session setup isn't free; reusing across the whole crawl matters). The default httpx path does not import `curl_cffi`.

## Test plan

- [x] All existing crawler tests pass; fixtures updated to `tls_impersonate=None` so the ones that target crawl behavior keep mocking httpx
- [x] `test_default_tls_impersonate_uses_httpx` -- unmodified configs stay on the httpx path
- [x] `test_tls_fallback_chain_advances_on_waf_block` -- 403 -> chain[1] succeeds; assert curl_cffi used 3x and httpx never touched
- [x] `test_tls_impersonate_none_uses_httpx_only` -- curl_cffi is not imported when impersonation is disabled
- [x] `test_tls_impersonate_requires_waf_crawl_extra` -- opt-in impersonation fails early with an actionable install message when the extra is missing
- [x] `test_404_does_not_trigger_fallback_chain` -- only chain[0] is attempted on a content-side error
- [x] `test_challenge_page_advances_chain` -- 200 CF challenge wrapper is recognized and advances
- [x] `test_tls_exception_chain_logs_warning` -- all-exception chain exhaustion logs a warning summary
- [ ] End-to-end live ingestion against detrack.com once this lands (post-merge verification)

## Known limitations

- Empirical evidence is from a single IP/ASN. The chain may stop working if WAFs add chrome116 / safari17_0 / safari15_5 to a blocklist. INFO logs fire on each fallback hit so we can detect drift before users do.
- Per-domain caching of "the fingerprint that worked here" was deferred -- the test data showed ~5s saving on a 100-page crawl, not enough yet to justify the persistence layer.
- `curl_cffi` is a C extension, image size +~30MB across arm64+x86_64 wheels when the `waf-crawl` extra is installed.
