### PR TITLE
feat: [v2 part5] add Auto pattern

### DIFF
--- a/src/xagent/core/agent_v2/__init__.py
+++ b/src/xagent/core/agent_v2/__init__.py
@@ -24,6 +24,9 @@ from .context import (
 from .frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from .pattern import (
     AgentPattern,
+    AutoAction,
+    AutoDecision,
+    AutoPattern,
     CallablePlanGenerator,
     DAGPattern,
     ExecutionPlan,
@@ -35,8 +38,8 @@ from .pattern import (
     PlanValidationError,
     ReActPattern,
     ReActReasoningMode,
+    ToolCallRecord,
 )
-from .pattern.react import ToolCallRecord
 from .registry import ExecutionHandle, ExecutionLifecycleStatus, ExecutionRegistry
 from .runner import AgentRunner
 from .runtime import PatternRuntime, load_pattern_checkpoint
@@ -46,6 +49,9 @@ __all__ = [
     "Agent",
     "AgentPattern",
     "AgentRunner",
+    "AutoAction",
+    "AutoDecision",
+    "AutoPattern",
     "CHECKPOINT_EVENT_TYPE",
     "CHECKPOINT_SCHEMA_VERSION",
     "CHECKPOINT_TYPE",
@@ -79,9 +85,9 @@ __all__ = [
     "PlanValidationError",
     "ReActPattern",
     "ReActReasoningMode",
+    "ToolCallRecord",
     "TraceCheckpointStore",
     "TraceEventCallback",
-    "ToolCallRecord",
     "WorkspaceComponent",
     "clone_component",
     "load_pattern_checkpoint",

--- a/src/xagent/core/agent_v2/agent.py
+++ b/src/xagent/core/agent_v2/agent.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .pattern import AgentPattern
     from .runner import AgentRunner
 
 
@@ -17,7 +18,7 @@ class Agent:
     """Minimal agent definition for the execution-centric v2 runtime."""
 
     name: str
-    patterns: list[Any]
+    patterns: list["AgentPattern"]
     tools: list[Any] = field(default_factory=list)
     llm: Any | None = None
     system_prompt: str | None = None

--- a/src/xagent/core/agent_v2/context/execution.py
+++ b/src/xagent/core/agent_v2/context/execution.py
@@ -337,6 +337,18 @@ class ExecutionContext:
     def _system_context(self) -> str:
         parts = [self._current_time_context()]
         dag_step_id = self.metadata.get("dag_step_id")
+        current_task = str(self.metadata.get("task") or "").strip()
+        if current_task and not dag_step_id:
+            parts.append(
+                "Current user request:\n"
+                f"{current_task}\n\n"
+                "Conversation focus rules: answer the current user request above. "
+                "Earlier user and assistant messages are context only; use them to "
+                "resolve references and preserve continuity, but do not re-answer "
+                "previous requests or repeat previous final answers unless the "
+                "current user request explicitly asks to revise, continue, compare, "
+                "or summarize them."
+            )
         if dag_step_id:
             dag_step_name = str(self.metadata.get("dag_step_name") or "").strip()
             dag_step_description = str(

--- a/src/xagent/core/agent_v2/pattern/__init__.py
+++ b/src/xagent/core/agent_v2/pattern/__init__.py
@@ -1,3 +1,4 @@
+from .auto import AutoAction, AutoDecision, AutoPattern
 from .base import AgentPattern, PatternResult
 from .dag import (
     CallablePlanGenerator,
@@ -13,15 +14,18 @@ from .react import ReActPattern, ReActReasoningMode, ToolCallRecord
 
 __all__ = [
     "AgentPattern",
+    "AutoAction",
+    "AutoDecision",
+    "AutoPattern",
     "CallablePlanGenerator",
     "DAGPattern",
     "ExecutionPlan",
     "LLMPlanGenerator",
-    "PatternResult",
     "PlanGenerationRequest",
     "PlanGenerator",
-    "PlanStep",
     "PlanValidationError",
+    "PlanStep",
+    "PatternResult",
     "ReActPattern",
     "ReActReasoningMode",
     "ToolCallRecord",

--- a/src/xagent/core/agent_v2/pattern/auto/__init__.py
+++ b/src/xagent/core/agent_v2/pattern/auto/__init__.py
@@ -1,0 +1,7 @@
+from .auto import AutoAction, AutoDecision, AutoPattern
+
+__all__ = [
+    "AutoAction",
+    "AutoDecision",
+    "AutoPattern",
+]

--- a/src/xagent/core/agent_v2/pattern/auto/auto.py
+++ b/src/xagent/core/agent_v2/pattern/auto/auto.py
@@ -960,11 +960,3 @@ class AutoPattern(AgentPattern):
             "waiting_for_user": ExecutionStatus.WAITING_FOR_USER,
         }
         return status_map.get(status, ExecutionStatus.RUNNING)
-
-    def _tool_name(self, tool: Any) -> str:
-        metadata = getattr(tool, "metadata", None)
-        if metadata is not None and getattr(metadata, "name", None):
-            return str(metadata.name)
-        if getattr(tool, "name", None):
-            return str(tool.name)
-        return str(tool.__class__.__name__)

--- a/src/xagent/core/agent_v2/pattern/auto/auto.py
+++ b/src/xagent/core/agent_v2/pattern/auto/auto.py
@@ -60,8 +60,12 @@ class AutoDecision:
         raw_action = payload.get("action") or payload.get("type")
         if raw_action == "dag":
             raw_action = AutoAction.PLAN_EXECUTE.value
+        try:
+            action = AutoAction(str(raw_action))
+        except ValueError as exc:
+            raise ValueError(f"Invalid AutoPattern action: {raw_action}") from exc
         return cls(
-            action=AutoAction(str(raw_action)),
+            action=action,
             reason=str(payload.get("reason", "")),
             answer=payload.get("answer"),
             requires_current_or_external_facts=_coerce_bool(

--- a/src/xagent/core/agent_v2/pattern/auto/auto.py
+++ b/src/xagent/core/agent_v2/pattern/auto/auto.py
@@ -1,0 +1,970 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from ...context.enrichment import (
+    enrich_context_with_memory,
+    enrich_context_with_skill,
+    latest_user_text,
+)
+from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+from ...runtime import LLMCallInterrupted, PatternRuntime
+from ..base import AgentPattern, PatternResult
+from ..dag import DAGPattern
+from ..react import ReActPattern
+
+logger = logging.getLogger(__name__)
+
+
+class AutoAction(str, Enum):
+    """High-level action selected by AutoPattern."""
+
+    FINAL_ANSWER = "final_answer"
+    REACT = "react"
+    PLAN_EXECUTE = "plan_execute"
+
+
+@dataclass
+class AutoDecision:
+    """Serializable AutoPattern decision."""
+
+    action: AutoAction
+    reason: str = ""
+    answer: str | None = None
+    requires_current_or_external_facts: bool = False
+    existing_context_sufficient: bool = True
+    evidence_basis: str = ""
+    missing_verification: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "action": self.action.value,
+            "reason": self.reason,
+            "requires_current_or_external_facts": (
+                self.requires_current_or_external_facts
+            ),
+            "existing_context_sufficient": self.existing_context_sufficient,
+            "evidence_basis": self.evidence_basis,
+            "missing_verification": self.missing_verification,
+        }
+        if self.answer is not None:
+            payload["answer"] = self.answer
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "AutoDecision":
+        raw_action = payload.get("action") or payload.get("type")
+        if raw_action == "dag":
+            raw_action = AutoAction.PLAN_EXECUTE.value
+        return cls(
+            action=AutoAction(str(raw_action)),
+            reason=str(payload.get("reason", "")),
+            answer=payload.get("answer"),
+            requires_current_or_external_facts=_coerce_bool(
+                payload.get("requires_current_or_external_facts"), default=False
+            ),
+            existing_context_sufficient=_coerce_bool(
+                payload.get("existing_context_sufficient"), default=True
+            ),
+            evidence_basis=str(payload.get("evidence_basis", "")),
+            missing_verification=str(payload.get("missing_verification", "")),
+        )
+
+
+DECISION_TOOL_NAME = "select_execution_pattern"
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    if value is None:
+        return default
+    return bool(value)
+
+
+@dataclass
+class _AutoChildRuntime:
+    """Runtime adapter that stores child checkpoints in the AutoPattern envelope."""
+
+    parent: PatternRuntime
+    auto_pattern: "AutoPattern"
+    root_context: Any
+
+    @property
+    def execution_id(self) -> str | None:
+        return self.parent.execution_id
+
+    @execution_id.setter
+    def execution_id(self, value: str | None) -> None:
+        self.parent.execution_id = value
+
+    @property
+    def interrupt_reason(self) -> str | None:
+        return self.parent.interrupt_reason
+
+    @property
+    def tracer(self) -> Any | None:
+        return self.parent.tracer
+
+    @property
+    def active_react_step_id(self) -> str | None:
+        return self.parent.active_react_step_id
+
+    async def should_interrupt(self) -> bool:
+        return await self.parent.should_interrupt()
+
+    async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
+        return await self.parent.run_llm_call(llm, **kwargs)
+
+    async def send_message(
+        self,
+        *,
+        message: str,
+        message_type: str = "info",
+        expect_response: bool = False,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await self.parent.send_message(
+            message=message,
+            message_type=message_type,
+            expect_response=expect_response,
+            metadata=metadata,
+        )
+
+    async def checkpoint(
+        self,
+        label: str,
+        *,
+        context: Any,
+        pattern: Any,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.auto_pattern._capture_child_state(pattern)
+        child_metadata = {
+            "child_label": label,
+            "child_pattern": pattern.__class__.__name__,
+        }
+        if metadata:
+            child_metadata.update(metadata)
+        return await self.parent.checkpoint(
+            label=f"auto_child_{label}",
+            context=self.root_context,
+            pattern=self.auto_pattern,
+            status=status,
+            metadata=child_metadata,
+        )
+
+    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
+        await self.parent.on_tool_start(tool_call=tool_call)
+
+    async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
+        await self.parent.on_tool_end(tool_call=tool_call, result=result)
+
+    async def on_tool_error(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        error: Exception,
+        result: Any | None = None,
+    ) -> None:
+        await self.parent.on_tool_error(tool_call=tool_call, error=error, result=result)
+
+    async def on_llm_start(
+        self,
+        *,
+        context: Any,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_llm_start(
+            context=context,
+            messages=messages,
+            tools=tools,
+            metadata=metadata,
+        )
+
+    async def on_llm_end(
+        self,
+        *,
+        context: Any,
+        response: Any,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_llm_end(
+            context=context,
+            response=response,
+            metadata=metadata,
+        )
+
+    async def compact_context_if_needed(
+        self,
+        *,
+        context: Any,
+        llm: Any = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self.parent.compact_context_if_needed(
+            context=context,
+            llm=llm,
+            metadata=metadata,
+        )
+
+    async def on_dag_step_start(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_dag_step_start(
+            context=context,
+            step_id=step_id,
+            data=data,
+        )
+
+    async def on_dag_step_end(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_dag_step_end(
+            context=context,
+            step_id=step_id,
+            data=data,
+        )
+
+    async def on_dag_execution(
+        self,
+        *,
+        context: Any,
+        phase: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        await self.parent.on_dag_execution(
+            context=context,
+            phase=phase,
+            data=data,
+        )
+
+    async def on_pattern_start(self, *, context: Any, pattern: Any) -> None:
+        await self.parent.on_pattern_start(context=context, pattern=pattern)
+
+    async def on_pattern_end(
+        self,
+        *,
+        context: Any,
+        pattern: Any,
+        result: dict[str, Any],
+    ) -> None:
+        await self.parent.on_pattern_end(
+            context=context,
+            pattern=pattern,
+            result=result,
+        )
+
+    async def on_pattern_error(
+        self,
+        *,
+        context: Any,
+        pattern: Any,
+        error: Exception,
+    ) -> None:
+        await self.parent.on_pattern_error(
+            context=context, pattern=pattern, error=error
+        )
+
+
+class AutoPattern(AgentPattern):
+    """Thin LLM-driven pattern that delegates to ReActPattern or DAGPattern."""
+
+    def __init__(
+        self,
+        *,
+        react_pattern: ReActPattern | None = None,
+        dag_pattern: DAGPattern | None = None,
+    ) -> None:
+        self.react_pattern = react_pattern or ReActPattern()
+        self.dag_pattern = dag_pattern
+        self.status = "idle"
+        self.decision: AutoDecision | None = None
+        self.selected_pattern: str | None = None
+        self.react_state: dict[str, Any] | None = None
+        self.dag_state: dict[str, Any] | None = None
+        self.last_result: dict[str, Any] | None = None
+
+    async def run(
+        self,
+        context: Any,
+        tools: list[Any],
+        llm: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        runtime = kwargs.get("runtime")
+        if runtime is None:
+            runtime = PatternRuntime(
+                execution_id=getattr(context, "execution_id", None)
+            )
+
+        await runtime.on_pattern_start(context=context, pattern=self)
+        try:
+            result = await self._run(
+                context=context,
+                tools=tools,
+                llm=llm,
+                runtime=runtime,
+                skill_manager=kwargs.get("skill_manager"),
+                allowed_skills=kwargs.get("allowed_skills"),
+                memory_store=kwargs.get("memory_store"),
+                memory_similarity_threshold=kwargs.get("memory_similarity_threshold"),
+            )
+        except Exception as exc:
+            self.status = "failed"
+            await runtime.on_pattern_error(context=context, pattern=self, error=exc)
+            raise
+        await runtime.on_pattern_end(context=context, pattern=self, result=result)
+        return result
+
+    async def _run(
+        self,
+        *,
+        context: Any,
+        tools: list[Any],
+        llm: Any,
+        runtime: PatternRuntime,
+        memory_store: Any | None = None,
+        memory_similarity_threshold: float | None = None,
+        skill_manager: Any | None = None,
+        allowed_skills: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if self.decision is None:
+            self.status = "deciding"
+            task_text = latest_user_text(context)
+            await enrich_context_with_memory(
+                context=context,
+                query=task_text,
+                category="react_memory",
+                memory_store=memory_store,
+                runtime=runtime,
+                similarity_threshold=memory_similarity_threshold,
+            )
+            try:
+                await enrich_context_with_skill(
+                    context=context,
+                    task=task_text,
+                    llm=llm,
+                    skill_manager=skill_manager,
+                    runtime=runtime,
+                    allowed_skills=allowed_skills,
+                )
+            except LLMCallInterrupted:
+                interrupted = await self._interrupt_if_requested(
+                    runtime=runtime,
+                    context=context,
+                    label="auto_during_enrichment",
+                )
+                if interrupted is not None:
+                    return interrupted
+                raise
+            interrupted = await self._interrupt_if_requested(
+                runtime=runtime,
+                context=context,
+                label="auto_before_decision",
+            )
+            if interrupted is not None:
+                return interrupted
+            await runtime.checkpoint(
+                "auto_before_decision", context=context, pattern=self
+            )
+            try:
+                self.decision = await self._decide(
+                    context=context, tools=tools, llm=llm, runtime=runtime
+                )
+            except LLMCallInterrupted:
+                interrupted = await self._interrupt_if_requested(
+                    runtime=runtime,
+                    context=context,
+                    label="auto_during_decision",
+                )
+                if interrupted is not None:
+                    return interrupted
+                raise
+            self._normalize_decision()
+            if self.decision is None:
+                raise RuntimeError("AutoPattern decision was not set.")
+            self.selected_pattern = self.decision.action.value
+            logger.info(
+                "AutoPattern selected %s for execution %s: %s",
+                self.selected_pattern,
+                getattr(context, "execution_id", None),
+                self.decision.reason,
+            )
+            await runtime.checkpoint(
+                "auto_after_decision", context=context, pattern=self
+            )
+            interrupted = await self._interrupt_if_requested(
+                runtime=runtime,
+                context=context,
+                label="auto_after_decision",
+            )
+            if interrupted is not None:
+                return interrupted
+
+        if self.decision.action == AutoAction.FINAL_ANSWER:
+            answer = self.decision.answer or ""
+            if answer:
+                context.add_assistant_message(answer)
+            self.status = "completed"
+            result = PatternResult(
+                success=True,
+                output=answer,
+                metadata={
+                    "status": self.status,
+                    "response": answer,
+                    "auto_decision": self.decision.to_dict(),
+                },
+            ).to_dict()
+            self.last_result = result
+            await runtime.checkpoint("auto_final", context=context, pattern=self)
+            return result
+
+        child = self._selected_child()
+        self._restore_child_state(child)
+        self.status = "running"
+        interrupted = await self._interrupt_if_requested(
+            runtime=runtime,
+            context=context,
+            label="auto_before_child",
+        )
+        if interrupted is not None:
+            return interrupted
+        await runtime.checkpoint("auto_before_child", context=context, pattern=self)
+        child_runtime = _AutoChildRuntime(
+            parent=runtime,
+            auto_pattern=self,
+            root_context=context,
+        )
+        result = await child.run(
+            context=context,
+            tools=tools,
+            llm=llm,
+            runtime=child_runtime,
+            memory_store=memory_store,
+            memory_similarity_threshold=memory_similarity_threshold,
+            skill_manager=skill_manager,
+            allowed_skills=allowed_skills,
+            **kwargs,
+        )
+        self._attach_decision_metadata(result)
+        self._capture_child_state(child)
+        self.status = str(
+            result.get("status", "completed" if result.get("success") else "failed")
+        )
+        self.last_result = dict(result)
+        await runtime.checkpoint("auto_after_child", context=context, pattern=self)
+        return result
+
+    async def _interrupt_if_requested(
+        self,
+        *,
+        runtime: PatternRuntime,
+        context: Any,
+        label: str,
+    ) -> dict[str, Any] | None:
+        if not await runtime.should_interrupt():
+            return None
+        self.status = "interrupted"
+        await runtime.checkpoint(
+            "auto_interrupted",
+            context=context,
+            pattern=self,
+            status=self.status,
+            metadata={"safe_point": label, "reason": runtime.interrupt_reason},
+        )
+        result = PatternResult(
+            success=False,
+            error="AutoPattern interrupted.",
+            metadata={
+                "status": self.status,
+                "interrupt_reason": runtime.interrupt_reason,
+            },
+        ).to_dict()
+        self.last_result = result
+        return result
+
+    def _normalize_decision(self) -> None:
+        if self.decision is None:
+            return
+        if (
+            self.decision.action == AutoAction.FINAL_ANSWER
+            and self.decision.requires_current_or_external_facts
+            and not self.decision.existing_context_sufficient
+        ):
+            logger.warning(
+                "AutoPattern selected final_answer for facts requiring external "
+                "verification without sufficient context; falling back to react. "
+                "reason=%s evidence_basis=%s missing_verification=%s",
+                self.decision.reason,
+                self.decision.evidence_basis,
+                self.decision.missing_verification,
+            )
+            self.decision = AutoDecision(
+                action=AutoAction.REACT,
+                reason=(
+                    "AutoPattern selected final_answer for a request requiring "
+                    "current or external facts without sufficient supporting "
+                    "context; falling back to react."
+                ),
+                requires_current_or_external_facts=True,
+                existing_context_sufficient=False,
+                evidence_basis=self.decision.evidence_basis,
+                missing_verification=self.decision.missing_verification,
+            )
+        if (
+            self.decision.action == AutoAction.FINAL_ANSWER
+            and not (self.decision.answer or "").strip()
+        ):
+            logger.warning(
+                "AutoPattern selected final_answer without answer; falling back to "
+                "react. reason=%s",
+                self.decision.reason,
+            )
+            self.decision = AutoDecision(
+                action=AutoAction.REACT,
+                reason=(
+                    "AutoPattern selected final_answer without a non-empty answer; "
+                    "falling back to react."
+                ),
+            )
+        if self.decision.action == AutoAction.PLAN_EXECUTE and self.dag_pattern is None:
+            raise ValueError(
+                "AutoPattern selected plan_execute without a DAGPattern configured."
+            )
+
+    def _attach_decision_metadata(self, result: dict[str, Any]) -> None:
+        if self.decision is None:
+            return
+        result.setdefault("auto_decision", self.decision.to_dict())
+        metadata = result.get("metadata")
+        if isinstance(metadata, dict):
+            metadata.setdefault("auto_decision", self.decision.to_dict())
+
+    async def _decide(
+        self, *, context: Any, tools: list[Any], llm: Any, runtime: PatternRuntime
+    ) -> AutoDecision:
+        if llm is None:
+            raise RuntimeError("AutoPattern requires an LLM with tool calling support.")
+
+        await runtime.compact_context_if_needed(
+            context=context,
+            llm=llm,
+            metadata={"phase": "auto_decision"},
+        )
+
+        messages = context.get_messages_for_llm()
+        decision_prompt = self._decision_prompt(tools)
+        messages.append({"role": "user", "content": decision_prompt})
+        decision_tools = [self._decision_tool_schema()]
+        metadata = {"phase": "auto_decision"}
+        await runtime.on_llm_start(
+            context=context,
+            messages=messages,
+            tools=decision_tools,
+            metadata=metadata,
+        )
+        try:
+            response = await runtime.run_llm_call(
+                llm,
+                messages=messages,
+                tools=decision_tools,
+                tool_choice="required",
+                thinking={"type": "disabled", "enable": False},
+            )
+        except Exception as exc:
+            await runtime.on_llm_error(context=context, error=exc, metadata=metadata)
+            raise
+        await runtime.on_llm_end(context=context, response=response, metadata=metadata)
+        return self._parse_decision(response)
+
+    def _decision_prompt(self, tools: list[Any]) -> str:
+        tool_count = len(tools)
+        tool_capability_summary = (
+            f"{tool_count} execution tools are available to the downstream "
+            "execution pattern."
+            if tool_count
+            else "No execution tools are available to the downstream execution pattern."
+        )
+        available_actions = ", ".join(self._available_auto_actions())
+        return (
+            "Choose how the agent should handle the user request. "
+            f"You must call the {DECISION_TOOL_NAME} tool exactly once. "
+            f"action must be one of: {available_actions}. "
+            "Use final_answer for simple conversational replies that need no tools; "
+            "when action is final_answer, you must include a complete non-empty "
+            "answer field in the same tool call. You must also classify whether "
+            "the latest request requires current or external facts, and whether "
+            "the existing context is sufficient evidence for those facts. "
+            "If the latest user message explicitly asks to call or use an available "
+            "tool, to pause for user input, or to wait for a user choice, choose "
+            "react; do not choose final_answer merely to restate or paraphrase the "
+            "requested tool action. "
+            "Use final_answer only when the current conversation and available "
+            "retrieved context already provide enough evidence for the answer. "
+            "Available retrieved context includes "
+            "prior tool results, knowledge base or RAG results, file contents, "
+            "memory, and other trusted context already present in the conversation, "
+            "but memory or skill instructions by themselves are not proof that a "
+            "new public factual claim is supported. "
+            "For requests about recent/latest/current public facts, news, security "
+            "incidents, affected vendors, dates, vulnerabilities, versions, or "
+            "source-backed claims, set requires_current_or_external_facts=true. "
+            "If those facts are not explicitly supported by current conversation, "
+            "prior tool results, files, or retrieved context, set "
+            "existing_context_sufficient=false and choose react so the agent can "
+            "verify using available tools or explicitly state that the context is "
+            "insufficient; in that case, do not choose final_answer. "
+            "Use react as the default tool-use mode for ordinary searches, "
+            "single-target tool calls, narrow corrections, and short iterative work. "
+            "For follow-up requests, interpret the latest user message in the full "
+            "conversation context and route by the actual work required now. The "
+            "latest/current user request is the task to answer; earlier messages "
+            "are context only and must not be re-added as separate requirements "
+            "unless the latest request explicitly asks to revisit them. Do not "
+            "choose plan_execute merely because the request references, corrects, "
+            "narrows, or extends a previous answer. "
+            "Use plan_execute only when the current request requires explicit "
+            "multi-step planning, dependency management, parallel subtask execution, "
+            "multiple coordinated deliverables, or user-visible DAG execution. "
+            f"{tool_capability_summary} Do not call those execution tools during "
+            "this routing decision; only call the routing tool provided in this "
+            "request."
+        )
+
+    def _decision_tool_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": DECISION_TOOL_NAME,
+                "description": (
+                    "Select the execution pattern for this user request. If action "
+                    "is final_answer, the answer argument is mandatory and must be "
+                    "a complete non-empty final response to the user."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": self._available_auto_actions(),
+                            "description": "Execution action to use.",
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Brief reason for the selected action.",
+                        },
+                        "answer": {
+                            "type": "string",
+                            "description": (
+                                "Mandatory when action is final_answer: complete "
+                                "non-empty final response to the user. Leave unset "
+                                "for react or plan_execute."
+                            ),
+                        },
+                        "requires_current_or_external_facts": {
+                            "type": "boolean",
+                            "description": (
+                                "True when the latest request depends on current, "
+                                "recent, public, source-backed, or otherwise "
+                                "external facts rather than only conversation-local "
+                                "reasoning."
+                            ),
+                        },
+                        "existing_context_sufficient": {
+                            "type": "boolean",
+                            "description": (
+                                "True only when the current conversation, prior tool "
+                                "results, files, or retrieved context explicitly "
+                                "support the facts needed to answer. Memory and skill "
+                                "instructions are supporting context, not automatic "
+                                "evidence for new public factual claims."
+                            ),
+                        },
+                        "evidence_basis": {
+                            "type": "string",
+                            "description": (
+                                "Briefly state what existing evidence supports the "
+                                "answer, such as conversation context, prior tool "
+                                "results, files, retrieved knowledge, or none."
+                            ),
+                        },
+                        "missing_verification": {
+                            "type": "string",
+                            "description": (
+                                "If existing_context_sufficient is false, state what "
+                                "needs verification before a final answer is safe. "
+                                "Use an empty string when no verification is missing."
+                            ),
+                        },
+                    },
+                    "required": [
+                        "action",
+                        "reason",
+                        "requires_current_or_external_facts",
+                        "existing_context_sufficient",
+                        "evidence_basis",
+                        "missing_verification",
+                    ],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def _available_auto_actions(self) -> list[str]:
+        actions = [AutoAction.FINAL_ANSWER.value, AutoAction.REACT.value]
+        if self.dag_pattern is not None:
+            actions.append(AutoAction.PLAN_EXECUTE.value)
+        return actions
+
+    def _parse_decision(self, response: Any) -> AutoDecision:
+        payload = self._extract_tool_arguments(response, DECISION_TOOL_NAME)
+        return AutoDecision.from_dict(payload)
+
+    def _extract_tool_arguments(self, response: Any, tool_name: str) -> dict[str, Any]:
+        tool_calls = self._response_tool_calls(response)
+        for tool_call in tool_calls:
+            function_payload = self._function_payload(tool_call)
+            if not function_payload:
+                continue
+            if function_payload.get("name") != tool_name:
+                continue
+            return self._coerce_arguments(function_payload.get("arguments", {}))
+        raise ValueError(
+            f"AutoPattern decision requires a {tool_name} tool call response."
+        )
+
+    def _response_tool_calls(self, response: Any) -> list[Any]:
+        if isinstance(response, dict):
+            return list(response.get("tool_calls") or [])
+        return list(getattr(response, "tool_calls", []) or [])
+
+    def _function_payload(self, tool_call: Any) -> dict[str, Any] | None:
+        if isinstance(tool_call, dict):
+            function_payload = tool_call.get("function")
+            return function_payload if isinstance(function_payload, dict) else None
+        function_payload = getattr(tool_call, "function", None)
+        if function_payload is None:
+            return None
+        return {
+            "name": getattr(function_payload, "name", None),
+            "arguments": getattr(function_payload, "arguments", {}),
+        }
+
+    def _coerce_arguments(self, arguments: Any) -> dict[str, Any]:
+        if isinstance(arguments, dict):
+            return arguments
+        if not isinstance(arguments, str):
+            raise TypeError("Tool call arguments must be an object or JSON string.")
+        try:
+            payload = json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Tool call arguments must be valid JSON.") from exc
+        if not isinstance(payload, dict):
+            raise TypeError("Tool call arguments must decode to an object.")
+        return payload
+
+    def _selected_child(self) -> AgentPattern:
+        if self.decision is None:
+            raise RuntimeError("AutoPattern has no decision.")
+        if self.decision.action == AutoAction.REACT:
+            return self.react_pattern
+        if self.decision.action == AutoAction.PLAN_EXECUTE:
+            if self.dag_pattern is None:
+                raise RuntimeError(
+                    "AutoPattern selected plan_execute without a DAGPattern."
+                )
+            return self.dag_pattern
+        raise RuntimeError(f"AutoPattern action has no child: {self.decision.action}")
+
+    def _capture_child_state(self, child: Any) -> None:
+        get_state = getattr(child, "get_state", None)
+        if not callable(get_state):
+            return
+        if child is self.react_pattern:
+            self.react_state = get_state()
+            return
+        if child is self.dag_pattern:
+            self.dag_state = get_state()
+
+    def _restore_child_state(self, child: Any) -> None:
+        state = None
+        if child is self.react_pattern:
+            state = self.react_state
+        elif child is self.dag_pattern:
+            state = self.dag_state
+        if not state:
+            return
+        load_state = getattr(child, "load_state", None)
+        if callable(load_state):
+            load_state(state)
+
+    def get_state(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "decision": self.decision.to_dict() if self.decision is not None else None,
+            "selected_pattern": self.selected_pattern,
+            "react_state": self.react_state,
+            "dag_state": self.dag_state,
+            "last_result": self.last_result,
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self.status = str(state.get("status", "idle"))
+        decision = state.get("decision")
+        self.decision = (
+            AutoDecision.from_dict(decision) if isinstance(decision, dict) else None
+        )
+        self.selected_pattern = state.get("selected_pattern")
+        self.react_state = state.get("react_state")
+        self.dag_state = state.get("dag_state")
+        self.last_result = state.get("last_result")
+
+    def get_execution_snapshot(self, context: Any) -> dict[str, Any]:
+        root_execution_id = getattr(context, "execution_id", "unknown")
+        root_frame_id = f"{root_execution_id}:auto"
+        child_frame_id = self._child_frame_id(root_execution_id)
+        root_frame = ExecutionFrame(
+            frame_id=root_frame_id,
+            root_execution_id=root_execution_id,
+            pattern_type="auto",
+            status=self._execution_status(self.status),
+            context=context.to_dict()
+            if callable(getattr(context, "to_dict", None))
+            else {},
+            pattern_state=self.get_state(),
+            children=[child_frame_id] if child_frame_id else [],
+            active_child_id=child_frame_id,
+            metadata={"selected_pattern": self.selected_pattern},
+        )
+        frames = {root_frame_id: root_frame}
+        active_frame_ids = [root_frame_id]
+        child_snapshot = self._child_execution_snapshot(context)
+        if child_snapshot is not None:
+            child_frames = {
+                frame_id: ExecutionFrame.from_dict(frame)
+                for frame_id, frame in child_snapshot.get("frames", {}).items()
+                if isinstance(frame, dict)
+            }
+            child_root_id = self._child_snapshot_root_frame_id(
+                child_snapshot, child_frames
+            )
+            if child_root_id is not None and child_root_id in child_frames:
+                child_root = child_frames[child_root_id]
+                child_root.parent_frame_id = root_frame_id
+                root_frame.children = [child_root_id]
+                root_frame.active_child_id = child_root_id
+                frames.update(child_frames)
+                child_active = [
+                    frame_id
+                    for frame_id in child_snapshot.get("active_frame_ids", [])
+                    if frame_id in child_frames
+                ]
+                active_frame_ids.extend(child_active or [child_root_id])
+        elif child_frame_id is not None:
+            child_type, child_state = self._child_snapshot_state()
+            frames[child_frame_id] = ExecutionFrame(
+                frame_id=child_frame_id,
+                parent_frame_id=root_frame_id,
+                root_execution_id=root_execution_id,
+                pattern_type=child_type,
+                status=self._execution_status(self.status),
+                context=context.to_dict()
+                if callable(getattr(context, "to_dict", None))
+                else {},
+                pattern_state=child_state,
+            )
+            active_frame_ids.append(child_frame_id)
+        return ExecutionSnapshot(
+            root_execution_id=root_execution_id,
+            status=self._execution_status(self.status),
+            frames=frames,
+            active_frame_ids=active_frame_ids,
+            control_state={"selected_pattern": self.selected_pattern},
+        ).to_dict()
+
+    def _child_execution_snapshot(self, context: Any) -> dict[str, Any] | None:
+        child = self._snapshot_child_pattern()
+        get_snapshot = getattr(child, "get_execution_snapshot", None)
+        if not callable(get_snapshot):
+            return None
+        try:
+            snapshot = get_snapshot(context)
+        except Exception:
+            logger.exception("Failed to build AutoPattern child execution snapshot")
+            return None
+        return snapshot if isinstance(snapshot, dict) else None
+
+    def _snapshot_child_pattern(self) -> Any | None:
+        if self.selected_pattern == AutoAction.PLAN_EXECUTE.value:
+            return self.dag_pattern
+        return None
+
+    def _child_snapshot_root_frame_id(
+        self,
+        snapshot: dict[str, Any],
+        frames: dict[str, ExecutionFrame],
+    ) -> str | None:
+        active_frame_ids = [
+            frame_id
+            for frame_id in snapshot.get("active_frame_ids", [])
+            if isinstance(frame_id, str) and frame_id in frames
+        ]
+        if active_frame_ids:
+            return active_frame_ids[0]
+        for frame_id, frame in frames.items():
+            if frame.parent_frame_id is None:
+                return frame_id
+        return None
+
+    def _child_frame_id(self, root_execution_id: str) -> str | None:
+        if self.selected_pattern in {
+            AutoAction.REACT.value,
+            AutoAction.PLAN_EXECUTE.value,
+        }:
+            return f"{root_execution_id}:auto:{self.selected_pattern}"
+        return None
+
+    def _child_snapshot_state(self) -> tuple[str, dict[str, Any]]:
+        if self.selected_pattern == AutoAction.REACT.value:
+            return "react", dict(self.react_state or {})
+        return "dag", dict(self.dag_state or {})
+
+    def _execution_status(self, status: str) -> ExecutionStatus:
+        status_map = {
+            "completed": ExecutionStatus.COMPLETED,
+            "failed": ExecutionStatus.FAILED,
+            "interrupted": ExecutionStatus.INTERRUPTED,
+            "waiting_for_user": ExecutionStatus.WAITING_FOR_USER,
+        }
+        return status_map.get(status, ExecutionStatus.RUNNING)
+
+    def _tool_name(self, tool: Any) -> str:
+        metadata = getattr(tool, "metadata", None)
+        if metadata is not None and getattr(metadata, "name", None):
+            return str(metadata.name)
+        if getattr(tool, "name", None):
+            return str(tool.name)
+        return str(tool.__class__.__name__)

--- a/src/xagent/core/agent_v2/pattern/auto/auto.py
+++ b/src/xagent/core/agent_v2/pattern/auto/auto.py
@@ -98,7 +98,7 @@ def _coerce_bool(value: Any, *, default: bool) -> bool:
 
 @dataclass
 class _AutoChildRuntime:
-    """Runtime adapter that stores child checkpoints in the AutoPattern envelope."""
+    """Runtime adapter that captures child state before parent checkpoints."""
 
     parent: PatternRuntime
     auto_pattern: "AutoPattern"
@@ -305,6 +305,7 @@ class AutoPattern(AgentPattern):
         self.dag_pattern = dag_pattern
         self.status = "idle"
         self.decision: AutoDecision | None = None
+        self.decision_user_messages: dict[str, Any] | None = None
         self.selected_pattern: str | None = None
         self.react_state: dict[str, Any] | None = None
         self.dag_state: dict[str, Any] | None = None
@@ -355,6 +356,7 @@ class AutoPattern(AgentPattern):
         allowed_skills: list[str] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
+        self._invalidate_stale_final_answer_decision(context)
         if self.decision is None:
             self.status = "deciding"
             task_text = latest_user_text(context)
@@ -410,6 +412,7 @@ class AutoPattern(AgentPattern):
             self._normalize_decision()
             if self.decision is None:
                 raise RuntimeError("AutoPattern decision was not set.")
+            self.decision_user_messages = self._user_message_signature(context)
             self.selected_pattern = self.decision.action.value
             logger.info(
                 "AutoPattern selected %s for execution %s: %s",
@@ -829,6 +832,7 @@ class AutoPattern(AgentPattern):
         return {
             "status": self.status,
             "decision": self.decision.to_dict() if self.decision is not None else None,
+            "decision_user_messages": self.decision_user_messages,
             "selected_pattern": self.selected_pattern,
             "react_state": self.react_state,
             "dag_state": self.dag_state,
@@ -840,6 +844,12 @@ class AutoPattern(AgentPattern):
         decision = state.get("decision")
         self.decision = (
             AutoDecision.from_dict(decision) if isinstance(decision, dict) else None
+        )
+        decision_user_messages = state.get("decision_user_messages")
+        self.decision_user_messages = (
+            dict(decision_user_messages)
+            if isinstance(decision_user_messages, dict)
+            else None
         )
         self.selected_pattern = state.get("selected_pattern")
         self.react_state = state.get("react_state")
@@ -924,7 +934,49 @@ class AutoPattern(AgentPattern):
     def _snapshot_child_pattern(self) -> Any | None:
         if self.selected_pattern == AutoAction.PLAN_EXECUTE.value:
             return self.dag_pattern
+        # DAG exposes a rich execution snapshot for visualization. ReAct is
+        # represented by the synthetic child frame created by AutoPattern.
         return None
+
+    def _invalidate_stale_final_answer_decision(self, context: Any) -> None:
+        if (
+            self.decision is None
+            or self.decision.action != AutoAction.FINAL_ANSWER
+            or self.decision.answer is None
+        ):
+            return
+
+        current_signature = self._user_message_signature(context)
+        if self.decision_user_messages is None:
+            stale = int(current_signature.get("count", 0)) > 1
+        else:
+            stale = current_signature != self.decision_user_messages
+
+        if not stale:
+            return
+
+        logger.info(
+            "AutoPattern invalidating cached final_answer decision after new user "
+            "input. previous=%s current=%s",
+            self.decision_user_messages,
+            current_signature,
+        )
+        self.decision = None
+        self.decision_user_messages = None
+        self.selected_pattern = None
+        self.last_result = None
+        self.status = "idle"
+
+    def _user_message_signature(self, context: Any) -> dict[str, Any]:
+        user_contents = [
+            str(getattr(message, "content", ""))
+            for message in getattr(context, "messages", [])
+            if getattr(message, "role", None) == "user"
+        ]
+        return {
+            "count": len(user_contents),
+            "latest": user_contents[-1] if user_contents else "",
+        }
 
     def _child_snapshot_root_frame_id(
         self,

--- a/src/xagent/core/agent_v2/pattern/auto/auto.py
+++ b/src/xagent/core/agent_v2/pattern/auto/auto.py
@@ -7,6 +7,10 @@ from enum import Enum
 from typing import Any
 
 from ...context.enrichment import (
+    MEMORY_CONTEXT_METADATA_KEY,
+    RETRIEVED_MEMORIES_METADATA_KEY,
+    SELECTED_SKILL_METADATA_KEY,
+    SKILL_CONTEXT_METADATA_KEY,
     enrich_context_with_memory,
     enrich_context_with_skill,
     latest_user_text,
@@ -966,6 +970,19 @@ class AutoPattern(AgentPattern):
         self.selected_pattern = None
         self.last_result = None
         self.status = "idle"
+        self._clear_request_scoped_enrichment(context)
+
+    def _clear_request_scoped_enrichment(self, context: Any) -> None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return
+        for key in (
+            RETRIEVED_MEMORIES_METADATA_KEY,
+            MEMORY_CONTEXT_METADATA_KEY,
+            SELECTED_SKILL_METADATA_KEY,
+            SKILL_CONTEXT_METADATA_KEY,
+        ):
+            metadata.pop(key, None)
 
     def _user_message_signature(self, context: Any) -> dict[str, Any]:
         user_contents = [

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -96,6 +96,8 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
                 }
                 for option in options
                 if isinstance(option, dict)
+                and isinstance(option.get("label"), str)
+                and option.get("label")
                 and isinstance(option.get("value"), str)
                 and option.get("value")
             ]

--- a/src/xagent/core/agent_v2/pattern/react/react.py
+++ b/src/xagent/core/agent_v2/pattern/react/react.py
@@ -61,6 +61,50 @@ class ToolCallRecord:
         )
 
 
+def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
+    """Normalize common model variants into the frontend interaction contract."""
+
+    if not isinstance(interactions, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for index, interaction in enumerate(interactions):
+        if not isinstance(interaction, dict):
+            continue
+
+        item = dict(interaction)
+        field = item.get("field") or item.get("id") or item.get("name")
+        if not isinstance(field, str) or not field.strip():
+            field = f"response_{index}"
+        item["field"] = field.strip()
+
+        if "options" not in item and isinstance(item.get("actions"), list):
+            item["options"] = item["actions"]
+
+        options = item.get("options")
+        if isinstance(options, list):
+            item["options"] = [
+                {
+                    key: value
+                    for key, value in {
+                        "label": option.get("label"),
+                        "value": option.get("value"),
+                        "description": option.get("description"),
+                        "action_type": option.get("action_type"),
+                    }.items()
+                    if value is not None
+                }
+                for option in options
+                if isinstance(option, dict)
+                and isinstance(option.get("value"), str)
+                and option.get("value")
+            ]
+
+        normalized.append(item)
+
+    return normalized
+
+
 class ReActPattern(AgentPattern):
     """Minimal ReAct loop for the v2 execution runtime."""
 
@@ -666,7 +710,53 @@ class ReActPattern(AgentPattern):
                             "message": {"type": "string"},
                             "interactions": {
                                 "type": "array",
-                                "items": {"type": "object"},
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "select_one",
+                                                "select_multiple",
+                                                "text_input",
+                                                "file_upload",
+                                                "confirm",
+                                                "number_input",
+                                                "action_cards",
+                                            ],
+                                        },
+                                        "field": {"type": "string"},
+                                        "label": {"type": "string"},
+                                        "options": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "label": {"type": "string"},
+                                                    "value": {"type": "string"},
+                                                    "description": {"type": "string"},
+                                                    "action_type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "upload",
+                                                            "input_url",
+                                                            "none",
+                                                        ],
+                                                    },
+                                                },
+                                                "required": ["label", "value"],
+                                            },
+                                        },
+                                        "placeholder": {"type": "string"},
+                                        "multiline": {"type": "boolean"},
+                                        "accept": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                        "multiple": {"type": "boolean"},
+                                    },
+                                    "required": ["type", "field", "label"],
+                                },
                             },
                         },
                         "required": ["message", "interactions"],
@@ -771,7 +861,9 @@ class ReActPattern(AgentPattern):
 
         if name == "ask_user_question":
             message = str(args.get("message", ""))
-            interactions = args.get("interactions", [])
+            interactions = _normalize_ask_user_interactions(
+                args.get("interactions", [])
+            )
             await runtime.send_message(
                 message=message,
                 message_type="question",

--- a/src/xagent/core/agent_v2/tracing.py
+++ b/src/xagent/core/agent_v2/tracing.py
@@ -61,11 +61,16 @@ class TraceEventCallback:
 
         if result.get("success"):
             if output:
+                completion_result: dict[str, Any] = {"content": output}
+                file_outputs = result.get("file_outputs")
+                if file_outputs:
+                    completion_result["file_outputs"] = file_outputs
+                    completion_result["output"] = output
                 await trace_ai_message(tracer, execution_id, output, data)
                 await trace_task_completion(
                     tracer,
                     execution_id,
-                    result={"content": output},
+                    result=completion_result,
                     success=True,
                 )
             return

--- a/tests/core/agent_v2/test_auto.py
+++ b/tests/core/agent_v2/test_auto.py
@@ -603,6 +603,57 @@ async def test_auto_pattern_resume_reuses_existing_decision() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_pattern_final_answer_resume_redecides_after_new_user_message() -> (
+    None
+):
+    first_llm = FakeLLM(
+        [decision_tool_response("final_answer", "Original answer.", answer="old")]
+    )
+    first_pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("first question")
+    runtime = PatternRuntime()
+
+    def interrupt_after_decision() -> bool:
+        return bool(
+            runtime.last_checkpoint
+            and runtime.last_checkpoint.get("label") == "auto_after_decision"
+        )
+
+    runtime.interrupt_checker = interrupt_after_decision
+
+    interrupted = await first_pattern.run(
+        context=context,
+        tools=[],
+        llm=first_llm,
+        runtime=runtime,
+    )
+
+    assert interrupted["status"] == "interrupted"
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["label"] == "auto_interrupted"
+
+    resumed_context = ExecutionContext.from_dict(runtime.last_checkpoint["context"])
+    resumed_context.add_user_message("replacement question")
+    resumed_pattern = AutoPattern()
+    resumed_pattern.load_state(runtime.last_checkpoint["pattern_state"])
+    resumed_llm = FakeLLM(
+        [decision_tool_response("final_answer", "Replacement answer.", answer="new")]
+    )
+
+    resumed = await resumed_pattern.run(
+        context=resumed_context,
+        tools=[],
+        llm=resumed_llm,
+        runtime=PatternRuntime(),
+    )
+
+    assert resumed["success"] is True
+    assert resumed["output"] == "new"
+    assert len(resumed_llm.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_auto_pattern_missing_decision_tool_call_fails() -> None:
     llm = FakeLLM(["not a tool call"])
     pattern = AutoPattern()
@@ -741,6 +792,35 @@ async def test_auto_pattern_plan_execute_without_dag_fails() -> None:
             llm=llm,
             runtime=PatternRuntime(),
         )
+
+
+def test_auto_pattern_get_execution_snapshot_builds_react_child_frame() -> None:
+    pattern = AutoPattern()
+    pattern.load_state(
+        {
+            "status": "running",
+            "decision": {"action": "react", "reason": "Needs ReAct."},
+            "selected_pattern": "react",
+            "react_state": {"iteration": 1},
+        }
+    )
+    context = ExecutionContext(execution_id="snap-1")
+    context.add_user_message("Continue")
+
+    snapshot = pattern.get_execution_snapshot(context)
+
+    assert snapshot["root_execution_id"] == "snap-1"
+    assert snapshot["status"] == "running"
+    assert snapshot["active_frame_ids"] == ["snap-1:auto", "snap-1:auto:react"]
+    assert snapshot["control_state"] == {"selected_pattern": "react"}
+    root_frame = snapshot["frames"]["snap-1:auto"]
+    assert root_frame["pattern_type"] == "auto"
+    assert root_frame["children"] == ["snap-1:auto:react"]
+    assert root_frame["active_child_id"] == "snap-1:auto:react"
+    child_frame = snapshot["frames"]["snap-1:auto:react"]
+    assert child_frame["parent_frame_id"] == "snap-1:auto"
+    assert child_frame["pattern_type"] == "react"
+    assert child_frame["pattern_state"] == {"iteration": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_auto.py
+++ b/tests/core/agent_v2/test_auto.py
@@ -1,0 +1,894 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent_v2 import (
+    Agent,
+    AgentRunner,
+    AutoAction,
+    AutoPattern,
+    DAGPattern,
+    ExecutionContext,
+    LLMPlanGenerator,
+    PatternRuntime,
+    ReActPattern,
+)
+from xagent.core.agent_v2.pattern.auto.auto import DECISION_TOOL_NAME
+
+
+class FakeWorkspace:
+    def __init__(self, task_id: str, tmp_path: Path) -> None:
+        workspace_dir = tmp_path / task_id
+        self.id = task_id
+        self.workspace_dir = workspace_dir
+        self.input_dir = workspace_dir / "input"
+        self.output_dir = workspace_dir / "output"
+        self.temp_dir = workspace_dir / "temp"
+        self.allowed_external_dirs: list[Path] = []
+
+
+class FakeWorkspaceManager:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def get_or_create_workspace(
+        self,
+        base_dir: str,
+        task_id: str,
+        allowed_external_dirs: list[str] | None = None,
+    ) -> FakeWorkspace:
+        del base_dir, allowed_external_dirs
+        return FakeWorkspace(task_id, self.tmp_path)
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class TimeoutLLM:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        raise TimeoutError("read timed out")
+
+
+class MemoryNote:
+    content = "Answer simple follow-ups using the project memory."
+    keywords = ["follow-up"]
+    metadata = {"source": "test"}
+    category = "react_memory"
+
+
+class FakeMemoryStore:
+    def __init__(self) -> None:
+        self.searches: list[dict[str, Any]] = []
+
+    def search(self, **kwargs: Any) -> list[MemoryNote]:
+        self.searches.append(kwargs)
+        return [MemoryNote()]
+
+
+class FakeSkillManager:
+    async def select_skill(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "name": "auto-skill",
+            "description": "Auto skill",
+            "content": "Use the Auto skill instructions.",
+        }
+
+
+class CapturingChildPattern:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] | None = None
+
+    async def run(self, **kwargs: Any) -> dict[str, Any]:
+        self.kwargs = kwargs
+        return {"success": True, "output": "child done"}
+
+    def get_state(self) -> dict[str, Any]:
+        return {"captured": True}
+
+
+def decision_tool_response(
+    action: str,
+    reason: str,
+    answer: str | None = None,
+    requires_current_or_external_facts: bool = False,
+    existing_context_sufficient: bool = True,
+    evidence_basis: str = "current conversation",
+    missing_verification: str = "",
+) -> dict[str, Any]:
+    arguments: dict[str, Any] = {
+        "action": action,
+        "reason": reason,
+        "requires_current_or_external_facts": requires_current_or_external_facts,
+        "existing_context_sufficient": existing_context_sufficient,
+        "evidence_basis": evidence_basis,
+        "missing_verification": missing_verification,
+    }
+    if answer is not None:
+        arguments["answer"] = answer
+    return {
+        "tool_calls": [
+            {
+                "id": f"call_{DECISION_TOOL_NAME}",
+                "type": "function",
+                "function": {
+                    "name": DECISION_TOOL_NAME,
+                    "arguments": json.dumps(arguments),
+                },
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_decision_sees_memory_and_skill_context() -> None:
+    llm = FakeLLM(
+        responses=[
+            decision_tool_response(
+                AutoAction.FINAL_ANSWER.value,
+                "simple",
+                "Done from context.",
+            )
+        ]
+    )
+    context = ExecutionContext(execution_id="auto-context")
+    context.add_user_message("Answer from context")
+    memory_store = FakeMemoryStore()
+
+    result = await AutoPattern().run(
+        context=context,
+        tools=[],
+        llm=llm,
+        memory_store=memory_store,
+        skill_manager=FakeSkillManager(),
+    )
+
+    assert result["success"] is True
+    assert [search["filters"]["category"] for search in memory_store.searches] == [
+        "react_memory",
+        "general",
+    ]
+    decision_messages = llm.calls[0]["messages"]
+    system_context = next(
+        message["content"]
+        for message in decision_messages
+        if message["role"] == "system"
+    )
+    assert "Answer simple follow-ups using the project memory." in system_context
+    assert "Available Skill: auto-skill" in system_context
+
+
+def plan_tool_response(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "tool_calls": [
+            {
+                "id": "call_generate_execution_plan",
+                "type": "function",
+                "function": {
+                    "name": "generate_execution_plan",
+                    "arguments": json.dumps({"steps": steps}),
+                },
+            }
+        ]
+    }
+
+
+class TracerCheckpointStore:
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+        self.checkpoints: list[dict[str, Any]] = []
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+        self.checkpoints.append(dict(payload))
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+class RecordingTracer:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+class RecordingRuntime(PatternRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hooks: list[tuple[str, dict[str, Any]]] = []
+
+    async def on_llm_start(
+        self,
+        *,
+        context: Any,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(
+            (
+                "llm_start",
+                {
+                    "message_count": len(messages),
+                    "tools_count": len(tools or []),
+                    "metadata": metadata or {},
+                },
+            )
+        )
+
+    async def on_llm_end(
+        self,
+        *,
+        context: Any,
+        response: Any,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(
+            (
+                "llm_end",
+                {
+                    "response": response,
+                    "metadata": metadata or {},
+                },
+            )
+        )
+
+    async def on_llm_error(
+        self,
+        *,
+        context: Any,
+        error: Exception,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(
+            (
+                "llm_error",
+                {
+                    "error": str(error),
+                    "metadata": metadata or {},
+                },
+            )
+        )
+
+    async def on_dag_step_start(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(("dag_step_start", {"step_id": step_id, "data": data or {}}))
+
+    async def on_dag_step_end(
+        self,
+        *,
+        context: Any,
+        step_id: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(("dag_step_end", {"step_id": step_id, "data": data or {}}))
+
+    async def on_dag_execution(
+        self,
+        *,
+        context: Any,
+        phase: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        del context
+        self.hooks.append(("dag_execution", {"phase": phase, "data": data or {}}))
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_final_answer_completes_without_child_pattern() -> None:
+    llm = FakeLLM(
+        [decision_tool_response("final_answer", "Greeting only.", answer="hi")]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("hi")
+    runtime = PatternRuntime()
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert result["output"] == "hi"
+    assert pattern.decision is not None
+    assert pattern.decision.action == AutoAction.FINAL_ANSWER
+    assert context.messages[-1].role == "assistant"
+    assert context.messages[-1].content == "hi"
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["tools"][0]["function"]["name"] == DECISION_TOOL_NAME
+    assert llm.calls[0]["tool_choice"] == "required"
+    assert llm.calls[0]["thinking"] == {"type": "disabled", "enable": False}
+    assert "response_format" not in llm.calls[0]
+    assert [message["role"] for message in llm.calls[0]["messages"]].count(
+        "system"
+    ) == 1
+    decision_prompt = llm.calls[0]["messages"][-1]["content"]
+    assert llm.calls[0]["messages"][-1]["role"] == "user"
+    assert "must include a complete non-empty answer field" in decision_prompt
+    assert (
+        "available retrieved context already provide enough evidence" in decision_prompt
+    )
+    assert "knowledge base or RAG results" in decision_prompt
+    assert "do not choose final_answer" in decision_prompt
+    assert "explicitly asks to call or use an available tool" in decision_prompt
+    assert "pause for user input" in decision_prompt
+    assert "Use react as the default tool-use mode" in decision_prompt
+    assert "For follow-up requests" in decision_prompt
+    assert "Do not choose plan_execute merely because" in decision_prompt
+    assert "user-visible DAG execution" in decision_prompt
+    assert "execution tools are available" in decision_prompt
+    assert "Available tool names" not in decision_prompt
+    tool_schema = llm.calls[0]["tools"][0]["function"]
+    assert "answer argument is mandatory" in tool_schema["description"]
+    answer_schema = tool_schema["parameters"]["properties"]["answer"]
+    assert "Mandatory when action is final_answer" in answer_schema["description"]
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["pattern"] == "AutoPattern"
+
+
+@pytest.mark.asyncio
+async def test_auto_decision_prompt_does_not_expose_execution_tool_names() -> None:
+    llm = FakeLLM([decision_tool_response("react", "Needs an execution tool.")])
+    child = CapturingChildPattern()
+    pattern = AutoPattern(react_pattern=child)  # type: ignore[arg-type]
+    context = ExecutionContext()
+    context.add_user_message("Create an agent from a knowledge base")
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "list_knowledge_bases",
+                "description": "List knowledge bases",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    result = await pattern.run(
+        context=context,
+        tools=tools,
+        llm=llm,
+        runtime=PatternRuntime(),
+    )
+
+    assert result["success"] is True
+    decision_call = llm.calls[0]
+    assert [tool["function"]["name"] for tool in decision_call["tools"]] == [
+        DECISION_TOOL_NAME
+    ]
+    decision_prompt = decision_call["messages"][-1]["content"]
+    assert "1 execution tools are available" in decision_prompt
+    assert "list_knowledge_bases" not in decision_prompt
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_interrupt_before_decision_skips_llm_call() -> None:
+    llm = FakeLLM(
+        [decision_tool_response("final_answer", "Should not be called.", answer="hi")]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("hi")
+    runtime = PatternRuntime()
+    runtime.request_interrupt("paused by test")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is False
+    assert result["status"] == "interrupted"
+    assert result["interrupt_reason"] == "paused by test"
+    assert len(llm.calls) == 0
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["label"] == "auto_interrupted"
+    assert runtime.last_checkpoint["metadata"] == {
+        "safe_point": "auto_before_decision",
+        "reason": "paused by test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_does_not_emit_general_task_start_or_completion() -> None:
+    llm = FakeLLM(
+        [decision_tool_response("final_answer", "Greeting only.", answer="hi")]
+    )
+    tracer = RecordingTracer()
+    pattern = AutoPattern()
+    context = ExecutionContext(execution_id="auto-final")
+    context.add_user_message("hi")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=PatternRuntime(tracer=tracer),
+    )
+
+    assert result["success"] is True
+    assert {event["event_type"] for event in tracer.events} == {
+        "action_start_llm",
+        "action_end_llm",
+        "task_update_general",
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_react_decision_delegates_to_react() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("react", "Ordinary response."),
+            "react done",
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Say done")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["output"] == "react done"
+    assert result["auto_decision"] == {
+        "action": "react",
+        "reason": "Ordinary response.",
+        "requires_current_or_external_facts": False,
+        "existing_context_sufficient": True,
+        "evidence_basis": "current conversation",
+        "missing_verification": "",
+    }
+    assert pattern.selected_pattern == "react"
+    assert pattern.react_state is not None
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["pattern_state"]["selected_pattern"] == "react"
+    assert [hook for hook, _ in runtime.hooks] == [
+        "llm_start",
+        "llm_end",
+        "llm_start",
+        "llm_end",
+    ]
+    assert runtime.hooks[0][1]["metadata"] == {"phase": "auto_decision"}
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_passes_memory_to_child_pattern() -> None:
+    child = CapturingChildPattern()
+    memory_store = FakeMemoryStore()
+    llm = FakeLLM(
+        [
+            decision_tool_response("react", "Needs child execution."),
+        ]
+    )
+    pattern = AutoPattern(react_pattern=child)  # type: ignore[arg-type]
+    context = ExecutionContext()
+    context.add_user_message("Use context and then execute")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        memory_store=memory_store,
+        memory_similarity_threshold=0.42,
+    )
+
+    assert result["success"] is True
+    assert child.kwargs is not None
+    assert child.kwargs["memory_store"] is memory_store
+    assert child.kwargs["memory_similarity_threshold"] == 0.42
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_emits_llm_error_for_decision_failure() -> None:
+    llm = TimeoutLLM()
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Use Python")
+    runtime = RecordingRuntime()
+
+    with pytest.raises(TimeoutError):
+        await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert [hook for hook, _ in runtime.hooks] == ["llm_start", "llm_error"]
+    assert runtime.hooks[0][1]["metadata"] == {"phase": "auto_decision"}
+    assert runtime.hooks[1][1]["metadata"] == {"phase": "auto_decision"}
+    assert "read timed out" in runtime.hooks[1][1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_plan_execute_decision_delegates_to_dag() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("plan_execute", "Needs a plan."),
+            plan_tool_response([{"id": "answer", "task": "Answer directly"}]),
+            "dag done",
+        ]
+    )
+    pattern = AutoPattern(dag_pattern=DAGPattern(LLMPlanGenerator()))
+    context = ExecutionContext()
+    context.add_user_message("Plan then answer")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["output"] == "dag done"
+    assert result["step_results"] == {"answer": "dag done"}
+    assert result["auto_decision"] == {
+        "action": "plan_execute",
+        "reason": "Needs a plan.",
+        "requires_current_or_external_facts": False,
+        "existing_context_sufficient": True,
+        "evidence_basis": "current conversation",
+        "missing_verification": "",
+    }
+    assert pattern.selected_pattern == "plan_execute"
+    assert pattern.dag_state is not None
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["pattern_state"]["selected_pattern"] == (
+        "plan_execute"
+    )
+    hook_names = [hook for hook, _ in runtime.hooks]
+    assert "dag_execution" in hook_names
+    assert "dag_step_start" in hook_names
+    assert "dag_step_end" in hook_names
+    assert hook_names.count("llm_start") >= 1
+    assert hook_names.count("llm_end") >= 1
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_resume_reuses_existing_decision() -> None:
+    llm = FakeLLM(["react after resume"])
+    pattern = AutoPattern(react_pattern=ReActPattern())
+    pattern.load_state(
+        {
+            "status": "running",
+            "decision": {"action": "react", "reason": "Already decided."},
+            "selected_pattern": "react",
+        }
+    )
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=PatternRuntime(),
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "react after resume"
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["tools"] is not None
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_missing_decision_tool_call_fails() -> None:
+    llm = FakeLLM(["not a tool call"])
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+
+    with pytest.raises(ValueError, match=DECISION_TOOL_NAME):
+        await pattern.run(
+            context=context,
+            tools=[],
+            llm=llm,
+            runtime=PatternRuntime(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_unknown_action_fails() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("unknown", "Bad action."),
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+
+    with pytest.raises(ValueError, match="unknown"):
+        await pattern.run(
+            context=context,
+            tools=[],
+            llm=llm,
+            runtime=PatternRuntime(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_empty_final_answer_falls_back_to_react() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("final_answer", "No answer.", answer="  "),
+            "react fallback",
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "react fallback"
+    assert result["auto_decision"] == {
+        "action": "react",
+        "reason": (
+            "AutoPattern selected final_answer without a non-empty answer; "
+            "falling back to react."
+        ),
+        "requires_current_or_external_facts": False,
+        "existing_context_sufficient": True,
+        "evidence_basis": "",
+        "missing_verification": "",
+    }
+    assert pattern.selected_pattern == "react"
+    assert len(llm.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_final_answer_requiring_external_facts_falls_back_to_react() -> (
+    None
+):
+    llm = FakeLLM(
+        [
+            decision_tool_response(
+                "final_answer",
+                "Recent public facts can be answered from memory.",
+                answer="Unsupported factual answer.",
+                requires_current_or_external_facts=True,
+                existing_context_sufficient=False,
+                evidence_basis="memory only",
+                missing_verification="Need current public-source verification.",
+            ),
+            "verified through react",
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("总结最近 AI 圈子的供应链攻击")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "verified through react"
+    assert result["auto_decision"] == {
+        "action": "react",
+        "reason": (
+            "AutoPattern selected final_answer for a request requiring current or "
+            "external facts without sufficient supporting context; falling back to "
+            "react."
+        ),
+        "requires_current_or_external_facts": True,
+        "existing_context_sufficient": False,
+        "evidence_basis": "memory only",
+        "missing_verification": "Need current public-source verification.",
+    }
+    assert pattern.selected_pattern == "react"
+    assert len(llm.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_plan_execute_without_dag_fails() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("plan_execute", "Needs DAG."),
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+
+    with pytest.raises(ValueError, match="DAGPattern"):
+        await pattern.run(
+            context=context,
+            tools=[],
+            llm=llm,
+            runtime=PatternRuntime(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_react_resume_from_tracer_does_not_redecide(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "auto-react-restart"
+    first_agent = Agent(
+        name="auto",
+        patterns=[AutoPattern()],
+        llm=None,
+    )
+    first_runner = AgentRunner(
+        agent=first_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    first_llm = FakeLLM(
+        responses=[
+            decision_tool_response("react", "Needs ReAct."),
+            {
+                "content": "Need input.",
+                "tool_calls": [
+                    {
+                        "id": "ask",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Need input","expect_response":true}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ],
+    )
+    first_agent.llm = first_llm
+
+    interrupted = await first_runner.run(
+        task="Answer through auto react",
+        execution_id=execution_id,
+    )
+
+    assert interrupted["status"] == "waiting_for_user"
+    latest = await tracer.load_latest_checkpoint(execution_id)
+    assert latest is not None
+    assert latest["pattern"] == "AutoPattern"
+    assert latest["pattern_state"]["selected_pattern"] == "react"
+
+    resumed_llm = FakeLLM(["resumed react"])
+    resumed_agent = Agent(
+        name="auto",
+        patterns=[AutoPattern()],
+        llm=resumed_llm,
+    )
+    resumed_runner = AgentRunner(
+        agent=resumed_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    await resumed_runner.post_user_message(
+        execution_id,
+        "User input",
+        request_interrupt=False,
+    )
+
+    resumed = await resumed_runner.resume(execution_id)
+
+    assert resumed["success"] is True
+    assert resumed["status"] == "completed"
+    assert resumed["output"] == "resumed react"
+    assert resumed["pattern"] == "AutoPattern"
+    assert len(resumed_llm.calls) == 1
+    assert resumed_llm.calls[0]["tools"] is not None
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_dag_resume_from_tracer_does_not_redecide(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "auto-dag-restart"
+    first_agent = Agent(
+        name="auto",
+        patterns=[AutoPattern(dag_pattern=DAGPattern(LLMPlanGenerator()))],
+        llm=None,
+    )
+    first_runner = AgentRunner(
+        agent=first_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    first_llm = FakeLLM(
+        responses=[
+            decision_tool_response("plan_execute", "Needs DAG."),
+            plan_tool_response([{"id": "answer", "task": "Answer directly"}]),
+            {
+                "content": "Need input.",
+                "tool_calls": [
+                    {
+                        "id": "ask",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Need input","expect_response":true}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ],
+    )
+    first_agent.llm = first_llm
+
+    interrupted = await first_runner.run(
+        task="Plan through auto dag",
+        execution_id=execution_id,
+    )
+
+    assert interrupted["status"] == "waiting_for_user"
+    latest = await tracer.load_latest_checkpoint(execution_id)
+    assert latest is not None
+    assert latest["pattern"] == "AutoPattern"
+    assert latest["pattern_state"]["selected_pattern"] == "plan_execute"
+    assert latest["pattern_state"]["dag_state"] is not None
+
+    resumed_llm = FakeLLM(["resumed dag"])
+    resumed_agent = Agent(
+        name="auto",
+        patterns=[AutoPattern(dag_pattern=DAGPattern(LLMPlanGenerator()))],
+        llm=resumed_llm,
+    )
+    resumed_runner = AgentRunner(
+        agent=resumed_agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    await resumed_runner.post_user_message(
+        execution_id,
+        "User input",
+        request_interrupt=False,
+    )
+
+    resumed = await resumed_runner.resume(execution_id)
+
+    assert resumed["success"] is True
+    assert resumed["status"] == "completed"
+    assert resumed["output"] == "resumed dag"
+    assert resumed["pattern"] == "AutoPattern"
+    assert len(resumed_llm.calls) == 1

--- a/tests/core/agent_v2/test_auto.py
+++ b/tests/core/agent_v2/test_auto.py
@@ -89,6 +89,39 @@ class FakeSkillManager:
         }
 
 
+class QueryMemoryNote:
+    keywords: list[str] = []
+    metadata = {"source": "test"}
+    category = "react_memory"
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class QueryMemoryStore:
+    def __init__(self) -> None:
+        self.searches: list[dict[str, Any]] = []
+
+    def search(self, **kwargs: Any) -> list[QueryMemoryNote]:
+        self.searches.append(kwargs)
+        query = str(kwargs.get("query") or "")
+        return [QueryMemoryNote(f"memory for {query}")]
+
+
+class QuerySkillManager:
+    def __init__(self) -> None:
+        self.tasks: list[str] = []
+
+    async def select_skill(self, **kwargs: Any) -> dict[str, Any]:
+        task = str(kwargs.get("task") or "")
+        self.tasks.append(task)
+        return {
+            "name": f"skill-for-{task}",
+            "description": "Task-specific skill",
+            "content": f"Use guidance for {task}.",
+        }
+
+
 class CapturingChildPattern:
     def __init__(self) -> None:
         self.kwargs: dict[str, Any] | None = None
@@ -651,6 +684,75 @@ async def test_auto_pattern_final_answer_resume_redecides_after_new_user_message
     assert resumed["success"] is True
     assert resumed["output"] == "new"
     assert len(resumed_llm.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_final_answer_redecision_refreshes_enrichment() -> None:
+    first_llm = FakeLLM(
+        [decision_tool_response("final_answer", "Original answer.", answer="old")]
+    )
+    first_pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("first question")
+    runtime = PatternRuntime()
+    memory_store = QueryMemoryStore()
+    skill_manager = QuerySkillManager()
+
+    def interrupt_after_decision() -> bool:
+        return bool(
+            runtime.last_checkpoint
+            and runtime.last_checkpoint.get("label") == "auto_after_decision"
+        )
+
+    runtime.interrupt_checker = interrupt_after_decision
+
+    interrupted = await first_pattern.run(
+        context=context,
+        tools=[],
+        llm=first_llm,
+        runtime=runtime,
+        memory_store=memory_store,
+        skill_manager=skill_manager,
+    )
+
+    assert interrupted["status"] == "interrupted"
+    assert runtime.last_checkpoint is not None
+
+    resumed_context = ExecutionContext.from_dict(runtime.last_checkpoint["context"])
+    resumed_context.add_user_message("replacement question")
+    resumed_pattern = AutoPattern()
+    resumed_pattern.load_state(runtime.last_checkpoint["pattern_state"])
+    resumed_llm = FakeLLM(
+        [decision_tool_response("final_answer", "Replacement answer.", answer="new")]
+    )
+
+    resumed = await resumed_pattern.run(
+        context=resumed_context,
+        tools=[],
+        llm=resumed_llm,
+        runtime=PatternRuntime(),
+        memory_store=memory_store,
+        skill_manager=skill_manager,
+    )
+
+    assert resumed["success"] is True
+    assert resumed["output"] == "new"
+    assert [search["query"] for search in memory_store.searches] == [
+        "first question",
+        "first question",
+        "replacement question",
+        "replacement question",
+    ]
+    assert skill_manager.tasks == ["first question", "replacement question"]
+    resumed_system_context = next(
+        message["content"]
+        for message in resumed_llm.calls[0]["messages"]
+        if message["role"] == "system"
+    )
+    assert "memory for replacement question" in resumed_system_context
+    assert "skill-for-replacement question" in resumed_system_context
+    assert "memory for first question" not in resumed_system_context
+    assert "skill-for-first question" not in resumed_system_context
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent_v2/test_auto.py
+++ b/tests/core/agent_v2/test_auto.py
@@ -629,7 +629,7 @@ async def test_auto_pattern_unknown_action_fails() -> None:
     context = ExecutionContext()
     context.add_user_message("Continue")
 
-    with pytest.raises(ValueError, match="unknown"):
+    with pytest.raises(ValueError, match="Invalid AutoPattern action: unknown"):
         await pattern.run(
             context=context,
             tools=[],

--- a/tests/core/agent_v2/test_context.py
+++ b/tests/core/agent_v2/test_context.py
@@ -385,6 +385,37 @@ def test_get_messages_for_llm_injects_time_context_without_system_prompt() -> No
     assert result[1] == {"role": "user", "content": "what happened recently?"}
 
 
+def test_get_messages_for_llm_injects_current_request_focus() -> None:
+    ctx = ExecutionContext()
+    ctx.metadata["task"] = "Compare Mistral, OpenAI, and Anthropic ARR."
+    ctx.add_user_message("Any recent Mistral news?")
+    ctx.add_assistant_message("Mistral recently announced updates.")
+    ctx.add_user_message("Compare Mistral, OpenAI, and Anthropic ARR.")
+
+    result = ctx.get_messages_for_llm()
+
+    system_content = result[0]["content"]
+    assert "Current user request:" in system_content
+    assert "Compare Mistral, OpenAI, and Anthropic ARR." in system_content
+    assert "Earlier user and assistant messages are context only" in system_content
+    assert "do not re-answer previous requests" in system_content
+
+
+def test_get_messages_for_llm_omits_current_request_focus_for_dag_step() -> None:
+    ctx = ExecutionContext()
+    ctx.metadata["task"] = "Create two posters."
+    ctx.metadata["dag_step_id"] = "step-1"
+    ctx.metadata["dag_step_name"] = "Extract release notes"
+    ctx.add_user_message("Create two posters.")
+
+    result = ctx.get_messages_for_llm()
+
+    system_content = result[0]["content"]
+    assert "Current user request:" not in system_content
+    assert "DAG step execution scope:" in system_content
+    assert "Only execute the current DAG step" in system_content
+
+
 def test_get_messages_for_llm_coalesces_system_messages() -> None:
     ctx = ExecutionContext(system_prompt="Base prompt.")
     ctx.add_system_message("Recovered system context.")

--- a/tests/core/agent_v2/test_react.py
+++ b/tests/core/agent_v2/test_react.py
@@ -876,6 +876,48 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_ask_user_question_drops_invalid_options() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need structured input.",
+                "tool_calls": [
+                    {
+                        "id": "call_question_form",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Pick one","interactions":'
+                                '[{"type":"select_one","field":"choice",'
+                                '"label":"Choice","options":['
+                                '{"label":"A","value":"a"},'
+                                '{"label":"","value":"empty-label"},'
+                                '{"value":"missing-label"},'
+                                '{"label":"Missing value"},'
+                                '{"label":"B","value":"b","description":"Bee"}'
+                                "]}]}"
+                            ),
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-1")
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["status"] == "waiting_for_user"
+    assert result["interactions"][0]["options"] == [
+        {"label": "A", "value": "a"},
+        {"label": "B", "value": "b", "description": "Bee"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_resume_waiting_without_user_response_stays_waiting() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Add the agent v2 AutoPattern that selects between direct final answers, ReAct execution, and DAG plan-execute.
- Persist child pattern state and snapshots through the AutoPattern envelope for resume/checkpoint flows.
- Add focused support updates for current-task system context, ask-user interaction normalization, Auto exports, and tracing file outputs.

## Tests
- uv run pytest tests/core/agent_v2/test_auto.py tests/core/agent_v2/test_context.py tests/core/agent_v2/test_react.py tests/core/agent_v2/test_dag.py -q
- uv run ruff format --check src/xagent/core/agent_v2 tests/core/agent_v2/test_auto.py tests/core/agent_v2/test_context.py
- uv run ruff check src/xagent/core/agent_v2 tests/core/agent_v2/test_auto.py tests/core/agent_v2/test_context.py
- uv run mypy src/xagent/core/agent_v2
- SKIP=mypy uv run pre-commit run --files src/xagent/core/agent_v2/__init__.py src/xagent/core/agent_v2/agent.py src/xagent/core/agent_v2/context/execution.py src/xagent/core/agent_v2/pattern/__init__.py src/xagent/core/agent_v2/pattern/auto/__init__.py src/xagent/core/agent_v2/pattern/auto/auto.py src/xagent/core/agent_v2/pattern/react/react.py src/xagent/core/agent_v2/tracing.py tests/core/agent_v2/test_auto.py tests/core/agent_v2/test_context.py

Note: full pre-commit mypy still fails on the existing src/xagent/core/model/image/openai.py OpenAI SDK overload issue, unrelated to this PR.