### PR TITLE
fix: allow assistant updates for published agents

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -562,7 +562,7 @@ class CreateAgentTool(AbstractBaseTool):
 
 class UpdateAgentTool(AbstractBaseTool):
     """
-    Tool for updating an existing draft agent during task execution.
+    Tool for updating an existing agent during task execution.
 
     This allows agents to dynamically update agents with specific capabilities
     by modifying their name, description, instructions, and allowed tools/skills.
@@ -626,7 +626,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
         return (
             "Update an existing agent with specific capabilities during task execution. "
-            "Only DRAFT agents can be updated - PUBLISHED agents must be edited through the web interface.\n\n"
+            "DRAFT and PUBLISHED agents can both be updated; the agent keeps its current status.\n\n"
             "Parameters:\n"
             "- agent_id: The ID of the agent to update (required)\n"
             "- name (optional): New name for the agent\n"
@@ -645,8 +645,8 @@ class UpdateAgentTool(AbstractBaseTool):
             "- markdown_link: Markdown link in format [Agent Name](agent://agent_id)\n"
             "- status: 'success' or 'error'\n"
             "- message: Detailed information about the updated agent\n\n"
-            "IMPORTANT: Only agents in DRAFT status can be updated. "
-            "If you need to modify a PUBLISHED agent, create a new one or edit it through the web interface."
+            "IMPORTANT: Updating a PUBLISHED agent does not unpublish it. "
+            "It remains PUBLISHED with the updated configuration."
         )
 
     @property
@@ -700,16 +700,17 @@ class UpdateAgentTool(AbstractBaseTool):
                     message=f"Error: Agent with ID {agent_id} not found",
                 ).model_dump()
 
-            # Check if agent is in DRAFT status
-            if agent.status != AgentStatus.DRAFT:
+            if agent.status == AgentStatus.ARCHIVED:
                 return UpdateAgentToolResult(
                     agent_id=agent_id,
                     agent_name=agent.name,
                     tool_name=gen_agent_tool_name(agent.name),
                     markdown_link=f"[{agent.name}](agent://{agent.id})",
                     status="error",
-                    message=f"Error: Only DRAFT agents can be updated. This agent is {agent.status.value.upper()}. "
-                    f"To modify a published agent, please edit it through the web interface or create a new one.",
+                    message=(
+                        "Error: Archived agents cannot be updated. "
+                        f"This agent is {agent.status.value.upper()}."
+                    ),
                 ).model_dump()
 
             # Track changes
@@ -791,6 +792,7 @@ class UpdateAgentTool(AbstractBaseTool):
                     markdown_link=f"[{agent.name}](agent://{agent.id})",
                     status="success",
                     message=f"ℹ️ No updates were made to agent '{agent.name}' (ID: {agent_id}). "
+                    f"Status: {agent.status.value.upper()}. "
                     f"All fields were the same or no values were provided.",
                 ).model_dump()
 
@@ -803,7 +805,7 @@ class UpdateAgentTool(AbstractBaseTool):
             markdown_link = f"[{agent.name}](agent://{agent.id})"
 
             logger.info(
-                f"Updated DRAFT agent '{agent.name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
+                f"Updated {agent.status.value.upper()} agent '{agent.name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
             )
 
             return UpdateAgentToolResult(
@@ -818,13 +820,13 @@ class UpdateAgentTool(AbstractBaseTool):
                     f"- Agent ID: {agent.id}\n"
                     f"- Agent Name: {agent.name}\n"
                     f"- Tool Name: {tool_name}\n"
-                    f"- Status: DRAFT\n\n"
+                    f"- Status: {agent.status.value.upper()}\n\n"
                     f"**Changes Applied:**\n"
                     + "\n".join(f"- {change}" for change in changes)
                     + f"\n\n**How to use this agent:**\n"
                     f"Include this link in your response: {markdown_link}\n"
                     f"Or use the tool: {tool_name}\n\n"
-                    f"*The agent will reflect the updated changes on next execution.*"
+                    f"*The agent keeps its current publication status and will reflect the updated changes on next execution.*"
                 ),
             ).model_dump()
 
@@ -986,7 +988,7 @@ class ListAgentsTool(AbstractBaseTool):
                 status="success",
                 message=(
                     f"✅ Found {total_count} agent(s){filter_msg}\n\n"
-                    f"*Only DRAFT agents can be updated using update_agent tool. "
+                    f"*DRAFT and PUBLISHED agents can be updated using update_agent. "
                     f"All agents can be called using their tool_name.*"
                 ),
             ).model_dump()

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -414,8 +414,8 @@ class TestUpdateAgentTool:
                 pass
 
     @pytest.mark.asyncio
-    async def test_update_published_agent_rejected(self) -> None:
-        """Test that published agents cannot be updated."""
+    async def test_update_published_agent_success_preserves_status(self) -> None:
+        """Test that published agents can be updated and remain published."""
         db, db_path = _create_session()
         try:
             user = User(
@@ -442,11 +442,67 @@ class TestUpdateAgentTool:
                 {
                     "agent_id": published_agent.id,
                     "name": "trying_to_rename",
+                    "instructions": "Updated published instructions",
+                }
+            )
+
+            assert result["status"] == "success"
+            assert result["agent_id"] == published_agent.id
+            assert result["agent_name"] == "trying_to_rename"
+            assert "Status: PUBLISHED" in result["message"]
+
+            db.refresh(published_agent)
+            assert published_agent.name == "trying_to_rename"
+            assert published_agent.instructions == "Updated published instructions"
+            assert published_agent.status == AgentStatus.PUBLISHED
+
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_update_archived_agent_rejected(self) -> None:
+        """Test that archived agents cannot be updated."""
+        db, db_path = _create_session()
+        try:
+            user = User(username="testuser_archived", password_hash="x", is_admin=False)
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            archived_agent = Agent(
+                user_id=user.id,
+                name="archived_agent",
+                description="Archived agent",
+                instructions="Original instructions",
+                status=AgentStatus.ARCHIVED,
+            )
+            db.add(archived_agent)
+            db.commit()
+            db.refresh(archived_agent)
+
+            tool = UpdateAgentTool(db=db, user_id=user.id)
+
+            result = await tool.run_json_async(
+                {
+                    "agent_id": archived_agent.id,
+                    "name": "trying_to_rename",
+                    "instructions": "Attempted update",
                 }
             )
 
             assert result["status"] == "error"
-            assert "only draft" in result["message"].lower()
+            assert "archived agents cannot be updated" in result["message"].lower()
+
+            db.refresh(archived_agent)
+            assert archived_agent.name == "archived_agent"
+            assert archived_agent.instructions == "Original instructions"
+            assert archived_agent.status == AgentStatus.ARCHIVED
 
         finally:
             db.close()


### PR DESCRIPTION
## Summary

Allow the Assistant `update_agent` tool to update published agents, while preserving the agent's current status.

## Background

The web UI update path already allows updating an agent through `PUT /api/agents/{id}` without restricting the agent to draft status. The Assistant tool path was stricter: `update_agent` rejected published agents with:

> Only DRAFT agents can be updated.

That made the same update possible from the web interface but impossible from the Assistant, even for the same owner and same agent.

## Changes

- Removed the draft-only guard from `UpdateAgentTool`.
- Updated the tool description and list-agents helper text to say draft and published agents can be updated.
- Preserved the current agent status after update; published agents remain published.
- Included the actual status in success/no-op messages.
- Updated the published-agent test expectation from rejection to successful update with status preserved.

## Validation

- `uv run ruff check src/xagent/core/tools/adapters/vibe/agent_tool.py tests/core/tools/test_create_agent_tool.py`
- `uv run pytest tests/core/tools/test_create_agent_tool.py -q`
- Commit hooks: ruff check, ruff format, mypy, end-of-file check, trailing whitespace, isort, codespell
