### PR TITLE
fix: surface real failures and unblock uploaded files in agent tools

### DIFF
--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -200,9 +200,18 @@ class PlanExecutor:
                 step.result = result if isinstance(result, dict) else {"value": result}
 
                 if not sub_success:
+                    # ReActPattern.run_with_context returns the LLM's failure
+                    # explanation under either ``error`` (when react.py wrote
+                    # an explicit failure final answer) or ``output`` (the
+                    # generic fallback wrapper). Prefer ``error``; fall back
+                    # to ``output``; finally a static string so the surfaced
+                    # message is never empty.
+                    failure_message = None
+                    if isinstance(result, dict):
+                        failure_message = result.get("error") or result.get("output")
                     failure_message = (
-                        result.get("error") if isinstance(result, dict) else None
-                    ) or "ReAct sub-agent reported success=false"
+                        failure_message or "ReAct sub-agent reported success=false"
+                    )
                     raise DAGStepError(
                         step_id=step.id,
                         step_name=step.name,

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -203,9 +203,7 @@ class PlanExecutor:
                 else:
                     step.status = StepStatus.FAILED
                     step.error = (
-                        result.get("error")
-                        if isinstance(result, dict)
-                        else None
+                        result.get("error") if isinstance(result, dict) else None
                     ) or "ReAct sub-agent reported success=false"
                     step.error_type = "ReActFailure"
 

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -184,41 +184,13 @@ class PlanExecutor:
                         is_builder_context,
                     )
 
-                # Determine whether the ReAct sub-agent actually succeeded.
-                # ReAct's final answer payload carries a ``success`` flag; when the
-                # LLM concludes the task cannot be completed it returns
-                # ``success: False``. Treating that as a "completed" step lets the
-                # task-level summary claim "Task completed successfully" even when
-                # every tool call inside failed, so we surface it as FAILED via
-                # the same exception path as other step failures — that way the
-                # DAG's failure recovery (dependency unblocking, trace, etc.)
-                # runs immediately instead of waiting for the deadlock detector.
-                sub_success = True
-                if isinstance(result, dict) and result.get("success") is False:
-                    sub_success = False
-
-                step.result = result if isinstance(result, dict) else {"value": result}
-
-                if not sub_success:
-                    # ReActPattern.run_with_context returns the LLM's failure
-                    # explanation under either ``error`` (when react.py wrote
-                    # an explicit failure final answer) or ``output`` (the
-                    # generic fallback wrapper). Prefer ``error``; fall back
-                    # to ``output``; finally a static string so the surfaced
-                    # message is never empty.
-                    failure_message = None
-                    if isinstance(result, dict):
-                        failure_message = result.get("error") or result.get("output")
-                    failure_message = (
-                        failure_message or "ReAct sub-agent reported success=false"
-                    )
-                    raise DAGStepError(
-                        step_id=step.id,
-                        step_name=step.name,
-                        message=failure_message,
-                    )
-
+                # Handle successful completion.
+                # ReAct's success=false case is converted into a DAGStepError
+                # INSIDE _execute_step_with_react_agent (before it stores
+                # step_execution_results / emits trace_step_end), so by the
+                # time we reach this line the step truly completed.
                 step.status = StepStatus.COMPLETED
+                step.result = result if isinstance(result, dict) else {"value": result}
                 completed_steps.add(step_id)
 
                 # Add to execution results
@@ -847,6 +819,24 @@ class PlanExecutor:
                 # to fire below, and we want the step to be marked as COMPLETED.
                 # The interrupt flags set above will cleanly break the execution loops.
 
+            # If the ReAct sub-agent's final answer explicitly reports failure,
+            # surface it as a failed step BEFORE we record execution results or
+            # emit a "completed" trace_step_end. The except block below catches
+            # the raise and emits trace_step_end(status: FAILED) so the
+            # frontend's DAG step view updates from running directly to failed
+            # without ever seeing a transient "completed" state.
+            if isinstance(result, dict) and result.get("success") is False:
+                failure_message = (
+                    result.get("error")
+                    or result.get("output")
+                    or "ReAct sub-agent reported success=false"
+                )
+                raise DAGStepError(
+                    step_id=step.id,
+                    step_name=step.name,
+                    message=failure_message,
+                )
+
             step.completed_at = datetime.now()
 
             # Store step execution result with complete message history for ContextBuilder
