### PR TITLE
fix: stabilize prompt-based agent management

### DIFF
--- a/src/xagent/core/agent/pattern/dag_plan_execute/dag_plan_execute.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/dag_plan_execute.py
@@ -155,6 +155,7 @@ class DAGPlanExecutePattern(AgentPattern):
             None  # Store skill context for execution phase
         )
         self._selected_skill_name: Optional[str] = None
+        self._builder_context_active: bool = False
 
         # Pause/resume control
         self._pause_event = asyncio.Event()
@@ -264,6 +265,19 @@ class DAGPlanExecutePattern(AgentPattern):
     def set_recovered_skill_context(self, skill_context: Optional[str]) -> None:
         """Load a recovered skill context from prior rounds."""
         self._recovered_skill_context = skill_context
+        if skill_context and "agent-builder" in skill_context:
+            self._builder_context_active = True
+
+    def _is_builder_context_active(self) -> bool:
+        """Return whether the current task/continuation is in agent-builder mode."""
+        return (
+            self._builder_context_active
+            or self._selected_skill_name == "agent-builder"
+            or bool(
+                self._recovered_skill_context
+                and "agent-builder" in self._recovered_skill_context
+            )
+        )
 
     def _get_messages_for_llm(self) -> List[Dict[str, str]]:
         """Get conversation history in standard format for LLM.
@@ -652,6 +666,8 @@ class DAGPlanExecutePattern(AgentPattern):
                             )
                             self._recovered_skill_context = skill_context
                             self._selected_skill_name = skill["name"]
+                            if skill["name"] == "agent-builder":
+                                self._builder_context_active = True
                             logger.info(f"Using skill: {skill['name']}")
                         else:
                             logger.info("No relevant skill found")
@@ -929,7 +945,7 @@ class DAGPlanExecutePattern(AgentPattern):
                     plan,
                     tool_map,
                     self._skill_context,
-                    is_builder_context=self._selected_skill_name == "agent-builder",
+                    is_builder_context=self._is_builder_context_active(),
                 )
 
                 # Send final dag_plan_end event with updated step statuses (including skipped steps)
@@ -1726,6 +1742,7 @@ class DAGPlanExecutePattern(AgentPattern):
         self._context = None
         self._skill_context = None
         self._selected_skill_name = None
+        self._builder_context_active = False
 
         # Reset execution flags
         self._execution_interrupted = False

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -36,6 +36,32 @@ from .step_agent_factory import StepAgentFactory
 
 logger = logging.getLogger(__name__)
 
+AGENT_BUILDER_TOOL_CLOSURE = (
+    "list_knowledge_bases",
+    "ask_user_question",
+    "create_knowledge_base_from_file",
+    "create_knowledge_base_from_url",
+    "create_agent",
+    "update_agent",
+)
+
+AGENT_BUILDER_STEP_KEYWORDS = (
+    "agent",
+    "knowledge base",
+    "kb",
+    "upload",
+    "file",
+    "url",
+    "website",
+    "reference",
+    "智能体",
+    "知识库",
+    "上传",
+    "文件",
+    "网址",
+    "链接",
+)
+
 
 class PlanExecutor:
     """Handles plan execution with dependency resolution and deadlock detection"""
@@ -85,6 +111,37 @@ class PlanExecutor:
         self._execution_interrupted = False
         if self._pause_event.is_set():
             self._pause_event.clear()
+
+    @staticmethod
+    def _resolve_step_tool_names(
+        step: PlanStep, tool_map: Dict[str, Tool]
+    ) -> List[str]:
+        """Resolve step tool names while preserving legacy None-as-all behavior."""
+        if step.tool_names is None:
+            return list(tool_map.keys())
+        return step.get_available_tools() or []
+
+    @staticmethod
+    def _should_extend_builder_tool_names(
+        step: PlanStep, tool_names: List[str]
+    ) -> bool:
+        """Return whether a builder step needs the agent/KB tool closure."""
+        if any(name in AGENT_BUILDER_TOOL_CLOSURE for name in tool_names):
+            return True
+
+        step_text = f"{step.name}\n{step.description}".lower()
+        return any(keyword in step_text for keyword in AGENT_BUILDER_STEP_KEYWORDS)
+
+    @staticmethod
+    def _extend_builder_tool_names(
+        tool_names: List[str], tool_map: Dict[str, Tool]
+    ) -> List[str]:
+        """Add the agent-builder tool closure while preserving order."""
+        extended_tool_names = list(tool_names or [])
+        for tool_name in AGENT_BUILDER_TOOL_CLOSURE:
+            if tool_name in tool_map and tool_name not in extended_tool_names:
+                extended_tool_names.append(tool_name)
+        return extended_tool_names
 
     async def execute_plan(
         self,
@@ -569,6 +626,24 @@ class PlanExecutor:
         """
         logger.info(f"Executing step {step.id}: {step.name}")
 
