### PR TITLE
fix: prevent duplicate template likes

### DIFF
--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -230,9 +230,15 @@ export default function TemplatesPage() {
                             </div>
                             <button
                               onClick={(e) => handleLikeTemplate(template.id, e)}
-                              className="flex items-center gap-1 hover:text-pink-500 transition-colors"
+                              className={`flex items-center gap-1 transition-colors ${
+                                template.is_liked ? "text-pink-500" : "hover:text-pink-500"
+                              }`}
                             >
-                              <Heart className="w-3 h-3 fill-current text-rose-400/70" />
+                              <Heart
+                                className={`w-3 h-3 fill-current ${
+                                  template.is_liked ? "text-rose-500" : "text-rose-400/70"
+                                }`}
+                              />
                               <span className="font-semibold text-foreground/70">{template.likes ?? 0}</span>
                             </button>
                           </div>
@@ -304,9 +310,15 @@ export default function TemplatesPage() {
                             </div>
                             <button
                               onClick={(e) => handleLikeTemplate(template.id, e)}
-                              className="flex items-center gap-1 hover:text-pink-500 transition-colors"
+                              className={`flex items-center gap-1 transition-colors ${
+                                template.is_liked ? "text-pink-500" : "hover:text-pink-500"
+                              }`}
                             >
-                              <Heart className="w-3 h-3 fill-current text-rose-400/70" />
+                              <Heart
+                                className={`w-3 h-3 fill-current ${
+                                  template.is_liked ? "text-rose-500" : "text-rose-400/70"
+                                }`}
+                              />
                               <span className="font-semibold">{template.likes ?? 0}</span>
                             </button>
                           </div>

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -27,12 +27,11 @@ export interface Template {
   views: number;
   likes: number;
   used_count: number;
+  is_liked?: boolean;
 }
 
 export interface TemplateDetail extends Template {
   agent_config: AgentConfig;
 }
 
-export interface TemplateWithStats extends Template {
-  is_liked?: boolean;
-}
+export type TemplateWithStats = Template;

--- a/src/xagent/migrations/versions/20260514_add_user_template_relations.py
+++ b/src/xagent/migrations/versions/20260514_add_user_template_relations.py
@@ -1,0 +1,122 @@
+"""Add user template relations table
+
+Revision ID: 20260514_add_user_template_relations
+Revises: 7f4d2c9a1b58
+Create Date: 2026-05-14
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260514_add_user_template_relations"
+down_revision: str | None = "7f4d2c9a1b58"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _index_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "user_template_relations" not in existing_tables:
+        constraints = [
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "user_id",
+                "template_id",
+                "relation_type",
+                name="uq_user_template_relation",
+            ),
+        ]
+        if "users" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE")
+            )
+
+        op.create_table(
+            "user_template_relations",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("template_id", sa.String(length=200), nullable=False),
+            sa.Column("relation_type", sa.String(length=50), nullable=False),
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            *constraints,
+        )
+
+    existing_indexes = _index_names("user_template_relations")
+    if "ix_user_template_relations_user_id" not in existing_indexes:
+        op.create_index(
+            op.f("ix_user_template_relations_user_id"),
+            "user_template_relations",
+            ["user_id"],
+            unique=False,
+        )
+    if "ix_user_template_relations_template_id" not in existing_indexes:
+        op.create_index(
+            op.f("ix_user_template_relations_template_id"),
+            "user_template_relations",
+            ["template_id"],
+            unique=False,
+        )
+    if "ix_user_template_relations_relation_type" not in existing_indexes:
+        op.create_index(
+            op.f("ix_user_template_relations_relation_type"),
+            "user_template_relations",
+            ["relation_type"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "user_template_relations" not in inspector.get_table_names():
+        return
+
+    existing_indexes = _index_names("user_template_relations")
+    if "ix_user_template_relations_relation_type" in existing_indexes:
+        op.drop_index(
+            op.f("ix_user_template_relations_relation_type"),
+            table_name="user_template_relations",
+        )
+    if "ix_user_template_relations_template_id" in existing_indexes:
+        op.drop_index(
+            op.f("ix_user_template_relations_template_id"),
+            table_name="user_template_relations",
+        )
+    if "ix_user_template_relations_user_id" in existing_indexes:
+        op.drop_index(
+            op.f("ix_user_template_relations_user_id"),
+            table_name="user_template_relations",
+        )
+
+    op.drop_table("user_template_relations")

--- a/src/xagent/web/api/templates.py
+++ b/src/xagent/web/api/templates.py
@@ -9,14 +9,17 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..auth_dependencies import get_current_user
 from ..models.database import get_db
-from ..models.template_stats import TemplateStats
+from ..models.template_stats import TemplateStats, UserTemplateRelation
 from ..models.user import User
 
 logger = logging.getLogger(__name__)
+
+TEMPLATE_RELATION_LIKE = "like"
 
 
 # ===== Helper Functions =====
@@ -93,6 +96,9 @@ class TemplateInfo(BaseModel):
     views: int = Field(default=0, description="Number of views")
     likes: int = Field(default=0, description="Number of likes")
     used_count: int = Field(default=0, description="Number of times used")
+    is_liked: bool = Field(
+        default=False, description="Whether the current user liked this template"
+    )
 
 
 class TemplateDetail(TemplateInfo):
@@ -129,6 +135,83 @@ def get_or_create_template_stats(db: Session, template_id: str) -> TemplateStats
     return stats
 
 
+def get_or_create_template_stats_map(
+    db: Session, template_ids: list[str]
+) -> dict[str, TemplateStats]:
+    """Get or create template stats records for a list of template IDs."""
+    unique_template_ids = list(dict.fromkeys(template_ids))
+    if not unique_template_ids:
+        return {}
+
+    stats_list = (
+        db.query(TemplateStats)
+        .filter(TemplateStats.template_id.in_(unique_template_ids))
+        .all()
+    )
+    stats_by_template_id = {stats.template_id: stats for stats in stats_list}
+    missing_template_ids = [
+        template_id
+        for template_id in unique_template_ids
+        if template_id not in stats_by_template_id
+    ]
+
+    if missing_template_ids:
+        new_stats = [
+            TemplateStats(template_id=template_id)
+            for template_id in missing_template_ids
+        ]
+        db.add_all(new_stats)
+        db.commit()
+        for stats in new_stats:
+            db.refresh(stats)
+            stats_by_template_id[stats.template_id] = stats
+
+    return stats_by_template_id
+
+
+def get_liked_template_ids(
+    db: Session, user_id: int, template_ids: list[str]
+) -> set[str]:
+    """Return template IDs liked by the given user."""
+    if not template_ids:
+        return set()
+
+    rows = (
+        db.query(UserTemplateRelation.template_id)
+        .filter(
+            UserTemplateRelation.user_id == user_id,
+            UserTemplateRelation.template_id.in_(template_ids),
+            UserTemplateRelation.relation_type == TEMPLATE_RELATION_LIKE,
+            UserTemplateRelation.is_active.is_(True),
+        )
+        .all()
+    )
+    return {row[0] for row in rows}
+
+
+def is_template_liked(db: Session, user_id: int, template_id: str) -> bool:
+    """Return whether the current user has an active like relation."""
+    return (
+        db.query(UserTemplateRelation.id)
+        .filter(
+            UserTemplateRelation.user_id == user_id,
+            UserTemplateRelation.template_id == template_id,
+            UserTemplateRelation.relation_type == TEMPLATE_RELATION_LIKE,
+            UserTemplateRelation.is_active.is_(True),
+        )
+        .first()
+        is not None
+    )
+
+
+def increment_template_likes(db: Session, template_id: str) -> None:
+    """Increment template likes atomically in the database."""
+    db.query(TemplateStats).filter(TemplateStats.template_id == template_id).update(
+        {TemplateStats.likes: TemplateStats.likes + 1},
+        synchronize_session=False,
+    )
+
+
 # ===== Endpoints =====
 
 
@@ -150,12 +233,16 @@ async def list_templates(
     """
     template_manager = request.app.state.template_manager
     templates = await template_manager.list_templates()
+    template_ids = [template["id"] for template in templates]
+    current_user_id = int(current_user.id)
+    liked_template_ids = get_liked_template_ids(db, current_user_id, template_ids)
+    stats_by_template_id = get_or_create_template_stats_map(db, template_ids)
 
     # Get statistics from database
     result = []
     for template in templates:
         template_id = template["id"]
-        stats = get_or_create_template_stats(db, template_id)
+        stats = stats_by_template_id[template_id]
 
         # Get localized values
         description = get_localized_value(template.get("descriptions", {}), lang, "")
@@ -182,6 +269,7 @@ async def list_templates(
                 views=stats.views,
                 likes=stats.likes,
                 used_count=stats.used_count,
+                is_liked=template_id in liked_template_ids,
             )
         )
 
@@ -246,6 +334,7 @@ async def get_template(
         views=stats.views,
         likes=stats.likes,
         used_count=stats.used_count,
+        is_liked=is_template_liked(db, int(current_user.id), template_id),
         agent_config={
             "instructions": template["agent_config"].get("instructions", ""),
             "skills": template["agent_config"].get("skills", []),
@@ -283,10 +372,44 @@ async def like_template(
         raise HTTPException(status_code=404, detail="Template not found")
 
     stats = get_or_create_template_stats(db, template_id)
+    current_user_id = int(current_user.id)
 
-    # Simple toggle like (in production, track user-specific likes)
-    stats.likes += 1
-    db.commit()
+    relation = (
+        db.query(UserTemplateRelation)
+        .filter(
+            UserTemplateRelation.user_id == current_user_id,
+            UserTemplateRelation.template_id == template_id,
+            UserTemplateRelation.relation_type == TEMPLATE_RELATION_LIKE,
+        )
+        .first()
+    )
+
+    if relation and relation.is_active:
+        return LikeResponse(liked=True, likes=stats.likes)
+
+    try:
+        if relation:
+            relation.is_active = True
+        else:
+            relation = UserTemplateRelation(
+                user_id=current_user_id,
+                template_id=template_id,
+                relation_type=TEMPLATE_RELATION_LIKE,
+                is_active=True,
+            )
+            db.add(relation)
+
+        increment_template_likes(db, template_id)
+        db.commit()
+        db.refresh(stats)
+    except IntegrityError:
+        db.rollback()
+        logger.info(
+            "Duplicate like relation detected for user_id=%s template_id=%s",
+            current_user_id,
+            template_id,
+        )
+        stats = get_or_create_template_stats(db, template_id)
 
     return LikeResponse(liked=True, likes=stats.likes)
 

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -9,7 +9,7 @@ from .public_mcp import PublicMCPApp
 from .sandbox import SandboxInfo, SandboxSnapshot
 from .system_setting import SystemSetting
 from .task import DAGExecution, Task
-from .template_stats import TemplateStats
+from .template_stats import TemplateStats, UserTemplateRelation
 from .text2sql import Text2SQLDatabase
 from .tool_config import ToolConfig, ToolUsage
 from .uploaded_file import UploadedFile
@@ -35,6 +35,7 @@ __all__ = [
     "Task",
     "DAGExecution",
     "TemplateStats",
+    "UserTemplateRelation",
     "Text2SQLDatabase",
     "ToolConfig",
     "ToolUsage",

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -58,6 +58,7 @@ def init_db(db_url: str | None = None) -> None:
         User,
         UserDefaultModel,
         UserModel,
+        UserTemplateRelation,
     )
     from .agent import Agent  # noqa: F401
     from .sandbox import SandboxInfo, SandboxSnapshot  # noqa: F401

--- a/src/xagent/web/models/template_stats.py
+++ b/src/xagent/web/models/template_stats.py
@@ -2,8 +2,16 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .database import Base
 
@@ -34,3 +42,44 @@ class TemplateStats(Base):  # type: ignore
 
     def __repr__(self) -> str:
         return f"<TemplateStats(template_id='{self.template_id}', views={self.views}, likes={self.likes})>"
+
+
+class UserTemplateRelation(Base):  # type: ignore
+    """User-template relationship state for likes and future template actions."""
+
+    __tablename__ = "user_template_relations"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "template_id",
+            "relation_type",
+            name="uq_user_template_relation",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    template_id: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    relation_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user = relationship("User", back_populates="template_relations")
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserTemplateRelation(user_id={self.user_id}, "
+            f"template_id='{self.template_id}', relation_type='{self.relation_type}', "
+            f"is_active={self.is_active})>"
+        )

--- a/src/xagent/web/models/user.py
+++ b/src/xagent/web/models/user.py
@@ -69,6 +69,9 @@ class User(Base):  # type: ignore
     tool_configs = relationship(
         "UserToolConfig", back_populates="user", cascade="all, delete-orphan"
     )
+    template_relations = relationship(
+        "UserTemplateRelation", back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, username='{self.username}', is_admin={self.is_admin})>"

--- a/tests/web/api/test_templates_api.py
+++ b/tests/web/api/test_templates_api.py
@@ -8,10 +8,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 
-from xagent.web.api.auth import auth_router
+from xagent.web.api.auth import auth_router, hash_password
+from xagent.web.api.templates import (
+    increment_template_likes,
+)
 from xagent.web.api.templates import router as templates_router
 from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.models.template_stats import TemplateStats, UserTemplateRelation
+from xagent.web.models.user import User
 
 
 def override_get_db():
@@ -45,6 +51,23 @@ def ensure_system_initialized() -> None:
         )
         assert setup_response.status_code == 200
         assert setup_response.json().get("success") is True
+
+
+def create_user_headers(username: str, password: str = "user123") -> dict[str, str]:
+    db = next(get_db())
+    user = User(username=username, password_hash=hash_password(password))
+    db.add(user)
+    db.commit()
+    db.close()
+
+    response = client.post(
+        "/api/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("success") is True
+    return {"Authorization": f"Bearer {data['access_token']}"}
 
 
 @pytest.fixture(scope="function")
@@ -210,9 +233,26 @@ class TestTemplatesAPI:
             assert "views" in template
             assert "likes" in template
             assert "used_count" in template
+            assert "is_liked" in template
             assert template["views"] == 0
             assert template["likes"] == 0
             assert template["used_count"] == 0
+            assert template["is_liked"] is False
+
+            db = next(get_db())
+            try:
+                assert db.query(TemplateStats).count() == 2
+            finally:
+                db.close()
+
+            response = client.get("/api/templates/", headers=admin_headers)
+            assert response.status_code == 200
+
+            db = next(get_db())
+            try:
+                assert db.query(TemplateStats).count() == 2
+            finally:
+                db.close()
 
     def test_get_template_detail(self, mock_app_state, admin_headers):
         """测试获取模板详情"""
@@ -244,9 +284,19 @@ class TestTemplatesAPI:
             assert response.status_code == 404
 
     def test_like_template(self, mock_app_state, admin_headers):
-        """测试点赞模板"""
+        """测试同一用户重复点赞只计数一次"""
         with patch.object(client.app, "state", mock_app_state):
             # 第一次点赞
+            response = client.post(
+                "/api/templates/customer_support/like", headers=admin_headers
+            )
+
+            assert response.status_code == 200
+            result = response.json()
+            assert result["liked"] is True
+            assert result["likes"] == 1
+
+            # 同一用户重复点赞应幂等，不重复增加
             response = client.post(
                 "/api/templates/customer_support/like", headers=admin_headers
             )
@@ -260,7 +310,161 @@ class TestTemplatesAPI:
             response = client.get(
                 "/api/templates/customer_support", headers=admin_headers
             )
+            detail = response.json()
+            assert detail["likes"] == 1
+            assert detail["is_liked"] is True
+
+            # 获取模板列表验证当前用户点赞状态
+            response = client.get("/api/templates/", headers=admin_headers)
+            assert response.status_code == 200
+            templates = response.json()
+            liked_template = next(
+                template
+                for template in templates
+                if template["id"] == "customer_support"
+            )
+            assert liked_template["likes"] == 1
+            assert liked_template["is_liked"] is True
+
+    def test_like_template_from_different_users_counts_separately(
+        self, mock_app_state, admin_headers
+    ):
+        """测试不同用户点赞同一模板分别计数"""
+        user_headers = create_user_headers("template_like_user")
+
+        with patch.object(client.app, "state", mock_app_state):
+            response = client.post(
+                "/api/templates/customer_support/like", headers=admin_headers
+            )
+            assert response.status_code == 200
             assert response.json()["likes"] == 1
+
+            response = client.post(
+                "/api/templates/customer_support/like", headers=user_headers
+            )
+            assert response.status_code == 200
+            assert response.json()["likes"] == 2
+
+    def test_like_template_not_found(self, mock_app_state, admin_headers):
+        """测试点赞不存在模板仍返回 404"""
+        with patch.object(client.app, "state", mock_app_state):
+            response = client.post(
+                "/api/templates/nonexistent/like", headers=admin_headers
+            )
+            assert response.status_code == 404
+
+    def test_user_template_relation_unique_constraint(self, admin_user):
+        """测试同一用户同一模板同一关系类型只能有一条数据"""
+        db = next(get_db())
+        try:
+            relation = UserTemplateRelation(
+                user_id=admin_user["id"],
+                template_id="customer_support",
+                relation_type="like",
+                is_active=True,
+            )
+            duplicate = UserTemplateRelation(
+                user_id=admin_user["id"],
+                template_id="customer_support",
+                relation_type="like",
+                is_active=True,
+            )
+            db.add(relation)
+            db.commit()
+
+            db.add(duplicate)
+            with pytest.raises(IntegrityError):
+                db.commit()
+            db.rollback()
+        finally:
+            db.close()
+
+    def test_inactive_like_relation_reactivates(
+        self, mock_app_state, admin_headers, admin_user
+    ):
+        """测试 inactive 的点赞关系再次 like 会重新激活并增加计数"""
+        db = next(get_db())
+        try:
+            db.add(TemplateStats(template_id="customer_support", likes=0))
+            db.add(
+                UserTemplateRelation(
+                    user_id=admin_user["id"],
+                    template_id="customer_support",
+                    relation_type="like",
+                    is_active=False,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        with patch.object(client.app, "state", mock_app_state):
+            response = client.post(
+                "/api/templates/customer_support/like", headers=admin_headers
+            )
+            assert response.status_code == 200
+            assert response.json()["likes"] == 1
+
+        db = next(get_db())
+        try:
+            relation = (
+                db.query(UserTemplateRelation)
+                .filter(
+                    UserTemplateRelation.user_id == admin_user["id"],
+                    UserTemplateRelation.template_id == "customer_support",
+                    UserTemplateRelation.relation_type == "like",
+                )
+                .one()
+            )
+            assert relation.is_active is True
+        finally:
+            db.close()
+
+    def test_increment_template_likes_uses_database_atomic_update(self, test_db):
+        """测试点赞计数不会被 stale session 覆盖"""
+        db = next(get_db())
+        try:
+            db.add(TemplateStats(template_id="customer_support", likes=0))
+            db.commit()
+        finally:
+            db.close()
+
+        db1 = next(get_db())
+        db2 = next(get_db())
+        try:
+            stats1 = (
+                db1.query(TemplateStats)
+                .filter(TemplateStats.template_id == "customer_support")
+                .one()
+            )
+            stats2 = (
+                db2.query(TemplateStats)
+                .filter(TemplateStats.template_id == "customer_support")
+                .one()
+            )
+            assert stats1.likes == 0
+            assert stats2.likes == 0
+
+            increment_template_likes(db1, "customer_support")
+            db1.commit()
+            db1.refresh(stats1)
+            increment_template_likes(db2, "customer_support")
+            db2.commit()
+            db2.refresh(stats2)
+        finally:
+            db1.close()
+            db2.close()
+
+        db = next(get_db())
+        try:
+            stats = (
+                db.query(TemplateStats)
+                .filter(TemplateStats.template_id == "customer_support")
+                .one()
+            )
+            assert stats.likes == 2
+        finally:
+            db.close()
 
     def test_use_template(self, mock_app_state, admin_headers):
         """测试使用模板"""
@@ -329,6 +533,7 @@ class TestTemplatesAPI:
                 "views",
                 "likes",
                 "used_count",
+                "is_liked",
             ]
             for field in required_fields:
                 assert field in template, f"Missing field: {field}"


### PR DESCRIPTION
## Summary

Fix template likes so the same user can only have one active like per template.

## Changes

- Add `user_template_relations` with `(user_id, template_id, relation_type)` uniqueness.
- Make `/api/templates/{template_id}/like` idempotent for repeated likes from the same user.
- Return `is_liked` in template list/detail responses and reflect liked state in the template cards.
- Use a database-side atomic increment for `template_stats.likes` after a like relation is created or reactivated.

## Validation

- `uv run pytest tests/web/api/test_templates_api.py`
- `uv run pre-commit run --files src/xagent/web/api/templates.py tests/web/api/test_templates_api.py`
- Earlier full scoped pre-commit run for this branch also covered ruff, mypy, alembic check, npm lint, and npm type-check.
