### PR TITLE
fix(dag): enforce task-scoped step ids

### DIFF
--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py
@@ -2,6 +2,7 @@
 Plan generation logic for DAG plan-execute pattern.
 """
 
+import copy
 import json
 import logging
 from datetime import datetime
@@ -71,6 +72,280 @@ class PlanGenerator:
         self.skill_manager = skill_manager
         self.allowed_skills = allowed_skills
 
+    def _collect_forbidden_step_ids(
+        self,
+        history: List[Dict[str, Any]],
+        current_plan: Optional[ExecutionPlan] = None,
+    ) -> List[str]:
+        """Collect task-scoped step IDs that newly generated steps must not reuse."""
+        forbidden_ids: List[str] = []
+        seen: set[str] = set()
+
+        def add_step_id(step_id: Any) -> None:
+            if step_id is None:
+                return
+            normalized = str(step_id).strip()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                forbidden_ids.append(normalized)
+
+        def collect_from_plan(plan_data: Any) -> None:
+            if isinstance(plan_data, ExecutionPlan):
+                for step in plan_data.steps:
+                    add_step_id(step.id)
+                return
+
+            if not isinstance(plan_data, dict):
+                return
+
+            steps = plan_data.get("steps")
+            if not isinstance(steps, list):
+                return
+
+            for step_data in steps:
+                if isinstance(step_data, PlanStep):
+                    add_step_id(step_data.id)
+                elif isinstance(step_data, dict):
+                    add_step_id(step_data.get("id"))
+
+        if current_plan:
+            collect_from_plan(current_plan)
+
+        for item in history or []:
+            if not isinstance(item, dict):
+                continue
+
+            collect_from_plan(item.get("plan"))
+            collect_from_plan(item)
+
+            content = item.get("content")
+            if isinstance(content, str):
+                content = content.strip()
+                if content.startswith("{"):
+                    json_str = content
+                elif "```" in content:
+                    json_str = extract_json_from_markdown(content)
+                    if not isinstance(
+                        json_str, str
+                    ) or not json_str.lstrip().startswith("{"):
+                        continue
+                else:
+                    continue
+                try:
+                    parsed_content = json.loads(json_str)
+                except (TypeError, ValueError):
+                    continue
+                if isinstance(parsed_content, dict):
+                    collect_from_plan(parsed_content.get("plan"))
+                    collect_from_plan(parsed_content)
+
+        return forbidden_ids
+
+    def _format_forbidden_step_ids_block(self, forbidden_step_ids: List[str]) -> str:
+        """Build a prompt block that makes task-scoped step ID constraints explicit."""
+        forbidden_json = json.dumps(forbidden_step_ids, ensure_ascii=False, indent=2)
+        return (
+            "STEP ID UNIQUENESS RULES:\n"
+            f"FORBIDDEN_STEP_IDS:\n{forbidden_json}\n\n"
+            "- Every new step id MUST be a non-empty string.\n"
+            "- Do NOT use any id listed in FORBIDDEN_STEP_IDS.\n"
+            "- No two steps in your returned steps array may share the same id.\n"
+            "- Step names are display labels and do NOT need to be unique.\n"
+            "- If you need a similar step, create a new id such as "
+            "`analyze_data_2` or `iteration3_analyze_data`.\n\n"
+        )
+
+    def _format_step_id_retry_guidance(
+        self, error_context: Optional[Dict[str, Any]]
+    ) -> str:
+        """Build retry guidance for step ID validation failures."""
+        if not error_context or not error_context.get("step_id_errors"):
+            return ""
+
+        return (
+            "STEP ID VALIDATION ERRORS:\n"
+            f"Missing ID step indices: {error_context.get('missing_step_id_indices', [])}\n"
+            "Reserved step IDs used:\n"
+            f"{json.dumps(error_context.get('reserved_step_ids', []), ensure_ascii=False)}\n"
+            "Duplicate step IDs in this response:\n"
+            f"{json.dumps(error_context.get('duplicate_step_ids', []), ensure_ascii=False)}\n"
+            "Forbidden step IDs for this task:\n"
+            f"{json.dumps(error_context.get('forbidden_step_ids', []), ensure_ascii=False)}\n\n"
+            "Please regenerate the plan with non-empty step IDs that are unique within "
+            "this response and not present in FORBIDDEN_STEP_IDS. Step names may repeat.\n\n"
+        )
+
+    def _prepare_steps_data(
+        self,
+        steps_data: List[Dict[str, Any]],
+        forbidden_step_ids: List[str],
+        rewrite_conflicts: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Validate or rewrite raw step dictionaries before creating PlanStep objects."""
+        prepared_steps = [copy.deepcopy(step) for step in steps_data]
+        forbidden_set = set(forbidden_step_ids)
+        self._normalize_raw_step_references(prepared_steps)
+
+        if rewrite_conflicts:
+            try:
+                self._validate_raw_step_ids(prepared_steps, forbidden_set)
+                return prepared_steps
+            except DAGPlanGenerationError as e:
+                if e.context and (
+                    e.context.get("missing_step_id_indices")
+                    or e.context.get("reserved_step_ids")
+                ):
+                    raise
+
+            rewritten_steps = self._rewrite_conflicting_step_ids(
+                prepared_steps, forbidden_set
+            )
+            logger.warning(
+                "Rewrote duplicate step IDs after validation retries were exhausted"
+            )
+            return rewritten_steps
+
+        self._validate_raw_step_ids(prepared_steps, forbidden_set)
+        return prepared_steps
+
+    def _normalize_step_id_value(self, step_id: Any) -> str:
+        """Normalize an LLM-provided step id to a string for validation."""
+        if step_id is None:
+            return ""
+        return str(step_id).strip()
+
+    def _normalize_raw_step_references(self, steps_data: List[Dict[str, Any]]) -> None:
+        """Normalize raw step IDs and references before validation."""
+        for step_data in steps_data:
+            if "id" in step_data:
+                step_data["id"] = self._normalize_step_id_value(step_data.get("id"))
+
+            dependencies = step_data.get("dependencies")
+            if isinstance(dependencies, list):
+                step_data["dependencies"] = [
+                    self._normalize_step_id_value(dep) for dep in dependencies
+                ]
+
+            conditional_branches = step_data.get("conditional_branches")
+            if isinstance(conditional_branches, dict):
+                step_data["conditional_branches"] = {
+                    branch_key: self._normalize_step_id_value(target_step_id)
+                    for branch_key, target_step_id in conditional_branches.items()
+                }
+
+    def _validate_raw_step_ids(
+        self,
+        steps_data: List[Dict[str, Any]],
+        forbidden_step_ids: set[str],
+    ) -> None:
+        """Reject empty, duplicate, or task-reserved step IDs in raw LLM output."""
+        missing_indices: List[int] = []
+        reserved_matches: List[Dict[str, Any]] = []
+        positions_by_id: Dict[str, List[int]] = {}
+
+        for index, step_data in enumerate(steps_data):
+            step_id = self._normalize_step_id_value(step_data.get("id"))
+            if not step_id:
+                missing_indices.append(index)
+                continue
+
+            step_data["id"] = step_id
+            if step_id in forbidden_step_ids:
+                reserved_matches.append({"id": step_id, "index": index})
+
+            positions_by_id.setdefault(step_id, []).append(index)
+
+        duplicates = [
+            {"id": step_id, "indices": indices}
+            for step_id, indices in positions_by_id.items()
+            if len(indices) > 1
+        ]
+
+        if not missing_indices and not reserved_matches and not duplicates:
+            return
+
+        raise DAGPlanGenerationError(
+            "Generated plan contains duplicate, empty, or reserved step IDs",
+            goal="",
+            iteration=1,
+            llm_response=None,
+            context={
+                "step_id_errors": True,
+                "missing_step_id_indices": missing_indices,
+                "reserved_step_ids": reserved_matches,
+                "duplicate_step_ids": duplicates,
+                "forbidden_step_ids": sorted(forbidden_step_ids),
+            },
+        )
+
+    def _rewrite_conflicting_step_ids(
+        self,
+        steps_data: List[Dict[str, Any]],
+        forbidden_step_ids: set[str],
+    ) -> List[Dict[str, Any]]:
+        """Deterministically rewrite only new step IDs that conflict or repeat."""
+        used_ids = set(forbidden_step_ids)
+        first_generated_id_by_original: Dict[str, str] = {}
+
+        for index, step_data in enumerate(steps_data):
+            original_id = self._normalize_step_id_value(step_data.get("id"))
+
+            final_id = original_id
+            if final_id in used_ids:
+                final_id = self._make_unique_step_id(original_id, used_ids)
+
+            step_data["id"] = final_id
+            used_ids.add(final_id)
+
+            first_generated_id_by_original.setdefault(original_id, final_id)
+
+        for step_data in steps_data:
+            dependencies = step_data.get("dependencies", [])
+            if not isinstance(dependencies, list):
+                dependencies = []
+            step_data["dependencies"] = [
+                self._rewrite_step_reference(
+                    dep, forbidden_step_ids, first_generated_id_by_original
+                )
+                for dep in dependencies
+            ]
+
+            conditional_branches = step_data.get("conditional_branches", {})
+            if isinstance(conditional_branches, dict):
+                step_data["conditional_branches"] = {
+                    branch_key: self._rewrite_step_reference(
+                        target_step_id,
+                        forbidden_step_ids,
+                        first_generated_id_by_original,
+                    )
+                    for branch_key, target_step_id in conditional_branches.items()
+                }
+
+        self._validate_raw_step_ids(steps_data, forbidden_step_ids)
+        return steps_data
+
+    def _make_unique_step_id(self, base_id: str, used_ids: set[str]) -> str:
+        """Create a deterministic suffixed step ID that is not already used."""
+        base = base_id or "step"
+        counter = 2
+        candidate = f"{base}_{counter}"
+        while candidate in used_ids:
+            counter += 1
+            candidate = f"{base}_{counter}"
+        return candidate
+
+    def _rewrite_step_reference(
+        self,
+        step_ref: Any,
+        forbidden_step_ids: set[str],
+        first_generated_id_by_original: Dict[str, str],
+    ) -> str:
+        """Rewrite dependency/branch references to the first generated final ID."""
+        normalized_ref = self._normalize_step_id_value(step_ref)
+        if normalized_ref in forbidden_step_ids:
+            return normalized_ref
+        return first_generated_id_by_original.get(normalized_ref, normalized_ref)
+
     async def _generate_plan_with_flow(
         self,
         tracer: Any,
@@ -94,6 +369,8 @@ class PlanGenerator:
                 For generation: execution_plan contains all steps, additional_steps is empty
                 For extension: execution_plan is None, additional_steps contains new steps
         """
+        forbidden_step_ids = self._collect_forbidden_step_ids(history, current_plan)
+
         # Send plan start event
         trace_task_id = (
             f"plan_extension_{uuid4()}" if is_extension else f"plan_{uuid4()}"
@@ -136,10 +413,17 @@ class PlanGenerator:
                     user_input_context,
                     tools,
                     context,
+                    forbidden_step_ids=forbidden_step_ids,
                 )
             else:
                 prompt = prompt_builder_func(
-                    goal, iteration, history, tools, context, skill_context
+                    goal,
+                    iteration,
+                    history,
+                    tools,
+                    context,
+                    skill_context,
+                    forbidden_step_ids=forbidden_step_ids,
                 )
 
             # Call LLM
@@ -185,24 +469,19 @@ class PlanGenerator:
                             )
 
                     # Create PlanStep objects and validate for first attempt
+                    prepared_steps_data = self._prepare_steps_data(
+                        steps_data,
+                        forbidden_step_ids=forbidden_step_ids,
+                        rewrite_conflicts=validation_attempt >= max_validation_retries,
+                    )
+
                     if is_extension:
                         # For extension, we need to handle existing step IDs
-                        existing_step_ids = (
-                            {step.id for step in current_plan.steps}
-                            if current_plan
-                            else set()
-                        )
                         additional_steps = []
 
-                        for step_data in steps_data:
-                            step_id = step_data.get("id", str(uuid4()))
-                            # Ensure unique step ID
-                            while step_id in existing_step_ids:
-                                step_id = str(uuid4())
-                            existing_step_ids.add(step_id)
-
+                        for step_data in prepared_steps_data:
                             step = PlanStep(
-                                id=step_id,
+                                id=step_data["id"],
                                 name=step_data["name"],
                                 description=step_data["description"],
                                 tool_names=step_data.get("tool_names", []),
@@ -216,9 +495,9 @@ class PlanGenerator:
                             additional_steps.append(step)
 
                         # Validate dependencies (both existing and new steps)
-                        all_step_ids = existing_step_ids.copy()
-                        for step in additional_steps:
-                            all_step_ids.add(step.id)
+                        all_step_ids = set(forbidden_step_ids) | {
+                            step.id for step in additional_steps
+                        }
 
                         for step in additional_steps:
                             invalid_deps = [
@@ -238,6 +517,18 @@ class PlanGenerator:
 
                         # Validate tool references for the new steps
                         self._validate_steps_tools(additional_steps, tools)
+                        if current_plan:
+                            all_steps = current_plan.steps + additional_steps
+                            self._validate_unique_step_ids(
+                                all_steps,
+                                goal=current_plan.goal,
+                                iteration=current_plan.iteration,
+                            )
+                            self._validate_conditional_branch_targets(
+                                all_steps,
+                                goal=current_plan.goal,
+                                iteration=current_plan.iteration,
+                            )
 
                         # Send trace event for extension
                         plan_data = {
@@ -280,14 +571,10 @@ class PlanGenerator:
                     else:
                         # For generation, create all steps
                         steps = []
-                        step_ids = set()
 
-                        for step_data in steps_data:
-                            step_id = step_data.get("id", str(uuid4()))
-                            step_ids.add(step_id)
-
+                        for step_data in prepared_steps_data:
                             step = PlanStep(
-                                id=step_id,
+                                id=step_data["id"],
                                 name=step_data["name"],
                                 description=step_data["description"],
                                 tool_names=step_data.get("tool_names", []),
@@ -301,16 +588,21 @@ class PlanGenerator:
                             steps.append(step)
 
                         # Validate dependencies
+                        allowed_dependency_ids = {step.id for step in steps}
                         for step in steps:
                             invalid_deps = [
-                                dep for dep in step.dependencies if dep not in step_ids
+                                dep
+                                for dep in step.dependencies
+                                if dep not in allowed_dependency_ids
                             ]
                             if invalid_deps:
                                 logger.warning(
                                     f"Step {step.id} has invalid dependencies: {invalid_deps}"
                                 )
                                 step.dependencies = [
-                                    dep for dep in step.dependencies if dep in step_ids
+                                    dep
+                                    for dep in step.dependencies
+                                    if dep in allowed_dependency_ids
                                 ]
 
                         # Create execution plan
@@ -392,12 +684,57 @@ class PlanGenerator:
                             else [],
                             "available_tools": available_tools_list,
                         }
+                        if e.context:
+                            error_context.update(
+                                {
+                                    "step_id_errors": e.context.get(
+                                        "step_id_errors", False
+                                    ),
+                                    "missing_step_id_indices": e.context.get(
+                                        "missing_step_id_indices", []
+                                    ),
+                                    "reserved_step_ids": e.context.get(
+                                        "reserved_step_ids", []
+                                    ),
+                                    "duplicate_step_ids": e.context.get(
+                                        "duplicate_step_ids", []
+                                    ),
+                                    "forbidden_step_ids": e.context.get(
+                                        "forbidden_step_ids", []
+                                    ),
+                                    "invalid_branches": e.context.get(
+                                        "invalid_branches", []
+                                    ),
+                                    "available_step_ids": e.context.get(
+                                        "available_step_ids", []
+                                    ),
+                                }
+                            )
 
                         # Need to regenerate content with error context, so call LLM again
                         # Add error context to the messages for retry
                         missing_tools = (
                             e.context.get("missing_tools", []) if e.context else []
                         )
+                        invalid_branches = (
+                            e.context.get("invalid_branches", []) if e.context else []
+                        )
+                        available_step_ids = (
+                            e.context.get("available_step_ids", []) if e.context else []
+                        )
+                        step_id_guidance = self._format_step_id_retry_guidance(
+                            e.context
+                        )
+                        branch_guidance = ""
+                        if invalid_branches:
+                            branch_guidance = (
+                                "INVALID CONDITIONAL BRANCH TARGETS:\n"
+                                f"{json.dumps(invalid_branches, ensure_ascii=False)}\n"
+                                "Available step IDs:\n"
+                                f"{json.dumps(available_step_ids, ensure_ascii=False)}\n\n"
+                                "Please update conditional_branches so every target "
+                                "points to an existing step ID in the plan context.\n\n"
+                            )
                         retry_messages = clean_messages(prompt) + [
                             {
                                 "role": "user",
@@ -407,6 +744,8 @@ class PlanGenerator:
                                 f"Missing Tools: {', '.join(missing_tools)}\n\n"
                                 f"Available Tools:\n"
                                 f"{', '.join(available_tools_list)}\n\n"
+                                f"{step_id_guidance}"
+                                f"{branch_guidance}"
                                 f"COMMON TOOL NAMING MISTAKES TO AVOID:\n"
                                 f"- Use 'write_file' NOT 'write__file' (single underscore, not double)\n"
                                 f"- Use 'read_file' NOT 'read__file'\n"
@@ -918,6 +1257,7 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
         user_input_context: Optional[Dict[str, Any]] = None,
         tools: Optional[List[Tool]] = None,
         context: Optional[AgentContext] = None,
+        forbidden_step_ids: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """Build prompt for extending existing plan with additional steps"""
 
@@ -1004,6 +1344,7 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
             f"Iteration: {iteration}\n"
             f"Current Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
             f"{current_plan_context}\n"
+            f"{self._format_forbidden_step_ids_block(forbidden_step_ids or [])}"
             f"{history_context}"
         )
 
@@ -1037,7 +1378,7 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
 
         user_prompt += (
             "Create additional steps as a JSON object with a 'plan' field containing a 'steps' array. Each step must have:\n"
-            "- id: unique identifier (string, different from existing step IDs)\n"
+            "- id: unique identifier (string, must obey STEP ID UNIQUENESS RULES above)\n"
             "- name: step name (string)\n"
             "- description: what this step does (string)\n"
             "- tool_names: list of tools available for this step (array of strings, can be empty)\n"
@@ -1081,6 +1422,7 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
         tools: List[Tool],
         context: Optional[AgentContext] = None,
         skill_context: Optional[str] = None,
+        forbidden_step_ids: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """Build prompt for plan generation"""
 
@@ -1202,7 +1544,15 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
         messages.append(
             {
                 "role": "user",
-                "content": f"Goal: {goal}\nIteration: {iteration}\nCurrent Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\nCreate a step-by-step execution plan as a JSON object.",
+                "content": (
+                    f"Goal: {goal}\n"
+                    f"Iteration: {iteration}\n"
+                    f"Current Time: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                    f"{self._format_forbidden_step_ids_block(forbidden_step_ids or [])}"
+                    "Create a step-by-step execution plan as a JSON object. "
+                    "Dependencies in this fresh plan must reference only step IDs "
+                    "returned in this same response."
+                ),
             }
         )
 
@@ -1221,7 +1571,7 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
             f"- task_name: A concise title for this task (REQUIRED, 3-10 words, meaningful for display in task lists, **MUST USE THE SAME LANGUAGE AS THE GOAL**)\n"
             f"- steps: array of execution steps\n\n"
             f"Each step must have:\n"
-            f"- id: unique identifier (string)\n"
+            f"- id: unique identifier (string, must obey STEP ID UNIQUENESS RULES above)\n"
             f"- name: step name (string)\n"
             f"- description: what this step does (string)\n"
             f"- tool_names: list of tools available for this step (array of strings, can be empty)\n"
@@ -1409,10 +1759,6 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
                 if not all(field in step for field in required_fields):
                     logger.warning(f"Step {i} missing required fields: {step}")
                     continue
-
-                # Set default ID if not provided
-                if "id" not in step:
-                    step["id"] = f"step_{i + 1}"
 
                 # Set default dependencies if not provided
                 if "dependencies" not in step:
@@ -1674,6 +2020,75 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
                 },
             )
 
+    def _validate_unique_step_ids(
+        self,
+        steps: List[PlanStep],
+        goal: str = "",
+        iteration: int = 1,
+    ) -> None:
+        """Validate that a set of plan steps has non-empty unique IDs."""
+        missing_step_id_indices: List[int] = []
+        positions_by_id: Dict[str, List[int]] = {}
+        for index, step in enumerate(steps):
+            step_id = self._normalize_step_id_value(step.id)
+            if not step_id:
+                missing_step_id_indices.append(index)
+                continue
+            step.id = step_id
+            positions_by_id.setdefault(step_id, []).append(index)
+
+        duplicate_step_ids = [
+            {"id": step_id, "indices": indices}
+            for step_id, indices in positions_by_id.items()
+            if len(indices) > 1
+        ]
+        if missing_step_id_indices or duplicate_step_ids:
+            logger.error("Plan validation failed: duplicate or empty step IDs detected")
+            raise DAGPlanGenerationError(
+                "Generated plan contains duplicate or empty step IDs",
+                goal=goal,
+                iteration=iteration,
+                llm_response=None,
+                context={
+                    "step_id_errors": True,
+                    "missing_step_id_indices": missing_step_id_indices,
+                    "duplicate_step_ids": duplicate_step_ids,
+                },
+            )
+
+    def _validate_conditional_branch_targets(
+        self,
+        steps: List[PlanStep],
+        goal: str = "",
+        iteration: int = 1,
+    ) -> None:
+        """Validate that conditional branches point to steps in the same plan view."""
+        available_step_ids = {step.id for step in steps}
+        invalid_branches = []
+        for step in steps:
+            if step.conditional_branches:
+                for branch_key, target_step_id in step.conditional_branches.items():
+                    if target_step_id not in available_step_ids:
+                        invalid_branches.append(
+                            f"{step.id}.{branch_key} -> {target_step_id}"
+                        )
+                        logger.warning(
+                            f"Step {step.id} branch '{branch_key}' points to non-existent step: {target_step_id}"
+                        )
+
+        if invalid_branches:
+            logger.error(f"Plan validation failed: invalid branches {invalid_branches}")
+            raise DAGPlanGenerationError(
+                "Generated plan has conditional branches pointing to non-existent steps",
+                goal=goal,
+                iteration=iteration,
+                llm_response=None,
+                context={
+                    "invalid_branches": invalid_branches,
+                    "available_step_ids": list(available_step_ids),
+                },
+            )
+
     def _validate_plan(self, plan: ExecutionPlan, tools: List[Tool]) -> None:
         """
         Validate the generated plan for tool existence
@@ -1686,6 +2101,12 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
             DAGPlanGenerationError: If validation fails
         """
         logger.info(f"Validating plan {plan.id} with {len(plan.steps)} steps")
+
+        self._validate_unique_step_ids(
+            plan.steps,
+            goal=plan.goal,
+            iteration=getattr(plan, "iteration", 1),
+        )
 
         # Build tool name map for validation
         available_tools = set()
@@ -1721,31 +2142,10 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
                 },
             )
 
-        # Validate conditional branches
-        available_step_ids = {step.id for step in plan.steps}
-        invalid_branches = []
-        for step in plan.steps:
-            if step.conditional_branches:
-                for branch_key, target_step_id in step.conditional_branches.items():
-                    if target_step_id not in available_step_ids:
-                        invalid_branches.append(
-                            f"{step.id}.{branch_key} -> {target_step_id}"
-                        )
-                        logger.warning(
-                            f"Step {step.id} branch '{branch_key}' points to non-existent step: {target_step_id}"
-                        )
-
-        if invalid_branches:
-            logger.error(f"Plan validation failed: invalid branches {invalid_branches}")
-            raise DAGPlanGenerationError(
-                "Generated plan has conditional branches pointing to non-existent steps",
-                goal=plan.goal,
-                iteration=getattr(plan, "iteration", 1),
-                llm_response=None,
-                context={
-                    "invalid_branches": invalid_branches,
-                    "available_step_ids": list(available_step_ids),
-                },
-            )
+        self._validate_conditional_branch_targets(
+            plan.steps,
+            goal=plan.goal,
+            iteration=getattr(plan, "iteration", 1),
+        )
 
         logger.info(f"Plan {plan.id} validation passed successfully")

--- a/tests/core/agent/pattern/dag_plan_execute/test_plan_generator.py
+++ b/tests/core/agent/pattern/dag_plan_execute/test_plan_generator.py
@@ -193,8 +193,8 @@ class TestPlanGenerator:
         assert steps[0]["id"] == "step1"
         assert steps[0]["name"] == "Valid Step"
 
-    def test_parse_auto_generate_id(self, plan_generator):
-        """测试自动生成步骤ID"""
+    def test_parse_preserves_missing_id(self, plan_generator):
+        """测试解析阶段保留缺失步骤ID，由后续校验触发重试"""
         response_without_ids = """
         {
             "plan": {
@@ -221,8 +221,8 @@ class TestPlanGenerator:
         steps = parsed_data["steps"]
 
         assert len(steps) == 2
-        assert steps[0]["id"] == "step_1"
-        assert steps[1]["id"] == "step_2"
+        assert "id" not in steps[0]
+        assert "id" not in steps[1]
 
     def test_parse_auto_generate_dependencies(self, plan_generator):
         """测试自动生成依赖数组"""

--- a/tests/core/agent/pattern/dag_plan_execute/test_plan_validation_retry.py
+++ b/tests/core/agent/pattern/dag_plan_execute/test_plan_validation_retry.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 
 from xagent.core.agent.exceptions import DAGPlanGenerationError
+from xagent.core.agent.pattern.dag_plan_execute.models import ExecutionPlan, PlanStep
 from xagent.core.agent.pattern.dag_plan_execute.plan_generator import PlanGenerator
 
 
@@ -239,11 +240,6 @@ async def test_plan_extension_retry_success(mock_llm, mock_tracer, mock_tool):
     """Test retry mechanism for plan extension"""
 
     # Create current plan
-    from xagent.core.agent.pattern.dag_plan_execute.models import (
-        ExecutionPlan,
-        PlanStep,
-    )
-
     current_step = PlanStep(
         id="existing_step",
         name="Existing Step",
@@ -414,3 +410,598 @@ async def test_plan_validation_multiple_missing_tools(mock_llm, mock_tracer):
     assert "missing_tool_1" in retry_user_message
     assert "missing_tool_2" in retry_user_message
     assert "write_file, read_file" in retry_user_message
+
+
+@pytest.mark.asyncio
+async def test_duplicate_step_ids_retry_success(mock_llm, mock_tracer, mock_tool):
+    """Duplicate IDs in one generated plan should trigger retry before execution."""
+
+    duplicate_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "step1",
+                    "name": "Repeated Name",
+                    "description": "First duplicated id",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy"
+                },
+                {
+                    "id": "step1",
+                    "name": "Repeated Name",
+                    "description": "Second duplicated id",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["step1"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    valid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "step1",
+                    "name": "Repeated Name",
+                    "description": "First unique id",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy"
+                },
+                {
+                    "id": "step2",
+                    "name": "Repeated Name",
+                    "description": "Second unique id",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["step1"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.side_effect = [
+        {"content": duplicate_response},
+        {"content": valid_response},
+    ]
+
+    plan_generator = PlanGenerator(mock_llm)
+    plan = await plan_generator.generate_plan(
+        goal="Test duplicate ids",
+        tools=[mock_tool],
+        iteration=1,
+        history=[],
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in plan.steps] == ["step1", "step2"]
+    assert [step.name for step in plan.steps] == ["Repeated Name", "Repeated Name"]
+    assert mock_llm.chat.call_count == 2
+
+    retry_user_message = mock_llm.chat.call_args_list[1][1]["messages"][-1]["content"]
+    assert "STEP ID VALIDATION ERRORS" in retry_user_message
+    assert "step1" in retry_user_message
+
+
+@pytest.mark.asyncio
+async def test_missing_step_id_retries_instead_of_defaulting(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Missing step IDs should be rejected and surfaced to the retry prompt."""
+
+    missing_id_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "name": "Missing ID",
+                    "description": "The model omitted the required id",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    valid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "step1",
+                    "name": "Valid ID",
+                    "description": "The retry includes the required id",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.side_effect = [
+        {"content": missing_id_response},
+        {"content": valid_response},
+    ]
+
+    plan_generator = PlanGenerator(mock_llm)
+    plan = await plan_generator.generate_plan(
+        goal="Test missing ids",
+        tools=[mock_tool],
+        iteration=1,
+        history=[],
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in plan.steps] == ["step1"]
+    assert mock_llm.chat.call_count == 2
+
+    retry_user_message = mock_llm.chat.call_args_list[1][1]["messages"][-1]["content"]
+    assert "Missing ID step indices: [0]" in retry_user_message
+
+
+@pytest.mark.asyncio
+async def test_step_references_are_normalized_before_dependency_validation(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Whitespace-padded step IDs, dependencies, and branch targets should match."""
+
+    response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": " step1 ",
+                    "name": "Branch",
+                    "description": "Branches to the second step",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy",
+                    "conditional_branches": {"continue": " step2 "}
+                },
+                {
+                    "id": " step2 ",
+                    "name": "Dependent",
+                    "description": "Depends on the first step",
+                    "tool_names": ["write_file"],
+                    "dependencies": [" step1 "],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.return_value = {"content": response}
+
+    plan_generator = PlanGenerator(mock_llm)
+    plan = await plan_generator.generate_plan(
+        goal="Test normalized refs",
+        tools=[mock_tool],
+        iteration=1,
+        history=[],
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in plan.steps] == ["step1", "step2"]
+    assert plan.steps[0].conditional_branches == {"continue": "step2"}
+    assert plan.steps[1].dependencies == ["step1"]
+    assert mock_llm.chat.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_extension_reserved_step_id_retry_success(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Extension steps must not reuse IDs from the current task plan."""
+
+    current_plan = ExecutionPlan(
+        id=str(uuid4()),
+        goal="Existing goal",
+        steps=[
+            PlanStep(
+                id="existing_step",
+                name="Existing Step",
+                description="Already exposed step",
+                tool_names=[],
+                dependencies=[],
+                difficulty="easy",
+            )
+        ],
+        iteration=1,
+    )
+
+    reserved_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "existing_step",
+                    "name": "New Work",
+                    "description": "Incorrectly reuses an existing id",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    valid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "new_step",
+                    "name": "New Work",
+                    "description": "Uses a unique id",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.side_effect = [
+        {"content": reserved_response},
+        {"content": valid_response},
+    ]
+
+    plan_generator = PlanGenerator(mock_llm)
+    additional_steps = await plan_generator.extend_plan(
+        goal="Test extension",
+        tools=[mock_tool],
+        iteration=2,
+        history=[],
+        current_plan=current_plan,
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in additional_steps] == ["new_step"]
+    assert additional_steps[0].dependencies == ["existing_step"]
+    assert mock_llm.chat.call_count == 2
+
+    initial_messages = mock_llm.chat.call_args_list[0][1]["messages"]
+    initial_prompt = "\n".join(message["content"] for message in initial_messages)
+    assert "FORBIDDEN_STEP_IDS" in initial_prompt
+    assert "existing_step" in initial_prompt
+
+    retry_user_message = mock_llm.chat.call_args_list[1][1]["messages"][-1]["content"]
+    assert "Reserved step IDs used" in retry_user_message
+    assert "existing_step" in retry_user_message
+
+
+@pytest.mark.asyncio
+async def test_extension_does_not_revalidate_historical_step_tools(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Extension uniqueness checks should not revalidate old step tool availability."""
+
+    current_plan = ExecutionPlan(
+        id=str(uuid4()),
+        goal="Existing goal",
+        steps=[
+            PlanStep(
+                id="existing_step",
+                name="Existing Step",
+                description="Already planned with a tool unavailable now",
+                tool_names=["old_tool"],
+                dependencies=[],
+                difficulty="easy",
+            )
+        ],
+        iteration=1,
+    )
+
+    valid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "new_step",
+                    "name": "New Work",
+                    "description": "Uses a currently available tool",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.return_value = {"content": valid_response}
+
+    plan_generator = PlanGenerator(mock_llm)
+    additional_steps = await plan_generator.extend_plan(
+        goal="Test extension",
+        tools=[mock_tool],
+        iteration=2,
+        history=[],
+        current_plan=current_plan,
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in additional_steps] == ["new_step"]
+    assert additional_steps[0].dependencies == ["existing_step"]
+    assert mock_llm.chat.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_extension_invalid_conditional_branch_target_retries(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Extension branch targets must resolve against historical and new steps."""
+
+    current_plan = ExecutionPlan(
+        id=str(uuid4()),
+        goal="Existing goal",
+        steps=[
+            PlanStep(
+                id="existing_step",
+                name="Existing Step",
+                description="Already exposed step",
+                tool_names=[],
+                dependencies=[],
+                difficulty="easy",
+            )
+        ],
+        iteration=1,
+    )
+
+    invalid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "branch_step",
+                    "name": "Branch Work",
+                    "description": "Branches to a missing step",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy",
+                    "conditional_branches": {"continue": "missing_step"}
+                }
+            ]
+        }
+    }"""
+
+    valid_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "branch_step",
+                    "name": "Branch Work",
+                    "description": "Branches to a valid new step",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy",
+                    "conditional_branches": {"continue": "followup_step"}
+                },
+                {
+                    "id": "followup_step",
+                    "name": "Follow Up",
+                    "description": "Handles the branch",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["branch_step"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.side_effect = [
+        {"content": invalid_response},
+        {"content": valid_response},
+    ]
+
+    plan_generator = PlanGenerator(mock_llm)
+    additional_steps = await plan_generator.extend_plan(
+        goal="Test extension",
+        tools=[mock_tool],
+        iteration=2,
+        history=[],
+        current_plan=current_plan,
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in additional_steps] == ["branch_step", "followup_step"]
+    assert additional_steps[0].conditional_branches == {"continue": "followup_step"}
+    assert mock_llm.chat.call_count == 2
+
+    retry_user_message = mock_llm.chat.call_args_list[1][1]["messages"][-1]["content"]
+    assert "conditional branches pointing to non-existent steps" in retry_user_message
+    assert "missing_step" in retry_user_message
+
+
+@pytest.mark.asyncio
+async def test_step_id_conflicts_fallback_rewrite_after_retries(
+    mock_llm, mock_tracer, mock_tool
+):
+    """After retries are exhausted, duplicate step IDs are deterministically rewritten."""
+
+    conflicting_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "analyze",
+                    "name": "Analyze",
+                    "description": "First analyze step",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["existing_step"],
+                    "difficulty": "easy",
+                    "conditional_branches": {"continue": "analyze"}
+                },
+                {
+                    "id": "analyze",
+                    "name": "Analyze",
+                    "description": "Second analyze step",
+                    "tool_names": ["write_file"],
+                    "dependencies": ["analyze"],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.return_value = {"content": conflicting_response}
+
+    plan_generator = PlanGenerator(mock_llm)
+    plan = await plan_generator.generate_plan(
+        goal="Test fallback",
+        tools=[mock_tool],
+        iteration=1,
+        history=[],
+        tracer=mock_tracer,
+        context=None,
+    )
+
+    assert [step.id for step in plan.steps] == ["analyze", "analyze_2"]
+    assert plan.steps[0].dependencies == []
+    assert plan.steps[0].conditional_branches == {"continue": "analyze"}
+    assert plan.steps[1].dependencies == ["analyze"]
+    assert mock_llm.chat.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_reserved_step_id_conflicts_fail_after_retries(
+    mock_llm, mock_tracer, mock_tool
+):
+    """Reserved step IDs are not rewritten because references are ambiguous."""
+
+    conflicting_response = """{
+        "plan": {
+            "steps": [
+                {
+                    "id": "existing_step",
+                    "name": "Existing Conflict",
+                    "description": "Conflicts with historical id",
+                    "tool_names": ["write_file"],
+                    "dependencies": [],
+                    "difficulty": "easy"
+                }
+            ]
+        }
+    }"""
+
+    mock_llm.chat.return_value = {"content": conflicting_response}
+
+    history = [
+        {
+            "role": "user",
+            "content": '{"plan": {"steps": [{"id": "existing_step"}]}}',
+        }
+    ]
+    plan_generator = PlanGenerator(mock_llm)
+    with pytest.raises(DAGPlanGenerationError) as exc_info:
+        await plan_generator.generate_plan(
+            goal="Test reserved fallback failure",
+            tools=[mock_tool],
+            iteration=1,
+            history=history,
+            tracer=mock_tracer,
+            context=None,
+        )
+
+    assert "reserved step IDs" in str(exc_info.value)
+    assert exc_info.value.context["reserved_step_ids"] == [
+        {"id": "existing_step", "index": 0}
+    ]
+    assert mock_llm.chat.call_count == 3
+
+
+def test_collect_forbidden_step_ids_skips_non_json_history_content(mock_llm):
+    """Plain conversation history should not be parsed as JSON while collecting IDs."""
+
+    plan_generator = PlanGenerator(mock_llm)
+    forbidden_step_ids = plan_generator._collect_forbidden_step_ids(
+        [
+            {"role": "user", "content": "please analyze the dataset"},
+            {
+                "role": "assistant",
+                "content": '{"plan": {"steps": [{"id": "historical_step"}]}}',
+            },
+        ]
+    )
+
+    assert forbidden_step_ids == ["historical_step"]
+
+
+def test_collect_forbidden_step_ids_reads_markdown_json_history_content(mock_llm):
+    """Markdown-wrapped JSON history should still contribute forbidden step IDs."""
+
+    plan_generator = PlanGenerator(mock_llm)
+    forbidden_step_ids = plan_generator._collect_forbidden_step_ids(
+        [
+            {
+                "role": "assistant",
+                "content": """Here is the plan:
+```json
+{"plan": {"steps": [{"id": "markdown_step"}]}}
+```
+""",
+            }
+        ]
+    )
+
+    assert forbidden_step_ids == ["markdown_step"]
+
+
+def test_validate_plan_rejects_duplicate_step_ids(mock_llm):
+    """Plan validation should reject duplicate step IDs even when called directly."""
+
+    plan = ExecutionPlan(
+        id=str(uuid4()),
+        goal="Duplicate validation",
+        steps=[
+            PlanStep(
+                id="dup",
+                name="First",
+                description="First step",
+                tool_names=[],
+                dependencies=[],
+            ),
+            PlanStep(
+                id="dup",
+                name="Second",
+                description="Second step",
+                tool_names=[],
+                dependencies=[],
+            ),
+        ],
+    )
+
+    plan_generator = PlanGenerator(mock_llm)
+    with pytest.raises(DAGPlanGenerationError) as exc_info:
+        plan_generator._validate_plan(plan, tools=[])
+
+    assert "duplicate or empty step IDs" in str(exc_info.value)
+
+
+def test_validate_plan_allows_duplicate_names(mock_llm):
+    """Step names are display labels and may repeat when IDs are unique."""
+
+    plan = ExecutionPlan(
+        id=str(uuid4()),
+        goal="Repeated names",
+        steps=[
+            PlanStep(
+                id="step_a",
+                name="Analyze",
+                description="First analysis",
+                tool_names=[],
+                dependencies=[],
+            ),
+            PlanStep(
+                id="step_b",
+                name="Analyze",
+                description="Second analysis",
+                tool_names=[],
+                dependencies=["step_a"],
+            ),
+        ],
+    )
+
+    plan_generator = PlanGenerator(mock_llm)
+    plan_generator._validate_plan(plan, tools=[])


### PR DESCRIPTION
## Background

DAG plans use LLM-generated step IDs and names. In multi-turn execution, especially during continuation or plan extension, the model can reuse an earlier step ID or emit the same ID more than once in a single plan response. That creates ambiguity for API and SDK consumers because trace events, step start/end events, and tool/LLM action events all rely on `step_id` to identify the DAG node they belong to.

Trace events already have unique event IDs, but those identify individual events, not stable DAG steps. The step ID still needs to be unique within a task so consumers can safely correlate all events for a step. Step names remain display labels and may repeat naturally.

## What changed

- Added task-scoped forbidden step ID collection before plan generation.
  - Existing IDs are collected from the current plan and execution history.
  - The planning prompts now include an explicit `FORBIDDEN_STEP_IDS` block.
  - Prompts clarify that step IDs must be unique, while step names do not need to be unique.

- Added hard validation for generated step IDs.
  - Empty IDs are rejected.
  - IDs already used in the same task are rejected.
  - Duplicate IDs within the same model response are rejected.
  - `_validate_plan()` now catches duplicate or empty IDs even when called directly.

- Kept the retry-first behavior.
  - Step ID validation failures are surfaced back into the retry prompt with the conflicting IDs and forbidden ID list.
  - The model gets a chance to regenerate a valid plan before any fallback rewrite is used.

- Added deterministic fallback rewriting after retries are exhausted.
  - Conflicting IDs are rewritten with stable suffixes, for example `analyze_2`.
  - Dependencies and conditional branch targets are rewritten to match the final generated IDs.
  - References to historical step IDs are preserved so new steps can still depend on previous steps.

- Tightened extension validation without revalidating old tools.
  - New extension steps are still checked against the current tool list.
  - The combined current plan plus new steps is checked for step ID uniqueness only, so historical steps are not rejected just because their original tools are not present in the current continuation context.

## Validation

- `uv run ruff check src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py tests/core/agent/pattern/dag_plan_execute/test_plan_validation_retry.py`
- `uv run ruff format src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py tests/core/agent/pattern/dag_plan_execute/test_plan_validation_retry.py`
- `uv run pytest tests/core/agent/pattern/dag_plan_execute/test_plan_generator.py tests/core/agent/pattern/dag_plan_execute/test_plan_validation_retry.py tests/core/agent/pattern/dag_plan_execute/test_conditional_branches.py`

Result: 37 passed, 1 skipped. The remaining warnings are third-party deprecation warnings from `deepdoc` imports.