+        original_tool_names = step.tool_names
+        tool_names = self._resolve_step_tool_names(step, tool_map)
+
+        if is_builder_context and self._should_extend_builder_tool_names(
+            step, tool_names
+        ):
+            tool_names = self._extend_builder_tool_names(tool_names, tool_map)
+            if tool_names != original_tool_names:
+                logger.info(
+                    "Extending agent-builder tools for step %s: %s -> %s",
+                    step.id,
+                    original_tool_names,
+                    tool_names,
+                )
+
+        # Normalize once so tracing and later execution use the same concrete list.
+        step.tool_names = tool_names
+
         # Trace step start with detailed context
         trace_step_id = f"step_{step.id}"
         step_start_data = {
@@ -593,7 +668,6 @@ class PlanExecutor:
 
         try:
             # Get tools for this step (handle steps with no tools)
-            tool_names = step.get_available_tools()
             tools: List[Tool] = []
 
             if tool_names:
@@ -701,8 +775,6 @@ class PlanExecutor:
             )
 
             # Add the current step task, with tool info and original goal context
-            tool_names = step.get_available_tools()
-
             # Get original goal for context
             original_goal = (
                 getattr(self.parent_pattern, "_original_goal", None)

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py
@@ -730,7 +730,9 @@ class PlanGenerator:
                 "The user has uploaded files (file_ids are present in the context above). "
                 'You MUST return `{"type": "plan"}` immediately. '
                 'Do NOT return type="chat". Do NOT ask the user to upload files again. '
+                "Do NOT create `get_file_id`, `list_files`, `wait_for_upload`, or `wait_for_file` steps. "
                 "Do NOT create a 'wait for upload' or 'wait for file' step — the files are already available. "
+                "Do NOT use filenames or paths as file_ids. "
                 "The plan must start directly with `create_knowledge_base_from_file` using the provided file_ids.\n\n"
             )
 
@@ -1022,13 +1024,33 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
             if "uploaded_files" in user_input_context:
                 uploaded_files = user_input_context["uploaded_files"]
                 file_info = user_input_context.get("file_info", [])
+                uploaded_file_ids = [
+                    str(f.get("file_id"))
+                    for f in file_info
+                    if isinstance(f, dict) and f.get("file_id")
+                ]
+                file_ids_str = ", ".join(f'"{fid}"' for fid in uploaded_file_ids)
                 user_prompt += f"\nUPLOADED FILES: {len(uploaded_files)} files available for processing:\n"
                 for f in file_info:
                     file_name = f.get("name", "unknown")
                     file_size = f.get("size", 0)
                     file_type = f.get("type", "unknown")
-                    user_prompt += f"- {file_name} ({file_size} bytes, {file_type})\n"
+                    file_id = f.get("file_id")
+                    user_prompt += f"- {file_name} ({file_size} bytes, {file_type})"
+                    if file_id:
+                        user_prompt += f"\n  File ID: {file_id}"
+                    user_prompt += "\n"
                 user_prompt += "These files have been uploaded and are available in the workspace.\n"
+                if uploaded_file_ids:
+                    user_prompt += (
+                        f"Use these exact file_ids (UUIDs): [{file_ids_str}].\n"
+                    )
+                user_prompt += (
+                    "Do NOT create `get_file_id`, `list_files`, `wait_for_upload`, or `wait_for_file` steps. "
+                    "Do NOT use filenames or paths as file_ids. "
+                    "For agent/knowledge-base goals, the next added step should call "
+                    "`create_knowledge_base_from_file` with the UUID file_ids above.\n"
+                )
                 user_prompt += (
                     "You should consider these files when planning additional steps.\n"
                 )
@@ -1095,7 +1117,11 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
                 use_custom_role = True
             if context.state.get("file_info"):
                 has_uploaded_files = True
-                uploaded_file_ids = [f["file_id"] for f in context.state["file_info"]]
+                uploaded_file_ids = [
+                    str(f["file_id"])
+                    for f in context.state["file_info"]
+                    if isinstance(f, dict) and f.get("file_id")
+                ]
 
         # Build tools context with new format
         tools_context = ""
