### PR TITLE
feat(upload): support .pptx / .ppt in task file uploads

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -672,7 +672,7 @@ export function ChatInput({
                       multiple
                       onChange={handleFileSelect}
                       className="hidden"
-                      accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.png,.jpg,.jpeg,.gif,.webp"
+                      accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
                     />
                     <Button
                       type="button"

--- a/frontend/src/components/file/file-upload.tsx
+++ b/frontend/src/components/file/file-upload.tsx
@@ -76,7 +76,7 @@ export function FileUpload({ onFilesChange, files }: FileUploadProps) {
           multiple
           onChange={handleFileSelect}
           className="hidden"
-          accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls"
+          accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx"
         />
         <Upload
           className={cn(

--- a/src/xagent/core/tools/core/file_analysis.py
+++ b/src/xagent/core/tools/core/file_analysis.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List, Tuple
 
 from pydantic import BaseModel
 
@@ -58,6 +58,8 @@ def analyze_uploaded_file(
         return _analyze_python_file(file_path, filename, file_size)
     elif file_ext == ".md":
         return _analyze_markdown_file(file_path, filename, file_size)
+    elif file_ext in (".pptx", ".ppt"):
+        return _analyze_pptx_file(file_path, filename, file_size, file_ext)
     else:
         return _analyze_generic_file(file_path, filename, file_size, file_ext)
 
@@ -326,6 +328,188 @@ def _analyze_markdown_file(
 
     except Exception as e:
         raise ValueError(f"Failed to analyze Markdown file: {e}")
+
+
+def iter_pptx_shapes(shapes: Any) -> Iterator[Any]:
+    """Yield individual shapes, recursing into ``GroupShape`` containers.
+
+    Top-level iteration over ``slide.shapes`` misses content nested inside
+    grouped shapes (a common PowerPoint pattern). This generator descends into
+    any group it encounters so callers see a flat stream of leaf shapes.
+    """
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    for shape in shapes:
+        if getattr(shape, "shape_type", None) == MSO_SHAPE_TYPE.GROUP:
+            yield from iter_pptx_shapes(shape.shapes)
+        else:
+            yield shape
+
+
+def collect_pptx_slide_blocks(prs: Any) -> Tuple[List[str], Dict[str, int]]:
+    """Walk a python-pptx ``Presentation`` and return per-slide text blocks.
+
+    Returns:
+        A pair ``(blocks, stats)`` where ``blocks`` is a list of formatted
+        per-slide strings (e.g. ``"Slide 1:\nTitle\n..."``). Slides with no
+        text / notes / table content are omitted. ``stats`` is a dict with
+        ``total_shapes``, ``total_chars``, ``notes_count``, ``image_count``.
+
+    Callers are expected to have verified that ``python-pptx`` is importable
+    before passing a Presentation in.
+    """
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    blocks: list[str] = []
+    total_shapes = 0
+    total_chars = 0
+    notes_count = 0
+    image_count = 0
+
+    for slide_num, slide in enumerate(prs.slides, 1):
+        slide_lines: list[str] = []
+        for shape in iter_pptx_shapes(slide.shapes):
+            total_shapes += 1
+            if getattr(shape, "shape_type", None) == MSO_SHAPE_TYPE.PICTURE:
+                image_count += 1
+            shape_text = getattr(shape, "text", None)
+            if shape_text:
+                txt = str(shape_text).strip()
+                if txt:
+                    slide_lines.append(txt)
+                    total_chars += len(txt)
+            elif getattr(shape, "has_table", False):
+                for row in shape.table.rows:
+                    for cell in row.cells:
+                        txt = cell.text_frame.text.strip()
+                        if txt:
+                            slide_lines.append(txt)
+                            total_chars += len(txt)
+        # ``slide.notes_slide`` creates a notes slide on access; guard with
+        # ``has_notes_slide`` so this analyzer stays read-only.
+        notes = ""
+        if getattr(slide, "has_notes_slide", False):
+            notes_frame = getattr(slide.notes_slide, "notes_text_frame", None)
+            notes = getattr(notes_frame, "text", "").strip() if notes_frame else ""
+        if notes:
+            notes_count += 1
+            slide_lines.append(f"[Notes] {notes}")
+            total_chars += len(notes)
+        if slide_lines:
+            blocks.append(f"Slide {slide_num}:\n" + "\n".join(slide_lines))
+
+    stats = {
+        "total_shapes": total_shapes,
+        "total_chars": total_chars,
+        "notes_count": notes_count,
+        "image_count": image_count,
+    }
+    return blocks, stats
+
+
+def _analyze_pptx_file(
+    file_path: Path, filename: str, file_size: int, file_ext: str
+) -> FileAnalysisResult:
+    """Analyze a PowerPoint presentation (.pptx / .ppt) file.
+
+    Uses python-pptx to extract slide titles, body text and speaker notes so the
+    agent receives a usable text representation instead of binary blob bytes.
+    Legacy ``.ppt`` (binary) files are not supported by python-pptx; they fall
+    back to the generic analyzer with a hint to convert.
+    """
+    if file_ext == ".ppt":
+        # python-pptx only supports the OOXML .pptx format. Return a binary
+        # fallback directly instead of letting _analyze_generic_file attempt a
+        # UTF-8 read on the binary CFB stream.
+        return FileAnalysisResult(
+            filename=filename,
+            file_type=file_ext,
+            size=file_size,
+            content_preview="[Binary or non-text file]",
+            structure_summary=(
+                f"Legacy PowerPoint file ({file_ext}) with {file_size} bytes"
+            ),
+            key_insights=[
+                "Legacy .ppt format detected; convert to .pptx for full text extraction.",
+                "File appears to be binary or encoded",
+            ],
+            suggested_actions=[
+                "Use appropriate binary file tools",
+                "Convert to .pptx format",
+            ],
+        )
+
+    try:
+        from pptx import Presentation
+    except ImportError:
+        result = _analyze_generic_file(file_path, filename, file_size, file_ext)
+        result.key_insights.insert(
+            0,
+            "python-pptx not installed; install xagent[document-processing] to parse .pptx.",
+        )
+        return result
+
+    try:
+        prs = Presentation(str(file_path))
+    except Exception as exc:  # noqa: BLE001
+        return FileAnalysisResult(
+            filename=filename,
+            file_type=file_ext,
+            size=file_size,
+            content_preview="[Failed to open presentation]",
+            structure_summary=f"Invalid or corrupt .pptx file ({file_size} bytes)",
+            key_insights=[f"python-pptx could not open file: {exc}"],
+            suggested_actions=[
+                "Verify the file is a valid .pptx",
+                "Re-export from PowerPoint or Keynote",
+            ],
+        )
+
+    slide_blocks, stats = collect_pptx_slide_blocks(prs)
+    total_shapes = stats["total_shapes"]
+    total_chars = stats["total_chars"]
+    notes_count = stats["notes_count"]
+    image_count = stats["image_count"]
+
+    full_text = "\n\n".join(slide_blocks)
+    content_preview = (full_text[:500] + "...") if len(full_text) > 500 else full_text
+
+    structure_summary = (
+        f"PowerPoint presentation with {len(prs.slides)} slide(s), "
+        f"{total_shapes} shape(s), {image_count} picture(s), "
+        f"{notes_count} slide(s) with speaker notes ({total_chars} text chars)"
+    )
+
+    insights = [
+        f"{len(prs.slides)} slide(s) extracted via python-pptx",
+        f"{total_chars} characters of text content available",
+    ]
+    if notes_count:
+        insights.append(f"{notes_count} slide(s) contain speaker notes")
+    if image_count:
+        insights.append(
+            f"{image_count} embedded picture(s) - consider OCR if text is in images"
+        )
+    if total_chars == 0:
+        insights.append("No extractable text - slides may consist of images only")
+
+    actions = [
+        "Use the extracted slide text as agent context",
+        "Pass to document_parser tool with parser_name='unstructured' for richer chunks",
+        "Render to PDF/HTML for visual preview if needed",
+    ]
+    if image_count:
+        actions.append("Run image OCR on slides whose text lives inside images")
+
+    return FileAnalysisResult(
+        filename=filename,
+        file_type=file_ext,
+        size=file_size,
+        content_preview=content_preview,
+        structure_summary=structure_summary,
+        key_insights=insights,
+        suggested_actions=actions,
+    )
 
 
 def _analyze_generic_file(

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -12,6 +12,10 @@ from sqlalchemy.orm import Session
 
 from ...config import get_uploads_dir
 from ...core.tools.adapters.vibe.file_tool import read_file
+from ...core.tools.core.file_analysis import (
+    collect_pptx_slide_blocks,
+    iter_pptx_shapes,
+)
 from ..auth_dependencies import get_current_user
 from ..config import (
     BINARY_EXTENSIONS,
@@ -403,6 +407,25 @@ async def _try_convert_pptx_to_pdf(path: Path) -> Optional[StreamingResponse]:
         return None
 
 
+def _pptx_text_preview(path: Path) -> str:
+    """Extract a plain-text preview from a .pptx file for upload responses.
+
+    Concatenates each slide's shape text and speaker notes. Returns an empty
+    string if python-pptx is not installed, the file is not .pptx, or
+    extraction fails.
+    """
+    if not pptx or path.suffix.lower() != ".pptx":
+        return ""
+    try:
+        prs = pptx.Presentation(str(path))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to open pptx for preview: %s", exc)
+        return ""
+
+    blocks, _stats = collect_pptx_slide_blocks(prs)
+    return "\n\n".join(blocks)
+
+
 def _pptx_fallback_html(path: Path) -> HTMLResponse:
     if not pptx:
         raise pptx_not_installed_exception
@@ -420,23 +443,41 @@ def _pptx_fallback_html(path: Path) -> HTMLResponse:
             .slide { border: 1px solid #ddd; padding: 20px; margin: 20px 0; background: #f9f9f9; border-radius: 8px; }
             .slide-number { color: #999; font-size: 12px; margin-top: 10px; }
             .text-content { white-space: pre-wrap; }
+            .notes { color: #666; font-style: italic; margin-top: 10px; }
         </style>
     </head>
     <body>
     """
     html_content += f"<h1>📊 {path.name}</h1>"
+    total_slides = len(prs.slides)
     for slide_num, slide in enumerate(prs.slides, 1):
-        slide_text = []
-        for shape in slide.shapes:
+        slide_text: list[str] = []
+        for shape in iter_pptx_shapes(slide.shapes):
             shape_text = getattr(shape, "text", None)
             if shape_text:
-                slide_text.append(str(shape_text))
-        if slide_text:
+                txt = str(shape_text).strip()
+                if txt:
+                    slide_text.append(txt)
+            elif getattr(shape, "has_table", False):
+                for row in shape.table.rows:
+                    for cell in row.cells:
+                        cell_text = cell.text_frame.text.strip()
+                        if cell_text:
+                            slide_text.append(cell_text)
+        notes_html = ""
+        if getattr(slide, "has_notes_slide", False):
+            notes_frame = getattr(slide.notes_slide, "notes_text_frame", None)
+            notes = getattr(notes_frame, "text", "").strip() if notes_frame else ""
+            if notes:
+                notes_html = f'<div class="notes">[Notes] {notes}</div>'
+        if slide_text or notes_html:
+            body_html = "<br>".join(slide_text)
             html_content += f"""
             <div class=\"slide\">
                 <h2>Slide {slide_num}</h2>
-                <div class=\"text-content\">{"<br>".join(slide_text)}</div>
-                <div class=\"slide-number\">Slide {slide_num} of {len(prs.slides)}</div>
+                <div class=\"text-content\">{body_html}</div>
+                {notes_html}
+                <div class=\"slide-number\">Slide {slide_num} of {total_slides}</div>
             </div>
             """
     html_content += "</body></html>"
@@ -509,7 +550,23 @@ async def upload_file(
             content_preview = ""
             # Skip preview generation for binary files (images, videos, etc.)
             file_extension = Path(uploaded.filename).suffix.lower()
-            if file_extension not in BINARY_EXTENSIONS:
+            if file_extension == ".pptx":
+                try:
+                    preview_content = await asyncio.to_thread(
+                        _pptx_text_preview, target_path
+                    )
+                    content_preview = (
+                        preview_content[:500] + "..."
+                        if len(preview_content) > 500
+                        else preview_content
+                    )
+                except Exception:
+                    content_preview = ""
+            elif file_extension == ".ppt":
+                # python-pptx does not support the legacy .ppt format; skip
+                # the thread dispatch and return an empty preview directly.
+                content_preview = ""
+            elif file_extension not in BINARY_EXTENSIONS:
                 try:
                     preview_content = read_file(str(target_path))
                     content_preview = (

--- a/src/xagent/web/config.py
+++ b/src/xagent/web/config.py
@@ -65,6 +65,7 @@ ALLOWED_EXTENSIONS = {
         ".xlsx",
         ".xls",
         ".pptx",
+        ".ppt",
     ]
     + list(BINARY_EXTENSIONS),
     "text": [".txt", ".md", ".html", ".htm"],
@@ -81,6 +82,7 @@ ALLOWED_EXTENSIONS = {
         ".xlsx",
         ".xls",
         ".pptx",
+        ".ppt",
     ],
     "image": [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".ico"],
 }

--- a/tests/core/tools/core/test_file_analysis.py
+++ b/tests/core/tools/core/test_file_analysis.py
@@ -1,0 +1,223 @@
+"""Tests for ``xagent.core.tools.core.file_analysis`` PowerPoint handling."""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from typing import Any, Iterable
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches
+
+from xagent.core.tools.core.file_analysis import (
+    analyze_uploaded_file,
+    collect_pptx_slide_blocks,
+    iter_pptx_shapes,
+)
+
+# --------------------------------------------------------------------------- #
+# Builders                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _build_pptx(tmp_path: Path, builder) -> Path:
+    """Run ``builder(prs)`` against a fresh Presentation, save it, return path."""
+    prs = Presentation()
+    builder(prs)
+    pptx_path = tmp_path / "deck.pptx"
+    prs.save(str(pptx_path))
+    return pptx_path
+
+
+def _add_title_body_slide(prs, title: str, body: str) -> None:
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = title
+    slide.placeholders[1].text = body
+
+
+# --------------------------------------------------------------------------- #
+# iter_pptx_shapes                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_iter_pptx_shapes_descends_into_groups(tmp_path: Path) -> None:
+    """Shapes inside a GroupShape are yielded as flat leaves."""
+
+    def build(prs):
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        slide.shapes.title.text = "top"
+        tb1 = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(3), Inches(1))
+        tb1.text_frame.text = "child A"
+        tb2 = slide.shapes.add_textbox(Inches(1), Inches(3), Inches(3), Inches(1))
+        tb2.text_frame.text = "child B"
+        slide.shapes.add_group_shape([tb1, tb2])
+
+    path = _build_pptx(tmp_path, build)
+    prs = Presentation(str(path))
+    texts = [
+        getattr(shape, "text", "")
+        for shape in iter_pptx_shapes(prs.slides[0].shapes)
+        if getattr(shape, "text", "")
+    ]
+    assert "top" in texts
+    assert "child A" in texts
+    assert "child B" in texts
+
+
+# --------------------------------------------------------------------------- #
+# collect_pptx_slide_blocks                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_collect_pptx_slide_blocks_text_tables_notes_groups(
+    tmp_path: Path,
+) -> None:
+    """Helper extracts shape text, table cells, speaker notes, and group content."""
+
+    def build(prs):
+        _add_title_body_slide(prs, "Intro", "subtitle")
+        prs.slides[0].notes_slide.notes_text_frame.text = "speaker notes"
+
+        # Slide with a table
+        s2 = prs.slides.add_slide(prs.slide_layouts[5])
+        s2.shapes.title.text = "Data"
+        tbl = s2.shapes.add_table(
+            2, 2, Inches(1), Inches(1), Inches(4), Inches(2)
+        ).table
+        tbl.cell(0, 0).text = "Name"
+        tbl.cell(0, 1).text = "City"
+        tbl.cell(1, 0).text = "Alice"
+        tbl.cell(1, 1).text = "Shanghai"
+
+        # Slide with a group
+        s3 = prs.slides.add_slide(prs.slide_layouts[5])
+        s3.shapes.title.text = "Grouped"
+        tb1 = s3.shapes.add_textbox(Inches(1), Inches(2), Inches(3), Inches(1))
+        tb1.text_frame.text = "g-a"
+        tb2 = s3.shapes.add_textbox(Inches(1), Inches(3), Inches(3), Inches(1))
+        tb2.text_frame.text = "g-b"
+        s3.shapes.add_group_shape([tb1, tb2])
+
+        # Empty slide
+        prs.slides.add_slide(prs.slide_layouts[6])
+
+    path = _build_pptx(tmp_path, build)
+    blocks, stats = collect_pptx_slide_blocks(Presentation(str(path)))
+    joined = "\n\n".join(blocks)
+
+    assert "Intro" in joined
+    assert "subtitle" in joined
+    assert "[Notes] speaker notes" in joined
+    assert "Alice" in joined
+    assert "Shanghai" in joined
+    assert "g-a" in joined
+    assert "g-b" in joined
+    # Empty slide must not produce a header
+    assert "Slide 4:" not in joined
+
+    assert stats["notes_count"] == 1
+    assert stats["total_chars"] > 0
+    assert stats["image_count"] == 0
+
+
+def test_collect_pptx_slide_blocks_does_not_create_notes_slide(
+    tmp_path: Path,
+) -> None:
+    """The analyzer must not mutate the deck by accessing slide.notes_slide."""
+
+    def build(prs):
+        _add_title_body_slide(prs, "no notes", "body")
+
+    path = _build_pptx(tmp_path, build)
+    collect_pptx_slide_blocks(Presentation(str(path)))
+
+    # Reload from disk and verify no notes slide was added
+    reloaded = Presentation(str(path))
+    assert reloaded.slides[0].has_notes_slide is False
+
+
+# --------------------------------------------------------------------------- #
+# analyze_uploaded_file - .pptx branch                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_pptx_returns_preview_and_summary(tmp_path: Path) -> None:
+    def build(prs):
+        _add_title_body_slide(prs, "Hello", "World")
+
+    path = _build_pptx(tmp_path, build)
+    result = analyze_uploaded_file(path.name, uploads_dir=str(path.parent))
+
+    assert result.file_type == ".pptx"
+    assert "Hello" in result.content_preview
+    assert "World" in result.content_preview
+    assert "PowerPoint presentation" in result.structure_summary
+    assert any("slide(s) extracted" in i for i in result.key_insights)
+
+
+def test_analyze_pptx_corrupt_file_returns_error_result(tmp_path: Path) -> None:
+    bad = tmp_path / "corrupt.pptx"
+    bad.write_bytes(b"not actually a pptx zip")
+
+    result = analyze_uploaded_file(bad.name, uploads_dir=str(tmp_path))
+
+    assert result.file_type == ".pptx"
+    assert result.content_preview == "[Failed to open presentation]"
+    assert "Invalid or corrupt" in result.structure_summary
+    assert any("python-pptx could not open" in i for i in result.key_insights)
+
+
+# --------------------------------------------------------------------------- #
+# analyze_uploaded_file - .ppt legacy fallback                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_legacy_ppt_returns_binary_fallback(tmp_path: Path) -> None:
+    """Legacy .ppt files take a direct binary-fallback path; no UTF-8 read."""
+    ppt = tmp_path / "legacy.ppt"
+    # CFB header bytes — content doesn't have to be a real .ppt
+    ppt.write_bytes(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1binary blob")
+
+    result = analyze_uploaded_file(ppt.name, uploads_dir=str(tmp_path))
+
+    assert result.file_type == ".ppt"
+    assert result.content_preview == "[Binary or non-text file]"
+    assert "Legacy PowerPoint file" in result.structure_summary
+    assert result.key_insights[0].startswith("Legacy .ppt format detected")
+
+
+# --------------------------------------------------------------------------- #
+# analyze_uploaded_file - ImportError fallback                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_pptx_without_python_pptx_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If python-pptx is unavailable at runtime, the analyzer degrades."""
+
+    def build(prs):
+        _add_title_body_slide(prs, "T", "B")
+
+    path = _build_pptx(tmp_path, build)
+
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals_: Any = None,
+        locals_: Any = None,
+        fromlist: Iterable[str] = (),
+        level: int = 0,
+    ):
+        if name == "pptx" or name.startswith("pptx."):
+            raise ImportError(name)
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = analyze_uploaded_file(path.name, uploads_dir=str(path.parent))
+
+    assert result.file_type == ".pptx"
+    assert any("python-pptx not installed" in i for i in result.key_insights)


### PR DESCRIPTION
## Summary

Adds first-class `.pptx` (and legacy `.ppt`) support across the task file
upload pipeline. Previously the backend whitelist already had `.pptx`, but
the frontend `<input accept>` excluded it, the upload preview tried to read
the binary as text, and the agent-facing file analyzer fell through to the
generic binary fallback — so an uploaded deck arrived at the agent as bytes
with no usable content.

This change makes pptx a fully supported document type, end to end.

## What's changed

**Frontend**
- `frontend/src/components/file/file-upload.tsx` — add `.ppt,.pptx` to the
  task upload component's `accept` list
- `frontend/src/components/chat/ChatInput.tsx` — same for the chat input
  attachment picker

**Backend — accept & store**
- `src/xagent/web/config.py` — add `.ppt` to both the `general` and
  `document` buckets of `ALLOWED_EXTENSIONS` (`.pptx` was already present)

**Backend — upload preview**
- `src/xagent/web/api/files.py` — new `_pptx_text_preview()` helper that
  uses `python-pptx` to extract slide text + speaker notes. The upload
  endpoint now routes `.pptx` / `.ppt` files through it instead of the
  generic `read_file()` path, which would otherwise return binary garbage.
  Falls back to an empty string when `python-pptx` isn't installed or the
  file is corrupt.

**Agent-facing parsing**
- `src/xagent/core/tools/core/file_analysis.py` — new
  `_analyze_pptx_file()` so `analyze_uploaded_file()` returns a real
  `FileAnalysisResult` for presentations:
  - per-slide title / body text, speaker notes labelled `[Notes] …`
  - structure summary: slide count, shape count, picture count, notes
    count, total text-char count
  - insights/actions hints (e.g. "n slide(s) contain speaker notes",
    "embedded pictures — consider OCR")
  - Legacy `.ppt` (binary CFB) is not supported by `python-pptx`; it
    degrades gracefully to the generic analyzer with a "convert to .pptx"
    hint.
  - If `python-pptx` is not installed, also degrades gracefully with an
    install hint.

The existing `document_parser.py` already routed `.pptx` / `.ppt` to the
`unstructured` parser, so no change was needed there.

## Verification

Tested locally with a generated 2-slide `.pptx` (title + body + speaker
notes on slide 1, title on slide 2):