@@ -1017,6 +1007,19 @@ class PlanExecutor:
             await trace_error(
                 self.tracer,
                 trace_step_id,
+                data=error_trace_data,
+            )
+
+            # Also emit trace_step_end with FAILED status. The frontend
+            # routes step status off dag_step_end (not trace_error), so
+            # without this the UI would either still show the step as
+            # running, or — if the success path had already fired
+            # trace_step_end(completed) — keep displaying it as completed.
+            await trace_step_end(
+                self.tracer,
+                trace_step_id,
+                step.id,
+                TraceCategory.DAG,
                 data=error_trace_data,
             )
 

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -184,10 +184,30 @@ class PlanExecutor:
                         is_builder_context,
                     )
 
-                # Handle successful completion
-                step.status = StepStatus.COMPLETED
+                # Determine whether the ReAct sub-agent actually succeeded.
+                # ReAct's final answer payload carries a ``success`` flag; when the
+                # LLM determined the task could not be completed it returns
+                # ``success: False``. Treating that as a "completed" step lets the
+                # task-level summary claim "Task completed successfully" even when
+                # every tool call inside failed, so we surface it as FAILED.
+                sub_success = True
+                if isinstance(result, dict):
+                    raw_success = result.get("success")
+                    if raw_success is False:
+                        sub_success = False
+
                 step.result = result if isinstance(result, dict) else {"value": result}
-                completed_steps.add(step_id)
+                if sub_success:
+                    step.status = StepStatus.COMPLETED
+                    completed_steps.add(step_id)
+                else:
+                    step.status = StepStatus.FAILED
+                    step.error = (
+                        result.get("error")
+                        if isinstance(result, dict)
+                        else None
+                    ) or "ReAct sub-agent reported success=false"
+                    step.error_type = "ReActFailure"
 
                 # Add to execution results
                 execution_results.append(

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -186,26 +186,31 @@ class PlanExecutor:
 
                 # Determine whether the ReAct sub-agent actually succeeded.
                 # ReAct's final answer payload carries a ``success`` flag; when the
-                # LLM determined the task could not be completed it returns
+                # LLM concludes the task cannot be completed it returns
                 # ``success: False``. Treating that as a "completed" step lets the
                 # task-level summary claim "Task completed successfully" even when
-                # every tool call inside failed, so we surface it as FAILED.
+                # every tool call inside failed, so we surface it as FAILED via
+                # the same exception path as other step failures — that way the
+                # DAG's failure recovery (dependency unblocking, trace, etc.)
+                # runs immediately instead of waiting for the deadlock detector.
                 sub_success = True
-                if isinstance(result, dict):
-                    raw_success = result.get("success")
-                    if raw_success is False:
-                        sub_success = False
+                if isinstance(result, dict) and result.get("success") is False:
+                    sub_success = False
 
                 step.result = result if isinstance(result, dict) else {"value": result}
-                if sub_success:
-                    step.status = StepStatus.COMPLETED
-                    completed_steps.add(step_id)
-                else:
-                    step.status = StepStatus.FAILED
-                    step.error = (
+
+                if not sub_success:
+                    failure_message = (
                         result.get("error") if isinstance(result, dict) else None
                     ) or "ReAct sub-agent reported success=false"
-                    step.error_type = "ReActFailure"
+                    raise DAGStepError(
+                        step_id=step.id,
+                        step_name=step.name,
+                        message=failure_message,
+                    )
+
+                step.status = StepStatus.COMPLETED
+                completed_steps.add(step_id)
 
                 # Add to execution results
                 execution_results.append(

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -1072,6 +1072,11 @@ class AgentService:
                 workspace_config = {
                     "base_dir": self.workspace.base_dir,
                     "task_id": self.workspace.id,
+                    # Forward the whitelist so file tools created from this
+                    # default config can still access the user's upload dir.
+                    "allowed_external_dirs": [
+                        str(d) for d in self.workspace.allowed_external_dirs
+                    ],
                 }
 
             return DefaultToolConfig(workspace_config)

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -328,13 +328,18 @@ class ToolFactory:
                     base_dir=workspace_config.get("base_dir") or str(get_uploads_dir()),
                 )
 
-            # Real task - create actual workspace
+            # Real task - create actual workspace.
+            # IMPORTANT: forward `allowed_external_dirs` so that file tools can
+            # access files outside the per-task workspace directory (e.g. the
+            # user's upload directory). Otherwise read_file/read_csv_file will
+            # reject every uploaded file as "outside the allowed directory".
             from ....workspace import WorkspaceManager
 
             workspace_manager = WorkspaceManager()
             workspace = workspace_manager.get_or_create_workspace(
                 workspace_config.get("base_dir") or str(get_uploads_dir()),
                 task_id or "default",
+                allowed_external_dirs=workspace_config.get("allowed_external_dirs"),
             )
             return workspace
         except Exception as e:

--- a/src/xagent/skills/builtin/presentation-generator/SKILL.md
+++ b/src/xagent/skills/builtin/presentation-generator/SKILL.md
@@ -15,15 +15,15 @@ Generate PowerPoint presentations using JavaScript code with the pptxgenjs libra
 2. **NEVER create custom color variables** like `const colorAccent = "0078D7"`
 3. **NEVER use hardcoded hex values** in your code - always reference `theme.xxx`
 4. **ALWAYS include the `#` prefix** in hex colors (e.g., `#EF4444` not `EF4444`)
-5. **Slide 0 MUST use `theme.cover`** - first slide is the cover with dark/high-contrast background
+5. **Slide 0 (first slide) MUST also be created via `const slide = pres.addSlide()`** and use `theme.cover` - first slide is the cover with dark/high-contrast background
 6. **Slides 1+ MUST use `theme.content`** - all other slides use light/readable background
 
 **WRONG:**
 ```javascript
 const colorAccent = "0078D7";  // ❌ WRONG - custom color
 slide1.addText("Title", { color: "363636" });  // ❌ WRONG - hardcoded hex
-pres.addSlide();
-pres.background = { color: theme.cover.background };  // ❌ WRONG - cover on non-first slide
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.cover.background };  // ❌ WRONG - cover on non-first slide
 ```
 
 **CORRECT:**
@@ -43,14 +43,15 @@ const theme = {
     text: '#0A0F1C'
   }
 };
-// Slide 0 (first slide, no addSlide) - use theme.cover
-pres.background = { color: theme.cover.background };
-pres.addText("Title", { color: theme.cover.title });
+// Slide 0 (cover) — pptxgenjs requires addSlide() for the FIRST slide too
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.cover.background };
+slide1.addText("Title", { color: theme.cover.title });
 
