### PR TITLE
feat: [v2 part3] add ReAct pattern

### DIFF
--- a/src/xagent/core/agent_v2/__init__.py
+++ b/src/xagent/core/agent_v2/__init__.py
@@ -22,6 +22,8 @@ from .context import (
     clone_component,
 )
 from .frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+from .pattern import AgentPattern, PatternResult, ReActPattern, ReActReasoningMode
+from .pattern.react import ToolCallRecord
 from .registry import ExecutionHandle, ExecutionLifecycleStatus, ExecutionRegistry
 from .runner import AgentRunner
 from .runtime import PatternRuntime, load_pattern_checkpoint
@@ -29,6 +31,7 @@ from .tracing import TraceEventCallback
 
 __all__ = [
     "Agent",
+    "AgentPattern",
     "AgentRunner",
     "CHECKPOINT_EVENT_TYPE",
     "CHECKPOINT_SCHEMA_VERSION",
@@ -51,9 +54,13 @@ __all__ = [
     "MemoryComponent",
     "MergeStrategy",
     "Message",
+    "PatternResult",
     "PatternRuntime",
+    "ReActPattern",
+    "ReActReasoningMode",
     "TraceCheckpointStore",
     "TraceEventCallback",
+    "ToolCallRecord",
     "WorkspaceComponent",
     "clone_component",
     "load_pattern_checkpoint",

--- a/src/xagent/core/agent_v2/pattern/__init__.py
+++ b/src/xagent/core/agent_v2/pattern/__init__.py
@@ -1,0 +1,10 @@
+from .base import AgentPattern, PatternResult
+from .react import ReActPattern, ReActReasoningMode, ToolCallRecord
+
+__all__ = [
+    "AgentPattern",
+    "PatternResult",
+    "ReActPattern",
+    "ReActReasoningMode",
+    "ToolCallRecord",
+]

--- a/src/xagent/core/agent_v2/pattern/base.py
+++ b/src/xagent/core/agent_v2/pattern/base.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..context import ExecutionContext
+
+
+@dataclass
+class PatternResult:
+    """Standard result envelope returned by v2 patterns."""
+
+    success: bool
+    output: Any = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"success": self.success}
+        if self.output is not None:
+            result["output"] = self.output
+        if self.error is not None:
+            result["error"] = self.error
+        if self.metadata:
+            result.update(self.metadata)
+        return result
+
+
+class AgentPattern(ABC):
+    """Abstract interface for agent_v2 execution patterns."""
+
+    @abstractmethod
+    async def run(
+        self,
+        context: ExecutionContext,
+        tools: list[Any],
+        llm: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Execute the pattern against an execution context."""

--- a/src/xagent/core/agent_v2/pattern/react/__init__.py
+++ b/src/xagent/core/agent_v2/pattern/react/__init__.py
@@ -1,0 +1,7 @@
+from .react import ReActPattern, ReActReasoningMode, ToolCallRecord
+
+__all__ = [
+    "ReActPattern",
+    "ReActReasoningMode",
+    "ToolCallRecord",
+]

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -200,9 +200,11 @@ class ReActPattern(AgentPattern):
         for iteration in range(self.current_iteration, self.max_iterations):
             self.current_iteration = iteration
             if self.pending_tool_calls:
+                self._ensure_pending_tool_call_envelope(context)
                 pending_result = await self._execute_pending_tool_calls(
                     context=context,
                     tools=tools,
+                    llm=llm,
                     runtime=runtime,
                 )
                 if pending_result is not None:
@@ -281,6 +283,7 @@ class ReActPattern(AgentPattern):
                 pending_result = await self._execute_pending_tool_calls(
                     context=context,
                     tools=tools,
+                    llm=llm,
                     runtime=runtime,
                 )
                 if pending_result is not None:
@@ -291,27 +294,12 @@ class ReActPattern(AgentPattern):
 
             await runtime.checkpoint("after_llm", context=context, pattern=self)
             if normalized.get("done", True):
-                self.force_final_answer_next = False
-                self.status = "completed"
-                await runtime.checkpoint("final", context=context, pattern=self)
-                result = PatternResult(
-                    success=True,
-                    output=assistant_content or normalized.get("raw"),
-                    metadata={
-                        "response": assistant_content or normalized.get("raw"),
-                        "status": self.status,
-                    },
-                ).to_dict()
-                await generate_and_store_react_memory(
+                return await self._finalize_success(
                     context=context,
-                    task=latest_user_text(context),
-                    result=result,
-                    iterations=self.current_iteration + 1,
                     llm=llm,
-                    memory_store=getattr(self, "_memory_store", None),
                     runtime=runtime,
+                    response=assistant_content or normalized.get("raw"),
                 )
-                return result
 
         self.status = "max_iterations"
         await runtime.checkpoint("max_iterations", context=context, pattern=self)
@@ -693,6 +681,7 @@ class ReActPattern(AgentPattern):
         self,
         tool_call: dict[str, Any],
         context: Any,
+        llm: Any,
         runtime: PatternRuntime,
     ) -> dict[str, Any] | None:
         name = tool_call["name"]
@@ -708,11 +697,12 @@ class ReActPattern(AgentPattern):
             self.status = "completed"
             if answer:
                 context.add_assistant_message(answer)
-            return PatternResult(
-                success=True,
-                output=answer,
-                metadata={"response": answer, "status": self.status},
-            ).to_dict()
+            return await self._finalize_success(
+                context=context,
+                llm=llm,
+                runtime=runtime,
+                response=answer,
+            )
 
         if name == "send_message":
             message = str(args.get("message", ""))
@@ -813,6 +803,7 @@ class ReActPattern(AgentPattern):
         *,
         context: Any,
         tools: list[Any],
+        llm: Any,
         runtime: PatternRuntime,
     ) -> dict[str, Any] | None:
         successful_tool_result = False
@@ -829,6 +820,7 @@ class ReActPattern(AgentPattern):
             control_result = await self._handle_control_tool(
                 tool_call,
                 context,
+                llm,
                 runtime,
             )
             if control_result is not None:
@@ -871,6 +863,79 @@ class ReActPattern(AgentPattern):
         if self.finalize_after_tool_result and successful_tool_result:
             self.force_final_answer_next = True
         return None
+
+    async def _finalize_success(
+        self,
+        *,
+        context: Any,
+        llm: Any,
+        runtime: PatternRuntime,
+        response: Any,
+    ) -> dict[str, Any]:
+        self.force_final_answer_next = False
+        self.status = "completed"
+        await runtime.checkpoint("final", context=context, pattern=self)
+        result = PatternResult(
+            success=True,
+            output=response,
+            metadata={"response": response, "status": self.status},
+        ).to_dict()
+        await generate_and_store_react_memory(
+            context=context,
+            task=latest_user_text(context),
+            result=result,
+            iterations=self.current_iteration + 1,
+            llm=llm,
+            memory_store=getattr(self, "_memory_store", None),
+            runtime=runtime,
+        )
+        return result
+
+    def _ensure_pending_tool_call_envelope(self, context: Any) -> None:
+        if not self.pending_tool_calls:
+            return
+        messages = [
+            message
+            for message in getattr(context, "messages", [])
+            if not getattr(message, "hidden", False)
+        ]
+        index = len(messages) - 1
+        while index >= 0 and messages[index].role == "tool":
+            index -= 1
+        if index >= 0 and messages[index].role == "assistant":
+            tool_calls = messages[index].tool_calls or []
+            existing_ids = {
+                str(tool_call.get("id"))
+                for tool_call in tool_calls
+                if isinstance(tool_call, dict) and tool_call.get("id")
+            }
+            pending_ids = {
+                str(tool_call.get("id"))
+                for tool_call in self.pending_tool_calls
+                if tool_call.get("id")
+            }
+            if pending_ids and pending_ids.issubset(existing_ids):
+                return
+            if not pending_ids and len(tool_calls) >= len(self.pending_tool_calls):
+                return
+
+        context.add_assistant_message(
+            "",
+            tool_calls=[
+                self._tool_call_for_context(tool_call)
+                for tool_call in self.pending_tool_calls
+            ],
+        )
+
+    def _tool_call_for_context(self, tool_call: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": tool_call.get("id"),
+            "type": "function",
+            "function": {
+                "name": tool_call.get("name"),
+                "arguments": json.dumps(tool_call.get("args", {}), default=str),
+            },
+        }
 
     def _tool_result_success(self, result: Any) -> bool:
         return not (isinstance(result, dict) and result.get("success") is False)
@@ -1000,6 +1065,17 @@ class ReActPattern(AgentPattern):
             schema_type = args_type()
             if hasattr(schema_type, "model_json_schema"):
                 return cast(dict[str, Any], schema_type.model_json_schema())
+        for schema_attr in ("args_schema", "tool_call_schema"):
+            schema_type = getattr(tool, schema_attr, None)
+            if schema_type is None:
+                continue
+            if hasattr(schema_type, "model_json_schema"):
+                return cast(dict[str, Any], schema_type.model_json_schema())
+            if hasattr(schema_type, "schema"):
+                return cast(dict[str, Any], schema_type.schema())
+        args = getattr(tool, "args", None)
+        if isinstance(args, dict) and args:
+            return {"type": "object", "properties": args}
         return {"type": "object", "properties": {}}
 
     async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -892,6 +892,8 @@ class ReActPattern(AgentPattern):
         runtime: PatternRuntime,
         response: Any,
     ) -> dict[str, Any]:
+        self.pending_tool_calls = []
+        self.waiting_for_user_request = None
         self.force_final_answer_next = False
         self.status = "completed"
         await runtime.checkpoint("final", context=context, pattern=self)

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, cast
 
@@ -51,7 +52,7 @@ class ToolCallRecord:
         return cls(
             tool_call_id=str(data["tool_call_id"]),
             tool_name=str(data["tool_name"]),
-            args=dict(data.get("args", {})),
+            args=dict(data.get("args") or {}),
             args_hash=str(data.get("args_hash", "")),
             status=str(data.get("status", "pending")),
             result=data.get("result"),
@@ -124,8 +125,15 @@ class ReActPattern(AgentPattern):
             self.status = "failed"
             result = PatternResult(
                 success=False,
-                error="ReActPattern reasoning_action mode is not implemented yet.",
-                metadata={"status": self.status},
+                error=(
+                    "ReActPattern reasoning_action mode is reserved for a future "
+                    "implementation; use tool_calling mode for this release."
+                ),
+                metadata={
+                    "status": self.status,
+                    "reasoning_mode": self.reasoning_mode.value,
+                    "error_type": "not_implemented",
+                },
             ).to_dict()
             await runtime.on_pattern_end(context=context, pattern=self, result=result)
             return result
@@ -327,6 +335,7 @@ class ReActPattern(AgentPattern):
             )
         elif has_tools:
             available_tools = ", ".join(tool_names or []) or "(none)"
+            current_date = datetime.now(timezone.utc).date().isoformat()
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "
@@ -347,9 +356,10 @@ class ReActPattern(AgentPattern):
                 "entities, incidents, dates, sources, or causal explanations "
                 "that are not supported by the conversation, retrieved "
                 "context, or tool results. If available context is insufficient, "
-                "say so or use an appropriate tool to verify. For recent, latest, current, or "
-                "time-sensitive requests, use the current date from the system context "
-                "when forming search queries and judging source relevance. Only call "
+                "say so or use an appropriate tool to verify. "
+                f"Current date (UTC): {current_date}. "
+                "For recent, latest, current, or time-sensitive requests, use this "
+                "date when forming search queries and judging source relevance. Only call "
                 "tools that are present in the current tool schema for this LLM call; "
                 "tool names mentioned in memory, previous tasks, plans, or error "
                 "messages are unavailable unless they are included in the current "

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -344,8 +344,8 @@ class ReActPattern(AgentPattern):
                 "instruction for follow-up requests. If the user corrects a previous "
                 "assumption, especially about dates or freshness, revise the answer "
                 "instead of restating prior content. Do not introduce specific "
-                "entities, incidents, dates, vulnerabilities, sources, or attack "
-                "paths that are not supported by the conversation, retrieved "
+                "entities, incidents, dates, sources, or causal explanations "
+                "that are not supported by the conversation, retrieved "
                 "context, or tool results. If available context is insufficient, "
                 "say so or use an appropriate tool to verify. For recent, latest, current, or "
                 "time-sensitive requests, use the current date from the system context "
@@ -826,11 +826,10 @@ class ReActPattern(AgentPattern):
                     pattern=self,
                     metadata={"tool_call": tool_call},
                 )
-                if control_result.get("status") in {
-                    "completed",
-                    "waiting_for_user",
-                }:
+                if control_result.get("status") == "completed":
                     self.pending_tool_calls = []
+                    return control_result
+                if control_result.get("status") == "waiting_for_user":
                     return control_result
                 continue
 

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 from dataclasses import dataclass, replace
@@ -67,6 +68,8 @@ class ReActPattern(AgentPattern):
         self,
         llm: Any | None = None,
         *,
+        # Intentionally high for interactive and long-running agent tasks; callers
+        # can pass a lower value when they need stricter cost or latency bounds.
         max_iterations: int = 200,
         tool_choice: str | dict[str, Any] | None = "auto",
         reasoning_mode: ReActReasoningMode | str = ReActReasoningMode.TOOL_CALLING,
@@ -977,13 +980,19 @@ class ReActPattern(AgentPattern):
             return str(metadata.name)
         if getattr(tool, "name", None):
             return str(tool.name)
+        if getattr(tool, "__name__", None):
+            return str(tool.__name__)
         raise ValueError(f"Tool {tool!r} is missing a name.")
 
     def _tool_description(self, tool: Any) -> str:
         metadata = getattr(tool, "metadata", None)
         if metadata is not None and getattr(metadata, "description", None):
             return str(metadata.description)
-        return str(getattr(tool, "description", "")) or self._tool_name(tool)
+        return (
+            str(getattr(tool, "description", ""))
+            or str(getattr(tool, "__doc__", "")).strip()
+            or self._tool_name(tool)
+        )
 
     def _tool_json_schema(self, tool: Any) -> dict[str, Any]:
         args_type = getattr(tool, "args_type", None)
@@ -1024,7 +1033,9 @@ class ReActPattern(AgentPattern):
         raise ValueError(f"Tool not found: {name}")
 
     async def _invoke_callable(self, fn: Any, **kwargs: Any) -> Any:
-        result = fn(**kwargs)
+        if inspect.iscoroutinefunction(fn):
+            return await fn(**kwargs)
+        result = await asyncio.to_thread(fn, **kwargs)
         if inspect.isawaitable(result):
             return await result
         return result

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -1085,6 +1085,8 @@ class ReActPattern(AgentPattern):
             schema_type = args_type()
             if hasattr(schema_type, "model_json_schema"):
                 return cast(dict[str, Any], schema_type.model_json_schema())
+            if hasattr(schema_type, "schema"):
+                return cast(dict[str, Any], schema_type.schema())
         for schema_attr in ("args_schema", "tool_call_schema"):
             schema_type = getattr(tool, schema_attr, None)
             if schema_type is None:

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -1,0 +1,1021 @@
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, cast
+
+from ...context.enrichment import (
+    enrich_context_with_memory,
+    enrich_context_with_skill,
+    generate_and_store_react_memory,
+    latest_user_text,
+)
+from ...runtime import LLMCallInterrupted, PatternRuntime
+from ..base import AgentPattern, PatternResult
+
+
+class ReActReasoningMode(str, Enum):
+    """Reasoning strategy used by ReActPattern."""
+
+    TOOL_CALLING = "tool_calling"
+    REASONING_ACTION = "reasoning_action"
+
+
+@dataclass
+class ToolCallRecord:
+    """Serializable ledger entry for a tool call."""
+
+    tool_call_id: str
+    tool_name: str
+    args: dict[str, Any]
+    args_hash: str
+    status: str
+    result: Any = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_call_id": self.tool_call_id,
+            "tool_name": self.tool_name,
+            "args": self.args,
+            "args_hash": self.args_hash,
+            "status": self.status,
+            "result": self.result,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ToolCallRecord":
+        return cls(
+            tool_call_id=str(data["tool_call_id"]),
+            tool_name=str(data["tool_name"]),
+            args=dict(data.get("args", {})),
+            args_hash=str(data.get("args_hash", "")),
+            status=str(data.get("status", "pending")),
+            result=data.get("result"),
+            error=data.get("error"),
+        )
+
+
+class ReActPattern(AgentPattern):
+    """Minimal ReAct loop for the v2 execution runtime."""
+
+    def __init__(
+        self,
+        llm: Any | None = None,
+        *,
+        max_iterations: int = 200,
+        tool_choice: str | dict[str, Any] | None = "auto",
+        reasoning_mode: ReActReasoningMode | str = ReActReasoningMode.TOOL_CALLING,
+        finalize_after_tool_result: bool = False,
+    ) -> None:
+        self.llm = llm
+        self.max_iterations = max_iterations
+        self.tool_choice = tool_choice
+        self.reasoning_mode = ReActReasoningMode(reasoning_mode)
+        self.finalize_after_tool_result = finalize_after_tool_result
+        self.status = "idle"
+        self.current_iteration = 0
+        self.last_response: Any = None
+        self.pending_tool_calls: list[dict[str, Any]] = []
+        self.tool_ledger: dict[str, ToolCallRecord] = {}
+        self.force_final_answer_next = False
+        self.waiting_for_user_request: dict[str, Any] | None = None
+        self._memory_store: Any | None = None
+
+    async def run(
+        self,
+        context: Any,
+        tools: list[Any],
+        llm: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        runtime = kwargs.get("runtime")
+        if runtime is None:
+            runtime = PatternRuntime(
+                execution_id=getattr(context, "execution_id", None)
+            )
+        elif getattr(runtime, "execution_id", None) is None:
+            setattr(runtime, "execution_id", getattr(context, "execution_id", None))
+
+        active_llm = llm or self.llm
+        if active_llm is None:
+            return PatternResult(
+                success=False,
+                error="ReActPattern requires an llm instance.",
+            ).to_dict()
+
+        await runtime.on_pattern_start(context=context, pattern=self)
+        waiting_result = await self._resume_waiting_for_user_if_needed(
+            context=context,
+            runtime=runtime,
+        )
+        if waiting_result is not None:
+            await runtime.on_pattern_end(
+                context=context,
+                pattern=self,
+                result=waiting_result,
+            )
+            return waiting_result
+
+        if self.reasoning_mode == ReActReasoningMode.REASONING_ACTION:
+            self.status = "failed"
+            result = PatternResult(
+                success=False,
+                error="ReActPattern reasoning_action mode is not implemented yet.",
+                metadata={"status": self.status},
+            ).to_dict()
+            await runtime.on_pattern_end(context=context, pattern=self, result=result)
+            return result
+
+        try:
+            task_text = latest_user_text(context)
+            self._memory_store = kwargs.get("memory_store")
+            await enrich_context_with_memory(
+                context=context,
+                query=task_text,
+                category="react_memory",
+                memory_store=self._memory_store,
+                runtime=runtime,
+                similarity_threshold=kwargs.get("memory_similarity_threshold"),
+            )
+            await enrich_context_with_skill(
+                context=context,
+                task=task_text,
+                llm=active_llm,
+                skill_manager=kwargs.get("skill_manager"),
+                runtime=runtime,
+                allowed_skills=kwargs.get("allowed_skills"),
+            )
+            result = await self._run_tool_calling_loop(
+                context=context,
+                tools=tools,
+                llm=active_llm,
+                runtime=runtime,
+            )
+        except LLMCallInterrupted:
+            interrupted = await self._interrupt_if_requested(
+                runtime=runtime,
+                context=context,
+                label="during_enrichment",
+            )
+            if interrupted is None:
+                raise
+            result = interrupted
+        except Exception as exc:
+            await runtime.on_pattern_error(context=context, pattern=self, error=exc)
+            raise
+
+        await runtime.on_pattern_end(context=context, pattern=self, result=result)
+        return result
+
+    async def _run_tool_calling_loop(
+        self,
+        *,
+        context: Any,
+        tools: list[Any],
+        llm: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any]:
+        self.status = "thinking"
+        base_tool_schemas = (
+            []
+            if self.tool_choice == "none"
+            else self._tool_schemas_with_builtin_controls(tools)
+        )
+
+        for iteration in range(self.current_iteration, self.max_iterations):
+            self.current_iteration = iteration
+            if self.pending_tool_calls:
+                pending_result = await self._execute_pending_tool_calls(
+                    context=context,
+                    tools=tools,
+                    runtime=runtime,
+                )
+                if pending_result is not None:
+                    return pending_result
+                self.current_iteration = iteration + 1
+                self.status = "thinking"
+                continue
+
+            tool_schemas = [] if self.force_final_answer_next else base_tool_schemas
+            interrupted = await self._interrupt_if_requested(
+                runtime=runtime,
+                context=context,
+                label="before_llm",
+            )
+            if interrupted is not None:
+                return interrupted
+
+            await runtime.compact_context_if_needed(
+                context=context,
+                llm=llm,
+                metadata={"iteration": iteration},
+            )
+
+            messages = self._messages_for_llm(
+                context,
+                has_tools=bool(tool_schemas),
+                force_final_answer=self.force_final_answer_next,
+                tool_names=self._schema_tool_names(tool_schemas),
+            )
+            await runtime.checkpoint("before_llm", context=context, pattern=self)
+            await runtime.on_llm_start(
+                context=context,
+                messages=messages,
+                tools=tool_schemas or None,
+                metadata={"iteration": iteration},
+            )
+            try:
+                response = await runtime.run_llm_call(
+                    llm,
+                    messages=messages,
+                    tools=tool_schemas or None,
+                    tool_choice=self.tool_choice if tool_schemas else None,
+                )
+            except LLMCallInterrupted:
+                interrupted = await self._interrupt_if_requested(
+                    runtime=runtime,
+                    context=context,
+                    label="during_llm",
+                )
+                if interrupted is not None:
+                    return interrupted
+                raise
+            await runtime.on_llm_end(
+                context=context,
+                response=response,
+                metadata={"iteration": iteration},
+            )
+            self.last_response = response
+            normalized = self._normalize_llm_response(response)
+            if self.force_final_answer_next and not normalized.get("tool_calls"):
+                normalized["done"] = True
+
+            assistant_content = normalized.get("content")
+            if assistant_content is not None or normalized.get("tool_calls"):
+                context.add_assistant_message(
+                    assistant_content or "",
+                    tool_calls=normalized.get("raw_tool_calls")
+                    or normalized.get("tool_calls"),
+                )
+
+            tool_calls = normalized.get("tool_calls", [])
+            if tool_calls:
+                self.status = "acting"
+                self.pending_tool_calls = list(tool_calls)
+                await runtime.checkpoint("after_llm", context=context, pattern=self)
+                pending_result = await self._execute_pending_tool_calls(
+                    context=context,
+                    tools=tools,
+                    runtime=runtime,
+                )
+                if pending_result is not None:
+                    return pending_result
+                self.current_iteration = iteration + 1
+                self.status = "thinking"
+                continue
+
+            await runtime.checkpoint("after_llm", context=context, pattern=self)
+            if normalized.get("done", True):
+                self.force_final_answer_next = False
+                self.status = "completed"
+                await runtime.checkpoint("final", context=context, pattern=self)
+                result = PatternResult(
+                    success=True,
+                    output=assistant_content or normalized.get("raw"),
+                    metadata={
+                        "response": assistant_content or normalized.get("raw"),
+                        "status": self.status,
+                    },
+                ).to_dict()
+                await generate_and_store_react_memory(
+                    context=context,
+                    task=latest_user_text(context),
+                    result=result,
+                    iterations=self.current_iteration + 1,
+                    llm=llm,
+                    memory_store=getattr(self, "_memory_store", None),
+                    runtime=runtime,
+                )
+                return result
+
+        self.status = "max_iterations"
+        await runtime.checkpoint("max_iterations", context=context, pattern=self)
+        return PatternResult(
+            success=False,
+            error="ReActPattern reached max iterations without a final answer.",
+            metadata={"iterations": self.max_iterations, "status": self.status},
+        ).to_dict()
+
+    def _messages_for_llm(
+        self,
+        context: Any,
+        *,
+        has_tools: bool,
+        force_final_answer: bool = False,
+        tool_names: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        messages = list(context.get_messages_for_llm())
+        if force_final_answer:
+            instruction = (
+                "You have already received the tool result needed for the current "
+                "step. Do not call tools again. Produce the final answer for this "
+                "step using the latest tool result."
+            )
+        elif has_tools:
+            available_tools = ", ".join(tool_names or []) or "(none)"
+            instruction = (
+                "Use available tools when the user asks you to generate, compute, run, "
+                "execute, inspect, read, write, or otherwise produce a concrete result "
+                "that a tool can determine. After a successful tool call, base the "
+                "final answer on the latest tool result instead of repeating the same "
+                "tool work. When the current task is complete, call the final_answer "
+                "tool exactly once instead of calling another work tool. If a tool "
+                "needs missing information from the user, call ask_user_question; do "
+                "not ask the question as plain assistant text. If the latest user "
+                "message explicitly asks you to call a named available tool, call "
+                "that tool instead of paraphrasing the request. If a tool "
+                "fails, retry with a corrected call when possible; "
+                "otherwise explain the failure instead of presenting an unverified "
+                "tutorial or example. Treat the latest user message as the controlling "
+                "instruction for follow-up requests. If the user corrects a previous "
+                "assumption, especially about dates or freshness, revise the answer "
+                "instead of restating prior content. Do not introduce specific "
+                "entities, incidents, dates, vulnerabilities, sources, or attack "
+                "paths that are not supported by the conversation, retrieved "
+                "context, or tool results. If available context is insufficient, "
+                "say so or use an appropriate tool to verify. For recent, latest, current, or "
+                "time-sensitive requests, use the current date from the system context "
+                "when forming search queries and judging source relevance. Only call "
+                "tools that are present in the current tool schema for this LLM call; "
+                "tool names mentioned in memory, previous tasks, plans, or error "
+                "messages are unavailable unless they are included in the current "
+                "schema. If a selected skill is already present in the system "
+                "context, treat its main SKILL.md guidance as already read. Use "
+                "skill documentation tools only when you need an additional "
+                "referenced file, example, asset, or detail that is not already in "
+                "the provided skill context."
+                f"\n\nAvailable tool names for this LLM call are exactly: {available_tools}. "
+                "Never call a tool name that is not in this list."
+            )
+        else:
+            return messages
+        if messages and messages[0].get("role") == "system":
+            return [
+                {
+                    **messages[0],
+                    "content": f"{messages[0].get('content', '')}\n\n{instruction}",
+                },
+                *messages[1:],
+            ]
+        return [{"role": "system", "content": instruction}, *messages]
+
+    def _schema_tool_names(self, tool_schemas: list[dict[str, Any]]) -> list[str]:
+        names: list[str] = []
+        for schema in tool_schemas:
+            function = schema.get("function")
+            if isinstance(function, dict) and function.get("name"):
+                names.append(str(function["name"]))
+        return names
+
+    def get_state(self) -> dict[str, Any]:
+        """Return JSON-serializable ReAct state for checkpointing."""
+        return {
+            "reasoning_mode": self.reasoning_mode.value,
+            "status": self.status,
+            "current_iteration": self.current_iteration,
+            "max_iterations": self.max_iterations,
+            "finalize_after_tool_result": self.finalize_after_tool_result,
+            "force_final_answer_next": self.force_final_answer_next,
+            "waiting_for_user_request": self.waiting_for_user_request,
+            "last_response": self.last_response,
+            "pending_tool_calls": self.pending_tool_calls,
+            "tool_ledger": {
+                key: record.to_dict() for key, record in self.tool_ledger.items()
+            },
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        """Restore ReAct state from a checkpoint payload."""
+        self.reasoning_mode = ReActReasoningMode(
+            state.get("reasoning_mode", ReActReasoningMode.TOOL_CALLING.value)
+        )
+        self.status = str(state.get("status", "idle"))
+        self.current_iteration = int(state.get("current_iteration", 0))
+        self.max_iterations = int(state.get("max_iterations", self.max_iterations))
+        self.finalize_after_tool_result = bool(
+            state.get("finalize_after_tool_result", self.finalize_after_tool_result)
+        )
+        self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
+        waiting_request = state.get("waiting_for_user_request")
+        self.waiting_for_user_request = (
+            dict(waiting_request) if isinstance(waiting_request, dict) else None
+        )
+        self.last_response = state.get("last_response")
+        self.pending_tool_calls = list(state.get("pending_tool_calls", []))
+        self.tool_ledger = {
+            key: ToolCallRecord.from_dict(value)
+            for key, value in state.get("tool_ledger", {}).items()
+        }
+
+    async def _resume_waiting_for_user_if_needed(
+        self,
+        *,
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any] | None:
+        if self.status != "waiting_for_user" or not self.waiting_for_user_request:
+            return None
+
+        waiting_message_count = int(
+            self.waiting_for_user_request.get("message_count", 0)
+        )
+        if len(getattr(context, "messages", [])) <= waiting_message_count:
+            await runtime.checkpoint(
+                "waiting_for_user",
+                context=context,
+                pattern=self,
+                metadata={"waiting_for_user_request": self.waiting_for_user_request},
+            )
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "message": self.waiting_for_user_request.get("message", ""),
+                "message_type": self.waiting_for_user_request.get(
+                    "message_type", "question"
+                ),
+                "interactions": self.waiting_for_user_request.get("interactions"),
+                "context": context,
+            }
+
+        self._mark_latest_user_message_as_waiting_response(
+            context=context,
+            after_message_count=waiting_message_count,
+        )
+        self.waiting_for_user_request = None
+        self.status = "thinking"
+        return None
+
+    def _mark_latest_user_message_as_waiting_response(
+        self,
+        *,
+        context: Any,
+        after_message_count: int,
+    ) -> None:
+        messages = getattr(context, "messages", [])
+        if not isinstance(messages, list):
+            return
+
+        for index in range(len(messages) - 1, after_message_count - 1, -1):
+            message = messages[index]
+            if getattr(message, "role", None) != "user":
+                continue
+            metadata = dict(getattr(message, "metadata", {}) or {})
+            if metadata.get("response_to_waiting_for_user"):
+                return
+            waiting_request = self.waiting_for_user_request or {}
+            metadata["response_to_waiting_for_user"] = {
+                "tool_name": waiting_request.get("tool_name"),
+                "tool_call_id": waiting_request.get("tool_call_id"),
+                "question": waiting_request.get("message", ""),
+                "message_type": waiting_request.get("message_type", "question"),
+                "interactions": waiting_request.get("interactions"),
+            }
+            messages[index] = replace(message, metadata=metadata)
+            return
+
+    def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
+        if isinstance(response, str):
+            return {
+                "content": response,
+                "tool_calls": [],
+                "done": True,
+                "raw": response,
+            }
+
+        if not isinstance(response, dict):
+            text = str(response)
+            return {"content": text, "tool_calls": [], "done": True, "raw": response}
+
+        tool_calls = self._normalize_tool_calls(response.get("tool_calls", []))
+        content = response.get("content")
+        if content is None:
+            content = (
+                response.get("answer")
+                or response.get("output")
+                or response.get("message")
+            )
+
+        done = response.get("done")
+        if done is None:
+            done = not tool_calls
+
+        return {
+            "content": content,
+            "tool_calls": tool_calls,
+            "raw_tool_calls": response.get("tool_calls", []),
+            "done": bool(done),
+            "raw": response,
+        }
+
+    def _normalize_tool_calls(self, tool_calls: list[Any]) -> list[dict[str, Any]]:
+        normalized: list[dict[str, Any]] = []
+        for index, tool_call in enumerate(tool_calls):
+            if isinstance(tool_call, dict):
+                function_payload = tool_call.get("function")
+                if isinstance(function_payload, dict):
+                    arguments = function_payload.get("arguments", {})
+                    normalized.append(
+                        {
+                            "id": tool_call.get("id") or f"tool_call_{index}",
+                            "name": function_payload.get("name"),
+                            "args": self._coerce_arguments(arguments),
+                        }
+                    )
+                    continue
+
+                normalized.append(
+                    {
+                        "id": tool_call.get("id") or f"tool_call_{index}",
+                        "name": tool_call.get("name"),
+                        "args": self._coerce_arguments(
+                            tool_call.get("args", tool_call.get("arguments", {}))
+                        ),
+                    }
+                )
+                continue
+
+            function_payload = getattr(tool_call, "function", None)
+            if function_payload is not None:
+                normalized.append(
+                    {
+                        "id": getattr(tool_call, "id", None) or f"tool_call_{index}",
+                        "name": getattr(function_payload, "name", None),
+                        "args": self._coerce_arguments(
+                            getattr(function_payload, "arguments", {})
+                        ),
+                    }
+                )
+
+        return [call for call in normalized if call.get("name")]
+
+    def _coerce_arguments(self, arguments: Any) -> dict[str, Any]:
+        if isinstance(arguments, dict):
+            return arguments
+        if isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                return {"input": arguments}
+            return parsed if isinstance(parsed, dict) else {"input": parsed}
+        return {}
+
+    def _build_tool_schema(self, tool: Any) -> dict[str, Any]:
+        name = self._tool_name(tool)
+        description = self._tool_description(tool)
+        schema = self._tool_json_schema(tool)
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": schema,
+            },
+        }
+
+    def _builtin_tool_schemas(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "final_answer",
+                    "description": (
+                        "Finish the current ReAct step and send the final answer to "
+                        "the user. Use this once the latest tool results satisfy the "
+                        "current user request. Do not call additional tools after this."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "answer": {"type": "string"},
+                        },
+                        "required": ["answer"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "send_message",
+                    "description": "Send a message to the user, optionally waiting for a response.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                            "message_type": {
+                                "type": "string",
+                                "enum": [
+                                    "info",
+                                    "question",
+                                    "confirmation",
+                                    "progress",
+                                    "warning",
+                                ],
+                            },
+                            "expect_response": {"type": "boolean"},
+                        },
+                        "required": ["message"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "ask_user_question",
+                    "description": (
+                        "Ask the user for structured input and pause execution until "
+                        "the user responds. Use this only when execution cannot "
+                        "continue without missing user-provided information, such "
+                        "as a required file, URL, account, target object, permission, "
+                        "or a choice between mutually exclusive actions with "
+                        "different side effects. Do not use it to confirm execution "
+                        "strategy, whether to search, whether to use memory, whether "
+                        "to apply formatting preferences, or whether to proceed with "
+                        "a sufficiently specified task; decide those yourself."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"},
+                            "interactions": {
+                                "type": "array",
+                                "items": {"type": "object"},
+                            },
+                        },
+                        "required": ["message", "interactions"],
+                    },
+                },
+            },
+        ]
+
+    def _tool_schemas_with_builtin_controls(
+        self,
+        tools: list[Any],
+    ) -> list[dict[str, Any]]:
+        control_tool_names = self._control_tool_names()
+        external_tools = [
+            self._build_tool_schema(tool)
+            for tool in tools
+            if self._tool_name(tool) not in control_tool_names
+        ]
+        return [*external_tools, *self._builtin_tool_schemas()]
+
+    def _control_tool_names(self) -> set[str]:
+        return {"final_answer", "send_message", "ask_user_question"}
+
+    async def _handle_control_tool(
+        self,
+        tool_call: dict[str, Any],
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any] | None:
+        name = tool_call["name"]
+        args = tool_call.get("args", {})
+
+        if name == "final_answer":
+            answer = str(args.get("answer", ""))
+            self._record_tool_call(
+                tool_call,
+                status="completed",
+                result={"answer": answer},
+            )
+            self.status = "completed"
+            if answer:
+                context.add_assistant_message(answer)
+            return PatternResult(
+                success=True,
+                output=answer,
+                metadata={"response": answer, "status": self.status},
+            ).to_dict()
+
+        if name == "send_message":
+            message = str(args.get("message", ""))
+            expect_response = bool(args.get("expect_response", False))
+            message_type = str(args.get("message_type", "info"))
+            await runtime.send_message(
+                message=message,
+                message_type=message_type,
+                expect_response=expect_response,
+            )
+            self._record_tool_call(
+                tool_call,
+                status="completed",
+                result={"message": message, "expect_response": expect_response},
+            )
+            if expect_response:
+                self.status = "waiting_for_user"
+                context.add_tool_result(
+                    tool_name=name,
+                    result={
+                        "status": "waiting_for_user",
+                        "message": message,
+                        "message_type": message_type,
+                    },
+                    tool_call_id=tool_call.get("id"),
+                )
+                self.waiting_for_user_request = {
+                    "tool_call_id": tool_call.get("id"),
+                    "tool_name": name,
+                    "message": message,
+                    "message_type": message_type,
+                    "message_count": len(getattr(context, "messages", [])),
+                }
+                return {
+                    "success": False,
+                    "status": self.status,
+                    "message": message,
+                    "message_type": message_type,
+                    "context": context,
+                }
+            context.add_tool_result(
+                tool_name=name,
+                result={"message": message, "status": "sent"},
+                tool_call_id=tool_call.get("id"),
+            )
+            return {"success": True, "status": "message_sent"}
+
+        if name == "ask_user_question":
+            message = str(args.get("message", ""))
+            interactions = args.get("interactions", [])
+            await runtime.send_message(
+                message=message,
+                message_type="question",
+                expect_response=True,
+                metadata={"interactions": interactions},
+            )
+            self._record_tool_call(
+                tool_call,
+                status="completed",
+                result={
+                    "message": message,
+                    "expect_response": True,
+                    "interactions": interactions,
+                },
+            )
+            self.status = "waiting_for_user"
+            context.add_tool_result(
+                tool_name=name,
+                result={
+                    "status": "waiting_for_user",
+                    "message": message,
+                    "message_type": "question",
+                    "interactions": interactions,
+                },
+                tool_call_id=tool_call.get("id"),
+            )
+            self.waiting_for_user_request = {
+                "tool_call_id": tool_call.get("id"),
+                "tool_name": name,
+                "message": message,
+                "message_type": "question",
+                "interactions": interactions,
+                "message_count": len(getattr(context, "messages", [])),
+            }
+            return {
+                "success": False,
+                "status": self.status,
+                "message": message,
+                "message_type": "question",
+                "interactions": interactions,
+                "context": context,
+            }
+
+        return None
+
+    async def _execute_pending_tool_calls(
+        self,
+        *,
+        context: Any,
+        tools: list[Any],
+        runtime: PatternRuntime,
+    ) -> dict[str, Any] | None:
+        successful_tool_result = False
+        while self.pending_tool_calls:
+            interrupted = await self._interrupt_if_requested(
+                runtime=runtime,
+                context=context,
+                label="before_tool",
+            )
+            if interrupted is not None:
+                return interrupted
+
+            tool_call = self.pending_tool_calls[0]
+            control_result = await self._handle_control_tool(
+                tool_call,
+                context,
+                runtime,
+            )
+            if control_result is not None:
+                self.pending_tool_calls = self.pending_tool_calls[1:]
+                await runtime.checkpoint(
+                    str(control_result.get("status", "control_tool")),
+                    context=context,
+                    pattern=self,
+                    metadata={"tool_call": tool_call},
+                )
+                if control_result.get("status") in {
+                    "completed",
+                    "waiting_for_user",
+                }:
+                    self.pending_tool_calls = []
+                    return control_result
+                continue
+
+            await runtime.checkpoint(
+                "before_tool",
+                context=context,
+                pattern=self,
+                metadata={"tool_call": tool_call},
+            )
+            result = await self._execute_tool_safely(tool_call, tools, runtime)
+            context.add_tool_result(
+                tool_name=tool_call["name"],
+                result=result,
+                tool_call_id=tool_call.get("id"),
+            )
+            self.pending_tool_calls = self.pending_tool_calls[1:]
+            await runtime.checkpoint(
+                "after_tool",
+                context=context,
+                pattern=self,
+                metadata={"tool_call": tool_call},
+            )
+            if self._tool_result_success(result):
+                successful_tool_result = True
+
+        if self.finalize_after_tool_result and successful_tool_result:
+            self.force_final_answer_next = True
+        return None
+
+    def _tool_result_success(self, result: Any) -> bool:
+        return not (isinstance(result, dict) and result.get("success") is False)
+
+    async def _interrupt_if_requested(
+        self,
+        *,
+        runtime: PatternRuntime,
+        context: Any,
+        label: str,
+    ) -> dict[str, Any] | None:
+        if not await runtime.should_interrupt():
+            return None
+
+        self.status = "interrupted"
+        await runtime.checkpoint(
+            "interrupted",
+            context=context,
+            pattern=self,
+            metadata={"safe_point": label, "reason": runtime.interrupt_reason},
+        )
+        return PatternResult(
+            success=False,
+            error="ReActPattern interrupted.",
+            metadata={
+                "status": self.status,
+                "interrupt_reason": runtime.interrupt_reason,
+            },
+        ).to_dict()
+
+    async def _execute_tool_safely(
+        self,
+        tool_call: dict[str, Any],
+        tools: list[Any],
+        runtime: PatternRuntime,
+    ) -> Any:
+        self._record_tool_call(tool_call, status="running")
+        await runtime.on_tool_start(tool_call=tool_call)
+        try:
+            result = await self._execute_tool(tool_call, tools)
+        except Exception as exc:  # noqa: BLE001
+            error_result = {
+                "success": False,
+                "error": str(exc),
+                "tool_name": tool_call["name"],
+            }
+            await runtime.on_tool_error(
+                tool_call=tool_call, error=exc, result=error_result
+            )
+            self._record_tool_call(
+                tool_call,
+                status="failed",
+                result=error_result,
+                error=str(exc),
+            )
+            return error_result
+
+        if isinstance(result, dict) and result.get("success") is False:
+            error_message = str(result.get("error") or result.get("message") or result)
+            await runtime.on_tool_error(
+                tool_call=tool_call,
+                error=RuntimeError(error_message),
+                result=result,
+            )
+            self._record_tool_call(
+                tool_call,
+                status="failed",
+                result=result,
+                error=error_message,
+            )
+            return result
+
+        self._record_tool_call(tool_call, status="completed", result=result)
+        await runtime.on_tool_end(tool_call=tool_call, result=result)
+        return result
+
+    def _record_tool_call(
+        self,
+        tool_call: dict[str, Any],
+        *,
+        status: str,
+        result: Any = None,
+        error: str | None = None,
+    ) -> None:
+        tool_call_id = str(tool_call.get("id") or f"tool_call_{len(self.tool_ledger)}")
+        args = dict(tool_call.get("args", {}))
+        args_hash = self._args_hash(args)
+        self.tool_ledger[tool_call_id] = ToolCallRecord(
+            tool_call_id=tool_call_id,
+            tool_name=str(tool_call["name"]),
+            args=args,
+            args_hash=args_hash,
+            status=status,
+            result=result,
+            error=error,
+        )
+
+    def _args_hash(self, args: dict[str, Any]) -> str:
+        try:
+            return json.dumps(args, sort_keys=True, default=str)
+        except TypeError:
+            return str(args)
+
+    def _tool_name(self, tool: Any) -> str:
+        metadata = getattr(tool, "metadata", None)
+        if metadata is not None and getattr(metadata, "name", None):
+            return str(metadata.name)
+        if getattr(tool, "name", None):
+            return str(tool.name)
+        raise ValueError(f"Tool {tool!r} is missing a name.")
+
+    def _tool_description(self, tool: Any) -> str:
+        metadata = getattr(tool, "metadata", None)
+        if metadata is not None and getattr(metadata, "description", None):
+            return str(metadata.description)
+        return str(getattr(tool, "description", "")) or self._tool_name(tool)
+
+    def _tool_json_schema(self, tool: Any) -> dict[str, Any]:
+        args_type = getattr(tool, "args_type", None)
+        if callable(args_type):
+            schema_type = args_type()
+            if hasattr(schema_type, "model_json_schema"):
+                return cast(dict[str, Any], schema_type.model_json_schema())
+        return {"type": "object", "properties": {}}
+
+    async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:
+        tool = self._find_tool(tool_call["name"], tools)
+        args = tool_call.get("args", {})
+
+        execute = getattr(tool, "execute", None)
+        if callable(execute):
+            return await self._invoke_callable(execute, **args)
+
+        run_json_async = getattr(tool, "run_json_async", None)
+        if callable(run_json_async):
+            return await run_json_async(args)
+
+        ainvoke = getattr(tool, "ainvoke", None)
+        if callable(ainvoke):
+            return await ainvoke(args)
+
+        call = getattr(tool, "__call__", None)
+        if callable(call):
+            return await self._invoke_callable(call, **args)
+
+        raise ValueError(
+            f"Tool {tool_call['name']} does not expose a supported executor."
+        )
+
+    def _find_tool(self, name: str, tools: list[Any]) -> Any:
+        for tool in tools:
+            if self._tool_name(tool) == name:
+                return tool
+        raise ValueError(f"Tool not found: {name}")
+
+    async def _invoke_callable(self, fn: Any, **kwargs: Any) -> Any:
+        result = fn(**kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -87,6 +87,7 @@ class ReActPattern(AgentPattern):
         self.tool_ledger: dict[str, ToolCallRecord] = {}
         self.force_final_answer_next = False
         self.waiting_for_user_request: dict[str, Any] | None = None
+        self.task_text: str | None = None
         self._memory_store: Any | None = None
 
     async def run(
@@ -142,7 +143,7 @@ class ReActPattern(AgentPattern):
             return result
 
         try:
-            task_text = latest_user_text(context)
+            task_text = self._task_text(context)
             self._memory_store = kwargs.get("memory_store")
             await enrich_context_with_memory(
                 context=context,
@@ -392,6 +393,7 @@ class ReActPattern(AgentPattern):
             "finalize_after_tool_result": self.finalize_after_tool_result,
             "force_final_answer_next": self.force_final_answer_next,
             "waiting_for_user_request": self.waiting_for_user_request,
+            "task_text": self.task_text,
             "last_response": self.last_response,
             "pending_tool_calls": self.pending_tool_calls,
             "tool_ledger": {
@@ -415,6 +417,8 @@ class ReActPattern(AgentPattern):
         self.waiting_for_user_request = (
             dict(waiting_request) if isinstance(waiting_request, dict) else None
         )
+        stored_task_text = state.get("task_text")
+        self.task_text = str(stored_task_text) if stored_task_text else None
         self.last_response = state.get("last_response")
         self.pending_tool_calls = list(state.get("pending_tool_calls", []))
         self.tool_ledger = {
@@ -456,9 +460,18 @@ class ReActPattern(AgentPattern):
             context=context,
             after_message_count=waiting_message_count,
         )
+        waiting_task = self.waiting_for_user_request.get("task_text")
+        if waiting_task and self.task_text is None:
+            self.task_text = str(waiting_task)
         self.waiting_for_user_request = None
         self.status = "thinking"
         return None
+
+    def _task_text(self, context: Any) -> str:
+        if self.task_text:
+            return self.task_text
+        self.task_text = latest_user_text(context)
+        return self.task_text
 
     def _mark_latest_user_message_as_waiting_response(
         self,
@@ -695,6 +708,11 @@ class ReActPattern(AgentPattern):
                 result={"answer": answer},
             )
             self.status = "completed"
+            context.add_tool_result(
+                tool_name=name,
+                result={"answer": answer},
+                tool_call_id=tool_call.get("id"),
+            )
             if answer:
                 context.add_assistant_message(answer)
             return await self._finalize_success(
@@ -734,6 +752,7 @@ class ReActPattern(AgentPattern):
                     "tool_name": name,
                     "message": message,
                     "message_type": message_type,
+                    "task_text": self.task_text,
                     "message_count": len(getattr(context, "messages", [])),
                 }
                 return {
@@ -785,6 +804,7 @@ class ReActPattern(AgentPattern):
                 "message": message,
                 "message_type": "question",
                 "interactions": interactions,
+                "task_text": self.task_text,
                 "message_count": len(getattr(context, "messages", [])),
             }
             return {
@@ -882,7 +902,7 @@ class ReActPattern(AgentPattern):
         ).to_dict()
         await generate_and_store_react_memory(
             context=context,
-            task=latest_user_text(context),
+            task=self._task_text(context),
             result=result,
             iterations=self.current_iteration + 1,
             llm=llm,
@@ -1076,7 +1096,47 @@ class ReActPattern(AgentPattern):
         args = getattr(tool, "args", None)
         if isinstance(args, dict) and args:
             return {"type": "object", "properties": args}
+        if inspect.isfunction(tool):
+            return self._signature_json_schema(tool)
         return {"type": "object", "properties": {}}
+
+    def _signature_json_schema(self, fn: Any) -> dict[str, Any]:
+        signature = inspect.signature(fn)
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for name, parameter in signature.parameters.items():
+            if name in {"self", "cls"}:
+                continue
+            if parameter.kind in {
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            }:
+                continue
+            properties[name] = self._annotation_json_schema(parameter.annotation)
+            if parameter.default is inspect.Parameter.empty:
+                required.append(name)
+
+        schema: dict[str, Any] = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return schema
+
+    def _annotation_json_schema(self, annotation: Any) -> dict[str, Any]:
+        if annotation is inspect.Parameter.empty:
+            return {}
+        if annotation is str or annotation == "str":
+            return {"type": "string"}
+        if annotation is int or annotation == "int":
+            return {"type": "integer"}
+        if annotation is float or annotation == "float":
+            return {"type": "number"}
+        if annotation is bool or annotation == "bool":
+            return {"type": "boolean"}
+        if annotation is dict or annotation == "dict":
+            return {"type": "object"}
+        if annotation is list or annotation == "list":
+            return {"type": "array"}
+        return {}
 
     async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:
         tool = self._find_tool(tool_call["name"], tools)

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -228,6 +228,57 @@ async def test_react_pattern_runs_tool_call_then_final_answer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_supports_plain_function_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    to_thread_calls: list[dict[str, Any]] = []
+
+    async def fake_to_thread(fn: Any, /, *args: Any, **kwargs: Any) -> Any:
+        to_thread_calls.append({"fn": fn, "args": args, "kwargs": kwargs})
+        return fn(*args, **kwargs)
+
+    def double_number(value: int) -> dict[str, Any]:
+        """Double a numeric input."""
+        return {"result": value * 2}
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Use the plain function.",
+                "tool_calls": [
+                    {
+                        "id": "call_plain",
+                        "function": {
+                            "name": "double_number",
+                            "arguments": '{"value":4}',
+                        },
+                    }
+                ],
+            },
+            {"content": "The result is 8.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("Double 4")
+
+    result = await pattern.run(context=context, tools=[double_number], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 8."
+    assert to_thread_calls
+    assert to_thread_calls[0]["kwargs"] == {"value": 4}
+    tool_schema = next(
+        schema
+        for schema in llm.calls[0]["tools"]
+        if schema["function"]["name"] == "double_number"
+    )
+    assert tool_schema["function"]["description"] == "Double a numeric input."
+    assert context.messages[2].content == "Tool double_number returned: {'result': 8}"
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_injects_v1_memory_and_skill_context() -> None:
     llm = FakeLLM(
         responses=[

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 import pytest
@@ -11,6 +12,7 @@ from xagent.core.agent_v2 import (
     PatternRuntime,
     ReActPattern,
     ReActReasoningMode,
+    ToolCallRecord,
 )
 
 
@@ -219,7 +221,8 @@ async def test_react_pattern_runs_tool_call_then_final_answer() -> None:
     assert llm.calls[0]["tools"][0]["function"]["name"] == "calculator"
     system_prompt = llm.calls[0]["messages"][0]["content"]
     assert "latest user message" in system_prompt
-    assert "current date" in system_prompt
+    assert re.search(r"Current date \(UTC\): \d{4}-\d{2}-\d{2}", system_prompt)
+    assert "use this date when forming search queries" in system_prompt
     assert "not supported by the conversation" in system_prompt
     assert "available context is insufficient" in system_prompt
 
@@ -1190,6 +1193,20 @@ def test_react_pattern_state_roundtrip() -> None:
     assert restored.tool_ledger["call_1"].result == {"result": 2}
 
 
+def test_tool_call_record_from_dict_handles_null_args() -> None:
+    record = ToolCallRecord.from_dict(
+        {
+            "tool_call_id": "call_1",
+            "tool_name": "calculator",
+            "args": None,
+        }
+    )
+
+    assert record.args == {}
+    assert record.args_hash == ""
+    assert record.status == "pending"
+
+
 @pytest.mark.asyncio
 async def test_react_pattern_reasoning_action_mode_is_explicit_placeholder() -> None:
     pattern = ReActPattern(reasoning_mode=ReActReasoningMode.REASONING_ACTION)
@@ -1200,7 +1217,9 @@ async def test_react_pattern_reasoning_action_mode_is_explicit_placeholder() -> 
 
     assert result["success"] is False
     assert result["status"] == "failed"
-    assert "not implemented" in result["error"]
+    assert "reserved for a future implementation" in result["error"]
+    assert result["reasoning_mode"] == ReActReasoningMode.REASONING_ACTION.value
+    assert result["error_type"] == "not_implemented"
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -82,6 +82,31 @@ class FakeAskUserTool:
         return args
 
 
+class LegacySchemaArgs:
+    @classmethod
+    def schema(cls) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+        }
+
+
+class LegacySchemaTool:
+    def __init__(self) -> None:
+        class Metadata:
+            name = "legacy_schema"
+            description = "Legacy schema tool."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[LegacySchemaArgs]:
+        return LegacySchemaArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        return {"value": args["value"]}
+
+
 class FakeLLM:
     def __init__(self, responses: list[Any]) -> None:
         self.responses = responses
@@ -327,6 +352,26 @@ async def test_react_pattern_uses_langchain_tool_schema() -> None:
     assert context.get_messages_by_role("tool")[-1].content == (
         "Tool add_numbers returned: 5"
     )
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_supports_legacy_args_type_schema() -> None:
+    llm = FakeLLM(responses=[{"content": "Done.", "done": True}])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Inspect schema")
+
+    result = await pattern.run(context=context, tools=[LegacySchemaTool()], llm=llm)
+
+    assert result["success"] is True
+    tool_schema = next(
+        schema
+        for schema in llm.calls[0]["tools"]
+        if schema["function"]["name"] == "legacy_schema"
+    )
+    parameters = tool_schema["function"]["parameters"]
+    assert parameters["properties"]["value"]["type"] == "integer"
+    assert parameters["required"] == ["value"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -642,6 +642,58 @@ async def test_react_pattern_final_answer_tool_persists_memory(
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_final_answer_clears_trailing_pending_before_checkpoint() -> (
+    None
+):
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Done."}',
+                        },
+                    },
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"9+1"}',
+                        },
+                    },
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime()
+    tool = FakeTool()
+    context = ExecutionContext()
+    context.add_user_message("Finish and do not continue")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "Done."
+    assert tool.calls == []
+    assert pattern.pending_tool_calls == []
+    final_checkpoint = next(
+        checkpoint
+        for checkpoint in runtime.checkpoints
+        if checkpoint["label"] == "final"
+    )
+    assert final_checkpoint["pattern_state"]["status"] == "completed"
+    assert final_checkpoint["pattern_state"]["pending_tool_calls"] == []
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_accepts_plain_text_response() -> None:
     llm = FakeLLM(responses=["Direct answer"])
     pattern = ReActPattern(max_iterations=1)

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import re
 from typing import Any
 
 import pytest
+from langchain_core.tools import tool as langchain_tool
 from pydantic import BaseModel
 
 from xagent.core.agent_v2 import (
@@ -14,6 +16,8 @@ from xagent.core.agent_v2 import (
     ReActReasoningMode,
     ToolCallRecord,
 )
+
+react_module = importlib.import_module("xagent.core.agent_v2.pattern.react.react")
 
 
 class CalculatorArgs(BaseModel):
@@ -279,6 +283,50 @@ async def test_react_pattern_supports_plain_function_tools(
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_uses_langchain_tool_schema() -> None:
+    @langchain_tool
+    def add_numbers(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_add",
+                        "function": {
+                            "name": "add_numbers",
+                            "arguments": '{"a":2,"b":3}',
+                        },
+                    }
+                ],
+            },
+            {"content": "The result is 5.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Add 2 and 3")
+
+    result = await pattern.run(context=context, tools=[add_numbers], llm=llm)
+
+    assert result["success"] is True
+    tool_schema = next(
+        schema
+        for schema in llm.calls[0]["tools"]
+        if schema["function"]["name"] == "add_numbers"
+    )
+    parameters = tool_schema["function"]["parameters"]
+    assert parameters["properties"]["a"]["type"] == "integer"
+    assert parameters["properties"]["b"]["type"] == "integer"
+    assert parameters["required"] == ["a", "b"]
+    assert context.get_messages_by_role("tool")[-1].content == (
+        "Tool add_numbers returned: 5"
+    )
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_injects_v1_memory_and_skill_context() -> None:
     llm = FakeLLM(
         responses=[
@@ -493,6 +541,49 @@ async def test_react_pattern_can_finish_with_final_answer_tool() -> None:
     assert tool.calls == [{"expression": "2+2"}]
     assert context.messages[-1].role == "assistant"
     assert context.messages[-1].content == "The result is 4."
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_final_answer_tool_persists_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory_calls: list[dict[str, Any]] = []
+
+    async def fake_generate_and_store_react_memory(**kwargs: Any) -> None:
+        memory_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        react_module,
+        "generate_and_store_react_memory",
+        fake_generate_and_store_react_memory,
+    )
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Done."}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext()
+    context.add_user_message("Finish")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Done."
+    assert memory_calls
+    assert memory_calls[0]["task"] == "Finish"
+    assert memory_calls[0]["result"]["response"] == "Done."
+    assert memory_calls[0]["iterations"] == 1
 
 
 @pytest.mark.asyncio
@@ -813,6 +904,18 @@ async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool(
     assert resumed["success"] is True
     assert tool.calls == [{"expression": "5+5"}]
     assert context.get_messages_by_role("tool")[-1].tool_call_id == "call_calc"
+    resumed_messages = resumed_llm.calls[0]["messages"]
+    resumed_tool_result = next(
+        message
+        for message in resumed_messages
+        if message.get("role") == "tool" and message.get("tool_call_id") == "call_calc"
+    )
+    resumed_tool_envelope_index = resumed_messages.index(resumed_tool_result) - 1
+    assert resumed_messages[resumed_tool_envelope_index]["role"] == "assistant"
+    assert resumed_messages[resumed_tool_envelope_index]["tool_calls"][0]["id"] == (
+        "call_calc"
+    )
+    assert "Tool calculator returned" in resumed_tool_result["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -1,0 +1,1190 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from xagent.core.agent_v2 import (
+    ExecutionContext,
+    PatternRuntime,
+    ReActPattern,
+    ReActReasoningMode,
+)
+
+
+class CalculatorArgs(BaseModel):
+    expression: str
+
+
+class FakeTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "calculator"
+            description = "Evaluate math expressions."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return CalculatorArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        expression = args["expression"]
+        return {"result": eval(expression), "expression": expression}  # noqa: S307
+
+
+class BrokenTool:
+    def __init__(self) -> None:
+        class Metadata:
+            name = "broken"
+            description = "Always fails."
+
+        self.metadata = Metadata()
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        raise RuntimeError(f"broken with {args}")
+
+
+class FailingResultTool:
+    def __init__(self) -> None:
+        class Metadata:
+            name = "failing_result"
+            description = "Returns a failed tool result."
+
+        self.metadata = Metadata()
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        return {"success": False, "output": "", "error": f"failed with {args}"}
+
+
+class FakeAskUserTool:
+    def __init__(self) -> None:
+        class Metadata:
+            name = "ask_user_question"
+            description = "Legacy ask user tool."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return BaseModel
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        return args
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class BlockingLLM:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = False
+
+    async def chat(self, **kwargs: Any) -> Any:
+        del kwargs
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def start_trace(self, **kwargs: Any) -> None:
+        self.events.append(("start_trace", kwargs))
+
+    async def finish_trace(self, **kwargs: Any) -> None:
+        self.events.append(("finish_trace", kwargs))
+
+    async def start_span(self, **kwargs: Any) -> None:
+        self.events.append(("start_span", kwargs))
+
+    async def finish_span(self, **kwargs: Any) -> None:
+        self.events.append(("finish_span", kwargs))
+
+
+class TraceEventRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+class MemoryNote:
+    content = "Use the stored project preference."
+    keywords = ["project", "preference"]
+    metadata = {"source": "test"}
+    category = "react_memory"
+
+
+class FakeMemoryStore:
+    def __init__(self) -> None:
+        self.searches: list[dict[str, Any]] = []
+
+    def search(self, **kwargs: Any) -> list[MemoryNote]:
+        self.searches.append(kwargs)
+        return [MemoryNote()]
+
+
+class FakeSkillManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def select_skill(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {
+            "name": "test-skill",
+            "description": "A test skill",
+            "content": "Follow the selected skill instructions.",
+        }
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_runs_tool_call_then_final_answer() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "I should calculate this first.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "The result is 4.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    tool = FakeTool()
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("Calculate 2+2")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert tool.calls == [{"expression": "2+2"}]
+    assert [message.role for message in context.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert context.messages[1].tool_calls == [
+        {
+            "id": "call_1",
+            "function": {
+                "name": "calculator",
+                "arguments": '{"expression":"2+2"}',
+            },
+        }
+    ]
+    assert llm.calls[0]["tools"][0]["function"]["name"] == "calculator"
+    system_prompt = llm.calls[0]["messages"][0]["content"]
+    assert "latest user message" in system_prompt
+    assert "current date" in system_prompt
+    assert "not supported by the conversation" in system_prompt
+    assert "available context is insufficient" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_injects_v1_memory_and_skill_context() -> None:
+    llm = FakeLLM(
+        responses=[
+            {"content": "Done.", "done": True},
+            {
+                "content": (
+                    '{"should_store": false, "reason": "routine", '
+                    '"core_insight": "", "user_preferences": "", '
+                    '"failure_patterns": "", "success_patterns": ""}'
+                )
+            },
+        ]
+    )
+    memory_store = FakeMemoryStore()
+    skill_manager = FakeSkillManager()
+    pattern = ReActPattern(max_iterations=1, tool_choice="none")
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("Do the thing")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        memory_store=memory_store,
+        skill_manager=skill_manager,
+        allowed_skills=["test-skill"],
+    )
+
+    assert result["success"] is True
+    assert [search["filters"]["category"] for search in memory_store.searches] == [
+        "react_memory",
+        "general",
+    ]
+    assert skill_manager.calls[0]["task"] == "Do the thing"
+    assert skill_manager.calls[0]["allowed_skills"] == ["test-skill"]
+    system_prompt = llm.calls[0]["messages"][0]["content"]
+    assert "Use the stored project preference." in system_prompt
+    assert "Available Skill: test-skill" in system_prompt
+    assert "Follow the selected skill instructions." in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_emits_memory_retrieve_trace_events() -> None:
+    llm = FakeLLM(
+        responses=[
+            {"content": "Done.", "done": True},
+            {
+                "content": (
+                    '{"should_store": false, "reason": "routine", '
+                    '"core_insight": "", "user_preferences": "", '
+                    '"failure_patterns": "", "success_patterns": ""}'
+                )
+            },
+        ]
+    )
+    memory_store = FakeMemoryStore()
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer, execution_id="task-memory-trace")
+    pattern = ReActPattern(max_iterations=1, tool_choice="none")
+    context = ExecutionContext(execution_id="task-memory-trace")
+    context.add_user_message("Use memory")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+        memory_store=memory_store,
+    )
+
+    assert result["success"] is True
+    memory_events = [
+        event for event in tracer.events if "memory_retrieve" in event["event_type"]
+    ]
+    assert [event["event_type"] for event in memory_events] == [
+        "task_start_memory_retrieve",
+        "task_end_memory_retrieve",
+    ]
+    assert all(event["task_id"] == "task-memory-trace" for event in memory_events)
+    store_events = [
+        event for event in tracer.events if "memory_store" in event["event_type"]
+    ]
+    assert [event["event_type"] for event in store_events] == ["task_end_memory_store"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_keeps_tools_available_after_successful_tool() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need calculation.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "final_call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"The result is 4."}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    tool = FakeTool()
+    context = ExecutionContext()
+    context.add_user_message("Calculate 2+2")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert tool.calls == [{"expression": "2+2"}]
+    assert llm.calls[0]["tools"][0]["function"]["name"] == "calculator"
+    second_call_tool_names = [
+        schema["function"]["name"] for schema in llm.calls[1]["tools"]
+    ]
+    assert "calculator" in second_call_tool_names
+    assert "final_answer" in second_call_tool_names
+    assert "Do not call tools again" not in llm.calls[1]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
+    llm = FakeLLM(responses=[{"content": "No tools needed."}])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Say hi")
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeAskUserTool()],
+        llm=llm,
+    )
+
+    assert result["success"] is True
+    tool_names = [schema["function"]["name"] for schema in llm.calls[0]["tools"]]
+    assert tool_names.count("ask_user_question") == 1
+    assert "final_answer" in tool_names
+    assert "send_message" in tool_names
+    assert "complete_task" not in tool_names
+    ask_user_schema = next(
+        schema
+        for schema in llm.calls[0]["tools"]
+        if schema["function"]["name"] == "ask_user_question"
+    )
+    ask_user_description = ask_user_schema["function"]["description"]
+    assert "cannot continue without missing user-provided information" in (
+        ask_user_description
+    )
+    assert "Do not use it to confirm execution strategy" in ask_user_description
+    assert "whether to use memory" in ask_user_description
+    system_prompt = llm.calls[0]["messages"][0]["content"]
+    assert "Only call tools that are present in the current tool schema" in (
+        system_prompt
+    )
+    assert "tool names mentioned in memory" in system_prompt
+    assert "call the final_answer tool exactly once" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_can_finish_with_final_answer_tool() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"The result is 4."}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    tool = FakeTool()
+    context = ExecutionContext()
+    context.add_user_message("Calculate 2+2")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert tool.calls == [{"expression": "2+2"}]
+    assert context.messages[-1].role == "assistant"
+    assert context.messages[-1].content == "The result is 4."
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_accepts_plain_text_response() -> None:
+    llm = FakeLLM(responses=["Direct answer"])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Say hi")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result == {
+        "success": True,
+        "output": "Direct answer",
+        "response": "Direct answer",
+        "status": "completed",
+    }
+    assert context.messages[-1].content == "Direct answer"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_can_run_as_strict_single_call() -> None:
+    llm = FakeLLM(responses=["Direct answer"])
+    pattern = ReActPattern(max_iterations=1, tool_choice="none")
+    context = ExecutionContext()
+    context.add_user_message("Say hi")
+
+    result = await pattern.run(context=context, tools=[FakeTool()], llm=llm)
+
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert llm.calls[0]["tools"] is None
+    assert llm.calls[0]["tool_choice"] is None
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_errors_without_llm() -> None:
+    pattern = ReActPattern()
+    context = ExecutionContext()
+    context.add_user_message("Hello")
+
+    result = await pattern.run(context=context, tools=[], llm=None)
+
+    assert result["success"] is False
+    assert "requires an llm" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_send_message_without_response_continues() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Sending progress.",
+                "tool_calls": [
+                    {
+                        "id": "call_message",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Still working","message_type":"progress","expect_response":false}',
+                        },
+                    }
+                ],
+            },
+            {"content": "All done."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    runtime = PatternRuntime()
+    context = ExecutionContext()
+    context.add_user_message("Work")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "All done."
+    assert runtime.outbound_messages == [
+        {
+            "type": "agent_message",
+            "execution_id": context.execution_id,
+            "message": "Still working",
+            "message_type": "progress",
+            "expect_response": False,
+            "metadata": {},
+        }
+    ]
+    tool_messages = context.get_messages_by_role("tool")
+    assert len(tool_messages) == 1
+    assert tool_messages[0].metadata["tool_name"] == "send_message"
+    assert pattern.tool_ledger["call_message"].status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_send_message_with_response_waits() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need input.",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Choose A or B","message_type":"question","expect_response":true}',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    sent_messages: list[dict[str, Any]] = []
+    runtime = PatternRuntime(outbound_message_handler=sent_messages.append)
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is False
+    assert result["status"] == "waiting_for_user"
+    assert result["message"] == "Choose A or B"
+    assert sent_messages == runtime.outbound_messages
+    assert sent_messages[0]["message"] == "Choose A or B"
+    assert sent_messages[0]["expect_response"] is True
+    assert pattern.status == "waiting_for_user"
+    tool_messages = context.get_messages_by_role("tool")
+    assert tool_messages[0].tool_call_id == "call_question"
+    assert tool_messages[0].metadata["raw_result"]["status"] == "waiting_for_user"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_ask_user_question_pauses_with_structured_payload() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need structured input.",
+                "tool_calls": [
+                    {
+                        "id": "call_question_form",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Pick one","interactions":'
+                                '[{"type":"select_one","field":"choice","label":"Choice"}]}'
+                            ),
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-1")
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is False
+    assert result["status"] == "waiting_for_user"
+    assert result["message"] == "Pick one"
+    assert runtime.outbound_messages == [
+        {
+            "type": "agent_message",
+            "execution_id": "exec-1",
+            "message": "Pick one",
+            "message_type": "question",
+            "expect_response": True,
+            "metadata": {
+                "interactions": [
+                    {
+                        "type": "select_one",
+                        "field": "choice",
+                        "label": "Choice",
+                    }
+                ]
+            },
+        }
+    ]
+    assert pattern.tool_ledger["call_question_form"].status == "completed"
+    tool_messages = context.get_messages_by_role("tool")
+    assert tool_messages[0].tool_call_id == "call_question_form"
+    assert tool_messages[0].metadata["raw_result"]["status"] == "waiting_for_user"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_resume_waiting_without_user_response_stays_waiting() -> (
+    None
+):
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need input.",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Choose A or B","message_type":"question","expect_response":true}',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    first = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert first["status"] == "waiting_for_user"
+
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_llm = FakeLLM([{"content": "Should not run"}])
+
+    resumed = await resumed_pattern.run(context=context, tools=[], llm=resumed_llm)
+
+    assert resumed["status"] == "waiting_for_user"
+    assert resumed["message"] == "Choose A or B"
+    assert resumed_llm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_resume_waiting_after_user_response_continues() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need input.",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Choose A or B","message_type":"question","expect_response":true}',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    first = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert first["status"] == "waiting_for_user"
+    context.add_user_message("B")
+
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_llm = FakeLLM([{"content": "Continuing with B."}])
+
+    resumed = await resumed_pattern.run(context=context, tools=[], llm=resumed_llm)
+
+    assert resumed["success"] is True
+    assert resumed["output"] == "Continuing with B."
+    assert len(resumed_llm.calls) == 1
+    assert context.messages[-2].content == "B"
+    resumed_messages = resumed_llm.calls[0]["messages"]
+    assert resumed_messages[-1]["role"] == "user"
+    assert "answer to a pending agent question" in resumed_messages[-1]["content"]
+    assert "Pending question: Choose A or B" in resumed_messages[-1]["content"]
+    assert "User answer: B" in resumed_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_tool_errors_are_written_as_observations() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Use missing tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_missing",
+                        "function": {
+                            "name": "missing",
+                            "arguments": '{"value":1}',
+                        },
+                    }
+                ],
+            },
+            {"content": "Recovered after missing tool."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Recover")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Recovered after missing tool."
+    tool_message = context.get_messages_by_role("tool")[0]
+    assert "Tool missing returned" in tool_message.content
+    assert tool_message.metadata["raw_result"]["success"] is False
+    assert "Tool not found" in tool_message.metadata["raw_result"]["error"]
+    assert pattern.tool_ledger["call_missing"].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_tool_exception_is_written_as_observation() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Use broken tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_broken",
+                        "function": {
+                            "name": "broken",
+                            "arguments": '{"value":2}',
+                        },
+                    }
+                ],
+            },
+            {"content": "Recovered after broken tool."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Recover")
+
+    result = await pattern.run(context=context, tools=[BrokenTool()], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Recovered after broken tool."
+    tool_message = context.get_messages_by_role("tool")[0]
+    assert tool_message.metadata["raw_result"]["success"] is False
+    assert "broken with" in tool_message.metadata["raw_result"]["error"]
+    assert pattern.tool_ledger["call_broken"].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_failed_tool_result_emits_tool_error_trace() -> None:
+    tracer = TraceEventRecorder()
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Use failing tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_failed_result",
+                        "function": {
+                            "name": "failing_result",
+                            "arguments": '{"value":3}',
+                        },
+                    }
+                ],
+            },
+            {"content": "Recovered after failed tool result."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(execution_id="failed-result")
+    context.add_user_message("Recover")
+    runtime = PatternRuntime(tracer=tracer)
+
+    result = await pattern.run(
+        context=context,
+        tools=[FailingResultTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    tool_message = context.get_messages_by_role("tool")[0]
+    assert tool_message.metadata["raw_result"]["success"] is False
+    assert pattern.tool_ledger["call_failed_result"].status == "failed"
+    event_types = {event["event_type"] for event in tracer.events}
+    assert "action_error_tool" in event_types
+    assert "task_start_react" in event_types
+    step_ids = {
+        event["step_id"]
+        for event in tracer.events
+        if event["event_type"] in {"task_start_react", "action_start_tool"}
+    }
+    assert len(step_ids) == 1
+    react_step_id = step_ids.pop()
+    assert react_step_id is not None
+    assert react_step_id.startswith("react_")
+    assert react_step_id != "failed-result"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_generates_new_step_id_per_run() -> None:
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="multi-react")
+    context.add_user_message("First")
+
+    first = ReActPattern(max_iterations=1)
+    first_result = await first.run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "First done."}]),
+        runtime=runtime,
+    )
+
+    context.add_user_message("Second")
+    second = ReActPattern(max_iterations=1)
+    second_result = await second.run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "Second done."}]),
+        runtime=runtime,
+    )
+
+    assert first_result["success"] is True
+    assert second_result["success"] is True
+    react_start_step_ids = [
+        event["step_id"]
+        for event in tracer.events
+        if event["event_type"] == "task_start_react"
+    ]
+    assert len(react_start_step_ids) == 2
+    assert all(step_id.startswith("react_") for step_id in react_start_step_ids)
+    assert react_start_step_ids[0] != react_start_step_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_traces_context_compaction() -> None:
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="compact-react")
+    context.compact_config.threshold = 1
+    for index in range(3):
+        context.add_user_message(f"message {index}")
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "done"}]),
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    compact_events = [
+        event for event in tracer.events if event["event_type"].endswith("_compact")
+    ]
+    assert [event["event_type"] for event in compact_events] == [
+        "action_start_compact",
+        "action_end_compact",
+    ]
+    assert compact_events[0]["step_id"].startswith("react_")
+    assert compact_events[1]["data"]["success"] is True
+    assert compact_events[1]["data"]["compact_type"] == "execution_context"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_emits_runtime_checkpoints() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "I should calculate this first.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"3+3"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "The result is 6.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Calculate 3+3")
+    runtime = PatternRuntime()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert [checkpoint["label"] for checkpoint in runtime.checkpoints] == [
+        "before_llm",
+        "after_llm",
+        "before_tool",
+        "after_tool",
+        "before_llm",
+        "after_llm",
+        "final",
+    ]
+    after_llm = runtime.checkpoints[1]
+    assert after_llm["pattern_state"]["pending_tool_calls"] == [
+        {"id": "call_1", "name": "calculator", "args": {"expression": "3+3"}}
+    ]
+    assert after_llm["context"]["messages"][1]["tool_calls"][0]["id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_runtime_emits_tracer_task_and_tool_events() -> None:
+    tracer = FakeTracer()
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need a tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_trace",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"3*3"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "The result is 9.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Calculate 3*3")
+    runtime = PatternRuntime(tracer=tracer)
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert [event for event, _ in tracer.events] == [
+        "start_trace",
+        "start_span",
+        "finish_span",
+        "finish_trace",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_pause_cancels_active_llm_call() -> None:
+    llm = BlockingLLM()
+    runtime = PatternRuntime()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Wait on model")
+
+    task = asyncio.create_task(
+        pattern.run(
+            context=context,
+            tools=[],
+            llm=llm,
+            runtime=runtime,
+        )
+    )
+    await asyncio.wait_for(llm.started.wait(), timeout=1)
+
+    runtime.request_interrupt("paused by test")
+    result = await asyncio.wait_for(task, timeout=1)
+
+    assert llm.cancelled is True
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert result["interrupt_reason"] == "paused by test"
+    assert runtime.last_checkpoint["label"] == "interrupted"
+    assert runtime.last_checkpoint["metadata"] == {
+        "safe_point": "during_llm",
+        "reason": "paused by test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_interrupts_at_tool_boundary() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "I should calculate this first.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"4+4"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    runtime = PatternRuntime()
+    runtime.interrupt_checker = lambda: len(runtime.checkpoints) >= 2
+    pattern = ReActPattern(max_iterations=3)
+    tool = FakeTool()
+    context = ExecutionContext()
+    context.add_user_message("Calculate 4+4")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert tool.calls == []
+    assert runtime.last_checkpoint["label"] == "interrupted"
+    assert pattern.pending_tool_calls == [
+        {"id": "call_1", "name": "calculator", "args": {"expression": "4+4"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_resumes_pending_tool_call_from_checkpoint() -> None:
+    first_llm = FakeLLM(
+        responses=[
+            {
+                "content": "I should calculate this first.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"4+4"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    first_runtime = PatternRuntime()
+    first_runtime.interrupt_checker = lambda: len(first_runtime.checkpoints) >= 2
+    first_pattern = ReActPattern(max_iterations=3)
+    first_context = ExecutionContext()
+    first_context.add_user_message("Calculate 4+4")
+
+    interrupted = await first_pattern.run(
+        context=first_context,
+        tools=[FakeTool()],
+        llm=first_llm,
+        runtime=first_runtime,
+    )
+    checkpoint = first_runtime.last_checkpoint
+
+    assert interrupted["status"] == "interrupted"
+    assert checkpoint is not None
+
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_pattern = ReActPattern(max_iterations=3)
+    restored_pattern.load_state(checkpoint["pattern_state"])
+    restored_tool = FakeTool()
+    restored_runtime = PatternRuntime()
+
+    result = await restored_pattern.run(
+        context=restored_context,
+        tools=[restored_tool],
+        llm=FakeLLM([{"content": "The result is 8.", "done": True}]),
+        runtime=restored_runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 8."
+    assert restored_tool.calls == [{"expression": "4+4"}]
+    assert [message.role for message in restored_context.messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+
+
+def test_react_pattern_state_roundtrip() -> None:
+    pattern = ReActPattern(max_iterations=5)
+    pattern.status = "acting"
+    pattern.current_iteration = 2
+    pattern.pending_tool_calls = [{"id": "call_1", "name": "calculator", "args": {}}]
+    pattern._record_tool_call(
+        {"id": "call_1", "name": "calculator", "args": {"expression": "1+1"}},
+        status="completed",
+        result={"result": 2},
+    )
+
+    restored = ReActPattern()
+    restored.load_state(pattern.get_state())
+
+    assert restored.status == "acting"
+    assert restored.current_iteration == 2
+    assert restored.max_iterations == 5
+    assert restored.reasoning_mode == ReActReasoningMode.TOOL_CALLING
+    assert restored.tool_ledger["call_1"].result == {"result": 2}
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_reasoning_action_mode_is_explicit_placeholder() -> None:
+    pattern = ReActPattern(reasoning_mode=ReActReasoningMode.REASONING_ACTION)
+    context = ExecutionContext()
+    context.add_user_message("Think")
+
+    result = await pattern.run(context=context, tools=[], llm=FakeLLM([]))
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert "not implemented" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_runtime_injected_from_runner_style_traces_events() -> None:
+    tracer = FakeTracer()
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need a tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_trace",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"3*3"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "The result is 9.", "done": True},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Calculate 3*3")
+    runtime = PatternRuntime(tracer=tracer)
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert [event for event, _ in tracer.events] == [
+        "start_trace",
+        "start_span",
+        "finish_span",
+        "finish_trace",
+    ]

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -279,6 +279,9 @@ async def test_react_pattern_supports_plain_function_tools(
         if schema["function"]["name"] == "double_number"
     )
     assert tool_schema["function"]["description"] == "Double a numeric input."
+    parameters = tool_schema["function"]["parameters"]
+    assert parameters["properties"]["value"]["type"] == "integer"
+    assert parameters["required"] == ["value"]
     assert context.messages[2].content == "Tool double_number returned: {'result': 8}"
 
 
@@ -539,6 +542,9 @@ async def test_react_pattern_can_finish_with_final_answer_tool() -> None:
     assert result["success"] is True
     assert result["response"] == "The result is 4."
     assert tool.calls == [{"expression": "2+2"}]
+    assert context.messages[-2].role == "tool"
+    assert context.messages[-2].tool_call_id == "call_final"
+    assert context.messages[-2].metadata["tool_name"] == "final_answer"
     assert context.messages[-1].role == "assistant"
     assert context.messages[-1].content == "The result is 4."
 
@@ -580,8 +586,12 @@ async def test_react_pattern_final_answer_tool_persists_memory(
 
     assert result["success"] is True
     assert result["response"] == "Done."
+    assert context.messages[-2].role == "tool"
+    assert context.messages[-2].tool_call_id == "call_final"
+    assert context.messages[-1].content == "Done."
     assert memory_calls
     assert memory_calls[0]["task"] == "Finish"
+    assert memory_calls[0]["context"].messages[-2].role == "tool"
     assert memory_calls[0]["result"]["response"] == "Done."
     assert memory_calls[0]["iterations"] == 1
 
@@ -916,6 +926,59 @@ async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool(
         "call_calc"
     )
     assert "Tool calculator returned" in resumed_tool_result["content"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_resume_uses_original_task_for_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory_calls: list[dict[str, Any]] = []
+
+    async def fake_generate_and_store_react_memory(**kwargs: Any) -> None:
+        memory_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        react_module,
+        "generate_and_store_react_memory",
+        fake_generate_and_store_react_memory,
+    )
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Choose A or B","message_type":"question","expect_response":true}',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext()
+    context.add_user_message("Ask, then calculate")
+
+    first = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert first["status"] == "waiting_for_user"
+    context.add_user_message("B")
+    resumed_pattern = ReActPattern(max_iterations=3)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_llm = FakeLLM([{"content": "Continuing with B.", "done": True}])
+
+    resumed = await resumed_pattern.run(
+        context=context,
+        tools=[],
+        llm=resumed_llm,
+        memory_store=object(),
+    )
+
+    assert resumed["success"] is True
+    assert memory_calls
+    assert memory_calls[0]["task"] == "Ask, then calculate"
 
 
 @pytest.mark.asyncio
@@ -1330,6 +1393,7 @@ def test_react_pattern_state_roundtrip() -> None:
     pattern = ReActPattern(max_iterations=5)
     pattern.status = "acting"
     pattern.current_iteration = 2
+    pattern.task_text = "Original task"
     pattern.pending_tool_calls = [{"id": "call_1", "name": "calculator", "args": {}}]
     pattern._record_tool_call(
         {"id": "call_1", "name": "calculator", "args": {"expression": "1+1"}},
@@ -1343,6 +1407,7 @@ def test_react_pattern_state_roundtrip() -> None:
     assert restored.status == "acting"
     assert restored.current_iteration == 2
     assert restored.max_iterations == 5
+    assert restored.task_text == "Original task"
     assert restored.reasoning_mode == ReActReasoningMode.TOOL_CALLING
     assert restored.tool_ledger["call_1"].result == {"result": 2}
 

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -707,6 +707,61 @@ async def test_react_pattern_resume_waiting_after_user_response_continues() -> N
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_preserves_pending_calls_after_waiting_control_tool() -> (
+    None
+):
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need input, then calculate.",
+                "tool_calls": [
+                    {
+                        "id": "call_question",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Choose A or B","message_type":"question","expect_response":true}',
+                        },
+                    },
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"5+5"}',
+                        },
+                    },
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=4)
+    tool = FakeTool()
+    context = ExecutionContext()
+    context.add_user_message("Ask, then calculate")
+
+    first = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert first["status"] == "waiting_for_user"
+    assert pattern.pending_tool_calls == [
+        {"id": "call_calc", "name": "calculator", "args": {"expression": "5+5"}}
+    ]
+
+    context.add_user_message("B")
+    resumed_pattern = ReActPattern(max_iterations=4)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_llm = FakeLLM([{"content": "The result is 10.", "done": True}])
+
+    resumed = await resumed_pattern.run(
+        context=context,
+        tools=[tool],
+        llm=resumed_llm,
+    )
+
+    assert resumed["success"] is True
+    assert tool.calls == [{"expression": "5+5"}]
+    assert context.get_messages_by_role("tool")[-1].tool_call_id == "call_calc"
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_tool_errors_are_written_as_observations() -> None:
     llm = FakeLLM(
         responses=[


### PR DESCRIPTION
## Summary
- Add the agent_v2 pattern package and base pattern result interface
- Add the v2 ReAct tool-calling pattern with pause/resume, built-in user question/final answer controls, memory/skill enrichment hooks, tracing, and checkpoint state support
- Add focused ReAct pattern tests covering tool execution, finalization, interrupts, waiting-for-user resume, memory/skill enrichment, and trace behavior

## Tests
- uv run pytest tests/core/agent_v2/test_react.py
- uv run pytest tests/core/agent_v2
- uv run mypy src/xagent/core/agent_v2
- uv run ruff check src/xagent/core/agent_v2 tests/core/agent_v2/test_react.py