### PR TITLE
fix(docker): add npm fetch retry config to prevent ECONNRESET on nightly build

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -139,7 +139,10 @@ COPY --from=backend-build /root/.cache/deepdoc /root/.cache/deepdoc
 
 # Copy frontend package files for npm tasks (e.g., PPTX generation)
 COPY frontend/package.json frontend/package-lock.json /opt/xagent/frontend/
-RUN cd /opt/xagent/frontend && npm ci \
+RUN cd /opt/xagent/frontend \
+    && npm config set fetch-retries 5 \
+    && npm config set fetch-retry-mintimeout 30000 \
+    && npm ci \
     && npm install -g pptxgenjs@4.0.1 \
     && python -m playwright install chromium \
     && chmod +x /opt/xagent/deploy/entrypoint.sh


### PR DESCRIPTION
## Summary
- Fix nightly Docker build failure (#361) caused by `npm ci` timing out with `ECONNRESET` on arm64 QEMU builds
- Add `npm fetch-retries 5` and `fetch-retry-mintimeout 30000` before `npm ci` in `Dockerfile.backend`

## Root Cause
The arm64 platform build runs via QEMU emulation, making `npm ci` take 160+ seconds. During this time, the npm registry connection can get reset (ECONNRESET, errno -104), causing npm to exit with code 152 and the entire build to fail.

## Fix
Added npm fetch retry configuration before `npm ci`:
- `fetch-retries 5` — retry failed fetches up to 5 times (default: 2)
- `fetch-retry-mintimeout 30000` — minimum 30s backoff between retries (default: 10s)

This applies to both `npm ci` and `npm install -g pptxgenjs`, giving the build resilience against transient network issues.