-// Slide 1+ (after addSlide) - use theme.content
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText("Content", { color: theme.content.primary });
+// Slide 1+ — call pres.addSlide() to get each new slide
+const slide2 = pres.addSlide();
+slide2.background = { color: theme.content.background };
+slide2.addText("Content", { color: theme.content.primary });
 ```
 
 ---
@@ -73,7 +74,7 @@ pres.addText("Content", { color: theme.content.primary });
    ```
    Then reference colors as `theme.background`, `theme.primary`, etc.
 
-3. **Slide Creation**: Always call `pres.addSlide()` before adding content to a new slide (except the first slide)
+3. **Slide Creation**: ALWAYS call `pres.addSlide()` before adding content to ANY slide, including the FIRST one. Capture its return value: `const slide = pres.addSlide();` then call `slide.addText(...)`, `slide.background = {...}`, `slide.addImage(...)`, etc. Calling `pres.addText(...)` or setting `pres.background` directly on the presentation object will throw `pres.addText is not a function`.
 
 4. **Font Consistency**: Keep font sizes consistent: titles 40-56pt, subtitles 24-32pt, body text 16-20pt
 
@@ -250,16 +251,17 @@ const theme = {
 const pres = new PptxGenJS();
 
 // Slide 0: Cover (use theme.cover)
-pres.background = { color: theme.cover.background };
-pres.addText('My Presentation', { x: 1, y: 3, fontSize: 60, bold: true, color: theme.cover.title });
-pres.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.cover.background };
+slide1.addText('My Presentation', { x: 1, y: 3, fontSize: 60, bold: true, color: theme.cover.title });
+slide1.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
 
 // Slide 1+: Content (use theme.content)
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
+const slide2 = pres.addSlide();
+slide2.background = { color: theme.content.background };
+slide2.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
 ['Point 1', 'Point 2', 'Point 3'].forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
