### PR TITLE
fix(model): skip unshare logic when share_with_users=false on already-unshared model

### DIFF
--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -1725,37 +1725,37 @@ async def update_model(
                 UserModel.user_id == user.id,
             ).update({"is_shared": True})
         else:
-            # Constraint 1: owner cannot un-share own default model
-            owner_defaults = (
-                db.query(UserDefaultModel)
-                .filter(
+            # `share_with_users=false` on an already-unshared model is a no-op
+            if is_shared:
+                # Constraint 1: owner cannot un-share own default model
+                owner_defaults = (
+                    db.query(UserDefaultModel)
+                    .filter(
+                        UserDefaultModel.model_id == db_model.id,
+                        UserDefaultModel.user_id == user.id,
+                    )
+                    .count()
+                )
+                if owner_defaults > 0:
+                    raise HTTPException(
+                        409,
+                        detail="Cannot un-share: you have this model as your default. Change default first.",
+                    )
+
+                # Disable sharing:
+                # 1. Update owner's record to shared=False
+                user_model.is_shared = False  # type: ignore[assignment]
+
+                # 2. Delete all non-owner UserModel records
+                db.query(UserModel).filter(
+                    UserModel.model_id == db_model.id, UserModel.is_owner.is_(False)
+                ).delete()
+
+                # 3. Clean up non-owner UserDefaultModel records
+                db.query(UserDefaultModel).filter(
                     UserDefaultModel.model_id == db_model.id,
-                    UserDefaultModel.user_id == user.id,
-                )
-                .count()
-            )
-            if owner_defaults > 0:
-                raise HTTPException(
-                    409,
-                    detail="Cannot un-share: you have this model as your default. Change default first.",
-                )
-
-            # Disable sharing:
-            # 1. Update owner's record to shared=False
-            db.query(UserModel).filter(
-                UserModel.model_id == db_model.id, UserModel.user_id == user.id
-            ).update({"is_shared": False})
-
-            # 2. Delete all non-owner UserModel records
-            db.query(UserModel).filter(
-                UserModel.model_id == db_model.id, UserModel.is_owner.is_(False)
-            ).delete()
-
-            # 3. Clean up non-owner UserDefaultModel records
-            db.query(UserDefaultModel).filter(
-                UserDefaultModel.model_id == db_model.id,
-                UserDefaultModel.user_id != user.id,
-            ).delete()
+                    UserDefaultModel.user_id != user.id,
+                ).delete()
 
     # Update model configuration in-place
     update_data = model_update.model_dump(exclude_unset=True)

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -562,6 +562,33 @@ class TestProtectionConstraints:
         assert update_response.status_code == 409
         assert "default" in update_response.json()["detail"].lower()
 
+    def test_unshared_default_model_sending_false_is_noop(
+        self, test_db, admin_headers, sample_model_data
+    ):
+        """share_with_users=false on an already-unshared default model is a no-op (200)."""
+        # Create model WITHOUT sharing
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_id_str = create_response.json()["model_id"]
+        model_db_id = create_response.json()["id"]
+
+        # Set as own default
+        client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+
+        # Sending share_with_users=False on an already-unshared model should be a no-op
+        update_response = client.put(
+            f"/api/models/{model_id_str}",
+            json={"share_with_users": False},
+            headers=admin_headers,
+        )
+        assert update_response.status_code == 200
+
     def test_owner_can_delete_when_no_default(
         self, test_db, admin_headers, sample_model_data
     ):


### PR DESCRIPTION
## Summary
- Frontend edit dialog always sends `share_with_users: false`, which triggered the unshare path and returned 409 if the model was a user default, even when the model was never shared.
- Added a guard: only execute unshare when the model is currently in shared state. A `false` value on an already-unshared model is a no-op.

## Reproduce
1. Create a model and set it as any default (general/small_fast/visual/compact)
2. Edit the model (e.g. change its name)
3. Observe 409 Conflict error

## Fix
In `update_model`, when `share_with_users` is `false`, first check if the model is currently shared. If not, skip the unshare logic entirely.