### PR TITLE
feat: [v2 part2] add agent v2 execution core

### DIFF
--- a/src/xagent/core/agent_v2/__init__.py
+++ b/src/xagent/core/agent_v2/__init__.py
@@ -1,0 +1,60 @@
+from .agent import Agent
+from .checkpoint import (
+    CHECKPOINT_EVENT_TYPE,
+    CHECKPOINT_SCHEMA_VERSION,
+    CHECKPOINT_TYPE,
+    CheckpointPersistenceError,
+    TraceCheckpointStore,
+)
+from .context import (
+    COMPONENT_LOADERS,
+    CompactConfig,
+    CompactResult,
+    ContextManager,
+    ExecutionComponent,
+    ExecutionContext,
+    GenericComponent,
+    LLMCallRecord,
+    MemoryComponent,
+    MergeStrategy,
+    Message,
+    WorkspaceComponent,
+    clone_component,
+)
+from .frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+from .registry import ExecutionHandle, ExecutionLifecycleStatus, ExecutionRegistry
+from .runner import AgentRunner
+from .runtime import PatternRuntime, load_pattern_checkpoint
+from .tracing import TraceEventCallback
+
+__all__ = [
+    "Agent",
+    "AgentRunner",
+    "CHECKPOINT_EVENT_TYPE",
+    "CHECKPOINT_SCHEMA_VERSION",
+    "CHECKPOINT_TYPE",
+    "CheckpointPersistenceError",
+    "COMPONENT_LOADERS",
+    "CompactConfig",
+    "CompactResult",
+    "ContextManager",
+    "ExecutionComponent",
+    "ExecutionContext",
+    "ExecutionFrame",
+    "ExecutionHandle",
+    "ExecutionLifecycleStatus",
+    "ExecutionRegistry",
+    "ExecutionSnapshot",
+    "ExecutionStatus",
+    "GenericComponent",
+    "LLMCallRecord",
+    "MemoryComponent",
+    "MergeStrategy",
+    "Message",
+    "PatternRuntime",
+    "TraceCheckpointStore",
+    "TraceEventCallback",
+    "WorkspaceComponent",
+    "clone_component",
+    "load_pattern_checkpoint",
+]

--- a/src/xagent/core/agent_v2/agent.py
+++ b/src/xagent/core/agent_v2/agent.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .runner import AgentRunner
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class Agent:
+    """Minimal agent definition for the execution-centric v2 runtime."""
+
+    name: str
+    patterns: list[Any]
+    tools: list[Any] = field(default_factory=list)
+    llm: Any | None = None
+    system_prompt: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    memory_store: Any | None = None
+    memory_similarity_threshold: float | None = None
+    skill_manager: Any | None = None
+    allowed_skills: list[str] | None = None
+    created_at: datetime = field(default_factory=_utcnow)
+
+    def get_runner(self, **kwargs: Any) -> "AgentRunner":
+        """Return a runner bound to this agent."""
+        from .runner import AgentRunner
+
+        return AgentRunner(agent=self, **kwargs)

--- a/src/xagent/core/agent_v2/checkpoint.py
+++ b/src/xagent/core/agent_v2/checkpoint.py
@@ -112,7 +112,7 @@ class TraceCheckpointStore:
             )
             if inspect.isawaitable(result):
                 result = await result
-            return str(result) if result is not None else ""
+            return str(result) if result is not None else None
 
         trace_event = getattr(self.tracer, "trace_event", None)
         if callable(trace_event):
@@ -131,7 +131,7 @@ class TraceCheckpointStore:
             )
             if inspect.isawaitable(result):
                 result = await result
-            return str(result) if result is not None else ""
+            return str(result) if result is not None else None
 
         return None
 

--- a/src/xagent/core/agent_v2/checkpoint.py
+++ b/src/xagent/core/agent_v2/checkpoint.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+CHECKPOINT_TYPE = "agent_v2_execution_checkpoint"
+CHECKPOINT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class _TracePart:
+    value: str
+
+
+class _CheckpointTraceEventType:
+    """TraceEventType-compatible object without importing legacy agent package."""
+
+    scope = _TracePart("system")
+    action = _TracePart("update")
+    category = _TracePart("general")
+    value = "system_update_general"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+CHECKPOINT_EVENT_TYPE = _CheckpointTraceEventType()
+
+
+class CheckpointPersistenceError(RuntimeError):
+    """Raised when a checkpoint cannot be durably persisted."""
+
+
+@dataclass
+class TraceCheckpointStore:
+    """Durable checkpoint adapter backed by the tracer event pipeline.
+
+    This object intentionally exposes the same method names that AgentRunner and
+    PatternRuntime already probe for: checkpoint/write_checkpoint for writes and
+    load_latest_checkpoint for reads.
+    """
+
+    tracer: Any
+    require_persisted: bool = True
+
+    async def checkpoint(self, **payload: Any) -> str | None:
+        return await self.save(payload)
+
+    async def write_checkpoint(self, payload: dict[str, Any]) -> str | None:
+        return await self.save(payload)
+
+    async def trace_event(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward non-checkpoint trace events to the wrapped tracer."""
+        trace_event = getattr(self.tracer, "trace_event", None)
+        if not callable(trace_event):
+            return None
+        result = trace_event(*args, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    async def save(self, payload: dict[str, Any]) -> str | None:
+        execution_id = self._execution_id(payload)
+        event_payload = self._event_payload(payload, execution_id=execution_id)
+
+        event_id = await self._call_checkpoint_writer(payload, event_payload)
+        if event_id is None:
+            raise CheckpointPersistenceError(
+                "Tracer does not expose a durable checkpoint write API."
+            )
+        return str(event_id)
+
+    async def load_latest_checkpoint(
+        self,
+        execution_id: str,
+    ) -> dict[str, Any] | None:
+        for method_name in (
+            "load_latest_checkpoint",
+            "get_latest_checkpoint",
+            "latest_checkpoint",
+        ):
+            method = getattr(self.tracer, method_name, None)
+            if not callable(method):
+                continue
+            payload = method(execution_id)
+            if inspect.isawaitable(payload):
+                payload = await payload
+            return self._unwrap_checkpoint_payload(payload)
+        return None
+
+    def get_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        raise NotImplementedError("Use async load_latest_checkpoint().")
+
+    def latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        raise NotImplementedError("Use async load_latest_checkpoint().")
+
+    async def _call_checkpoint_writer(
+        self,
+        payload: dict[str, Any],
+        event_payload: dict[str, Any],
+    ) -> str | None:
+        for method_name in ("save_checkpoint", "checkpoint", "write_checkpoint"):
+            method = getattr(self.tracer, method_name, None)
+            if not callable(method):
+                continue
+            result = (
+                method(payload)
+                if method_name == "write_checkpoint"
+                else method(**payload)
+            )
+            if inspect.isawaitable(result):
+                result = await result
+            return str(result) if result is not None else ""
+
+        trace_event = getattr(self.tracer, "trace_event", None)
+        if callable(trace_event):
+            if self.require_persisted and not self._supports_kwarg(
+                trace_event,
+                "require_persisted",
+            ):
+                raise CheckpointPersistenceError(
+                    "Tracer.trace_event() cannot guarantee checkpoint persistence."
+                )
+            result = trace_event(
+                self._checkpoint_trace_event_type(trace_event),
+                task_id=event_payload["root_execution_id"],
+                data=event_payload,
+                require_persisted=self.require_persisted,
+            )
+            if inspect.isawaitable(result):
+                result = await result
+            return str(result) if result is not None else ""
+
+        return None
+
+    def _event_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        execution_id: str,
+    ) -> dict[str, Any]:
+        metadata = payload.get("metadata")
+        sequence = metadata.get("sequence") if isinstance(metadata, dict) else None
+        return {
+            "checkpoint_type": CHECKPOINT_TYPE,
+            "snapshot_schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "root_execution_id": execution_id,
+            "execution_id": execution_id,
+            "sequence": sequence,
+            "status": payload.get("status"),
+            "label": payload.get("label"),
+            "saved_at": datetime.now(timezone.utc).isoformat(),
+            "snapshot": dict(payload),
+        }
+
+    def _unwrap_checkpoint_payload(self, payload: Any) -> dict[str, Any] | None:
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("checkpoint_type") == CHECKPOINT_TYPE:
+            snapshot = payload.get("snapshot")
+            return dict(snapshot) if isinstance(snapshot, dict) else None
+        data = payload.get("data")
+        if isinstance(data, dict) and data.get("checkpoint_type") == CHECKPOINT_TYPE:
+            snapshot = data.get("snapshot")
+            return dict(snapshot) if isinstance(snapshot, dict) else None
+        if payload.get("type") == "checkpoint" or "context" in payload:
+            return dict(payload)
+        return None
+
+    def _execution_id(self, payload: dict[str, Any]) -> str:
+        execution_id = payload.get("execution_id")
+        if not execution_id:
+            raise CheckpointPersistenceError(
+                "Checkpoint payload is missing execution_id."
+            )
+        return str(execution_id)
+
+    def _supports_kwarg(self, method: Any, name: str) -> bool:
+        try:
+            signature = inspect.signature(method)
+        except (TypeError, ValueError):
+            return False
+        return name in signature.parameters or any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+
+    def _checkpoint_trace_event_type(self, trace_event: Any) -> Any:
+        fn = getattr(trace_event, "__func__", trace_event)
+        globals_payload = getattr(fn, "__globals__", {})
+        trace_event_type = globals_payload.get("TraceEventType")
+        trace_scope = globals_payload.get("TraceScope")
+        trace_action = globals_payload.get("TraceAction")
+        trace_category = globals_payload.get("TraceCategory")
+        if (
+            trace_event_type is None
+            or trace_scope is None
+            or trace_action is None
+            or trace_category is None
+        ):
+            return CHECKPOINT_EVENT_TYPE
+        return trace_event_type(
+            trace_scope.SYSTEM,
+            trace_action.UPDATE,
+            trace_category.GENERAL,
+        )

--- a/src/xagent/core/agent_v2/checkpoint.py
+++ b/src/xagent/core/agent_v2/checkpoint.py
@@ -5,28 +5,17 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from ..agent.trace import TraceAction, TraceCategory, TraceEventType, TraceScope
+
 CHECKPOINT_TYPE = "agent_v2_execution_checkpoint"
 CHECKPOINT_SCHEMA_VERSION = 1
 
 
-@dataclass(frozen=True)
-class _TracePart:
-    value: str
-
-
-class _CheckpointTraceEventType:
-    """TraceEventType-compatible object without importing legacy agent package."""
-
-    scope = _TracePart("system")
-    action = _TracePart("update")
-    category = _TracePart("general")
-    value = "system_update_general"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-CHECKPOINT_EVENT_TYPE = _CheckpointTraceEventType()
+CHECKPOINT_EVENT_TYPE = TraceEventType(
+    TraceScope.SYSTEM,
+    TraceAction.UPDATE,
+    TraceCategory.GENERAL,
+)
 
 
 class CheckpointPersistenceError(RuntimeError):
@@ -188,21 +177,5 @@ class TraceCheckpointStore:
         )
 
     def _checkpoint_trace_event_type(self, trace_event: Any) -> Any:
-        fn = getattr(trace_event, "__func__", trace_event)
-        globals_payload = getattr(fn, "__globals__", {})
-        trace_event_type = globals_payload.get("TraceEventType")
-        trace_scope = globals_payload.get("TraceScope")
-        trace_action = globals_payload.get("TraceAction")
-        trace_category = globals_payload.get("TraceCategory")
-        if (
-            trace_event_type is None
-            or trace_scope is None
-            or trace_action is None
-            or trace_category is None
-        ):
-            return CHECKPOINT_EVENT_TYPE
-        return trace_event_type(
-            trace_scope.SYSTEM,
-            trace_action.UPDATE,
-            trace_category.GENERAL,
-        )
+        del trace_event
+        return CHECKPOINT_EVENT_TYPE

--- a/src/xagent/core/agent_v2/context/__init__.py
+++ b/src/xagent/core/agent_v2/context/__init__.py
@@ -1,0 +1,27 @@
+from .components import (
+    COMPONENT_LOADERS,
+    ExecutionComponent,
+    GenericComponent,
+    MemoryComponent,
+    WorkspaceComponent,
+    clone_component,
+)
+from .execution import CompactConfig, CompactResult, ExecutionContext, MergeStrategy
+from .manager import ContextManager
+from .message import LLMCallRecord, Message
+
+__all__ = [
+    "COMPONENT_LOADERS",
+    "CompactConfig",
+    "CompactResult",
+    "ContextManager",
+    "ExecutionComponent",
+    "ExecutionContext",
+    "GenericComponent",
+    "LLMCallRecord",
+    "MemoryComponent",
+    "MergeStrategy",
+    "Message",
+    "WorkspaceComponent",
+    "clone_component",
+]

--- a/src/xagent/core/agent_v2/context/components.py
+++ b/src/xagent/core/agent_v2/context/components.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol, runtime_checkable
 
@@ -25,7 +26,7 @@ class WorkspaceComponent:
             workspace_id=self.workspace_id,
             workspace_path=self.workspace_path,
             cwd=self.cwd,
-            state=dict(self.state),
+            state=copy.deepcopy(self.state),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/xagent/core/agent_v2/context/components.py
+++ b/src/xagent/core/agent_v2/context/components.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ExecutionComponent(Protocol):
+    def clone(self) -> "ExecutionComponent": ...
+
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+@dataclass
+class WorkspaceComponent:
+    """Sandbox and workspace state for an execution."""
+
+    workspace_id: str | None = None
+    workspace_path: str | None = None
+    cwd: str | None = None
+    state: dict[str, Any] = field(default_factory=dict)
+
+    def clone(self) -> "WorkspaceComponent":
+        return WorkspaceComponent(
+            workspace_id=self.workspace_id,
+            workspace_path=self.workspace_path,
+            cwd=self.cwd,
+            state=dict(self.state),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workspace_id": self.workspace_id,
+            "workspace_path": self.workspace_path,
+            "cwd": self.cwd,
+            "state": self.state,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WorkspaceComponent":
+        return cls(
+            workspace_id=data.get("workspace_id"),
+            workspace_path=data.get("workspace_path"),
+            cwd=data.get("cwd"),
+            state=data.get("state", {}),
+        )
+
+
+@dataclass
+class MemoryComponent:
+    """Memory session state for an execution."""
+
+    session_id: str | None = None
+    snapshot: dict[str, Any] | None = None
+
+    def clone(self) -> "MemoryComponent":
+        snapshot = (
+            dict(self.snapshot) if isinstance(self.snapshot, dict) else self.snapshot
+        )
+        return MemoryComponent(session_id=self.session_id, snapshot=snapshot)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"session_id": self.session_id, "snapshot": self.snapshot}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MemoryComponent":
+        return cls(
+            session_id=data.get("session_id"),
+            snapshot=data.get("snapshot"),
+        )
+
+
+@dataclass
+class GenericComponent:
+    """Fallback component for unknown serialized component payloads."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def clone(self) -> "GenericComponent":
+        return GenericComponent(data=dict(self.data))
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.data)
+
+
+COMPONENT_LOADERS: dict[str, Callable[[dict[str, Any]], ExecutionComponent]] = {
+    "workspace": WorkspaceComponent.from_dict,
+    "memory": MemoryComponent.from_dict,
+}
+
+
+def clone_component(component: ExecutionComponent) -> ExecutionComponent:
+    return component.clone()