+  slide2.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
 });
 ```
 
@@ -292,16 +294,17 @@ const theme = {
 const pres = new PptxGenJS();
 
 // Slide 0: Cover slide (use theme.cover)
-pres.background = { color: theme.cover.background };
-pres.addText('My Presentation', { x: 1, y: 3, fontSize: 60, bold: true, color: theme.cover.title });
-pres.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.cover.background };
+slide1.addText('My Presentation', { x: 1, y: 3, fontSize: 60, bold: true, color: theme.cover.title });
+slide1.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
 
 // Slide 1: Content slide (use theme.content)
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
+const slide2 = pres.addSlide();
+slide2.background = { color: theme.content.background };
+slide2.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
 ['Point 1', 'Point 2', 'Point 3'].forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
+  slide2.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
 });
 
 pres.writeFile({ fileName: 'my_presentation.pptx' });
@@ -334,16 +337,17 @@ const theme = {
 };
 
 // Slide 0: Cover (dark background, white title)
-pres.background = { color: theme.cover.background };
-pres.addText('Annual Report 2024', { x: 1, y: 3, fontSize: 64, bold: true, color: theme.cover.title });
-pres.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.cover.background };
+slide1.addText('Annual Report 2024', { x: 1, y: 3, fontSize: 64, bold: true, color: theme.cover.title });
+slide1.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.cover.subtitle });
 
 // Slide 1: Content (light background, readable)
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
+const slide2 = pres.addSlide();
+slide2.background = { color: theme.content.background };
+slide2.addText('Key Points', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.content.primary });
 ['Point 1', 'Point 2', 'Point 3'].forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
+  slide2.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
 });
 
 pres.writeFile({ fileName: 'strategy.pptx' });
@@ -372,9 +376,9 @@ const theme = {
 };
 
 // Content slide
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText('System Architecture', { x: 1, y: 0.8, fontSize: 48, bold: true, color: theme.content.primary });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.content.background };
+slide1.addText('System Architecture', { x: 1, y: 0.8, fontSize: 48, bold: true, color: theme.content.primary });
 
 const bullets = [
   'Microservices architecture',
@@ -383,7 +387,7 @@ const bullets = [
 ];
 
 bullets.forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
+  slide1.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.content.text, bullet: true });
 });
 
 pres.writeFile({ fileName: 'technical.pptx' });
@@ -413,9 +417,9 @@ const theme = {
 };
 
 // Content slide with metrics
-pres.addSlide();
-pres.background = { color: theme.content.background };
-pres.addText('Q4 Key Metrics', { x: 1, y: 0.8, fontSize: 52, bold: true, color: theme.content.primary });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.content.background };
+slide1.addText('Q4 Key Metrics', { x: 1, y: 0.8, fontSize: 52, bold: true, color: theme.content.primary });
 
 const metrics = [
   { label: 'Revenue', value: '$1.5M', color: theme.content.success },
@@ -426,17 +430,18 @@ const metrics = [
 metrics.forEach((metric, i) => {
   const x = 1 + (i % 3) * 3;
   const y = 2.5 + Math.floor(i / 3) * 2;
-  pres.addText(metric.label, { x, y: y, fontSize: 16, color: theme.content.secondary });
-  pres.addText(metric.value, { x, y: y + 0.4, fontSize: 36, bold: true, color: metric.color });
+  slide1.addText(metric.label, { x, y: y, fontSize: 16, color: theme.content.secondary });
+  slide1.addText(metric.value, { x, y: y + 0.4, fontSize: 36, bold: true, color: metric.color });
 });
 
 pres.writeFile({ fileName: 'metrics.pptx' });
 ```
 };
 
-pres.background = { color: theme.background };
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.background };
 