@@ -1141,6 +1167,8 @@ When you return type="chat" (direct answer mode), you are providing a TEXT RESPO
             system_prompt += (
                 "\n\n## CRITICAL OVERRIDE: Files Have Been Uploaded\n"
                 f"The user has already uploaded files. Their exact UUIDs are: [{file_ids_str}]\n"
+                "Use only these UUIDs as file_ids. Do NOT use filenames or paths as file_ids.\n"
+                "You MUST NOT create `get_file_id`, `list_files`, `wait_for_upload`, or `wait_for_file` steps in your plan.\n"
                 "You MUST NOT create a 'wait for upload' or 'wait for file' step in your plan.\n"
                 "The plan MUST start immediately with processing these files. "
                 "If the goal is to build an agent/knowledge base, start directly with `create_knowledge_base_from_file` using the file_ids listed above.\n\n"

--- a/src/xagent/core/agent/pattern/react.py
+++ b/src/xagent/core/agent/pattern/react.py
@@ -58,6 +58,15 @@ logger = logging.getLogger(__name__)
 CONTEXT_KEY_FILE_INFO = "file_info"
 CONTEXT_KEY_UPLOADED_FILES = "uploaded_files"
 
+CRITICAL_BUSINESS_FAILURE_TOOLS = frozenset(
+    {
+        "create_agent",
+        "update_agent",
+        "create_knowledge_base_from_file",
+        "create_knowledge_base_from_url",
+    }
+)
+
 
 class ReActStepType(Enum):
     """Types of steps in ReAct execution"""
@@ -149,6 +158,37 @@ class ReActPattern(AgentPattern):
             threshold=compact_threshold or CompactConfig().threshold,
         )
         self._compact_stats = {"total_compacts": 0, "tokens_saved": 0}
+
+    @staticmethod
+    def _normalize_tool_result(result: Any) -> Any:
+        """Return a JSON-like value for checking tool business status."""
+        if hasattr(result, "model_dump"):
+            return result.model_dump()
+        return result
+
+    @classmethod
+    def _tool_result_is_business_failure(cls, result: Any) -> bool:
+        """Detect tool-level business failures encoded in successful returns."""
+        normalized_result = cls._normalize_tool_result(result)
+        if not isinstance(normalized_result, dict):
+            return False
+
+        if normalized_result.get("success") is False:
+            return True
+
+        status = normalized_result.get("status")
+        return isinstance(status, str) and status.lower() == "error"
+
+    @classmethod
+    def _tool_business_failure_message(cls, result: Any) -> str:
+        """Extract the original business failure message from a tool result."""
+        normalized_result = cls._normalize_tool_result(result)
+        if isinstance(normalized_result, dict):
+            for key in ("message", "error", "detail"):
+                value = normalized_result.get(key)
+                if value:
+                    return str(value)
+        return str(normalized_result)
 
     def _estimate_message_tokens(self, messages: List[Dict[str, str]]) -> int:
         """
@@ -2190,6 +2230,15 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                     )
 
                 result = await tool.run_json_async(tool_args)
+                normalized_result = self._normalize_tool_result(result)
+                business_failed = self._tool_result_is_business_failure(
+                    normalized_result
+                )
+                business_failure_message = (
+                    self._tool_business_failure_message(normalized_result)
+                    if business_failed
+                    else ""
+                )
 
                 # Trace tool execution end
                 if task_id is not None and step_id is not None:
@@ -2202,20 +2251,54 @@ Remember: Return ONLY ONE JSON object. No additional text, no multiple objects.
                             "tool_name": action.tool_name,
                             "tool_args": tool_args,
                             "tool_execution_id": tool_execution_id,
-                            "result": result,
-                            "success": True,
+                            "result": normalized_result,
+                            "success": not business_failed,
                             "step_id": step_id,
                             "step_name": getattr(self, "_current_step_name", "main"),
                             "sandboxed": is_sandboxed,
                         },
                     )
 
+                if business_failed:
+                    failure_content = (
+                        f"Tool '{action.tool_name}' reported failure. "
+                        f"Result: {normalized_result}"
+                    )
+                    if action.tool_name in CRITICAL_BUSINESS_FAILURE_TOOLS:
+                        logger.warning(
+                            "Critical tool %s reported business failure: %s",
+                            action.tool_name,
+                            business_failure_message,
+                        )
+                        return {
+                            "type": "final_answer",
+                            "content": failure_content,
+                            "reasoning": action.reasoning,
+                            "success": False,
+                            "error": business_failure_message,
+                            "tool_name": action.tool_name,
+                            "tool_args": tool_args,
+                            "result": normalized_result,
+                            "tool_execution_id": tool_execution_id,
+                        }
+
+                    return {
+                        "type": "observation",
+                        "content": failure_content,
+                        "tool_name": action.tool_name,
+                        "tool_args": tool_args,
+                        "result": normalized_result,
+                        "success": False,
+                        "error": business_failure_message,
+                        "tool_execution_id": tool_execution_id,
+                    }
+
                 return {
                     "type": "observation",
-                    "content": f"Tool '{action.tool_name}' executed successfully. Result: {result}",
+                    "content": f"Tool '{action.tool_name}' executed successfully. Result: {normalized_result}",
                     "tool_name": action.tool_name,
                     "tool_args": tool_args,
-                    "result": result,
+                    "result": normalized_result,
                     "tool_execution_id": tool_execution_id,
                 }
 

--- a/src/xagent/core/agent/utils/context_builder.py
+++ b/src/xagent/core/agent/utils/context_builder.py
@@ -115,14 +115,17 @@ class ContextBuilder:
                 and len(uploaded_files) == len(file_info)
             ):
                 for f, fpath in zip(file_info, uploaded_files):
-                    file_list_lines.append(
-                        f"- {f.get('name', 'unknown')} ({f.get('size', 0)} bytes, {f.get('type', 'unknown')})\n  Absolute Path: {fpath}"
-                    )
+                    details = f"- {f.get('name', 'unknown')} ({f.get('size', 0)} bytes, {f.get('type', 'unknown')})"
+                    if f.get("file_id"):
+                        details += f"\n  File ID: {f.get('file_id')}"
+                    details += f"\n  Absolute Path: {fpath}"
+                    file_list_lines.append(details)
             else:
                 for f in file_info:
-                    file_list_lines.append(
-                        f"- {f.get('name', 'unknown')} ({f.get('size', 0)} bytes, {f.get('type', 'unknown')})"
-                    )
+                    details = f"- {f.get('name', 'unknown')} ({f.get('size', 0)} bytes, {f.get('type', 'unknown')})"
+                    if f.get("file_id"):
+                        details += f"\n  File ID: {f.get('file_id')}"
+                    file_list_lines.append(details)
 
             file_list_str = "\n".join(file_list_lines)
 

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -562,7 +562,7 @@ class CreateAgentTool(AbstractBaseTool):
 
 class UpdateAgentTool(AbstractBaseTool):
     """
