### PR TITLE
fix(custom-api): thread body field through WebToolConfig

### DIFF
--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -725,6 +725,7 @@ class WebToolConfig(BaseToolConfig):
                             "url": api.url,
                             "method": api.method or "GET",
                             "headers": api.headers or {},
+                            "body": api.body,
                             "env": api.env or {},
                         }
                     )

--- a/tests/core/tools/adapters/vibe/test_custom_api_factory.py
+++ b/tests/core/tools/adapters/vibe/test_custom_api_factory.py
@@ -38,6 +38,7 @@ async def test_create_db_custom_api_tools_with_configs():
             "url": "https://api.example.com/api1",
             "method": "POST",
             "headers": {"X-Key": "$k1"},
+            "body": '{"message": "hello"}',
             "env": {"k1": "v1"},
         }
     ]
@@ -46,6 +47,10 @@ async def test_create_db_custom_api_tools_with_configs():
     assert len(tools) == 1
     assert tools[0].name == "api_api1_call"
     assert "Configured endpoint: https://api.example.com/api1" in tools[0].description
+    # Body template must thread through to the tool so POST requests
+    # actually carry the configured payload at runtime.
+    assert tools[0]._default_body == '{"message": "hello"}'
+    assert "Configured body template:" in tools[0].description
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -889,3 +889,90 @@ class TestWebToolConfigUserOverride:
             assert "calculator" in tool_names
         finally:
             set_user_tool_overrides_hook(None)
+
+
+class TestWebToolConfigCustomApi:
+    """Verify WebToolConfig.get_custom_api_configs() exposes the body field
+    so that POST custom-api tools actually send their configured payload."""
+
+    def test_get_custom_api_configs_includes_body(self):
+        """Regression test for production bug (Task 898 / Agent 170):
+
+        A user had a Custom API entry with method=POST and a JSON body
+        template, but their POST requests went out with empty bodies.
+        Root cause: WebToolConfig.get_custom_api_configs() built its
+        config dict without the `body` field, so by the time the tool
+        was constructed the body template was already gone.
+
+        This test mirrors the actual production record (Post_HelloAPI)
+        and asserts the body field survives the DB -> dict translation.
+        """
+        from unittest.mock import MagicMock
+
+        from xagent.web.tools.config import WebToolConfig
+
+        # Mirror of production custom_apis row (id=5, name=Post_HelloAPI)
+        api = MagicMock()
+        api.name = "Post_HelloAPI"
+        api.description = None
+        api.url = "https://helloapi-u6nc.onrender.com/"
+        api.method = "POST"
+        api.headers = {}
+        api.body = '{\n  "message": "example message"\n}'
+        api.env = None
+
+        user_api = MagicMock()
+        user_api.custom_api = api
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [user_api]
+
+        cfg = WebToolConfig(
+            db=db,
+            request=MagicMock(),
+            user_id=33,
+            workspace_config={"base_dir": "/tmp", "task_id": "test"},
+        )
+        configs = cfg.get_custom_api_configs()
+
+        assert len(configs) == 1
+        config = configs[0]
+        assert config["name"] == "Post_HelloAPI"
+        assert config["method"] == "POST"
+        # The crucial assertion: body must propagate
+        assert config["body"] == '{\n  "message": "example message"\n}'
+
+    def test_get_custom_api_configs_body_optional(self):
+        """When the user has not configured a body (e.g. GET-only tools),
+        the body field should still be present in the config but None,
+        so downstream code can rely on the key existing."""
+        from unittest.mock import MagicMock
+
+        from xagent.web.tools.config import WebToolConfig
+
+        api = MagicMock()
+        api.name = "Get_HiAPI"
+        api.description = None
+        api.url = "https://helloapi-u6nc.onrender.com/"
+        api.method = "GET"
+        api.headers = {"message": ""}
+        api.body = None
+        api.env = None
+
+        user_api = MagicMock()
+        user_api.custom_api = api
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [user_api]
+
+        cfg = WebToolConfig(
+            db=db,
+            request=MagicMock(),
+            user_id=33,
+            workspace_config={"base_dir": "/tmp", "task_id": "test"},
+        )
+        configs = cfg.get_custom_api_configs()
+
+        assert len(configs) == 1
+        assert "body" in configs[0]
+        assert configs[0]["body"] is None


### PR DESCRIPTION
## Summary

POST custom-API tools were sending empty bodies even when the user had configured a body template in the UI. Reproduced from a production task (agent 170, task 898): the user's `Post_HelloAPI` had `method=POST` and `body='{\"message\": \"example message\"}'` saved in the DB, but the agent's tool call went out as `tool_args: {}` and the target server returned:

```json
{"detail": [{"loc": ["body"], "msg": "Field required", "input": null}]}
```

The same agent's GET tools worked fine, which is consistent with body being missing rather than the request itself being broken.

## Root cause

PR #344 added the body-template column to `custom_apis` and wired it through five places — DB column, model, API CRUD, the frontend form, the `CustomApiTool` constructor + `create_custom_api_tools` factory. It missed one: `WebToolConfig.get_custom_api_configs()`, which is the layer that materializes the DB record into the dict consumed by the tool factory at agent runtime. With `body` dropped at that hop, `CustomApiTool._default_body` ends up `None`, the tool's description doesn't include the configured template, the LLM has no idea what payload to send, and the request goes out with an empty body.

## Fix

One line — include `api.body` in the config dict alongside the other fields. The other six places that read this column were already correct; only the runtime config bridge was stale.

## Test plan

- [x] `tests/web/api/test_tools_api.py::TestWebToolConfigCustomApi`:
  - `test_get_custom_api_configs_includes_body` — uses the actual production `Post_HelloAPI` shape and asserts the body field survives the DB→dict translation.
  - `test_get_custom_api_configs_body_optional` — covers the existing GET-only case (body is None).
- [x] `tests/core/tools/adapters/vibe/test_custom_api_factory.py::test_create_db_custom_api_tools_with_configs` extended to pass `body` in the test config and assert it ends up on `tool._default_body` and in the tool's description.
- [x] Existing tests in both files still pass (40/40).