-pres.addText('Q4 Key Metrics', { x: 1, y: 0.8, fontSize: 52, bold: true, color: theme.primary });
+slide1.addText('Q4 Key Metrics', { x: 1, y: 0.8, fontSize: 52, bold: true, color: theme.primary });
 
 const metrics = [
   { label: 'Revenue', value: '$1.5M', color: theme.success },
@@ -447,8 +452,8 @@ const metrics = [
 metrics.forEach((metric, i) => {
   const x = 1 + (i % 3) * 3;
   const y = 2.5 + Math.floor(i / 3) * 2;
-  pres.addText(metric.label, { x, y: y, fontSize: 16, color: theme.secondary });
-  pres.addText(metric.value, { x, y: y + 0.4, fontSize: 36, bold: true, color: metric.color });
+  slide1.addText(metric.label, { x, y: y, fontSize: 16, color: theme.secondary });
+  slide1.addText(metric.value, { x, y: y + 0.4, fontSize: 36, bold: true, color: metric.color });
 });
 
 pres.writeFile({ fileName: 'metrics.pptx' });
@@ -467,12 +472,13 @@ const theme = {
   text: '#111111'
 };
 
-pres.background = { color: theme.background };
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.background };
 
-pres.addText('Our Journey', { x: 1, y: 0.8, fontSize: 56, bold: true, color: theme.primary });
+slide1.addText('Our Journey', { x: 1, y: 0.8, fontSize: 56, bold: true, color: theme.primary });
 
 ['Founded in 2020', 'Team of 10', 'Bootstrapped'].forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2.5 + i * 0.8, fontSize: 20, color: theme.text });
+  slide1.addText(text, { x: 1, y: 2.5 + i * 0.8, fontSize: 20, color: theme.text });
 });
 
 pres.writeFile({ fileName: 'minimal.pptx' });
@@ -493,24 +499,25 @@ const theme = {
 };
 
 // Slide 1: Title
-pres.background = { color: theme.background };
-pres.addText('Strategic Vision 2025', { x: 1, y: 3, fontSize: 64, bold: true, color: theme.primary });
-pres.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.secondary });
+const slide1 = pres.addSlide();
+slide1.background = { color: theme.background };
+slide1.addText('Strategic Vision 2025', { x: 1, y: 3, fontSize: 64, bold: true, color: theme.primary });
+slide1.addText('Company Name', { x: 1, y: 4.2, fontSize: 28, color: theme.secondary });
 
 // Slide 2: Content
-pres.addSlide();
-pres.background = { color: theme.background };
-pres.addText('Key Initiatives', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.primary });
+const slide2 = pres.addSlide();
+slide2.background = { color: theme.background };
+slide2.addText('Key Initiatives', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.primary });
 ['AI Platform Launch', 'Market Expansion', 'Team Growth'].forEach((text, i) => {
-  pres.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.text, bullet: true });
+  slide2.addText(text, { x: 1, y: 2 + i * 0.7, fontSize: 18, color: theme.text, bullet: true });
 });
 
 // Slide 3: Metrics
-pres.addSlide();
-pres.background = { color: theme.background };
-pres.addText('Performance Targets', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.primary });
-pres.addText('Revenue: $5M', { x: 1, y: 2.5, fontSize: 28, color: theme.accent });
-pres.addText('Growth: 150%', { x: 5, y: 2.5, fontSize: 28, color: theme.highlight });
+const slide3 = pres.addSlide();
+slide3.background = { color: theme.background };
+slide3.addText('Performance Targets', { x: 1, y: 0.8, fontSize: 44, bold: true, color: theme.primary });
+slide3.addText('Revenue: $5M', { x: 1, y: 2.5, fontSize: 28, color: theme.accent });
+slide3.addText('Growth: 150%', { x: 5, y: 2.5, fontSize: 28, color: theme.highlight });
 
 pres.writeFile({ fileName: 'strategy.pptx' });
 ```
@@ -524,18 +531,18 @@ const pres = new PptxGenJS();
 const fs = require('fs');
 
 // Slide with image
-pres.addSlide();
-pres.addText('Revenue Chart', { x: 0.5, y: 0.8, fontSize: 40, bold: true, color: theme.content.primary });
+const slide1 = pres.addSlide();
+slide1.addText('Revenue Chart', { x: 0.5, y: 0.8, fontSize: 40, bold: true, color: theme.content.primary });
 
 // Check if image exists
 if (fs.existsSync('revenue_chart.png')) {
   // GOOD: Specify both w and h to control exact dimensions
-  pres.addImage({ path: 'revenue_chart.png', x: 1, y: 1.5, w: 8, h: 4.5 });
+  slide1.addImage({ path: 'revenue_chart.png', x: 1, y: 1.5, w: 8, h: 4.5 });
 
   // BETTER: Use sizing: 'contain' to fit within bounds while maintaining aspect ratio
-  // pres.addImage({ path: 'revenue_chart.png', x: 1, y: 1.5, sizing: { type: 'contain', w: 8, h: 4.5 } });
+  // slide1.addImage({ path: 'revenue_chart.png', x: 1, y: 1.5, sizing: { type: 'contain', w: 8, h: 4.5 } });
 } else {
-  pres.addText('Image not available: revenue_chart.png', { x: 1, y: 3, fontSize: 18, color: theme.content.secondary || theme.content.warning });
+  slide1.addText('Image not available: revenue_chart.png', { x: 1, y: 3, fontSize: 18, color: theme.content.secondary || theme.content.warning });
 }
 
 pres.writeFile({ fileName: 'with_image.pptx' });
@@ -552,19 +559,21 @@ pres.writeFile({ fileName: 'with_image.pptx' });
 **WRONG - May overflow slide:**
 ```javascript
 // ❌ Only width - height depends on aspect ratio, may exceed slide bounds