--- a/src/xagent/core/agent_v2/context/enrichment.py
+++ b/src/xagent/core/agent_v2/context/enrichment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from typing import Any, cast
@@ -69,12 +70,12 @@ async def enrich_context_with_memory(
         return cached if isinstance(cached, list) else []
 
     task_id = str(
-        getattr(runtime, "execution_id", None)
+        _runtime_attr(runtime, "execution_id")
         or getattr(context, "execution_id", None)
         or ""
     )
-    step_id = getattr(runtime, "active_react_step_id", None)
-    tracer = getattr(runtime, "tracer", None)
+    step_id = _runtime_attr(runtime, "active_react_step_id")
+    tracer = _runtime_attr(runtime, "tracer")
     user_id = _current_user_id()
 
     if tracer is not None and task_id:
@@ -145,14 +146,15 @@ async def enrich_context_with_skill(
         return attempted if isinstance(attempted, dict) else None
 
     task_id = str(
-        getattr(runtime, "execution_id", None)
+        _runtime_attr(runtime, "execution_id")
         or getattr(context, "execution_id", None)
         or ""
     )
+    tracer = _runtime_attr(runtime, "tracer")
     selected_skill = await skill_manager.select_skill(
         task=task,
         llm=_RuntimeLLMProxy(runtime=runtime, llm=llm) if runtime is not None else llm,
-        tracer=getattr(runtime, "tracer", None),
+        tracer=tracer,
         task_id=task_id or None,
         allowed_skills=allowed_skills,
     )
@@ -194,12 +196,12 @@ async def generate_and_store_react_memory(
         return
 
     task_id = str(
-        getattr(runtime, "execution_id", None)
+        _runtime_attr(runtime, "execution_id")
         or getattr(context, "execution_id", None)
         or ""
     )
-    step_id = getattr(runtime, "active_react_step_id", None)
-    tracer = getattr(runtime, "tracer", None)
+    step_id = _runtime_attr(runtime, "active_react_step_id")
+    tracer = _runtime_attr(runtime, "tracer")
     output = str(result.get("output") or result.get("response") or "")
     messages = [
         message.to_dict()
@@ -396,28 +398,48 @@ Respond with JSON:
 
 def _parse_json_object(content: str) -> dict[str, Any] | None:
     text = content.strip()
-    if text.startswith("```"):
-        newline_idx = text.find("\n")
-        if newline_idx > 0:
-            text = text[newline_idx:].strip()
-        if text.endswith("```"):
-            text = text[:-3].strip()
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError:
+    for candidate in _json_candidates(text):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _json_candidates(text: str) -> list[str]:
+    candidates = [text]
+    fence_start = text.find("```")
+    if fence_start >= 0:
+        content_start = text.find("\n", fence_start + 3)
+        fence_end = text.find("```", content_start + 1)
+        if content_start >= 0 and fence_end > content_start:
+            candidates.append(text[content_start + 1 : fence_end].strip())
+
+    object_start = text.find("{")
+    object_end = text.rfind("}")
+    if object_start >= 0 and object_end > object_start:
+        candidates.append(text[object_start : object_end + 1].strip())
+
+    return candidates
+
+
+def _runtime_attr(runtime: Any | None, name: str) -> Any | None:
+    if runtime is None:
         return None
-    return payload if isinstance(payload, dict) else None
+    return getattr(runtime, name, None)
 
 
 def _skill_selection_attempt_key(
     task: str,
     allowed_skills: list[str] | None,
 ) -> str:
-    return json.dumps(
+    payload = json.dumps(
         {"task": task, "allowed_skills": sorted(allowed_skills or [])},
         ensure_ascii=False,
         sort_keys=True,
     )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _build_memory_context(

--- a/src/xagent/core/agent_v2/context/enrichment.py
+++ b/src/xagent/core/agent_v2/context/enrichment.py
@@ -258,20 +258,6 @@ async def generate_and_store_react_memory(
             )
         return
 
-    if memory_store is None:
-        if tracer is not None and task_id:
-            await trace_memory_store_end(
-                tracer,
-                task_id,
-                data={
-                    "storage_success": False,
-                    "decision": "no_memory_store",
-                    "reason": reason,
-                    "step_id": step_id,
-                },
-            )
-        return
-
     if tracer is not None and task_id:
         await trace_memory_store_start(
             tracer,
@@ -450,7 +436,10 @@ def _build_memory_context(
     if not memories:
         return str(existing_context or "")
     enhanced = enhance_goal_with_memory(query, memories)
-    context_text = enhanced.replace(query, "", 1).strip()
+    context_text = enhanced
+    if query and enhanced.startswith(query):
+        context_text = enhanced[len(query) :].lstrip()
+    context_text = context_text.strip()
     if not context_text:
         context_text = enhanced
     if existing_context:

--- a/src/xagent/core/agent_v2/context/enrichment.py
+++ b/src/xagent/core/agent_v2/context/enrichment.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, cast
+
+from ...agent.pattern.memory_utils import (
+    enhance_goal_with_memory,
+    lookup_relevant_memories,
+    store_react_task_memory,
+)
+from ...agent.trace import (
+    trace_memory_generate_end,
+    trace_memory_generate_start,
+    trace_memory_retrieve_end,
+    trace_memory_retrieve_start,
+    trace_memory_store_end,
+    trace_memory_store_start,
+)
+from ...user_context import current_user_id
+from ..runtime import LLMCallInterrupted
+
+logger = logging.getLogger(__name__)
+
+MEMORY_CONTEXT_METADATA_KEY = "retrieved_memory_context"
+RETRIEVED_MEMORIES_METADATA_KEY = "retrieved_memories"
+SELECTED_SKILL_METADATA_KEY = "selected_skill"
+SKILL_CONTEXT_METADATA_KEY = "selected_skill_context"
+SKILL_SELECTION_ATTEMPTS_METADATA_KEY = "skill_selection_attempts"
+
+
+class _RuntimeLLMProxy:
+    def __init__(self, *, runtime: Any, llm: Any) -> None:
+        self.runtime = runtime
+        self.llm = llm
+
+    async def chat(self, **kwargs: Any) -> Any:
+        run_llm_call = getattr(self.runtime, "run_llm_call", None)
+        if callable(run_llm_call):
+            return await run_llm_call(self.llm, **kwargs)
+        return await self.llm.chat(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.llm, name)
+
+
+async def enrich_context_with_memory(
+    *,
+    context: Any,
+    query: str,
+    category: str,
+    memory_store: Any | None,
+    runtime: Any | None = None,
+    similarity_threshold: float | None = None,
+    include_general: bool = True,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Retrieve relevant v1-style memories and attach them to context metadata."""
+
+    if memory_store is None or not query.strip():
+        return []
+
+    retrieved_by_category = context.metadata.setdefault(
+        RETRIEVED_MEMORIES_METADATA_KEY, {}
+    )
+    if category in retrieved_by_category:
+        cached = retrieved_by_category.get(category)
+        return cached if isinstance(cached, list) else []
+
+    task_id = str(
+        getattr(runtime, "execution_id", None)
+        or getattr(context, "execution_id", None)
+        or ""
+    )
+    step_id = getattr(runtime, "active_react_step_id", None)
+    tracer = getattr(runtime, "tracer", None)
+    user_id = _current_user_id()
+
+    if tracer is not None and task_id:
+        await trace_memory_retrieve_start(
+            tracer,
+            task_id=task_id,
+            step_id=step_id,
+            data={"query": query[:200], "category": category},
+        )
+
+    memories = await asyncio.to_thread(
+        _lookup_relevant_memories_with_context,
+        memory_store,
+        query,
+        category,
+        include_general,
+        limit,
+        similarity_threshold,
+        user_id,
+    )
+    retrieved_by_category[category] = memories
+    context.metadata[MEMORY_CONTEXT_METADATA_KEY] = _build_memory_context(
+        context.metadata.get(MEMORY_CONTEXT_METADATA_KEY), query, memories
+    )
+
+    if tracer is not None and task_id:
+        await trace_memory_retrieve_end(
+            tracer,
+            task_id=task_id,
+            step_id=step_id,
+            data={
+                "query": query[:200],
+                "category": category,
+                "memories_count": len(memories),
+                "found": bool(memories),
+            },
+        )
+
+    logger.info(
+        "Retrieved %s v2 memories for category=%s execution=%s",
+        len(memories),
+        category,
+        getattr(context, "execution_id", None),
+    )
+    return memories
+
+
+async def enrich_context_with_skill(
+    *,
+    context: Any,
+    task: str,
+    llm: Any | None,
+    skill_manager: Any | None,
+    runtime: Any | None = None,
+    allowed_skills: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Select a skill and attach full skill guidance to context metadata."""
+
+    if skill_manager is None or llm is None or not task.strip():
+        return None
+    existing = context.metadata.get(SELECTED_SKILL_METADATA_KEY)
+    if isinstance(existing, dict):
+        return existing
+    attempt_key = _skill_selection_attempt_key(task, allowed_skills)
+    attempts = context.metadata.setdefault(SKILL_SELECTION_ATTEMPTS_METADATA_KEY, {})
+    if isinstance(attempts, dict) and attempt_key in attempts:
+        attempted = attempts.get(attempt_key)
+        return attempted if isinstance(attempted, dict) else None
+
+    task_id = str(
+        getattr(runtime, "execution_id", None)
+        or getattr(context, "execution_id", None)
+        or ""
+    )
+    selected_skill = await skill_manager.select_skill(
+        task=task,
+        llm=_RuntimeLLMProxy(runtime=runtime, llm=llm) if runtime is not None else llm,
+        tracer=getattr(runtime, "tracer", None),
+        task_id=task_id or None,
+        allowed_skills=allowed_skills,
+    )
+    if not selected_skill:
+        if isinstance(attempts, dict):
+            attempts[attempt_key] = None
+        return None
+
+    selected_summary = {
+        "name": selected_skill.get("name"),
+        "description": selected_skill.get("description"),
+        "when_to_use": selected_skill.get("when_to_use"),
+    }
+    if isinstance(attempts, dict):
+        attempts[attempt_key] = selected_summary
+    context.metadata[SELECTED_SKILL_METADATA_KEY] = selected_summary
+    context.metadata[SKILL_CONTEXT_METADATA_KEY] = build_skill_context(selected_skill)
+    logger.info(
+        "Selected v2 skill %s for execution %s",
+        selected_skill.get("name"),
+        getattr(context, "execution_id", None),
+    )
+    return cast(dict[str, Any], selected_skill)
+
+
+async def generate_and_store_react_memory(
+    *,
+    context: Any,
+    task: str,
+    result: dict[str, Any],
+    iterations: int,
+    llm: Any | None,
+    memory_store: Any | None,
+    runtime: Any | None = None,
+) -> None:
+    """Generate v1-style ReAct memory insights and store valuable memories."""
+
+    if memory_store is None or llm is None or not task.strip():
+        return
+
+    task_id = str(
+        getattr(runtime, "execution_id", None)
+        or getattr(context, "execution_id", None)
+        or ""
+    )
+    step_id = getattr(runtime, "active_react_step_id", None)
+    tracer = getattr(runtime, "tracer", None)
+    output = str(result.get("output") or result.get("response") or "")
+    messages = [
+        message.to_dict()
+        for message in getattr(context, "messages", [])
+        if not getattr(message, "hidden", False)
+    ]
+
+    if tracer is not None and task_id:
+        await trace_memory_generate_start(
+            tracer,
+            task_id,
+            data={
+                "task": task[:200],
+                "iterations": iterations,
+                "result_length": len(output),
+                "messages_count": len(messages),
+                "step_id": step_id,
+            },
+        )
+
+    insights = await _generate_react_memory_insights(
+        task=task,
+        output=output,
+        iterations=iterations,
+        messages=messages,
+        llm=llm,
+    )
+    should_store = bool(insights and insights.get("should_store"))
+    reason = str(insights.get("reason", "") if insights else "")
+
+    if tracer is not None and task_id:
+        await trace_memory_generate_end(
+            tracer,
+            task_id,
+            data={
+                "insights_generated": insights is not None,
+                "should_store": should_store,
+                "reason": reason,
+                "step_id": step_id,
+            },
+        )
+
+    if not should_store:
+        if tracer is not None and task_id:
+            await trace_memory_store_end(
+                tracer,
+                task_id,
+                data={
+                    "storage_success": False,
+                    "decision": "not_worth_storing",
+                    "reason": reason or "No valuable memory insight generated.",
+                    "step_id": step_id,
+                },
+            )
+        return
+
+    if memory_store is None:
+        if tracer is not None and task_id:
+            await trace_memory_store_end(
+                tracer,
+                task_id,
+                data={
+                    "storage_success": False,
+                    "decision": "no_memory_store",
+                    "reason": reason,
+                    "step_id": step_id,
+                },
+            )
+        return
+
+    if tracer is not None and task_id:
+        await trace_memory_store_start(
+            tracer,
+            task_id,
+            data={
+                "task": task[:200],
+                "memory_category": "react_memory",
+                "step_id": step_id,
+            },
+        )
+
+    assert insights is not None
+    memory_id = await asyncio.to_thread(
+        store_react_task_memory,
+        memory_store=memory_store,
+        task=task,
+        result={
+            "success": bool(result.get("success", True)),
+            "output": output,
+            "iterations": iterations,
+            "history": messages[-10:] if len(messages) > 10 else messages,
+        },
+        tool_usage_insights=str(insights.get("tool_usage_insights", "")),
+        reasoning_strategy=str(insights.get("reasoning_strategy", "")),
+        classification={
+            "user_preferences": insights.get("user_preferences", ""),
+            "core_insight": insights.get("core_insight", ""),
+            "failure_patterns": insights.get("failure_patterns", ""),
+            "success_patterns": insights.get("success_patterns", ""),
+        },
+    )
+
+    if tracer is not None and task_id:
+        await trace_memory_store_end(
+            tracer,
+            task_id,
+            data={
+                "storage_success": bool(memory_id),
+                "memory_id": memory_id,
+                "reason": reason,
+                "step_id": step_id,
+            },
+        )
+
+
+def build_skill_context(skill: dict[str, Any]) -> str:
+    name = str(skill.get("name") or "Unnamed Skill")
+    content = str(skill.get("content") or "").strip()
+    if not content:
+        parts = [
+            str(skill.get("description") or "").strip(),
+            str(skill.get("when_to_use") or "").strip(),
+        ]
+        content = "\n\n".join(part for part in parts if part)
+    return f"## Available Skill: {name}\n\n{content}".strip()
+
+
+def latest_user_text(context: Any) -> str:
+    for message in reversed(getattr(context, "messages", []) or []):
+        if getattr(message, "role", None) == "user":
+            return str(getattr(message, "content", "") or "")
+    task = context.metadata.get("task") if hasattr(context, "metadata") else None
+    return str(task or "")
+
+
+async def _generate_react_memory_insights(
+    *,
+    task: str,
+    output: str,
+    iterations: int,
+    messages: list[dict[str, Any]],
+    llm: Any,
+) -> dict[str, Any] | None:
+    analysis_summary = f"""MEMORY STORAGE EVALUATION:
+
+TASK: {task}
+ITERATIONS: {iterations}
+
+RESULT PREVIEW:
+{output[:300]}{"..." if len(output) > 300 else ""}
+
+Evaluate if this execution contains UNIQUE, NON-OBVIOUS insights that would be valuable for FUTURE tasks.
+
+STORE ONLY IF it contains at least one of:
+- Clear user preferences or stable behavior patterns
+- Non-obvious failures and fixes
+- Reusable strategies that are not routine
+- Domain-specific insights hard to obtain otherwise
+
+DO NOT STORE routine task completion, generic tool usage, common facts, or obvious strategies.
+
+Respond with JSON:
+{{
+  "should_store": true/false,
+  "reason": "specific storage or rejection reason",
+  "core_insight": "essential learning if stored",
+  "user_preferences": "observable user preferences",
+  "failure_patterns": "non-obvious failure modes and solutions",
+  "success_patterns": "non-obvious success patterns",
+  "tool_usage_insights": "non-obvious tool usage insight",
+  "reasoning_strategy": "reusable reasoning strategy"
+}}"""
+    working_messages = list(messages)
+    working_messages.append({"role": "user", "content": analysis_summary})
+    try:
+        run_llm_call = getattr(llm, "run_llm_call", None)
+        response = (
+            await run_llm_call(messages=working_messages)
+            if callable(run_llm_call)
+            else await llm.chat(messages=working_messages)
+        )
+        content = (
+            response.get("content", str(response))
+            if isinstance(response, dict)
+            else str(response)
+        )
+        return _parse_json_object(content)
+    except LLMCallInterrupted:
+        raise
+    except Exception:
+        logger.exception("Failed to generate v2 ReAct memory insights")
+        return None
+
+
+def _parse_json_object(content: str) -> dict[str, Any] | None:
+    text = content.strip()
+    if text.startswith("```"):
+        newline_idx = text.find("\n")
+        if newline_idx > 0:
+            text = text[newline_idx:].strip()
+        if text.endswith("```"):
+            text = text[:-3].strip()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _skill_selection_attempt_key(
+    task: str,
+    allowed_skills: list[str] | None,
+) -> str:
+    return json.dumps(
+        {"task": task, "allowed_skills": sorted(allowed_skills or [])},
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _build_memory_context(
+    existing_context: Any,
+    query: str,
+    memories: list[dict[str, Any]],
+) -> str:
+    if not memories:
+        return str(existing_context or "")
+    enhanced = enhance_goal_with_memory(query, memories)
+    context_text = enhanced.replace(query, "", 1).strip()
+    if not context_text:
+        context_text = enhanced
+    if existing_context:
+        existing = str(existing_context)
+        if context_text in existing:
+            return existing
+        return f"{existing}\n\n{context_text}"
+    return context_text
+
+
+def _lookup_relevant_memories_with_context(
+    memory_store: Any,
+    query: str,
+    category: str,
+    include_general: bool,
+    limit: int,
+    similarity_threshold: float | None,
+    user_id: Any | None,
+) -> list[dict[str, Any]]:
+    if user_id is not None:
+        try:
+            token = current_user_id.set(user_id)
+            try:
+                return lookup_relevant_memories(
+                    memory_store,
+                    query,
+                    category,
+                    include_general=include_general,
+                    limit=limit,
+                    similarity_threshold=similarity_threshold,
+                )
+            finally:
+                current_user_id.reset(token)
+        except Exception:
+            logger.exception("Failed to retrieve memories with user context")
+            return []
+
+    return lookup_relevant_memories(
+        memory_store,
+        query,
+        category,
+        include_general=include_general,
+        limit=limit,
+        similarity_threshold=similarity_threshold,
+    )
+
+
+def _current_user_id() -> Any | None:
+    return current_user_id.get()

--- a/src/xagent/core/agent_v2/context/execution.py
+++ b/src/xagent/core/agent_v2/context/execution.py
@@ -1,0 +1,856 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+from .components import (
+    COMPONENT_LOADERS,
+    ExecutionComponent,
+    GenericComponent,
+    MemoryComponent,
+    WorkspaceComponent,
+    clone_component,
+)
+from .enrichment import MEMORY_CONTEXT_METADATA_KEY, SKILL_CONTEXT_METADATA_KEY
+from .message import LLMCallRecord, Message
+
+READ_FILE_CONTEXT_LIMIT = 12_000
+WRITE_FILE_CONTENT_PREVIEW_LIMIT = 400
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class MergeStrategy(str, Enum):
+    """Strategies for merging multiple execution contexts."""
+
+    CHRONOLOGICAL = "chronological"
+    TOPOLOGICAL = "topological"
+    PREFER_FIRST = "prefer_first"
+
+
+@dataclass
+class CompactConfig:
+    """Compaction policy for message history."""
+
+    enabled: bool = True
+    threshold: int = 8000
+    strategy: str = "truncate"
+
+
+@dataclass
+class CompactResult:
+    """Result returned by context compaction."""
+
+    compacted: bool
+    original_count: int
+    final_count: int
+    strategy: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExecutionContext:
+    """Execution state plus pluggable runtime components."""
+
+    execution_id: str = field(default_factory=lambda: str(uuid4()))
+    user_id: str | None = None
+    session_id: str | None = None
+    components: dict[str, ExecutionComponent] = field(default_factory=dict)
+    messages: list[Message] = field(default_factory=list)
+    system_prompt: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utcnow)
+    compact_config: CompactConfig = field(default_factory=CompactConfig)
+    llm_calls: list[LLMCallRecord] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.components.setdefault("workspace", WorkspaceComponent())
+        self.components.setdefault("memory", MemoryComponent())
+
+    def get_component(self, name: str) -> ExecutionComponent | None:
+        return self.components.get(name)
+
+    def set_component(self, name: str, component: ExecutionComponent) -> None:
+        self.components[name] = component
+
+    def _workspace_component(self) -> WorkspaceComponent:
+        component = self.components.get("workspace")
+        if not isinstance(component, WorkspaceComponent):
+            component = WorkspaceComponent()
+            self.components["workspace"] = component
+        return component
+
+    def _memory_component(self) -> MemoryComponent:
+        component = self.components.get("memory")
+        if not isinstance(component, MemoryComponent):
+            component = MemoryComponent()
+            self.components["memory"] = component
+        return component
+
+    @property
+    def workspace_id(self) -> str | None:
+        return self._workspace_component().workspace_id
+
+    @property
+    def workspace_path(self) -> str | None:
+        return self._workspace_component().workspace_path
+
+    @property
+    def cwd(self) -> str | None:
+        return self._workspace_component().cwd
+
+    @property
+    def workspace_state(self) -> dict[str, Any]:
+        return self._workspace_component().state
+
+    @property
+    def memory_session_id(self) -> str | None:
+        return self._memory_component().session_id
+
+    @property
+    def memory_snapshot(self) -> dict[str, Any] | None:
+        return self._memory_component().snapshot
+
+    def add_message(self, role: str, content: str, **kwargs: Any) -> Message:
+        message = Message(role=role, content=content, **kwargs)
+        self.messages.append(message)
+        return message
+
+    def add_user_message(self, content: str, **kwargs: Any) -> Message:
+        return self.add_message("user", content, **kwargs)
+
+    def add_assistant_message(self, content: str, **kwargs: Any) -> Message:
+        if kwargs.get("tool_calls"):
+            kwargs["tool_calls"] = self._sanitize_tool_calls_for_context(
+                kwargs["tool_calls"]
+            )
+        return self.add_message("assistant", content, **kwargs)
+
+    def add_system_message(self, content: str, **kwargs: Any) -> Message:
+        return self.add_message("system", content, **kwargs)
+
+    def add_tool_result(
+        self,
+        tool_name: str,
+        result: Any,
+        tool_call_id: str | None = None,
+    ) -> Message:
+        context_result = self._sanitize_tool_result_for_context(tool_name, result)
+        content = self._format_tool_result(tool_name, context_result)
+        metadata = {
+            "tool_name": tool_name,
+            "raw_result": context_result,
+            "workspace_id": self.workspace_id,
+            "workspace_path": self.workspace_path,
+            "cwd": self.cwd,
+            "memory_session_id": self.memory_session_id,
+        }
+        return self.add_message(
+            "tool",
+            content,
+            tool_call_id=tool_call_id,
+            metadata=metadata,
+        )
+
+    def attach_workspace(
+        self,
+        workspace_id: str | None,
+        workspace_path: str | None,
+        cwd: str | None = None,
+        state: dict[str, Any] | None = None,
+    ) -> None:
+        workspace = self._workspace_component()
+        workspace.workspace_id = workspace_id
+        workspace.workspace_path = workspace_path
+        workspace.cwd = cwd
+        if state:
+            workspace.state.update(state)
+
+    def attach_memory_session(
+        self,
+        session_id: str | None,
+        snapshot: dict[str, Any] | None = None,
+    ) -> None:
+        memory = self._memory_component()
+        memory.session_id = session_id
+        memory.snapshot = snapshot
+
+    def _format_tool_result(self, tool_name: str, result: Any) -> str:
+        if isinstance(result, dict):
+            formatted = result.get("output", result)
+        else:
+            formatted = result
+        return f"Tool {tool_name} returned: {formatted}"
+
+    def _sanitize_tool_result_for_context(self, tool_name: str, result: Any) -> Any:
+        if tool_name != "read_file" or not isinstance(result, str):
+            return result
+        if self._looks_like_binary_text(result):
+            return {
+                "content_omitted": True,
+                "reason": "read_file returned binary-like content",
+                "original_chars": len(result),
+            }
+        if len(result) <= READ_FILE_CONTEXT_LIMIT:
+            return result
+        return {
+            "content_preview": result[:READ_FILE_CONTEXT_LIMIT],
+            "content_truncated": True,
+            "original_chars": len(result),
+        }
+
+    def _sanitize_tool_calls_for_context(
+        self, tool_calls: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        sanitized: list[dict[str, Any]] = []
+        for tool_call in tool_calls:
+            copied = dict(tool_call)
+            function = copied.get("function")
+            if isinstance(function, dict):
+                function_copy = dict(function)
+                if function_copy.get("name") == "write_file":
+                    function_copy["arguments"] = self._sanitize_write_file_arguments(
+                        function_copy.get("arguments")
+                    )
+                copied["function"] = function_copy
+            elif copied.get("name") == "write_file" and isinstance(
+                copied.get("args"), dict
+            ):
+                copied["args"] = self._sanitize_write_file_args_dict(copied["args"])
+            sanitized.append(copied)
+        return sanitized
+
+    def _sanitize_write_file_arguments(self, arguments: Any) -> Any:
+        if not isinstance(arguments, str):
+            return arguments
+        try:
+            parsed = json.loads(arguments)
+        except (TypeError, ValueError):
+            return arguments
+        if not isinstance(parsed, dict):
+            return arguments
+        return json.dumps(
+            self._sanitize_write_file_args_dict(parsed),
+            ensure_ascii=False,
+        )
+
+    def _sanitize_write_file_args_dict(self, args: dict[str, Any]) -> dict[str, Any]:
+        sanitized = dict(args)
+        content = sanitized.get("content")
+        if not isinstance(content, str):
+            return sanitized
+        sanitized["content"] = (
+            f"[omitted from LLM context: write_file content, {len(content)} chars]"
+        )
+        if content:
+            sanitized["content_preview"] = content[:WRITE_FILE_CONTENT_PREVIEW_LIMIT]
+            sanitized["content_truncated"] = (
+                len(content) > WRITE_FILE_CONTENT_PREVIEW_LIMIT
+            )
+        return sanitized
+
+    def _looks_like_binary_text(self, value: str) -> bool:
+        if "\x00" in value:
+            return True
+        sample = value[:4096]
+        if not sample:
+            return False
+        allowed_controls = {"\n", "\r", "\t"}
+        control_count = sum(
+            1 for char in sample if ord(char) < 32 and char not in allowed_controls
+        )
+        return control_count / len(sample) > 0.05
+
+    def get_messages_for_llm(
+        self,
+        include_system: bool = True,
+        max_tokens: int | None = None,
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        system_parts: list[str] = []
+        if include_system and self.system_prompt:
+            system_parts.append(self.system_prompt)
+        if include_system:
+            system_parts.append(self._system_context())
+
+        visible_messages = [message for message in self.messages if not message.hidden]
+        if max_tokens:
+            visible_messages = self._truncate_by_tokens(visible_messages, max_tokens)
+        visible_messages = self._sanitize_tool_message_pairs(visible_messages)
+
+        for message in visible_messages:
+            message_dict = message.to_dict()
+            waiting_response = message.metadata.get("response_to_waiting_for_user")
+            if message_dict.get("role") == "user" and isinstance(
+                waiting_response, dict
+            ):
+                question = str(waiting_response.get("question") or "").strip()
+                answer = str(message_dict.get("content") or "").strip()
+                message_dict["content"] = (
+                    "This user message is the answer to a pending agent question. "
+                    "Treat it as the response to that pending question, not as a new "
+                    "independent task.\n"
+                    f"Pending question: {question}\n"
+                    f"User answer: {answer}"
+                )
+            if include_system and message_dict.get("role") == "system":
+                content = str(message_dict.get("content") or "").strip()
+                if content:
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                "Previous system-context message retained for "
+                                "continuity. Current system instructions above "
+                                "take precedence:\n"
+                                f"{content}"
+                            ),
+                        }
+                    )
+                continue
+            messages.append(message_dict)
+
+        if include_system:
+            system_content = "\n\n".join(
+                part.strip() for part in system_parts if part.strip()
+            )
+            if system_content:
+                messages.insert(0, {"role": "system", "content": system_content})
+        return messages
+
+    def _current_time_context(self) -> str:
+        current_time = _utcnow()
+        return (
+            "Current date and time: "
+            f"{current_time.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
+            "Use this as the reference for relative dates such as today, recent, "
+            "latest, yesterday, and tomorrow."
+        )
+
+    def _system_context(self) -> str:
+        parts = [self._current_time_context()]
+        memory_context = self.metadata.get(MEMORY_CONTEXT_METADATA_KEY)
+        if memory_context:
+            parts.append(
+                "Relevant memories from previous tasks:\n"
+                f"{str(memory_context).strip()}\n\n"
+                "Memory usage rules: treat memory as auxiliary context, not as "
+                "the current user instruction and not as sufficient evidence for "
+                "new factual claims. Memory may inform preferences, prior attempts, "
+                "known leads, and failure patterns. For requests that depend on "
+                "recent, latest, current, public, source-backed, or otherwise "
+                "verifiable facts, use memory only as search or reasoning leads; "
+                "verify with available current context, files, knowledge-base "
+                "results, or tools before answering. Do not ask the user whether "
+                "to use memory or whether to search; decide the appropriate "
+                "execution strategy yourself."
+            )
+        skill_context = self.metadata.get(SKILL_CONTEXT_METADATA_KEY)
+        if skill_context:
+            parts.append(
+                "Selected skill guidance. Use it when relevant to the current task:\n"
+                f"{str(skill_context).strip()}"
+            )
+        return "\n\n".join(part for part in parts if part.strip())
+
+    def get_recent_messages(self, n: int = 10) -> list[Message]:
+        if n <= 0:
+            return self.messages[:]
+        return self.messages[-n:]
+
+    def get_messages_by_role(self, role: str) -> list[Message]:
+        return [message for message in self.messages if message.role == role]
+
+    def record_llm_call(
+        self,
+        response_message: Message,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> Message:
+        updated_response = Message(
+            role=response_message.role,
+            content=response_message.content,
+            timestamp=response_message.timestamp,
+            metadata=response_message.metadata,
+            tool_calls=response_message.tool_calls,
+            tool_call_id=response_message.tool_call_id,
+            hidden=response_message.hidden,
+            output_tokens=output_tokens,
+        )
+        self.messages.append(updated_response)
+        self.llm_calls.append(
+            LLMCallRecord(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+                message_index=len(self.messages) - 1,
+                prompt_message_count=max(0, len(self.messages) - 1),
+                prompt_content_chars=self._message_content_chars(
+                    self.messages[: max(0, len(self.messages) - 1)]
+                ),
+            )
+        )
+        return updated_response
+
+    def record_llm_usage(
+        self,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        prompt_message_count: int | None = None,
+    ) -> None:
+        """Record provider usage for an LLM call without appending a message."""
+
+        if input_tokens <= 0 and output_tokens <= 0:
+            return
+
+        if prompt_message_count is None:
+            prompt_message_count = len(self.messages)
+        prompt_message_count = max(0, min(prompt_message_count, len(self.messages)))
+        self.llm_calls.append(
+            LLMCallRecord(
+                input_tokens=max(0, input_tokens),
+                output_tokens=max(0, output_tokens),
+                total_tokens=max(0, input_tokens) + max(0, output_tokens),
+                message_index=max(0, prompt_message_count - 1),
+                prompt_message_count=prompt_message_count,
+                prompt_content_chars=self._message_content_chars(
+                    self.messages[:prompt_message_count]
+                ),
+            )
+        )
+
+    def get_total_token_usage(self) -> dict[str, int]:
+        total_input = sum(call.input_tokens for call in self.llm_calls)
+        total_output = sum(call.output_tokens for call in self.llm_calls)
+        return {
+            "total": total_input + total_output,
+            "input": total_input,
+            "output": total_output,
+            "call_count": len(self.llm_calls),
+        }
+
+    def extend_with_messages(self, messages: list[Message]) -> None:
+        existing: dict[Message, Message] = {
+            message: message for message in self.messages
+        }
+        for message in messages:
+            existing[message] = message
+        self.messages = list(existing.values())
+
+    @classmethod
+    def merge_contexts(
+        cls,
+        contexts: list["ExecutionContext"],
+        strategy: MergeStrategy = MergeStrategy.CHRONOLOGICAL,
+    ) -> "ExecutionContext":
+        if not contexts:
+            return cls()
+
+        base = contexts[0]
+        merged = cls(
+            execution_id=f"{base.execution_id}_merged_{uuid4().hex[:8]}",
+            user_id=base.user_id,
+            session_id=base.session_id,
+            components={
+                name: clone_component(component)
+                for name, component in base.components.items()
+            },
+            system_prompt=base.system_prompt,
+            metadata=dict(base.metadata),
+            compact_config=replace(base.compact_config),
+        )
+        merged.messages = base.messages.copy()
+        merged.llm_calls = [replace(call) for call in base.llm_calls]
+        merged._merge_contexts_from_list(contexts, strategy)
+        return merged
+
+    def _merge_contexts_from_list(
+        self,
+        contexts: list["ExecutionContext"],
+        strategy: MergeStrategy,
+    ) -> None:
+        if not contexts:
+            self.messages = []
+            self.llm_calls = []
+            return
+
+        if strategy == MergeStrategy.CHRONOLOGICAL:
+            messages_with_source: list[tuple[Message, datetime]] = []
+            for context in contexts:
+                for message in context.messages:
+                    messages_with_source.append((message, message.timestamp))
+            messages_with_source.sort(key=lambda item: item[1])
+            self._merge_messages_dedup(messages_with_source)
+        elif strategy == MergeStrategy.TOPOLOGICAL:
+            self.messages = []
+            for context in contexts:
+                self.extend_with_messages(context.messages)
+        elif strategy == MergeStrategy.PREFER_FIRST:
+            seen: set[Message] = set()
+            ordered: list[Message] = []
+            for context in contexts:
+                for message in context.messages:
+                    if message not in seen:
+                        seen.add(message)
+                        ordered.append(message)
+            self.messages = ordered
+        else:
+            self.messages = []
+
+        self._merge_llm_calls(contexts)
+
+    def _merge_messages_dedup(
+        self, messages_with_source: list[tuple[Message, datetime]]
+    ) -> None:
+        seen: dict[Message, Message] = {}
+        ordered: list[Message] = []
+        for message, _ in messages_with_source:
+            if message in seen:
+                continue
+            seen[message] = message
+            ordered.append(message)
+        self.messages = ordered
+
+    def _merge_llm_calls(self, contexts: list["ExecutionContext"]) -> None:
+        if not contexts:
+            return
+
+        message_index_map = {message: idx for idx, message in enumerate(self.messages)}
+        merged_calls: list[LLMCallRecord] = []
+        for context in contexts:
+            for call in context.llm_calls:
+                new_index = call.message_index
+                if 0 <= call.message_index < len(context.messages):
+                    original_message = context.messages[call.message_index]
+                    new_index = message_index_map.get(original_message, new_index)
+
+                merged_calls.append(
+                    LLMCallRecord(
+                        input_tokens=call.input_tokens,
+                        output_tokens=call.output_tokens,
+                        total_tokens=call.total_tokens,
+                        message_index=new_index,
+                        prompt_message_count=call.prompt_message_count,
+                        prompt_content_chars=call.prompt_content_chars,
+                        timestamp=call.timestamp,
+                    )
+                )
+        self.llm_calls = merged_calls
+
+    def create_child_context(
+        self,
+        execution_id: str | None = None,
+        task: str | None = None,
+        include_system_prompt: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> "ExecutionContext":
+        child_metadata = dict(self.metadata)
+        if metadata:
+            child_metadata.update(metadata)
+        if task:
+            child_metadata["task"] = task
+
+        child = ExecutionContext(
+            execution_id=execution_id or f"{self.execution_id}_child_{uuid4().hex[:8]}",
+            user_id=self.user_id,
+            session_id=self.session_id,
+            components={
+                name: clone_component(component)
+                for name, component in self.components.items()
+            },
+            messages=self.messages.copy(),
+            system_prompt=self.system_prompt if include_system_prompt else None,
+            metadata=child_metadata,
+            compact_config=replace(self.compact_config),
+            llm_calls=[replace(call) for call in self.llm_calls],
+        )
+        if task:
+            child.add_user_message(task)
+        return child
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "execution_id": self.execution_id,
+            "user_id": self.user_id,
+            "session_id": self.session_id,
+            "components": {
+                name: component.to_dict() for name, component in self.components.items()
+            },
+            "messages": [
+                {
+                    "role": message.role,
+                    "content": message.content,
+                    "timestamp": message.timestamp.isoformat(),
+                    "metadata": message.metadata,
+                    "tool_calls": message.tool_calls,
+                    "tool_call_id": message.tool_call_id,
+                    "hidden": message.hidden,
+                    "output_tokens": message.output_tokens,
+                }
+                for message in self.messages
+            ],
+            "system_prompt": self.system_prompt,
+            "metadata": self.metadata,
+            "created_at": self.created_at.isoformat(),
+            "llm_calls": [
+                {
+                    "input_tokens": call.input_tokens,
+                    "output_tokens": call.output_tokens,
+                    "total_tokens": call.total_tokens,
+                    "message_index": call.message_index,
+                    "prompt_message_count": call.prompt_message_count,
+                    "prompt_content_chars": call.prompt_content_chars,
+                    "timestamp": call.timestamp.isoformat(),
+                }
+                for call in self.llm_calls
+            ],
+            "compact_config": {
+                "enabled": self.compact_config.enabled,
+                "threshold": self.compact_config.threshold,
+                "strategy": self.compact_config.strategy,
+            },
+            # Backward compatibility for older serialized payloads.
+            "workspace_id": self.workspace_id,
+            "workspace_path": self.workspace_path,
+            "cwd": self.cwd,
+            "workspace_state": self.workspace_state,
+            "memory_session_id": self.memory_session_id,
+            "memory_snapshot": self.memory_snapshot,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExecutionContext":
+        messages = [
+            Message(
+                role=item["role"],
+                content=item["content"],
+                timestamp=datetime.fromisoformat(item["timestamp"]),
+                metadata=item.get("metadata", {}),
+                tool_calls=item.get("tool_calls"),
+                tool_call_id=item.get("tool_call_id"),
+                hidden=item.get("hidden", False),
+                output_tokens=item.get("output_tokens"),
+            )
+            for item in data.get("messages", [])
+        ]
+        llm_calls = [
+            LLMCallRecord(
+                input_tokens=call["input_tokens"],
+                output_tokens=call["output_tokens"],
+                total_tokens=call["total_tokens"],
+                message_index=call["message_index"],
+                prompt_message_count=call.get("prompt_message_count"),
+                prompt_content_chars=call.get("prompt_content_chars"),
+                timestamp=datetime.fromisoformat(call["timestamp"]),
+            )
+            for call in data.get("llm_calls", [])
+        ]
+        compact = data.get("compact_config", {})
+        compact_config = CompactConfig(
+            enabled=compact.get("enabled", True),
+            threshold=compact.get("threshold", 8000),
+            strategy=compact.get("strategy", "truncate"),
+        )
+        created_at = (
+            datetime.fromisoformat(data["created_at"])
+            if data.get("created_at")
+            else _utcnow()
+        )
+
+        components_payload = data.get("components", {})
+        components: dict[str, ExecutionComponent] = {}
+        for name, payload in components_payload.items():
+            loader = COMPONENT_LOADERS.get(name)
+            if loader:
+                components[name] = loader(payload)
+            else:
+                components[name] = GenericComponent(data=payload)
+
+        context = cls(
+            execution_id=data.get("execution_id", str(uuid4())),
+            user_id=data.get("user_id"),
+            session_id=data.get("session_id"),
+            components=components,
+            messages=messages,
+            system_prompt=data.get("system_prompt"),
+            metadata=data.get("metadata", {}),
+            created_at=created_at,
+            llm_calls=llm_calls,
+            compact_config=compact_config,
+        )
+
+        if not components_payload:
+            if any(
+                data.get(key) is not None
+                for key in ("workspace_id", "workspace_path", "cwd", "workspace_state")
+            ):
+                context.attach_workspace(
+                    workspace_id=data.get("workspace_id"),
+                    workspace_path=data.get("workspace_path"),
+                    cwd=data.get("cwd"),
+                    state=data.get("workspace_state"),
+                )
+            if data.get("memory_session_id") or data.get("memory_snapshot") is not None:
+                context.attach_memory_session(
+                    session_id=data.get("memory_session_id"),
+                    snapshot=data.get("memory_snapshot"),
+                )
+
+        return context
+
+    def compact_if_needed(self, llm: Any = None) -> CompactResult:
+        if not self.compact_config.enabled:
+            return CompactResult(
+                compacted=False,
+                original_count=len(self.messages),
+                final_count=len(self.messages),
+                strategy="none",
+            )
+
+        total_tokens = self._get_total_tokens()
+        if total_tokens > self.compact_config.threshold:
+            result = self._compact(llm)
+            result.metadata.setdefault("original_tokens", total_tokens)
+            result.metadata.setdefault("threshold", self.compact_config.threshold)
+            return result
+
+        return CompactResult(
+            compacted=False,
+            original_count=len(self.messages),
+            final_count=len(self.messages),
+            strategy="none",
+        )
+
+    def _compact(self, llm: Any = None) -> CompactResult:
+        original_count = len(self.messages)
+        if self.compact_config.strategy == "truncate":
+            keep_count = min(20, original_count)
+            self.messages = self._tail_window_preserving_tool_pairs(keep_count)
+            removed = max(0, original_count - len(self.messages))
+            return CompactResult(
+                compacted=True,
+                original_count=original_count,
+                final_count=len(self.messages),
+                strategy="truncate",
+                metadata={"removed_count": removed},
+            )
+
+        return CompactResult(
+            compacted=False,
+            original_count=original_count,
+            final_count=len(self.messages),
+            strategy="none",
+        )
+
+    def _get_total_tokens(self) -> int:
+        if self.llm_calls:
+            latest_call = self.llm_calls[-1]
+            if latest_call.input_tokens > 0:
+                prompt_message_count = latest_call.prompt_message_count
+                prompt_content_chars = latest_call.prompt_content_chars
+                if (
+                    prompt_message_count is not None
+                    and prompt_content_chars is not None
+                    and 0 <= prompt_message_count <= len(self.messages)
+                    and self._message_content_chars(
+                        self.messages[:prompt_message_count]
+                    )
+                    == prompt_content_chars
+                ):
+                    delta_chars = self._message_content_chars(
+                        self.messages[prompt_message_count:]
+                    )
+                    return latest_call.input_tokens + max(0, delta_chars // 4)
+        return self._estimate_message_tokens(self.messages)
+
+    def _estimate_message_tokens(self, messages: list[Message]) -> int:
+        return sum(max(1, len(message.content) // 4) for message in messages)
+
+    def _message_content_chars(self, messages: list[Message]) -> int:
+        return sum(len(message.content) for message in messages)
+
+    def _tail_window_preserving_tool_pairs(self, keep_count: int) -> list[Message]:
+        """Keep recent messages without cutting a native tool-call exchange."""
+
+        if keep_count <= 0:
+            return []
+
+        start = max(0, len(self.messages) - keep_count)
+        while start > 0 and self.messages[start].role == "tool":
+            start -= 1
+
+        return self._sanitize_tool_message_pairs(self.messages[start:])
+
+    def _sanitize_tool_message_pairs(self, messages: list[Message]) -> list[Message]:
+        """Drop native tool protocol fragments that providers reject.
+
+        OpenAI-style chat requires every ``tool`` message to immediately follow an
+        assistant message that declared the corresponding ``tool_calls``. Context
+        compaction and token truncation must therefore treat an assistant tool-call
+        message and its tool results as an atomic block.
+        """
+
+        sanitized: list[Message] = []
+        index = 0
+        while index < len(messages):
+            message = messages[index]
+            if message.role != "assistant" or not message.tool_calls:
+                if message.role != "tool":
+                    sanitized.append(message)
+                index += 1
+                continue
+
+            tool_messages: list[Message] = []
+            next_index = index + 1
+            while next_index < len(messages) and messages[next_index].role == "tool":
+                tool_messages.append(messages[next_index])
+                next_index += 1
+
+            expected_ids = {
+                str(tool_call.get("id"))
+                for tool_call in message.tool_calls
+                if isinstance(tool_call, dict) and tool_call.get("id")
+            }
+            received_ids = {
+                str(tool_message.tool_call_id)
+                for tool_message in tool_messages
+                if tool_message.tool_call_id
+            }
+            if expected_ids and expected_ids.issubset(received_ids):
+                sanitized.append(message)
+                sanitized.extend(tool_messages)
+
+            index = next_index
+
+        return sanitized
+
+    def _truncate_by_tokens(
+        self,
+        messages: list[Message],
+        max_tokens: int,
+    ) -> list[Message]:
+        current_tokens = 0
+        start = len(messages)
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if message.role == "assistant" and message.output_tokens is not None:
+                message_tokens = message.output_tokens
+            else:
+                message_tokens = max(1, len(message.content) // 4)
+
+            if current_tokens + message_tokens > max_tokens:
+                break
+            start = index
+            current_tokens += message_tokens
+
+        while start > 0 and messages[start].role == "tool":
+            start -= 1
+
+        return self._sanitize_tool_message_pairs(messages[start:])

--- a/src/xagent/core/agent_v2/context/execution.py
+++ b/src/xagent/core/agent_v2/context/execution.py
@@ -465,9 +465,9 @@ class ExecutionContext:
             },
             system_prompt=base.system_prompt,
             metadata=dict(base.metadata),
+            created_at=base.created_at,
             compact_config=replace(base.compact_config),
         )
-        merged.messages = base.messages.copy()
         merged.llm_calls = [replace(call) for call in base.llm_calls]
         merged._merge_contexts_from_list(contexts, strategy)
         return merged
@@ -827,6 +827,9 @@ class ExecutionContext:
                 if tool_message.tool_call_id
             }
             if expected_ids and expected_ids.issubset(received_ids):
+                sanitized.append(message)
+                sanitized.extend(tool_messages)
+            elif not expected_ids and len(tool_messages) >= len(message.tool_calls):
                 sanitized.append(message)
                 sanitized.extend(tool_messages)
 

--- a/src/xagent/core/agent_v2/context/execution.py
+++ b/src/xagent/core/agent_v2/context/execution.py
@@ -41,6 +41,7 @@ class CompactConfig:
     enabled: bool = True
     threshold: int = 8000
     strategy: str = "truncate"
+    max_messages: int = 20
 
 
 @dataclass
@@ -615,6 +616,7 @@ class ExecutionContext:
                 "enabled": self.compact_config.enabled,
                 "threshold": self.compact_config.threshold,
                 "strategy": self.compact_config.strategy,
+                "max_messages": self.compact_config.max_messages,
             },
             # Backward compatibility for older serialized payloads.
             "workspace_id": self.workspace_id,
@@ -657,6 +659,7 @@ class ExecutionContext:
             enabled=compact.get("enabled", True),
             threshold=compact.get("threshold", 8000),
             strategy=compact.get("strategy", "truncate"),
+            max_messages=compact.get("max_messages", 20),
         )
         created_at = (
             datetime.fromisoformat(data["created_at"])
@@ -731,7 +734,7 @@ class ExecutionContext:
     def _compact(self, llm: Any = None) -> CompactResult:
         original_count = len(self.messages)
         if self.compact_config.strategy == "truncate":
-            keep_count = min(20, original_count)
+            keep_count = min(max(0, self.compact_config.max_messages), original_count)
             self.messages = self._tail_window_preserving_tool_pairs(keep_count)
             removed = max(0, original_count - len(self.messages))
             return CompactResult(

--- a/src/xagent/core/agent_v2/context/manager.py
+++ b/src/xagent/core/agent_v2/context/manager.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
+import logging
+import threading
 from typing import Any
 
 from .execution import ExecutionContext
+
+logger = logging.getLogger(__name__)
 
 
 class ContextManager:
     """Singleton registry for active execution contexts."""
 
     _instance: "ContextManager" | None = None
+    _instance_lock = threading.Lock()
     _contexts: dict[str, ExecutionContext]
+    _lock: threading.RLock
 
     def __new__(cls) -> "ContextManager":
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._instance._contexts = {}
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._contexts = {}
+                cls._instance._lock = threading.RLock()
         return cls._instance
 
     def create_context(
@@ -52,22 +60,35 @@ class ContextManager:
                 session_id=memory_session_id,
                 snapshot=memory_snapshot,
             )
-        self._contexts[execution_id] = context
+        with self._lock:
+            if execution_id in self._contexts:
+                logger.warning("Replacing existing execution context %s", execution_id)
+            self._contexts[execution_id] = context
         return context
 
     def get_context(self, execution_id: str) -> ExecutionContext | None:
-        return self._contexts.get(execution_id)
+        with self._lock:
+            return self._contexts.get(execution_id)
 
     def set_context(self, context: ExecutionContext) -> ExecutionContext:
-        self._contexts[context.execution_id] = context
+        with self._lock:
+            if context.execution_id in self._contexts:
+                logger.warning(
+                    "Replacing existing execution context %s",
+                    context.execution_id,
+                )
+            self._contexts[context.execution_id] = context
         return context
 
     def remove_context(self, execution_id: str) -> None:
-        self._contexts.pop(execution_id, None)
+        with self._lock:
+            self._contexts.pop(execution_id, None)
 
     def list_active_contexts(
         self, user_id: str | None = None
     ) -> list[ExecutionContext]:
+        with self._lock:
+            contexts = list(self._contexts.values())
         if user_id:
-            return [ctx for ctx in self._contexts.values() if ctx.user_id == user_id]
-        return list(self._contexts.values())
+            return [ctx for ctx in contexts if ctx.user_id == user_id]
+        return contexts

--- a/src/xagent/core/agent_v2/context/manager.py
+++ b/src/xagent/core/agent_v2/context/manager.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .execution import ExecutionContext
+
+
+class ContextManager:
+    """Singleton registry for active execution contexts."""
+
+    _instance: "ContextManager" | None = None
+    _contexts: dict[str, ExecutionContext]
+
+    def __new__(cls) -> "ContextManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._contexts = {}
+        return cls._instance
+
+    def create_context(
+        self,
+        execution_id: str,
+        user_id: str | None = None,
+        session_id: str | None = None,
+        system_prompt: str | None = None,
+        *,
+        workspace_id: str | None = None,
+        workspace_path: str | None = None,
+        cwd: str | None = None,
+        workspace_state: dict[str, Any] | None = None,
+        memory_session_id: str | None = None,
+        memory_snapshot: dict[str, Any] | None = None,
+    ) -> ExecutionContext:
+        context = ExecutionContext(
+            execution_id=execution_id,
+            user_id=user_id,
+            session_id=session_id,
+            system_prompt=system_prompt,
+        )
+        if any(
+            value is not None
+            for value in (workspace_id, workspace_path, cwd, workspace_state)
+        ):
+            context.attach_workspace(
+                workspace_id=workspace_id,
+                workspace_path=workspace_path,
+                cwd=cwd,
+                state=workspace_state,
+            )
+        if memory_session_id or memory_snapshot is not None:
+            context.attach_memory_session(
+                session_id=memory_session_id,
+                snapshot=memory_snapshot,
+            )
+        self._contexts[execution_id] = context
+        return context
+
+    def get_context(self, execution_id: str) -> ExecutionContext | None:
+        return self._contexts.get(execution_id)
+
+    def set_context(self, context: ExecutionContext) -> ExecutionContext:
+        self._contexts[context.execution_id] = context
+        return context
+
+    def remove_context(self, execution_id: str) -> None:
+        self._contexts.pop(execution_id, None)
+
+    def list_active_contexts(
+        self, user_id: str | None = None
+    ) -> list[ExecutionContext]:
+        if user_id:
+            return [ctx for ctx in self._contexts.values() if ctx.user_id == user_id]
+        return list(self._contexts.values())

--- a/src/xagent/core/agent_v2/context/message.py
+++ b/src/xagent/core/agent_v2/context/message.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class Message:
+    """Unified message format with content-based deduplication."""
+
+    role: str
+    content: str
+    timestamp: datetime = field(default_factory=_utcnow)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    tool_calls: list[dict[str, Any]] | None = None
+    tool_call_id: str | None = None
+    hidden: bool = False
+    output_tokens: int | None = None
+
+    @classmethod
+    def role_system(cls, content: str, **kwargs: Any) -> "Message":
+        return cls(role="system", content=content, **kwargs)
+
+    @classmethod
+    def role_user(cls, content: str, **kwargs: Any) -> "Message":
+        return cls(role="user", content=content, **kwargs)
+
+    @classmethod
+    def role_assistant(cls, content: str, **kwargs: Any) -> "Message":
+        return cls(role="assistant", content=content, **kwargs)
+
+    @classmethod
+    def role_tool(cls, content: str, **kwargs: Any) -> "Message":
+        return cls(role="tool", content=content, **kwargs)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"role": self.role, "content": self.content}
+        if self.tool_calls:
+            result["tool_calls"] = self.tool_calls
+        if self.tool_call_id:
+            result["tool_call_id"] = self.tool_call_id
+        if self.hidden:
+            result["hidden"] = True
+        return result
+
+    def __hash__(self) -> int:
+        return hash((self.role, self.content))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Message):
+            return False
+        return (self.role, self.content) == (other.role, other.content)
+
+
+@dataclass
+class LLMCallRecord:
+    """Tracks token usage for a single LLM call."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    message_index: int
+    prompt_message_count: int | None = None
+    prompt_content_chars: int | None = None
+    timestamp: datetime = field(default_factory=_utcnow)

--- a/src/xagent/core/agent_v2/context/message.py
+++ b/src/xagent/core/agent_v2/context/message.py
@@ -49,12 +49,20 @@ class Message:
         return result
 
     def __hash__(self) -> int:
-        return hash((self.role, self.content))
+        return hash(self._identity_key())
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Message):
             return False
-        return (self.role, self.content) == (other.role, other.content)
+        return self._identity_key() == other._identity_key()
+
+    def _identity_key(self) -> tuple[Any, ...]:
+        tool_call_ids = tuple(
+            tool_call.get("id")
+            for tool_call in self.tool_calls or []
+            if isinstance(tool_call, dict)
+        )
+        return (self.role, self.content, tool_call_ids, self.tool_call_id)
 
 
 @dataclass

--- a/src/xagent/core/agent_v2/frame.py
+++ b/src/xagent/core/agent_v2/frame.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class ExecutionStatus(str, Enum):
+    RUNNING = "running"
+    PAUSED = "paused"
+    WAITING_FOR_USER = "waiting_for_user"
+    INTERRUPTED = "interrupted"
+    REPLANNING = "replanning"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _status_value(status: ExecutionStatus | str) -> str:
+    return status.value if isinstance(status, ExecutionStatus) else str(status)
+
+
+@dataclass
+class ExecutionFrame:
+    frame_id: str
+    root_execution_id: str
+    pattern_type: str
+    status: ExecutionStatus | str
+    context: dict[str, Any]
+    pattern_state: dict[str, Any]
+    parent_frame_id: str | None = None
+    children: list[str] = field(default_factory=list)
+    active_child_id: str | None = None
+    tool_calls: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "frame_id": self.frame_id,
+            "parent_frame_id": self.parent_frame_id,
+            "root_execution_id": self.root_execution_id,
+            "pattern_type": self.pattern_type,
+            "status": _status_value(self.status),
+            "context": dict(self.context),
+            "pattern_state": dict(self.pattern_state),
+            "children": list(self.children),
+            "active_child_id": self.active_child_id,
+            "tool_calls": dict(self.tool_calls),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExecutionFrame":
+        return cls(
+            frame_id=str(data["frame_id"]),
+            parent_frame_id=data.get("parent_frame_id"),
+            root_execution_id=str(data["root_execution_id"]),
+            pattern_type=str(data["pattern_type"]),
+            status=str(data["status"]),
+            context=dict(data.get("context", {})),
+            pattern_state=dict(data.get("pattern_state", {})),
+            children=list(data.get("children", [])),
+            active_child_id=data.get("active_child_id"),
+            tool_calls=dict(data.get("tool_calls", {})),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+@dataclass
+class ExecutionSnapshot:
+    root_execution_id: str
+    status: ExecutionStatus | str
+    frames: dict[str, ExecutionFrame]
+    active_frame_ids: list[str] = field(default_factory=list)
+    control_state: dict[str, Any] = field(default_factory=dict)
+    updated_at: datetime = field(default_factory=_utcnow)
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "root_execution_id": self.root_execution_id,
+            "status": _status_value(self.status),
+            "frames": {
+                frame_id: frame.to_dict() for frame_id, frame in self.frames.items()
+            },
+            "active_frame_ids": list(self.active_frame_ids),
+            "control_state": dict(self.control_state),
+            "updated_at": self.updated_at.isoformat(),
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExecutionSnapshot":
+        return cls(
+            root_execution_id=str(data["root_execution_id"]),
+            status=str(data["status"]),
+            frames={
+                frame_id: ExecutionFrame.from_dict(frame)
+                for frame_id, frame in data.get("frames", {}).items()
+            },
+            active_frame_ids=list(data.get("active_frame_ids", [])),
+            control_state=dict(data.get("control_state", {})),
+            updated_at=datetime.fromisoformat(data["updated_at"])
+            if data.get("updated_at")
+            else _utcnow(),
+            schema_version=int(data.get("schema_version", 1)),
+        )

--- a/src/xagent/core/agent_v2/frame.py
+++ b/src/xagent/core/agent_v2/frame.py
@@ -96,13 +96,16 @@ class ExecutionSnapshot:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ExecutionSnapshot":
+        frames: dict[str, ExecutionFrame] = {}
+        for frame_id, frame_payload in data.get("frames", {}).items():
+            frame = ExecutionFrame.from_dict(frame_payload)
+            if frame.frame_id != frame_id:
+                raise ValueError(f"Frame key mismatch: {frame_id} vs {frame.frame_id}")
+            frames[frame_id] = frame
         return cls(
             root_execution_id=str(data["root_execution_id"]),
             status=str(data["status"]),
-            frames={
-                frame_id: ExecutionFrame.from_dict(frame)
-                for frame_id, frame in data.get("frames", {}).items()
-            },
+            frames=frames,
             active_frame_ids=list(data.get("active_frame_ids", [])),
             control_state=dict(data.get("control_state", {})),
             updated_at=datetime.fromisoformat(data["updated_at"])

--- a/src/xagent/core/agent_v2/registry.py
+++ b/src/xagent/core/agent_v2/registry.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Callable
+
+from .context import ExecutionContext
+
+if TYPE_CHECKING:
+    from .runner import AgentRunner
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ExecutionLifecycleStatus(str, Enum):
+    """Lifecycle states exposed to callers of the execution registry."""
+
+    REGISTERED = "registered"
+    RUNNING = "running"
+    INTERRUPTED = "interrupted"
+    WAITING_FOR_USER = "waiting_for_user"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class ExecutionHandle:
+    """Live execution handle stored by the registry."""
+
+    execution_id: str
+    runner: "AgentRunner"
+    task: asyncio.Task[dict[str, Any]] | None = None
+    requested_task: str | None = None
+    status: ExecutionLifecycleStatus = ExecutionLifecycleStatus.REGISTERED
+    metadata: dict[str, Any] = field(default_factory=dict)
+    last_result: dict[str, Any] | None = None
+    last_error: str | None = None
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
+
+    @property
+    def is_running(self) -> bool:
+        return self.task is not None and not self.task.done()
+
+    @property
+    def is_resumable(self) -> bool:
+        return self.status in {
+            ExecutionLifecycleStatus.INTERRUPTED,
+            ExecutionLifecycleStatus.WAITING_FOR_USER,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "execution_id": self.execution_id,
+            "requested_task": self.requested_task,
+            "status": self.status.value,
+            "is_running": self.is_running,
+            "is_resumable": self.is_resumable,
+            "metadata": dict(self.metadata),
+            "last_error": self.last_error,
+            "has_result": self.last_result is not None,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+
+class ExecutionRegistry:
+    """Tracks active execution handles and routes control operations."""
+
+    def __init__(self) -> None:
+        self._handles: dict[str, ExecutionHandle] = {}
+        self._subscribers: dict[int, Callable[[dict[str, Any]], Any]] = {}
+        self._next_subscription_id = 1
+
+    def subscribe(self, callback: Callable[[dict[str, Any]], Any]) -> int:
+        subscription_id = self._next_subscription_id
+        self._next_subscription_id += 1
+        self._subscribers[subscription_id] = callback
+        return subscription_id
+
+    def unsubscribe(self, subscription_id: int) -> bool:
+        return self._subscribers.pop(subscription_id, None) is not None
+
+    def register(
+        self,
+        execution_id: str,
+        runner: "AgentRunner",
+        *,
+        task: asyncio.Task[dict[str, Any]] | None = None,
+        requested_task: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ExecutionHandle:
+        handle = ExecutionHandle(
+            execution_id=execution_id,
+            runner=runner,
+            task=task,
+            requested_task=requested_task,
+            status=(
+                ExecutionLifecycleStatus.RUNNING
+                if task is not None
+                else ExecutionLifecycleStatus.REGISTERED
+            ),
+            metadata=dict(metadata or {}),
+        )
+        self._handles[execution_id] = handle
+        if task is not None:
+            task.add_done_callback(self._make_task_done_callback(execution_id))
+        self._emit_event(
+            "execution.started" if task is not None else "execution.registered",
+            handle,
+        )
+        return handle
+
+    def start(
+        self,
+        runner: "AgentRunner",
+        *,
+        execution_id: str,
+        task: str | None,
+        metadata: dict[str, Any] | None = None,
+        **run_kwargs: Any,
+    ) -> ExecutionHandle:
+        run_task = asyncio.create_task(
+            runner.run(task=task, execution_id=execution_id, **run_kwargs)
+        )
+        return self.register(
+            execution_id,
+            runner,
+            task=run_task,
+            requested_task=task,
+            metadata=metadata,
+        )
+
+    def get(self, execution_id: str) -> ExecutionHandle | None:
+        return self._handles.get(execution_id)
+
+    def get_status(self, execution_id: str) -> dict[str, Any] | None:
+        handle = self.get(execution_id)
+        if handle is None:
+            return None
+        return handle.to_dict()
+
+    def unregister(self, execution_id: str) -> ExecutionHandle | None:
+        return self._handles.pop(execution_id, None)
+
+    def list_handles(self) -> list[ExecutionHandle]:
+        return list(self._handles.values())
+
+    def list_statuses(self) -> list[dict[str, Any]]:
+        return [handle.to_dict() for handle in self.list_handles()]
+
+    def pause(self, execution_id: str, reason: str | None = None) -> bool:
+        handle = self.get(execution_id)
+        if handle is None:
+            return False
+        handle.updated_at = _utcnow()
+        return handle.runner.pause(execution_id, reason=reason)
+
+    def cancel(self, execution_id: str, reason: str | None = None) -> bool:
+        handle = self.get(execution_id)
+        if handle is None:
+            return False
+
+        handle.updated_at = _utcnow()
+        handle.runner.cancel(execution_id, reason=reason)
+        if handle.task is not None and not handle.task.done():
+            handle.task.cancel()
+            return True
+
+        handle.status = ExecutionLifecycleStatus.CANCELLED
+        handle.last_error = reason or "Execution was cancelled."
+        self._emit_event("execution.cancelled", handle)
+        self.unregister(execution_id)
+        return True
+
+    async def resume(self, execution_id: str, **kwargs: Any) -> dict[str, Any] | None:
+        handle = self.get(execution_id)
+        if handle is None:
+            return None
+        if handle.status == ExecutionLifecycleStatus.CANCELLED:
+            return None
+        result = await handle.runner.resume(execution_id, **kwargs)
+        self._apply_result(handle, result)
+        if not handle.is_resumable:
+            self.unregister(execution_id)
+        return result
+
+    async def inject_user_message(
+        self,
+        execution_id: str,
+        message: str,
+        *,
+        request_interrupt: bool = True,
+        reason: str | None = None,
+    ) -> ExecutionContext | None:
+        handle = self.get(execution_id)
+        if handle is None:
+            return None
+        handle.updated_at = _utcnow()
+        return await handle.runner.inject_user_message(
+            execution_id,
+            message,
+            request_interrupt=request_interrupt,
+            reason=reason,
+        )
+
+    async def post_user_message(
+        self,
+        execution_id: str,
+        message: str,
+        *,
+        request_interrupt: bool = True,
+        reason: str | None = None,
+    ) -> ExecutionContext | None:
+        context = await self.inject_user_message(
+            execution_id,
+            message,
+            request_interrupt=request_interrupt,
+            reason=reason,
+        )
+        handle = self.get(execution_id)
+        if handle is not None and context is not None:
+            self._emit_event(
+                "execution.message_posted",
+                handle,
+                {"message": message, "request_interrupt": request_interrupt},
+            )
+        return context
+
+    def _on_task_done(
+        self,
+        execution_id: str,
+        task: asyncio.Task[dict[str, Any]],
+    ) -> None:
+        handle = self.get(execution_id)
+        if handle is None:
+            return
+
+        handle.task = None
+        handle.updated_at = _utcnow()
+        if task.cancelled():
+            handle.status = ExecutionLifecycleStatus.CANCELLED
+            handle.last_error = "Execution task was cancelled."
+            self._emit_event("execution.cancelled", handle)
+            self.unregister(execution_id)
+            return
+
+        try:
+            result = task.result()
+        except Exception:  # noqa: BLE001
+            handle.status = ExecutionLifecycleStatus.FAILED
+            handle.last_error = "Execution task failed without a normalized result."
+            self._emit_event("execution.failed", handle)
+            self.unregister(execution_id)
+            return
+
+        self._apply_result(handle, result)
+        if not handle.is_resumable:
+            self.unregister(execution_id)
+
+    def _make_task_done_callback(
+        self,
+        execution_id: str,
+    ) -> Callable[[asyncio.Task[dict[str, Any]]], None]:
+        def callback(task: asyncio.Task[dict[str, Any]]) -> None:
+            self._on_task_done(execution_id, task)
+
+        return callback
+
+    def _apply_result(
+        self,
+        handle: ExecutionHandle,
+        result: dict[str, Any],
+    ) -> None:
+        handle.last_result = result
+        handle.updated_at = _utcnow()
+        handle.last_error = None
+
+        status = result.get("status")
+        if status == "interrupted":
+            handle.status = ExecutionLifecycleStatus.INTERRUPTED
+            error = result.get("error")
+            handle.last_error = str(error) if error is not None else None
+            self._emit_event("execution.interrupted", handle)
+            return
+        if status == "waiting_for_user":
+            handle.status = ExecutionLifecycleStatus.WAITING_FOR_USER
+            self._emit_event("execution.waiting_for_user", handle)
+            return
+        if result.get("success"):
+            handle.status = ExecutionLifecycleStatus.COMPLETED
+            self._emit_event("execution.completed", handle)
+            return
+
+        handle.status = ExecutionLifecycleStatus.FAILED
+        error = result.get("error")
+        handle.last_error = str(error) if error is not None else None
+        self._emit_event("execution.failed", handle)
+
+    def _emit_event(
+        self,
+        event_type: str,
+        handle: ExecutionHandle,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if not self._subscribers:
+            return
+
+        payload = {
+            "type": event_type,
+            "execution_id": handle.execution_id,
+            "timestamp": _utcnow().isoformat(),
+            "handle": handle.to_dict(),
+        }
+        if extra:
+            payload.update(extra)
+
+        for callback in self._subscribers.values():
+            result = callback(dict(payload))
+            if inspect.isawaitable(result):
+                asyncio.ensure_future(result)

--- a/src/xagent/core/agent_v2/registry.py
+++ b/src/xagent/core/agent_v2/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -11,6 +12,8 @@ from .context import ExecutionContext
 
 if TYPE_CHECKING:
     from .runner import AgentRunner
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow() -> datetime:
@@ -324,4 +327,13 @@ class ExecutionRegistry:
         for callback in self._subscribers.values():
             result = callback(dict(payload))
             if inspect.isawaitable(result):
-                asyncio.ensure_future(result)
+                task = asyncio.ensure_future(result)
+                task.add_done_callback(self._log_subscriber_error)
+
+    def _log_subscriber_error(self, task: asyncio.Future[Any]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            logger.exception("Execution registry subscriber failed")

--- a/src/xagent/core/agent_v2/registry.py
+++ b/src/xagent/core/agent_v2/registry.py
@@ -173,6 +173,8 @@ class ExecutionRegistry:
         handle.updated_at = _utcnow()
         handle.runner.cancel(execution_id, reason=reason)
         if handle.task is not None and not handle.task.done():
+            handle.status = ExecutionLifecycleStatus.CANCELLED
+            handle.last_error = reason or "Execution was cancelled."
             handle.task.cancel()
             return True
 
@@ -325,7 +327,11 @@ class ExecutionRegistry:
             payload.update(extra)
 
         for callback in self._subscribers.values():
-            result = callback(dict(payload))
+            try:
+                result = callback(dict(payload))
+            except Exception:
+                logger.exception("Execution registry subscriber failed")
+                continue
             if inspect.isawaitable(result):
                 task = asyncio.ensure_future(result)
                 task.add_done_callback(self._log_subscriber_error)

--- a/src/xagent/core/agent_v2/result.py
+++ b/src/xagent/core/agent_v2/result.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_assistant_message(result: dict[str, Any]) -> str | None:
+    """Return the assistant-facing output from a normalized pattern result."""
+
+    for key in ("response", "answer", "output", "content", "message"):
+        value = result.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None

--- a/src/xagent/core/agent_v2/runner.py
+++ b/src/xagent/core/agent_v2/runner.py
@@ -1,0 +1,609 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass
+from typing import Any, cast
+from uuid import uuid4
+
+from ..workspace import WorkspaceManager
+from .context import ContextManager, ExecutionContext
+from .runtime import PatternRuntime, load_pattern_checkpoint
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionControl:
+    """In-memory control state for an active execution."""
+
+    runtime: PatternRuntime
+    task: str
+
+
+class AgentRunner:
+    """Execute an agent by materializing an execution context and invoking patterns."""
+
+    def __init__(
+        self,
+        agent: Any,
+        *,
+        workspace_manager: WorkspaceManager | None = None,
+        memory_manager: Any | None = None,
+        tracer: Any | None = None,
+        callbacks: list[Any] | None = None,
+        context_manager: ContextManager | None = None,
+        workspace_base_dir: str = "workspace",
+        outbound_message_handler: Any | None = None,
+    ) -> None:
+        self.agent = agent
+        self.workspace_manager = workspace_manager or WorkspaceManager()
+        self.memory_manager = memory_manager
+        self.tracer = tracer
+        self.callbacks = callbacks or []
+        self.context_manager = context_manager or ContextManager()
+        self.workspace_base_dir = workspace_base_dir
+        self.outbound_message_handler = outbound_message_handler
+        self._active_controls: dict[str, ExecutionControl] = {}
+
+    async def run(
+        self,
+        task: str | None,
+        user_id: str | None = None,
+        execution_id: str | None = None,
+        *,
+        session_id: str | None = None,
+        workspace_id: str | None = None,
+        allowed_external_dirs: list[str] | None = None,
+        base_dir: str | None = None,
+        resume: bool = False,
+        checkpoint: dict[str, Any] | None = None,
+        runtime: PatternRuntime | None = None,
+        interrupt_checker: Any | None = None,
+        streaming_handler: Any | None = None,
+        extra_tools: list[Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        initial_messages: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        execution_id = execution_id or str(uuid4())
+        checkpoint = checkpoint or (
+            await self._load_latest_checkpoint(execution_id) if resume else None
+        )
+        if task is None:
+            task = self._resolve_task(
+                task=task,
+                checkpoint=checkpoint,
+                execution_id=execution_id,
+            )
+        if checkpoint and isinstance(checkpoint.get("context"), dict):
+            context = ExecutionContext.from_dict(checkpoint["context"])
+            execution_id = context.execution_id
+        else:
+            context = self._build_context(
+                task=task,
+                execution_id=execution_id,
+                user_id=user_id,
+                session_id=session_id,
+                workspace_id=workspace_id,
+                allowed_external_dirs=allowed_external_dirs,
+                base_dir=base_dir,
+                metadata=metadata,
+            )
+            for message in initial_messages or []:
+                role = str(message.get("role") or "").strip()
+                content = str(message.get("content") or "").strip()
+                if role and content:
+                    context.add_message(role, content)
+            context.add_user_message(task)
+
+        runtime = runtime or PatternRuntime(
+            tracer=self.tracer,
+            execution_id=execution_id,
+            interrupt_checker=interrupt_checker,
+            outbound_message_handler=self.outbound_message_handler,
+        )
+        self._active_controls[execution_id] = ExecutionControl(
+            runtime=runtime,
+            task=task,
+        )
+
+        await self._dispatch_callback(
+            "on_run_start",
+            runner=self,
+            context=context,
+            resume=resume,
+            checkpoint=checkpoint,
+        )
+
+        try:
+            patterns = list(getattr(self.agent, "patterns", []))
+            if not patterns:
+                result = {
+                    "success": False,
+                    "error": "Agent has no execution patterns configured.",
+                    "execution_id": execution_id,
+                    "context": context,
+                }
+                await self._dispatch_callback(
+                    "on_run_end", runner=self, context=context, result=result
+                )
+                return result
+
+            tools = [*getattr(self.agent, "tools", []), *(extra_tools or [])]
+            pattern_errors: list[dict[str, Any]] = []
+
+            for pattern in patterns:
+                load_pattern_checkpoint(pattern, checkpoint)
+                try:
+                    result = await pattern.run(
+                        **self._build_pattern_kwargs(
+                            pattern=pattern,
+                            task=task,
+                            context=context,
+                            tools=tools,
+                            runtime=runtime,
+                            streaming_handler=streaming_handler,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception("Pattern %s failed", pattern.__class__.__name__)
+                    pattern_errors.append(
+                        {
+                            "pattern": pattern.__class__.__name__,
+                            "error": str(exc),
+                            "exception_type": exc.__class__.__name__,
+                        }
+                    )
+                    continue
+
+                normalized = self._normalize_result(
+                    result=result,
+                    pattern=pattern,
+                    context=context,
+                    execution_id=execution_id,
+                )
+                if normalized.get("success"):
+                    await self._dispatch_callback(
+                        "on_run_end", runner=self, context=context, result=normalized
+                    )
+                    return normalized
+                if normalized.get("status") in {"interrupted", "waiting_for_user"}:
+                    await self._dispatch_callback(
+                        "on_run_end", runner=self, context=context, result=normalized
+                    )
+                    return normalized
+
+                pattern_errors.append(
+                    {
+                        "pattern": pattern.__class__.__name__,
+                        "error": normalized.get(
+                            "error", "Pattern failed without a detailed error."
+                        ),
+                        "result": normalized,
+                    }
+                )
+
+            if len(pattern_errors) == 1:
+                single_result = pattern_errors[0].get("result")
+                if isinstance(single_result, dict):
+                    await self._dispatch_callback(
+                        "on_run_end", runner=self, context=context, result=single_result
+                    )
+                    return single_result
+
+            result = {
+                "success": False,
+                "error": f"All {len(patterns)} patterns failed or returned unsuccessful results.",
+                "pattern_errors": pattern_errors,
+                "patterns_attempted": len(patterns),
+                "execution_id": execution_id,
+                "context": context,
+            }
+            await self._dispatch_callback(
+                "on_run_end", runner=self, context=context, result=result
+            )
+            return result
+        finally:
+            self._active_controls.pop(execution_id, None)
+
+    def pause(self, execution_id: str, reason: str | None = None) -> bool:
+        control = self._active_controls.get(execution_id)
+        if control is None:
+            return False
+        control.runtime.request_interrupt(reason or "paused by runner")
+        return True
+
+    def cancel(self, execution_id: str, reason: str | None = None) -> bool:
+        control = self._active_controls.get(execution_id)
+        if control is None:
+            return False
+        control.runtime.request_interrupt(reason or "cancelled by runner")
+        return True
+
+    async def resume(
+        self,
+        execution_id: str,
+        *,
+        task: str | None = None,
+        user_id: str | None = None,
+        session_id: str | None = None,
+        workspace_id: str | None = None,
+        allowed_external_dirs: list[str] | None = None,
+        base_dir: str | None = None,
+        streaming_handler: Any | None = None,
+        extra_tools: list[Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        checkpoint = await self._load_latest_checkpoint(execution_id)
+        resolved_task = self._resolve_task(
+            task=task,
+            checkpoint=checkpoint,
+            execution_id=execution_id,
+        )
+        return await self.run(
+            task=resolved_task,
+            user_id=user_id,
+            execution_id=execution_id,
+            session_id=session_id,
+            workspace_id=workspace_id,
+            allowed_external_dirs=allowed_external_dirs,
+            base_dir=base_dir,
+            resume=True,
+            checkpoint=checkpoint,
+            streaming_handler=streaming_handler,
+            extra_tools=extra_tools,
+            metadata=metadata,
+        )
+
+    async def inject_user_message(
+        self,
+        execution_id: str,
+        message: str,
+        *,
+        request_interrupt: bool = True,
+        reason: str | None = None,
+    ) -> ExecutionContext | None:
+        context = self.context_manager.get_context(execution_id)
+        if context is None:
+            checkpoint = await self._load_latest_checkpoint(execution_id)
+            if not (
+                isinstance(checkpoint, dict)
+                and isinstance(checkpoint.get("context"), dict)
+            ):
+                return None
+            context = ExecutionContext.from_dict(checkpoint["context"])
+            self.context_manager.set_context(context)
+
+        context.add_user_message(message)
+        await self._persist_injected_context(
+            execution_id=execution_id,
+            context=context,
+            label="user_message_injected",
+        )
+        if request_interrupt:
+            self.pause(execution_id, reason=reason or "new user message")
+        return context
+
+    async def post_user_message(
+        self,
+        execution_id: str,
+        message: str,
+        *,
+        request_interrupt: bool = True,
+        reason: str | None = None,
+    ) -> ExecutionContext | None:
+        """Alias for external callers to inject a user message into an execution.
+
+        `send_message` is an agent-side tool (`agent -> user`).
+        `post_user_message` is a runner-side control API (`user/system -> execution`).
+        """
+        return await self.inject_user_message(
+            execution_id,
+            message,
+            request_interrupt=request_interrupt,
+            reason=reason,
+        )
+
+    def _build_context(
+        self,
+        *,
+        task: str,
+        execution_id: str,
+        user_id: str | None,
+        session_id: str | None,
+        workspace_id: str | None,
+        allowed_external_dirs: list[str] | None,
+        base_dir: str | None,
+        metadata: dict[str, Any] | None,
+    ) -> ExecutionContext:
+        workspace = self.workspace_manager.get_or_create_workspace(
+            base_dir=base_dir or self.workspace_base_dir,
+            task_id=workspace_id or execution_id,
+            allowed_external_dirs=allowed_external_dirs,
+        )
+        context = self.context_manager.create_context(
+            execution_id=execution_id,
+            user_id=user_id,
+            session_id=session_id,
+            system_prompt=getattr(self.agent, "system_prompt", None),
+            workspace_id=workspace.id,
+            workspace_path=str(workspace.workspace_dir),
+            cwd=str(workspace.workspace_dir),
+            workspace_state=self._workspace_state(workspace),
+        )
+        if metadata:
+            context.metadata.update(metadata)
+        context.metadata.setdefault("task", task)
+
+        memory_session = self._resolve_memory_session(
+            execution_id=execution_id,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if memory_session is not None:
+            memory_id, snapshot = memory_session
+            context.attach_memory_session(memory_id, snapshot)
+
+        return context
+
+    def _resolve_task(
+        self,
+        *,
+        task: str | None,
+        checkpoint: dict[str, Any] | None,
+        execution_id: str,
+    ) -> str:
+        if task:
+            return task
+
+        if isinstance(checkpoint, dict):
+            context_payload = checkpoint.get("context")
+            if isinstance(context_payload, dict):
+                metadata = context_payload.get("metadata")
+                if isinstance(metadata, dict):
+                    saved_task = metadata.get("task")
+                    if isinstance(saved_task, str) and saved_task:
+                        return saved_task
+                messages = context_payload.get("messages")
+                if isinstance(messages, list):
+                    for message in reversed(messages):
+                        if (
+                            isinstance(message, dict)
+                            and message.get("role") == "user"
+                            and isinstance(message.get("content"), str)
+                            and message["content"]
+                        ):
+                            content = cast(str, message["content"])
+                            return content
+
+        control = self._active_controls.get(execution_id)
+        if control is not None:
+            return control.task
+
+        return ""
+
+    def _workspace_state(self, workspace: Any) -> dict[str, Any]:
+        state: dict[str, Any] = {
+            "input_dir": str(getattr(workspace, "input_dir", "")),
+            "output_dir": str(getattr(workspace, "output_dir", "")),
+            "temp_dir": str(getattr(workspace, "temp_dir", "")),
+        }
+        allowed_dirs = getattr(workspace, "allowed_external_dirs", None)
+        if allowed_dirs is not None:
+            state["allowed_external_dirs"] = [str(path) for path in allowed_dirs]
+        return state
+
+    def _resolve_memory_session(
+        self,
+        *,
+        execution_id: str,
+        user_id: str | None,
+        session_id: str | None,
+    ) -> tuple[str | None, dict[str, Any] | None] | None:
+        if self.memory_manager is None:
+            return None
+
+        for method_name in (
+            "get_or_create_session",
+            "create_session",
+            "get_session",
+            "load_session",
+        ):
+            method = getattr(self.memory_manager, method_name, None)
+            if method is None:
+                continue
+            payload = self._call_with_supported_kwargs(
+                method,
+                execution_id=execution_id,
+                user_id=user_id,
+                session_id=session_id,
+            )
+            return self._normalize_memory_session(payload, session_id=session_id)
+
+        return None
+
+    def _normalize_memory_session(
+        self,
+        payload: Any,
+        *,
+        session_id: str | None,
+    ) -> tuple[str | None, dict[str, Any] | None]:
+        if payload is None:
+            return session_id, None
+        if isinstance(payload, tuple) and len(payload) == 2:
+            return payload[0], payload[1]
+        if isinstance(payload, str):
+            return payload, None
+        if isinstance(payload, dict):
+            resolved_id = payload.get("session_id") or payload.get("id") or session_id
+            snapshot = payload.get("snapshot")
+            if snapshot is None:
+                snapshot = {
+                    key: value
+                    for key, value in payload.items()
+                    if key not in {"session_id", "id"}
+                }
+            return resolved_id, snapshot
+
+        resolved_id = (
+            getattr(payload, "session_id", None)
+            or getattr(payload, "id", None)
+            or session_id
+        )
+        snapshot = getattr(payload, "snapshot", None)
+        if snapshot is None and hasattr(payload, "to_dict"):
+            snapshot = payload.to_dict()
+        return resolved_id, snapshot
+
+    def _build_pattern_kwargs(
+        self,
+        *,
+        pattern: Any,
+        task: str,
+        context: ExecutionContext,
+        tools: list[Any],
+        runtime: PatternRuntime,
+        streaming_handler: Any | None,
+    ) -> dict[str, Any]:
+        return self._call_signature_kwargs(
+            pattern.run,
+            agent=self.agent,
+            task=task,
+            context=context,
+            llm=getattr(self.agent, "llm", None),
+            tools=tools,
+            tracer=self.tracer,
+            runtime=runtime,
+            callbacks=self.callbacks,
+            streaming_handler=streaming_handler,
+            memory_store=getattr(self.agent, "memory_store", None),
+            memory_similarity_threshold=getattr(
+                self.agent, "memory_similarity_threshold", None
+            ),
+            skill_manager=getattr(self.agent, "skill_manager", None),
+            allowed_skills=getattr(self.agent, "allowed_skills", None),
+        )
+
+    async def _load_latest_checkpoint(
+        self,
+        execution_id: str,
+    ) -> dict[str, Any] | None:
+        if self.tracer is None:
+            return None
+
+        for method_name in (
+            "load_latest_checkpoint",
+            "get_latest_checkpoint",
+            "latest_checkpoint",
+        ):
+            method = getattr(self.tracer, method_name, None)
+            if not callable(method):
+                continue
+            payload = method(execution_id)
+            if inspect.isawaitable(payload):
+                payload = await payload
+            if isinstance(payload, dict):
+                return payload
+        return None
+
+    async def _persist_injected_context(
+        self,
+        *,
+        execution_id: str,
+        context: ExecutionContext,
+        label: str,
+    ) -> None:
+        if self.tracer is None:
+            return
+
+        control = self._active_controls.get(execution_id)
+        baseline = (
+            control.runtime.last_checkpoint
+            if control is not None and control.runtime.last_checkpoint is not None
+            else await self._load_latest_checkpoint(execution_id)
+        )
+        payload = dict(baseline or {})
+        payload.update(
+            {
+                "type": "checkpoint",
+                "label": label,
+                "execution_id": execution_id,
+                "context": context.to_dict(),
+            }
+        )
+
+        checkpoint = getattr(self.tracer, "checkpoint", None)
+        if callable(checkpoint):
+            result = checkpoint(**payload)
+            if inspect.isawaitable(result):
+                await result
+            return
+
+        write_checkpoint = getattr(self.tracer, "write_checkpoint", None)
+        if callable(write_checkpoint):
+            result = write_checkpoint(payload)
+            if inspect.isawaitable(result):
+                await result
+            return
+
+    def _normalize_result(
+        self,
+        *,
+        result: Any,
+        pattern: Any,
+        context: ExecutionContext,
+        execution_id: str,
+    ) -> dict[str, Any]:
+        if isinstance(result, dict):
+            normalized = dict(result)
+        else:
+            normalized = {"success": True, "output": result}
+
+        normalized.setdefault("success", True)
+        normalized.setdefault("execution_id", execution_id)
+        normalized.setdefault("context", context)
+        normalized.setdefault("pattern", pattern.__class__.__name__)
+
+        assistant_message = self._extract_assistant_message(normalized)
+        if assistant_message and not self._has_assistant_message(
+            context, assistant_message
+        ):
+            context.add_assistant_message(assistant_message)
+
+        return normalized
+
+    def _extract_assistant_message(self, result: dict[str, Any]) -> str | None:
+        for key in ("response", "answer", "output", "content", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def _has_assistant_message(self, context: ExecutionContext, content: str) -> bool:
+        return any(
+            message.role == "assistant" and message.content == content
+            for message in context.messages
+        )
+
+    async def _dispatch_callback(self, event: str, **payload: Any) -> None:
+        for callback in self.callbacks:
+            handler = getattr(callback, event, None)
+            if handler is None:
+                continue
+            maybe_coroutine = handler(**payload)
+            if inspect.isawaitable(maybe_coroutine):
+                await maybe_coroutine
+
+    def _call_with_supported_kwargs(self, fn: Any, **kwargs: Any) -> Any:
+        return fn(**self._call_signature_kwargs(fn, **kwargs))
+
+    def _call_signature_kwargs(self, fn: Any, **kwargs: Any) -> dict[str, Any]:
+        signature = inspect.signature(fn)
+        parameters = signature.parameters.values()
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
+            return kwargs
+        return {
+            name: value
+            for name, value in kwargs.items()
+            if name in signature.parameters
+        }

--- a/src/xagent/core/agent_v2/runner.py
+++ b/src/xagent/core/agent_v2/runner.py
@@ -18,7 +18,7 @@ class ExecutionControl:
     """In-memory control state for an active execution."""
 
     runtime: PatternRuntime
-    task: str
+    task: str | None
 
 
 class AgentRunner:
@@ -77,6 +77,7 @@ class AgentRunner:
             )
         if checkpoint and isinstance(checkpoint.get("context"), dict):
             context = ExecutionContext.from_dict(checkpoint["context"])
+            self.context_manager.set_context(context)
             execution_id = context.execution_id
         else:
             context = await self._build_context(
@@ -94,7 +95,8 @@ class AgentRunner:
                 content = str(message.get("content") or "").strip()
                 if role and content:
                     context.add_message(role, content)
-            context.add_user_message(task)
+            if task:
+                context.add_user_message(task)
 
         runtime = runtime or PatternRuntime(
             tracer=self.tracer,
@@ -138,7 +140,7 @@ class AgentRunner:
                     result = await pattern.run(
                         **self._build_pattern_kwargs(
                             pattern=pattern,
-                            task=task,
+                            task=task or "",
                             context=context,
                             tools=tools,
                             runtime=runtime,
@@ -320,7 +322,7 @@ class AgentRunner:
     async def _build_context(
         self,
         *,
-        task: str,
+        task: str | None,
         execution_id: str,
         user_id: str | None,
         session_id: str | None,
@@ -348,7 +350,8 @@ class AgentRunner:
         )
         if metadata:
             context.metadata.update(metadata)
-        context.metadata.setdefault("task", task)
+        if task:
+            context.metadata.setdefault("task", task)
 
         memory_session = await self._resolve_memory_session(
             execution_id=execution_id,
@@ -367,7 +370,7 @@ class AgentRunner:
         task: str | None,
         checkpoint: dict[str, Any] | None,
         execution_id: str,
-    ) -> str:
+    ) -> str | None:
         if task:
             return task
 
@@ -395,7 +398,7 @@ class AgentRunner:
         if control is not None:
             return control.task
 
-        return ""
+        return None
 
     def _workspace_state(self, workspace: Any) -> dict[str, Any]:
         state: dict[str, Any] = {
@@ -615,7 +618,10 @@ class AgentRunner:
         return fn(**self._call_signature_kwargs(fn, **kwargs))
 
     def _call_signature_kwargs(self, fn: Any, **kwargs: Any) -> dict[str, Any]:
-        signature = inspect.signature(fn)
+        try:
+            signature = inspect.signature(fn)
+        except (TypeError, ValueError):
+            return kwargs
         parameters = signature.parameters.values()
         if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
             return kwargs

--- a/src/xagent/core/agent_v2/runner.py
+++ b/src/xagent/core/agent_v2/runner.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from ..workspace import WorkspaceManager
 from .context import ContextManager, ExecutionContext
-from .runtime import PatternRuntime, load_pattern_checkpoint
+from .runtime import LLMCallInterrupted, PatternRuntime, load_pattern_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +145,19 @@ class AgentRunner:
                             streaming_handler=streaming_handler,
                         )
                     )
+                except LLMCallInterrupted as exc:
+                    normalized = {
+                        "success": False,
+                        "status": "interrupted",
+                        "error": str(exc),
+                        "execution_id": execution_id,
+                        "context": context,
+                        "pattern": pattern.__class__.__name__,
+                    }
+                    await self._dispatch_callback(
+                        "on_run_end", runner=self, context=context, result=normalized
+                    )
+                    return normalized
                 except Exception as exc:  # noqa: BLE001
                     logger.exception("Pattern %s failed", pattern.__class__.__name__)
                     pattern_errors.append(

--- a/src/xagent/core/agent_v2/runner.py
+++ b/src/xagent/core/agent_v2/runner.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from ..workspace import WorkspaceManager
 from .context import ContextManager, ExecutionContext
+from .result import extract_assistant_message
 from .runtime import LLMCallInterrupted, PatternRuntime, load_pattern_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -584,20 +585,13 @@ class AgentRunner:
         normalized.setdefault("context", context)
         normalized.setdefault("pattern", pattern.__class__.__name__)
 
-        assistant_message = self._extract_assistant_message(normalized)
+        assistant_message = extract_assistant_message(normalized)
         if assistant_message and not self._has_assistant_message(
             context, assistant_message
         ):
             context.add_assistant_message(assistant_message)
 
         return normalized
-
-    def _extract_assistant_message(self, result: dict[str, Any]) -> str | None:
-        for key in ("response", "answer", "output", "content", "message"):
-            value = result.get(key)
-            if isinstance(value, str) and value:
-                return value
-        return None
 
     def _has_assistant_message(self, context: ExecutionContext, content: str) -> bool:
         return any(

--- a/src/xagent/core/agent_v2/runner.py
+++ b/src/xagent/core/agent_v2/runner.py
@@ -79,7 +79,7 @@ class AgentRunner:
             context = ExecutionContext.from_dict(checkpoint["context"])
             execution_id = context.execution_id
         else:
-            context = self._build_context(
+            context = await self._build_context(
                 task=task,
                 execution_id=execution_id,
                 user_id=user_id,
@@ -304,7 +304,7 @@ class AgentRunner:
             reason=reason,
         )
 
-    def _build_context(
+    async def _build_context(
         self,
         *,
         task: str,
@@ -321,6 +321,8 @@ class AgentRunner:
             task_id=workspace_id or execution_id,
             allowed_external_dirs=allowed_external_dirs,
         )
+        if inspect.isawaitable(workspace):
+            workspace = await workspace
         context = self.context_manager.create_context(
             execution_id=execution_id,
             user_id=user_id,
@@ -335,7 +337,7 @@ class AgentRunner:
             context.metadata.update(metadata)
         context.metadata.setdefault("task", task)
 
-        memory_session = self._resolve_memory_session(
+        memory_session = await self._resolve_memory_session(
             execution_id=execution_id,
             user_id=user_id,
             session_id=session_id,
@@ -393,7 +395,7 @@ class AgentRunner:
             state["allowed_external_dirs"] = [str(path) for path in allowed_dirs]
         return state
 
-    def _resolve_memory_session(
+    async def _resolve_memory_session(
         self,
         *,
         execution_id: str,
@@ -418,6 +420,8 @@ class AgentRunner:
                 user_id=user_id,
                 session_id=session_id,
             )
+            if inspect.isawaitable(payload):
+                payload = await payload
             return self._normalize_memory_session(payload, session_id=session_id)
 
         return None

--- a/src/xagent/core/agent_v2/runtime.py
+++ b/src/xagent/core/agent_v2/runtime.py
@@ -698,6 +698,8 @@ class PatternRuntime:
 
     def _checkpoint_trace_event_type(self, trace_event: Any) -> Any:
         del trace_event
+        # Runtime checkpoints are task-scoped progress events. Durable checkpoint
+        # persistence uses TraceCheckpointStore, which emits system-scoped events.
         return TraceEventType(
             TraceScope.TASK,
             TraceAction.UPDATE,

--- a/src/xagent/core/agent_v2/runtime.py
+++ b/src/xagent/core/agent_v2/runtime.py
@@ -697,41 +697,12 @@ class PatternRuntime:
         return "agent.task"
 
     def _checkpoint_trace_event_type(self, trace_event: Any) -> Any:
-        fn = getattr(trace_event, "__func__", trace_event)
-        globals_payload = getattr(fn, "__globals__", {})
-        trace_event_type = globals_payload.get("TraceEventType")
-        trace_scope = globals_payload.get("TraceScope")
-        trace_action = globals_payload.get("TraceAction")
-        trace_category = globals_payload.get("TraceCategory")
-        if (
-            trace_event_type is None
-            or trace_scope is None
-            or trace_action is None
-            or trace_category is None
-        ):
-            return _CheckpointTraceEventType()
-        return trace_event_type(
-            trace_scope.TASK,
-            trace_action.UPDATE,
-            trace_category.GENERAL,
+        del trace_event
+        return TraceEventType(
+            TraceScope.TASK,
+            TraceAction.UPDATE,
+            TraceCategory.GENERAL,
         )
-
-
-@dataclass(frozen=True)
-class _TracePart:
-    value: str
-
-
-class _CheckpointTraceEventType:
-    """TraceEventType-compatible object without importing legacy agent package."""
-
-    scope = _TracePart("task")
-    action = _TracePart("update")
-    category = _TracePart("general")
-    value = "task_update_general"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 def load_pattern_checkpoint(pattern: Any, checkpoint: dict[str, Any] | None) -> None:

--- a/src/xagent/core/agent_v2/runtime.py
+++ b/src/xagent/core/agent_v2/runtime.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable
+from uuid import uuid4
+
+from ..agent.trace import (
+    TraceAction,
+    TraceCategory,
+    TraceEventType,
+    TraceScope,
+)
+
+
+class LLMCallInterrupted(Exception):
+    """Raised when an active LLM call is cancelled by an execution interrupt."""
+
+
+@dataclass
+class PatternRuntime:
+    """Thin runtime services shared by execution patterns.
+
+    Patterns own execution state; the runtime owns cross-cutting concerns such as
+    checkpoint emission and interrupt requests.
+    """
+
+    tracer: Any | None = None
+    execution_id: str | None = None
+    interrupt_checker: Callable[[], bool] | Callable[[], Any] | None = None
+    outbound_message_handler: Callable[[dict[str, Any]], Any] | None = None
+    _interrupt_requested: bool = False
+    interrupt_reason: str | None = None
+    last_checkpoint: dict[str, Any] | None = None
+    checkpoints: list[dict[str, Any]] = field(default_factory=list)
+    outbound_messages: list[dict[str, Any]] = field(default_factory=list)
+    spans: list[dict[str, Any]] = field(default_factory=list)
+    finished_spans: list[dict[str, Any]] = field(default_factory=list)
+    trace_runs: list[dict[str, Any]] = field(default_factory=list)
+    active_react_step_id: str | None = None
+    _active_llm_tasks: set[asyncio.Future[Any]] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
+
+    def request_interrupt(self, reason: str | None = None) -> None:
+        self._interrupt_requested = True
+        self.interrupt_reason = reason
+        for task in list(self._active_llm_tasks):
+            if not task.done():
+                task.cancel()
+
+    def clear_interrupt(self) -> None:
+        self._interrupt_requested = False
+        self.interrupt_reason = None
+
+    async def should_interrupt(self) -> bool:
+        if self._interrupt_requested:
+            return True
+        if self.interrupt_checker is None:
+            return False
+
+        result = self.interrupt_checker()
+        if inspect.isawaitable(result):
+            result = await result
+        if result:
+            self._interrupt_requested = True
+            self.request_interrupt(self.interrupt_reason)
+        return bool(result)
+
+    async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
+        """Run an LLM call as a cancellable subtask owned by this runtime."""
+
+        call = llm.chat(**kwargs)
+        if not inspect.isawaitable(call):
+            return call
+
+        task: asyncio.Future[Any] = asyncio.ensure_future(call)
+        self._active_llm_tasks.add(task)
+        try:
+            return await task
+        except asyncio.CancelledError as exc:
+            if self._interrupt_requested:
+                raise LLMCallInterrupted(
+                    self.interrupt_reason or "interrupted during LLM call"
+                ) from exc
+            raise
+        finally:
+            self._active_llm_tasks.discard(task)
+
+    async def checkpoint(
+        self,
+        label: str,
+        *,
+        context: Any,
+        pattern: Any,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload = self._build_checkpoint_payload(
+            label=label,
+            context=context,
+            pattern=pattern,
+            status=status,
+            metadata=metadata,
+        )
+        self.last_checkpoint = payload
+        self.checkpoints.append(payload)
+        await self._emit_checkpoint(payload)
+        return payload
+
+    async def send_message(
+        self,
+        *,
+        message: str,
+        message_type: str = "info",
+        expect_response: bool = False,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Emit an agent-to-user message through the runtime boundary."""
+
+        payload = {
+            "type": "agent_message",
+            "execution_id": self.execution_id,
+            "message": message,
+            "message_type": message_type,
+            "expect_response": expect_response,
+            "metadata": metadata or {},
+        }
+        self.outbound_messages.append(payload)
+
+        if self.outbound_message_handler is not None:
+            await self._maybe_await(self.outbound_message_handler(payload))
+
+        return payload
+
+    async def on_pattern_start(self, *, context: Any, pattern: Any) -> None:
+        if pattern.__class__.__name__ == "ReActPattern":
+            self.active_react_step_id = f"react_{uuid4().hex[:8]}"
+        await self._emit_pattern_trace(context=context, pattern=pattern, action="start")
+        if self.tracer is None:
+            return
+        payload = {
+            "name": self._pattern_trace_name(pattern),
+            "execution_id": getattr(context, "execution_id", self.execution_id),
+            "input": context.to_dict()
+            if callable(getattr(context, "to_dict", None))
+            else None,
+            "metadata": {
+                "execution_id": getattr(context, "execution_id", self.execution_id),
+                "workspace_id": getattr(context, "workspace_id", None),
+                "memory_session_id": getattr(context, "memory_session_id", None),
+                "pattern": pattern.__class__.__name__,
+            },
+        }
+        self.trace_runs.append(payload)
+        start_trace = getattr(self.tracer, "start_trace", None)
+        if callable(start_trace):
+            await self._maybe_await(start_trace(**payload))
+
+    async def on_pattern_end(
+        self,
+        *,
+        context: Any,
+        pattern: Any,
+        result: dict[str, Any],
+    ) -> None:
+        await self._emit_pattern_trace(
+            context=context,
+            pattern=pattern,
+            action="end",
+            data={"result": result, "status": result.get("status")},
+        )
+        if pattern.__class__.__name__ == "ReActPattern":
+            self.active_react_step_id = None
+        if self.tracer is None:
+            return
+        finish_trace = getattr(self.tracer, "finish_trace", None)
+        if callable(finish_trace):
+            await self._maybe_await(
+                finish_trace(
+                    name=self._pattern_trace_name(pattern),
+                    status="success",
+                    output=result,
+                    metadata={
+                        "execution_id": getattr(
+                            context, "execution_id", self.execution_id
+                        ),
+                        "pattern": pattern.__class__.__name__,
+                    },
+                )
+            )
+
+    async def on_pattern_error(
+        self,
+        *,
+        context: Any,
+        pattern: Any,
+        error: Exception,
+    ) -> None:
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.TASK, TraceAction.ERROR, TraceCategory.GENERAL),
+            task_id=self._task_id(context),
+            step_id=self._step_id(context),
+            data={
+                "error_type": "agent_v2_pattern_error",
+                "error_message": str(error),
+                "pattern": pattern.__class__.__name__,
+            },
+        )
+        if pattern.__class__.__name__ == "ReActPattern":
+            self.active_react_step_id = None
+        if self.tracer is None:
+            return
+        finish_trace = getattr(self.tracer, "finish_trace", None)
+        if callable(finish_trace):
+            await self._maybe_await(
+                finish_trace(
+                    name=self._pattern_trace_name(pattern),
+                    status="error",
+                    output={"error": str(error)},
+                    metadata={
+                        "execution_id": getattr(
+                            context, "execution_id", self.execution_id
+                        ),
+                        "pattern": pattern.__class__.__name__,
+                    },
+                )
+            )
+
+    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.START, TraceCategory.TOOL),
+            task_id=self._task_id_from_payload(tool_call),
+            step_id=self._step_id_from_payload(tool_call),
+            data={
+                "tool_name": tool_call.get("name"),
+                "tool_params": tool_call.get("args", {}),
+                "tool_call_id": tool_call.get("id"),
+            },
+        )
+        if self.tracer is None:
+            return
+        payload = {
+            "name": f"tool.{tool_call['name']}",
+            "execution_id": tool_call.get("id"),
+            "metadata": {"arguments": tool_call.get("args", {})},
+        }
+        self.spans.append(payload)
+        start_span = getattr(self.tracer, "start_span", None)
+        if callable(start_span):
+            await self._maybe_await(start_span(**payload))
+
+    async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
+        success = self._tool_result_success(result)
+        if not success:
+            await self.on_tool_error(
+                tool_call=tool_call, error=self._tool_result_error(result)
+            )
+            return
+
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL),
+            task_id=self._task_id_from_payload(tool_call),
+            step_id=self._step_id_from_payload(tool_call),
+            data={
+                "tool_name": tool_call.get("name"),
+                "tool_params": tool_call.get("args", {}),
+                "tool_call_id": tool_call.get("id"),
+                "result": result,
+                "success": True,
+            },
+        )
+        if self.tracer is None:
+            return
+        payload = {
+            "name": f"tool.{tool_call['name']}",
+            "status": "success",
+            "output": result,
+        }
+        self.finished_spans.append(payload)
+        finish_span = getattr(self.tracer, "finish_span", None)
+        if callable(finish_span):
+            await self._maybe_await(finish_span(**payload))
+
+    async def on_tool_error(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        error: Exception,
+        result: Any | None = None,
+    ) -> None:
+        data = {
+            "error_type": "agent_v2_tool_error",
+            "error": str(error),
+            "error_message": str(error),
+            "tool_name": tool_call.get("name"),
+            "tool_call_id": tool_call.get("id"),
+        }
+        if result is not None:
+            data["result"] = result
+
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.TOOL),
+            task_id=self._task_id_from_payload(tool_call),
+            step_id=self._step_id_from_payload(tool_call),
+            data=data,
+        )
+        if self.tracer is None:
+            return
+        payload = {
+            "name": f"tool.{tool_call['name']}",
+            "status": "error",
+            "output": {"error": str(error)},
+        }
+        self.finished_spans.append(payload)
+        finish_span = getattr(self.tracer, "finish_span", None)
+        if callable(finish_span):
+            await self._maybe_await(finish_span(**payload))
+
+    def _tool_result_success(self, result: Any) -> bool:
+        if isinstance(result, dict) and result.get("success") is False:
+            return False
+        return True
+
+    def _tool_result_error(self, result: Any) -> Exception:
+        if isinstance(result, dict):
+            message = result.get("error") or result.get("message") or str(result)
+        else:
+            message = str(result)
+        return RuntimeError(message)
+
+    async def on_llm_start(
+        self,
+        *,
+        context: Any,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        event_metadata = metadata or {}
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.START, TraceCategory.LLM),
+            task_id=str(event_metadata.get("task_id") or self._task_id(context)),
+            step_id=str(event_metadata.get("step_id") or self._step_id(context)),
+            data={
+                "context_messages_count": len(messages),
+                "tools_count": len(tools or []),
+                "context_preview": messages[-5:],
+                **event_metadata,
+            },
+        )
+
+    async def on_llm_end(
+        self,
+        *,
+        context: Any,
+        response: Any,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        event_metadata = metadata or {}
+        usage = self._extract_token_usage(response)
+        if usage is not None and callable(getattr(context, "record_llm_usage", None)):
+            context.record_llm_usage(
+                input_tokens=usage[0],
+                output_tokens=usage[1],
+                prompt_message_count=len(getattr(context, "messages", [])),
+            )
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.LLM),
+            task_id=str(event_metadata.get("task_id") or self._task_id(context)),
+            step_id=str(event_metadata.get("step_id") or self._step_id(context)),
+            data={
+                "response": self._short_response(response),
+                "success": True,
+                **(
+                    {
+                        "input_tokens": usage[0],
+                        "output_tokens": usage[1],
+                        "total_tokens": usage[0] + usage[1],
+                    }
+                    if usage is not None
+                    else {}
+                ),
+                **event_metadata,
+            },
+        )
+
+    def _extract_token_usage(self, response: Any) -> tuple[int, int] | None:
+        usage = self._get_value(response, "usage")
+        if usage is not None:
+            input_tokens = self._first_int(
+                usage, ("prompt_tokens", "input_tokens", "prompt_token_count")
+            )
+            output_tokens = self._first_int(
+                usage,
+                (
+                    "completion_tokens",
+                    "output_tokens",
+                    "candidates_token_count",
+                    "completion_token_count",
+                ),
+            )
+            if input_tokens > 0 or output_tokens > 0:
+                return input_tokens, output_tokens
+
+        usage_metadata = self._get_value(response, "usage_metadata")
+        if usage_metadata is not None:
+            input_tokens = self._first_int(
+                usage_metadata, ("prompt_token_count", "prompt_tokens", "input_tokens")
+            )
+            output_tokens = self._first_int(
+                usage_metadata,
+                ("candidates_token_count", "completion_tokens", "output_tokens"),
+            )
+            if input_tokens > 0 or output_tokens > 0:
+                return input_tokens, output_tokens
+
+        return None
+
+    def _first_int(self, source: Any, keys: tuple[str, ...]) -> int:
+        for key in keys:
+            value = self._get_value(source, key)
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+        return 0
+
+    def _get_value(self, source: Any, key: str) -> Any:
+        if isinstance(source, dict):
+            return source.get(key)
+        return getattr(source, key, None)
+
+    async def on_llm_error(
+        self,
+        *,
+        context: Any,
+        error: Exception,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        event_metadata = metadata or {}
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.LLM),
+            task_id=str(event_metadata.get("task_id") or self._task_id(context)),
+            step_id=str(event_metadata.get("step_id") or self._step_id(context)),
+            data={
+                "error_type": "agent_v2_llm_error",
+                "error": str(error),
+                "error_message": str(error),
+                "success": False,
+                **event_metadata,
+            },
+        )
+
+    async def compact_context_if_needed(
+        self,
+        *,
+        context: Any,
+        llm: Any = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        compact_if_needed = getattr(context, "compact_if_needed", None)
+        if not callable(compact_if_needed):
+            return None
+
+        result = compact_if_needed(llm)
+        if not getattr(result, "compacted", False):
+            return result
+
+        event_metadata = metadata or {}
+        compact_data = {
+            "agent_runtime": "v2",
+            "compact_type": "execution_context",
+            "strategy": getattr(result, "strategy", None),
+            "original_count": getattr(result, "original_count", None),
+            "final_count": getattr(result, "final_count", None),
+            **(getattr(result, "metadata", None) or {}),
+            **event_metadata,
+        }
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.START, TraceCategory.COMPACT),
+            task_id=str(event_metadata.get("task_id") or self._task_id(context)),
+            step_id=str(event_metadata.get("step_id") or self._step_id(context)),
+            data=compact_data,
+        )
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.COMPACT),
+            task_id=str(event_metadata.get("task_id") or self._task_id(context)),
+            step_id=str(event_metadata.get("step_id") or self._step_id(context)),
+            data={**compact_data, "success": True},
+        )
+        return result
+
+    async def on_dag_step_start(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.STEP, TraceAction.START, TraceCategory.DAG),
+            task_id=self._task_id(context),
+            step_id=step_id,
+            data=data or {},
+        )
+
+    async def on_dag_step_end(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.STEP, TraceAction.END, TraceCategory.DAG),
+            task_id=self._task_id(context),
+            step_id=step_id,
+            data=data or {},
+        )
+
+    async def on_dag_execution(
+        self,
+        *,
+        context: Any,
+        phase: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.TASK, TraceAction.UPDATE, TraceCategory.DAG),
+            task_id=self._task_id(context),
+            data={"phase": phase, **(data or {})},
+        )
+
+    def _build_checkpoint_payload(
+        self,
+        *,
+        label: str,
+        context: Any,
+        pattern: Any,
+        status: str | None,
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        execution_id = getattr(context, "execution_id", None) or self.execution_id
+        pattern_state: dict[str, Any] | None = None
+        get_state = getattr(pattern, "get_state", None)
+        if callable(get_state):
+            pattern_state = get_state()
+
+        context_payload = (
+            context.to_dict() if callable(getattr(context, "to_dict", None)) else None
+        )
+        execution_snapshot: dict[str, Any] | None = None
+        get_execution_snapshot = getattr(pattern, "get_execution_snapshot", None)
+        if callable(get_execution_snapshot):
+            execution_snapshot = get_execution_snapshot(context)
+
+        payload = {
+            "type": "checkpoint",
+            "label": label,
+            "execution_id": execution_id,
+            "pattern": pattern.__class__.__name__,
+            "pattern_state": pattern_state,
+            "context": context_payload,
+            "status": status or getattr(pattern, "status", None),
+            "metadata": metadata or {},
+        }
+        if execution_snapshot is not None:
+            payload["execution_snapshot"] = execution_snapshot
+        return payload
+
+    async def _emit_checkpoint(self, payload: dict[str, Any]) -> None:
+        if self.tracer is None:
+            return
+
+        checkpoint = getattr(self.tracer, "checkpoint", None)
+        if callable(checkpoint):
+            await self._maybe_await(checkpoint(**payload))
+            return
+
+        write_checkpoint = getattr(self.tracer, "write_checkpoint", None)
+        if callable(write_checkpoint):
+            await self._maybe_await(write_checkpoint(payload))
+            return
+
+        trace_event = getattr(self.tracer, "trace_event", None)
+        if callable(trace_event):
+            await self._maybe_await(
+                trace_event(
+                    self._checkpoint_trace_event_type(trace_event),
+                    task_id=str(payload.get("execution_id") or self.execution_id),
+                    data=payload,
+                )
+            )
+
+    async def _maybe_await(self, result: Any) -> None:
+        if inspect.isawaitable(result):
+            await result
+
+    async def _emit_pattern_trace(
+        self,
+        *,
+        context: Any,
+        pattern: Any,
+        action: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        category = self._pattern_category(pattern)
+        if category is None:
+            return
+        event_action = TraceAction.START if action == "start" else TraceAction.END
+        await self._emit_trace_event(
+            TraceEventType(TraceScope.TASK, event_action, category),
+            task_id=self._task_id(context),
+            step_id=self._step_id(context),
+            data={
+                "agent_runtime": "v2",
+                "pattern": pattern.__class__.__name__,
+                **(data or {}),
+            },
+        )
+
+    async def _emit_trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        if self.tracer is None:
+            return
+        trace_event = getattr(self.tracer, "trace_event", None)
+        if not callable(trace_event):
+            return
+        try:
+            await self._maybe_await(
+                trace_event(
+                    event_type,
+                    task_id=task_id or self.execution_id,
+                    step_id=step_id,
+                    data=data or {},
+                )
+            )
+        except Exception:
+            # UI trace events are best-effort; checkpoint persistence remains strict.
+            return
+
+    def _pattern_category(self, pattern: Any) -> TraceCategory | None:
+        name = pattern.__class__.__name__
+        if name == "DAGPattern":
+            return TraceCategory.DAG
+        if name == "ReActPattern":
+            return TraceCategory.REACT
+        return None
+
+    def _task_id(self, context: Any) -> str | None:
+        return str(getattr(context, "execution_id", None) or self.execution_id or "")
+
+    def _step_id(self, context: Any) -> str:
+        metadata = getattr(context, "metadata", None)
+        if isinstance(metadata, dict) and metadata.get("dag_step_id"):
+            return str(metadata["dag_step_id"])
+        if self.active_react_step_id:
+            return self.active_react_step_id
+        return self._task_id(context) or "root"
+
+    def _task_id_from_payload(self, payload: dict[str, Any]) -> str | None:
+        return str(payload.get("task_id") or self.execution_id or "")
+
+    def _step_id_from_payload(self, payload: dict[str, Any]) -> str:
+        return str(
+            payload.get("step_id")
+            or payload.get("dag_step_id")
+            or self.active_react_step_id
+            or payload.get("task_id")
+            or self.execution_id
+            or "root"
+        )
+
+    def _short_response(self, response: Any) -> Any:
+        if isinstance(response, str):
+            return response
+        if isinstance(response, dict):
+            return {
+                key: response.get(key)
+                for key in ("content", "answer", "output", "message", "tool_calls")
+                if key in response
+            }
+        return str(response)
+
+    def _pattern_trace_name(self, pattern: Any) -> str:
+        del pattern
+        return "agent.task"
+
+    def _checkpoint_trace_event_type(self, trace_event: Any) -> Any:
+        fn = getattr(trace_event, "__func__", trace_event)
+        globals_payload = getattr(fn, "__globals__", {})
+        trace_event_type = globals_payload.get("TraceEventType")
+        trace_scope = globals_payload.get("TraceScope")
+        trace_action = globals_payload.get("TraceAction")
+        trace_category = globals_payload.get("TraceCategory")
+        if (
+            trace_event_type is None
+            or trace_scope is None
+            or trace_action is None
+            or trace_category is None
+        ):
+            return _CheckpointTraceEventType()
+        return trace_event_type(
+            trace_scope.TASK,
+            trace_action.UPDATE,
+            trace_category.GENERAL,
+        )
+
+
+@dataclass(frozen=True)
+class _TracePart:
+    value: str
+
+
+class _CheckpointTraceEventType:
+    """TraceEventType-compatible object without importing legacy agent package."""
+
+    scope = _TracePart("task")
+    action = _TracePart("update")
+    category = _TracePart("general")
+    value = "task_update_general"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def load_pattern_checkpoint(pattern: Any, checkpoint: dict[str, Any] | None) -> None:
+    """Restore a pattern from a checkpoint when the payload matches it."""
+    if not checkpoint:
+        return
+    if checkpoint.get("pattern") not in {None, pattern.__class__.__name__}:
+        return
+
+    load_state = getattr(pattern, "load_state", None)
+    state = checkpoint.get("pattern_state")
+    if callable(load_state) and isinstance(state, dict):
+        load_state(state)

--- a/src/xagent/core/agent_v2/tracing.py
+++ b/src/xagent/core/agent_v2/tracing.py
@@ -83,11 +83,6 @@ class TraceEventCallback:
             data=data,
         )
 
-    def _pattern_names(self, runner: Any) -> str:
-        agent = getattr(runner, "agent", None)
-        patterns = getattr(agent, "patterns", []) if agent is not None else []
-        return ",".join(pattern.__class__.__name__ for pattern in patterns)
-
     def _context_payload(self, context: Any) -> dict[str, Any] | None:
         to_dict = getattr(context, "to_dict", None)
         if callable(to_dict):

--- a/src/xagent/core/agent_v2/tracing.py
+++ b/src/xagent/core/agent_v2/tracing.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..agent.trace import (
+    trace_ai_message,
+    trace_error,
+    trace_task_completion,
+    trace_user_message,
+)
+
+
+@dataclass
+class TraceEventCallback:
+    """Bridge agent_v2 runner callbacks into the existing web trace stream."""
+
+    async def on_run_start(
+        self,
+        *,
+        runner: Any,
+        context: Any,
+        resume: bool = False,
+        checkpoint: dict[str, Any] | None = None,
+    ) -> None:
+        tracer = getattr(runner, "tracer", None)
+        if tracer is None or not callable(getattr(tracer, "trace_event", None)):
+            return
+
+        execution_id = str(getattr(context, "execution_id", "") or "")
+
+        task = self._task_from_context(context)
+        if task and not (resume or checkpoint):
+            await trace_user_message(
+                tracer,
+                execution_id,
+                task,
+                {"agent_runtime": "v2", "context": self._context_payload(context)},
+            )
+
+    async def on_run_end(
+        self, *, runner: Any, context: Any, result: dict[str, Any]
+    ) -> None:
+        tracer = getattr(runner, "tracer", None)
+        if tracer is None or not callable(getattr(tracer, "trace_event", None)):
+            return
+
+        execution_id = str(
+            result.get("execution_id") or getattr(context, "execution_id", "") or ""
+        )
+        status = str(result.get("status") or "")
+        output = self._extract_assistant_message(result)
+        data = {
+            "agent_runtime": "v2",
+            "execution_id": execution_id,
+            "status": status or ("completed" if result.get("success") else "failed"),
+            "pattern": result.get("pattern"),
+            "context": self._context_payload(context),
+        }
+
+        if result.get("success"):
+            if output:
+                await trace_ai_message(tracer, execution_id, output, data)
+                await trace_task_completion(
+                    tracer,
+                    execution_id,
+                    result={"content": output},
+                    success=True,
+                )
+            return
+
+        if status in {"interrupted", "waiting_for_user"}:
+            # Paused/interrupted executions are resumable control states, not
+            # completions. The web trace compatibility layer maps
+            # TASK_END_GENERAL to task_completion, so do not emit it here.
+            return
+
+        await trace_error(
+            tracer,
+            execution_id,
+            error_type="agent_v2_error",
+            error_message=str(result.get("error") or "agent_v2 execution failed"),
+            data=data,
+        )
+
+    def _pattern_names(self, runner: Any) -> str:
+        agent = getattr(runner, "agent", None)
+        patterns = getattr(agent, "patterns", []) if agent is not None else []
+        return ",".join(pattern.__class__.__name__ for pattern in patterns)
+
+    def _context_payload(self, context: Any) -> dict[str, Any] | None:
+        to_dict = getattr(context, "to_dict", None)
+        if callable(to_dict):
+            payload = to_dict()
+            return dict(payload) if isinstance(payload, dict) else None
+        return None
+
+    def _task_from_context(self, context: Any) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if isinstance(metadata, dict):
+            task = metadata.get("task")
+            if isinstance(task, str) and task:
+                return task
+        messages = getattr(context, "messages", [])
+        for message in messages:
+            if getattr(message, "role", None) == "user":
+                content = getattr(message, "content", None)
+                if isinstance(content, str) and content:
+                    return content
+        return None
+
+    def _extract_assistant_message(self, result: dict[str, Any]) -> str | None:
+        for key in ("response", "answer", "output", "content", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None

--- a/src/xagent/core/agent_v2/tracing.py
+++ b/src/xagent/core/agent_v2/tracing.py
@@ -9,6 +9,7 @@ from ..agent.trace import (
     trace_task_completion,
     trace_user_message,
 )
+from .result import extract_assistant_message
 
 
 @dataclass
@@ -49,7 +50,7 @@ class TraceEventCallback:
             result.get("execution_id") or getattr(context, "execution_id", "") or ""
         )
         status = str(result.get("status") or "")
-        output = self._extract_assistant_message(result)
+        output = extract_assistant_message(result)
         data = {
             "agent_runtime": "v2",
             "execution_id": execution_id,
@@ -102,11 +103,4 @@ class TraceEventCallback:
                 content = getattr(message, "content", None)
                 if isinstance(content, str) and content:
                     return content
-        return None
-
-    def _extract_assistant_message(self, result: dict[str, Any]) -> str | None:
-        for key in ("response", "answer", "output", "content", "message"):
-            value = result.get(key)
-            if isinstance(value, str) and value:
-                return value
         return None

--- a/src/xagent/core/user_context.py
+++ b/src/xagent/core/user_context.py
@@ -1,0 +1,10 @@
+"""Shared user-scoped execution context."""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Optional
+
+current_user_id: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "current_user_id", default=None
+)

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -5,11 +5,7 @@ from typing import Any, List, Optional
 
 from xagent.core.memory.base import MemoryStore
 from xagent.core.memory.core import MemoryNote, MemoryResponse
-
-# Context variable for current user ID
-current_user_id: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
-    "current_user_id", default=None
-)
+from xagent.core.user_context import current_user_id
 
 
 class UserIsolatedMemoryStore(MemoryStore):