-    Tool for updating an existing draft agent during task execution.
+    Tool for updating an existing agent during task execution.
 
     This allows agents to dynamically update agents with specific capabilities
     by modifying their name, description, instructions, and allowed tools/skills.
@@ -626,7 +626,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
         return (
             "Update an existing agent with specific capabilities during task execution. "
-            "Only DRAFT agents can be updated - PUBLISHED agents must be edited through the web interface.\n\n"
+            "DRAFT and PUBLISHED agents can both be updated; the agent keeps its current status.\n\n"
             "Parameters:\n"
             "- agent_id: The ID of the agent to update (required)\n"
             "- name (optional): New name for the agent\n"
@@ -645,8 +645,8 @@ class UpdateAgentTool(AbstractBaseTool):
             "- markdown_link: Markdown link in format [Agent Name](agent://agent_id)\n"
             "- status: 'success' or 'error'\n"
             "- message: Detailed information about the updated agent\n\n"
-            "IMPORTANT: Only agents in DRAFT status can be updated. "
-            "If you need to modify a PUBLISHED agent, create a new one or edit it through the web interface."
+            "IMPORTANT: Updating a PUBLISHED agent does not unpublish it. "
+            "It remains PUBLISHED with the updated configuration."
         )
 
     @property
@@ -668,7 +668,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Update an existing agent with the given configuration."""
-        from .....web.models.agent import Agent, AgentStatus
+        from .....web.models.agent import Agent
 
         try:
             agent_id = args.get("agent_id")
@@ -698,18 +698,6 @@ class UpdateAgentTool(AbstractBaseTool):
                     markdown_link="",
                     status="error",
                     message=f"Error: Agent with ID {agent_id} not found",
-                ).model_dump()
-
-            # Check if agent is in DRAFT status
-            if agent.status != AgentStatus.DRAFT:
-                return UpdateAgentToolResult(
-                    agent_id=agent_id,
-                    agent_name=agent.name,
-                    tool_name=gen_agent_tool_name(agent.name),
-                    markdown_link=f"[{agent.name}](agent://{agent.id})",
-                    status="error",
-                    message=f"Error: Only DRAFT agents can be updated. This agent is {agent.status.value.upper()}. "
-                    f"To modify a published agent, please edit it through the web interface or create a new one.",
                 ).model_dump()
 
             # Track changes
@@ -791,6 +779,7 @@ class UpdateAgentTool(AbstractBaseTool):
                     markdown_link=f"[{agent.name}](agent://{agent.id})",
                     status="success",
                     message=f"ℹ️ No updates were made to agent '{agent.name}' (ID: {agent_id}). "
+                    f"Status: {agent.status.value.upper()}. "
                     f"All fields were the same or no values were provided.",
                 ).model_dump()
 
@@ -803,7 +792,7 @@ class UpdateAgentTool(AbstractBaseTool):
             markdown_link = f"[{agent.name}](agent://{agent.id})"
 
             logger.info(
-                f"Updated DRAFT agent '{agent.name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
+                f"Updated {agent.status.value.upper()} agent '{agent.name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
             )
 
             return UpdateAgentToolResult(
@@ -818,13 +807,13 @@ class UpdateAgentTool(AbstractBaseTool):
                     f"- Agent ID: {agent.id}\n"
                     f"- Agent Name: {agent.name}\n"
                     f"- Tool Name: {tool_name}\n"
-                    f"- Status: DRAFT\n\n"
+                    f"- Status: {agent.status.value.upper()}\n\n"
                     f"**Changes Applied:**\n"
                     + "\n".join(f"- {change}" for change in changes)
                     + f"\n\n**How to use this agent:**\n"
                     f"Include this link in your response: {markdown_link}\n"
                     f"Or use the tool: {tool_name}\n\n"
-                    f"*The agent will reflect the updated changes on next execution.*"
+                    f"*The agent keeps its current publication status and will reflect the updated changes on next execution.*"
                 ),
             ).model_dump()
 
@@ -986,7 +975,7 @@ class ListAgentsTool(AbstractBaseTool):
                 status="success",
                 message=(
                     f"✅ Found {total_count} agent(s){filter_msg}\n\n"
-                    f"*Only DRAFT agents can be updated using update_agent tool. "
+                    f"*DRAFT and PUBLISHED agents can be updated using update_agent. "
                     f"All agents can be called using their tool_name.*"
                 ),
             ).model_dump()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1371,8 +1371,13 @@ async def handle_chat_message(
                         context["uploaded_files"] = uploaded_file_paths
                         context["file_info"] = file_info_list
                         file_ids = [f["file_id"] for f in file_info_list]
-                        file_names = [f["name"] for f in file_info_list]
                         file_id_list_str = ", ".join(f'"{fid}"' for fid in file_ids)
+                        file_summary = "\n".join(
+                            [
+                                f"- {f['name']} (File ID: {f['file_id']}, {f['size']} bytes, {f['type']})"
+                                for f in file_info_list
+                            ]
+                        )
 
                         # Check if this task is an agent-builder task to inject KB instructions
                         is_agent_builder = False
@@ -1397,7 +1402,8 @@ async def handle_chat_message(
 
                         file_prompt = (
                             "## UPLOADED FILES\n"
-                            f"The user has uploaded {len(file_info_list)} file(s): {file_names}\n\n"
+                            f"The user has uploaded {len(file_info_list)} file(s):\n"
+                            f"{file_summary}\n\n"
                         )
 
                         if is_agent_builder:
@@ -1413,6 +1419,7 @@ async def handle_chat_message(
                         else:
                             file_prompt += (
                                 "These files have been successfully uploaded to the workspace and are ready for processing.\n"
+                                "Use the File ID values above when a tool requires a file_id. "
                                 "You can use standard workspace tools to read, analyze, or process them."
                             )
 
@@ -2526,8 +2533,8 @@ async def handle_builder_chat(
 ) -> None:
     """Handle individual builder chat requests via WebSocket using an in-memory ReAct agent.
 
