### PR TITLE
feat(trace): audit-trace infrastructure (truncate + __audit_only__) + skill selection coverage

### DIFF
--- a/example.env
+++ b/example.env
@@ -60,6 +60,13 @@ OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
 # MILVUS_TOKEN=""
 # MILVUS_DB_NAME=""
 
+# ===========================================
+# Other Configuration
+# ===========================================
+# Agent runtime version (default: v1)
+# Use v2 to route new task executions through agent_v2 while v1 remains available.
+# XAGENT_AGENT_RUNTIME="v1"
+
 # JWT Authentication (required for production)
 # Generate a secure secret with:
 # python -c "import secrets; print(secrets.token_urlsafe(48))"
@@ -81,6 +88,12 @@ LANGFUSE_TRACING_ENABLED="true"
 LANGFUSE_BASE_URL="http://127.0.0.1:3000"
 LANGFUSE_PUBLIC_KEY="public key"
 LANGFUSE_SECRET_KEY="secret key"
+
+# Per-field byte cap for the LLM I/O audit trace written to trace_events
+# (data.messages / data.response / etc.). Anything larger is truncated with a
+# "[truncated N chars]" suffix. A long DAG task hitting all audit sites can
+# otherwise write multi-MB rows. Default: 50000 (~50KB).
+# XAGENT_MAX_TRACE_PAYLOAD_BYTES="50000"
 
 # Web Search API Keys
 # Provider selection: auto, google, tavily, exa, zhipu (default: auto)

--- a/example.env
+++ b/example.env
@@ -63,10 +63,6 @@ OPENAI_EMBEDDING_API_KEY="your-openai-api-key"
 # ===========================================
 # Other Configuration
 # ===========================================
-# Agent runtime version (default: v1)
-# Use v2 to route new task executions through agent_v2 while v1 remains available.
-# XAGENT_AGENT_RUNTIME="v1"
-
 # JWT Authentication (required for production)
 # Generate a secure secret with:
 # python -c "import secrets; print(secrets.token_urlsafe(48))"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ UPLOADS_DIR = "XAGENT_UPLOADS_DIR"
 WEB_DIR = "XAGENT_WEB_DIR"
 EXTERNAL_UPLOAD_DIRS = "XAGENT_EXTERNAL_UPLOAD_DIRS"
 EXTERNAL_SKILLS_LIBRARY_DIRS = "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
+AGENT_RUNTIME = "XAGENT_AGENT_RUNTIME"
 TASK_LEASE_TTL_SECONDS = "XAGENT_TASK_LEASE_TTL_SECONDS"
 TASK_LEASE_HEARTBEAT_SECONDS = "XAGENT_TASK_LEASE_HEARTBEAT_SECONDS"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
@@ -47,8 +49,28 @@ WEB_SEARCH_PROVIDER = "XAGENT_WEB_SEARCH_PROVIDER"
 TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
 TOOL_MAX_RECURSION_DEPTH = "XAGENT_TOOL_MAX_RECURSION_DEPTH"
 TOOL_MAX_FIELD_COUNT = "XAGENT_TOOL_MAX_FIELD_COUNT"
+MAX_TRACE_PAYLOAD_BYTES = "XAGENT_MAX_TRACE_PAYLOAD_BYTES"
 
 WEB_SEARCH_PROVIDERS = {"auto", "google", "tavily", "exa", "zhipu"}
+
+
+def get_agent_runtime() -> Literal["v1", "v2"]:
+    """Get the agent execution runtime version.
+
+    Priority:
+        1. XAGENT_AGENT_RUNTIME environment variable
+        2. "v1" default for compatibility
+
+    Returns:
+        "v1" or "v2"
+    """
+    runtime = os.getenv(AGENT_RUNTIME, "v1").strip().lower()
+    if runtime == "v1":
+        return "v1"
+    if runtime == "v2":
+        return "v2"
+    logger.warning("Invalid %s=%r; falling back to v1", AGENT_RUNTIME, runtime)
+    return "v1"
 
 
 def get_agent_pattern_for_execution_mode(execution_mode: str | None) -> str:
@@ -73,17 +95,23 @@ def get_agent_pattern_for_execution_mode(execution_mode: str | None) -> str:
 def get_default_task_execution_mode(
     *,
     agent_id: object | None = None,
+    agent_runtime: str | None = None,
 ) -> str:
     """Get the default UI execution mode for a newly-created task.
 
-    Standalone tasks default to auto so simple prompts can answer directly while
-    complex prompts can still route into ReAct or DAG. Agent Builder tasks keep
-    balanced because the agent's explicit tool/KB setup is usually better served
-    by ReAct.
+    Standalone v2 tasks default to auto so simple prompts can answer directly
+    while complex prompts can still route into ReAct or DAG. v1 keeps the legacy
+    standalone DAG default for compatibility. Agent Builder tasks keep balanced
+    in both runtimes because the agent's explicit tool/KB setup is usually
+    better served by ReAct.
     """
     if agent_id is not None:
         return "balanced"
-    return "auto"
+
+    runtime = (agent_runtime or get_agent_runtime()).strip().lower()
+    if runtime == "v2":
+        return "auto"
+    return "think"
 
 
 def get_task_lease_ttl_seconds() -> int:
@@ -613,3 +641,34 @@ def get_tool_max_field_count() -> int:
         except ValueError:
             logger.warning("Invalid TOOL_MAX_FIELDS value: {env_str}")
     return 1000
+
+
+def get_max_trace_payload_bytes() -> int:
+    """Max byte size for individual trace payload fields (e.g. data.messages,
+    data.response) before truncation.
+
+    Applies to the LLM I/O audit trace added in fix/llm-trace-coverage. A
+    long DAG task hitting all 9 audit sites can otherwise write multi-MB
+    rows into trace_events.
+
+    Priority:
+        1. XAGENT_MAX_TRACE_PAYLOAD_BYTES env var
+        2. Default 50_000 (~50KB, large enough for typical compacted
+           messages while bounding worst case)
+
+    Returns:
+        Maximum bytes per truncated trace field.
+    """
+    env_str = os.getenv(MAX_TRACE_PAYLOAD_BYTES)
+    if env_str:
+        try:
+            value = int(env_str)
+            if value < 0:
+                logger.warning(
+                    f"Invalid {MAX_TRACE_PAYLOAD_BYTES} value (negative): {env_str!r}"
+                )
+            else:
+                return value
+        except ValueError:
+            logger.warning(f"Invalid {MAX_TRACE_PAYLOAD_BYTES} value: {env_str!r}")
+    return 50_000

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,6 @@ UPLOADS_DIR = "XAGENT_UPLOADS_DIR"
 WEB_DIR = "XAGENT_WEB_DIR"
 EXTERNAL_UPLOAD_DIRS = "XAGENT_EXTERNAL_UPLOAD_DIRS"
 EXTERNAL_SKILLS_LIBRARY_DIRS = "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
-AGENT_RUNTIME = "XAGENT_AGENT_RUNTIME"
 TASK_LEASE_TTL_SECONDS = "XAGENT_TASK_LEASE_TTL_SECONDS"
 TASK_LEASE_HEARTBEAT_SECONDS = "XAGENT_TASK_LEASE_HEARTBEAT_SECONDS"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
@@ -52,25 +50,6 @@ TOOL_MAX_FIELD_COUNT = "XAGENT_TOOL_MAX_FIELD_COUNT"
 MAX_TRACE_PAYLOAD_BYTES = "XAGENT_MAX_TRACE_PAYLOAD_BYTES"
 
 WEB_SEARCH_PROVIDERS = {"auto", "google", "tavily", "exa", "zhipu"}
-
-
-def get_agent_runtime() -> Literal["v1", "v2"]:
-    """Get the agent execution runtime version.
-
-    Priority:
-        1. XAGENT_AGENT_RUNTIME environment variable
-        2. "v1" default for compatibility
-
-    Returns:
-        "v1" or "v2"
-    """
-    runtime = os.getenv(AGENT_RUNTIME, "v1").strip().lower()
-    if runtime == "v1":
-        return "v1"
-    if runtime == "v2":
-        return "v2"
-    logger.warning("Invalid %s=%r; falling back to v1", AGENT_RUNTIME, runtime)
-    return "v1"
 
 
 def get_agent_pattern_for_execution_mode(execution_mode: str | None) -> str:
@@ -95,23 +74,17 @@ def get_agent_pattern_for_execution_mode(execution_mode: str | None) -> str:
 def get_default_task_execution_mode(
     *,
     agent_id: object | None = None,
-    agent_runtime: str | None = None,
 ) -> str:
     """Get the default UI execution mode for a newly-created task.
 
-    Standalone v2 tasks default to auto so simple prompts can answer directly
-    while complex prompts can still route into ReAct or DAG. v1 keeps the legacy
-    standalone DAG default for compatibility. Agent Builder tasks keep balanced
-    in both runtimes because the agent's explicit tool/KB setup is usually
-    better served by ReAct.
+    Standalone tasks default to auto so simple prompts can answer directly while
+    complex prompts can still route into ReAct or DAG. Agent Builder tasks keep
+    balanced because the agent's explicit tool/KB setup is usually better served
+    by ReAct.
     """
     if agent_id is not None:
         return "balanced"
-
-    runtime = (agent_runtime or get_agent_runtime()).strip().lower()
-    if runtime == "v2":
-        return "auto"
-    return "think"
+    return "auto"
 
 
 def get_task_lease_ttl_seconds() -> int:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -11,6 +11,7 @@ from ..agent.trace import (
     TraceCategory,
     TraceEventType,
     TraceScope,
+    normalize_llm_trace_payload,
 )
 
 
@@ -638,6 +639,13 @@ class PatternRuntime:
         trace_event = getattr(self.tracer, "trace_event", None)
         if not callable(trace_event):
             return