--- a/tests/core/agent_v2/test_agent.py
+++ b/tests/core/agent_v2/test_agent.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from xagent.core.agent_v2 import Agent
+from xagent.core.agent_v2.runner import AgentRunner
+
+
+def test_agent_exposes_runner_and_core_configuration() -> None:
+    pattern = object()
+    tool = object()
+
+    agent = Agent(
+        name="writer",
+        patterns=[pattern],
+        tools=[tool],
+        llm="fake-llm",
+        system_prompt="You are helpful.",
+    )
+
+    runner = agent.get_runner()
+
+    assert isinstance(runner, AgentRunner)
+    assert runner.agent is agent
+    assert agent.patterns == [pattern]
+    assert agent.tools == [tool]
+    assert agent.llm == "fake-llm"
+    assert agent.system_prompt == "You are helpful."

--- a/tests/core/agent_v2/test_checkpoint.py
+++ b/tests/core/agent_v2/test_checkpoint.py
@@ -60,6 +60,24 @@ class BestEffortTraceBackend:
         return "best-effort"
 
 
+class NoneReturningCheckpointBackend:
+    async def checkpoint(self, **_: Any) -> None:
+        return None
+
+
+class NoneReturningTraceEventBackend:
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        require_persisted: bool = False,
+    ) -> None:
+        del event_type, task_id, data, require_persisted
+        return None
+
+
 class FakeLLM:
     async def chat(self, **_: Any) -> str:
         return "done"