-    This creates an agent that only has access to the 'create_agent' tool, allowing
-    dynamic agent creation during the conversation.
+    This creates an agent with the agent-builder tool closure, allowing dynamic
+    agent creation/update and knowledge-base clarification/import during the conversation.
 
     Sends messages in the format expected by the frontend:
     - message_delta: Streaming text chunks
@@ -2536,7 +2543,7 @@ async def handle_builder_chat(
 
     Performance optimizations:
     - Reuses AgentService across messages (only creates on first message)
-    - Pre-creates CreateAgentTool directly without full tool loading
+    - Pre-creates the builder tool closure directly without full tool loading
     - Caches LLM configuration in websocket state
     """
     import uuid
@@ -2581,6 +2588,7 @@ async def handle_builder_chat(
             from ..models.uploaded_file import UploadedFile as _UploadedFile
 
             file_ids = []
+            uploaded_file_lines = []
             for file_info in files:
                 file_id = file_info.get("file_id")
                 if not file_id:
@@ -2595,11 +2603,17 @@ async def handle_builder_chat(
                 )
                 if record:
                     file_ids.append(file_id)
+                    uploaded_file_lines.append(
+                        f"- {record.filename} (File ID: {record.file_id})"
+                    )
 
             if file_ids:
+                uploaded_files_summary = "\n".join(uploaded_file_lines)
                 user_message += (
-                    f"\n\n[Uploaded file_ids: {file_ids}. "
+                    f"\n\n[Uploaded files:\n{uploaded_files_summary}\n"
+                    f"Use these exact file_ids: {file_ids}. "
                     "Please call `create_knowledge_base_from_file` with these file_ids immediately, "
+                    "do not use filenames or paths as file_ids, "
                     "then create or update the agent with the resulting collection_name.]"
                 )
 
@@ -3435,7 +3449,7 @@ async def handle_build_preview_execution(
                 if file_info_list:
                     file_summary = "\n".join(
                         [
-                            f"- {f['name']} (ID: {f['file_id']}, {f['size']} bytes, {f['type']}, Path: {f['path']})"
+                            f"- {f['name']} (File ID: {f['file_id']}, {f['size']} bytes, {f['type']}, Path: {f['path']})"
                             for f in file_info_list
                         ]
                     )

--- a/tests/core/agent/pattern/test_react_args_normalization.py
+++ b/tests/core/agent/pattern/test_react_args_normalization.py
@@ -43,12 +43,12 @@ class MockUpdateAgentTool(Tool):
         return True
 
     async def run_json_async(self, args: dict[str, Any]) -> Any:
-        # Simulate failure for PUBLISHED agent
+        # Simulate a tool-level business failure returned without raising.
         if args.get("agent_id") == 100:
             return {
                 "agent_id": 100,
                 "status": "error",
-                "message": "Error: Only DRAFT agents can be updated",
+                "message": "Error: downstream validation failed",
             }
         return {"agent_id": args.get("agent_id"), "status": "success", "message": "OK"}
 
@@ -152,11 +152,12 @@ async def test_react_tool_args_normalization(patch_traces):
     )
     assert end_trace["kwargs"]["data"]["tool_args"]["tool_categories"] == ["vision"]
     assert end_trace["kwargs"]["data"]["result"]["status"] == "success"
+    assert end_trace["kwargs"]["data"]["success"] is True
 
 
 @pytest.mark.asyncio
-async def test_react_tool_execution_failure_not_mutating_config(patch_traces):
-    """Test that a failed tool execution (like updating PUBLISHED agent) is correctly traced as error."""
+async def test_react_critical_tool_business_failure_becomes_failed_result(patch_traces):
+    """Critical tool business failures should trace success=false and fail the step."""
     registry = ToolRegistry()
     tool = MockUpdateAgentTool()
     registry.register(tool)
@@ -171,10 +172,9 @@ async def test_react_tool_execution_failure_not_mutating_config(patch_traces):
 
     pattern = MockReAct()
 
-    # 2. Test failure case (e.g. published agent)
     action = Action(
         type="tool_call",
-        reasoning="test published",
+        reasoning="test business failure",
         tool_name="update_agent",
         tool_args={
             "agent_id": 100,
@@ -187,11 +187,12 @@ async def test_react_tool_execution_failure_not_mutating_config(patch_traces):
     # Tool args should still be normalized
     assert res["tool_args"]["tool_categories"] == ["vision"]
 
-    # The result should contain the error status
+    # Critical business failures become a failed final result so DAG can mark the step failed.
+    assert res["type"] == "final_answer"
+    assert res["success"] is False
     assert res["result"]["status"] == "error"
+    assert res["error"] == "Error: downstream validation failed"
 
-    # The frontend uses data.result.status === "success" to decide whether to update the config.
-    # We verify that the trace contains the error status in the result.
     end_trace = next(
         t
         for t in tracer.traces
@@ -199,3 +200,4 @@ async def test_react_tool_execution_failure_not_mutating_config(patch_traces):
         and t["kwargs"]["data"].get("result", {}).get("agent_id") == 100
     )
     assert end_trace["kwargs"]["data"]["result"]["status"] == "error"
+    assert end_trace["kwargs"]["data"]["success"] is False

--- a/tests/core/agent/test_file_info_propagation.py
+++ b/tests/core/agent/test_file_info_propagation.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from xagent.core.agent.pattern.dag_plan_execute.models import PlanStep
 from xagent.core.agent.pattern.dag_plan_execute.plan_executor import PlanExecutor
 from xagent.core.agent.utils.context_builder import ContextBuilder
 
@@ -16,8 +17,18 @@ async def test_file_info_propagation_from_context():
     parent_pattern._context = {
         "uploaded_files": ["file1.jpg", "file2.png"],
         "file_info": [
-            {"name": "file1.jpg", "size": 1024, "type": "image/jpeg"},
-            {"name": "file2.png", "size": 2048, "type": "image/png"},
+            {
+                "name": "file1.jpg",
+                "size": 1024,
+                "type": "image/jpeg",
+                "file_id": "11111111-1111-4111-8111-111111111111",
+            },
+            {
+                "name": "file2.png",
+                "size": 2048,
+                "type": "image/png",
+                "file_id": "22222222-2222-4222-8222-222222222222",
+            },
         ],
     }
 
@@ -57,6 +68,9 @@ async def test_file_info_propagation_from_context():
     assert "2048 bytes" in content
     assert "image/jpeg" in content
     assert "image/png" in content
+    assert "File ID: 11111111-1111-4111-8111-111111111111" in content
+    assert "File ID: 22222222-2222-4222-8222-222222222222" in content
+    assert "Absolute Path: file1.jpg" in content
 
 
 @pytest.mark.asyncio
@@ -67,8 +81,18 @@ async def test_plan_executor_retrieves_file_info_from_parent_context():
     parent_pattern._context = {
         "uploaded_files": ["file1.jpg", "file2.png"],
         "file_info": [
-            {"name": "file1.jpg", "size": 1024, "type": "image/jpeg"},
-            {"name": "file2.png", "size": 2048, "type": "image/png"},
+            {
+                "name": "file1.jpg",
+                "size": 1024,
+                "type": "image/jpeg",
+                "file_id": "11111111-1111-4111-8111-111111111111",
+            },
+            {
+                "name": "file2.png",
+                "size": 2048,
+                "type": "image/png",
+                "file_id": "22222222-2222-4222-8222-222222222222",
+            },
         ],
     }
 
@@ -124,6 +148,108 @@ async def test_context_builder_with_empty_file_info():
     # Verify no file information message
     for msg in messages:
         assert "UPLOADED FILES" not in msg.get("content", "")
+
+
+@pytest.mark.asyncio
+async def test_context_builder_agent_builder_uses_file_ids_without_paths():
+    """Agent-builder context should expose UUID file_ids and avoid path confusion."""
+    context_builder = ContextBuilder(llm=Mock())
+
+    messages = await context_builder.build_context_for_step(
+        step_name="create_kb",
+        step_description="Create KB from uploaded FAQ",
+        dependencies=[],
+        dependency_results={},
+        file_info=[
+            {
+                "name": "Velvet_Enterprise_FAQ.docx",
+                "size": 4096,
+                "type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "file_id": "b341b1e0-e960-4158-8199-b11539025ced",
+            }
+        ],
+        uploaded_files=["/tmp/Velvet_Enterprise_FAQ.docx"],
+        is_builder_context=True,
+    )
+
+    content = "\n".join(msg.get("content", "") for msg in messages)
+    assert "File ID: b341b1e0-e960-4158-8199-b11539025ced" in content
+    assert 'file_ids = ["b341b1e0-e960-4158-8199-b11539025ced"]' in content
+    assert "Absolute Path:" not in content
+
+
+def test_plan_executor_extends_agent_builder_tool_closure():
+    """Builder steps should keep their declared tools and gain the KB/agent closure."""
+    tool_map = {
+        "create_agent": Mock(),
+        "update_agent": Mock(),
+        "ask_user_question": Mock(),
+        "list_knowledge_bases": Mock(),
+        "create_knowledge_base_from_file": Mock(),
+        "create_knowledge_base_from_url": Mock(),
+    }
+
+    extended = PlanExecutor._extend_builder_tool_names(["create_agent"], tool_map)
+
+    assert extended == [
+        "create_agent",
+        "list_knowledge_bases",
+        "ask_user_question",
+        "create_knowledge_base_from_file",
+        "create_knowledge_base_from_url",
+        "update_agent",
+    ]
+
+
+def test_plan_executor_resolves_none_tool_names_as_all_tools():
+    """Legacy tool_names=None should continue to mean all available tools."""
+    tool_map = {
+        "create_agent": Mock(),
+        "ask_user_question": Mock(),
+        "custom_tool": Mock(),
+    }
+    step = PlanStep(
+        id="create_agent",
+        name="Create agent",
+        description="Create an agent from the uploaded FAQ",
+    )
+    step.tool_names = None
+
+    resolved = PlanExecutor._resolve_step_tool_names(step, tool_map)
+
+    assert resolved == ["create_agent", "ask_user_question", "custom_tool"]
+
+
+def test_plan_executor_extends_builder_tool_closure_from_all_tools():
+    """Builder closure should preserve all-tools semantics and add missing closure tools."""
+    tool_map = {
+        "create_agent": Mock(),
+        "ask_user_question": Mock(),
+        "custom_tool": Mock(),
+        "list_knowledge_bases": Mock(),
+        "create_knowledge_base_from_file": Mock(),
+        "create_knowledge_base_from_url": Mock(),
+        "update_agent": Mock(),
+    }
+    step = PlanStep(
+        id="create_agent",
+        name="Create agent",
+        description="Create an agent from the uploaded FAQ",
+    )
+    step.tool_names = None
+
+    tool_names = PlanExecutor._resolve_step_tool_names(step, tool_map)
+    extended = PlanExecutor._extend_builder_tool_names(tool_names, tool_map)
+
+    assert extended == [
+        "create_agent",
+        "ask_user_question",
+        "custom_tool",
+        "list_knowledge_bases",
+        "create_knowledge_base_from_file",
+        "create_knowledge_base_from_url",
+        "update_agent",
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -414,8 +414,8 @@ class TestUpdateAgentTool:
                 pass
 
     @pytest.mark.asyncio
-    async def test_update_published_agent_rejected(self) -> None:
-        """Test that published agents cannot be updated."""
+    async def test_update_published_agent_success_preserves_status(self) -> None:
+        """Test that published agents can be updated and remain published."""
         db, db_path = _create_session()
         try:
             user = User(
@@ -442,11 +442,19 @@ class TestUpdateAgentTool:
                 {
                     "agent_id": published_agent.id,
                     "name": "trying_to_rename",
+                    "instructions": "Updated published instructions",
                 }
             )
 
-            assert result["status"] == "error"
-            assert "only draft" in result["message"].lower()
+            assert result["status"] == "success"
+            assert result["agent_id"] == published_agent.id
+            assert result["agent_name"] == "trying_to_rename"
+            assert "Status: PUBLISHED" in result["message"]
+
+            db.refresh(published_agent)
+            assert published_agent.name == "trying_to_rename"
+            assert published_agent.instructions == "Updated published instructions"
+            assert published_agent.status == AgentStatus.PUBLISHED
 
         finally:
             db.close()

--- a/tests/web/api/test_websocket_builder_chat.py
+++ b/tests/web/api/test_websocket_builder_chat.py
@@ -14,7 +14,7 @@ from xagent.web.models.user import User
 @pytest.mark.asyncio
 async def test_handle_builder_chat_basic():
     """
-    Test that handle_builder_chat creates an agent with only create_agent tool.
+    Test that handle_builder_chat creates the agent-builder ReAct service.
     """
     # Arrange
     mock_websocket = AsyncMock()


### PR DESCRIPTION
## Summary

This PR stabilizes the prompt-based agent management flow observed in the 5/13 feedback.

- Keep agent-builder context active across clarification and upload continuations.
- Expose uploaded file UUIDs consistently and guide KB creation to use `file_ids` rather than names or paths.
- Add the KB/agent tool closure to agent-builder execution steps so a step is not stranded with only `create_agent` available.
- Treat tool-level business failures as real execution failures in ReAct traces and DAG step results.
- Allow `update_agent` to update published agents while preserving their current status, matching the web UI update path.

## Problem Details

The 5/13 failure pattern was not a single prompt issue. The execution chain had several mismatches:

- The initial task could determine that the target knowledge base did not exist.
- A later agent creation step only exposed `create_agent`, while the builder instructions required asking the user for a file or URL when the KB was missing.
- After the user uploaded a file, the backend had a real UUID `file_id`, but the step context made the filename/path more visible than the UUID. That allowed `create_knowledge_base_from_file` to be called with a filename instead of a UUID.
- `create_knowledge_base_from_file` returned a business failure, but the ReAct trace recorded the tool execution as successful because the Python call itself returned normally.
- `update_agent` rejected published agents in the Assistant tool path, while the web UI `PUT /api/agents/{id}` path allowed updates.

## Changes

- Added sticky agent-builder context detection for continuation runs.
- Updated uploaded file context and WebSocket upload prompts to include `File ID: <uuid>` explicitly.
- Hardened planning prompts to avoid `get_file_id`, `list_files`, and wait-for-upload recovery steps after files are already available.
- Added agent-builder tool closure expansion for relevant DAG steps.
- Added ReAct business failure detection for tool results with `success: false` or `status: "error"`.
- Converted critical side-effect tool failures into failed step results for `create_agent`, `update_agent`, `create_knowledge_base_from_file`, and `create_knowledge_base_from_url`.
- Removed the draft-only restriction from `update_agent`; published agents keep their current status after updates.

## Validation

- `uv run ruff check src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py src/xagent/core/agent/pattern/dag_plan_execute/plan_generator.py src/xagent/core/agent/pattern/react.py src/xagent/core/agent/utils/context_builder.py src/xagent/core/tools/adapters/vibe/agent_tool.py src/xagent/web/api/websocket.py tests/core/agent/test_file_info_propagation.py tests/core/agent/pattern/test_react_args_normalization.py tests/core/tools/test_create_agent_tool.py tests/web/api/test_websocket_builder_chat.py`
- `uv run pytest tests/core/agent/test_file_info_propagation.py tests/core/agent/pattern/test_react_args_normalization.py tests/core/tools/test_create_agent_tool.py tests/web/api/test_websocket_builder_chat.py -q`
- Commit hooks: ruff check, ruff format, mypy, end-of-file check, trailing whitespace, isort, codespell