+        # Cap LLM event payloads at the tracer boundary. The normalizer
+        # preserves reserved control / routing / metrics fields and only
+        # truncates bulky content (messages, response, tool_calls, ...).
+        # Non-LLM categories (TOOL / DAG / REACT / COMPACT / GENERAL)
+        # pass through unchanged.
+        if data and getattr(event_type, "category", None) == TraceCategory.LLM:
+            data = normalize_llm_trace_payload(data)
         try:
             await self._maybe_await(
                 trace_event(

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1,11 +1,12 @@
 """Generic tracing module for tracking events in the xagent system."""
 
 import inspect
+import json
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
@@ -100,37 +101,376 @@ def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
     return _trim_subtree(value, max_bytes)
 
 
+# Short per-message metadata kept verbatim by ``_reduce_messages``. These
+# fields (typically 4-12 bytes each) are essential for RCA grouping —
+# losing ``role`` makes a trace event impossible to interpret.
+_MESSAGE_METADATA_KEYS = frozenset({"role", "name", "type", "tool_call_id"})
+
+
+def _serialized_size(value: Any) -> int:
+    """UTF-8 byte length of ``json.dumps`` output, used for size budgeting."""
+    try:
+        return len(json.dumps(value, default=str, ensure_ascii=False).encode("utf-8"))
+    except (TypeError, ValueError):
+        return len(str(value).encode("utf-8"))
+
+
+def _truncate_string(value: str, budget: int) -> str:
+    """Byte-boundary string truncate with multi-byte UTF-8 safety.
+
+    Reserves a small slack (~30 bytes) for the trailing
+    ``...[truncated N chars]`` marker so the post-marker length still
+    fits ``budget``.
+    """
+    if budget <= 0:
+        return ""
+    encoded = value.encode("utf-8", errors="replace")
+    if len(encoded) <= budget:
+        return value
+    slack = min(30, max(8, budget // 4))
+    head_budget = max(1, budget - slack)
+    head = encoded[:head_budget].decode("utf-8", errors="ignore")
+    return f"{head}...[truncated {len(value) - len(head)} chars]"
+
+
+def _placeholder(message: str) -> Dict[str, str]:
+    return {"__truncated__": message}
+
+
+def _reduce_text(value: Any, budget: int) -> Any:
+    """Reducer for plain text fields (``content``, ``error``, ``traceback``)."""
+    if not isinstance(value, str):
+        value = str(value)
+    return _truncate_string(value, budget)
+
+
+def _reduce_text_list(value: Any, budget: int) -> Any:
+    """Reducer for ``candidate_names`` and similar list-of-string fields.
+
+    Preserves head + tail entries with a middle-omitted marker.
+    """
+    if not isinstance(value, list):
+        return value
+    if _serialized_size(value) <= budget:
+        return value
+
+    for keep_head, keep_tail in [(3, 3), (2, 2), (1, 1), (1, 0)]:
+        if keep_head + keep_tail >= len(value):
+            continue
+        per_item = max(8, (budget - 64) // (keep_head + keep_tail))
+        head = [_reduce_text(v, per_item) for v in value[:keep_head]]
+        tail = (
+            [_reduce_text(v, per_item) for v in value[-keep_tail:]] if keep_tail else []
+        )
+        omitted = len(value) - keep_head - keep_tail
+        marker = f"...[truncated {omitted} middle items]"
+        candidate: List[Any] = head + [marker] + tail
+        if _serialized_size(candidate) <= budget:
+            return candidate
+
+    return [_placeholder(f"{len(value)} list items exceed {budget}-byte budget")]
+
+
+def _shrink_message(msg: Any, msg_budget: int) -> Any:
+    """Preserve short metadata keys verbatim, reduce large content keys."""
+    if not isinstance(msg, dict):
+        return _reduce_text(msg, msg_budget)
+
+    out: Dict[str, Any] = {}
+    for k in _MESSAGE_METADATA_KEYS:
+        if k in msg:
+            out[k] = msg[k]
+
+    # Reserve ~40 bytes for JSON braces / commas / quotes around content keys.
+    content_keys = [k for k in msg if k not in _MESSAGE_METADATA_KEYS]
+    if not content_keys:
+        return out
+    remaining = max(64, msg_budget - _serialized_size(out) - 40)
+    per_content = max(32, remaining // len(content_keys))
+
+    for k in content_keys:
+        v = msg[k]
+        if k == "tool_calls" and isinstance(v, list):
+            out[k] = _reduce_tool_calls(v, per_content)
+        elif isinstance(v, str):
+            out[k] = _reduce_text(v, per_content)
+        elif isinstance(v, (dict, list)):
+            out[k] = _reduce_text(
+                json.dumps(v, default=str, ensure_ascii=False), per_content
+            )
+        else:
+            out[k] = v
+    return out
+
+
+def _reduce_messages(value: Any, budget: int) -> Any:
+    """Reducer for ``messages`` / ``context_preview``.
+
+    Keeps head + tail entries (system / recent prompts have the highest
+    RCA value) with their ``role`` / ``name`` / ``type`` metadata intact;
+    each kept message's content is text-reduced. Middle entries become a
+    single ``{"__truncated__": "K messages omitted ..."}`` placeholder.
+    Iteratively shrinks the kept-count if budget still overshoots.
+    """
+    if not isinstance(value, list):
+        return value
+    if _serialized_size(value) <= budget:
+        return value
+
+    # If the list is already short, no middle to omit — just shrink each
+    # entry to a per-msg budget.
+    if len(value) <= 4:
+        per_msg = max(128, (budget - 16) // len(value))
+        shrunk = [_shrink_message(m, per_msg) for m in value]
+        if _serialized_size(shrunk) <= budget:
+            return shrunk
+        return [_placeholder(f"{len(value)} messages exceed {budget}-byte budget")]
+
+    for keep_head, keep_tail in [(2, 2), (1, 2), (1, 1), (1, 0)]:
+        if keep_head + keep_tail >= len(value):
+            continue
+        omitted = len(value) - keep_head - keep_tail
+        marker = _placeholder(
+            f"{omitted} middle messages omitted to fit {budget}-byte budget"
+        )
+        marker_size = _serialized_size(marker)
+        per_msg = max(128, (budget - marker_size - 16) // (keep_head + keep_tail))
+        head = [_shrink_message(m, per_msg) for m in value[:keep_head]]
+        tail = (
+            [_shrink_message(m, per_msg) for m in value[-keep_tail:]]
+            if keep_tail
+            else []
+        )
+        candidate: List[Any] = head + [marker] + tail
+        if _serialized_size(candidate) <= budget:
+            return candidate
+
+    # Even (1 head, 0 tail) overshoots — collapse the whole list.
+    return [_placeholder(f"{len(value)} messages exceed {budget}-byte budget")]
+
+
+def _shrink_tool(tool: Any, tool_budget: int) -> Any:
+    """Per-tool: keep type/function.name/function.description; truncate parameters schema."""
+    if not isinstance(tool, dict):
+        return _reduce_text(tool, tool_budget)
+    out: Dict[str, Any] = {"type": tool.get("type", "function")}
+    func = tool.get("function")
+    if isinstance(func, dict):
+        shrunk_func: Dict[str, Any] = {}
+        if "name" in func:
+            shrunk_func["name"] = func["name"]
+        if "description" in func and isinstance(func["description"], str):
+            desc_budget = max(64, (tool_budget - _serialized_size(shrunk_func)) // 2)
+            shrunk_func["description"] = _reduce_text(func["description"], desc_budget)
+        if "parameters" in func:
+            remaining = max(
+                32,
+                tool_budget
+                - _serialized_size({"type": out["type"], "function": shrunk_func})
+                - 30,
+            )
+            if _serialized_size(func["parameters"]) <= remaining:
+                shrunk_func["parameters"] = func["parameters"]
+            else:
+                shrunk_func["parameters"] = _placeholder(
+                    f"schema exceeds {remaining}-byte budget"
+                )
+        out["function"] = shrunk_func
+    return out
+
+
+def _reduce_tools(value: Any, budget: int) -> Any:
+    """Reducer for ``tools``. Keeps tool names + descriptions, truncates schemas."""
+    if not isinstance(value, list):
+        return value
+    if _serialized_size(value) <= budget:
+        return value
+
+    # Short list: no middle to omit — shrink each tool to per-tool budget.
+    if len(value) <= 3:
+        per_tool = max(128, (budget - 16) // len(value))
+        shrunk = [_shrink_tool(t, per_tool) for t in value]
+        if _serialized_size(shrunk) <= budget:
+            return shrunk
+        return [_placeholder(f"{len(value)} tools exceed {budget}-byte budget")]
+
+    for keep_head in (3, 2, 1):
+        omitted = len(value) - keep_head
+        marker = _placeholder(f"{omitted} tools omitted to fit {budget}-byte budget")
+        per_tool = max(128, (budget - _serialized_size(marker) - 16) // keep_head)
+        head = [_shrink_tool(t, per_tool) for t in value[:keep_head]]
+        candidate: List[Any] = head + [marker]
+        if _serialized_size(candidate) <= budget:
+            return candidate
+
+    return [_placeholder(f"{len(value)} tools exceed {budget}-byte budget")]
+
+
+def _shrink_tool_call(call: Any, call_budget: int) -> Any:
+    """Per-call: keep id/type/function.name; truncate function.arguments."""
+    if not isinstance(call, dict):
+        return _reduce_text(call, call_budget)
+    out: Dict[str, Any] = {}
+    for k in ("id", "type"):
+        if k in call:
+            out[k] = call[k]
+    func = call.get("function")
+    if isinstance(func, dict):
+        shrunk_func: Dict[str, Any] = {}
+        if "name" in func:
+            shrunk_func["name"] = func["name"]
+        if "arguments" in func:
+            args = func["arguments"]
+            args_str = (
+                args
+                if isinstance(args, str)
+                else json.dumps(args, default=str, ensure_ascii=False)
+            )
+            arg_budget = max(
+                64,
+                call_budget - _serialized_size({**out, "function": shrunk_func}) - 30,
+            )
+            shrunk_func["arguments"] = _reduce_text(args_str, arg_budget)
+        out["function"] = shrunk_func
+    return out
+
+
+def _reduce_tool_calls(value: Any, budget: int) -> Any:
+    """Reducer for ``tool_calls``. Keeps id + name per call, truncates arguments."""
+    if not isinstance(value, list):
+        return value
+    if _serialized_size(value) <= budget:
+        return value
+
+    # Short list: no middle to omit — shrink each call to per-call budget.
+    if len(value) <= 3:
+        per_call = max(128, (budget - 16) // len(value))
+        shrunk = [_shrink_tool_call(c, per_call) for c in value]
+        if _serialized_size(shrunk) <= budget:
+            return shrunk
+        return [_placeholder(f"{len(value)} tool_calls exceed {budget}-byte budget")]
+
+    for keep_head in (3, 2, 1):
+        omitted = len(value) - keep_head
+        marker = _placeholder(
+            f"{omitted} tool_calls omitted to fit {budget}-byte budget"
+        )
+        per_call = max(128, (budget - _serialized_size(marker) - 16) // keep_head)
+        head = [_shrink_tool_call(c, per_call) for c in value[:keep_head]]
+        candidate: List[Any] = head + [marker]
+        if _serialized_size(candidate) <= budget:
+            return candidate
+
+    return [_placeholder(f"{len(value)} tool_calls exceed {budget}-byte budget")]
+
+
+def _reduce_response(value: Any, budget: int) -> Any:
+    """Reducer for ``response``. String → text trim; dict → trim text sub-fields,
+    preserve scalars verbatim (e.g. usage / token counts coming back from
+    ``_short_response``).
+    """
+    if isinstance(value, str):
+        return _reduce_text(value, budget)
+    if not isinstance(value, dict):
+        return _reduce_text(str(value), budget)
+    if _serialized_size(value) <= budget:
+        return value
+
+    text_keys = ("content", "answer", "output", "message")
+    out: Dict[str, Any] = {}
+    other_keys = [k for k in value if k not in text_keys]
+    for k in other_keys:
+        out[k] = value[k]
+
+    content_keys = [k for k in value if k in text_keys]
+    if content_keys:
+        remaining = max(64, budget - _serialized_size(out) - 30)
+        per_content = max(64, remaining // len(content_keys))
+        for k in content_keys:
+            v = value[k]
+            if k == "tool_calls" and isinstance(v, list):
+                out[k] = _reduce_tool_calls(v, per_content)
+            elif isinstance(v, str):
+                out[k] = _reduce_text(v, per_content)
+            else:
+                out[k] = _reduce_text(str(v), per_content)
+
+    if _serialized_size(out) > budget:
+        return _placeholder(f"response exceeds {budget}-byte budget after reduction")
+    return out
+
+
+# Dispatch table: field name -> reducer. ``normalize_llm_trace_payload``
+# routes each present truncatable field to its reducer. Fields not in this
+# table but in ``_TRUNCATABLE_CONTENT_FIELDS`` fall back to ``_reduce_text``.
+_FIELD_REDUCERS: Dict[str, Callable[[Any, int], Any]] = {
+    "messages": _reduce_messages,
+    "context_preview": _reduce_messages,
+    "tools": _reduce_tools,
+    "tool_calls": _reduce_tool_calls,
+    "response": _reduce_response,
+    "content": _reduce_text,
+    "error": _reduce_text,
+    "error_message": _reduce_text,
+    "traceback": _reduce_text,
+    "candidate_names": _reduce_text_list,
+}
+
+
 def normalize_llm_trace_payload(
     data: Any,
     max_bytes: Optional[int] = None,
 ) -> Any:
     """Trace-boundary normalizer for LLM-category trace event payloads.
 
-    Truncates only the fields in :data:`_TRUNCATABLE_CONTENT_FIELDS` so
-    bulky LLM I/O doesn't write multi-MB rows to ``trace_events``.
-    Reserved control / routing / metrics fields
-    (:data:`_RESERVED_TRACE_FIELDS`) pass through unchanged so downstream
-    consumers (``WebSocketTraceHandler`` reading ``__audit_only__``,
-    audit SQL on ``model_name`` / ``task_type``, Langfuse observation
-    naming) keep working under truncation. Unknown fields also pass
-    through — conservative, so a future emit that adds a new routing
-    flag is not silently dropped.
+    Three layers:
+
+      1. **Reserved + unknown fields pass through verbatim.** Routing /
+         control / metrics fields (:data:`_RESERVED_TRACE_FIELDS`) and
+         fields not in :data:`_TRUNCATABLE_CONTENT_FIELDS` are copied
+         as-is so downstream consumers (WS visibility filter, audit SQL,
+         Langfuse) keep working under truncation. Unknown-field
+         passthrough is intentional — a future emit that adds a new
+         routing flag must not be silently dropped.
+
+      2. **Per-field semantic reducers.** Each present truncatable
+         field is routed to its reducer in :data:`_FIELD_REDUCERS`:
+
+           - ``messages`` / ``context_preview``: keep head + tail with
+             role/name/type metadata intact, truncate kept content
+           - ``tools``: keep tool name + description, truncate
+             parameters schema
+           - ``tool_calls``: keep id + function.name, truncate
+             function.arguments
+           - ``response``: dict-shape-preserving for ``_short_response``
+             output; string → byte slice with truncation marker
+           - ``content`` / ``error`` / ``error_message`` / ``traceback``:
+             direct text truncation
+           - ``candidate_names``: head + tail list slice
+
+         Reducers self-verify their output (post-reduce serialized size
+         ≤ budget) and fall back to a single placeholder dict if even
+         the smallest preservation overshoots.
+
+      3. **Envelope-level hard cap.** After all reducers, if the
+         serialized total still exceeds ``max_bytes`` (extreme case —
+         e.g. reserved metadata itself oversized), collapse the
+         currently-largest truncatable field to a single placeholder
+         and re-check. Outer reserved metadata always survives.
 
     Wired into :func:`PatternRuntime._emit_trace_event` for LLM-category
     events so every v2-runtime LLM trace is capped, not just calls that
-    go through the convenience helpers :func:`trace_llm_call_start` /
-    :func:`trace_action_end`.
+    go through :func:`trace_llm_call_start` / :func:`trace_action_end`.
 
     Args:
         data: Event ``data`` dict for an LLM-category trace event.
             Non-dict input is returned unchanged.
-        max_bytes: Total byte budget split across present truncatable
-            fields. When ``None``, reads
-            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000, 0 disables).
+        max_bytes: Total byte budget for the serialized result. When
+            ``None``, reads ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default
+            50_000, ``0`` disables).
 
     Returns:
-        A new dict with reserved and unknown fields verbatim and
-        truncatable fields routed through :func:`_trim_subtree`.
+        A new dict honoring the cap with reserved metadata intact.
     """
     if not isinstance(data, dict):
         return data
@@ -145,20 +485,48 @@ def normalize_llm_trace_payload(
 
     present_content = [k for k in data if k in _TRUNCATABLE_CONTENT_FIELDS]
     if not present_content:
-        # Nothing to cap — all reserved or unknown scalars.
+        # Nothing to cap — all reserved or unknown. Even if reserved
+        # itself overshoots, we don't touch it (that would defeat the
+        # routing contract).
         return data
 
-    per_field_budget = max(1, max_bytes // len(present_content))
+    # Reserve envelope budget for non-truncatable fields + JSON separators.
+    reserved_part = {
+        k: v for k, v in data.items() if k not in _TRUNCATABLE_CONTENT_FIELDS
+    }
+    reserved_overhead = _serialized_size(reserved_part)
+    content_budget = max(256, max_bytes - reserved_overhead - 64)
+    per_field_budget = max(128, content_budget // len(present_content))
 
     out: Dict[str, Any] = {}
     for k, v in data.items():
         if k in _TRUNCATABLE_CONTENT_FIELDS:
-            out[k] = _trim_subtree(v, per_field_budget)
+            reducer = _FIELD_REDUCERS.get(k, _reduce_text)
+            out[k] = reducer(v, per_field_budget)
         else:
-            # Reserved or unknown — pass through. Unknown-field
-            # passthrough is intentional: a future emit that adds a new
-            # routing flag must NOT be silently truncated.
             out[k] = v
+
+    # Final envelope hard cap. Collapse the largest remaining truncatable
+    # field iteratively until under cap. Stops if all collapsed (already
+    # placeholders) — at that point we can't shrink any further without
+    # touching reserved metadata, which is contractually off-limits.
+    while _serialized_size(out) > max_bytes:
+        largest = None
+        largest_size = -1
+        for k in present_content:
+            v = out.get(k)
+            if isinstance(v, dict) and "__truncated__" in v:
+                continue  # already collapsed
+            size = _serialized_size(v)
+            if size > largest_size:
+                largest_size = size
+                largest = k
+        if largest is None or largest_size < 100:
+            break
+        out[largest] = _placeholder(
+            f"{largest} exceeded total {max_bytes}-byte envelope cap"
+        )
+
     return out
 
 

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1,7 +1,6 @@
 """Generic tracing module for tracking events in the xagent system."""
 
 import inspect
-import json
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
@@ -12,30 +11,82 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 
 
-def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
-    """Truncate a trace payload so a single row in trace_events stays bounded.
+# Fields the trace pipeline reads as identifiers, routing flags, or metrics
+# (WS visibility filter, audit SQL queries, Langfuse observation naming,
+# frontend rendering). Must survive normalization untouched.
+_RESERVED_TRACE_FIELDS = frozenset(
+    {
+        # routing / visibility
+        "__audit_only__",
+        # call attribution
+        "model_name",
+        "llm_type",
+        "task_type",
+        "step_id",
+        "step_name",
+        "action",
+        "attempt",
+        "json_mode_failed",
+        # outcomes
+        "success",
+        "error_type",
+        "response_type",
+        # metrics
+        "usage",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        # cardinality counters (not the values they count)
+        "messages_count",
+        "candidates_count",
+        "tools_count",
+        "is_tool_call",
+        "has_tools",
+    }
+)
 
-    Applies to LLM I/O audit trace fields (data.messages, data.response, ...).
-    Returns a value of the same shape with overly-long strings replaced by
-    ``"...[truncated N chars]"`` markers. Dicts/lists are walked recursively
-    and the result is then checked against ``max_bytes`` after JSON
-    serialization; if the per-child split plus suffix overhead still
-    overshoots the budget (e.g. a list of N strings each accruing a
-    ~25-byte ``...[truncated N chars]`` suffix), the entire container is
-    replaced with a single placeholder. This guarantees the documented
-    ``max_bytes`` cap is a hard upper bound on the serialized payload,
-    not just on scalar leaves.
+# Fields that carry the bulky LLM I/O payload we actually want to cap.
+# Each present field gets ``max_bytes // N_present`` budget; the rest pass
+# through unchanged.
+_TRUNCATABLE_CONTENT_FIELDS = frozenset(
+    {
+        "messages",
+        "context_preview",
+        "response",
+        "content",
+        "tool_calls",
+        "tools",
+        "error",
+        "error_message",
+        "traceback",
+        "candidate_names",
+    }
+)
+
+
+def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
+    """Recursive per-leaf truncation of a trace value.
+
+    Strings longer than ``max_bytes`` are sliced on a UTF-8 byte boundary
+    and suffixed with ``"...[truncated N chars]"``. Lists and dicts are
+    walked with the budget split evenly across children. Scalars
+    (int / bool / None) pass through unchanged.
+
+    Unlike :func:`normalize_llm_trace_payload`, this helper does NOT
+    distinguish reserved control fields from content fields and does NOT
+    enforce a total-size cap on the serialized result. The serialized
+    payload can exceed ``max_bytes`` once per-child suffix overhead is
+    accounted for. Callers that need a tracer-boundary cap on LLM event
+    payloads should use ``normalize_llm_trace_payload`` instead — this
+    function is the low-level worker.
 
     Args:
-        value: Original value (str / list / dict / scalar).
-        max_bytes: Override the total byte budget for *this subtree*. When
-            None, reads XAGENT_MAX_TRACE_PAYLOAD_BYTES via xagent.config
-            (default 50_000).
+        value: Original value.
+        max_bytes: Per-subtree byte budget. When ``None``, reads
+            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000, 0 disables).
 
     Returns:
-        The original value or a truncated copy. Scalars (int/bool/None) pass
-        through unchanged. Containers that cannot be trimmed within budget
-        collapse to a string placeholder.
+        The original value or a recursively trimmed copy.
     """
     if max_bytes is None:
         # Local import to avoid circular dependency at module load
@@ -46,39 +97,69 @@ def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
     if max_bytes <= 0:
         return value
 
-    trimmed = _trim_subtree(value, max_bytes)
+    return _trim_subtree(value, max_bytes)
 
-    # Hard cap for containers: per-child budget splitting plus the
-    # ``...[truncated N chars]`` suffix can compound for large N (a list
-    # of 1000 strings with max_bytes=1000 still serializes to ~25KB).
-    # If the final JSON exceeds max_bytes, collapse to a placeholder so
-    # callers get a real upper bound.
-    #
-    # CRITICAL: preserve the container TYPE on collapse. Downstream
-    # trace pipeline code (``Tracer.trace_event`` logging
-    # ``list(data.keys())``, ``DatabaseTraceHandler._serialize_data_for_json``,
-    # ``WebSocketTraceHandler._serialize_data``) all assume the ``data``
-    # field is a dict / list, not a string. Returning a raw string would
-    # break those callers with ``AttributeError: 'str' has no .keys()``.
-    if isinstance(trimmed, (list, dict)):
-        try:
-            serialized = json.dumps(trimmed, ensure_ascii=False, default=str)
-            if len(serialized.encode("utf-8")) > max_bytes:
-                container_kind = "list" if isinstance(value, list) else "dict"
-                element_count = len(value) if isinstance(value, (list, dict)) else 0
-                placeholder = (
-                    f"...[truncated {container_kind} "
-                    f"({element_count} elements) exceeds {max_bytes}-byte cap]"
-                )
-                if isinstance(value, list):
-                    return [placeholder]
-                return {"__truncated__": placeholder}
-        except (TypeError, ValueError):
-            # Non-serializable subtree: let downstream trace handlers
-            # (DatabaseTraceHandler._serialize_data_for_json) deal with it.
-            pass
 
-    return trimmed
+def normalize_llm_trace_payload(
+    data: Any,
+    max_bytes: Optional[int] = None,
+) -> Any:
+    """Trace-boundary normalizer for LLM-category trace event payloads.
+
+    Truncates only the fields in :data:`_TRUNCATABLE_CONTENT_FIELDS` so
+    bulky LLM I/O doesn't write multi-MB rows to ``trace_events``.
+    Reserved control / routing / metrics fields
+    (:data:`_RESERVED_TRACE_FIELDS`) pass through unchanged so downstream
+    consumers (``WebSocketTraceHandler`` reading ``__audit_only__``,
+    audit SQL on ``model_name`` / ``task_type``, Langfuse observation
+    naming) keep working under truncation. Unknown fields also pass
+    through — conservative, so a future emit that adds a new routing
+    flag is not silently dropped.
+
+    Wired into :func:`PatternRuntime._emit_trace_event` for LLM-category
+    events so every v2-runtime LLM trace is capped, not just calls that
+    go through the convenience helpers :func:`trace_llm_call_start` /
+    :func:`trace_action_end`.
+
+    Args:
+        data: Event ``data`` dict for an LLM-category trace event.
+            Non-dict input is returned unchanged.
+        max_bytes: Total byte budget split across present truncatable
+            fields. When ``None``, reads
+            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000, 0 disables).
+
+    Returns:
+        A new dict with reserved and unknown fields verbatim and
+        truncatable fields routed through :func:`_trim_subtree`.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    if max_bytes is None:
+        from ...config import get_max_trace_payload_bytes
+
+        max_bytes = get_max_trace_payload_bytes()
+
+    if max_bytes <= 0:
+        return data
+
+    present_content = [k for k in data if k in _TRUNCATABLE_CONTENT_FIELDS]
+    if not present_content:
+        # Nothing to cap — all reserved or unknown scalars.
+        return data
+
+    per_field_budget = max(1, max_bytes // len(present_content))
+
+    out: Dict[str, Any] = {}
+    for k, v in data.items():
+        if k in _TRUNCATABLE_CONTENT_FIELDS:
+            out[k] = _trim_subtree(v, per_field_budget)
+        else:
+            # Reserved or unknown — pass through. Unknown-field
+            # passthrough is intentional: a future emit that adds a new
+            # routing flag must NOT be silently truncated.
+            out[k] = v
+    return out
 
 
 # Bound on recursion depth inside `_trim_subtree`. LLM payloads we care
@@ -616,10 +697,10 @@ async def trace_action_end(
     """Trace action end event."""
     event_type = TraceEventType(TraceScope.ACTION, TraceAction.END, category)
     payload = data or {}
-    # Bound LLM I/O audit rows (messages / response can be tens of KB each).
-    # Other categories pass through unchanged.
+    # Bound LLM I/O audit rows (messages / response can be tens of KB each)
+    # while preserving reserved control fields. Other categories pass through.
     if category == TraceCategory.LLM and payload:
-        payload = truncate_for_trace(payload)
+        payload = normalize_llm_trace_payload(payload)
     return await tracer.trace_event(
         event_type, task_id=task_id, step_id=step_id, data=payload
     )
@@ -823,8 +904,9 @@ async def trace_llm_call_start(
     tracer: Tracer, task_id: str, step_id: str, data: Optional[Dict[str, Any]] = None
 ) -> str:
     """Trace LLM call start event."""
-    # Bound the payload — see truncate_for_trace docstring.
-    payload = truncate_for_trace(data) if data else data
+    # Bound the payload via the tracer-boundary normalizer so reserved
+    # control fields survive even when content fields are truncated.
+    payload = normalize_llm_trace_payload(data) if data else data
     return await trace_action_start(
         tracer, task_id, step_id, TraceCategory.LLM, payload
     )

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1,6 +1,7 @@
 """Generic tracing module for tracking events in the xagent system."""
 
 import inspect
+import json
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
@@ -9,6 +10,106 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
+
+
+def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
+    """Truncate a trace payload so a single row in trace_events stays bounded.
+
+    Applies to LLM I/O audit trace fields (data.messages, data.response, ...).
+    Returns a value of the same shape with overly-long strings replaced by
+    ``"...[truncated N chars]"`` markers. Dicts/lists are walked recursively
+    and the result is then checked against ``max_bytes`` after JSON
+    serialization; if the per-child split plus suffix overhead still
+    overshoots the budget (e.g. a list of N strings each accruing a
+    ~25-byte ``...[truncated N chars]`` suffix), the entire container is
+    replaced with a single placeholder. This guarantees the documented
+    ``max_bytes`` cap is a hard upper bound on the serialized payload,
+    not just on scalar leaves.
+
+    Args:
+        value: Original value (str / list / dict / scalar).
+        max_bytes: Override the total byte budget for *this subtree*. When
+            None, reads XAGENT_MAX_TRACE_PAYLOAD_BYTES via xagent.config
+            (default 50_000).
+
+    Returns:
+        The original value or a truncated copy. Scalars (int/bool/None) pass
+        through unchanged. Containers that cannot be trimmed within budget
+        collapse to a string placeholder.
+    """
+    if max_bytes is None:
+        # Local import to avoid circular dependency at module load
+        from ...config import get_max_trace_payload_bytes
+
+        max_bytes = get_max_trace_payload_bytes()
+
+    if max_bytes <= 0:
+        return value
+
+    trimmed = _trim_subtree(value, max_bytes)
+
+    # Hard cap for containers: per-child budget splitting plus the
+    # ``...[truncated N chars]`` suffix can compound for large N (a list
+    # of 1000 strings with max_bytes=1000 still serializes to ~25KB).
+    # If the final JSON exceeds max_bytes, collapse to a placeholder so
+    # callers get a real upper bound.
+    #
+    # CRITICAL: preserve the container TYPE on collapse. Downstream
+    # trace pipeline code (``Tracer.trace_event`` logging
+    # ``list(data.keys())``, ``DatabaseTraceHandler._serialize_data_for_json``,
+    # ``WebSocketTraceHandler._serialize_data``) all assume the ``data``
+    # field is a dict / list, not a string. Returning a raw string would
+    # break those callers with ``AttributeError: 'str' has no .keys()``.
+    if isinstance(trimmed, (list, dict)):
+        try:
+            serialized = json.dumps(trimmed, ensure_ascii=False, default=str)
+            if len(serialized.encode("utf-8")) > max_bytes:
+                container_kind = "list" if isinstance(value, list) else "dict"
+                element_count = len(value) if isinstance(value, (list, dict)) else 0
+                placeholder = (
+                    f"...[truncated {container_kind} "
+                    f"({element_count} elements) exceeds {max_bytes}-byte cap]"
+                )
+                if isinstance(value, list):
+                    return [placeholder]
+                return {"__truncated__": placeholder}
+        except (TypeError, ValueError):
+            # Non-serializable subtree: let downstream trace handlers
+            # (DatabaseTraceHandler._serialize_data_for_json) deal with it.
+            pass
+
+    return trimmed
+
+
+def _trim_subtree(value: Any, max_bytes: int) -> Any:
+    """Recursive worker for :func:`truncate_for_trace`.
+
+    Handles scalar truncation and container recursion. Does NOT enforce
+    the final container size cap -- that's the outer function's job.
+    Keeping the recursive case in its own function avoids re-running the
+    expensive serialization-based check at every nesting level.
+    """
+    if isinstance(value, str):
+        encoded = value.encode("utf-8", errors="replace")
+        if len(encoded) <= max_bytes:
+            return value
+        # Slice on byte boundary, then decode with errors="ignore" so an
+        # incomplete trailing multi-byte char is dropped instead of producing
+        # U+FFFD replacement chars — otherwise len(head) inflates and the
+        # reported truncation count becomes inaccurate (can even go negative).
+        head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+        return f"{head}...[truncated {len(value) - len(head)} chars]"
+
+    if isinstance(value, list):
+        per_item = max(1, max_bytes // max(1, len(value)))
+        return [_trim_subtree(item, per_item) for item in value]
+
+    if isinstance(value, dict):
+        per_value = max(1, max_bytes // max(1, len(value)))
+        return {k: _trim_subtree(v, per_value) for k, v in value.items()}
+
+    # Numbers, bools, None — pass through
+    return value
 
 
 class TraceScope(Enum):
@@ -504,8 +605,13 @@ async def trace_action_end(
 ) -> str:
     """Trace action end event."""
     event_type = TraceEventType(TraceScope.ACTION, TraceAction.END, category)
+    payload = data or {}
+    # Bound LLM I/O audit rows (messages / response can be tens of KB each).
+    # Other categories pass through unchanged.
+    if category == TraceCategory.LLM and payload:
+        payload = truncate_for_trace(payload)
     return await tracer.trace_event(
-        event_type, task_id=task_id, step_id=step_id, data=data or {}
+        event_type, task_id=task_id, step_id=step_id, data=payload
     )
 
 
@@ -707,7 +813,11 @@ async def trace_llm_call_start(
     tracer: Tracer, task_id: str, step_id: str, data: Optional[Dict[str, Any]] = None
 ) -> str:
     """Trace LLM call start event."""
-    return await trace_action_start(tracer, task_id, step_id, TraceCategory.LLM, data)
+    # Bound the payload — see truncate_for_trace docstring.
+    payload = truncate_for_trace(data) if data else data
+    return await trace_action_start(
+        tracer, task_id, step_id, TraceCategory.LLM, payload
+    )
 
 
 async def trace_task_llm_call_start(

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -81,7 +81,14 @@ def truncate_for_trace(value: Any, max_bytes: Optional[int] = None) -> Any:
     return trimmed
 
 
-def _trim_subtree(value: Any, max_bytes: int) -> Any:
+# Bound on recursion depth inside `_trim_subtree`. LLM payloads we care
+# about (messages[*].content, tool_calls) nest at most 4-5 levels; 50 is
+# well above that and well below Python's default 1000-frame limit, so a
+# pathological payload can't blow the stack via this helper.
+_MAX_TRACE_DEPTH = 50
+
+
+def _trim_subtree(value: Any, max_bytes: int, _depth: int = 0) -> Any:
     """Recursive worker for :func:`truncate_for_trace`.
 
     Handles scalar truncation and container recursion. Does NOT enforce
@@ -89,6 +96,9 @@ def _trim_subtree(value: Any, max_bytes: int) -> Any:
     Keeping the recursive case in its own function avoids re-running the
     expensive serialization-based check at every nesting level.
     """
+    if _depth >= _MAX_TRACE_DEPTH:
+        return f"...[truncated: depth exceeds {_MAX_TRACE_DEPTH}]"
+
     if isinstance(value, str):
         encoded = value.encode("utf-8", errors="replace")
         if len(encoded) <= max_bytes:
@@ -102,11 +112,11 @@ def _trim_subtree(value: Any, max_bytes: int) -> Any:
 
     if isinstance(value, list):
         per_item = max(1, max_bytes // max(1, len(value)))
-        return [_trim_subtree(item, per_item) for item in value]
+        return [_trim_subtree(item, per_item, _depth + 1) for item in value]
 
     if isinstance(value, dict):
         per_value = max(1, max_bytes // max(1, len(value)))
-        return {k: _trim_subtree(v, per_value) for k, v in value.items()}
+        return {k: _trim_subtree(v, per_value, _depth + 1) for k, v in value.items()}
 
     # Numbers, bools, None — pass through
     return value

--- a/src/xagent/skills/manager.py
+++ b/src/xagent/skills/manager.py
@@ -161,7 +161,12 @@ class SkillManager:
         selector = SkillSelector(llm)
 
         try:
-            selected_skill = await selector.select(task=task, candidates=candidates)
+            selected_skill = await selector.select(
+                task=task,
+                candidates=candidates,
+                tracer=tracer,
+                task_id=task_id,
+            )
 
             # Send skill selection end event if tracer is provided
             if tracer and task_id:

--- a/src/xagent/skills/selector.py
+++ b/src/xagent/skills/selector.py
@@ -5,6 +5,13 @@ Skill Selector - Use LLM to select the most appropriate skill
 import json
 import logging
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from xagent.core.agent.trace import (
+    TraceCategory,
+    trace_action_end,
+    trace_llm_call_start,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,13 +77,21 @@ If no skill is directly relevant, return selected: false."""
         """
         self.llm = llm
 
-    async def select(self, task: str, candidates: List[Dict]) -> Optional[Dict]:
+    async def select(
+        self,
+        task: str,
+        candidates: List[Dict],
+        tracer: Any = None,
+        task_id: Optional[str] = None,
+    ) -> Optional[Dict]:
         """
         Select the most appropriate skill, or return None
 
         Args:
             task: User task
             candidates: List of candidate skills
+            tracer: Optional Tracer for audit trace coverage
+            task_id: Real task id to attribute audit events to
 
         Returns:
             Selected skill, or None
@@ -89,26 +104,158 @@ If no skill is directly relevant, return selected: false."""
         logger.info(f"Available candidates: {len(candidates)} skills")
 
         prompt = self._build_prompt(task, candidates)
+        messages = [
+            {"role": "system", "content": self.SELECTOR_SYSTEM},
+            {"role": "user", "content": prompt},
+        ]
 
         logger.info("Calling LLM for skill selection...")
+
+        # Audit trace setup — virtual step_id outside dag_step_*/react_step_*.
+        # SkillManager.select_skill already emits trace_skill_select_start/end
+        # at the process level; this captures the LLM messages/response.
+        audit_task_id = task_id or f"dag_skill_selection_{uuid4().hex[:8]}"
+        audit_step_id = "dag_skill_selection"
+        audit_model_name = getattr(self.llm, "model_name", type(self.llm).__name__)
+        audit_attempt = 1
+        audit_trace_sent = False
+
+        if tracer is not None:
+            await trace_llm_call_start(
+                tracer,
+                audit_task_id,
+                audit_step_id,
+                data={
+                    "action": "LLM call started",
+                    "model_name": audit_model_name,
+                    "__audit_only__": True,
+                    "task_type": "dag_skill_selection",
+                    "attempt": audit_attempt,
+                    "messages_count": len(messages),
+                    "messages": messages,
+                    "candidates_count": len(candidates),
+                    "candidate_names": [c.get("name") for c in candidates],
+                    "has_tools": False,
+                    "step_id": audit_step_id,
+                    "step_name": "skill_selection",
+                },
+            )
 
         # First try JSON mode, fall back to normal mode if not supported
         try:
             response = await self.llm.chat(
-                messages=[
-                    {"role": "system", "content": self.SELECTOR_SYSTEM},
-                    {"role": "user", "content": prompt},
-                ],
+                messages=messages,
                 response_format={"type": "json_object"},
             )
         except Exception as e:
             logger.warning(f"JSON mode not supported, falling back to normal mode: {e}")
-            response = await self.llm.chat(
-                messages=[
-                    {"role": "system", "content": self.SELECTOR_SYSTEM},
-                    {"role": "user", "content": prompt},
-                ]
+            # Close attempt=1 with an error end so start/end remain paired
+            # (mirrors the plan_generator retry pattern).
+            if tracer is not None:
+                await trace_action_end(
+                    tracer,
+                    audit_task_id,
+                    audit_step_id,
+                    TraceCategory.LLM,
+                    data={
+                        "action": "LLM call failed",
+                        "model_name": audit_model_name,
+                        "__audit_only__": True,
+                        "task_type": "dag_skill_selection",
+                        "attempt": audit_attempt,
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        "llm_type": type(self.llm).__name__,
+                        "is_tool_call": False,
+                        "step_id": audit_step_id,
+                        "step_name": "skill_selection",
+                    },
+                )
+
+            audit_attempt = 2
+            if tracer is not None:
+                await trace_llm_call_start(
+                    tracer,
+                    audit_task_id,
+                    audit_step_id,
+                    data={
+                        "action": "LLM call started",
+                        "model_name": audit_model_name,
+                        "__audit_only__": True,
+                        "task_type": "dag_skill_selection",
+                        "attempt": audit_attempt,
+                        "messages_count": len(messages),
+                        "messages": messages,
+                        "candidates_count": len(candidates),
+                        "has_tools": False,
+                        "step_id": audit_step_id,
+                        "step_name": "skill_selection",
+                        "json_mode_failed": True,
+                    },
+                )
+            try:
+                response = await self.llm.chat(messages=messages)
+            except Exception as fallback_err:
+                # Close attempt=2 with an error end so start/end stay paired,
+                # then re-raise to let SkillManager's outer trace_error fire.
+                if tracer is not None:
+                    try:
+                        await trace_action_end(
+                            tracer,
+                            audit_task_id,
+                            audit_step_id,
+                            TraceCategory.LLM,
+                            data={
+                                "action": "LLM call failed",
+                                "model_name": audit_model_name,
+                                "__audit_only__": True,
+                                "task_type": "dag_skill_selection",
+                                "attempt": audit_attempt,
+                                "error": str(fallback_err),
+                                "error_type": type(fallback_err).__name__,
+                                "llm_type": type(self.llm).__name__,
+                                "is_tool_call": False,
+                                "step_id": audit_step_id,
+                                "step_name": "skill_selection",
+                            },
+                        )
+                        audit_trace_sent = True
+                    except Exception as trace_err:
+                        logger.warning(
+                            f"Failed to emit error trace for skill selection fallback: {trace_err}"
+                        )
+                raise
+
+        if tracer is not None and not audit_trace_sent:
+            if isinstance(response, str):
+                response_content: Any = response
+                response_usage: Any = None
+            elif isinstance(response, dict):
+                response_content = response.get("content", str(response))
+                response_usage = response.get("usage")
+            else:
+                response_content = str(response)
+                response_usage = None
+            await trace_action_end(
+                tracer,
+                audit_task_id,
+                audit_step_id,
+                TraceCategory.LLM,
+                data={
+                    "action": "LLM call completed",
+                    "model_name": audit_model_name,
+                    "__audit_only__": True,
+                    "task_type": "dag_skill_selection",
+                    "attempt": audit_attempt,
+                    "response_type": type(response).__name__,
+                    "is_tool_call": False,
+                    "response": response_content,
+                    "usage": response_usage,
+                    "step_id": audit_step_id,
+                    "step_name": "skill_selection",
+                },
             )
+            audit_trace_sent = True
 
         # Handle different return types
         if isinstance(response, str):

--- a/src/xagent/skills/selector.py
+++ b/src/xagent/skills/selector.py
@@ -117,28 +117,60 @@ If no skill is directly relevant, return selected: false."""
         audit_task_id = task_id or f"dag_skill_selection_{uuid4().hex[:8]}"
         audit_step_id = "dag_skill_selection"
         audit_model_name = getattr(self.llm, "model_name", type(self.llm).__name__)
-        audit_attempt = 1
-        audit_trace_sent = False
+        fallback_failure_emitted = False
+        used_attempt = 1
+        used_json_mode_failed = False
+
+        def _build_audit_data(
+            *,
+            action: str,
+            attempt: int,
+            json_mode_failed: bool,
+            include_input: bool = False,
+            response_type: Optional[str] = None,
+            response: Any = None,
+            response_usage: Any = None,
+            error: Optional[str] = None,
+            error_type: Optional[str] = None,
+        ) -> Dict[str, Any]:
+            data: Dict[str, Any] = {
+                "action": action,
+                "model_name": audit_model_name,
+                "__audit_only__": True,
+                "task_type": "dag_skill_selection",
+                "attempt": attempt,
+                "json_mode_failed": json_mode_failed,
+                "is_tool_call": False,
+                "has_tools": False,
+                "step_id": audit_step_id,
+                "step_name": "skill_selection",
+            }
+            if include_input:
+                data["messages_count"] = len(messages)
+                data["messages"] = messages
+                data["candidates_count"] = len(candidates)
+                data["candidate_names"] = [c.get("name") for c in candidates]
+            if response_type is not None:
+                data["response_type"] = response_type
+                data["response"] = response
+                data["usage"] = response_usage
+            if error is not None:
+                data["error"] = error
+                data["error_type"] = error_type
+                data["llm_type"] = type(self.llm).__name__
+            return data
 
         if tracer is not None:
             await trace_llm_call_start(
                 tracer,
                 audit_task_id,
                 audit_step_id,
-                data={
-                    "action": "LLM call started",
-                    "model_name": audit_model_name,
-                    "__audit_only__": True,
-                    "task_type": "dag_skill_selection",
-                    "attempt": audit_attempt,
-                    "messages_count": len(messages),
-                    "messages": messages,
-                    "candidates_count": len(candidates),
-                    "candidate_names": [c.get("name") for c in candidates],
-                    "has_tools": False,
-                    "step_id": audit_step_id,
-                    "step_name": "skill_selection",
-                },
+                data=_build_audit_data(
+                    action="LLM call started",
+                    attempt=1,
+                    json_mode_failed=False,
+                    include_input=True,
+                ),
             )
 
         # First try JSON mode, fall back to normal mode if not supported
@@ -149,52 +181,42 @@ If no skill is directly relevant, return selected: false."""
             )
         except Exception as e:
             logger.warning(f"JSON mode not supported, falling back to normal mode: {e}")
-            # Close attempt=1 with an error end so start/end remain paired
-            # (mirrors the plan_generator retry pattern).
+            # Close attempt=1 with an error end so start/end remain paired.
+            # ``json_mode_failed=True`` on the attempt=1 close marks this
+            # event as the JSON-mode failure record; SQL queries can count
+            # ``attempt=1 AND action='LLM call failed' AND json_mode_failed=true``
+            # to get the JSON-mode-fallback rate.
             if tracer is not None:
                 await trace_action_end(
                     tracer,
                     audit_task_id,
                     audit_step_id,
                     TraceCategory.LLM,
-                    data={
-                        "action": "LLM call failed",
-                        "model_name": audit_model_name,
-                        "__audit_only__": True,
-                        "task_type": "dag_skill_selection",
-                        "attempt": audit_attempt,
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                        "llm_type": type(self.llm).__name__,
-                        "is_tool_call": False,
-                        "step_id": audit_step_id,
-                        "step_name": "skill_selection",
-                    },
+                    data=_build_audit_data(
+                        action="LLM call failed",
+                        attempt=1,
+                        json_mode_failed=True,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    ),
                 )
 
-            audit_attempt = 2
             if tracer is not None:
                 await trace_llm_call_start(
                     tracer,
                     audit_task_id,
                     audit_step_id,
-                    data={
-                        "action": "LLM call started",
-                        "model_name": audit_model_name,
-                        "__audit_only__": True,
-                        "task_type": "dag_skill_selection",
-                        "attempt": audit_attempt,
-                        "messages_count": len(messages),
-                        "messages": messages,
-                        "candidates_count": len(candidates),
-                        "has_tools": False,
-                        "step_id": audit_step_id,
-                        "step_name": "skill_selection",
-                        "json_mode_failed": True,
-                    },
+                    data=_build_audit_data(
+                        action="LLM call started",
+                        attempt=2,
+                        json_mode_failed=True,
+                        include_input=True,
+                    ),
                 )
             try:
                 response = await self.llm.chat(messages=messages)
+                used_attempt = 2
+                used_json_mode_failed = True
             except Exception as fallback_err:
                 # Close attempt=2 with an error end so start/end stay paired,
                 # then re-raise to let SkillManager's outer trace_error fire.
@@ -205,28 +227,22 @@ If no skill is directly relevant, return selected: false."""
                             audit_task_id,
                             audit_step_id,
                             TraceCategory.LLM,
-                            data={
-                                "action": "LLM call failed",
-                                "model_name": audit_model_name,
-                                "__audit_only__": True,
-                                "task_type": "dag_skill_selection",
-                                "attempt": audit_attempt,
-                                "error": str(fallback_err),
-                                "error_type": type(fallback_err).__name__,
-                                "llm_type": type(self.llm).__name__,
-                                "is_tool_call": False,
-                                "step_id": audit_step_id,
-                                "step_name": "skill_selection",
-                            },
+                            data=_build_audit_data(
+                                action="LLM call failed",
+                                attempt=2,
+                                json_mode_failed=True,
+                                error=str(fallback_err),
+                                error_type=type(fallback_err).__name__,
+                            ),
                         )
-                        audit_trace_sent = True
+                        fallback_failure_emitted = True
                     except Exception as trace_err:
                         logger.warning(
                             f"Failed to emit error trace for skill selection fallback: {trace_err}"
                         )
                 raise
 
-        if tracer is not None and not audit_trace_sent:
+        if tracer is not None and not fallback_failure_emitted:
             if isinstance(response, str):
                 response_content: Any = response
                 response_usage: Any = None
@@ -241,21 +257,15 @@ If no skill is directly relevant, return selected: false."""
                 audit_task_id,
                 audit_step_id,
                 TraceCategory.LLM,
-                data={
-                    "action": "LLM call completed",
-                    "model_name": audit_model_name,
-                    "__audit_only__": True,
-                    "task_type": "dag_skill_selection",
-                    "attempt": audit_attempt,
-                    "response_type": type(response).__name__,
-                    "is_tool_call": False,
-                    "response": response_content,
-                    "usage": response_usage,
-                    "step_id": audit_step_id,
-                    "step_name": "skill_selection",
-                },
+                data=_build_audit_data(
+                    action="LLM call completed",
+                    attempt=used_attempt,
+                    json_mode_failed=used_json_mode_failed,
+                    response_type=type(response).__name__,
+                    response=response_content,
+                    response_usage=response_usage,
+                ),
             )
-            audit_trace_sent = True
 
         # Handle different return types
         if isinstance(response, str):

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -317,7 +317,29 @@ class WebSocketTraceHandler(TraceHandler):
     def _convert_trace_event_to_stream_event(
         self, event: TraceEvent
     ) -> Optional[Dict[str, Any]]:
-        """Convert trace event to unified stream format."""
+        """Convert trace event to unified stream format.
+
+        Returns ``None`` to skip the broadcast entirely. The caller
+        (``handle_event``) checks ``if stream_event:`` before sending,
+        so a ``None`` here means the event still reaches
+        ``DatabaseTraceHandler`` (audit row persisted) but never reaches
+        any WebSocket client. Two reasons we drop:
+
+          1. ``__audit_only__=True`` in ``event.data`` -- server-only
+             RCA payload (raw LLM messages / response) that must not
+             leak to clients.
+          2. Agent checkpoint data -- internal runtime state the
+             frontend doesn't render (checked after serialization).
+        """
+        # Server-only audit traces: drop early so we don't waste effort
+        # serializing payloads we're about to discard.
+        if isinstance(event.data, dict) and event.data.get("__audit_only__") is True:
+            logger.debug(
+                f"Dropping audit-only trace event from WS broadcast: "
+                f"step_id={event.step_id} task={self.task_id}"
+            )
+            return None
+
         event_type_str = get_event_type_mapping(event)
         logger.debug(
             f"Converting trace event to stream event: {event_type_str} for task {self.task_id}"

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -12,7 +12,7 @@ The v2-runtime audit injection (centralized in
 follow-up PR.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -245,3 +245,192 @@ async def test_trace_action_end_truncates_llm_payload(
     assert len(captured) == 1
     assert "[truncated" in captured[0]["response"]
     assert captured[0]["model_name"] == "m"
+
+
+# ---------------------------------------------------------------------------
+# Skill selector audit emit coverage
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTracer:
+    """Capture-only tracer used by selector audit emit tests."""
+
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        task_id: Any = None,
+        step_id: Any = None,
+        data: Any = None,
+        parent_id: Any = None,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": dict(data or {}),
+            }
+        )
+        return "evt"
+
+
+class _FakeLLM:
+    """Minimal stub matching the surface area used by SkillSelector.select."""
+
+    model_name = "fake-model"
+
+    def __init__(
+        self,
+        *,
+        fail_json_mode: bool = False,
+        fail_all: bool = False,
+        response_payload: str = '{"selected": true, "skill_name": "skill_a", "reasoning": "fits"}',
+    ) -> None:
+        self.fail_json_mode = fail_json_mode
+        self.fail_all = fail_all
+        self.response_payload = response_payload
+        self.calls: List[Dict[str, Any]] = []
+
+    async def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        response_format: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        self.calls.append({"messages": messages, "response_format": response_format})
+        if self.fail_all:
+            raise RuntimeError("LLM unavailable")
+        if response_format is not None and self.fail_json_mode:
+            raise RuntimeError("JSON mode unsupported")
+        return self.response_payload
+
+
+_FAKE_CANDIDATES = [
+    {"name": "skill_a", "description": "do A"},
+    {"name": "skill_b", "description": "do B"},
+]
+
+
+@pytest.mark.asyncio
+async def test_selector_audit_emits_start_end_on_success() -> None:
+    """Happy path: JSON mode works -> start + end emitted on attempt=1."""
+    from xagent.skills.selector import SkillSelector
+
+    tracer = _RecordingTracer()
+    selector = SkillSelector(llm=_FakeLLM())
+
+    result = await selector.select(
+        task="do thing A",
+        candidates=_FAKE_CANDIDATES,
+        tracer=tracer,
+        task_id="task-1",
+    )
+
+    assert result is not None
+    assert result["name"] == "skill_a"
+
+    audit_events = [e for e in tracer.events if e["data"].get("__audit_only__") is True]
+    assert len(audit_events) == 2, (
+        f"expected 1 start + 1 end on success, got {len(audit_events)}: "
+        f"{[e['data'].get('action') for e in audit_events]}"
+    )
+
+    start, end = audit_events
+    assert start["data"]["action"] == "LLM call started"
+    assert start["data"]["attempt"] == 1
+    assert start["data"]["json_mode_failed"] is False
+    assert end["data"]["action"] == "LLM call completed"
+    assert end["data"]["attempt"] == 1
+    assert end["data"]["json_mode_failed"] is False
+    assert end["data"]["step_id"] == "dag_skill_selection"
+
+
+@pytest.mark.asyncio
+async def test_selector_audit_emits_fallback_on_json_mode_failure() -> None:
+    """attempt=1 fails JSON mode -> 4 events with json_mode_failed semantics."""
+    from xagent.skills.selector import SkillSelector
+
+    tracer = _RecordingTracer()
+    selector = SkillSelector(llm=_FakeLLM(fail_json_mode=True))
+
+    result = await selector.select(
+        task="do thing A",
+        candidates=_FAKE_CANDIDATES,
+        tracer=tracer,
+        task_id="task-2",
+    )
+
+    assert result is not None
+    assert result["name"] == "skill_a"
+
+    audit_events = [e for e in tracer.events if e["data"].get("__audit_only__") is True]
+    assert len(audit_events) == 4, (
+        f"expected start1+err1+start2+end2, got "
+        f"{[e['data'].get('action') for e in audit_events]}"
+    )
+
+    actions = [(e["data"]["attempt"], e["data"]["action"]) for e in audit_events]
+    assert actions == [
+        (1, "LLM call started"),
+        (1, "LLM call failed"),
+        (2, "LLM call started"),
+        (2, "LLM call completed"),
+    ]
+
+    # json_mode_failed: False only on attempt=1 start; True on the rest
+    assert audit_events[0]["data"]["json_mode_failed"] is False
+    for event in audit_events[1:]:
+        assert event["data"]["json_mode_failed"] is True, (
+            f"expected json_mode_failed=True on {event['data']['action']} "
+            f"attempt={event['data']['attempt']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_selector_audit_emits_failure_end_when_both_attempts_fail() -> None:
+    """Both attempts blow -> emit 4 events then re-raise."""
+    from xagent.skills.selector import SkillSelector
+
+    tracer = _RecordingTracer()
+    selector = SkillSelector(llm=_FakeLLM(fail_all=True))
+
+    with pytest.raises(RuntimeError, match="LLM unavailable"):
+        await selector.select(
+            task="do thing A",
+            candidates=_FAKE_CANDIDATES,
+            tracer=tracer,
+            task_id="task-3",
+        )
+
+    audit_events = [e for e in tracer.events if e["data"].get("__audit_only__") is True]
+    actions = [(e["data"]["attempt"], e["data"]["action"]) for e in audit_events]
+    assert actions == [
+        (1, "LLM call started"),
+        (1, "LLM call failed"),
+        (2, "LLM call started"),
+        (2, "LLM call failed"),
+    ], f"unexpected emit sequence: {actions}"
+
+    # Critical: every audit event must carry the server-only flag
+    for event in audit_events:
+        assert event["data"]["__audit_only__"] is True
+
+
+@pytest.mark.asyncio
+async def test_selector_audit_no_emit_when_tracer_is_none() -> None:
+    """Defensive: passing tracer=None must not crash selector."""
+    from xagent.skills.selector import SkillSelector
+
+    selector = SkillSelector(llm=_FakeLLM())
+
+    result = await selector.select(
+        task="do thing A",
+        candidates=_FAKE_CANDIDATES,
+        tracer=None,
+        task_id=None,
+    )
+
+    assert result is not None
+    assert result["name"] == "skill_a"

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -1,0 +1,166 @@
+"""Unit tests for the LLM-payload truncation helper used by the audit
+trace infrastructure.
+
+The v1 runtime (which used to host per-pattern audit emit sites
+covered here) was removed in upstream PR #403
+(``feat: [v2 part8] remove agent v1 runtime``); per-site audit tests
+have been dropped along with their targets. This file keeps the
+transport-agnostic infrastructure tests that still apply on v2.
+
+The v2-runtime audit injection (centralized in
+``agent/runtime.py:on_llm_start / on_llm_end``) is covered by a
+follow-up PR.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+
+def test_truncate_for_trace_short_string_passthrough() -> None:
+    from xagent.core.agent.trace import truncate_for_trace
+
+    assert truncate_for_trace("hi", max_bytes=100) == "hi"
+
+
+def test_truncate_for_trace_long_string_truncated() -> None:
+    from xagent.core.agent.trace import truncate_for_trace
+
+    out = truncate_for_trace("x" * 1000, max_bytes=100)
+    assert isinstance(out, str)
+    assert "[truncated" in out
+    # Head of original preserved
+    assert out.startswith("x" * 100)
+
+
+def test_truncate_for_trace_walks_dict_and_list() -> None:
+    """Per-leaf truncation: dict shape preserved, only oversized string
+    leaves get the ``[truncated N chars]`` marker.
+
+    Uses ``max_bytes=4000`` so the post-trim serialized payload stays
+    inside the hard-cap envelope and the original dict shape survives.
+    The over-budget collapse path is covered by the separate
+    ``..._dict_total_bounded_by_max_bytes`` test below.
+    """
+    from xagent.core.agent.trace import truncate_for_trace
+
+    payload = {
+        "messages": [
+            {"role": "user", "content": "x" * 5000},
+            {"role": "assistant", "content": "short"},
+        ],
+        "response": "y" * 5000,
+        "model_name": "stub",
+        "attempt": 1,
+    }
+    out = truncate_for_trace(payload, max_bytes=4000)
+    # Dict survives: shape preserved, not collapsed to placeholder
+    assert isinstance(out, dict)
+    assert "__truncated__" not in out
+    # Scalars unchanged
+    assert out["model_name"] == "stub"
+    assert out["attempt"] == 1
+    # Large string truncated
+    assert "[truncated" in out["response"]
+    # Nested list element truncated
+    assert "[truncated" in out["messages"][0]["content"]
+    # Short nested element unchanged
+    assert out["messages"][1]["content"] == "short"
+
+
+def test_truncate_for_trace_dict_total_bounded_by_max_bytes() -> None:
+    """A multi-field dict must not fan out to N*max_bytes total size.
+
+    Two ways the cap is honored:
+
+      - Budget enough for per-field trim to fit: dict shape survives,
+        every value carries the ``[truncated N chars]`` marker.
+      - Budget too small for trimmed shape: the dict collapses to
+        ``{"__truncated__": "..."}`` (container TYPE preserved so
+        downstream ``data.keys()`` callers don't break).
+    """
+    import json
+
+    from xagent.core.agent.trace import truncate_for_trace
+
+    big = "z" * 5000
+    payload = {"a": big, "b": big, "c": big, "d": big}
+    out = truncate_for_trace(payload, max_bytes=200)
+
+    serialized = json.dumps(out)
+    assert len(serialized) < 800, (
+        f"dict fan-out broke the cap; serialized={len(serialized)} bytes"
+    )
+    assert isinstance(out, dict)
+    if "__truncated__" in out:
+        # Hard-cap path: dict collapsed to placeholder marker.
+        assert "[truncated" in out["__truncated__"]
+    else:
+        # Per-field trim path: every value got truncated.
+        for key in ("a", "b", "c", "d"):
+            assert "[truncated" in out[key]
+
+
+def test_truncate_for_trace_multibyte_head_no_replacement_chars() -> None:
+    """Multi-byte UTF-8 truncation must not produce U+FFFD chars.
+
+    Regression: decoding the byte-sliced head with ``errors="replace"``
+    inserts a replacement char whenever the slice ends mid-codepoint,
+    which inflates ``len(head)`` and makes the reported truncated
+    count inaccurate (can go negative for small budgets).
+    """
+    from xagent.core.agent.trace import truncate_for_trace
+
+    # 100 CJK chars = 300 UTF-8 bytes; slice at 50 lands mid-codepoint.
+    value = "中" * 100
+    out = truncate_for_trace(value, max_bytes=50)
+    assert isinstance(out, str)
+    assert "�" not in out, f"replacement char leaked into head: {out!r}"
+    assert "[truncated" in out
+
+
+def test_truncate_for_trace_zero_disables() -> None:
+    from xagent.core.agent.trace import truncate_for_trace
+
+    long = "z" * 10_000
+    assert truncate_for_trace(long, max_bytes=0) == long
+
+
+@pytest.mark.asyncio
+async def test_trace_action_end_truncates_llm_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration: trace_action_end with category=LLM applies the cap."""
+    from xagent.core.agent.trace import (
+        TraceCategory,
+        Tracer,
+        trace_action_end,
+    )
+
+    captured: List[Dict[str, Any]] = []
+
+    class _RecordingTracer(Tracer):
+        async def trace_event(  # type: ignore[override]
+            self,
+            event_type: Any,
+            task_id: Any = None,
+            step_id: Any = None,
+            data: Any = None,
+            parent_id: Any = None,
+        ) -> str:
+            captured.append(data or {})
+            return "evt"
+
+    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "200")
+
+    await trace_action_end(
+        _RecordingTracer(),
+        "t",
+        "s",
+        TraceCategory.LLM,
+        data={"response": "x" * 1000, "model_name": "m"},
+    )
+
+    assert len(captured) == 1
+    assert "[truncated" in captured[0]["response"]
+    assert captured[0]["model_name"] == "m"

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -126,6 +126,36 @@ def test_truncate_for_trace_zero_disables() -> None:
     assert truncate_for_trace(long, max_bytes=0) == long
 
 
+def test_truncate_for_trace_deep_nesting_collapses() -> None:
+    """Pathologically nested structures must not hit Python's recursion limit.
+
+    Builds a 100-deep dict (well above the 50-frame guard, well below
+    Python's default 1000-frame limit). Without the guard, sufficiently
+    deep + large payloads could still blow the stack since each level
+    eats a frame for both the dict comprehension and the recursive call.
+    """
+    from xagent.core.agent.trace import truncate_for_trace
+
+    deep: Any = "leaf"
+    for _ in range(100):
+        deep = {"nested": deep}
+
+    out = truncate_for_trace(deep, max_bytes=10_000)
+
+    cur: Any = out
+    depth = 0
+    while isinstance(cur, dict) and "nested" in cur:
+        cur = cur["nested"]
+        depth += 1
+        if depth > 200:
+            pytest.fail("recursion guard never collapsed deep payload")
+
+    assert isinstance(cur, str)
+    assert "depth exceeds" in cur, (
+        f"expected depth-guard placeholder at leaf, got {cur!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_trace_action_end_truncates_llm_payload(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -68,37 +68,28 @@ def test_truncate_for_trace_walks_dict_and_list() -> None:
     assert out["messages"][1]["content"] == "short"
 
 
-def test_truncate_for_trace_dict_total_bounded_by_max_bytes() -> None:
-    """A multi-field dict must not fan out to N*max_bytes total size.
+def test_truncate_for_trace_walks_dict_per_field() -> None:
+    """Multi-field dict: every oversized value gets the trim marker;
+    shape is preserved.
 
-    Two ways the cap is honored:
-
-      - Budget enough for per-field trim to fit: dict shape survives,
-        every value carries the ``[truncated N chars]`` marker.
-      - Budget too small for trimmed shape: the dict collapses to
-        ``{"__truncated__": "..."}`` (container TYPE preserved so
-        downstream ``data.keys()`` callers don't break).
+    Per-field budget is ``max_bytes // N_fields``, so a single field can
+    overshoot by its truncation-suffix overhead (~25 bytes). The overall
+    cap is enforced one level up by
+    :func:`normalize_llm_trace_payload`, which only routes the
+    truncatable subset of fields through this helper.
     """
-    import json
-
     from xagent.core.agent.trace import truncate_for_trace
 
     big = "z" * 5000
     payload = {"a": big, "b": big, "c": big, "d": big}
     out = truncate_for_trace(payload, max_bytes=200)
 
-    serialized = json.dumps(out)
-    assert len(serialized) < 800, (
-        f"dict fan-out broke the cap; serialized={len(serialized)} bytes"
-    )
     assert isinstance(out, dict)
-    if "__truncated__" in out:
-        # Hard-cap path: dict collapsed to placeholder marker.
-        assert "[truncated" in out["__truncated__"]
-    else:
-        # Per-field trim path: every value got truncated.
-        for key in ("a", "b", "c", "d"):
-            assert "[truncated" in out[key]
+    assert set(out.keys()) == {"a", "b", "c", "d"}
+    for key in ("a", "b", "c", "d"):
+        assert "[truncated" in out[key], (
+            f"expected per-field trim marker on {key!r}, got {out[key]!r}"
+        )
 
 
 def test_truncate_for_trace_multibyte_head_no_replacement_chars() -> None:
@@ -245,6 +236,218 @@ async def test_trace_action_end_truncates_llm_payload(
     assert len(captured) == 1
     assert "[truncated" in captured[0]["response"]
     assert captured[0]["model_name"] == "m"
+
+
+# ---------------------------------------------------------------------------
+# normalize_llm_trace_payload — reserved-field preservation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_preserves_reserved_under_truncation() -> None:
+    """Reserved control / routing / metrics fields must pass through
+    untouched even when truncatable content fields are trimmed.
+
+    Regression for the bug rogercloud flagged: hard-cap collapse used
+    to drop ``__audit_only__`` and break WS visibility filtering.
+    """
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        # routing / metadata / metrics — must survive verbatim
+        "__audit_only__": True,
+        "model_name": "gpt-4",
+        "task_type": "dag_skill_selection",
+        "step_id": "step-1",
+        "step_name": "skill_selection",
+        "action": "LLM call completed",
+        "attempt": 1,
+        "json_mode_failed": False,
+        "success": True,
+        "usage": {"input_tokens": 12, "output_tokens": 34, "total_tokens": 46},
+        "messages_count": 2,
+        # bulky content — must be trimmed
+        "messages": [{"role": "user", "content": "x" * 200_000}],
+        "response": "y" * 200_000,
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=200)
+
+    assert isinstance(out, dict)
+    assert out["__audit_only__"] is True
+    assert out["model_name"] == "gpt-4"
+    assert out["task_type"] == "dag_skill_selection"
+    assert out["step_id"] == "step-1"
+    assert out["step_name"] == "skill_selection"
+    assert out["action"] == "LLM call completed"
+    assert out["attempt"] == 1
+    assert out["json_mode_failed"] is False
+    assert out["success"] is True
+    assert out["usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 34,
+        "total_tokens": 46,
+    }
+    assert out["messages_count"] == 2
+    assert "[truncated" in str(out["messages"])
+    assert "[truncated" in out["response"]
+
+
+def test_normalize_passthrough_when_no_content_fields() -> None:
+    """All-reserved payload returns unchanged (no spurious trim).
+
+    Important so ``_emit_trace_event`` calling normalize on every LLM
+    event is cheap when the event only carries metadata.
+    """
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {"__audit_only__": True, "model_name": "gpt-4", "attempt": 2}
+    out = normalize_llm_trace_payload(payload, max_bytes=100)
+    assert out is payload or out == payload
+
+
+def test_normalize_passes_through_non_dict() -> None:
+    """Non-dict input returns as-is — defensive for unusual callers."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    assert normalize_llm_trace_payload("not a dict") == "not a dict"
+    assert normalize_llm_trace_payload(None) is None
+
+
+def test_normalize_zero_disables() -> None:
+    """``max_bytes=0`` (XAGENT_MAX_TRACE_PAYLOAD_BYTES=0) disables truncation."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    long_response = "x" * 10_000
+    payload = {"response": long_response, "model_name": "m"}
+    out = normalize_llm_trace_payload(payload, max_bytes=0)
+    assert out["response"] == long_response
+
+
+def test_normalize_unknown_fields_pass_through() -> None:
+    """Unknown fields (neither reserved nor truncatable) pass through.
+
+    Future-proofs against silently truncating a new routing flag added
+    by an audit emit that this list hasn't been updated for yet.
+    """
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "future_routing_flag": True,
+        "future_metric": 42,
+        "response": "y" * 10_000,  # known truncatable
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=200)
+    assert out["future_routing_flag"] is True
+    assert out["future_metric"] == 42
+    assert "[truncated" in out["response"]
+
+
+# ---------------------------------------------------------------------------
+# PatternRuntime trace-boundary cap (Finding 3 regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_v2_runtime_emit_trace_caps_llm_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: PatternRuntime.on_llm_end with a 100 KB response gets
+    capped at the trace boundary. Previously the runtime bypassed
+    truncate_for_trace entirely and emitted the raw payload to the
+    tracer.
+    """
+    from xagent.core.agent.runtime import PatternRuntime
+
+    events: List[Dict[str, Any]] = []
+
+    class _CaptureTracer:
+        async def trace_event(
+            self,
+            event_type: Any,
+            task_id: Any = None,
+            step_id: Any = None,
+            data: Any = None,
+            parent_id: Any = None,
+        ) -> str:
+            events.append(
+                {
+                    "event_type": getattr(event_type, "value", str(event_type)),
+                    "task_id": task_id,
+                    "step_id": step_id,
+                    "data": dict(data or {}),
+                }
+            )
+            return "evt"
+
+    class _FakeContext:
+        execution_id = "task-x"
+        messages: List[Any] = []
+
+        def record_llm_usage(self, **_: Any) -> None:
+            pass
+
+    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "1000")
+    runtime = PatternRuntime(tracer=_CaptureTracer(), execution_id="task-x")
+
+    await runtime.on_llm_end(context=_FakeContext(), response="x" * 100_000)
+
+    assert events, "no trace event captured"
+    data = events[-1]["data"]
+    assert isinstance(data.get("response"), str)
+    assert len(data["response"]) < 5_000, (
+        f"response should be capped well under 100k, got {len(data['response'])}"
+    )
+    assert "[truncated" in data["response"]
+    # Reserved control field survives the boundary cap
+    assert data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_v2_runtime_emit_trace_does_not_cap_tool_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: only LLM-category events get normalized at the
+    boundary. TOOL / DAG / REACT / COMPACT / GENERAL events must pass
+    through their data unchanged so we don't silently truncate tool
+    output, DAG plans, etc.
+    """
+    from xagent.core.agent.runtime import PatternRuntime
+    from xagent.core.agent.trace import (
+        TraceAction,
+        TraceCategory,
+        TraceEventType,
+        TraceScope,
+    )
+
+    events: List[Dict[str, Any]] = []
+
+    class _CaptureTracer:
+        async def trace_event(
+            self,
+            event_type: Any,
+            task_id: Any = None,
+            step_id: Any = None,
+            data: Any = None,
+            parent_id: Any = None,
+        ) -> str:
+            events.append({"data": dict(data or {})})
+            return "evt"
+
+    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "1000")
+    runtime = PatternRuntime(tracer=_CaptureTracer(), execution_id="task-x")
+
+    tool_end_event = TraceEventType(
+        TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL
+    )
+    huge_tool_output = "z" * 100_000
+    await runtime._emit_trace_event(
+        tool_end_event,
+        task_id="task-x",
+        step_id="step-1",
+        data={"tool_output": huge_tool_output, "tool_name": "noop"},
+    )
+
+    assert len(events[-1]["data"]["tool_output"]) == 100_000
+    assert "[truncated" not in events[-1]["data"]["tool_output"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -223,17 +223,20 @@ async def test_trace_action_end_truncates_llm_payload(
             captured.append(data or {})
             return "evt"
 
-    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "200")
+    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "2000")
 
     await trace_action_end(
         _RecordingTracer(),
         "t",
         "s",
         TraceCategory.LLM,
-        data={"response": "x" * 1000, "model_name": "m"},
+        data={"response": "x" * 10_000, "model_name": "m"},
     )
 
     assert len(captured) == 1
+    # response is the only truncatable field; at 2000-byte cap it goes
+    # through _reduce_response → _reduce_text and emits the [truncated]
+    # marker. model_name (reserved) passes through verbatim.
     assert "[truncated" in captured[0]["response"]
     assert captured[0]["model_name"] == "m"
 
@@ -269,7 +272,7 @@ def test_normalize_preserves_reserved_under_truncation() -> None:
         "messages": [{"role": "user", "content": "x" * 200_000}],
         "response": "y" * 200_000,
     }
-    out = normalize_llm_trace_payload(payload, max_bytes=200)
+    out = normalize_llm_trace_payload(payload, max_bytes=4_000)
 
     assert isinstance(out, dict)
     assert out["__audit_only__"] is True
@@ -287,6 +290,9 @@ def test_normalize_preserves_reserved_under_truncation() -> None:
         "total_tokens": 46,
     }
     assert out["messages_count"] == 2
+    # Content fields hit the reducer at 4 KB; messages get the
+    # semantic-reducer treatment (role preserved, content trimmed)
+    # and response gets the text-reducer treatment.
     assert "[truncated" in str(out["messages"])
     assert "[truncated" in out["response"]
 
@@ -335,7 +341,7 @@ def test_normalize_unknown_fields_pass_through() -> None:
         "future_metric": 42,
         "response": "y" * 10_000,  # known truncatable
     }
-    out = normalize_llm_trace_payload(payload, max_bytes=200)
+    out = normalize_llm_trace_payload(payload, max_bytes=2_000)
     assert out["future_routing_flag"] is True
     assert out["future_metric"] == 42
     assert "[truncated" in out["response"]
@@ -448,6 +454,230 @@ async def test_v2_runtime_emit_trace_does_not_cap_tool_events(
 
     assert len(events[-1]["data"]["tool_output"]) == 100_000
     assert "[truncated" not in events[-1]["data"]["tool_output"]
+
+
+# ---------------------------------------------------------------------------
+# Per-field semantic reducers (Finding 4 — Roger 2026-05-16)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_messages_keeps_head_tail_under_cap() -> None:
+    """Regression for Roger's exact example: 1000 messages × 5 KB at
+    50 KB cap. Old equal-split implementation produced ~83 KB output and
+    decayed every message to a 50-byte head + suffix. New semantic
+    reducer preserves head + tail with full role metadata and meaningful
+    content prefix, replaces middle with a single placeholder, and
+    keeps total serialized ≤ cap.
+    """
+    import json
+
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "__audit_only__": True,
+        "model_name": "gpt-4o",
+        "task_type": "dag_skill_selection",
+        "messages": [{"role": "user", "content": "x" * 5000} for _ in range(1000)],
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=50_000)
+
+    total = len(json.dumps(out, ensure_ascii=False).encode("utf-8"))
+    assert total <= 50_000, f"envelope cap broken: {total} bytes > 50000"
+
+    # Reserved metadata intact
+    assert out["__audit_only__"] is True
+    assert out["model_name"] == "gpt-4o"
+    assert out["task_type"] == "dag_skill_selection"
+
+    # messages: head + tail + middle placeholder, not 1000 broken entries
+    msgs = out["messages"]
+    assert len(msgs) < 10, f"expected head/tail summary, got {len(msgs)} entries"
+
+    # First and last messages keep their role
+    assert msgs[0]["role"] == "user"
+    assert msgs[-1]["role"] == "user"
+
+    # First/last messages keep substantial content prefix (not a 50-byte stub)
+    assert len(msgs[0]["content"]) > 1000, (
+        f"head message content too short: {len(msgs[0]['content'])}"
+    )
+
+    # Middle placeholder describes omitted count
+    middle = [m for m in msgs if isinstance(m, dict) and "__truncated__" in m]
+    assert middle, "expected middle placeholder for omitted messages"
+    assert "messages omitted" in middle[0]["__truncated__"]
+
+
+def test_normalize_messages_passthrough_when_small() -> None:
+    """Short messages list well under budget passes through unchanged."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "model_name": "m",
+        "messages": [
+            {"role": "system", "content": "hi"},
+            {"role": "user", "content": "yo"},
+        ],
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=50_000)
+    assert out["messages"] == payload["messages"]
+
+
+def test_normalize_tools_keeps_name_description() -> None:
+    """tools: tool name + description preserved, only big parameters
+    schema gets trimmed/collapsed."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    huge_schema = {
+        "type": "object",
+        "properties": {
+            f"prop_{i}": {"type": "string", "description": "x" * 200}
+            for i in range(100)
+        },
+    }
+    payload = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web for information",
+                    "parameters": huge_schema,
+                },
+            },
+        ],
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=2_000)
+
+    tool = out["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "web_search"
+    assert tool["function"]["description"] == "Search the web for information"
+    # parameters schema got collapsed; name + description survive
+    assert isinstance(tool["function"]["parameters"], dict)
+
+
+def test_normalize_tool_calls_keeps_id_name() -> None:
+    """tool_calls: call id + function.name preserved, only arguments trimmed."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "tool_calls": [
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "arguments": '{"query":"' + "x" * 5000 + '"}',
+                },
+            },
+        ],
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=2_000)
+
+    call = out["tool_calls"][0]
+    assert call["id"] == "call_abc"
+    assert call["type"] == "function"
+    assert call["function"]["name"] == "search"
+    # arguments truncated
+    assert "[truncated" in call["function"]["arguments"]
+
+
+def test_normalize_response_dict_truncates_content() -> None:
+    """response: dict shape preserved (e.g. _short_response output);
+    text fields (content/answer/output) trimmed, scalars unchanged."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "response": {
+            "content": "x" * 10_000,
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f"}}],
+        },
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=2_000)
+
+    resp = out["response"]
+    assert isinstance(resp, dict)
+    assert "[truncated" in resp["content"]
+    # tool_calls scalar metadata preserved
+    assert resp["tool_calls"][0]["id"] == "c1"
+
+
+def test_normalize_envelope_bounded_under_mixed_oversized_fields() -> None:
+    """All four heavy field types present and oversized — total
+    serialized envelope still <= max_bytes."""
+    import json
+
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "__audit_only__": True,
+        "model_name": "gpt-4o",
+        "messages": [{"role": "user", "content": "x" * 5000}] * 500,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": f"tool_{i}",
+                    "description": "d" * 200,
+                    "parameters": {"big": "y" * 1000},
+                },
+            }
+            for i in range(50)
+        ],
+        "tool_calls": [
+            {
+                "id": f"call_{i}",
+                "type": "function",
+                "function": {"name": "f", "arguments": "z" * 1000},
+            }
+            for i in range(50)
+        ],
+        "response": {"content": "r" * 20_000},
+    }
+    out = normalize_llm_trace_payload(payload, max_bytes=50_000)
+    total = len(json.dumps(out, ensure_ascii=False).encode("utf-8"))
+    assert total <= 50_000, f"envelope cap broken under mixed payload: {total}"
+    # Reserved metadata always survives
+    assert out["__audit_only__"] is True
+    assert out["model_name"] == "gpt-4o"
+
+
+def test_normalize_extreme_payload_collapses_largest_field() -> None:
+    """Pathological budget where even semantic reducers can't fit —
+    envelope-level guard collapses the largest remaining truncatable
+    field to placeholder. Reserved metadata still survives.
+    """
+    import json
+
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {
+        "__audit_only__": True,
+        "model_name": "gpt-4o",
+        "messages": [{"role": "user", "content": "x" * 5000}] * 1000,
+    }
+    # Very small cap: reducer's per-field budget already too small
+    out = normalize_llm_trace_payload(payload, max_bytes=500)
+
+    total = len(json.dumps(out, ensure_ascii=False).encode("utf-8"))
+    assert total <= 500 + 200, (  # small slack for edge case
+        f"envelope cap broken under extreme cap: {total}"
+    )
+    # Reserved metadata still survives
+    assert out["__audit_only__"] is True
+    assert out["model_name"] == "gpt-4o"
+
+
+def test_normalize_response_string_falls_back_to_text_reducer() -> None:
+    """response can be a raw string (not dict) — should go through
+    _reduce_text and emit the truncated marker."""
+    from xagent.core.agent.trace import normalize_llm_trace_payload
+
+    payload = {"model_name": "m", "response": "y" * 10_000}
+    out = normalize_llm_trace_payload(payload, max_bytes=2_000)
+    assert isinstance(out["response"], str)
+    assert "[truncated" in out["response"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -156,6 +156,57 @@ def test_truncate_for_trace_deep_nesting_collapses() -> None:
     )
 
 
+def test_ws_handler_drops_audit_only_events() -> None:
+    """Server-only audit traces with ``__audit_only__: True`` must be
+    dropped before reaching WebSocket clients.
+
+    This is a security-critical assertion: the audit pipeline persists
+    raw LLM I/O (messages, response) via DatabaseTraceHandler, and the
+    drop in WebSocketTraceHandler is the only barrier preventing that
+    same payload from being broadcast to connected clients.
+    """
+    from xagent.core.agent.trace import ACTION_START_LLM, TraceEvent
+    from xagent.web.api.ws_trace_handlers import WebSocketTraceHandler
+
+    handler = WebSocketTraceHandler(task_id=1)
+
+    audit_event = TraceEvent(
+        event_type=ACTION_START_LLM,
+        task_id="t1",
+        step_id="dag_skill_selection",
+        data={
+            "__audit_only__": True,
+            "messages": [{"role": "user", "content": "raw prompt body"}],
+            "action": "LLM call started",
+        },
+    )
+
+    result = handler._convert_trace_event_to_stream_event(audit_event)
+    assert result is None, (
+        "audit_only event must be dropped before WS broadcast; "
+        "got non-None stream event"
+    )
+
+
+def test_ws_handler_passes_non_audit_events() -> None:
+    """Regression: dropping ``__audit_only__`` must not affect normal events."""
+    from xagent.core.agent.trace import ACTION_START_LLM, TraceEvent
+    from xagent.web.api.ws_trace_handlers import WebSocketTraceHandler
+
+    handler = WebSocketTraceHandler(task_id=1)
+
+    event = TraceEvent(
+        event_type=ACTION_START_LLM,
+        task_id="t1",
+        step_id="step1",
+        data={"action": "LLM call started", "step_name": "test_step"},
+    )
+
+    result = handler._convert_trace_event_to_stream_event(event)
+    assert result is not None, "non-audit event was incorrectly dropped"
+    assert result.get("step_id") == "step1"
+
+
 @pytest.mark.asyncio
 async def test_trace_action_end_truncates_llm_payload(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -6,11 +6,13 @@ from pathlib import Path
 import pytest
 
 from xagent.config import (
+    AGENT_RUNTIME,
     BOXLITE_HOME_DIR,
     DATABASE_URL,
     EXTERNAL_SKILLS_LIBRARY_DIRS,
     EXTERNAL_UPLOAD_DIRS,
     LANCEDB_PATH,
+    MAX_TRACE_PAYLOAD_BYTES,
     MAX_UPLOAD_SIZE,
     SANDBOX_CPUS,
     SANDBOX_ENV,
@@ -23,6 +25,7 @@ from xagent.config import (
     WEB_SEARCH_PROVIDER,
     format_file_size,
     get_agent_pattern_for_execution_mode,
+    get_agent_runtime,
     get_boxlite_home_dir,
     get_database_url,
     get_default_sqlite_db_path,
@@ -30,6 +33,7 @@ from xagent.config import (
     get_external_skills_dirs,
     get_external_upload_dirs,
     get_lancedb_path,
+    get_max_trace_payload_bytes,
     get_max_upload_size_bytes,
     get_sandbox_cpus,
     get_sandbox_env,
@@ -57,6 +61,9 @@ class TestEnvironmentVariableConstants:
 
     def test_external_skills_dirs_constant(self):
         assert EXTERNAL_SKILLS_LIBRARY_DIRS == "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
+
+    def test_agent_runtime_constant(self):
+        assert AGENT_RUNTIME == "XAGENT_AGENT_RUNTIME"
 
     def test_storage_root_constant(self):
         assert STORAGE_ROOT == "XAGENT_STORAGE_ROOT"
@@ -180,6 +187,26 @@ class TestGetWebDir:
         assert result == Path("/custom/web")
 
 
+class TestGetAgentRuntime:
+    """Test get_agent_runtime() function."""
+
+    def test_default_agent_runtime(self, monkeypatch):
+        monkeypatch.delenv(AGENT_RUNTIME, raising=False)
+        assert get_agent_runtime() == "v1"
+
+    def test_agent_runtime_v2(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, "v2")
+        assert get_agent_runtime() == "v2"
+
+    def test_agent_runtime_normalizes_case_and_spaces(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, " V2 ")
+        assert get_agent_runtime() == "v2"
+
+    def test_invalid_agent_runtime_falls_back_to_v1(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, "unknown")
+        assert get_agent_runtime() == "v1"
+
+
 class TestGetAgentPatternForExecutionMode:
     """Test get_agent_pattern_for_execution_mode() function."""
 
@@ -200,11 +227,20 @@ class TestGetAgentPatternForExecutionMode:
 class TestGetDefaultTaskExecutionMode:
     """Test default task execution mode selection."""
 
-    def test_standalone_defaults_to_auto(self):
+    def test_v1_standalone_defaults_to_think(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, "v1")
+        assert get_default_task_execution_mode() == "think"
+
+    def test_v2_standalone_defaults_to_auto(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, "v2")
         assert get_default_task_execution_mode() == "auto"
 
-    def test_agent_tasks_default_to_balanced(self):
+    def test_agent_tasks_default_to_balanced_in_v2(self, monkeypatch):
+        monkeypatch.setenv(AGENT_RUNTIME, "v2")
         assert get_default_task_execution_mode(agent_id=123) == "balanced"
+
+    def test_explicit_runtime_can_be_passed(self):
+        assert get_default_task_execution_mode(agent_runtime="v2") == "auto"
 
 
 class TestGetExternalUploadDirs:
@@ -502,3 +538,28 @@ class TestGetBoxliteHomeDir:
         monkeypatch.setenv(BOXLITE_HOME_DIR, "/custom/boxlite")
         result = get_boxlite_home_dir()
         assert result == Path("/custom/boxlite")
+
+
+class TestGetMaxTracePayloadBytes:
+    """Test get_max_trace_payload_bytes() function."""
+
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv(MAX_TRACE_PAYLOAD_BYTES, raising=False)
+        assert get_max_trace_payload_bytes() == 50_000
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(MAX_TRACE_PAYLOAD_BYTES, "1234")
+        assert get_max_trace_payload_bytes() == 1234
+
+    def test_zero_passes_through(self, monkeypatch):
+        """Zero disables truncation (handled by truncate_for_trace)."""
+        monkeypatch.setenv(MAX_TRACE_PAYLOAD_BYTES, "0")
+        assert get_max_trace_payload_bytes() == 0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(MAX_TRACE_PAYLOAD_BYTES, "not-a-number")
+        assert get_max_trace_payload_bytes() == 50_000
+
+    def test_negative_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(MAX_TRACE_PAYLOAD_BYTES, "-100")
+        assert get_max_trace_payload_bytes() == 50_000

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 
 from xagent.config import (
-    AGENT_RUNTIME,
     BOXLITE_HOME_DIR,
     DATABASE_URL,
     EXTERNAL_SKILLS_LIBRARY_DIRS,
@@ -25,7 +24,6 @@ from xagent.config import (
     WEB_SEARCH_PROVIDER,
     format_file_size,
     get_agent_pattern_for_execution_mode,
-    get_agent_runtime,
     get_boxlite_home_dir,
     get_database_url,
     get_default_sqlite_db_path,
@@ -61,9 +59,6 @@ class TestEnvironmentVariableConstants:
 
     def test_external_skills_dirs_constant(self):
         assert EXTERNAL_SKILLS_LIBRARY_DIRS == "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
-
-    def test_agent_runtime_constant(self):
-        assert AGENT_RUNTIME == "XAGENT_AGENT_RUNTIME"
 
     def test_storage_root_constant(self):
         assert STORAGE_ROOT == "XAGENT_STORAGE_ROOT"
@@ -187,26 +182,6 @@ class TestGetWebDir:
         assert result == Path("/custom/web")
 
 
-class TestGetAgentRuntime:
-    """Test get_agent_runtime() function."""
-
-    def test_default_agent_runtime(self, monkeypatch):
-        monkeypatch.delenv(AGENT_RUNTIME, raising=False)
-        assert get_agent_runtime() == "v1"
-
-    def test_agent_runtime_v2(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, "v2")
-        assert get_agent_runtime() == "v2"
-
-    def test_agent_runtime_normalizes_case_and_spaces(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, " V2 ")
-        assert get_agent_runtime() == "v2"
-
-    def test_invalid_agent_runtime_falls_back_to_v1(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, "unknown")
-        assert get_agent_runtime() == "v1"
-
-
 class TestGetAgentPatternForExecutionMode:
     """Test get_agent_pattern_for_execution_mode() function."""
 
@@ -227,20 +202,11 @@ class TestGetAgentPatternForExecutionMode:
 class TestGetDefaultTaskExecutionMode:
     """Test default task execution mode selection."""
 
-    def test_v1_standalone_defaults_to_think(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, "v1")
-        assert get_default_task_execution_mode() == "think"
-
-    def test_v2_standalone_defaults_to_auto(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, "v2")
+    def test_standalone_defaults_to_auto(self):
         assert get_default_task_execution_mode() == "auto"
 
-    def test_agent_tasks_default_to_balanced_in_v2(self, monkeypatch):
-        monkeypatch.setenv(AGENT_RUNTIME, "v2")
+    def test_agent_tasks_default_to_balanced(self):
         assert get_default_task_execution_mode(agent_id=123) == "balanced"
-
-    def test_explicit_runtime_can_be_passed(self):
-        assert get_default_task_execution_mode(agent_runtime="v2") == "auto"
 
 
 class TestGetExternalUploadDirs:


### PR DESCRIPTION
## Summary

Lays down trace infrastructure for the audit pipeline so LLM I/O payloads can
be persisted server-side without reaching WS clients. Adds one initial audit
emit site (DAG skill selection); v2-runtime audit injection at
`agent/runtime.py:on_llm_start` / `on_llm_end` is deferred to a follow-up PR
since the v1 runtime that hosted the original sites was removed in
upstream #403 (`feat: [v2 part8] remove agent v1 runtime`).

## Changes

- **`truncate_for_trace`** (`core/agent/trace.py`): bounded LLM payload
  truncation with per-leaf string trim, container-aware total-size cap, and
  multi-byte UTF-8 safe slicing. Configurable via
  `XAGENT_MAX_TRACE_PAYLOAD_BYTES` (default 50 KB, `0` disables). Recursion
  depth bounded at 50 frames so a pathological nested payload can't blow
  the stack.
- **`__audit_only__` flag** (`web/api/ws_trace_handlers.py`): trace events
  carrying this flag are dropped before WS broadcast. They still reach
  `DatabaseTraceHandler` for server-side audit. Drop runs before
  serialization to keep hot-path overhead at a single `dict.get`.
- **Skill selection audit emit** (`skills/selector.py`): captures LLM input
  (messages, candidate names) and output (response, usage) around the
  selector call. Handles the JSON-mode fallback with paired start/end on
  both attempts, propagates errors after closing audit traces, and stamps
  `json_mode_failed` consistently so SQL queries can count fallback
  events with a single predicate. Audit data construction shares one
  helper across the four emit sites to keep them aligned.

## Tests

- `truncate_for_trace`: short/long string, multi-byte UTF-8, dict/list
  walk, hard-cap collapse, env zero-disable, deep-nesting depth guard (8).
- Config plumbing for `XAGENT_MAX_TRACE_PAYLOAD_BYTES` (5).
- WS handler `__audit_only__` drop + non-audit passthrough regression (2).
- Selector emit: happy path, JSON-mode fallback, both-attempts-fail,
  tracer=None defensive (4).

## Out of scope

- v2-runtime audit injection at `agent/runtime.py:on_llm_start/on_llm_end`
  → follow-up PR.
- Per-pattern audit emits in DAG / ReAct paths — those source files were
  deleted in upstream #403.

## Verification

```bash
pytest tests/core/agent/pattern/test_llm_trace_audit.py tests/core/test_config.py
```

Staging query after a skill-selection task run (Postgres):

```sql
SELECT step_id,
       data->>'attempt' AS attempt,
       data->>'action' AS action,
       data->>'json_mode_failed' AS json_mode_failed
FROM trace_events
WHERE step_id = 'dag_skill_selection'
ORDER BY created_at DESC
LIMIT 10;
```

WS clients connected during the run should not have received any event
whose `data` contains `__audit_only__: true`.

---

## Follow-up addressing rogercloud's review (2026-05-15)

- **Removed stale `XAGENT_AGENT_RUNTIME` v1 fallback in `config.py`.** The v1
  runtime was removed in upstream #403 (`feat: [v2 part8] remove agent v1
  runtime`); the fallback was inadvertently reintroduced during this PR's
  rebase. With v1 dead but `get_default_task_execution_mode()` still defaulting
  to it, standalone task creation returned `"think"` and broke
  `test_standalone_task_create_defaults_to_auto` on CI. Aligned with upstream
  `f58c9c9` — `get_agent_runtime()` and the `agent_runtime` parameter are
  gone; standalone tasks unconditionally default to `"auto"`.

- **Pulled `truncate_for_trace` up to a `normalize_llm_trace_payload` at the
  tracer boundary.** Reserved control / routing / metrics fields
  (`__audit_only__`, `model_name`, `task_type`, `step_id`, `step_name`,
  `attempt`, `json_mode_failed`, `usage`, `input_tokens` / `output_tokens` /
  `total_tokens`, ...) now pass through unchanged; only bulky content fields
  (`messages`, `context_preview`, `response`, `content`, `tool_calls`,
  `error`, ...) get truncated. Hook moved into
  `PatternRuntime._emit_trace_event`, so every LLM event emitted by the v2
  runtime is capped — not just the two convenience helpers. Drops the
  dict-collapse branch from `truncate_for_trace` that used to drop
  `__audit_only__` under heavy payloads (visibility-contract regression).
