### PR TITLE
fix(web-ingestion): show real failure reason instead of 'completed' on error

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -296,19 +296,11 @@ async def run_web_ingestion(
     # (pages_failed includes both crawl failures and ingestion failures)
     pages_failed = len(failed_urls)
 
-    # Determine overall status
-    # Check if there were any ingestion failures
-    # (in failed_urls but not in crawler failed_urls)
-    has_ingestion_failures = any(
-        url in failed_urls and url not in crawler.failed_urls
-        for url in [r.url for r in crawl_results if r.status == "success"]
-    )
-
     # Status determination:
     # - "error": No docs created AND there were actual failures
     # - "partial": Some docs created but some failures
     # - "success": No failures (empty results are successful)
-    total_failures = pages_failed + (1 if has_ingestion_failures else 0)
+    total_failures = pages_failed
 
     if documents_created == 0 and total_failures > 0:
         status = "error"

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -327,7 +327,7 @@ async def run_web_ingestion(
     # something actionable.
     if status == "error" and failed_urls:
         first_url, first_err = next(iter(failed_urls.items()))
-        message = f"Website crawling failed: {first_url} returned {first_err}"
+        message = f"Web ingestion failed: {first_url} returned {first_err}"
     elif status == "partial" and failed_urls:
         first_url, first_err = next(iter(failed_urls.items()))
         message = (

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -319,6 +319,28 @@ async def run_web_ingestion(
 
     crawled_urls_list = [r.url for r in crawl_results if r.status == "success"]
 
+    # Build a status-aware message. Previously this was unconditionally
+    # "Web ingestion completed: ..." even on error, which produced the
+    # "red error toast + green-toned 'completed' text" UX in the frontend
+    # whenever every crawl attempt got blocked. On error/partial we now
+    # surface the first failing URL and its reason so the user sees
+    # something actionable.
+    if status == "error" and failed_urls:
+        first_url, first_err = next(iter(failed_urls.items()))
+        message = f"Website crawling failed: {first_url} returned {first_err}"
+    elif status == "partial" and failed_urls:
+        first_url, first_err = next(iter(failed_urls.items()))
+        message = (
+            f"Web ingestion partial: {documents_created} documents from "
+            f"{pages_crawled} pages, {len(failed_urls)} failed "
+            f"(first: {first_url} returned {first_err})"
+        )
+    else:
+        message = (
+            f"Web ingestion completed: {documents_created} documents, "
+            f"{total_chunks} chunks, {total_embeddings} embeddings"
+        )
+
     result = WebIngestionResult(
         status=status,
         collection=collection,
@@ -330,10 +352,7 @@ async def run_web_ingestion(
         embeddings_created=total_embeddings,
         crawled_urls=crawled_urls_list,
         failed_urls=failed_urls,
-        message=(
-            f"Web ingestion completed: {documents_created} documents, "
-            f"{total_chunks} chunks, {total_embeddings} embeddings"
-        ),
+        message=message,
         warnings=warnings,
         elapsed_time_ms=elapsed_ms,
     )

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -167,6 +167,7 @@ class TestWebIngestionPipeline:
         assert result.documents_created == 0
         # The message must surface the actual failure, not "completed"
         assert "completed" not in result.message.lower()
+        assert result.message.startswith("Web ingestion failed:")
         assert "https://www.detrack.com" in result.message
         assert "HTTP 403" in result.message
 

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -130,6 +130,47 @@ class TestWebIngestionPipeline:
         assert "Crawl failed" in result.message
 
     @pytest.mark.asyncio
+    async def test_error_message_uses_first_failed_url(
+        self, crawl_config, ingestion_config
+    ):
+        """When the crawler returns normally but every URL was blocked
+        (e.g. all 403s), the result message must reflect the actual
+        failure -- NOT the misleading 'Web ingestion completed' string
+        that previously appeared with status=error.
+
+        Regression test for the UX bug where the frontend showed a red
+        error toast carrying "completed: 0 documents" text whenever a
+        site was WAF-blocked.
+        """
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            # Crawler returns successfully but with empty results +
+            # populated failed_urls (this is the path that previously
+            # produced the misleading message)
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=[])
+            mock_crawler.failed_urls = {
+                "https://www.detrack.com": "HTTP 403",
+                "https://www.detrack.com/about": "HTTP 403",
+            }
+            mock_crawler.total_urls_found = 0
+            mock_crawler_class.return_value = mock_crawler
+
+            result = await run_web_ingestion(
+                collection="test_collection",
+                crawl_config=crawl_config,
+                ingestion_config=ingestion_config,
+            )
+
+        assert result.status == "error"
+        assert result.documents_created == 0
+        # The message must surface the actual failure, not "completed"
+        assert "completed" not in result.message.lower()
+        assert "https://www.detrack.com" in result.message
+        assert "HTTP 403" in result.message
+
+    @pytest.mark.asyncio
     async def test_partial_ingestion_failure(self, crawl_config, ingestion_config):
         """Test handling of partial ingestion failures."""
         # Mock crawl results

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -247,6 +247,10 @@ class TestWebIngestionPipeline:
         assert result.pages_crawled == 2
         assert result.documents_created == 1
         assert result.pages_failed == 1
+        assert "partial" in result.message.lower()
+        assert "completed" not in result.message.lower()
+        assert "https://example.com/page2" in result.message
+        assert "Parse failed" in result.message
         assert len(result.failed_urls) == 1
         assert "https://example.com/page2" in result.failed_urls
 


### PR DESCRIPTION
## Summary

When the crawler returned normally but every URL got blocked (e.g. all 403s from a WAF), `run_web_ingestion` always built `message="Web ingestion completed: 0 documents, 0 chunks, 0 embeddings"` regardless of the result status. Since `kb.py` turns `status="error"` into HTTP 500 and the frontend renders `message` directly into a red error toast, users got "red error icon + 'completed' text" -- which is what showed up in the original bug report screenshot.

Only the post-crawl branch was wrong; the crawler-exception branch upstream of it already builds a meaningful `Website crawling failed: ...` string.

## Fix

Make the post-crawl message status-aware:

| Status | Message |
|---|---|
| `error` (with failed_urls) | `Web ingestion failed: <first_url> returned <reason>` |
| `partial` (with failed_urls) | `Web ingestion partial: N documents from M pages, K failed (first: <url> returned <reason>)` |
| `success` (or no failed_urls fallback) | existing `Web ingestion completed: ...` |

Picking the first entry from `failed_urls` is reliable because Python 3.7+ preserves dict insertion order and the crawler enqueues URLs BFS-style -- so the first failure is typically the start URL, which is exactly what the user wants surfaced.

Also simplified the status calculation by removing the redundant `has_ingestion_failures` adjustment; `pages_failed = len(failed_urls)` already includes both crawl failures and ingestion failures.

## Test plan

- [x] All existing web_ingestion tests pass
- [x] `test_error_message_uses_first_failed_url` -- assert the message contains the failed URL and error code, and crucially does NOT contain "completed"
- [x] `test_partial_ingestion_failure` -- assert the partial branch message contains "partial", omits "completed", and includes the failed URL and reason