-pres.addImage({ path: 'chart.png', x: 1, y: 2, w: 9 });
+const slide1 = pres.addSlide();
+slide1.addImage({ path: 'chart.png', x: 1, y: 2, w: 9 });
 
 // ❌ Only height - width may exceed slide width
-pres.addImage({ path: 'photo.png', x: 1, y: 1, h: 6 });
+slide1.addImage({ path: 'photo.png', x: 1, y: 1, h: 6 });
 ```
 
 **CORRECT - Stay within bounds:**
 ```javascript
 // ✅ Both w and h specified
-pres.addImage({ path: 'chart.png', x: 1, y: 1.5, w: 8, h: 4.5 });
+const slide1 = pres.addSlide();
+slide1.addImage({ path: 'chart.png', x: 1, y: 1.5, w: 8, h: 4.5 });
 
 // ✅ Using contain with max bounds
-pres.addImage({ path: 'photo.png', x: 0.5, y: 1, sizing: { type: 'contain', w: 9, h: 6 } });
+slide1.addImage({ path: 'photo.png', x: 0.5, y: 1, sizing: { type: 'contain', w: 9, h: 6 } });
 ```
 
 **Important Notes:**

--- a/src/xagent/skills/builtin/presentation-generator/SKILL.md
+++ b/src/xagent/skills/builtin/presentation-generator/SKILL.md
@@ -436,28 +436,6 @@ metrics.forEach((metric, i) => {
 
 pres.writeFile({ fileName: 'metrics.pptx' });
 ```