@@ -110,6 +128,30 @@ async def test_trace_checkpoint_store_rejects_best_effort_trace_event() -> None:
             type="checkpoint",
             label="before_llm",
             execution_id="exec-best-effort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_rejects_none_checkpoint_writer() -> None:
+    store = TraceCheckpointStore(NoneReturningCheckpointBackend())
+
+    with pytest.raises(CheckpointPersistenceError):
+        await store.checkpoint(
+            type="checkpoint",
+            label="before_llm",
+            execution_id="exec-none-writer",
+        )
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_rejects_none_trace_event_writer() -> None:
+    store = TraceCheckpointStore(NoneReturningTraceEventBackend())
+
+    with pytest.raises(CheckpointPersistenceError):
+        await store.checkpoint(
+            type="checkpoint",
+            label="before_llm",
+            execution_id="exec-none-trace-event",
         )
 
 

--- a/tests/core/agent_v2/test_checkpoint.py
+++ b/tests/core/agent_v2/test_checkpoint.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import Agent, AgentRunner
+from xagent.core.agent_v2.checkpoint import (
+    CHECKPOINT_TYPE,
+    CheckpointPersistenceError,
+    TraceCheckpointStore,
+)
+
+
+class PersistentTraceBackend:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        require_persisted: bool = False,
+        **_: Any,
+    ) -> str:
+        event_id = f"event-{len(self.events) + 1}"
+        self.events.append(
+            {
+                "event_id": event_id,
+                "event_type": str(event_type),
+                "task_id": task_id,
+                "data": dict(data or {}),
+                "require_persisted": require_persisted,
+            }
+        )
+        return event_id
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        for event in reversed(self.events):
+            data = event["data"]
+            if (
+                data.get("checkpoint_type") == CHECKPOINT_TYPE
+                and data.get("root_execution_id") == execution_id
+            ):
+                return dict(data)
+        return None
+
+
+class BestEffortTraceBackend:
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        del event_type, task_id, data
+        return "best-effort"
+
+
+class FakeLLM:
+    async def chat(self, **_: Any) -> str:
+        return "done"
+
+
+class CheckpointingPattern:
+    async def run(self, *, context: Any, runtime: Any, **_: Any) -> dict[str, Any]:
+        context.add_assistant_message("done")
+        await runtime.checkpoint(
+            "final",
+            context=context,
+            pattern=self,
+            status="completed",
+        )
+        return {"success": True, "output": "done"}
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_persists_full_snapshot_event() -> None:
+    backend = PersistentTraceBackend()
+    store = TraceCheckpointStore(backend)
+    payload = {
+        "type": "checkpoint",
+        "label": "before_llm",
+        "execution_id": "exec-checkpoint",
+        "context": {"messages": []},
+        "pattern": "ReActPattern",
+        "pattern_state": {"current_iteration": 0},
+        "status": "thinking",
+    }
+
+    event_id = await store.checkpoint(**payload)
+    loaded = await store.load_latest_checkpoint("exec-checkpoint")
+
+    assert event_id == "event-1"
+    assert backend.events[0]["require_persisted"] is True
+    assert backend.events[0]["data"]["checkpoint_type"] == CHECKPOINT_TYPE
+    assert backend.events[0]["data"]["snapshot"] == payload
+    assert loaded == payload
+
+
+@pytest.mark.asyncio
+async def test_trace_checkpoint_store_rejects_best_effort_trace_event() -> None:
+    store = TraceCheckpointStore(BestEffortTraceBackend())
+
+    with pytest.raises(CheckpointPersistenceError):
+        await store.checkpoint(
+            type="checkpoint",
+            label="before_llm",
+            execution_id="exec-best-effort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_can_use_trace_checkpoint_store_for_resume() -> None:
+    backend = PersistentTraceBackend()
+    store = TraceCheckpointStore(backend)
+    agent = Agent(
+        name="checkpointed",
+        patterns=[CheckpointingPattern()],
+        llm=FakeLLM(),
+    )
+    runner = AgentRunner(agent=agent, tracer=store)
+
+    result = await runner.run(task="Say done", execution_id="exec-runner-store")
+    loaded = await store.load_latest_checkpoint("exec-runner-store")
+
+    assert result["success"] is True
+    assert loaded is not None
+    assert loaded["label"] == "final"
+    assert loaded["context"]["messages"][-1]["content"] == "done"

--- a/tests/core/agent_v2/test_context.py
+++ b/tests/core/agent_v2/test_context.py
@@ -17,7 +17,11 @@ from xagent.core.agent_v2.context.enrichment import (
     _lookup_relevant_memories_with_context,
     _parse_json_object,
     _skill_selection_attempt_key,
+    enrich_context_with_memory,
+    enrich_context_with_skill,
+    generate_and_store_react_memory,
 )
+from xagent.core.agent_v2.runtime import LLMCallInterrupted
 from xagent.web.user_isolated_memory import current_user_id
 
 
@@ -74,6 +78,217 @@ def test_memory_enrichment_uses_web_user_context(
     assert memories == [{"content": "memory"}]
     assert observed_user_ids == [42]
     assert current_user_id.get() is None
+
+
+@pytest.mark.asyncio
+async def test_enrich_context_with_memory_caches_and_builds_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_lookup_relevant_memories(*_: object, **__: object) -> list[dict[str, str]]:
+        calls.append("lookup")
+        return [{"content": "Prefer concise answers."}]
+
+    def fake_enhance_goal_with_memory(
+        query: str,
+        memories: list[dict[str, str]],
+    ) -> str:
+        return f"{query}\nMemory: {memories[0]['content']}"
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "lookup_relevant_memories",
+        fake_lookup_relevant_memories,
+    )
+    monkeypatch.setattr(
+        enrichment_module,
+        "enhance_goal_with_memory",
+        fake_enhance_goal_with_memory,
+    )
+    ctx = ExecutionContext(execution_id="exec-memory")
+
+    first = await enrich_context_with_memory(
+        context=ctx,
+        query="Summarize",
+        category="general",
+        memory_store=object(),
+    )
+    second = await enrich_context_with_memory(
+        context=ctx,
+        query="Summarize",
+        category="general",
+        memory_store=object(),
+    )
+
+    assert first == [{"content": "Prefer concise answers."}]
+    assert second == first
+    assert calls == ["lookup"]
+    assert ctx.metadata[MEMORY_CONTEXT_METADATA_KEY] == (
+        "Memory: Prefer concise answers."
+    )
+
+
+class FakeSkillManager:
+    def __init__(self, selected: dict[str, str] | None) -> None:
+        self.selected = selected
+        self.calls: list[dict[str, object]] = []
+
+    async def select_skill(self, **kwargs: object) -> dict[str, str] | None:
+        self.calls.append(kwargs)
+        return self.selected
+
+
+@pytest.mark.asyncio
+async def test_enrich_context_with_skill_records_selected_skill() -> None:
+    skill = {
+        "name": "writer",
+        "description": "Writes concise copy",
+        "when_to_use": "Writing",
+        "content": "Use short sentences.",
+    }
+    manager = FakeSkillManager(skill)
+    ctx = ExecutionContext(execution_id="exec-skill")
+
+    selected = await enrich_context_with_skill(
+        context=ctx,
+        task="Write release notes",
+        llm=object(),
+        skill_manager=manager,
+        allowed_skills=["writer"],
+    )
+
+    assert selected == skill
+    assert ctx.metadata[enrichment_module.SELECTED_SKILL_METADATA_KEY]["name"] == (
+        "writer"
+    )
+    assert "Use short sentences." in ctx.metadata[SKILL_CONTEXT_METADATA_KEY]
+
+
+@pytest.mark.asyncio
+async def test_enrich_context_with_skill_caches_no_skill() -> None:
+    manager = FakeSkillManager(None)
+    ctx = ExecutionContext(execution_id="exec-skill")
+
+    first = await enrich_context_with_skill(
+        context=ctx,
+        task="No matching skill",
+        llm=object(),
+        skill_manager=manager,
+        allowed_skills=["writer"],
+    )
+    second = await enrich_context_with_skill(
+        context=ctx,
+        task="No matching skill",
+        llm=object(),
+        skill_manager=manager,
+        allowed_skills=["writer"],
+    )
+
+    assert first is None
+    assert second is None
+    assert len(manager.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_and_store_react_memory_store_and_skip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored: list[dict[str, object]] = []
+
+    async def fake_generate(**_: object) -> dict[str, object]:
+        return {
+            "should_store": True,
+            "reason": "useful",
+            "core_insight": "core",
+            "tool_usage_insights": "tools",
+            "reasoning_strategy": "strategy",
+        }
+
+    def fake_store_react_task_memory(**kwargs: object) -> str:
+        stored.append(kwargs)
+        return "memory-1"
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "_generate_react_memory_insights",
+        fake_generate,
+    )
+    monkeypatch.setattr(
+        enrichment_module,
+        "store_react_task_memory",
+        fake_store_react_task_memory,
+    )
+    ctx = ExecutionContext(execution_id="exec-memory")
+    ctx.add_user_message("Do work")
+
+    await generate_and_store_react_memory(
+        context=ctx,
+        task="Do work",
+        result={"success": True, "output": "Done"},
+        iterations=2,
+        llm=object(),
+        memory_store=object(),
+    )
+
+    assert stored[0]["task"] == "Do work"
+    assert stored[0]["tool_usage_insights"] == "tools"
+
+
+@pytest.mark.asyncio
+async def test_generate_and_store_react_memory_parse_failure_skips_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored: list[dict[str, object]] = []
+
+    async def fake_generate(**_: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "_generate_react_memory_insights",
+        fake_generate,
+    )
+    monkeypatch.setattr(
+        enrichment_module,
+        "store_react_task_memory",
+        lambda **kwargs: stored.append(kwargs),
+    )
+
+    await generate_and_store_react_memory(
+        context=ExecutionContext(execution_id="exec-memory"),
+        task="Do work",
+        result={"success": True, "output": "Done"},
+        iterations=2,
+        llm=object(),
+        memory_store=object(),
+    )
+
+    assert stored == []
+
+
+@pytest.mark.asyncio
+async def test_generate_and_store_react_memory_propagates_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_generate(**_: object) -> None:
+        raise LLMCallInterrupted("paused")
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "_generate_react_memory_insights",
+        fake_generate,
+    )
+
+    with pytest.raises(LLMCallInterrupted, match="paused"):
+        await generate_and_store_react_memory(
+            context=ExecutionContext(execution_id="exec-memory"),
+            task="Do work",
+            result={"success": True, "output": "Done"},
+            iterations=2,
+            llm=object(),
+            memory_store=object(),
+        )
 
 
 def test_add_messages() -> None:

--- a/tests/core/agent_v2/test_context.py
+++ b/tests/core/agent_v2/test_context.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.agent_v2.context import (
+    ContextManager,
+    ExecutionContext,
+    GenericComponent,
+    MergeStrategy,
+    Message,
+)
+from xagent.core.agent_v2.context.enrichment import (
+    MEMORY_CONTEXT_METADATA_KEY,
+    SKILL_CONTEXT_METADATA_KEY,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_context_manager() -> None:
+    manager = ContextManager()
+    manager._contexts.clear()  # type: ignore[attr-defined]
+    yield
+    manager._contexts.clear()  # type: ignore[attr-defined]
+
+
+def test_create_context() -> None:
+    ctx = ExecutionContext()
+    ctx.execution_id = "task-1"
+    ctx.user_id = "user-1"
+    ctx.attach_workspace("ws-1", "/tmp/ws-1", cwd=".", state={"files": 2})
+    ctx.attach_memory_session("mem-1", {"summary": "hello"})
+
+    assert ctx.execution_id == "task-1"
+    assert ctx.user_id == "user-1"
+    assert ctx.workspace_id == "ws-1"
+    assert ctx.workspace_state["files"] == 2
+    assert ctx.memory_session_id == "mem-1"
+    assert ctx.memory_snapshot == {"summary": "hello"}
+
+
+def test_add_messages() -> None:
+    ctx = ExecutionContext()
+    user = ctx.add_user_message("hello")
+    assistant = ctx.add_assistant_message("hi there")
+    system = ctx.add_system_message("sys")
+    tool = ctx.add_tool_result("python", {"output": "done"}, tool_call_id="tool-1")
+
+    assert user.role == "user"
+    assert assistant.role == "assistant"
+    assert system.role == "system"
+    assert tool.role == "tool"
+    assert tool.metadata["tool_name"] == "python"
+    assert tool.metadata["raw_result"]["output"] == "done"
+
+
+def test_read_file_tool_result_omits_binary_like_content_from_context() -> None:
+    ctx = ExecutionContext()
+    binary_like = "PNG\x00" + ("x" * 100)
+
+    tool = ctx.add_tool_result("read_file", binary_like, tool_call_id="tool-1")
+
+    assert "binary-like content" in tool.content
+    assert binary_like not in tool.content
+    assert tool.metadata["raw_result"]["content_omitted"] is True
+    assert tool.metadata["raw_result"]["original_chars"] == len(binary_like)
+
+
+def test_read_file_tool_result_truncates_large_text_for_context() -> None:
+    ctx = ExecutionContext()
+    large_text = "a" * 13_000
+
+    tool = ctx.add_tool_result("read_file", large_text, tool_call_id="tool-1")
+
+    assert tool.metadata["raw_result"]["content_truncated"] is True
+    assert tool.metadata["raw_result"]["original_chars"] == len(large_text)
+    assert len(tool.metadata["raw_result"]["content_preview"]) == 12_000
+    assert len(tool.content) < len(large_text)
+
+
+def test_write_file_tool_call_omits_content_from_context() -> None:
+    ctx = ExecutionContext()
+    content = "<html>" + ("x" * 1000)
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "arguments": (
+                        '{"file_path":"index.html","content":"' + content + '"}'
+                    ),
+                },
+            }
+        ],
+    )
+
+    tool_call = ctx.messages[-1].tool_calls[0]
+    arguments = tool_call["function"]["arguments"]
+    assert "omitted from LLM context" in arguments
+    assert content not in arguments
+    assert "content_preview" in arguments
+
+
+def test_get_messages_for_llm_filters_hidden_and_truncates() -> None:
+    ctx = ExecutionContext()
+    ctx.system_prompt = "You are helpful"
+    ctx.add_user_message("visible-1")
+    ctx.add_user_message("hidden", hidden=True)
+    ctx.add_assistant_message("visible-2", output_tokens=2)
+    ctx.add_assistant_message("visible-3", output_tokens=3)
+
+    result = ctx.get_messages_for_llm(max_tokens=4)
+    assert result[0]["role"] == "system"
+    assert result[0]["content"].startswith("You are helpful")
+    assert "Current date and time:" in result[0]["content"]
+    # Max tokens = 4 should keep only last assistant message (3 tokens)
+    assert len(result) == 2
+    assert result[-1]["content"] == "visible-3"
+
+
+def test_get_messages_for_llm_injects_time_context_without_system_prompt() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("what happened recently?")
+
+    result = ctx.get_messages_for_llm()
+
+    assert result[0]["role"] == "system"
+    assert "Current date and time:" in result[0]["content"]
+    assert "relative dates" in result[0]["content"]
+    assert result[1] == {"role": "user", "content": "what happened recently?"}
+
+
+def test_get_messages_for_llm_coalesces_system_messages() -> None:
+    ctx = ExecutionContext(system_prompt="Base prompt.")
+    ctx.add_system_message("Recovered system context.")
+    ctx.add_user_message("hello")
+
+    result = ctx.get_messages_for_llm()
+
+    assert [message["role"] for message in result].count("system") == 1
+    assert result[0]["role"] == "system"
+    assert "Base prompt." in result[0]["content"]
+    assert "Current date and time:" in result[0]["content"]
+    assert "Recovered system context." not in result[0]["content"]
+    assert result[1]["role"] == "user"
+    assert "Previous system-context message" in result[1]["content"]
+    assert "Recovered system context." in result[1]["content"]
+    assert result[2] == {"role": "user", "content": "hello"}
+
+
+def test_get_messages_for_llm_injects_memory_and_skill_context() -> None:
+    ctx = ExecutionContext(system_prompt="Base prompt.")
+    ctx.metadata[MEMORY_CONTEXT_METADATA_KEY] = "Remember project convention X."
+    ctx.metadata[SKILL_CONTEXT_METADATA_KEY] = "## Available Skill: docs"
+    ctx.add_user_message("Use context")
+
+    result = ctx.get_messages_for_llm()
+
+    system_content = result[0]["content"]
+    assert "Relevant memories from previous tasks" in system_content
+    assert "Remember project convention X." in system_content
+    assert "Memory usage rules" in system_content
+    assert "not as sufficient evidence for new factual claims" in system_content
+    assert "Do not ask the user whether to use memory or whether to search" in (
+        system_content
+    )
+    assert "Selected skill guidance" in system_content
+    assert "## Available Skill: docs" in system_content
+
+
+def test_get_messages_for_llm_can_skip_system_time_context() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("hello")
+
+    result = ctx.get_messages_for_llm(include_system=False)
+
+    assert result == [{"role": "user", "content": "hello"}]
+
+
+def test_compact_truncate() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    for i in range(30):
+        ctx.add_user_message(f"message-{i}")
+
+    result = ctx.compact_if_needed()
+    assert result.compacted
+    assert result.strategy == "truncate"
+    assert len(ctx.messages) == 20
+    assert result.metadata["removed_count"] == 10
+
+
+def test_compact_truncate_preserves_tool_call_pair_boundary() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    for i in range(10):
+        ctx.add_user_message(f"message-{i}")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}},
+            {"id": "call-2", "type": "function", "function": {"name": "write_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "read"}, tool_call_id="call-1")
+    ctx.add_tool_result("write_file", {"output": "written"}, tool_call_id="call-2")
+    for i in range(19):
+        ctx.add_user_message(f"tail-{i}")
+
+    result = ctx.compact_if_needed()
+
+    assert result.compacted
+    assert ctx.messages[0].role == "assistant"
+    assert ctx.messages[0].tool_calls
+    assert ctx.messages[1].role == "tool"
+    assert ctx.messages[1].tool_call_id == "call-1"
+    assert ctx.messages[2].role == "tool"
+    assert ctx.messages[2].tool_call_id == "call-2"
+
+
+def test_get_messages_for_llm_drops_orphan_tool_messages() -> None:
+    ctx = ExecutionContext()
+    ctx.add_tool_result("read_file", {"output": "orphaned"}, tool_call_id="call-1")
+    ctx.add_user_message("continue")
+
+    messages = ctx.get_messages_for_llm()
+
+    assert [message["role"] for message in messages] == ["system", "user"]
+    assert messages[1]["content"] == "continue"
+
+
+def test_token_truncation_preserves_tool_call_pair_boundary() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("older")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "x"}, tool_call_id="call-1")
+
+    tool_tokens = max(1, len(ctx.messages[-1].content) // 4)
+    messages = ctx.get_messages_for_llm(max_tokens=tool_tokens)
+
+    assert [message["role"] for message in messages[1:]] == ["assistant", "tool"]
+    assert messages[1]["tool_calls"][0]["id"] == "call-1"
+    assert messages[2]["tool_call_id"] == "call-1"
+
+
+def test_compact_disabled() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.enabled = False
+    for i in range(5):
+        ctx.add_user_message(f"message-{i}")
+
+    result = ctx.compact_if_needed()
+    assert not result.compacted
+    assert len(ctx.messages) == 5
+
+
+def test_token_estimate_uses_latest_prompt_usage_plus_append_delta() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("a" * 20)
+    ctx.record_llm_usage(input_tokens=100, output_tokens=10)
+    ctx.add_assistant_message("b" * 16)
+    ctx.add_user_message("c" * 8)
+
+    assert ctx._get_total_tokens() == 106
+
+
+def test_token_estimate_falls_back_when_history_is_rewritten() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("a" * 20)
+    ctx.record_llm_usage(input_tokens=100, output_tokens=10)
+    ctx.messages[0] = Message.role_user("rewritten")
+
+    assert ctx._get_total_tokens() == max(1, len("rewritten") // 4)
+
+
+def test_serialization_roundtrip() -> None:
+    ctx = ExecutionContext()
+    ctx.execution_id = "task-x"
+    ctx.system_prompt = "sys"
+    ctx.attach_workspace("ws-1", "/tmp/ws1", cwd="work")
+    ctx.attach_memory_session("mem-2", {"state": "ok"})
+    ctx.add_user_message("hi")
+    msg = Message.role_assistant("response")
+    ctx.record_llm_call(msg, input_tokens=10, output_tokens=5)
+
+    data = ctx.to_dict()
+    restored = ExecutionContext.from_dict(data)
+
+    assert restored.execution_id == "task-x"
+    assert restored.system_prompt == "sys"
+    assert restored.workspace_id == "ws-1"
+    assert restored.memory_session_id == "mem-2"
+    assert len(restored.messages) == 2
+    assert restored.llm_calls[0].total_tokens == 15
+    assert restored.llm_calls[0].prompt_message_count == 1
+
+
+def test_context_manager_lifecycle() -> None:
+    manager = ContextManager()
+    ctx = manager.create_context(
+        execution_id="task-a",
+        user_id="user-a",
+        system_prompt="sys",
+        workspace_id="ws-1",
+        workspace_path="/tmp/ws-1",
+    )
+    assert manager.get_context("task-a") is ctx
+    assert manager.list_active_contexts("user-a") == [ctx]
+    manager.remove_context("task-a")
+    assert manager.get_context("task-a") is None
+
+
+def test_message_hash_and_eq() -> None:
+    m1 = Message.role_user("same content")
+    m2 = Message.role_user("same content")
+    assert m1 == m2
+    assert len({m1, m2}) == 1
+
+
+def test_extend_with_messages_auto_dedup() -> None:
+    ctx = ExecutionContext()
+    ctx.add_user_message("question")
+    duplicate = Message.role_user("question")
+    ctx.extend_with_messages([duplicate])
+
+    assert len(ctx.messages) == 1
+    assert ctx.messages[0] is duplicate
+    assert ctx.messages[0].content == "question"
+
+
+def test_merge_contexts_multiple_inputs() -> None:
+    ctx_a = ExecutionContext()
+    ctx_a.execution_id = "A"
+    ctx_a.add_user_message("do task")
+
+    ctx_b = ctx_a.create_child_context(execution_id="B")
+    ctx_b.add_assistant_message("step B done")
+
+    ctx_c = ctx_a.create_child_context(execution_id="C")
+    ctx_c.add_assistant_message("step C done")
+
+    merged = ExecutionContext.merge_contexts(
+        [ctx_b, ctx_c],
+        strategy=MergeStrategy.CHRONOLOGICAL,
+    )
+    assert len(merged.messages) == 3
+    assert merged.messages[0].content == "do task"
+
+
+def test_merge_strategies_topological_and_prefer_first() -> None:
+    ctx_a = ExecutionContext()
+    ctx_a.execution_id = "A"
+    msg = ctx_a.add_user_message("root")
+
+    ctx_b = ctx_a.create_child_context(execution_id="B")
+    ctx_b.add_assistant_message("B first")
+
+    ctx_c = ctx_a.create_child_context(execution_id="C")
+    ctx_c.add_assistant_message("C second")
+
+    topo = ExecutionContext.merge_contexts(
+        [ctx_b, ctx_c], strategy=MergeStrategy.TOPOLOGICAL
+    )
+    assert [m.content for m in topo.messages] == ["root", "B first", "C second"]
+
+    prefer = ExecutionContext.merge_contexts(
+        [ctx_c, ctx_b], strategy=MergeStrategy.PREFER_FIRST
+    )
+    assert prefer.messages[0] == msg
+    # prefer_first should keep first unique order (ctx_c before ctx_b)
+    assert [m.content for m in prefer.messages] == ["root", "C second", "B first"]
+
+
+def test_create_child_context_isolation_and_metadata() -> None:
+    ctx = ExecutionContext(metadata={"parent": True})
+    ctx.execution_id = "parent"
+    ctx.attach_workspace("ws-1", "/tmp/ws1", cwd="work")
+    ctx.add_user_message("parent-msg")
+
+    child = ctx.create_child_context(
+        execution_id="child", task="child task", metadata={"child": True}
+    )
+    child.add_assistant_message("child-msg")
+
+    assert child.execution_id == "child"
+    assert child.metadata["parent"] is True
+    assert child.metadata["child"] is True
+    assert child.metadata["task"] == "child task"
+    assert ctx.workspace_id == child.workspace_id
+    assert (
+        len(child.messages) == len(ctx.messages) + 2
+    )  # parent history + task + child msg
+    assert ctx.messages[-1].content == "parent-msg"
+
+
+def test_llm_call_token_tracking() -> None:
+    ctx = ExecutionContext()
+    response = Message.role_assistant("result")
+    ctx.record_llm_call(response, input_tokens=8, output_tokens=3)
+
+    usage = ctx.get_total_token_usage()
+    assert usage["total"] == 11
+    assert usage["input"] == 8
+    assert usage["output"] == 3
+    assert ctx.llm_calls[0].message_index == len(ctx.messages) - 1
+
+
+def test_custom_component_roundtrip_without_context_schema_change() -> None:
+    ctx = ExecutionContext()
+    ctx.set_component(
+        "skills",
+        GenericComponent(data={"library_dirs": ["/tmp/skills"], "active": ["writer"]}),
+    )
+
+    restored = ExecutionContext.from_dict(ctx.to_dict())
+    component = restored.get_component("skills")
+
+    assert isinstance(component, GenericComponent)
+    assert component.data == {
+        "library_dirs": ["/tmp/skills"],
+        "active": ["writer"],
+    }

--- a/tests/core/agent_v2/test_context.py
+++ b/tests/core/agent_v2/test_context.py
@@ -12,6 +12,8 @@ from xagent.core.agent_v2.context import (
 from xagent.core.agent_v2.context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
+    _parse_json_object,
+    _skill_selection_attempt_key,
 )
 
 
@@ -192,6 +194,20 @@ def test_compact_truncate() -> None:
     assert result.metadata["removed_count"] == 10
 
 
+def test_compact_truncate_uses_configured_message_limit() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.compact_config.max_messages = 30
+    for i in range(50):
+        ctx.add_user_message(f"message-{i}")
+
+    result = ctx.compact_if_needed()
+
+    assert result.compacted
+    assert len(ctx.messages) == 30
+    assert result.metadata["removed_count"] == 20
+
+
 def test_compact_truncate_preserves_tool_call_pair_boundary() -> None:
     ctx = ExecutionContext()
     ctx.compact_config.threshold = 1
@@ -300,6 +316,30 @@ def test_serialization_roundtrip() -> None:
     assert len(restored.messages) == 2
     assert restored.llm_calls[0].total_tokens == 15
     assert restored.llm_calls[0].prompt_message_count == 1
+    assert restored.compact_config.max_messages == ctx.compact_config.max_messages
+
+
+def test_parse_json_object_extracts_fenced_json_with_preamble() -> None:
+    content = """Here is the analysis:
+
+```json
+{"should_store": false, "reason": "routine"}
+```
+"""
+
+    parsed = _parse_json_object(content)
+
+    assert parsed == {"should_store": False, "reason": "routine"}
+
+
+def test_skill_selection_attempt_key_hashes_task_payload() -> None:
+    task = "x" * 1000
+
+    key = _skill_selection_attempt_key(task, ["b", "a"])
+
+    assert len(key) == 64
+    assert task not in key
+    assert key == _skill_selection_attempt_key(task, ["a", "b"])
 
 
 def test_context_manager_lifecycle() -> None:

--- a/tests/core/agent_v2/test_context.py
+++ b/tests/core/agent_v2/test_context.py
@@ -9,12 +9,16 @@ from xagent.core.agent_v2.context import (
     MergeStrategy,
     Message,
 )
+from xagent.core.agent_v2.context import enrichment as enrichment_module
 from xagent.core.agent_v2.context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
+    _current_user_id,
+    _lookup_relevant_memories_with_context,
     _parse_json_object,
     _skill_selection_attempt_key,
 )
+from xagent.web.user_isolated_memory import current_user_id
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +42,38 @@ def test_create_context() -> None:
     assert ctx.workspace_state["files"] == 2
     assert ctx.memory_session_id == "mem-1"
     assert ctx.memory_snapshot == {"summary": "hello"}
+
+
+def test_memory_enrichment_uses_web_user_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_user_ids: list[int | None] = []
+
+    def fake_lookup_relevant_memories(*_: object, **__: object) -> list[dict[str, str]]:
+        observed_user_ids.append(current_user_id.get())
+        return [{"content": "memory"}]
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "lookup_relevant_memories",
+        fake_lookup_relevant_memories,
+    )
+
+    assert current_user_id.get() is None
+    assert _current_user_id() is None
+    memories = _lookup_relevant_memories_with_context(
+        memory_store=object(),
+        query="query",
+        category="general",
+        include_general=True,
+        limit=5,
+        similarity_threshold=None,
+        user_id=42,
+    )
+
+    assert memories == [{"content": "memory"}]
+    assert observed_user_ids == [42]
+    assert current_user_id.get() is None
 
 
 def test_add_messages() -> None:
@@ -266,6 +302,21 @@ def test_token_truncation_preserves_tool_call_pair_boundary() -> None:
     assert messages[2]["tool_call_id"] == "call-1"
 
 
+def test_get_messages_for_llm_preserves_tool_call_pair_without_ids() -> None:
+    ctx = ExecutionContext()
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"type": "function", "function": {"name": "read_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "x"})
+
+    messages = ctx.get_messages_for_llm()
+
+    assert [message["role"] for message in messages[1:]] == ["assistant", "tool"]
+
+
 def test_compact_disabled() -> None:
     ctx = ExecutionContext()
     ctx.compact_config.enabled = False
@@ -357,11 +408,40 @@ def test_context_manager_lifecycle() -> None:
     assert manager.get_context("task-a") is None
 
 
+def test_context_manager_warns_on_duplicate_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = ContextManager()
+    manager.create_context(execution_id="duplicate")
+
+    manager.create_context(execution_id="duplicate")
+
+    assert "Replacing existing execution context duplicate" in caplog.text
+
+
 def test_message_hash_and_eq() -> None:
     m1 = Message.role_user("same content")
     m2 = Message.role_user("same content")
     assert m1 == m2
     assert len({m1, m2}) == 1
+
+
+def test_message_identity_includes_tool_calls() -> None:
+    first = Message.role_assistant(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    second = Message.role_assistant(
+        "",
+        tool_calls=[
+            {"id": "call-2", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+
+    assert first != second
+    assert len({first, second}) == 2
 
 
 def test_extend_with_messages_auto_dedup() -> None:
@@ -392,6 +472,18 @@ def test_merge_contexts_multiple_inputs() -> None:
     )
     assert len(merged.messages) == 3
     assert merged.messages[0].content == "do task"
+
+
+def test_merge_contexts_preserves_base_created_at_and_deep_copies_workspace() -> None:
+    ctx = ExecutionContext()
+    ctx.attach_workspace("ws-1", "/tmp/ws1", state={"nested": {"count": 1}})
+    original_created_at = ctx.created_at
+
+    merged = ExecutionContext.merge_contexts([ctx])
+    merged.workspace_state["nested"]["count"] = 2
+
+    assert merged.created_at == original_created_at
+    assert ctx.workspace_state["nested"]["count"] == 1
 
 
 def test_merge_strategies_topological_and_prefer_first() -> None:

--- a/tests/core/agent_v2/test_frame.py
+++ b/tests/core/agent_v2/test_frame.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from xagent.core.agent_v2 import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 
 
@@ -38,3 +40,23 @@ def test_execution_snapshot_roundtrip() -> None:
     assert restored.status == "interrupted"
     assert restored.frames[root.frame_id].active_child_id == child.frame_id
     assert restored.frames[child.frame_id].metadata["dag_step_id"] == "step_1"
+
+
+def test_execution_snapshot_rejects_mismatched_frame_key() -> None:
+    frame = ExecutionFrame(
+        frame_id="actual",
+        root_execution_id="exec-1",
+        pattern_type="dag",
+        status=ExecutionStatus.RUNNING,
+        context={},
+        pattern_state={},
+    )
+    payload = ExecutionSnapshot(
+        root_execution_id="exec-1",
+        status=ExecutionStatus.RUNNING,
+        frames={"actual": frame},
+    ).to_dict()
+    payload["frames"]["wrong"] = payload["frames"].pop("actual")
+
+    with pytest.raises(ValueError, match="Frame key mismatch"):
+        ExecutionSnapshot.from_dict(payload)

--- a/tests/core/agent_v2/test_frame.py
+++ b/tests/core/agent_v2/test_frame.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from xagent.core.agent_v2 import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+
+
+def test_execution_snapshot_roundtrip() -> None:
+    root = ExecutionFrame(
+        frame_id="exec-1:dag",
+        root_execution_id="exec-1",
+        pattern_type="dag",
+        status=ExecutionStatus.RUNNING,
+        context={"execution_id": "exec-1"},
+        pattern_state={"status": "running"},
+        children=["exec-1:dag_step:step_1"],
+        active_child_id="exec-1:dag_step:step_1",
+    )
+    child = ExecutionFrame(
+        frame_id="exec-1:dag_step:step_1",
+        parent_frame_id="exec-1:dag",
+        root_execution_id="exec-1",
+        pattern_type="react",
+        status=ExecutionStatus.INTERRUPTED,
+        context={"execution_id": "exec-1_child"},
+        pattern_state={"pending_tool_calls": []},
+        metadata={"dag_step_id": "step_1"},
+    )
+    snapshot = ExecutionSnapshot(
+        root_execution_id="exec-1",
+        status=ExecutionStatus.INTERRUPTED,
+        frames={root.frame_id: root, child.frame_id: child},
+        active_frame_ids=[root.frame_id, child.frame_id],
+        control_state={"planned_user_message_count": 1},
+    )
+
+    restored = ExecutionSnapshot.from_dict(snapshot.to_dict())
+
+    assert restored.root_execution_id == "exec-1"
+    assert restored.status == "interrupted"
+    assert restored.frames[root.frame_id].active_child_id == child.frame_id
+    assert restored.frames[child.frame_id].metadata["dag_step_id"] == "step_1"

--- a/tests/core/agent_v2/test_registry.py
+++ b/tests/core/agent_v2/test_registry.py
@@ -14,6 +14,7 @@ from xagent.core.agent_v2 import (
     ExecutionLifecycleStatus,
     PatternRuntime,
 )
+from xagent.core.agent_v2 import registry as registry_module
 from xagent.core.agent_v2.registry import ExecutionRegistry
 from xagent.core.agent_v2.runner import AgentRunner
 
@@ -220,6 +221,33 @@ async def test_registry_emits_lifecycle_and_message_events(
     assert events[2]["message"] == "Reply with only the number."
     assert registry.unsubscribe(subscription_id) is True
     assert registry.unsubscribe(subscription_id) is False
+
+
+@pytest.mark.asyncio
+async def test_registry_logs_async_subscriber_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ExecutionRegistry()
+    logged_messages: list[str] = []
+
+    async def failing_subscriber(_: dict[str, Any]) -> None:
+        raise RuntimeError("subscriber failed")
+
+    def fake_exception(message: str) -> None:
+        logged_messages.append(message)
+
+    monkeypatch.setattr(registry_module.logger, "exception", fake_exception)
+    registry.subscribe(failing_subscriber)
+
+    registry.register(
+        "exec-subscriber-error",
+        AgentRunner(agent=Agent(name="writer", patterns=[SuccessfulPattern()])),
+        requested_task="manual task",
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert logged_messages == ["Execution registry subscriber failed"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_registry.py
+++ b/tests/core/agent_v2/test_registry.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import (
+    Agent,
+    ContextManager,
+    ExecutionContext,
+    ExecutionLifecycleStatus,
+    PatternRuntime,
+)
+from xagent.core.agent_v2.registry import ExecutionRegistry
+from xagent.core.agent_v2.runner import AgentRunner
+
+
+@pytest.fixture(autouse=True)
+def reset_context_manager() -> None:
+    manager = ContextManager()
+    manager._contexts.clear()  # type: ignore[attr-defined]
+    yield
+    manager._contexts.clear()  # type: ignore[attr-defined]
+
+
+@dataclass
+class FakeWorkspace:
+    id: str
+    workspace_dir: Path
+    input_dir: Path
+    output_dir: Path
+    temp_dir: Path
+    allowed_external_dirs: list[Path]
+
+
+class FakeWorkspaceManager:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def get_or_create_workspace(
+        self,
+        base_dir: str,
+        task_id: str,
+        allowed_external_dirs: list[str] | None = None,
+    ) -> FakeWorkspace:
+        del base_dir
+        workspace_dir = self.tmp_path / task_id
+        return FakeWorkspace(
+            id=task_id,
+            workspace_dir=workspace_dir,
+            input_dir=workspace_dir / "input",
+            output_dir=workspace_dir / "output",
+            temp_dir=workspace_dir / "temp",
+            allowed_external_dirs=[Path(path) for path in allowed_external_dirs or []],
+        )
+
+
+class TracerCheckpointStore:
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+class InterruptingPattern:
+    def __init__(self, runner: AgentRunner, execution_id: str) -> None:
+        self.runner = runner
+        self.execution_id = execution_id
+
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        runtime: PatternRuntime,
+        **_: Any,
+    ) -> dict[str, Any]:
+        self.runner.pause(self.execution_id, reason="pause before step")
+        if await runtime.should_interrupt():
+            await runtime.checkpoint(
+                "interrupted",
+                context=context,
+                pattern=self,
+                status="interrupted",
+                metadata={"safe_point": "during_pattern"},
+            )
+            return {
+                "success": False,
+                "status": "interrupted",
+                "error": "InterruptingPattern interrupted.",
+            }
+
+        return {"success": True, "output": "continued"}
+
+
+class SuccessfulPattern:
+    async def run(self, **_: Any) -> dict[str, Any]:
+        return {"success": True, "output": "done"}
+
+
+class BlockingPattern:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def run(self, **_: Any) -> dict[str, Any]:
+        self.started.set()
+        await asyncio.Future()
+        return {"success": True, "output": "unreachable"}
+
+
+@pytest.mark.asyncio
+async def test_registry_routes_live_execution_control_and_resume(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-registry"
+    registry = ExecutionRegistry()
+    first_agent = Agent(name="writer", patterns=[])
+    first_runner = AgentRunner(
+        agent=first_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    first_agent.patterns = [InterruptingPattern(first_runner, execution_id)]
+
+    handle = registry.start(
+        first_runner,
+        execution_id=execution_id,
+        task="Calculate 6*7",
+    )
+    assert handle.status == ExecutionLifecycleStatus.RUNNING
+    assert handle.requested_task == "Calculate 6*7"
+    interrupted = await handle.task
+
+    assert interrupted["status"] == "interrupted"
+    stored = registry.get(execution_id)
+    assert stored is not None
+    assert stored.status == ExecutionLifecycleStatus.INTERRUPTED
+    assert stored.is_resumable is True
+    assert stored.last_error == "InterruptingPattern interrupted."
+    assert stored.to_dict()["status"] == "interrupted"
+    assert registry.get_status(execution_id) == stored.to_dict()
+    assert registry.list_statuses() == [stored.to_dict()]
+
+    context = await registry.post_user_message(
+        execution_id,
+        "Reply with only the number.",
+        request_interrupt=False,
+    )
+    assert context is not None
+    assert any(
+        message.role == "user" and message.content == "Reply with only the number."
+        for message in context.messages
+    )
+
+    resumed_agent = Agent(
+        name="writer",
+        patterns=[SuccessfulPattern()],
+    )
+    resumed_runner = AgentRunner(
+        agent=resumed_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    registry.register(execution_id, resumed_runner)
+
+    resumed = await registry.resume(execution_id)
+
+    assert resumed is not None
+    assert resumed["success"] is True
+    assert resumed["output"] == "done"
+    assert registry.get(execution_id) is None
+
+
+@pytest.mark.asyncio
+async def test_registry_emits_lifecycle_and_message_events(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-events"
+    registry = ExecutionRegistry()
+    events: list[dict[str, Any]] = []
+    subscription_id = registry.subscribe(events.append)
+    first_agent = Agent(name="writer", patterns=[])
+    first_runner = AgentRunner(
+        agent=first_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    first_agent.patterns = [InterruptingPattern(first_runner, execution_id)]
+
+    handle = registry.start(
+        first_runner,
+        execution_id=execution_id,
+        task="Calculate 6*7",
+    )
+    assert handle.task is not None
+    await handle.task
+    await registry.post_user_message(
+        execution_id,
+        "Reply with only the number.",
+        request_interrupt=False,
+    )
+
+    event_types = [event["type"] for event in events]
+    assert event_types == [
+        "execution.started",
+        "execution.interrupted",
+        "execution.message_posted",
+    ]
+    assert all(event["execution_id"] == execution_id for event in events)
+    assert events[1]["handle"]["status"] == "interrupted"
+    assert events[2]["message"] == "Reply with only the number."
+    assert registry.unsubscribe(subscription_id) is True
+    assert registry.unsubscribe(subscription_id) is False
+
+
+@pytest.mark.asyncio
+async def test_registry_cancel_running_execution_emits_cancelled_and_cleans_up(
+    tmp_path: Path,
+) -> None:
+    registry = ExecutionRegistry()
+    events: list[dict[str, Any]] = []
+    registry.subscribe(events.append)
+    pattern = BlockingPattern()
+    runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[pattern]),
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    handle = registry.start(
+        runner,
+        execution_id="exec-cancel",
+        task="Block forever",
+    )
+    await pattern.started.wait()
+
+    assert registry.cancel("exec-cancel", reason="user cancelled") is True
+    with pytest.raises(asyncio.CancelledError):
+        assert handle.task is not None
+        await handle.task
+
+    assert registry.get("exec-cancel") is None
+    event_types = [event["type"] for event in events]
+    assert event_types == ["execution.started", "execution.cancelled"]
+    assert events[-1]["handle"]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_registry_cancelled_execution_cannot_resume(tmp_path: Path) -> None:
+    registry = ExecutionRegistry()
+    pattern = BlockingPattern()
+    runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[pattern]),
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    handle = registry.start(
+        runner,
+        execution_id="exec-cancel-resume",
+        task="Block forever",
+    )
+    await pattern.started.wait()
+    assert registry.cancel("exec-cancel-resume") is True
+    with pytest.raises(asyncio.CancelledError):
+        assert handle.task is not None
+        await handle.task
+
+    assert await registry.resume("exec-cancel-resume") is None
+
+
+@pytest.mark.asyncio
+async def test_registry_unregisters_completed_execution_tasks(tmp_path: Path) -> None:
+    registry = ExecutionRegistry()
+    runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[SuccessfulPattern()]),
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    handle = registry.start(
+        runner,
+        execution_id="exec-complete",
+        task="Say done",
+    )
+    assert handle.task is not None
+    result = await handle.task
+
+    assert result["success"] is True
+    assert registry.get("exec-complete") is None
+
+
+@pytest.mark.asyncio
+async def test_registry_returns_none_for_unknown_execution_on_message_post() -> None:
+    registry = ExecutionRegistry()
+
+    context = await registry.post_user_message("missing", "hello")
+
+    assert context is None
+
+
+@pytest.mark.asyncio
+async def test_registry_pause_returns_false_for_unknown_execution() -> None:
+    registry = ExecutionRegistry()
+
+    assert registry.pause("missing") is False
+
+
+@pytest.mark.asyncio
+async def test_registry_cancel_returns_false_for_unknown_execution() -> None:
+    registry = ExecutionRegistry()
+
+    assert registry.cancel("missing") is False
+
+
+@pytest.mark.asyncio
+async def test_registry_resume_returns_none_for_unknown_execution() -> None:
+    registry = ExecutionRegistry()
+
+    result = await registry.resume("missing")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_registry_registers_handle_metadata() -> None:
+    runner = AgentRunner(agent=Agent(name="writer", patterns=[SuccessfulPattern()]))
+    registry = ExecutionRegistry()
+
+    handle = registry.register(
+        "exec-meta",
+        runner,
+        requested_task="metadata task",
+        metadata={"source": "test"},
+    )
+
+    assert handle.metadata == {"source": "test"}
+    assert handle.requested_task == "metadata task"
+    assert handle.status == ExecutionLifecycleStatus.REGISTERED
+    assert registry.get("exec-meta") is handle
+    assert registry.get_status("exec-meta") == handle.to_dict()
+    assert registry.list_statuses() == [handle.to_dict()]
+    assert handle.to_dict()["is_resumable"] is False
+
+
+@pytest.mark.asyncio
+async def test_registry_emits_registered_event_for_manual_handle_registration() -> None:
+    runner = AgentRunner(agent=Agent(name="writer", patterns=[SuccessfulPattern()]))
+    registry = ExecutionRegistry()
+    events: list[dict[str, Any]] = []
+    registry.subscribe(events.append)
+
+    registry.register(
+        "exec-manual",
+        runner,
+        requested_task="manual task",
+        metadata={"source": "manual"},
+    )
+
+    assert [event["type"] for event in events] == ["execution.registered"]
+    assert events[0]["handle"]["status"] == "registered"
+
+
+@pytest.mark.asyncio
+async def test_registry_cancel_non_running_handle_marks_terminal_and_unregisters() -> (
+    None
+):
+    runner = AgentRunner(agent=Agent(name="writer", patterns=[SuccessfulPattern()]))
+    registry = ExecutionRegistry()
+    events: list[dict[str, Any]] = []
+    registry.subscribe(events.append)
+
+    registry.register(
+        "exec-manual-cancel",
+        runner,
+        requested_task="manual task",
+        metadata={"source": "manual"},
+    )
+
+    assert registry.cancel("exec-manual-cancel", reason="manual cancel") is True
+    assert registry.get("exec-manual-cancel") is None
+    assert [event["type"] for event in events] == [
+        "execution.registered",
+        "execution.cancelled",
+    ]
+    assert events[-1]["handle"]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_registry_status_queries_return_none_or_empty_for_missing_handles() -> (
+    None
+):
+    registry = ExecutionRegistry()
+
+    assert registry.get_status("missing") is None
+    assert registry.list_statuses() == []

--- a/tests/core/agent_v2/test_registry.py
+++ b/tests/core/agent_v2/test_registry.py
@@ -250,6 +250,33 @@ async def test_registry_logs_async_subscriber_failures(
     assert logged_messages == ["Execution registry subscriber failed"]
 
 
+def test_registry_logs_sync_subscriber_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ExecutionRegistry()
+    logged_messages: list[str] = []
+    events: list[dict[str, Any]] = []
+
+    def failing_subscriber(_: dict[str, Any]) -> None:
+        raise RuntimeError("subscriber failed")
+
+    def fake_exception(message: str) -> None:
+        logged_messages.append(message)
+
+    monkeypatch.setattr(registry_module.logger, "exception", fake_exception)
+    registry.subscribe(failing_subscriber)
+    registry.subscribe(events.append)
+
+    registry.register(
+        "exec-sync-subscriber-error",
+        AgentRunner(agent=Agent(name="writer", patterns=[SuccessfulPattern()])),
+        requested_task="manual task",
+    )
+
+    assert logged_messages == ["Execution registry subscriber failed"]
+    assert events[0]["type"] == "execution.registered"
+
+
 @pytest.mark.asyncio
 async def test_registry_cancel_running_execution_emits_cancelled_and_cleans_up(
     tmp_path: Path,
@@ -271,6 +298,7 @@ async def test_registry_cancel_running_execution_emits_cancelled_and_cleans_up(
     await pattern.started.wait()
 
     assert registry.cancel("exec-cancel", reason="user cancelled") is True
+    assert handle.status == ExecutionLifecycleStatus.CANCELLED
     with pytest.raises(asyncio.CancelledError):
         assert handle.task is not None
         await handle.task

--- a/tests/core/agent_v2/test_runner.py
+++ b/tests/core/agent_v2/test_runner.py
@@ -143,6 +143,24 @@ class StatefulPattern:
         }
 
 
+class InjectingPattern:
+    def __init__(self, runner: AgentRunner, execution_id: str) -> None:
+        self.runner = runner
+        self.execution_id = execution_id
+
+    async def run(self, *, context: ExecutionContext, **_: Any) -> dict[str, Any]:
+        injected = await self.runner.inject_user_message(
+            self.execution_id,
+            "Injected while resumed.",
+            request_interrupt=False,
+        )
+        return {
+            "success": True,
+            "same_context": injected is context,
+            "messages": [message.content for message in context.messages],
+        }
+
+
 class TrackingCallback:
     def __init__(self) -> None:
         self.events: list[tuple[str, str]] = []
@@ -388,6 +406,22 @@ async def test_runner_returns_single_pattern_failure_result(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_runner_does_not_add_empty_user_message_for_missing_task(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task=None, execution_id="exec-empty-task")
+
+    assert result["success"] is True
+    assert result["context"].messages == []
+
+
+@pytest.mark.asyncio
 async def test_runner_stops_on_llm_call_interrupt(tmp_path: Path) -> None:
     fallback = FakePattern({"success": True, "output": "should not run"})
     agent = Agent(name="writer", patterns=[LLMInterruptedPattern(), fallback])
@@ -437,6 +471,35 @@ async def test_runner_restores_context_and_pattern_from_checkpoint(
         "Original task",
         "restored",
     ]
+
+
+@pytest.mark.asyncio
+async def test_runner_registers_restored_context_for_live_message_injection(
+    tmp_path: Path,
+) -> None:
+    checkpoint_context = ExecutionContext(execution_id="exec-restore-inject")
+    checkpoint_context.add_user_message("Original task")
+    checkpoint = {
+        "context": checkpoint_context.to_dict(),
+        "pattern": "InjectingPattern",
+        "pattern_state": {},
+    }
+    agent = Agent(name="writer", patterns=[])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    agent.patterns = [InjectingPattern(runner, "exec-restore-inject")]
+
+    result = await runner.run(
+        task=None,
+        execution_id="exec-restore-inject",
+        checkpoint=checkpoint,
+    )
+
+    assert result["success"] is True
+    assert result["same_context"] is True
+    assert result["messages"] == ["Original task", "Injected while resumed."]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_runner.py
+++ b/tests/core/agent_v2/test_runner.py
@@ -87,6 +87,21 @@ class FakeMemoryManager:
         }
 
 
+class AsyncMemoryManager(FakeMemoryManager):
+    async def get_or_create_session(
+        self,
+        *,
+        execution_id: str,
+        user_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        return super().get_or_create_session(
+            execution_id=execution_id,
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+
 class FakePattern:
     def __init__(self, result: dict[str, Any]) -> None:
         self.result = result
@@ -269,6 +284,28 @@ async def test_runner_builds_context_and_invokes_pattern(tmp_path: Path) -> None
     assert isinstance(pattern_call["runtime"], PatternRuntime)
     assert workspace_manager.calls[0]["task_id"] == "exec-1"
     assert callback.events == [("start", "exec-1"), ("end", "exec-1")]
+
+
+@pytest.mark.asyncio
+async def test_runner_awaits_async_memory_manager(tmp_path: Path) -> None:
+    memory_manager = AsyncMemoryManager()
+    pattern = FakePattern({"success": True, "output": "done"})
+    agent = Agent(name="writer", patterns=[pattern])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+        memory_manager=memory_manager,
+    )
+
+    result = await runner.run(
+        task="Write a summary",
+        execution_id="exec-async-memory",
+        session_id="session-async",
+    )
+
+    assert result["success"] is True
+    assert result["context"].memory_session_id == "session-async"
+    assert result["context"].memory_snapshot == {"summary": "resume exec-async-memory"}
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_runner.py
+++ b/tests/core/agent_v2/test_runner.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import (
+    Agent,
+    ContextManager,
+    ExecutionContext,
+    PatternRuntime,
+    TraceEventCallback,
+)
+from xagent.core.agent_v2.runner import AgentRunner
+
+
+@pytest.fixture(autouse=True)
+def reset_context_manager() -> None:
+    manager = ContextManager()
+    manager._contexts.clear()  # type: ignore[attr-defined]
+    yield
+    manager._contexts.clear()  # type: ignore[attr-defined]
+
+
+@dataclass
+class FakeWorkspace:
+    id: str
+    workspace_dir: Path
+    input_dir: Path
+    output_dir: Path
+    temp_dir: Path
+    allowed_external_dirs: list[Path]
+
+
+class FakeWorkspaceManager:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.calls: list[dict[str, Any]] = []
+
+    def get_or_create_workspace(
+        self,
+        base_dir: str,
+        task_id: str,
+        allowed_external_dirs: list[str] | None = None,
+    ) -> FakeWorkspace:
+        self.calls.append(
+            {
+                "base_dir": base_dir,
+                "task_id": task_id,
+                "allowed_external_dirs": allowed_external_dirs,
+            }
+        )
+        workspace_dir = self.tmp_path / task_id
+        return FakeWorkspace(
+            id=task_id,
+            workspace_dir=workspace_dir,
+            input_dir=workspace_dir / "input",
+            output_dir=workspace_dir / "output",
+            temp_dir=workspace_dir / "temp",
+            allowed_external_dirs=[Path(path) for path in allowed_external_dirs or []],
+        )
+
+
+class FakeMemoryManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get_or_create_session(
+        self,
+        *,
+        execution_id: str,
+        user_id: str | None = None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "execution_id": execution_id,
+                "user_id": user_id,
+                "session_id": session_id,
+            }
+        )
+        return {
+            "session_id": session_id or f"memory-{execution_id}",
+            "snapshot": {"summary": f"resume {execution_id}"},
+        }
+
+
+class FakePattern:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def run(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return dict(self.result)
+
+
+class FailingPattern:
+    def __init__(self, error: str) -> None:
+        self.error = error
+
+    async def run(self, **_: Any) -> dict[str, Any]:
+        return {"success": False, "error": self.error}
+
+
+class StatefulPattern:
+    def __init__(self) -> None:
+        self.state: dict[str, Any] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self.state = state
+
+    async def run(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {
+            "success": True,
+            "output": self.state["output"],
+            "message_count": len(kwargs["context"].messages),
+        }
+
+
+class TrackingCallback:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    async def on_run_start(self, **payload: Any) -> None:
+        context = payload["context"]
+        self.events.append(("start", context.execution_id))
+
+    async def on_run_end(self, **payload: Any) -> None:
+        context = payload["context"]
+        self.events.append(("end", context.execution_id))
+
+
+class RecordingTraceEventTracer:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+class InterruptingPattern:
+    def __init__(
+        self,
+        runner: AgentRunner,
+        execution_id: str,
+        *,
+        before_interrupt_check: Any | None = None,
+    ) -> None:
+        self.runner = runner
+        self.execution_id = execution_id
+        self.before_interrupt_check = before_interrupt_check
+
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        runtime: PatternRuntime,
+        **_: Any,
+    ) -> dict[str, Any]:
+        if callable(self.before_interrupt_check):
+            maybe_result = self.before_interrupt_check()
+            if maybe_result is not None:
+                await maybe_result
+        else:
+            self.runner.pause(self.execution_id, reason="pause before step")
+
+        if await runtime.should_interrupt():
+            await runtime.checkpoint(
+                "interrupted",
+                context=context,
+                pattern=self,
+                status="interrupted",
+                metadata={"safe_point": "during_pattern"},
+            )
+            return {
+                "success": False,
+                "status": "interrupted",
+                "error": runtime.interrupt_reason or "interrupted",
+            }
+
+        return {"success": True, "output": "continued"}
+
+
+class TracerCheckpointStore:
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+@pytest.mark.asyncio
+async def test_runner_builds_context_and_invokes_pattern(tmp_path: Path) -> None:
+    workspace_manager = FakeWorkspaceManager(tmp_path)
+    memory_manager = FakeMemoryManager()
+    callback = TrackingCallback()
+    pattern = FakePattern({"success": True, "output": "done"})
+    agent = Agent(
+        name="writer",
+        patterns=[pattern],
+        tools=["local-tool"],
+        llm="fake-llm",
+        system_prompt="System prompt",
+    )
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=workspace_manager,
+        memory_manager=memory_manager,
+        callbacks=[callback],
+        workspace_base_dir=str(tmp_path / "workspaces"),
+    )
+
+    result = await runner.run(
+        task="Write a summary",
+        execution_id="exec-1",
+        user_id="user-1",
+        session_id="session-1",
+        allowed_external_dirs=[str(tmp_path / "kb")],
+        extra_tools=["extra-tool"],
+        metadata={"source": "test"},
+    )
+
+    assert result["success"] is True
+    assert result["execution_id"] == "exec-1"
+    context = result["context"]
+    assert isinstance(context, ExecutionContext)
+    assert context.system_prompt == "System prompt"
+    assert context.user_id == "user-1"
+    assert context.session_id == "session-1"
+    assert context.workspace_id == "exec-1"
+    assert context.memory_session_id == "session-1"
+    assert context.memory_snapshot == {"summary": "resume exec-1"}
+    assert context.metadata["task"] == "Write a summary"
+    assert context.metadata["source"] == "test"
+    assert [message.role for message in context.messages] == ["user", "assistant"]
+    assert context.messages[0].content == "Write a summary"
+    assert context.messages[1].content == "done"
+    assert ContextManager().get_context("exec-1") is context
+
+    pattern_call = pattern.calls[0]
+    assert pattern_call["task"] == "Write a summary"
+    assert pattern_call["context"] is context
+    assert pattern_call["tools"] == ["local-tool", "extra-tool"]
+    assert pattern_call["llm"] == "fake-llm"
+    assert isinstance(pattern_call["runtime"], PatternRuntime)
+    assert workspace_manager.calls[0]["task_id"] == "exec-1"
+    assert callback.events == [("start", "exec-1"), ("end", "exec-1")]
+
+
+@pytest.mark.asyncio
+async def test_runner_tries_multiple_patterns_and_collects_failures(
+    tmp_path: Path,
+) -> None:
+    first = FailingPattern("first failed")
+    second = FakePattern({"success": True, "message": "second worked"})
+    agent = Agent(name="writer", patterns=[first, second])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Recover", execution_id="exec-2")
+
+    assert result["success"] is True
+    assert result["pattern"] == "FakePattern"
+    context = result["context"]
+    assert [message.content for message in context.messages] == [
+        "Recover",
+        "second worked",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_returns_aggregate_error_when_all_patterns_fail(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(
+        name="writer",
+        patterns=[FailingPattern("first failed"), FailingPattern("second failed")],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Impossible", execution_id="exec-3")
+
+    assert result["success"] is False
+    assert result["patterns_attempted"] == 2
+    assert len(result["pattern_errors"]) == 2
+    assert result["context"].messages[0].content == "Impossible"
+
+
+@pytest.mark.asyncio
+async def test_runner_returns_single_pattern_failure_result(tmp_path: Path) -> None:
+    agent = Agent(
+        name="writer",
+        patterns=[
+            FakePattern(
+                {
+                    "success": False,
+                    "status": "failed",
+                    "failure_reason": "structured_failure",
+                    "error": "failed with details",
+                }
+            )
+        ],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Impossible", execution_id="exec-single-fail")
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "structured_failure"
+    assert result["error"] == "failed with details"
+    assert "pattern_errors" not in result
+
+
+@pytest.mark.asyncio
+async def test_runner_restores_context_and_pattern_from_checkpoint(
+    tmp_path: Path,
+) -> None:
+    checkpoint_context = ExecutionContext(execution_id="exec-resume")
+    checkpoint_context.add_user_message("Original task")
+    checkpoint = {
+        "context": checkpoint_context.to_dict(),
+        "pattern": "StatefulPattern",
+        "pattern_state": {"output": "restored"},
+    }
+    pattern = StatefulPattern()
+    agent = Agent(name="writer", patterns=[pattern])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(
+        task="Should not be appended",
+        execution_id="exec-resume",
+        checkpoint=checkpoint,
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "restored"
+    assert result["message_count"] == 1
+    assert pattern.state == {"output": "restored"}
+    assert [message.content for message in result["context"].messages] == [
+        "Original task",
+        "restored",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_pause_requests_interrupt_for_active_execution(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="writer", patterns=[])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    agent.patterns = [InterruptingPattern(runner, "exec-pause")]
+
+    result = await runner.run(task="Calculate 6*7", execution_id="exec-pause")
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert tracer.by_execution_id["exec-pause"]["label"] == "interrupted"
+    assert (
+        tracer.by_execution_id["exec-pause"]["metadata"]["safe_point"]
+        == "during_pattern"
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_inject_user_message_updates_live_context_and_requests_interrupt(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="writer", patterns=[])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    agent.patterns = [
+        InterruptingPattern(
+            runner,
+            "exec-inject",
+            before_interrupt_check=lambda: runner.inject_user_message(
+                "exec-inject",
+                "Use metric units.",
+                reason="new user message",
+            ),
+        )
+    ]
+
+    result = await runner.run(task="Calculate 6*7", execution_id="exec-inject")
+    context = result["context"]
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    user_messages = [msg.content for msg in context.messages if msg.role == "user"]
+    assert user_messages == ["Calculate 6*7", "Use metric units."]
+    checkpoint_messages = tracer.by_execution_id["exec-inject"]["context"]["messages"]
+    assert any(
+        message["role"] == "user" and message["content"] == "Use metric units."
+        for message in checkpoint_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_resume_restores_from_latest_checkpoint_after_restart(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-restart"
+    first_agent = Agent(name="writer", patterns=[])
+    first_runner = AgentRunner(
+        agent=first_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    first_agent.patterns = [InterruptingPattern(first_runner, execution_id)]
+
+    interrupted = await first_runner.run(
+        task="Calculate 6*7",
+        execution_id=execution_id,
+    )
+
+    assert interrupted["status"] == "interrupted"
+    await first_runner.inject_user_message(
+        execution_id,
+        "Reply with only the number.",
+        request_interrupt=False,
+    )
+
+    agent = Agent(
+        name="writer",
+        patterns=[FakePattern({"success": True, "response": "42"})],
+    )
+    resumed_runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    resumed = await resumed_runner.resume(execution_id)
+
+    assert resumed["success"] is True
+    assert resumed["response"] == "42"
+    resumed_contents = [message.content for message in resumed["context"].messages]
+    assert "Reply with only the number." in resumed_contents
+    assert resumed_contents.index(
+        "Reply with only the number."
+    ) < resumed_contents.index("42")
+
+
+@pytest.mark.asyncio
+async def test_runner_post_user_message_alias_matches_inject_behavior(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    checkpoint_context = ExecutionContext(execution_id="exec-alias")
+    checkpoint_context.add_user_message("Original task")
+    await tracer.checkpoint(
+        type="checkpoint",
+        execution_id="exec-alias",
+        pattern="FakePattern",
+        label="before_llm",
+        status="interrupted",
+        context=checkpoint_context.to_dict(),
+        pattern_state={},
+        metadata={},
+    )
+
+    context = await runner.post_user_message(
+        "exec-alias",
+        "Follow-up from user.",
+        request_interrupt=False,
+    )
+
+    assert context is not None
+    user_messages = [
+        message.content for message in context.messages if message.role == "user"
+    ]
+    assert user_messages == ["Original task", "Follow-up from user."]
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_does_not_emit_completion_for_interrupted_run(
+    tmp_path: Path,
+) -> None:
+    tracer = RecordingTraceEventTracer()
+    agent = Agent(
+        name="paused",
+        patterns=[
+            FakePattern(
+                {
+                    "success": False,
+                    "status": "interrupted",
+                    "error": "Paused by user.",
+                }
+            )
+        ],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        callbacks=[TraceEventCallback()],
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Pause this", execution_id="exec-paused")
+
+    assert result["status"] == "interrupted"
+    event_types = [event["event_type"] for event in tracer.events]
+    assert event_types == ["task_start_message"]
+    assert "task_end_general" not in event_types

--- a/tests/core/agent_v2/test_runner.py
+++ b/tests/core/agent_v2/test_runner.py
@@ -13,8 +13,8 @@ from xagent.core.agent_v2 import (
     PatternRuntime,
     TraceEventCallback,
 )
-from xagent.core.agent_v2.runtime import LLMCallInterrupted
 from xagent.core.agent_v2.runner import AgentRunner
+from xagent.core.agent_v2.runtime import LLMCallInterrupted
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/agent_v2/test_runner.py
+++ b/tests/core/agent_v2/test_runner.py
@@ -13,6 +13,7 @@ from xagent.core.agent_v2 import (
     PatternRuntime,
     TraceEventCallback,
 )
+from xagent.core.agent_v2.runtime import LLMCallInterrupted
 from xagent.core.agent_v2.runner import AgentRunner
 
 
@@ -118,6 +119,11 @@ class FailingPattern:
 
     async def run(self, **_: Any) -> dict[str, Any]:
         return {"success": False, "error": self.error}
+
+
+class LLMInterruptedPattern:
+    async def run(self, **_: Any) -> dict[str, Any]:
+        raise LLMCallInterrupted("paused during LLM call")
 
 
 class StatefulPattern:
@@ -379,6 +385,24 @@ async def test_runner_returns_single_pattern_failure_result(tmp_path: Path) -> N
     assert result["failure_reason"] == "structured_failure"
     assert result["error"] == "failed with details"
     assert "pattern_errors" not in result
+
+
+@pytest.mark.asyncio
+async def test_runner_stops_on_llm_call_interrupt(tmp_path: Path) -> None:
+    fallback = FakePattern({"success": True, "output": "should not run"})
+    agent = Agent(name="writer", patterns=[LLMInterruptedPattern(), fallback])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Pause me", execution_id="exec-llm-interrupt")
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert result["error"] == "paused during LLM call"
+    assert result["pattern"] == "LLMInterruptedPattern"
+    assert fallback.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_runtime.py
+++ b/tests/core/agent_v2/test_runtime.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import ExecutionContext, PatternRuntime
+from xagent.core.agent_v2.runtime import LLMCallInterrupted
+
+
+class SlowLLM:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def chat(self, **_: Any) -> str:
+        self.started.set()
+        await asyncio.sleep(60)
+        return "never"
+
+
+class CancelledLLM:
+    async def chat(self, **_: Any) -> str:
+        raise asyncio.CancelledError
+
+
+class CheckpointTracer:
+    def __init__(self) -> None:
+        self.checkpoints: list[dict[str, Any]] = []
+        self.events: list[dict[str, Any]] = []
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.checkpoints.append(payload)
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+
+
+class TraceOnlyTracer:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "data": data or {},
+            }
+        )
+
+
+class FailingTraceOnlyTracer:
+    async def trace_event(self, *_: Any, **__: Any) -> None:
+        raise RuntimeError("trace failed")
+
+
+class PatternWithState:
+    status = "running"
+
+    def get_state(self) -> dict[str, Any]:
+        return {"step": 1}
+
+
+@pytest.mark.asyncio
+async def test_runtime_interrupt_converts_active_llm_cancel() -> None:
+    runtime = PatternRuntime()
+    llm = SlowLLM()
+    task = asyncio.create_task(runtime.run_llm_call(llm))
+
+    await llm.started.wait()
+    runtime.request_interrupt("stop now")
+
+    with pytest.raises(LLMCallInterrupted, match="stop now"):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_runtime_preserves_non_interrupt_cancelled_error() -> None:
+    runtime = PatternRuntime()
+
+    with pytest.raises(asyncio.CancelledError):
+        await runtime.run_llm_call(CancelledLLM())
+
+
+@pytest.mark.asyncio
+async def test_runtime_checkpoint_prefers_checkpoint_api() -> None:
+    tracer = CheckpointTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="exec-runtime")
+    context = ExecutionContext(execution_id="exec-runtime")
+
+    payload = await runtime.checkpoint(
+        "before_llm",
+        context=context,
+        pattern=PatternWithState(),
+        status="running",
+    )
+
+    assert payload["label"] == "before_llm"
+    assert tracer.checkpoints[0]["execution_id"] == "exec-runtime"
+    assert tracer.checkpoints[0]["pattern_state"] == {"step": 1}
+
+
+@pytest.mark.asyncio
+async def test_runtime_checkpoint_trace_event_fallback_is_task_scoped() -> None:
+    tracer = TraceOnlyTracer()
+    runtime = PatternRuntime(tracer=tracer, execution_id="exec-runtime")
+    context = ExecutionContext(execution_id="exec-runtime")
+
+    await runtime.checkpoint("fallback", context=context, pattern=PatternWithState())
+
+    assert tracer.events[0]["event_type"] == "task_update_general"
+    assert tracer.events[0]["task_id"] == "exec-runtime"
+    assert tracer.events[0]["data"]["label"] == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_runtime_trace_events_are_best_effort() -> None:
+    runtime = PatternRuntime(
+        tracer=FailingTraceOnlyTracer(), execution_id="exec-runtime"
+    )
+
+    await runtime.on_llm_start(context=ExecutionContext(), messages=[], tools=[])

--- a/tests/core/agent_v2/test_tracing.py
+++ b/tests/core/agent_v2/test_tracing.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import ExecutionContext, TraceEventCallback
+
+
+class TraceRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_success_emits_user_assistant_and_completion() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Write summary"
+
+    await callback.on_run_start(runner=runner, context=context)
+    await callback.on_run_end(
+        runner=runner,
+        context=context,
+        result={"success": True, "execution_id": "exec-trace", "answer": "Done"},
+    )
+
+    assert [event["event_type"] for event in tracer.events] == [
+        "task_start_message",
+        "task_end_message",
+        "task_end_general",
+    ]
+    assert tracer.events[1]["data"]["content"] == "Done"
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_failed_run_emits_error() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+
+    await callback.on_run_end(
+        runner=runner,
+        context=context,
+        result={
+            "success": False,
+            "execution_id": "exec-trace",
+            "error": "failed",
+        },
+    )
+
+    assert tracer.events[0]["event_type"] == "task_error_general"
+    assert tracer.events[0]["data"]["error_message"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_resume_does_not_duplicate_task_start() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Resume task"
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+    await callback.on_run_start(
+        runner=runner, context=context, checkpoint={"context": {}}
+    )
+
+    assert tracer.events == []
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_no_tracer_is_noop() -> None:
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=None)
+    context = ExecutionContext(execution_id="exec-trace")
+
+    await callback.on_run_start(runner=runner, context=context)
+    await callback.on_run_end(
+        runner=runner,
+        context=context,
+        result={"success": True, "output": "Done"},
+    )


### PR DESCRIPTION
## Summary

This PR adds the core Agent v2 execution infrastructure as the next small slice from the refactor branch.

Included:
- New `xagent.core.agent_v2` execution core: agent container, runner, runtime services, execution frames, registry, tracing callback, and trace-backed checkpoint persistence.
- Execution context model with components, message handling, memory/skill enrichment hooks, workspace state, compaction support, and sanitized tool context for large or binary `read_file` results and `write_file` content.
- Runner controls for pause/cancel/resume and user message injection, backed by resumable checkpoints.
- Focused unit tests for agent configuration, context behavior, checkpoints, frames, registry lifecycle, and runner behavior.

Out of scope for this PR:
- Concrete ReAct/DAG/auto pattern implementations. The core keeps the pattern boundary generic so those can land in follow-up PRs.

## Testing

- `uv run pytest tests/core/agent_v2/test_agent.py tests/core/agent_v2/test_checkpoint.py tests/core/agent_v2/test_context.py tests/core/agent_v2/test_frame.py tests/core/agent_v2/test_registry.py tests/core/agent_v2/test_runner.py`
- `uv run ruff check src/xagent/core/agent_v2 src/xagent/core/user_context.py tests/core/agent_v2`