-};
-
-const slide1 = pres.addSlide();
-slide1.background = { color: theme.background };
-
-slide1.addText('Q4 Key Metrics', { x: 1, y: 0.8, fontSize: 52, bold: true, color: theme.primary });
-
-const metrics = [
-  { label: 'Revenue', value: '$1.5M', color: theme.success },
-  { label: 'Growth', value: '+25%', color: theme.accent },
-  { label: 'Customers', value: '86', color: theme.warning }
-];
-
-metrics.forEach((metric, i) => {
-  const x = 1 + (i % 3) * 3;
-  const y = 2.5 + Math.floor(i / 3) * 2;
-  slide1.addText(metric.label, { x, y: y, fontSize: 16, color: theme.secondary });
-  slide1.addText(metric.value, { x, y: y + 0.4, fontSize: 36, bold: true, color: metric.color });
-});
-
-pres.writeFile({ fileName: 'metrics.pptx' });
-```
 
 ### Minimalist Content (MINIMA - Founder Story)
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -127,6 +127,31 @@ def create_default_llm() -> Optional[BaseLLM]:
         return None
 
 
+def _build_allowed_external_dirs(
+    user_id: Optional[int], *, only_existing: bool = False
+) -> list[str]:
+    """Build the allowed_external_dirs list for AgentService / tool
+    workspace_config.
+
+    Without this whitelist, file tools (read_file, read_csv_file,
+    list_files, ...) restrict themselves to the per-task workspace dir
+    and reject every uploaded file with "outside the allowed directory".
+
+    The list always contains:
+      - the user's upload directory ``<uploads>/user_<id>``
+        (when ``only_existing`` is True, only if that directory exists)
+      - any directories returned by ``get_external_upload_dirs()`` (used
+        for shared knowledge bases configured at the deployment level)
+    """
+    dirs: list[str] = []
+    if user_id is not None:
+        user_upload_dir = get_uploads_dir() / f"user_{user_id}"
+        if not only_existing or user_upload_dir.exists():
+            dirs.append(str(user_upload_dir))
+    dirs.extend([str(d) for d in get_external_upload_dirs()])
+    return dirs
+
+
 async def create_default_tools(
     db: Session,
     request: Any = None,
@@ -150,13 +175,8 @@ async def create_default_tools(
     from ..tools.config import WebToolConfig
 
     # Build allowed external directories so file tools can reach the user's
-    # uploads (the upload dir lives one level above the per-task workspace dir,
-    # so without this whitelist read_file/read_csv_file/list_files will reject
-    # uploaded files as "outside the allowed directory").
-    allowed_external_dirs: list[str] = []
-    user_upload_dir = get_uploads_dir() / f"user_{user.id}"
-    allowed_external_dirs.append(str(user_upload_dir))
-    allowed_external_dirs.extend([str(d) for d in get_external_upload_dirs()])
+    # uploads (see _build_allowed_external_dirs docstring).
+    allowed_external_dirs = _build_allowed_external_dirs(int(user.id))
 
     tool_config = WebToolConfig(
         db=db,
@@ -823,14 +843,8 @@ class AgentServiceManager:
                         ]
 
                     # Build allowed external directories (user's upload directory for knowledge base files)
-                    allowed_external_dirs = []
-                    if user and user.id:
-                        user_upload_dir = get_uploads_dir() / f"user_{user.id}"
-                        allowed_external_dirs.append(str(user_upload_dir))
-
-                    # Add configured external upload directories (for knowledge base files from other projects)
-                    allowed_external_dirs.extend(
-                        [str(d) for d in get_external_upload_dirs()]
+                    allowed_external_dirs = _build_allowed_external_dirs(
+                        int(user.id) if user and user.id else None
                     )
 
                     # Create AgentService first (this creates the workspace)
@@ -1032,23 +1046,11 @@ class AgentServiceManager:
             )
         workspace_ids.append((f"web_task_{task_id}", str(get_uploads_dir())))
 
-        # Build allowed external directories (user's upload directory for knowledge base files)
-        allowed_external_dirs = []
-        if user_id:
-            user_upload_dir = get_uploads_dir() / f"user_{user_id}"
-            if user_upload_dir.exists():
-                allowed_external_dirs.append(str(user_upload_dir))
-                logger.info(
-                    f"Added user upload directory to allowed external dirs: {user_upload_dir}"
-                )
-
-        # Add configured external upload directories (for knowledge base files from other projects)
-        external_upload_dirs = get_external_upload_dirs()
-        allowed_external_dirs.extend([str(d) for d in external_upload_dirs])
-        if external_upload_dirs:
-            logger.info(
-                f"Added {len(external_upload_dirs)} external upload directories from config"
-            )
+        # Build allowed external directories (user's upload directory for knowledge base files).
+        # Use only_existing=True here because cleanup runs against on-disk state.
+        allowed_external_dirs = _build_allowed_external_dirs(
+            user_id, only_existing=True
+        )
 
         for workspace_id, base_dir in workspace_ids:
             workspace = TaskWorkspace(
@@ -1123,12 +1125,8 @@ class AgentServiceManager:
                 database_type = self._infer_database_type(database_url)
 
                 # Build allowed external directories
-                allowed_external_dirs = []
-                if user and user.id:
-                    user_upload_dir = get_uploads_dir() / f"user_{user.id}"
-                    allowed_external_dirs.append(str(user_upload_dir))
-                allowed_external_dirs.extend(
-                    [str(d) for d in get_external_upload_dirs()]
+                allowed_external_dirs = _build_allowed_external_dirs(
+                    int(user.id) if user and user.id else None
                 )
 
                 # Create AgentService with Text2SQL agent type
@@ -1338,12 +1336,8 @@ class AgentServiceManager:
                     task_compact_llm = None
 
                 # Build allowed external directories
-                allowed_external_dirs = []
-                if user_id is not None:
-                    user_upload_dir = get_uploads_dir() / f"user_{user_id}"
-                    allowed_external_dirs.append(str(user_upload_dir))
-                allowed_external_dirs.extend(
-                    [str(d) for d in get_external_upload_dirs()]
+                allowed_external_dirs = _build_allowed_external_dirs(
+                    int(user_id) if user_id is not None else None
                 )
 
                 # Create agent with basic configuration

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -149,6 +149,15 @@ async def create_default_tools(
     # Create a WebToolConfig to properly initialize tools
     from ..tools.config import WebToolConfig
 
+    # Build allowed external directories so file tools can reach the user's
+    # uploads (the upload dir lives one level above the per-task workspace dir,
+    # so without this whitelist read_file/read_csv_file/list_files will reject
+    # uploaded files as "outside the allowed directory").
+    allowed_external_dirs: list[str] = []
+    user_upload_dir = get_uploads_dir() / f"user_{user.id}"
+    allowed_external_dirs.append(str(user_upload_dir))
+    allowed_external_dirs.extend([str(d) for d in get_external_upload_dirs()])
+
     tool_config = WebToolConfig(
         db=db,
         request=request,
@@ -159,6 +168,7 @@ async def create_default_tools(
         workspace_config={
             "base_dir": str(get_uploads_dir() / f"user_{user.id}"),
             "task_id": task_id,
+            "allowed_external_dirs": allowed_external_dirs,
         },
         include_mcp_tools=bool(
             allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)


### PR DESCRIPTION
## Problem

The UI reports `Task completed successfully with N steps` but the agent
produces no usable output. Three independent bugs combine to cause this.

## Fixes

### 1. `read_file` / `read_csv_file` / `list_files` cannot reach the user's uploaded files

`AgentService` is constructed with `allowed_external_dirs=[user upload dir, ...]`,
but when tools are built via `ToolFactory._create_workspace` the whitelist is
dropped, because `workspace_config` only carried `base_dir` + `task_id`.
The workspace handed to the file tools is therefore restricted to
`<uploads>/web_task_N/` only, while the uploaded file actually lives at
`<uploads>/user_X/<name>`. Every read on an uploaded file fails with
`Path ... is outside allowed directories`.

Plumbed `allowed_external_dirs` through `workspace_config`:

- `web/api/chat.py::create_default_tools` builds the whitelist and adds it
  to `workspace_config`.
- `core/agent/service.py` propagates `self.workspace.allowed_external_dirs`
  into the fallback `DefaultToolConfig`.
- `core/tools/adapters/vibe/factory.py::_create_workspace` forwards
  `workspace_config["allowed_external_dirs"]` to
  `WorkspaceManager.get_or_create_workspace`.

### 2. Steps with `success=false` were still marked `COMPLETED`

`plan_executor` flipped `step.status = StepStatus.COMPLETED` whenever the
ReAct sub-agent returned without raising. The ReAct final-answer payload
already carries a `success` flag, but it was ignored, so
`_generate_simple_summary` produced `Task completed successfully with N steps`
even when every tool call inside failed.

`plan_executor.py` now inspects `result["success"]` and downgrades the
step to `FAILED` when the sub-agent explicitly reports failure.

### 3. `presentation-generator` SKILL.md teaches an invalid pptxgenjs API

The examples called `pres.addText(...)`, `pres.background = ...`,
`pres.addImage(...)` directly on the presentation object. pptxgenjs only
exposes those on slide objects returned by `pres.addSlide()`. Every PPT
task hit `pres.addText is not a function`.

Rewrote every code sample and the explanatory rules to use the correct
pattern:

```js
const slide1 = pres.addSlide();
slide1.background = { color: theme.cover.background };
slide1.addText("Title", { color: theme.cover.title });
```

## Files changed

- `src/xagent/web/api/chat.py`
- `src/xagent/core/agent/service.py`
- `src/xagent/core/tools/adapters/vibe/factory.py`
- `src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py`
- `src/xagent/skills/builtin/presentation-generator/SKILL.md`

## Verification suggestions

- Upload a CSV/PDF to a task and confirm `read_csv_file` / `read_file`
  actually returns content rather than `Path ... is outside allowed
  directories`.
- Run a presentation-generator task end to end and confirm a `.pptx`
  artifact appears under `output/` without `pres.addText is not a function`.
- Force a ReAct step to set `success=false` (e.g. a task with an
  impossible tool requirement) and confirm the task summary is
  `Task failed` / `Partial success`, not `Task completed successfully`.