### PR TITLE
feat(workforce): add core runtime and UI

### DIFF
--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -21,13 +21,14 @@ import { FilePreviewActionButtons } from "@/components/file/file-preview-action-
 import { getTaskBackHref } from "./task-navigation";
 
 function TaskDetailContent() {
-  const { state, sendMessage, setTaskId, openFilePreview, closeFilePreview, requestStatus, dispatch, pauseTask, resumeTask } = useApp();
+  const { state, sendMessage, executeTask, setTaskId, openFilePreview, closeFilePreview, requestStatus, dispatch, pauseTask, resumeTask, isConnected } = useApp();
   const { t } = useI18n();
   const [files, setFiles] = useState<File[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const params = useParams();
   const router = useRouter();
   const taskIdFromUrl = params.id;
+  const autoStartedWorkforceTasksRef = useRef<Set<number>>(new Set());
 
   // DAG preview toggle and layout
   const [dagPreviewOpen, setDagPreviewOpen] = useState(false);
@@ -87,6 +88,24 @@ function TaskDetailContent() {
       }
     }
   }, [taskIdFromUrl, setTaskId, state.taskId]);
+
+  useEffect(() => {
+    const task = state.currentTask;
+    if (!isConnected || !state.taskId || !task?.workforceId || !task.description) {
+      return;
+    }
+
+    if (task.status?.toLowerCase() !== "pending") {
+      return;
+    }
+
+    if (autoStartedWorkforceTasksRef.current.has(state.taskId)) {
+      return;
+    }
+
+    autoStartedWorkforceTasksRef.current.add(state.taskId);
+    executeTask(task.description);
+  }, [executeTask, isConnected, state.currentTask, state.taskId]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -198,6 +217,23 @@ function TaskDetailContent() {
     merged.sort((a, b) => a.timestamp - b.timestamp);
     return merged;
   }, [state.messages]);
+
+  const timelineItems: CombinedItem[] = useMemo(() => {
+    if (combinedItems.length > 0 || !state.currentTask?.description) {
+      return combinedItems;
+    }
+
+    const createdAt = state.currentTask.createdAt
+      ? new Date(state.currentTask.createdAt).getTime()
+      : Date.now();
+
+    return [{
+      id: `task-${state.currentTask.id}-description`,
+      role: "user",
+      content: state.currentTask.description,
+      timestamp: Number.isNaN(createdAt) ? Date.now() : createdAt,
+    }];
+  }, [combinedItems, state.currentTask]);
 
   // DAG node and edge calculation
   const dagreGraph = new dagre.graphlib.Graph();
@@ -311,8 +347,8 @@ function TaskDetailContent() {
   }
 
   const hasFinalAssistantMessage =
-    combinedItems.length > 0 &&
-    combinedItems[combinedItems.length - 1].role === "assistant";
+    timelineItems.length > 0 &&
+    timelineItems[timelineItems.length - 1].role === "assistant";
 
   const isPlanning = dagNodes.length === 0 && state.dagExecution?.phase === "planning";
   const hasError = dagNodes.length === 0 && (state.dagExecution?.phase === "failed" || state.currentTask?.status === "failed");
@@ -348,7 +384,7 @@ function TaskDetailContent() {
         <div className="flex-1 overflow-y-auto">
           <main className={`container max-w-4xl mx-auto px-4 py-8 relative z-0 transition-all`}>
             <div className="space-y-6 pb-4">
-              {state.isHistoryLoading || combinedItems.length === 0 ? (
+              {state.isHistoryLoading && timelineItems.length === 0 ? (
                 <div className="flex flex-col items-center justify-center min-h-[60vh] py-16 text-center">
                   <div className="relative mb-6">
                     <div className="w-16 h-16 rounded-2xl bg-muted/30 flex items-center justify-center animate-pulse">
@@ -361,7 +397,7 @@ function TaskDetailContent() {
                 </div>
               ) : (
                 <>
-                  {combinedItems.map((item) => (
+                  {timelineItems.map((item) => (
                     <ChatMessage
                       key={item.id}
                       role={item.role}

--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -18,6 +18,7 @@ import type React from "react";
 import dagre from "dagre"
 import { CenterPanel } from "@/components/layout/center-panel"
 import { FilePreviewActionButtons } from "@/components/file/file-preview-action-buttons"
+import { getTaskBackHref } from "./task-navigation";
 
 function TaskDetailContent() {
   const { state, sendMessage, setTaskId, openFilePreview, closeFilePreview, requestStatus, dispatch, pauseTask, resumeTask } = useApp();
@@ -321,20 +322,15 @@ function TaskDetailContent() {
       ref={containerRef}
       className={`h-full bg-background relative transition-all flex ${anyPreviewOpen ? 'flex-row items-stretch' : 'flex-col'} overflow-hidden`}
     >
-      {/* Back Button - Only show if this task is from an agent */}
-      {state.currentTask?.agentId && (
+      {/* Back Button - Show for agent and workforce tasks */}
+      {(state.currentTask?.agentId || state.currentTask?.workforceId) && (
         <div className="absolute top-4 left-4 z-50">
           <Button
             variant="ghost"
             size="icon"
             className="rounded-full bg-background/50 hover:bg-background/80 backdrop-blur border shadow-sm"
             onClick={() => {
-              const agentId = state.currentTask?.agentId;
-              if (agentId) {
-                router.push(`/agent/${agentId}`);
-              } else {
-                router.push("/task");
-              }
+              router.push(getTaskBackHref(state.currentTask));
             }}
             title={t("common.back")}
           >

--- a/frontend/src/app/task/[id]/task-navigation.test.ts
+++ b/frontend/src/app/task/[id]/task-navigation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { getTaskBackHref } from "./task-navigation"
+
+describe("getTaskBackHref", () => {
+  it("prefers workforce run pages for workforce tasks", () => {
+    expect(getTaskBackHref({ agentId: 10, workforceId: 20 })).toBe("/workforces/20/run")
+  })
+
+  it("falls back to the agent page for regular agent tasks", () => {
+    expect(getTaskBackHref({ agentId: 10 })).toBe("/agent/10")
+  })
+
+  it("falls back to the task list without a task source", () => {
+    expect(getTaskBackHref(null)).toBe("/task")
+  })
+})

--- a/frontend/src/app/task/[id]/task-navigation.ts
+++ b/frontend/src/app/task/[id]/task-navigation.ts
@@ -1,0 +1,14 @@
+interface TaskBackTarget {
+  agentId?: number
+  workforceId?: number
+}
+
+export function getTaskBackHref(task: TaskBackTarget | null | undefined): string {
+  if (task?.workforceId) {
+    return `/workforces/${task.workforceId}/run`
+  }
+  if (task?.agentId) {
+    return `/agent/${task.agentId}`
+  }
+  return "/task"
+}

--- a/frontend/src/app/workforces/[id]/builder/page.tsx
+++ b/frontend/src/app/workforces/[id]/builder/page.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useParams } from "next/navigation"
+import { toast } from "sonner"
+import {
+  applyWorkforceChanges,
+  getWorkforce,
+  getWorkforceBuilderMessages,
+  proposeWorkforceChanges,
+} from "@/lib/workforces-api"
+import type {
+  WorkforceBuilderMessage,
+  WorkforceBuilderPatch,
+  WorkforceDetail,
+} from "@/types/workforce"
+import { WorkforceBuilderChat } from "../../components/workforce-builder-chat"
+import { ProposedPatchCard } from "../../components/proposed-patch-card"
+import { WorkforceSummary } from "../../components/workforce-summary"
+import { WorkforceTestPanel } from "../../components/workforce-test-panel"
+
+function latestProposedAssistantMessage(
+  messages: WorkforceBuilderMessage[],
+): WorkforceBuilderMessage | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const item = messages[index]
+    if (item.role === "assistant" && item.proposed_patch) {
+      return item
+    }
+  }
+  return null
+}
+
+export default function WorkforceBuilderPage() {
+  const params = useParams()
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [messages, setMessages] = useState<WorkforceBuilderMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [applying, setApplying] = useState(false)
+
+  const activeProposal = useMemo(() => latestProposedAssistantMessage(messages), [messages])
+
+  useEffect(() => {
+    if (!id) return
+
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const [workforceData, historyData] = await Promise.all([
+          getWorkforce(id),
+          getWorkforceBuilderMessages(id),
+        ])
+        setWorkforce(workforceData)
+        setMessages(historyData.items)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load builder")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void load()
+  }, [id])
+
+  const handleSubmit = async (message: string) => {
+    if (!id) return
+    try {
+      setSubmitting(true)
+      const result = await proposeWorkforceChanges(id, { message })
+      const history = await getWorkforceBuilderMessages(id)
+      setMessages(history.items)
+      toast.success(result.assistant_message || "Builder proposal created")
+    } catch (err) {
+      const nextError = err instanceof Error ? err.message : "Failed to propose changes"
+      toast.error(nextError)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleApply = async (messageId: number, patch: WorkforceBuilderPatch) => {
+    if (!id) return
+    try {
+      setApplying(true)
+      const result = await applyWorkforceChanges(id, {
+        message_id: messageId,
+        proposed_patch: patch,
+      })
+      setWorkforce(result.workforce)
+      const history = await getWorkforceBuilderMessages(id)
+      setMessages(history.items)
+      toast.success("Workforce changes applied")
+    } catch (err) {
+      const nextError = err instanceof Error ? err.message : "Failed to apply changes"
+      toast.error(nextError)
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  if (loading) return <div className="p-8 text-muted-foreground">Loading builder...</div>
+  if (error) return <div className="p-8 text-red-500">{error}</div>
+  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+
+  return (
+    <div className="mx-auto grid w-full max-w-[1600px] gap-6 p-8 xl:grid-cols-[0.95fr_1.05fr_0.8fr]">
+      <div className="min-h-[640px]">
+        <WorkforceBuilderChat
+          messages={messages}
+          loading={loading}
+          submitting={submitting}
+          onSubmit={handleSubmit}
+        />
+      </div>
+      <div className="space-y-6">
+        <WorkforceSummary workforce={workforce} />
+        <ProposedPatchCard
+          patch={activeProposal?.proposed_patch ?? null}
+          messageId={activeProposal?.id ?? null}
+          status={activeProposal?.status ?? null}
+          applying={applying}
+          onApply={handleApply}
+        />
+      </div>
+      <div>
+        <WorkforceTestPanel workforceId={workforce.id} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/builder/page.tsx
+++ b/frontend/src/app/workforces/[id]/builder/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { useParams } from "next/navigation"
 import { toast } from "sonner"
+import { useI18n } from "@/contexts/i18n-context"
 import {
   applyWorkforceChanges,
   getWorkforce,
@@ -32,6 +33,7 @@ function latestProposedAssistantMessage(
 }
 
 export default function WorkforceBuilderPage() {
+  const { t } = useI18n()
   const params = useParams()
   const id = Array.isArray(params.id) ? params.id[0] : params.id
   const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
@@ -57,14 +59,14 @@ export default function WorkforceBuilderPage() {
         setWorkforce(workforceData)
         setMessages(historyData.items)
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load builder")
+        setError(err instanceof Error ? err.message : t("workforces.errors.loadBuilder"))
       } finally {
         setLoading(false)
       }
     }
 
     void load()
-  }, [id])
+  }, [id, t])
 
   const handleSubmit = async (message: string) => {
     if (!id) return
@@ -73,9 +75,9 @@ export default function WorkforceBuilderPage() {
       const result = await proposeWorkforceChanges(id, { message })
       const history = await getWorkforceBuilderMessages(id)
       setMessages(history.items)
-      toast.success(result.assistant_message || "Builder proposal created")
+      toast.success(result.assistant_message || t("workforces.messages.proposalCreated"))
     } catch (err) {
-      const nextError = err instanceof Error ? err.message : "Failed to propose changes"
+      const nextError = err instanceof Error ? err.message : t("workforces.errors.proposeChanges")
       toast.error(nextError)
     } finally {
       setSubmitting(false)
@@ -93,18 +95,18 @@ export default function WorkforceBuilderPage() {
       setWorkforce(result.workforce)
       const history = await getWorkforceBuilderMessages(id)
       setMessages(history.items)
-      toast.success("Workforce changes applied")
+      toast.success(t("workforces.messages.changesApplied"))
     } catch (err) {
-      const nextError = err instanceof Error ? err.message : "Failed to apply changes"
+      const nextError = err instanceof Error ? err.message : t("workforces.errors.applyChanges")
       toast.error(nextError)
     } finally {
       setApplying(false)
     }
   }
 
-  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading builder...</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.builder")}</div>
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
-  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
   return (
     <div className="h-full overflow-y-auto">

--- a/frontend/src/app/workforces/[id]/builder/page.tsx
+++ b/frontend/src/app/workforces/[id]/builder/page.tsx
@@ -102,32 +102,34 @@ export default function WorkforceBuilderPage() {
     }
   }
 
-  if (loading) return <div className="p-8 text-muted-foreground">Loading builder...</div>
-  if (error) return <div className="p-8 text-red-500">{error}</div>
-  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading builder...</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
 
   return (
-    <div className="mx-auto grid w-full max-w-[1600px] gap-6 p-8 xl:grid-cols-[0.95fr_1.05fr_0.8fr]">
-      <div className="min-h-[640px]">
-        <WorkforceBuilderChat
-          messages={messages}
-          loading={loading}
-          submitting={submitting}
-          onSubmit={handleSubmit}
-        />
-      </div>
-      <div className="space-y-6">
-        <WorkforceSummary workforce={workforce} />
-        <ProposedPatchCard
-          patch={activeProposal?.proposed_patch ?? null}
-          messageId={activeProposal?.id ?? null}
-          status={activeProposal?.status ?? null}
-          applying={applying}
-          onApply={handleApply}
-        />
-      </div>
-      <div>
-        <WorkforceTestPanel workforceId={workforce.id} />
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto grid w-full max-w-[1600px] gap-6 p-4 sm:p-8 xl:grid-cols-[0.95fr_1.05fr_0.8fr]">
+        <div className="min-h-[640px]">
+          <WorkforceBuilderChat
+            messages={messages}
+            loading={loading}
+            submitting={submitting}
+            onSubmit={handleSubmit}
+          />
+        </div>
+        <div className="space-y-6">
+          <WorkforceSummary workforce={workforce} />
+          <ProposedPatchCard
+            patch={activeProposal?.proposed_patch ?? null}
+            messageId={activeProposal?.id ?? null}
+            status={activeProposal?.status ?? null}
+            applying={applying}
+            onApply={handleApply}
+          />
+        </div>
+        <div>
+          <WorkforceTestPanel workforceId={workforce.id} />
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -1,7 +1,10 @@
 "use client"
 
+import Link from "next/link"
 import { useEffect, useState } from "react"
 import { useParams } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { useI18n } from "@/contexts/i18n-context"
 import { getWorkforceCanvas } from "@/lib/workforces-api"
 import type { WorkforceCanvasResponse } from "@/types/workforce"
@@ -35,13 +38,24 @@ export default function WorkforceCanvasPage() {
     void load()
   }, [params.id, t])
 
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const backHref = id ? `/workforces/${id}` : "/workforces"
+
   if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.canvas")}</div>
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
   if (!canvas) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.canvasUnavailable")}</div>
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-7xl p-4 sm:p-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-8">
+        <div>
+          <Link href={backHref}>
+            <Button variant="outline" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t("workforces.canvas.backToDetails")}
+            </Button>
+          </Link>
+        </div>
         <WorkforceCanvas canvas={canvas} />
       </div>
     </div>

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -33,13 +33,15 @@ export default function WorkforceCanvasPage() {
     void load()
   }, [params.id])
 
-  if (loading) return <div className="p-8 text-muted-foreground">Loading canvas...</div>
-  if (error) return <div className="p-8 text-red-500">{error}</div>
-  if (!canvas) return <div className="p-8 text-muted-foreground">Canvas unavailable.</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading canvas...</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!canvas) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Canvas unavailable.</div>
 
   return (
-    <div className="mx-auto w-full max-w-7xl p-8">
-      <WorkforceCanvas canvas={canvas} />
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-7xl p-4 sm:p-8">
+        <WorkforceCanvas canvas={canvas} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useState } from "react"
 import { useParams } from "next/navigation"
+import { useI18n } from "@/contexts/i18n-context"
 import { getWorkforceCanvas } from "@/lib/workforces-api"
 import type { WorkforceCanvasResponse } from "@/types/workforce"
 import { WorkforceCanvas } from "../../components/workforce-canvas"
 
 export default function WorkforceCanvasPage() {
+  const { t } = useI18n()
   const params = useParams()
   const [canvas, setCanvas] = useState<WorkforceCanvasResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -25,17 +27,17 @@ export default function WorkforceCanvasPage() {
         const data = await getWorkforceCanvas(id)
         setCanvas(data)
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load workforce canvas")
+        setError(err instanceof Error ? err.message : t("workforces.errors.loadCanvas"))
       } finally {
         setLoading(false)
       }
     }
     void load()
-  }, [params.id])
+  }, [params.id, t])
 
-  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading canvas...</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.canvas")}</div>
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
-  if (!canvas) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Canvas unavailable.</div>
+  if (!canvas) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.canvasUnavailable")}</div>
 
   return (
     <div className="h-full overflow-y-auto">

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { getWorkforceCanvas } from "@/lib/workforces-api"
+import type { WorkforceCanvasResponse } from "@/types/workforce"
+import { WorkforceCanvas } from "../../components/workforce-canvas"
+
+export default function WorkforceCanvasPage() {
+  const params = useParams()
+  const [canvas, setCanvas] = useState<WorkforceCanvasResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const id = Array.isArray(params.id) ? params.id[0] : params.id
+        if (!id) {
+          setCanvas(null)
+          return
+        }
+        const data = await getWorkforceCanvas(id)
+        setCanvas(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load workforce canvas")
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [params.id])
+
+  if (loading) return <div className="p-8 text-muted-foreground">Loading canvas...</div>
+  if (error) return <div className="p-8 text-red-500">{error}</div>
+  if (!canvas) return <div className="p-8 text-muted-foreground">Canvas unavailable.</div>
+
+  return (
+    <div className="mx-auto w-full max-w-7xl p-8">
+      <WorkforceCanvas canvas={canvas} />
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { getWorkforce } from "@/lib/workforces-api"
+import type { WorkforceDetail } from "@/types/workforce"
+import { WorkforceSummary } from "../components/workforce-summary"
+
+export default function WorkforceDetailPage() {
+  const params = useParams()
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const id = Array.isArray(params.id) ? params.id[0] : params.id
+        if (!id) {
+          setWorkforce(null)
+          return
+        }
+        const data = await getWorkforce(id)
+        setWorkforce(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load workforce")
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [params.id])
+
+  if (loading) return <div className="p-8 text-muted-foreground">Loading workforce...</div>
+  if (error) return <div className="p-8 text-red-500">{error}</div>
+  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">{workforce.name}</h1>
+          <p className="mt-2 text-muted-foreground">
+            Review the current orchestration, then move into Builder, Canvas, or Run.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link href={`/workforces/${workforce.id}/builder`}>
+            <Button variant="outline">Builder</Button>
+          </Link>
+          <Link href={`/workforces/${workforce.id}/canvas`}>
+            <Button variant="outline">Canvas</Button>
+          </Link>
+          <Link href={`/workforces/${workforce.id}/run`}>
+            <Button>Run Workforce</Button>
+          </Link>
+        </div>
+      </div>
+      <WorkforceSummary workforce={workforce} />
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Select } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
 import {
   addWorkforceAgent,
   getWorkforce,
@@ -49,6 +50,7 @@ function buildWorkerEditState(workers: WorkforceWorker[]): Record<number, Worker
 }
 
 export default function WorkforceDetailPage() {
+  const { t } = useI18n()
   const params = useParams()
   const id = Array.isArray(params.id) ? params.id[0] : params.id
   const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
@@ -93,11 +95,11 @@ export default function WorkforceDetailPage() {
       setAgents(agentData)
       syncForm(workforceData)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load workforce")
+      setError(err instanceof Error ? err.message : t("workforces.errors.load"))
     } finally {
       setLoading(false)
     }
-  }, [id, syncForm])
+  }, [id, syncForm, t])
 
   useEffect(() => {
     void load()
@@ -136,9 +138,9 @@ export default function WorkforceDetailPage() {
       })
       setWorkforce(next)
       syncForm(next)
-      setMessage("Workforce updated")
+      setMessage(t("workforces.messages.updated"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update workforce")
+      setError(err instanceof Error ? err.message : t("workforces.errors.update"))
     } finally {
       setSaving(false)
     }
@@ -161,9 +163,9 @@ export default function WorkforceDetailPage() {
       setNewWorkerAlias("")
       setNewWorkerInstructions("")
       await load()
-      setMessage("Worker added")
+      setMessage(t("workforces.messages.workerAdded"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to add worker")
+      setError(err instanceof Error ? err.message : t("workforces.errors.addWorker"))
     } finally {
       setSaving(false)
     }
@@ -192,9 +194,9 @@ export default function WorkforceDetailPage() {
             }
           : current,
       )
-      setMessage("Worker updated")
+      setMessage(t("workforces.messages.workerUpdated"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update worker")
+      setError(err instanceof Error ? err.message : t("workforces.errors.updateWorker"))
     } finally {
       setSaving(false)
     }
@@ -207,17 +209,17 @@ export default function WorkforceDetailPage() {
       setError(null)
       await removeWorkforceAgent(id, workerId)
       await load()
-      setMessage("Worker removed")
+      setMessage(t("workforces.messages.workerRemoved"))
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to remove worker")
+      setError(err instanceof Error ? err.message : t("workforces.errors.removeWorker"))
     } finally {
       setSaving(false)
     }
   }
 
-  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading workforce...</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.detail")}</div>
   if (error && !workforce) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
-  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
   return (
     <div className="h-full overflow-y-auto">
@@ -226,18 +228,18 @@ export default function WorkforceDetailPage() {
         <div>
           <h1 className="text-3xl font-bold">{workforce.name}</h1>
           <p className="mt-2 text-muted-foreground">
-            Review and edit the current orchestration before running it.
+            {t("workforces.detail.description")}
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
           <Link href={`/workforces/${workforce.id}/builder`}>
-            <Button variant="outline">Builder</Button>
+            <Button variant="outline">{t("workforces.actions.builder")}</Button>
           </Link>
           <Link href={`/workforces/${workforce.id}/canvas`}>
-            <Button variant="outline">Canvas</Button>
+            <Button variant="outline">{t("workforces.actions.canvas")}</Button>
           </Link>
           <Link href={`/workforces/${workforce.id}/run`}>
-            <Button>Run Workforce</Button>
+            <Button>{t("workforces.actions.runWorkforce")}</Button>
           </Link>
         </div>
       </div>
@@ -248,15 +250,15 @@ export default function WorkforceDetailPage() {
       <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
         <Card>
           <CardHeader>
-            <CardTitle>Edit Workforce</CardTitle>
+            <CardTitle>{t("workforces.detail.editTitle")}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label>Name</Label>
+              <Label>{t("workforces.fields.name")}</Label>
               <Input value={name} onChange={(event) => setName(event.target.value)} />
             </div>
             <div className="space-y-2">
-              <Label>Description</Label>
+              <Label>{t("workforces.fields.description")}</Label>
               <Textarea
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
@@ -264,7 +266,7 @@ export default function WorkforceDetailPage() {
               />
             </div>
             <div className="space-y-2">
-              <Label>Manager</Label>
+              <Label>{t("workforces.fields.manager")}</Label>
               <Select
                 value={managerAgentId}
                 onValueChange={setManagerAgentId}
@@ -272,7 +274,7 @@ export default function WorkforceDetailPage() {
               />
             </div>
             <div className="space-y-2">
-              <Label>Manager Instructions</Label>
+              <Label>{t("workforces.fields.managerInstructions")}</Label>
               <Textarea
                 value={managerInstructions}
                 onChange={(event) => setManagerInstructions(event.target.value)}
@@ -283,7 +285,7 @@ export default function WorkforceDetailPage() {
               onClick={saveWorkforce}
               disabled={saving || !name.trim() || !managerAgentId}
             >
-              {saving ? "Saving..." : "Save Workforce"}
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.saveWorkforce")}
             </Button>
           </CardContent>
         </Card>
@@ -293,29 +295,29 @@ export default function WorkforceDetailPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Add Worker</CardTitle>
+          <CardTitle>{t("workforces.workers.addTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label>Published Agent</Label>
+            <Label>{t("workforces.fields.publishedAgent")}</Label>
             <Select
               value={newWorkerAgentId}
               onValueChange={setNewWorkerAgentId}
-              placeholder="Choose a worker agent"
+              placeholder={t("workforces.workers.chooseAgent")}
               options={workerOptions}
             />
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label>Alias</Label>
+              <Label>{t("workforces.fields.alias")}</Label>
               <Input
                 value={newWorkerAlias}
                 onChange={(event) => setNewWorkerAlias(event.target.value)}
-                placeholder="Optional display name"
+                placeholder={t("workforces.workers.aliasPlaceholder")}
               />
             </div>
             <div className="space-y-2">
-              <Label>Assignment Instructions</Label>
+              <Label>{t("workforces.fields.assignmentInstructions")}</Label>
               <Textarea
                 value={newWorkerInstructions}
                 onChange={(event) => setNewWorkerInstructions(event.target.value)}
@@ -327,19 +329,19 @@ export default function WorkforceDetailPage() {
             onClick={addWorker}
             disabled={saving || !newWorkerAgentId || !newWorkerInstructions.trim()}
           >
-            Add Worker
+            {t("workforces.actions.addWorker")}
           </Button>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle>Manage Workers</CardTitle>
+          <CardTitle>{t("workforces.workers.manageTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {workforce.workers.length === 0 ? (
             <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-              No workers configured.
+              {t("workforces.workers.noneConfigured")}
             </div>
           ) : (
             workforce.workers
@@ -355,13 +357,13 @@ export default function WorkforceDetailPage() {
                           {worker.alias || worker.agent.name}
                         </div>
                         <div className="text-sm text-muted-foreground">
-                          {worker.agent.name} · {worker.agent.status}
+                          {worker.agent.name} · {t(`workforces.status.${worker.agent.status}`)}
                         </div>
                       </div>
                       <div className="flex flex-wrap gap-2">
                         <Link href={`/build/${worker.agent.id}`} target="_blank">
                           <Button variant="outline" size="sm">
-                            Open Agent
+                            {t("workforces.actions.openAgent")}
                           </Button>
                         </Link>
                         <Button
@@ -370,13 +372,13 @@ export default function WorkforceDetailPage() {
                           onClick={() => void removeWorker(worker.id)}
                           disabled={saving}
                         >
-                          Remove
+                          {t("workforces.actions.remove")}
                         </Button>
                       </div>
                     </div>
                     <div className="mt-4 grid gap-4 md:grid-cols-[1fr_140px_140px]">
                       <div className="space-y-2">
-                        <Label>Alias</Label>
+                        <Label>{t("workforces.fields.alias")}</Label>
                         <Input
                           value={edit.alias}
                           onChange={(event) =>
@@ -388,7 +390,7 @@ export default function WorkforceDetailPage() {
                         />
                       </div>
                       <div className="space-y-2">
-                        <Label>Order</Label>
+                        <Label>{t("workforces.fields.order")}</Label>
                         <Input
                           type="number"
                           value={String(edit.sort_order)}
@@ -404,7 +406,7 @@ export default function WorkforceDetailPage() {
                         />
                       </div>
                       <div className="flex items-center justify-between rounded-lg border px-3 py-2">
-                        <div className="font-medium">Enabled</div>
+                        <div className="font-medium">{t("workforces.fields.enabled")}</div>
                         <Switch
                           checked={edit.enabled}
                           onCheckedChange={(checked) =>
@@ -417,7 +419,7 @@ export default function WorkforceDetailPage() {
                       </div>
                     </div>
                     <div className="mt-4 space-y-2">
-                      <Label>Assignment Instructions</Label>
+                      <Label>{t("workforces.fields.assignmentInstructions")}</Label>
                       <Textarea
                         value={edit.assignment_instructions}
                         onChange={(event) =>
@@ -438,7 +440,7 @@ export default function WorkforceDetailPage() {
                       onClick={() => void saveWorker(worker)}
                       disabled={saving || !edit.assignment_instructions.trim()}
                     >
-                      Save Worker
+                      {t("workforces.actions.saveWorker")}
                     </Button>
                   </div>
                 )

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -15,7 +15,9 @@ import {
   addWorkforceAgent,
   getWorkforce,
   listAgentOptions,
+  publishWorkforce,
   removeWorkforceAgent,
+  unpublishWorkforce,
   updateWorkforce,
   updateWorkforceAgent,
 } from "@/lib/workforces-api"
@@ -217,6 +219,38 @@ export default function WorkforceDetailPage() {
     }
   }
 
+  const publishCurrentWorkforce = async () => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await publishWorkforce(id)
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.published"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.publish"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const unpublishCurrentWorkforce = async () => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await unpublishWorkforce(id)
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.unpublished"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.unpublish"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
   if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.detail")}</div>
   if (error && !workforce) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
   if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
@@ -232,6 +266,20 @@ export default function WorkforceDetailPage() {
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
+          {workforce.status === "draft" ? (
+            <Button onClick={() => void publishCurrentWorkforce()} disabled={saving}>
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.publish")}
+            </Button>
+          ) : null}
+          {workforce.status === "active" ? (
+            <Button
+              variant="outline"
+              onClick={() => void unpublishCurrentWorkforce()}
+              disabled={saving}
+            >
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.unpublish")}
+            </Button>
+          ) : null}
           <Link href={`/workforces/${workforce.id}/builder`}>
             <Button variant="outline">{t("workforces.actions.builder")}</Button>
           </Link>

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -1,42 +1,222 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { getWorkforce } from "@/lib/workforces-api"
-import type { WorkforceDetail } from "@/types/workforce"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  addWorkforceAgent,
+  getWorkforce,
+  listAgentOptions,
+  removeWorkforceAgent,
+  updateWorkforce,
+  updateWorkforceAgent,
+} from "@/lib/workforces-api"
+import type {
+  WorkforceAgentOption,
+  WorkforceDetail,
+  WorkforceWorker,
+} from "@/types/workforce"
 import { WorkforceSummary } from "../components/workforce-summary"
+
+interface WorkerEditState {
+  alias: string
+  assignment_instructions: string
+  enabled: boolean
+  sort_order: number
+}
+
+function workerEditState(worker: WorkforceWorker): WorkerEditState {
+  return {
+    alias: worker.alias || "",
+    assignment_instructions: worker.assignment_instructions,
+    enabled: worker.enabled,
+    sort_order: worker.sort_order,
+  }
+}
+
+function buildWorkerEditState(workers: WorkforceWorker[]): Record<number, WorkerEditState> {
+  return workers.reduce<Record<number, WorkerEditState>>((accumulator, worker) => {
+    accumulator[worker.id] = workerEditState(worker)
+    return accumulator
+  }, {})
+}
 
 export default function WorkforceDetailPage() {
   const params = useParams()
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
   const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [agents, setAgents] = useState<WorkforceAgentOption[]>([])
   const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [managerAgentId, setManagerAgentId] = useState("")
+  const [managerInstructions, setManagerInstructions] = useState("")
+  const [workerEdits, setWorkerEdits] = useState<Record<number, WorkerEditState>>({})
+  const [newWorkerAgentId, setNewWorkerAgentId] = useState("")
+  const [newWorkerAlias, setNewWorkerAlias] = useState("")
+  const [newWorkerInstructions, setNewWorkerInstructions] = useState("")
+
+  const publishedAgents = useMemo(
+    () => agents.filter((agent) => agent.status === "published"),
+    [agents],
+  )
+
+  const syncForm = useCallback((nextWorkforce: WorkforceDetail) => {
+    setName(nextWorkforce.name)
+    setDescription(nextWorkforce.description || "")
+    setManagerAgentId(String(nextWorkforce.manager.id))
+    setManagerInstructions(nextWorkforce.manager_instructions || "")
+    setWorkerEdits(buildWorkerEditState(nextWorkforce.workers))
+  }, [])
+
+  const load = useCallback(async () => {
+    if (!id) return
+    try {
+      setLoading(true)
+      setError(null)
+      const [workforceData, agentData] = await Promise.all([
+        getWorkforce(id),
+        listAgentOptions(),
+      ])
+      setWorkforce(workforceData)
+      setAgents(agentData)
+      syncForm(workforceData)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load workforce")
+    } finally {
+      setLoading(false)
+    }
+  }, [id, syncForm])
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        setLoading(true)
-        setError(null)
-        const id = Array.isArray(params.id) ? params.id[0] : params.id
-        if (!id) {
-          setWorkforce(null)
-          return
-        }
-        const data = await getWorkforce(id)
-        setWorkforce(data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load workforce")
-      } finally {
-        setLoading(false)
-      }
-    }
     void load()
-  }, [params.id])
+  }, [load])
+
+  const managerOptions = publishedAgents
+    .filter((agent) => !workforce?.workers.some((worker) => worker.agent.id === agent.id))
+    .map((agent) => ({
+      value: String(agent.id),
+      label: agent.name,
+      description: agent.description || undefined,
+    }))
+
+  const workerOptions = publishedAgents
+    .filter(
+      (agent) =>
+        String(agent.id) !== managerAgentId &&
+        !workforce?.workers.some((worker) => worker.agent.id === agent.id),
+    )
+    .map((agent) => ({
+      value: String(agent.id),
+      label: agent.name,
+      description: agent.description || undefined,
+    }))
+
+  const saveWorkforce = async () => {
+    if (!id || !name.trim() || !managerAgentId) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await updateWorkforce(id, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        manager_agent_id: Number(managerAgentId),
+        manager_instructions: managerInstructions.trim() || undefined,
+      })
+      setWorkforce(next)
+      syncForm(next)
+      setMessage("Workforce updated")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update workforce")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const addWorker = async () => {
+    if (!id || !newWorkerAgentId || !newWorkerInstructions.trim()) return
+    try {
+      setSaving(true)
+      setError(null)
+      await addWorkforceAgent(id, {
+        source_type: "existing",
+        agent_id: Number(newWorkerAgentId),
+        alias: newWorkerAlias.trim() || undefined,
+        assignment_instructions: newWorkerInstructions.trim(),
+        enabled: true,
+        sort_order: (workforce?.workers.length || 0) + 1,
+      })
+      setNewWorkerAgentId("")
+      setNewWorkerAlias("")
+      setNewWorkerInstructions("")
+      await load()
+      setMessage("Worker added")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add worker")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveWorker = async (worker: WorkforceWorker) => {
+    if (!id) return
+    const edit = workerEdits[worker.id]
+    if (!edit || !edit.assignment_instructions.trim()) return
+    try {
+      setSaving(true)
+      setError(null)
+      const updated = await updateWorkforceAgent(id, worker.id, {
+        alias: edit.alias.trim() || undefined,
+        assignment_instructions: edit.assignment_instructions.trim(),
+        enabled: edit.enabled,
+        sort_order: edit.sort_order,
+      })
+      setWorkforce((current) =>
+        current
+          ? {
+              ...current,
+              workers: current.workers.map((item) =>
+                item.id === updated.id ? updated : item,
+              ),
+            }
+          : current,
+      )
+      setMessage("Worker updated")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update worker")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const removeWorker = async (workerId: number) => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      await removeWorkforceAgent(id, workerId)
+      await load()
+      setMessage("Worker removed")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove worker")
+    } finally {
+      setSaving(false)
+    }
+  }
 
   if (loading) return <div className="p-8 text-muted-foreground">Loading workforce...</div>
-  if (error) return <div className="p-8 text-red-500">{error}</div>
+  if (error && !workforce) return <div className="p-8 text-red-500">{error}</div>
   if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
 
   return (
@@ -45,7 +225,7 @@ export default function WorkforceDetailPage() {
         <div>
           <h1 className="text-3xl font-bold">{workforce.name}</h1>
           <p className="mt-2 text-muted-foreground">
-            Review the current orchestration, then move into Builder, Canvas, or Run.
+            Review and edit the current orchestration before running it.
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
@@ -60,7 +240,211 @@ export default function WorkforceDetailPage() {
           </Link>
         </div>
       </div>
-      <WorkforceSummary workforce={workforce} />
+
+      {error ? <div className="text-sm text-red-500">{error}</div> : null}
+      {message ? <div className="text-sm text-emerald-600">{message}</div> : null}
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Edit Workforce</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Name</Label>
+              <Input value={name} onChange={(event) => setName(event.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label>Description</Label>
+              <Textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Manager</Label>
+              <Select
+                value={managerAgentId}
+                onValueChange={setManagerAgentId}
+                options={managerOptions}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Manager Instructions</Label>
+              <Textarea
+                value={managerInstructions}
+                onChange={(event) => setManagerInstructions(event.target.value)}
+                rows={5}
+              />
+            </div>
+            <Button
+              onClick={saveWorkforce}
+              disabled={saving || !name.trim() || !managerAgentId}
+            >
+              {saving ? "Saving..." : "Save Workforce"}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <WorkforceSummary workforce={workforce} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Worker</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Published Agent</Label>
+            <Select
+              value={newWorkerAgentId}
+              onValueChange={setNewWorkerAgentId}
+              placeholder="Choose a worker agent"
+              options={workerOptions}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Alias</Label>
+              <Input
+                value={newWorkerAlias}
+                onChange={(event) => setNewWorkerAlias(event.target.value)}
+                placeholder="Optional display name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Assignment Instructions</Label>
+              <Textarea
+                value={newWorkerInstructions}
+                onChange={(event) => setNewWorkerInstructions(event.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+          <Button
+            onClick={addWorker}
+            disabled={saving || !newWorkerAgentId || !newWorkerInstructions.trim()}
+          >
+            Add Worker
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Manage Workers</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {workforce.workers.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+              No workers configured.
+            </div>
+          ) : (
+            workforce.workers
+              .slice()
+              .sort((a, b) => a.sort_order - b.sort_order)
+              .map((worker) => {
+                const edit = workerEdits[worker.id] || workerEditState(worker)
+                return (
+                  <div key={worker.id} className="rounded-xl border p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div>
+                        <div className="font-medium">
+                          {worker.alias || worker.agent.name}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {worker.agent.name} · {worker.agent.status}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Link href={`/build/${worker.agent.id}`} target="_blank">
+                          <Button variant="outline" size="sm">
+                            Open Agent
+                          </Button>
+                        </Link>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void removeWorker(worker.id)}
+                          disabled={saving}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="mt-4 grid gap-4 md:grid-cols-[1fr_140px_140px]">
+                      <div className="space-y-2">
+                        <Label>Alias</Label>
+                        <Input
+                          value={edit.alias}
+                          onChange={(event) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: { ...edit, alias: event.target.value },
+                            }))
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Order</Label>
+                        <Input
+                          type="number"
+                          value={String(edit.sort_order)}
+                          onChange={(event) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: {
+                                ...edit,
+                                sort_order: Number(event.target.value) || worker.sort_order,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+                      <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+                        <div className="font-medium">Enabled</div>
+                        <Switch
+                          checked={edit.enabled}
+                          onCheckedChange={(checked) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: { ...edit, enabled: checked },
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-4 space-y-2">
+                      <Label>Assignment Instructions</Label>
+                      <Textarea
+                        value={edit.assignment_instructions}
+                        onChange={(event) =>
+                          setWorkerEdits((current) => ({
+                            ...current,
+                            [worker.id]: {
+                              ...edit,
+                              assignment_instructions: event.target.value,
+                            },
+                          }))
+                        }
+                        rows={4}
+                      />
+                    </div>
+                    <Button
+                      className="mt-4"
+                      variant="outline"
+                      onClick={() => void saveWorker(worker)}
+                      disabled={saving || !edit.assignment_instructions.trim()}
+                    >
+                      Save Worker
+                    </Button>
+                  </div>
+                )
+              })
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -215,12 +215,13 @@ export default function WorkforceDetailPage() {
     }
   }
 
-  if (loading) return <div className="p-8 text-muted-foreground">Loading workforce...</div>
-  if (error && !workforce) return <div className="p-8 text-red-500">{error}</div>
-  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading workforce...</div>
+  if (error && !workforce) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8">
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-8">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold">{workforce.name}</h1>
@@ -445,6 +446,7 @@ export default function WorkforceDetailPage() {
           )}
         </CardContent>
       </Card>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/workforces/[id]/run/page.tsx
+++ b/frontend/src/app/workforces/[id]/run/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { getWorkforce } from "@/lib/workforces-api"
+import type { WorkforceDetail } from "@/types/workforce"
+import { WorkforceSummary } from "../../components/workforce-summary"
+import { WorkforceTestPanel } from "../../components/workforce-test-panel"
+
+export default function WorkforceRunPage() {
+  const params = useParams()
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const id = Array.isArray(params.id) ? params.id[0] : params.id
+        if (!id) {
+          setWorkforce(null)
+          return
+        }
+        const data = await getWorkforce(id)
+        setWorkforce(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load workforce")
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [params.id])
+
+  if (loading) return <div className="p-8 text-muted-foreground">Loading run view...</div>
+  if (error) return <div className="p-8 text-red-500">{error}</div>
+  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+
+  return (
+    <div className="mx-auto grid w-full max-w-7xl gap-6 p-8 lg:grid-cols-[1.1fr_0.9fr]">
+      <WorkforceSummary workforce={workforce} />
+      <WorkforceTestPanel workforceId={workforce.id} />
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/run/page.tsx
+++ b/frontend/src/app/workforces/[id]/run/page.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useState } from "react"
 import { useParams } from "next/navigation"
+import { useI18n } from "@/contexts/i18n-context"
 import { getWorkforce } from "@/lib/workforces-api"
 import type { WorkforceDetail } from "@/types/workforce"
 import { WorkforceSummary } from "../../components/workforce-summary"
 import { WorkforceTestPanel } from "../../components/workforce-test-panel"
 
 export default function WorkforceRunPage() {
+  const { t } = useI18n()
   const params = useParams()
   const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
   const [loading, setLoading] = useState(true)
@@ -26,17 +28,17 @@ export default function WorkforceRunPage() {
         const data = await getWorkforce(id)
         setWorkforce(data)
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load workforce")
+        setError(err instanceof Error ? err.message : t("workforces.errors.load"))
       } finally {
         setLoading(false)
       }
     }
     void load()
-  }, [params.id])
+  }, [params.id, t])
 
-  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading run view...</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.runView")}</div>
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
-  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
   return (
     <div className="h-full overflow-y-auto">

--- a/frontend/src/app/workforces/[id]/run/page.tsx
+++ b/frontend/src/app/workforces/[id]/run/page.tsx
@@ -34,14 +34,16 @@ export default function WorkforceRunPage() {
     void load()
   }, [params.id])
 
-  if (loading) return <div className="p-8 text-muted-foreground">Loading run view...</div>
-  if (error) return <div className="p-8 text-red-500">{error}</div>
-  if (!workforce) return <div className="p-8 text-muted-foreground">Workforce not found.</div>
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading run view...</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Workforce not found.</div>
 
   return (
-    <div className="mx-auto grid w-full max-w-7xl gap-6 p-8 lg:grid-cols-[1.1fr_0.9fr]">
-      <WorkforceSummary workforce={workforce} />
-      <WorkforceTestPanel workforceId={workforce.id} />
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto grid w-full max-w-7xl gap-6 p-4 sm:p-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <WorkforceSummary workforce={workforce} />
+        <WorkforceTestPanel workforceId={workforce.id} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/workforces/components/manager-step.tsx
+++ b/frontend/src/app/workforces/components/manager-step.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Select } from "@/components/ui/select"
+import { useI18n } from "@/contexts/i18n-context"
 import type { WorkforceAgentOption } from "@/types/workforce"
 
 interface ManagerStepProps {
@@ -16,17 +17,19 @@ export function ManagerStep({
   onManagerAgentIdChange,
   agents,
 }: ManagerStepProps) {
+  const { t } = useI18n()
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Manager</CardTitle>
+        <CardTitle>{t("workforces.fields.manager")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
-        <Label>Select the manager agent</Label>
+        <Label>{t("workforces.create.manager.selectLabel")}</Label>
         <Select
           value={managerAgentId}
           onValueChange={onManagerAgentIdChange}
-          placeholder="Choose an agent"
+          placeholder={t("workforces.create.manager.placeholder")}
           options={agents.map((agent) => ({
             value: String(agent.id),
             label: agent.name,

--- a/frontend/src/app/workforces/components/manager-step.tsx
+++ b/frontend/src/app/workforces/components/manager-step.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
+import type { WorkforceAgentOption } from "@/types/workforce"
+
+interface ManagerStepProps {
+  managerAgentId: string
+  onManagerAgentIdChange: (value: string) => void
+  agents: WorkforceAgentOption[]
+}
+
+export function ManagerStep({
+  managerAgentId,
+  onManagerAgentIdChange,
+  agents,
+}: ManagerStepProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Manager</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Label>Select the manager agent</Label>
+        <Select
+          value={managerAgentId}
+          onValueChange={onManagerAgentIdChange}
+          placeholder="Choose an agent"
+          options={agents.map((agent) => ({
+            value: String(agent.id),
+            label: agent.name,
+            description: agent.description || undefined,
+          }))}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/proposed-patch-card.tsx
+++ b/frontend/src/app/workforces/components/proposed-patch-card.tsx
@@ -82,6 +82,14 @@ export function ProposedPatchCard({
               </div>
             </div>
 
+            {patch.clarification ? (
+              <Alert>
+                <AlertTriangle className="size-4" />
+                <AlertTitle>Clarification needed</AlertTitle>
+                <AlertDescription>{patch.clarification}</AlertDescription>
+              </Alert>
+            ) : null}
+
             {patch.warnings.length > 0 ? (
               <Alert className="border-amber-200 bg-amber-50 text-amber-900">
                 <AlertTriangle className="size-4" />

--- a/frontend/src/app/workforces/components/proposed-patch-card.tsx
+++ b/frontend/src/app/workforces/components/proposed-patch-card.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import { AlertTriangle, CheckCircle2, Loader2, Sparkles } from "lucide-react"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type { WorkforceBuilderPatch } from "@/types/workforce"
+
+interface ProposedPatchCardProps {
+  patch: WorkforceBuilderPatch | null
+  messageId: number | null
+  status?: string | null
+  applying?: boolean
+  onApply: (messageId: number, patch: WorkforceBuilderPatch) => Promise<void> | void
+}
+
+function formatOperationTitle(op: string) {
+  return op
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function operationSubtitle(operation: Record<string, unknown>) {
+  if (operation.op === "add_existing_worker") {
+    return `agent_id=${String(operation.agent_id || "")}`
+  }
+  if (operation.op === "add_worker_from_template") {
+    return `template_id=${String(operation.template_id || "")}`
+  }
+  if (operation.op === "create_worker_agent") {
+    const agent = operation.agent as Record<string, unknown> | undefined
+    return `agent=${String(agent?.name || "")}`
+  }
+  if (operation.op === "update_worker" || operation.op === "remove_worker") {
+    return `member_id=${String(operation.member_id || "")}`
+  }
+  return null
+}
+
+export function ProposedPatchCard({
+  patch,
+  messageId,
+  status,
+  applying = false,
+  onApply,
+}: ProposedPatchCardProps) {
+  const alreadyApplied = status === "applied"
+  const canApply = Boolean(
+    patch && messageId && patch.operations.length > 0 && !applying && !alreadyApplied,
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Proposed Patch</CardTitle>
+        <CardDescription>
+          Review the generated workforce changes before applying them.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!patch ? (
+          <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            No proposal yet. Send a request in Builder Chat to generate a patch.
+          </div>
+        ) : (
+          <>
+            <div className="rounded-xl border bg-muted/20 p-4">
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-0.5 size-4 text-primary" />
+                <div>
+                  <div className="font-medium">Summary</div>
+                  <p className="mt-1 text-sm text-muted-foreground">{patch.summary}</p>
+                </div>
+              </div>
+            </div>
+
+            {patch.warnings.length > 0 ? (
+              <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                <AlertTriangle className="size-4" />
+                <AlertTitle>Warnings</AlertTitle>
+                <AlertDescription>
+                  <div className="space-y-1">
+                    {patch.warnings.map((warning, index) => (
+                      <p key={`${warning}-${index}`}>{warning}</p>
+                    ))}
+                  </div>
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Alert>
+                <CheckCircle2 className="size-4 text-emerald-600" />
+                <AlertTitle>Ready to apply</AlertTitle>
+                <AlertDescription>No destructive warning was detected in this patch.</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-medium">Operations</div>
+                <Badge variant="outline">{patch.operations.length} change(s)</Badge>
+              </div>
+              {patch.operations.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                  This proposal does not contain any executable operation yet.
+                </div>
+              ) : (
+                patch.operations.map((operation, index) => (
+                  <div key={`${operation.op}-${index}`} className="rounded-lg border bg-background p-4">
+                    <div className="mb-3 flex items-center justify-between gap-3">
+                      <div>
+                        <div className="font-medium">{formatOperationTitle(operation.op)}</div>
+                        {operationSubtitle(operation) ? (
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {operationSubtitle(operation)}
+                          </div>
+                        ) : null}
+                      </div>
+                      <Badge variant="secondary">#{index + 1}</Badge>
+                    </div>
+                    <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs leading-6 text-muted-foreground">
+                      {JSON.stringify(operation, null, 2)}
+                    </pre>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <Button
+              className="w-full"
+              disabled={!canApply}
+              onClick={() => {
+                if (patch && messageId) {
+                  void onApply(messageId, patch)
+                }
+              }}
+            >
+              {applying ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Applying Changes...
+                </>
+              ) : alreadyApplied ? (
+                "Already Applied"
+              ) : (
+                "Apply Changes"
+              )}
+            </Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/proposed-patch-card.tsx
+++ b/frontend/src/app/workforces/components/proposed-patch-card.tsx
@@ -30,17 +30,17 @@ function formatOperationTitle(op: string) {
 
 function operationSubtitle(operation: Record<string, unknown>) {
   if (operation.op === "add_existing_worker") {
-    return `agent_id=${String(operation.agent_id || "")}`
+    return `agent_id=${String(operation.agent_id ?? "")}`
   }
   if (operation.op === "add_worker_from_template") {
-    return `template_id=${String(operation.template_id || "")}`
+    return `template_id=${String(operation.template_id ?? "")}`
   }
   if (operation.op === "create_worker_agent") {
     const agent = operation.agent as Record<string, unknown> | undefined
-    return `agent=${String(agent?.name || "")}`
+    return `agent=${String(agent?.name ?? "")}`
   }
   if (operation.op === "update_worker" || operation.op === "remove_worker") {
-    return `member_id=${String(operation.member_id || "")}`
+    return `member_id=${String(operation.member_id ?? "")}`
   }
   return null
 }

--- a/frontend/src/app/workforces/components/proposed-patch-card.tsx
+++ b/frontend/src/app/workforces/components/proposed-patch-card.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { useI18n } from "@/contexts/i18n-context"
 import type { WorkforceBuilderPatch } from "@/types/workforce"
 
 interface ProposedPatchCardProps {
@@ -26,6 +27,12 @@ function formatOperationTitle(op: string) {
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ")
+}
+
+function operationTitle(op: string, t: (key: string) => string) {
+  const key = `workforces.builder.operations.${op}`
+  const value = t(key)
+  return value === key ? formatOperationTitle(op) : value
 }
 
 function operationSubtitle(operation: Record<string, unknown>) {
@@ -52,6 +59,7 @@ export function ProposedPatchCard({
   applying = false,
   onApply,
 }: ProposedPatchCardProps) {
+  const { t } = useI18n()
   const alreadyApplied = status === "applied"
   const canApply = Boolean(
     patch && messageId && patch.operations.length > 0 && !applying && !alreadyApplied,
@@ -60,15 +68,15 @@ export function ProposedPatchCard({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Proposed Patch</CardTitle>
+        <CardTitle>{t("workforces.builder.patchTitle")}</CardTitle>
         <CardDescription>
-          Review the generated workforce changes before applying them.
+          {t("workforces.builder.patchDescription")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {!patch ? (
           <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-            No proposal yet. Send a request in Builder Chat to generate a patch.
+            {t("workforces.builder.noProposal")}
           </div>
         ) : (
           <>
@@ -76,7 +84,7 @@ export function ProposedPatchCard({
               <div className="flex items-start gap-3">
                 <Sparkles className="mt-0.5 size-4 text-primary" />
                 <div>
-                  <div className="font-medium">Summary</div>
+                  <div className="font-medium">{t("workforces.builder.summary")}</div>
                   <p className="mt-1 text-sm text-muted-foreground">{patch.summary}</p>
                 </div>
               </div>
@@ -85,7 +93,7 @@ export function ProposedPatchCard({
             {patch.clarification ? (
               <Alert>
                 <AlertTriangle className="size-4" />
-                <AlertTitle>Clarification needed</AlertTitle>
+                <AlertTitle>{t("workforces.builder.clarificationNeeded")}</AlertTitle>
                 <AlertDescription>{patch.clarification}</AlertDescription>
               </Alert>
             ) : null}
@@ -93,7 +101,7 @@ export function ProposedPatchCard({
             {patch.warnings.length > 0 ? (
               <Alert className="border-amber-200 bg-amber-50 text-amber-900">
                 <AlertTriangle className="size-4" />
-                <AlertTitle>Warnings</AlertTitle>
+                <AlertTitle>{t("workforces.builder.warnings")}</AlertTitle>
                 <AlertDescription>
                   <div className="space-y-1">
                     {patch.warnings.map((warning, index) => (
@@ -105,26 +113,26 @@ export function ProposedPatchCard({
             ) : (
               <Alert>
                 <CheckCircle2 className="size-4 text-emerald-600" />
-                <AlertTitle>Ready to apply</AlertTitle>
-                <AlertDescription>No destructive warning was detected in this patch.</AlertDescription>
+                <AlertTitle>{t("workforces.builder.readyToApply")}</AlertTitle>
+                <AlertDescription>{t("workforces.builder.noDestructiveWarning")}</AlertDescription>
               </Alert>
             )}
 
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-3">
-                <div className="font-medium">Operations</div>
-                <Badge variant="outline">{patch.operations.length} change(s)</Badge>
+                <div className="font-medium">{t("workforces.builder.operationsTitle")}</div>
+                <Badge variant="outline">{t("workforces.builder.changeCount", { count: patch.operations.length })}</Badge>
               </div>
               {patch.operations.length === 0 ? (
                 <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-                  This proposal does not contain any executable operation yet.
+                  {t("workforces.builder.noOperations")}
                 </div>
               ) : (
                 patch.operations.map((operation, index) => (
                   <div key={`${operation.op}-${index}`} className="rounded-lg border bg-background p-4">
                     <div className="mb-3 flex items-center justify-between gap-3">
                       <div>
-                        <div className="font-medium">{formatOperationTitle(operation.op)}</div>
+                        <div className="font-medium">{operationTitle(operation.op, t)}</div>
                         {operationSubtitle(operation) ? (
                           <div className="mt-1 text-xs text-muted-foreground">
                             {operationSubtitle(operation)}
@@ -153,12 +161,12 @@ export function ProposedPatchCard({
               {applying ? (
                 <>
                   <Loader2 className="size-4 animate-spin" />
-                  Applying Changes...
+                  {t("workforces.loading.applyingChanges")}
                 </>
               ) : alreadyApplied ? (
-                "Already Applied"
+                t("workforces.actions.alreadyApplied")
               ) : (
-                "Apply Changes"
+                t("workforces.actions.applyChanges")
               )}
             </Button>
           </>

--- a/frontend/src/app/workforces/components/review-step.tsx
+++ b/frontend/src/app/workforces/components/review-step.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { AlertTriangle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useI18n } from "@/contexts/i18n-context"
 import type {
   WorkforceAgentOption,
   WorkforceWorkerDraft,
@@ -26,33 +27,34 @@ export function ReviewStep({
   workers,
   agents,
 }: ReviewStepProps) {
+  const { t } = useI18n()
   const manager = agents.find((agent) => String(agent.id) === managerAgentId)
 
   const warnings: string[] = []
   if (manager && manager.status !== "published") {
-    warnings.push("Manager is not published yet.")
+    warnings.push(t("workforces.review.warnings.managerNotPublished"))
   }
   for (const worker of workers) {
     const agent = agents.find((item) => item.id === worker.agent_id)
     if (agent && agent.status !== "published") {
-      warnings.push(`${worker.alias || agent.name} is not published yet.`)
+      warnings.push(t("workforces.review.warnings.workerNotPublished", { name: worker.alias || agent.name }))
     }
     if (!worker.assignment_instructions.trim()) {
-      warnings.push(`${worker.alias || "A worker"} is missing assignment instructions.`)
+      warnings.push(t("workforces.review.warnings.missingInstructions", { name: worker.alias || t("workforces.workers.aWorker") }))
     }
   }
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Review</CardTitle>
+        <CardTitle>{t("workforces.create.steps.review")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         {warnings.length > 0 ? (
           <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-900">
             <div className="flex items-center gap-2 font-medium">
               <AlertTriangle className="size-4" />
-              Potential Risks
+              {t("workforces.review.potentialRisks")}
             </div>
             <div className="mt-2 space-y-1 text-sm">
               {warnings.map((warning, index) => (
@@ -64,14 +66,14 @@ export function ReviewStep({
 
         <div className="grid gap-4 md:grid-cols-2">
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
-            <div className="mt-1 font-medium">{name || "Untitled Workforce"}</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.name")}</div>
+            <div className="mt-1 font-medium">{name || t("workforces.review.untitled")}</div>
           </div>
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Manager</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.manager")}</div>
             <div className="mt-1 flex items-center gap-2 font-medium">
-              <span>{manager?.name || "Not selected"}</span>
-              {manager ? <Badge variant="outline">{manager.status}</Badge> : null}
+              <span>{manager?.name || t("workforces.common.notSelected")}</span>
+              {manager ? <Badge variant="outline">{t(`workforces.status.${manager.status}`)}</Badge> : null}
             </div>
             {manager ? (
               <Link
@@ -79,44 +81,44 @@ export function ReviewStep({
                 target="_blank"
                 className="mt-2 inline-block text-sm text-primary hover:underline"
               >
-                Open Agent Editor
+                {t("workforces.actions.openAgentEditor")}
               </Link>
             ) : null}
           </div>
         </div>
         <div>
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
-          <div className="mt-1 text-sm text-muted-foreground">{description || "No description"}</div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.description")}</div>
+          <div className="mt-1 text-sm text-muted-foreground">{description || t("workforces.common.noDescription")}</div>
         </div>
         <div>
           <div className="text-xs uppercase tracking-wide text-muted-foreground">
-            Manager Instructions
+            {t("workforces.fields.managerInstructions")}
           </div>
           <div className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
-            {managerInstructions || "No manager instructions"}
+            {managerInstructions || t("workforces.review.noManagerInstructions")}
           </div>
         </div>
         <div>
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.workers")}</div>
           <div className="mt-3 space-y-3">
             {workers.length === 0 ? (
               <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-                No workers configured.
+                {t("workforces.workers.noneConfigured")}
               </div>
             ) : (
               workers.map((worker, index) => {
                 const agent = agents.find((item) => item.id === worker.agent_id)
-                const title = worker.alias || agent?.name || `Worker ${index + 1}`
+                const title = worker.alias || agent?.name || t("workforces.workers.fallbackName", { index: index + 1 })
 
                 return (
                   <div key={`${worker.source_type}-${index}`} className="rounded-lg border p-4">
                     <div className="flex flex-wrap items-center gap-2">
                       <div className="font-medium">{title}</div>
-                      <Badge variant="outline">{worker.source_type}</Badge>
-                      {agent ? <Badge variant="secondary">{agent.status}</Badge> : null}
+                      <Badge variant="outline">{t(`workforces.sourceTypes.${worker.source_type}`)}</Badge>
+                      {agent ? <Badge variant="secondary">{t(`workforces.status.${agent.status}`)}</Badge> : null}
                     </div>
                     <div className="mt-1 text-sm text-muted-foreground">
-                      {agent?.description || "Published agent"}
+                      {agent?.description || t("workforces.workers.publishedAgent")}
                     </div>
                     <div className="mt-3 text-sm text-muted-foreground">
                       {worker.assignment_instructions}

--- a/frontend/src/app/workforces/components/review-step.tsx
+++ b/frontend/src/app/workforces/components/review-step.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import Link from "next/link"
+import { AlertTriangle } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type {
+  WorkforceAgentOption,
+  WorkforceTemplateOption,
+  WorkforceWorkerDraft,
+} from "@/types/workforce"
+
+interface ReviewStepProps {
+  name: string
+  description: string
+  managerAgentId: string
+  managerInstructions: string
+  workers: WorkforceWorkerDraft[]
+  agents: WorkforceAgentOption[]
+  templates: WorkforceTemplateOption[]
+}
+
+export function ReviewStep({
+  name,
+  description,
+  managerAgentId,
+  managerInstructions,
+  workers,
+  agents,
+  templates,
+}: ReviewStepProps) {
+  const manager = agents.find((agent) => String(agent.id) === managerAgentId)
+
+  const warnings: string[] = []
+  if (manager && manager.status !== "published") {
+    warnings.push("Manager is not published yet.")
+  }
+  for (const worker of workers) {
+    if (worker.source_type === "existing") {
+      const agent = agents.find((item) => item.id === worker.agent_id)
+      if (agent && agent.status !== "published") {
+        warnings.push(`${worker.alias || agent.name} is not published yet.`)
+      }
+    }
+    if (!worker.assignment_instructions.trim()) {
+      warnings.push(`${worker.alias || "A worker"} is missing assignment instructions.`)
+    }
+    if (worker.source_type === "new" && worker.agent && !worker.agent.instructions.trim()) {
+      warnings.push(
+        `${worker.alias || worker.agent.name || "A new worker"} is missing agent instructions.`,
+      )
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Review</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {warnings.length > 0 ? (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-900">
+            <div className="flex items-center gap-2 font-medium">
+              <AlertTriangle className="size-4" />
+              Potential Risks
+            </div>
+            <div className="mt-2 space-y-1 text-sm">
+              {warnings.map((warning, index) => (
+                <p key={`${warning}-${index}`}>{warning}</p>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
+            <div className="mt-1 font-medium">{name || "Untitled Workforce"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Manager</div>
+            <div className="mt-1 flex items-center gap-2 font-medium">
+              <span>{manager?.name || "Not selected"}</span>
+              {manager ? <Badge variant="outline">{manager.status}</Badge> : null}
+            </div>
+            {manager ? (
+              <Link
+                href={`/build/${manager.id}`}
+                target="_blank"
+                className="mt-2 inline-block text-sm text-primary hover:underline"
+              >
+                Open Agent Editor
+              </Link>
+            ) : null}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
+          <div className="mt-1 text-sm text-muted-foreground">{description || "No description"}</div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            Manager Instructions
+          </div>
+          <div className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+            {managerInstructions || "No manager instructions"}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+          <div className="mt-3 space-y-3">
+            {workers.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                No workers configured.
+              </div>
+            ) : (
+              workers.map((worker, index) => {
+                const agent = worker.agent_id
+                  ? agents.find((item) => item.id === worker.agent_id)
+                  : null
+                const template = worker.template_id
+                  ? templates.find((item) => item.id === worker.template_id)
+                  : null
+                const title =
+                  worker.alias ||
+                  agent?.name ||
+                  template?.name ||
+                  worker.agent?.name ||
+                  `Worker ${index + 1}`
+
+                return (
+                  <div key={`${worker.source_type}-${index}`} className="rounded-lg border p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="font-medium">{title}</div>
+                      <Badge variant="outline">{worker.source_type}</Badge>
+                      {agent ? <Badge variant="secondary">{agent.status}</Badge> : null}
+                    </div>
+                    <div className="mt-1 text-sm text-muted-foreground">
+                      {worker.source_type === "existing"
+                        ? agent?.description || "Existing agent"
+                        : worker.source_type === "template"
+                          ? template?.description || "Template-based worker"
+                          : worker.agent?.description || "Brand new worker"}
+                    </div>
+                    <div className="mt-3 text-sm text-muted-foreground">
+                      {worker.assignment_instructions}
+                    </div>
+                    {worker.source_type === "new" && worker.agent ? (
+                      <div className="mt-3 rounded-lg bg-muted/30 p-3 text-sm text-muted-foreground">
+                        <div>Agent name: {worker.agent.name}</div>
+                        <div>Execution mode: {worker.agent.execution_mode}</div>
+                      </div>
+                    ) : null}
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/review-step.tsx
+++ b/frontend/src/app/workforces/components/review-step.tsx
@@ -6,7 +6,6 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type {
   WorkforceAgentOption,
-  WorkforceTemplateOption,
   WorkforceWorkerDraft,
 } from "@/types/workforce"
 
@@ -17,7 +16,6 @@ interface ReviewStepProps {
   managerInstructions: string
   workers: WorkforceWorkerDraft[]
   agents: WorkforceAgentOption[]
-  templates: WorkforceTemplateOption[]
 }
 
 export function ReviewStep({
@@ -27,7 +25,6 @@ export function ReviewStep({
   managerInstructions,
   workers,
   agents,
-  templates,
 }: ReviewStepProps) {
   const manager = agents.find((agent) => String(agent.id) === managerAgentId)
 
@@ -36,19 +33,12 @@ export function ReviewStep({
     warnings.push("Manager is not published yet.")
   }
   for (const worker of workers) {
-    if (worker.source_type === "existing") {
-      const agent = agents.find((item) => item.id === worker.agent_id)
-      if (agent && agent.status !== "published") {
-        warnings.push(`${worker.alias || agent.name} is not published yet.`)
-      }
+    const agent = agents.find((item) => item.id === worker.agent_id)
+    if (agent && agent.status !== "published") {
+      warnings.push(`${worker.alias || agent.name} is not published yet.`)
     }
     if (!worker.assignment_instructions.trim()) {
       warnings.push(`${worker.alias || "A worker"} is missing assignment instructions.`)
-    }
-    if (worker.source_type === "new" && worker.agent && !worker.agent.instructions.trim()) {
-      warnings.push(
-        `${worker.alias || worker.agent.name || "A new worker"} is missing agent instructions.`,
-      )
     }
   }
 
@@ -115,18 +105,8 @@ export function ReviewStep({
               </div>
             ) : (
               workers.map((worker, index) => {
-                const agent = worker.agent_id
-                  ? agents.find((item) => item.id === worker.agent_id)
-                  : null
-                const template = worker.template_id
-                  ? templates.find((item) => item.id === worker.template_id)
-                  : null
-                const title =
-                  worker.alias ||
-                  agent?.name ||
-                  template?.name ||
-                  worker.agent?.name ||
-                  `Worker ${index + 1}`
+                const agent = agents.find((item) => item.id === worker.agent_id)
+                const title = worker.alias || agent?.name || `Worker ${index + 1}`
 
                 return (
                   <div key={`${worker.source_type}-${index}`} className="rounded-lg border p-4">
@@ -136,21 +116,11 @@ export function ReviewStep({
                       {agent ? <Badge variant="secondary">{agent.status}</Badge> : null}
                     </div>
                     <div className="mt-1 text-sm text-muted-foreground">
-                      {worker.source_type === "existing"
-                        ? agent?.description || "Existing agent"
-                        : worker.source_type === "template"
-                          ? template?.description || "Template-based worker"
-                          : worker.agent?.description || "Brand new worker"}
+                      {agent?.description || "Published agent"}
                     </div>
                     <div className="mt-3 text-sm text-muted-foreground">
                       {worker.assignment_instructions}
                     </div>
-                    {worker.source_type === "new" && worker.agent ? (
-                      <div className="mt-3 rounded-lg bg-muted/30 p-3 text-sm text-muted-foreground">
-                        <div>Agent name: {worker.agent.name}</div>
-                        <div>Execution mode: {worker.agent.execution_mode}</div>
-                      </div>
-                    ) : null}
                   </div>
                 )
               })

--- a/frontend/src/app/workforces/components/workers-step.tsx
+++ b/frontend/src/app/workforces/components/workers-step.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label"
 import { Select } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
 import type { WorkforceAgentOption, WorkforceWorkerDraft } from "@/types/workforce"
 
 interface WorkersStepProps {
@@ -23,6 +24,7 @@ export function WorkersStep({
   workers,
   onWorkersChange,
 }: WorkersStepProps) {
+  const { t } = useI18n()
   const [draftAgentId, setDraftAgentId] = useState("")
   const [draftAlias, setDraftAlias] = useState("")
   const [draftInstructions, setDraftInstructions] = useState("")
@@ -91,15 +93,15 @@ export function WorkersStep({
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Add Worker</CardTitle>
+          <CardTitle>{t("workforces.workers.addTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label>Published Agent</Label>
+            <Label>{t("workforces.fields.publishedAgent")}</Label>
             <Select
               value={draftAgentId}
               onValueChange={setDraftAgentId}
-              placeholder="Choose a worker agent"
+              placeholder={t("workforces.workers.chooseAgent")}
               options={selectableAgents.map((agent) => ({
                 value: String(agent.id),
                 label: agent.name,
@@ -109,42 +111,42 @@ export function WorkersStep({
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label>Alias</Label>
+              <Label>{t("workforces.fields.alias")}</Label>
               <Input
                 value={draftAlias}
                 onChange={(event) => setDraftAlias(event.target.value)}
-                placeholder="Optional display name"
+                placeholder={t("workforces.workers.aliasPlaceholder")}
               />
             </div>
             <div className="space-y-2">
-              <Label>Assignment Instructions</Label>
+              <Label>{t("workforces.fields.assignmentInstructions")}</Label>
               <Textarea
                 value={draftInstructions}
                 onChange={(event) => setDraftInstructions(event.target.value)}
-                placeholder="Describe what this worker handles inside the workforce."
+                placeholder={t("workforces.workers.instructionsPlaceholder")}
                 rows={3}
               />
             </div>
           </div>
           <Button onClick={addWorker} disabled={!canAdd}>
-            Add Worker
+            {t("workforces.actions.addWorker")}
           </Button>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle>Workers</CardTitle>
+          <CardTitle>{t("workforces.fields.workers")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {workers.length === 0 ? (
             <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-              No workers selected yet.
+              {t("workforces.workers.noneSelected")}
             </div>
           ) : (
             workers.map((worker, index) => {
               const agent = agents.find((item) => item.id === worker.agent_id)
-              const title = worker.alias || agent?.name || `Worker ${index + 1}`
+              const title = worker.alias || agent?.name || t("workforces.workers.fallbackName", { index: index + 1 })
 
               return (
                 <div key={`${worker.agent_id}-${index}`} className="rounded-xl border p-4">
@@ -152,7 +154,7 @@ export function WorkersStep({
                     <div>
                       <div className="font-medium">{title}</div>
                       <div className="text-sm text-muted-foreground">
-                        {agent?.description || "Published agent worker"}
+                        {agent?.description || t("workforces.workers.defaultDescription")}
                       </div>
                     </div>
                     <div className="flex flex-wrap gap-2">
@@ -162,7 +164,7 @@ export function WorkersStep({
                         onClick={() => moveWorker(index, -1)}
                         disabled={index === 0}
                       >
-                        Up
+                        {t("workforces.actions.up")}
                       </Button>
                       <Button
                         variant="outline"
@@ -170,16 +172,16 @@ export function WorkersStep({
                         onClick={() => moveWorker(index, 1)}
                         disabled={index === workers.length - 1}
                       >
-                        Down
+                        {t("workforces.actions.down")}
                       </Button>
                       <Button variant="outline" size="sm" onClick={() => removeWorker(index)}>
-                        Remove
+                        {t("workforces.actions.remove")}
                       </Button>
                     </div>
                   </div>
                   <div className="mt-4 grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
-                      <Label>Alias</Label>
+                      <Label>{t("workforces.fields.alias")}</Label>
                       <Input
                         value={worker.alias}
                         onChange={(event) =>
@@ -189,9 +191,9 @@ export function WorkersStep({
                     </div>
                     <div className="flex items-center justify-between rounded-lg border px-3 py-2">
                       <div>
-                        <div className="font-medium">Enabled</div>
+                        <div className="font-medium">{t("workforces.fields.enabled")}</div>
                         <div className="text-sm text-muted-foreground">
-                          Disabled workers are kept in the Workforce but skipped at runtime.
+                          {t("workforces.workers.disabledHelp")}
                         </div>
                       </div>
                       <Switch
@@ -203,7 +205,7 @@ export function WorkersStep({
                     </div>
                   </div>
                   <div className="mt-4 space-y-2">
-                    <Label>Assignment Instructions</Label>
+                      <Label>{t("workforces.fields.assignmentInstructions")}</Label>
                     <Textarea
                       value={worker.assignment_instructions}
                       onChange={(event) =>

--- a/frontend/src/app/workforces/components/workers-step.tsx
+++ b/frontend/src/app/workforces/components/workers-step.tsx
@@ -7,112 +7,50 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
-import type {
-  WorkforceAgentOption,
-  WorkforceNewAgentDraft,
-  WorkforceTemplateOption,
-  WorkforceWorkerDraft,
-} from "@/types/workforce"
+import type { WorkforceAgentOption, WorkforceWorkerDraft } from "@/types/workforce"
 
 interface WorkersStepProps {
   managerAgentId: string
   agents: WorkforceAgentOption[]
-  templates: WorkforceTemplateOption[]
   workers: WorkforceWorkerDraft[]
   onWorkersChange: (workers: WorkforceWorkerDraft[]) => void
 }
 
-const emptyNewAgentDraft = (): WorkforceNewAgentDraft => ({
-  name: "",
-  description: "",
-  instructions: "",
-  execution_mode: "balanced",
-  knowledge_bases: [],
-  skills: [],
-  tool_categories: ["basic"],
-  suggested_prompts: [],
-})
-
 export function WorkersStep({
   managerAgentId,
   agents,
-  templates,
   workers,
   onWorkersChange,
 }: WorkersStepProps) {
-  const [mode, setMode] = useState<"existing" | "template" | "new">("existing")
   const [draftAgentId, setDraftAgentId] = useState("")
-  const [draftTemplateId, setDraftTemplateId] = useState("")
   const [draftAlias, setDraftAlias] = useState("")
   const [draftInstructions, setDraftInstructions] = useState("")
-  const [draftNewAgent, setDraftNewAgent] = useState<WorkforceNewAgentDraft>(emptyNewAgentDraft())
 
   const selectableAgents = useMemo(
     () =>
       agents.filter(
         (agent) =>
           String(agent.id) !== managerAgentId &&
-          !workers.some(
-            (worker) => worker.source_type === "existing" && worker.agent_id === agent.id,
-          ),
+          !workers.some((worker) => worker.agent_id === agent.id),
       ),
     [agents, managerAgentId, workers],
   )
 
   const addWorker = () => {
-    if (!draftInstructions.trim()) return
-
-    if (mode === "existing") {
-      if (!draftAgentId) return
-      onWorkersChange([
-        ...workers,
-        {
-          source_type: "existing",
-          agent_id: Number(draftAgentId),
-          alias: draftAlias.trim(),
-          assignment_instructions: draftInstructions.trim(),
-          enabled: true,
-          sort_order: workers.length + 1,
-        },
-      ])
-      setDraftAgentId("")
-    } else if (mode === "template") {
-      if (!draftTemplateId) return
-      onWorkersChange([
-        ...workers,
-        {
-          source_type: "template",
-          template_id: draftTemplateId,
-          alias: draftAlias.trim(),
-          assignment_instructions: draftInstructions.trim(),
-          enabled: true,
-          sort_order: workers.length + 1,
-        },
-      ])
-      setDraftTemplateId("")
-    } else {
-      if (!draftNewAgent.name.trim() || !draftNewAgent.instructions.trim()) return
-      onWorkersChange([
-        ...workers,
-        {
-          source_type: "new",
-          agent: {
-            ...draftNewAgent,
-            name: draftNewAgent.name.trim(),
-            description: draftNewAgent.description.trim(),
-            instructions: draftNewAgent.instructions.trim(),
-          },
-          alias: draftAlias.trim(),
-          assignment_instructions: draftInstructions.trim(),
-          enabled: true,
-          sort_order: workers.length + 1,
-        },
-      ])
-      setDraftNewAgent(emptyNewAgentDraft())
-    }
-
+    if (!draftAgentId || !draftInstructions.trim()) return
+    onWorkersChange([
+      ...workers,
+      {
+        source_type: "existing",
+        agent_id: Number(draftAgentId),
+        alias: draftAlias.trim(),
+        assignment_instructions: draftInstructions.trim(),
+        enabled: true,
+        sort_order: workers.length + 1,
+      },
+    ])
+    setDraftAgentId("")
     setDraftAlias("")
     setDraftInstructions("")
   }
@@ -121,6 +59,20 @@ export function WorkersStep({
     const next = [...workers]
     next[index] = nextWorker
     onWorkersChange(next)
+  }
+
+  const moveWorker = (index: number, direction: -1 | 1) => {
+    const targetIndex = index + direction
+    if (targetIndex < 0 || targetIndex >= workers.length) return
+    const next = [...workers]
+    const [worker] = next.splice(index, 1)
+    next.splice(targetIndex, 0, worker)
+    onWorkersChange(
+      next.map((item, currentIndex) => ({
+        ...item,
+        sort_order: currentIndex + 1,
+      })),
+    )
   }
 
   const removeWorker = (index: number) => {
@@ -133,13 +85,7 @@ export function WorkersStep({
     )
   }
 
-  const canAdd =
-    Boolean(draftInstructions.trim()) &&
-    (mode === "existing"
-      ? Boolean(draftAgentId)
-      : mode === "template"
-        ? Boolean(draftTemplateId)
-        : Boolean(draftNewAgent.name.trim() && draftNewAgent.instructions.trim()))
+  const canAdd = Boolean(draftAgentId && draftInstructions.trim())
 
   return (
     <div className="space-y-6">
@@ -148,103 +94,19 @@ export function WorkersStep({
           <CardTitle>Add Worker</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Tabs value={mode} onValueChange={(value) => setMode(value as typeof mode)}>
-            <TabsList>
-              <TabsTrigger value="existing">Existing Agent</TabsTrigger>
-              <TabsTrigger value="template">Template</TabsTrigger>
-              <TabsTrigger value="new">Brand New Agent</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="existing" className="space-y-4">
-              <div className="space-y-2">
-                <Label>Agent</Label>
-                <Select
-                  value={draftAgentId}
-                  onValueChange={setDraftAgentId}
-                  placeholder="Choose a worker agent"
-                  options={selectableAgents.map((agent) => ({
-                    value: String(agent.id),
-                    label: agent.name,
-                    description: agent.description || undefined,
-                  }))}
-                />
-              </div>
-            </TabsContent>
-
-            <TabsContent value="template" className="space-y-4">
-              <div className="space-y-2">
-                <Label>Template</Label>
-                <Select
-                  value={draftTemplateId}
-                  onValueChange={setDraftTemplateId}
-                  placeholder="Choose a template"
-                  options={templates.map((template) => ({
-                    value: template.id,
-                    label: template.name,
-                    description: template.description || undefined,
-                  }))}
-                />
-              </div>
-            </TabsContent>
-
-            <TabsContent value="new" className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label>Agent Name</Label>
-                  <Input
-                    value={draftNewAgent.name}
-                    onChange={(event) =>
-                      setDraftNewAgent((current) => ({ ...current, name: event.target.value }))
-                    }
-                    placeholder="Launch Copywriter Agent"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>Execution Mode</Label>
-                  <Select
-                    value={draftNewAgent.execution_mode}
-                    onValueChange={(value) =>
-                      setDraftNewAgent((current) => ({ ...current, execution_mode: value }))
-                    }
-                    options={[
-                      { value: "flash", label: "Flash" },
-                      { value: "balanced", label: "Balanced" },
-                      { value: "think", label: "Think" },
-                    ]}
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label>Description</Label>
-                <Textarea
-                  value={draftNewAgent.description}
-                  onChange={(event) =>
-                    setDraftNewAgent((current) => ({
-                      ...current,
-                      description: event.target.value,
-                    }))
-                  }
-                  placeholder="Short summary of what this new worker agent does."
-                  rows={3}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>Agent Instructions</Label>
-                <Textarea
-                  value={draftNewAgent.instructions}
-                  onChange={(event) =>
-                    setDraftNewAgent((current) => ({
-                      ...current,
-                      instructions: event.target.value,
-                    }))
-                  }
-                  placeholder="System instructions for the new worker agent."
-                  rows={5}
-                />
-              </div>
-            </TabsContent>
-          </Tabs>
-
+          <div className="space-y-2">
+            <Label>Published Agent</Label>
+            <Select
+              value={draftAgentId}
+              onValueChange={setDraftAgentId}
+              placeholder="Choose a worker agent"
+              options={selectableAgents.map((agent) => ({
+                value: String(agent.id),
+                label: agent.name,
+                description: agent.description || undefined,
+              }))}
+            />
+          </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <Label>Alias</Label>
@@ -259,7 +121,7 @@ export function WorkersStep({
               <Textarea
                 value={draftInstructions}
                 onChange={(event) => setDraftInstructions(event.target.value)}
-                placeholder="Describe what this worker is responsible for inside the workforce."
+                placeholder="Describe what this worker handles inside the workforce."
                 rows={3}
               />
             </div>
@@ -281,41 +143,39 @@ export function WorkersStep({
             </div>
           ) : (
             workers.map((worker, index) => {
-              const agent = worker.agent_id
-                ? agents.find((item) => item.id === worker.agent_id)
-                : null
-              const template = worker.template_id
-                ? templates.find((item) => item.id === worker.template_id)
-                : null
-              const title =
-                worker.alias ||
-                agent?.name ||
-                template?.name ||
-                worker.agent?.name ||
-                `Worker ${index + 1}`
+              const agent = agents.find((item) => item.id === worker.agent_id)
+              const title = worker.alias || agent?.name || `Worker ${index + 1}`
 
               return (
-                <div
-                  key={`${worker.source_type}-${worker.sort_order}-${index}`}
-                  className="rounded-xl border p-4"
-                >
+                <div key={`${worker.agent_id}-${index}`} className="rounded-xl border p-4">
                   <div className="flex items-start justify-between gap-4">
                     <div>
                       <div className="font-medium">{title}</div>
                       <div className="text-sm text-muted-foreground">
-                        {worker.source_type === "existing"
-                          ? agent?.description || "Existing agent worker"
-                          : worker.source_type === "template"
-                            ? template?.description || "Template-based worker"
-                            : worker.agent?.description || "Brand new worker agent"}
-                      </div>
-                      <div className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
-                        {worker.source_type}
+                        {agent?.description || "Published agent worker"}
                       </div>
                     </div>
-                    <Button variant="outline" size="sm" onClick={() => removeWorker(index)}>
-                      Remove
-                    </Button>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => moveWorker(index, -1)}
+                        disabled={index === 0}
+                      >
+                        Up
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => moveWorker(index, 1)}
+                        disabled={index === workers.length - 1}
+                      >
+                        Down
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => removeWorker(index)}>
+                        Remove
+                      </Button>
+                    </div>
                   </div>
                   <div className="mt-4 grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
@@ -331,7 +191,7 @@ export function WorkersStep({
                       <div>
                         <div className="font-medium">Enabled</div>
                         <div className="text-sm text-muted-foreground">
-                          Disabled workers stay in draft but won&apos;t be used at runtime.
+                          Disabled workers are kept in the Workforce but skipped at runtime.
                         </div>
                       </div>
                       <Switch
@@ -355,52 +215,6 @@ export function WorkersStep({
                       rows={4}
                     />
                   </div>
-                  {worker.source_type === "new" && worker.agent ? (
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label>Agent Name</Label>
-                        <Input
-                          value={worker.agent.name}
-                          onChange={(event) =>
-                            updateWorker(index, {
-                              ...worker,
-                              agent: { ...worker.agent!, name: event.target.value },
-                            })
-                          }
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label>Execution Mode</Label>
-                        <Select
-                          value={worker.agent.execution_mode}
-                          onValueChange={(value) =>
-                            updateWorker(index, {
-                              ...worker,
-                              agent: { ...worker.agent!, execution_mode: value },
-                            })
-                          }
-                          options={[
-                            { value: "flash", label: "Flash" },
-                            { value: "balanced", label: "Balanced" },
-                            { value: "think", label: "Think" },
-                          ]}
-                        />
-                      </div>
-                      <div className="space-y-2 md:col-span-2">
-                        <Label>Agent Instructions</Label>
-                        <Textarea
-                          value={worker.agent.instructions}
-                          onChange={(event) =>
-                            updateWorker(index, {
-                              ...worker,
-                              agent: { ...worker.agent!, instructions: event.target.value },
-                            })
-                          }
-                          rows={4}
-                        />
-                      </div>
-                    </div>
-                  ) : null}
                 </div>
               )
             })

--- a/frontend/src/app/workforces/components/workers-step.tsx
+++ b/frontend/src/app/workforces/components/workers-step.tsx
@@ -1,0 +1,412 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import type {
+  WorkforceAgentOption,
+  WorkforceNewAgentDraft,
+  WorkforceTemplateOption,
+  WorkforceWorkerDraft,
+} from "@/types/workforce"
+
+interface WorkersStepProps {
+  managerAgentId: string
+  agents: WorkforceAgentOption[]
+  templates: WorkforceTemplateOption[]
+  workers: WorkforceWorkerDraft[]
+  onWorkersChange: (workers: WorkforceWorkerDraft[]) => void
+}
+
+const emptyNewAgentDraft = (): WorkforceNewAgentDraft => ({
+  name: "",
+  description: "",
+  instructions: "",
+  execution_mode: "balanced",
+  knowledge_bases: [],
+  skills: [],
+  tool_categories: ["basic"],
+  suggested_prompts: [],
+})
+
+export function WorkersStep({
+  managerAgentId,
+  agents,
+  templates,
+  workers,
+  onWorkersChange,
+}: WorkersStepProps) {
+  const [mode, setMode] = useState<"existing" | "template" | "new">("existing")
+  const [draftAgentId, setDraftAgentId] = useState("")
+  const [draftTemplateId, setDraftTemplateId] = useState("")
+  const [draftAlias, setDraftAlias] = useState("")
+  const [draftInstructions, setDraftInstructions] = useState("")
+  const [draftNewAgent, setDraftNewAgent] = useState<WorkforceNewAgentDraft>(emptyNewAgentDraft())
+
+  const selectableAgents = useMemo(
+    () =>
+      agents.filter(
+        (agent) =>
+          String(agent.id) !== managerAgentId &&
+          !workers.some(
+            (worker) => worker.source_type === "existing" && worker.agent_id === agent.id,
+          ),
+      ),
+    [agents, managerAgentId, workers],
+  )
+
+  const addWorker = () => {
+    if (!draftInstructions.trim()) return
+
+    if (mode === "existing") {
+      if (!draftAgentId) return
+      onWorkersChange([
+        ...workers,
+        {
+          source_type: "existing",
+          agent_id: Number(draftAgentId),
+          alias: draftAlias.trim(),
+          assignment_instructions: draftInstructions.trim(),
+          enabled: true,
+          sort_order: workers.length + 1,
+        },
+      ])
+      setDraftAgentId("")
+    } else if (mode === "template") {
+      if (!draftTemplateId) return
+      onWorkersChange([
+        ...workers,
+        {
+          source_type: "template",
+          template_id: draftTemplateId,
+          alias: draftAlias.trim(),
+          assignment_instructions: draftInstructions.trim(),
+          enabled: true,
+          sort_order: workers.length + 1,
+        },
+      ])
+      setDraftTemplateId("")
+    } else {
+      if (!draftNewAgent.name.trim() || !draftNewAgent.instructions.trim()) return
+      onWorkersChange([
+        ...workers,
+        {
+          source_type: "new",
+          agent: {
+            ...draftNewAgent,
+            name: draftNewAgent.name.trim(),
+            description: draftNewAgent.description.trim(),
+            instructions: draftNewAgent.instructions.trim(),
+          },
+          alias: draftAlias.trim(),
+          assignment_instructions: draftInstructions.trim(),
+          enabled: true,
+          sort_order: workers.length + 1,
+        },
+      ])
+      setDraftNewAgent(emptyNewAgentDraft())
+    }
+
+    setDraftAlias("")
+    setDraftInstructions("")
+  }
+
+  const updateWorker = (index: number, nextWorker: WorkforceWorkerDraft) => {
+    const next = [...workers]
+    next[index] = nextWorker
+    onWorkersChange(next)
+  }
+
+  const removeWorker = (index: number) => {
+    const next = workers.filter((_, currentIndex) => currentIndex !== index)
+    onWorkersChange(
+      next.map((worker, currentIndex) => ({
+        ...worker,
+        sort_order: currentIndex + 1,
+      })),
+    )
+  }
+
+  const canAdd =
+    Boolean(draftInstructions.trim()) &&
+    (mode === "existing"
+      ? Boolean(draftAgentId)
+      : mode === "template"
+        ? Boolean(draftTemplateId)
+        : Boolean(draftNewAgent.name.trim() && draftNewAgent.instructions.trim()))
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Worker</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Tabs value={mode} onValueChange={(value) => setMode(value as typeof mode)}>
+            <TabsList>
+              <TabsTrigger value="existing">Existing Agent</TabsTrigger>
+              <TabsTrigger value="template">Template</TabsTrigger>
+              <TabsTrigger value="new">Brand New Agent</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="existing" className="space-y-4">
+              <div className="space-y-2">
+                <Label>Agent</Label>
+                <Select
+                  value={draftAgentId}
+                  onValueChange={setDraftAgentId}
+                  placeholder="Choose a worker agent"
+                  options={selectableAgents.map((agent) => ({
+                    value: String(agent.id),
+                    label: agent.name,
+                    description: agent.description || undefined,
+                  }))}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="template" className="space-y-4">
+              <div className="space-y-2">
+                <Label>Template</Label>
+                <Select
+                  value={draftTemplateId}
+                  onValueChange={setDraftTemplateId}
+                  placeholder="Choose a template"
+                  options={templates.map((template) => ({
+                    value: template.id,
+                    label: template.name,
+                    description: template.description || undefined,
+                  }))}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="new" className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Agent Name</Label>
+                  <Input
+                    value={draftNewAgent.name}
+                    onChange={(event) =>
+                      setDraftNewAgent((current) => ({ ...current, name: event.target.value }))
+                    }
+                    placeholder="Launch Copywriter Agent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Execution Mode</Label>
+                  <Select
+                    value={draftNewAgent.execution_mode}
+                    onValueChange={(value) =>
+                      setDraftNewAgent((current) => ({ ...current, execution_mode: value }))
+                    }
+                    options={[
+                      { value: "flash", label: "Flash" },
+                      { value: "balanced", label: "Balanced" },
+                      { value: "think", label: "Think" },
+                    ]}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label>Description</Label>
+                <Textarea
+                  value={draftNewAgent.description}
+                  onChange={(event) =>
+                    setDraftNewAgent((current) => ({
+                      ...current,
+                      description: event.target.value,
+                    }))
+                  }
+                  placeholder="Short summary of what this new worker agent does."
+                  rows={3}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Agent Instructions</Label>
+                <Textarea
+                  value={draftNewAgent.instructions}
+                  onChange={(event) =>
+                    setDraftNewAgent((current) => ({
+                      ...current,
+                      instructions: event.target.value,
+                    }))
+                  }
+                  placeholder="System instructions for the new worker agent."
+                  rows={5}
+                />
+              </div>
+            </TabsContent>
+          </Tabs>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Alias</Label>
+              <Input
+                value={draftAlias}
+                onChange={(event) => setDraftAlias(event.target.value)}
+                placeholder="Optional display name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Assignment Instructions</Label>
+              <Textarea
+                value={draftInstructions}
+                onChange={(event) => setDraftInstructions(event.target.value)}
+                placeholder="Describe what this worker is responsible for inside the workforce."
+                rows={3}
+              />
+            </div>
+          </div>
+          <Button onClick={addWorker} disabled={!canAdd}>
+            Add Worker
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Workers</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {workers.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+              No workers selected yet.
+            </div>
+          ) : (
+            workers.map((worker, index) => {
+              const agent = worker.agent_id
+                ? agents.find((item) => item.id === worker.agent_id)
+                : null
+              const template = worker.template_id
+                ? templates.find((item) => item.id === worker.template_id)
+                : null
+              const title =
+                worker.alias ||
+                agent?.name ||
+                template?.name ||
+                worker.agent?.name ||
+                `Worker ${index + 1}`
+
+              return (
+                <div
+                  key={`${worker.source_type}-${worker.sort_order}-${index}`}
+                  className="rounded-xl border p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <div className="font-medium">{title}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {worker.source_type === "existing"
+                          ? agent?.description || "Existing agent worker"
+                          : worker.source_type === "template"
+                            ? template?.description || "Template-based worker"
+                            : worker.agent?.description || "Brand new worker agent"}
+                      </div>
+                      <div className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
+                        {worker.source_type}
+                      </div>
+                    </div>
+                    <Button variant="outline" size="sm" onClick={() => removeWorker(index)}>
+                      Remove
+                    </Button>
+                  </div>
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Alias</Label>
+                      <Input
+                        value={worker.alias}
+                        onChange={(event) =>
+                          updateWorker(index, { ...worker, alias: event.target.value })
+                        }
+                      />
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+                      <div>
+                        <div className="font-medium">Enabled</div>
+                        <div className="text-sm text-muted-foreground">
+                          Disabled workers stay in draft but won&apos;t be used at runtime.
+                        </div>
+                      </div>
+                      <Switch
+                        checked={worker.enabled}
+                        onCheckedChange={(checked) =>
+                          updateWorker(index, { ...worker, enabled: checked })
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    <Label>Assignment Instructions</Label>
+                    <Textarea
+                      value={worker.assignment_instructions}
+                      onChange={(event) =>
+                        updateWorker(index, {
+                          ...worker,
+                          assignment_instructions: event.target.value,
+                        })
+                      }
+                      rows={4}
+                    />
+                  </div>
+                  {worker.source_type === "new" && worker.agent ? (
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label>Agent Name</Label>
+                        <Input
+                          value={worker.agent.name}
+                          onChange={(event) =>
+                            updateWorker(index, {
+                              ...worker,
+                              agent: { ...worker.agent!, name: event.target.value },
+                            })
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Execution Mode</Label>
+                        <Select
+                          value={worker.agent.execution_mode}
+                          onValueChange={(value) =>
+                            updateWorker(index, {
+                              ...worker,
+                              agent: { ...worker.agent!, execution_mode: value },
+                            })
+                          }
+                          options={[
+                            { value: "flash", label: "Flash" },
+                            { value: "balanced", label: "Balanced" },
+                            { value: "think", label: "Think" },
+                          ]}
+                        />
+                      </div>
+                      <div className="space-y-2 md:col-span-2">
+                        <Label>Agent Instructions</Label>
+                        <Textarea
+                          value={worker.agent.instructions}
+                          onChange={(event) =>
+                            updateWorker(index, {
+                              ...worker,
+                              agent: { ...worker.agent!, instructions: event.target.value },
+                            })
+                          }
+                          rows={4}
+                        />
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              )
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-builder-chat.tsx
+++ b/frontend/src/app/workforces/components/workforce-builder-chat.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Bot, Loader2, User } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Textarea } from "@/components/ui/textarea"
+import { cn, formatDate } from "@/lib/utils"
+import type { WorkforceBuilderMessage } from "@/types/workforce"
+
+interface WorkforceBuilderChatProps {
+  messages: WorkforceBuilderMessage[]
+  loading?: boolean
+  submitting?: boolean
+  onSubmit: (message: string) => Promise<void> | void
+}
+
+function roleIcon(role: string) {
+  return role === "assistant" ? Bot : User
+}
+
+function roleLabel(role: string) {
+  return role === "assistant" ? "Builder" : "You"
+}
+
+export function WorkforceBuilderChat({
+  messages,
+  loading = false,
+  submitting = false,
+  onSubmit,
+}: WorkforceBuilderChatProps) {
+  const [message, setMessage] = useState("")
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const canSubmit = useMemo(() => message.trim().length > 0 && !submitting, [message, submitting])
+
+  useEffect(() => {
+    const viewport = containerRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]",
+    ) as HTMLDivElement | null
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight
+    }
+  }, [messages, submitting])
+
+  const handleSubmit = async () => {
+    const value = message.trim()
+    if (!value || submitting) return
+    setMessage("")
+    await onSubmit(value)
+  }
+
+  return (
+    <Card className="h-full min-h-[640px]">
+      <CardHeader>
+        <CardTitle>Builder Chat</CardTitle>
+        <CardDescription>
+          Describe the workforce change you want. The builder will turn it into a reviewable patch.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex h-full flex-col gap-4">
+        <div ref={containerRef}>
+          <ScrollArea className="h-[440px] rounded-lg border bg-muted/20">
+            <div className="space-y-4 p-4">
+              {loading ? (
+                <div className="text-sm text-muted-foreground">Loading builder history...</div>
+              ) : messages.length === 0 ? (
+                <div className="rounded-lg border border-dashed bg-background p-4 text-sm text-muted-foreground">
+                  Start with something like: add worker Research Agent to handle competitor
+                  research.
+                </div>
+              ) : (
+                messages.map((item) => {
+                  const Icon = roleIcon(item.role)
+                  return (
+                    <div
+                      key={item.id}
+                      className={cn(
+                        "flex gap-3",
+                        item.role === "user" ? "justify-end" : "justify-start",
+                      )}
+                    >
+                      {item.role !== "user" ? (
+                        <div className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                          <Icon className="size-4" />
+                        </div>
+                      ) : null}
+                      <div
+                        className={cn(
+                          "max-w-[85%] rounded-2xl border px-4 py-3",
+                          item.role === "user"
+                            ? "border-primary/20 bg-primary text-primary-foreground"
+                            : "bg-background",
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            "mb-2 flex items-center gap-2 text-xs",
+                            item.role === "user"
+                              ? "text-primary-foreground/80"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          <span className="font-medium">{roleLabel(item.role)}</span>
+                          {item.created_at ? <span>{formatDate(item.created_at)}</span> : null}
+                        </div>
+                        <div className="whitespace-pre-wrap text-sm leading-6">{item.content}</div>
+                      </div>
+                      {item.role === "user" ? (
+                        <div className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+                          <Icon className="size-4" />
+                        </div>
+                      ) : null}
+                    </div>
+                  )
+                })
+              )}
+              {submitting ? (
+                <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  <span>Preparing a proposed patch...</span>
+                </div>
+              ) : null}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <div className="space-y-3">
+          <Textarea
+            placeholder='Rename this workforce to "Launch Crew" and make Writer focus on launch email copy.'
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            rows={6}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                event.preventDefault()
+                void handleSubmit()
+              }
+            }}
+          />
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-xs text-muted-foreground">Press Ctrl/Cmd + Enter to send.</div>
+            <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
+              {submitting ? "Proposing..." : "Propose Changes"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-builder-chat.tsx
+++ b/frontend/src/app/workforces/components/workforce-builder-chat.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
 import { cn, formatDate } from "@/lib/utils"
 import type { WorkforceBuilderMessage } from "@/types/workforce"
 
@@ -26,16 +27,13 @@ function roleIcon(role: string) {
   return role === "assistant" ? Bot : User
 }
 
-function roleLabel(role: string) {
-  return role === "assistant" ? "Builder" : "You"
-}
-
 export function WorkforceBuilderChat({
   messages,
   loading = false,
   submitting = false,
   onSubmit,
 }: WorkforceBuilderChatProps) {
+  const { t } = useI18n()
   const [message, setMessage] = useState("")
   const containerRef = useRef<HTMLDivElement | null>(null)
 
@@ -60,9 +58,9 @@ export function WorkforceBuilderChat({
   return (
     <Card className="h-full min-h-[640px]">
       <CardHeader>
-        <CardTitle>Builder Chat</CardTitle>
+        <CardTitle>{t("workforces.builder.chatTitle")}</CardTitle>
         <CardDescription>
-          Describe the workforce change you want. The builder will turn it into a reviewable patch.
+          {t("workforces.builder.chatDescription")}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex h-full flex-col gap-4">
@@ -70,11 +68,10 @@ export function WorkforceBuilderChat({
           <ScrollArea className="h-[440px] rounded-lg border bg-muted/20">
             <div className="space-y-4 p-4">
               {loading ? (
-                <div className="text-sm text-muted-foreground">Loading builder history...</div>
+                <div className="text-sm text-muted-foreground">{t("workforces.loading.builderHistory")}</div>
               ) : messages.length === 0 ? (
                 <div className="rounded-lg border border-dashed bg-background p-4 text-sm text-muted-foreground">
-                  Start with something like: add worker Research Agent to handle competitor
-                  research.
+                  {t("workforces.builder.emptyPrompt")}
                 </div>
               ) : (
                 messages.map((item) => {
@@ -108,7 +105,7 @@ export function WorkforceBuilderChat({
                               : "text-muted-foreground",
                           )}
                         >
-                          <span className="font-medium">{roleLabel(item.role)}</span>
+                          <span className="font-medium">{item.role === "assistant" ? t("workforces.builder.roleBuilder") : t("workforces.builder.roleYou")}</span>
                           {item.created_at ? <span>{formatDate(item.created_at)}</span> : null}
                         </div>
                         <div className="whitespace-pre-wrap text-sm leading-6">{item.content}</div>
@@ -125,7 +122,7 @@ export function WorkforceBuilderChat({
               {submitting ? (
                 <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3 text-sm text-muted-foreground">
                   <Loader2 className="size-4 animate-spin" />
-                  <span>Preparing a proposed patch...</span>
+                  <span>{t("workforces.builder.preparingPatch")}</span>
                 </div>
               ) : null}
             </div>
@@ -134,7 +131,7 @@ export function WorkforceBuilderChat({
 
         <div className="space-y-3">
           <Textarea
-            placeholder='Rename this workforce to "Launch Crew" and make Writer focus on launch email copy.'
+            placeholder={t("workforces.builder.messagePlaceholder")}
             value={message}
             onChange={(event) => setMessage(event.target.value)}
             rows={6}
@@ -146,9 +143,9 @@ export function WorkforceBuilderChat({
             }}
           />
           <div className="flex items-center justify-between gap-3">
-            <div className="text-xs text-muted-foreground">Press Ctrl/Cmd + Enter to send.</div>
+            <div className="text-xs text-muted-foreground">{t("workforces.builder.sendHint")}</div>
             <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
-              {submitting ? "Proposing..." : "Propose Changes"}
+              {submitting ? t("workforces.loading.proposing") : t("workforces.actions.proposeChanges")}
             </Button>
           </div>
         </div>

--- a/frontend/src/app/workforces/components/workforce-canvas.tsx
+++ b/frontend/src/app/workforces/components/workforce-canvas.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useI18n } from "@/contexts/i18n-context"
 import type { WorkforceCanvasResponse } from "@/types/workforce"
 
 interface WorkforceCanvasProps {
@@ -8,10 +9,12 @@ interface WorkforceCanvasProps {
 }
 
 export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
+  const { t } = useI18n()
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Canvas</CardTitle>
+        <CardTitle>{t("workforces.actions.canvas")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="grid gap-3 md:grid-cols-3">
@@ -22,14 +25,14 @@ export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
               </div>
               <div className="mt-2 font-medium">{node.label}</div>
               {node.enabled === false ? (
-                <div className="mt-2 text-xs text-muted-foreground">Disabled</div>
+                <div className="mt-2 text-xs text-muted-foreground">{t("workforces.status.disabled")}</div>
               ) : null}
             </div>
           ))}
         </div>
         <div>
           <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
-            Connections
+            {t("workforces.canvas.connections")}
           </div>
           <div className="space-y-2">
             {canvas.edges.map((edge) => (

--- a/frontend/src/app/workforces/components/workforce-canvas.tsx
+++ b/frontend/src/app/workforces/components/workforce-canvas.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { WorkforceCanvasResponse } from "@/types/workforce"
+
+interface WorkforceCanvasProps {
+  canvas: WorkforceCanvasResponse
+}
+
+export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Canvas</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-3 md:grid-cols-3">
+          {canvas.nodes.map((node) => (
+            <div key={node.id} className="rounded-xl border bg-background/40 p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                {node.type}
+              </div>
+              <div className="mt-2 font-medium">{node.label}</div>
+              {node.enabled === false ? (
+                <div className="mt-2 text-xs text-muted-foreground">Disabled</div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+        <div>
+          <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Connections
+          </div>
+          <div className="space-y-2">
+            {canvas.edges.map((edge) => (
+              <div key={edge.id} className="rounded-lg border px-3 py-2 text-sm text-muted-foreground">
+                {edge.source} → {edge.target}
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-canvas.tsx
+++ b/frontend/src/app/workforces/components/workforce-canvas.tsx
@@ -1,8 +1,9 @@
 "use client"
 
+import { ArrowRight, Network } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useI18n } from "@/contexts/i18n-context"
-import type { WorkforceCanvasResponse } from "@/types/workforce"
+import type { WorkforceCanvasNode, WorkforceCanvasResponse } from "@/types/workforce"
 
 interface WorkforceCanvasProps {
   canvas: WorkforceCanvasResponse
@@ -10,6 +11,13 @@ interface WorkforceCanvasProps {
 
 export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
   const { t } = useI18n()
+  const nodesById = new Map(canvas.nodes.map((node) => [node.id, node]))
+
+  const nodeTypeLabel = (node: WorkforceCanvasNode) => {
+    const key = `workforces.canvas.nodeTypes.${node.type}`
+    const translated = t(key)
+    return translated === key ? node.type : translated
+  }
 
   return (
     <Card>
@@ -19,9 +27,9 @@ export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
       <CardContent className="space-y-6">
         <div className="grid gap-3 md:grid-cols-3">
           {canvas.nodes.map((node) => (
-            <div key={node.id} className="rounded-xl border bg-background/40 p-4">
+            <div key={node.id} className="rounded-lg border bg-background/40 p-4">
               <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                {node.type}
+                {nodeTypeLabel(node)}
               </div>
               <div className="mt-2 font-medium">{node.label}</div>
               {node.enabled === false ? (
@@ -31,16 +39,50 @@ export function WorkforceCanvas({ canvas }: WorkforceCanvasProps) {
           ))}
         </div>
         <div>
-          <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
-            {t("workforces.canvas.connections")}
+          <div className="mb-3 flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+            <Network className="h-3.5 w-3.5" />
+            <span>{t("workforces.canvas.connections")}</span>
           </div>
-          <div className="space-y-2">
-            {canvas.edges.map((edge) => (
-              <div key={edge.id} className="rounded-lg border px-3 py-2 text-sm text-muted-foreground">
-                {edge.source} → {edge.target}
-              </div>
-            ))}
-          </div>
+          {canvas.edges.length > 0 ? (
+            <div className="grid gap-2 lg:grid-cols-2">
+              {canvas.edges.map((edge) => {
+                const sourceNode = nodesById.get(edge.source)
+                const targetNode = nodesById.get(edge.target)
+                return (
+                  <div
+                    key={edge.id}
+                    className="flex min-w-0 items-center gap-3 rounded-lg border bg-background/40 px-3 py-2 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-medium">
+                        {sourceNode?.label || edge.source}
+                      </div>
+                      {sourceNode ? (
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          {nodeTypeLabel(sourceNode)}
+                        </div>
+                      ) : null}
+                    </div>
+                    <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-medium">
+                        {targetNode?.label || edge.target}
+                      </div>
+                      {targetNode ? (
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          {nodeTypeLabel(targetNode)}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed px-3 py-4 text-sm text-muted-foreground">
+              {t("workforces.canvas.noConnections")}
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/frontend/src/app/workforces/components/workforce-prompt-creator.tsx
+++ b/frontend/src/app/workforces/components/workforce-prompt-creator.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { ArrowLeft, Loader2, Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
+import { createWorkforceFromPrompt } from "@/lib/workforces-api"
+
+interface WorkforcePromptCreatorProps {
+  onManualSetup: () => void
+}
+
+export function WorkforcePromptCreator({ onManualSetup }: WorkforcePromptCreatorProps) {
+  const router = useRouter()
+  const { t } = useI18n()
+  const [prompt, setPrompt] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCreate = async () => {
+    const value = prompt.trim()
+    if (!value || submitting) return
+    try {
+      setSubmitting(true)
+      setError(null)
+      const workforce = await createWorkforceFromPrompt({ prompt: value })
+      router.push(`/workforces/${workforce.id}/builder`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.create"))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 sm:p-8">
+        <div className="space-y-4">
+          <Button variant="ghost" className="w-fit gap-2 px-0" onClick={() => router.push("/workforces")}>
+            <ArrowLeft className="h-4 w-4" />
+            {t("workforces.create.backToWorkforces")}
+          </Button>
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              <Sparkles className="h-3.5 w-3.5" />
+              {t("workforces.create.prompt.badge")}
+            </div>
+            <h1 className="mt-4 text-3xl font-bold">{t("workforces.create.prompt.title")}</h1>
+            <p className="mt-2 max-w-2xl text-muted-foreground">
+              {t("workforces.create.prompt.description")}
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("workforces.create.prompt.cardTitle")}</CardTitle>
+            <CardDescription>{t("workforces.create.prompt.cardDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Textarea
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder={t("workforces.create.prompt.placeholder")}
+              rows={10}
+            />
+            {error ? <div className="text-sm text-red-500">{error}</div> : null}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Button variant="outline" onClick={onManualSetup} disabled={submitting}>
+                {t("workforces.create.prompt.manualSetup")}
+              </Button>
+              <Button onClick={handleCreate} disabled={submitting || !prompt.trim()}>
+                {submitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t("workforces.loading.creating")}
+                  </>
+                ) : (
+                  t("workforces.create.prompt.generate")
+                )}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-summary.tsx
+++ b/frontend/src/app/workforces/components/workforce-summary.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useI18n } from "@/contexts/i18n-context"
 import type { WorkforceDetail } from "@/types/workforce"
 
 interface WorkforceSummaryProps {
@@ -16,48 +17,54 @@ function statusVariant(status: string) {
 }
 
 export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
+  const { locale, t } = useI18n()
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center justify-between gap-4">
           <span>{workforce.name}</span>
-          <Badge variant={statusVariant(workforce.status)}>{workforce.status}</Badge>
+          <Badge variant={statusVariant(workforce.status)}>
+            {t(`workforces.status.${workforce.status}`)}
+          </Badge>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid gap-4 md:grid-cols-3">
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Manager</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.manager")}</div>
             <div className="mt-1 font-medium">{workforce.manager.name}</div>
             <div className="text-sm text-muted-foreground">
-              {workforce.manager.description || "No description"}
+              {workforce.manager.description || t("workforces.common.noDescription")}
             </div>
             <Link
               href={`/build/${workforce.manager.id}`}
               target="_blank"
               className="mt-2 inline-block text-sm text-primary hover:underline"
             >
-              Open Agent Editor
+              {t("workforces.actions.openAgentEditor")}
             </Link>
           </div>
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.workers")}</div>
             <div className="mt-1 font-medium">{workforce.workers.length}</div>
             <div className="text-sm text-muted-foreground">
-              {workforce.workers.filter((item) => item.enabled).length} enabled
+              {t("workforces.summary.enabledCount", {
+                count: workforce.workers.filter((item) => item.enabled).length,
+              })}
             </div>
           </div>
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Updated</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.updated")}</div>
             <div className="mt-1 font-medium">
-              {workforce.updated_at ? new Date(workforce.updated_at).toLocaleString() : "N/A"}
+              {workforce.updated_at ? new Date(workforce.updated_at).toLocaleString(locale) : t("workforces.common.notAvailable")}
             </div>
           </div>
         </div>
 
         {workforce.description && (
           <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.description")}</div>
             <p className="mt-1 text-sm text-muted-foreground">{workforce.description}</p>
           </div>
         )}
@@ -65,7 +72,7 @@ export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
         {workforce.manager_instructions && (
           <div>
             <div className="text-xs uppercase tracking-wide text-muted-foreground">
-              Manager Instructions
+              {t("workforces.fields.managerInstructions")}
             </div>
             <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
               {workforce.manager_instructions}
@@ -74,11 +81,11 @@ export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
         )}
 
         <div>
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">{t("workforces.fields.workers")}</div>
           <div className="mt-3 grid gap-3">
             {workforce.workers.length === 0 ? (
               <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-                No workers yet.
+                {t("workforces.workers.noneYet")}
               </div>
             ) : (
               workforce.workers.map((worker) => (
@@ -87,10 +94,10 @@ export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
                     <div>
                       <div className="font-medium">{worker.alias || worker.agent.name}</div>
                       <div className="text-sm text-muted-foreground">
-                        {worker.agent.description || "No description"}
+                        {worker.agent.description || t("workforces.common.noDescription")}
                       </div>
                       <div className="mt-2 flex flex-wrap items-center gap-2">
-                        <Badge variant="outline">{worker.source_type}</Badge>
+                        <Badge variant="outline">{t(`workforces.sourceTypes.${worker.source_type}`)}</Badge>
                         {worker.template_id ? (
                           <Badge variant="outline">{worker.template_id}</Badge>
                         ) : null}
@@ -99,12 +106,12 @@ export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
                           target="_blank"
                           className="text-sm text-primary hover:underline"
                         >
-                          Edit Agent
+                          {t("workforces.actions.editAgent")}
                         </Link>
                       </div>
                     </div>
                     <Badge variant={worker.enabled ? "default" : "secondary"}>
-                      {worker.enabled ? "enabled" : "disabled"}
+                      {worker.enabled ? t("workforces.status.enabled") : t("workforces.status.disabled")}
                     </Badge>
                   </div>
                   <p className="mt-3 text-sm text-muted-foreground">

--- a/frontend/src/app/workforces/components/workforce-summary.tsx
+++ b/frontend/src/app/workforces/components/workforce-summary.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { WorkforceDetail } from "@/types/workforce"
+
+interface WorkforceSummaryProps {
+  workforce: WorkforceDetail
+}
+
+function statusVariant(status: string) {
+  if (status === "active") return "default"
+  if (status === "archived") return "secondary"
+  return "outline"
+}
+
+export function WorkforceSummary({ workforce }: WorkforceSummaryProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between gap-4">
+          <span>{workforce.name}</span>
+          <Badge variant={statusVariant(workforce.status)}>{workforce.status}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Manager</div>
+            <div className="mt-1 font-medium">{workforce.manager.name}</div>
+            <div className="text-sm text-muted-foreground">
+              {workforce.manager.description || "No description"}
+            </div>
+            <Link
+              href={`/build/${workforce.manager.id}`}
+              target="_blank"
+              className="mt-2 inline-block text-sm text-primary hover:underline"
+            >
+              Open Agent Editor
+            </Link>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+            <div className="mt-1 font-medium">{workforce.workers.length}</div>
+            <div className="text-sm text-muted-foreground">
+              {workforce.workers.filter((item) => item.enabled).length} enabled
+            </div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Updated</div>
+            <div className="mt-1 font-medium">
+              {workforce.updated_at ? new Date(workforce.updated_at).toLocaleString() : "N/A"}
+            </div>
+          </div>
+        </div>
+
+        {workforce.description && (
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
+            <p className="mt-1 text-sm text-muted-foreground">{workforce.description}</p>
+          </div>
+        )}
+
+        {workforce.manager_instructions && (
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">
+              Manager Instructions
+            </div>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+              {workforce.manager_instructions}
+            </p>
+          </div>
+        )}
+
+        <div>
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">Workers</div>
+          <div className="mt-3 grid gap-3">
+            {workforce.workers.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                No workers yet.
+              </div>
+            ) : (
+              workforce.workers.map((worker) => (
+                <div key={worker.id} className="rounded-lg border bg-background/40 p-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="font-medium">{worker.alias || worker.agent.name}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {worker.agent.description || "No description"}
+                      </div>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <Badge variant="outline">{worker.source_type}</Badge>
+                        {worker.template_id ? (
+                          <Badge variant="outline">{worker.template_id}</Badge>
+                        ) : null}
+                        <Link
+                          href={`/build/${worker.agent.id}`}
+                          target="_blank"
+                          className="text-sm text-primary hover:underline"
+                        >
+                          Edit Agent
+                        </Link>
+                      </div>
+                    </div>
+                    <Badge variant={worker.enabled ? "default" : "secondary"}>
+                      {worker.enabled ? "enabled" : "disabled"}
+                    </Badge>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {worker.assignment_instructions}
+                  </p>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-test-panel.tsx
+++ b/frontend/src/app/workforces/components/workforce-test-panel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
 import { runWorkforce } from "@/lib/workforces-api"
 
 interface WorkforceTestPanelProps {
@@ -12,6 +13,7 @@ interface WorkforceTestPanelProps {
 }
 
 export function WorkforceTestPanel({ workforceId }: WorkforceTestPanelProps) {
+  const { t } = useI18n()
   const router = useRouter()
   const [message, setMessage] = useState("")
   const [loading, setLoading] = useState(false)
@@ -25,7 +27,7 @@ export function WorkforceTestPanel({ workforceId }: WorkforceTestPanelProps) {
       const result = await runWorkforce(workforceId, message.trim())
       router.push(result.redirect_url)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to run workforce")
+      setError(err instanceof Error ? err.message : t("workforces.errors.run"))
     } finally {
       setLoading(false)
     }
@@ -34,18 +36,18 @@ export function WorkforceTestPanel({ workforceId }: WorkforceTestPanelProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Test Workforce</CardTitle>
+        <CardTitle>{t("workforces.run.testTitle")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <Textarea
-          placeholder="Describe the task you want the manager to coordinate."
+          placeholder={t("workforces.run.placeholder")}
           value={message}
           onChange={(event) => setMessage(event.target.value)}
           rows={8}
         />
         {error ? <div className="text-sm text-red-500">{error}</div> : null}
         <Button onClick={handleRun} disabled={loading || !message.trim()} className="w-full">
-          {loading ? "Starting..." : "Run Workforce"}
+          {loading ? t("workforces.loading.starting") : t("workforces.actions.runWorkforce")}
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/app/workforces/components/workforce-test-panel.tsx
+++ b/frontend/src/app/workforces/components/workforce-test-panel.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { runWorkforce } from "@/lib/workforces-api"
+
+interface WorkforceTestPanelProps {
+  workforceId: number
+}
+
+export function WorkforceTestPanel({ workforceId }: WorkforceTestPanelProps) {
+  const router = useRouter()
+  const [message, setMessage] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleRun = async () => {
+    if (!message.trim()) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await runWorkforce(workforceId, message.trim())
+      router.push(result.redirect_url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to run workforce")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Test Workforce</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Textarea
+          placeholder="Describe the task you want the manager to coordinate."
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          rows={8}
+        />
+        {error ? <div className="text-sm text-red-500">{error}</div> : null}
+        <Button onClick={handleRun} disabled={loading || !message.trim()} className="w-full">
+          {loading ? "Starting..." : "Run Workforce"}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/workforces/components/workforce-wizard.tsx
+++ b/frontend/src/app/workforces/components/workforce-wizard.tsx
@@ -27,7 +27,11 @@ const STEPS = [
   "workforces.create.steps.review",
 ] as const
 
-export function WorkforceWizard() {
+interface WorkforceWizardProps {
+  onPromptSetup?: () => void
+}
+
+export function WorkforceWizard({ onPromptSetup }: WorkforceWizardProps) {
   const router = useRouter()
   const { t } = useI18n()
   const [step, setStep] = useState(0)
@@ -120,14 +124,21 @@ export function WorkforceWizard() {
     <div className="h-full overflow-y-auto">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4 sm:p-8">
       <div className="space-y-4">
-        <Button variant="ghost" className="w-fit gap-2 px-0" onClick={() => router.push("/workforces")}>
-          <ArrowLeft className="h-4 w-4" />
-          {t("workforces.create.backToWorkforces")}
-        </Button>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="ghost" className="w-fit gap-2 px-0" onClick={() => router.push("/workforces")}>
+            <ArrowLeft className="h-4 w-4" />
+            {t("workforces.create.backToWorkforces")}
+          </Button>
+          {onPromptSetup ? (
+            <Button variant="outline" onClick={onPromptSetup}>
+              {t("workforces.create.manual.backToPrompt")}
+            </Button>
+          ) : null}
+        </div>
         <div>
-          <h1 className="text-3xl font-bold">{t("workforces.create.title")}</h1>
+          <h1 className="text-3xl font-bold">{t("workforces.create.manual.title")}</h1>
           <p className="mt-2 text-muted-foreground">
-            {t("workforces.create.description")}
+            {t("workforces.create.manual.description")}
           </p>
         </div>
       </div>

--- a/frontend/src/app/workforces/components/workforce-wizard.tsx
+++ b/frontend/src/app/workforces/components/workforce-wizard.tsx
@@ -98,11 +98,12 @@ export function WorkforceWizard() {
   }
 
   if (loadingAgents) {
-    return <div className="p-8 text-muted-foreground">Loading agents...</div>
+    return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading agents...</div>
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-8">
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4 sm:p-8">
       <div>
         <h1 className="text-3xl font-bold">Create Workforce</h1>
         <p className="mt-2 text-muted-foreground">
@@ -210,6 +211,7 @@ export function WorkforceWizard() {
             </Button>
           )}
         </div>
+      </div>
       </div>
     </div>
   )

--- a/frontend/src/app/workforces/components/workforce-wizard.tsx
+++ b/frontend/src/app/workforces/components/workforce-wizard.tsx
@@ -10,11 +10,9 @@ import { Textarea } from "@/components/ui/textarea"
 import {
   createWorkforce,
   listAgentOptions,
-  listWorkforceTemplates,
 } from "@/lib/workforces-api"
 import type {
   WorkforceAgentOption,
-  WorkforceTemplateOption,
   WorkforceWorkerDraft,
 } from "@/types/workforce"
 import { ManagerStep } from "./manager-step"
@@ -30,7 +28,6 @@ export function WorkforceWizard() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [agents, setAgents] = useState<WorkforceAgentOption[]>([])
-  const [templates, setTemplates] = useState<WorkforceTemplateOption[]>([])
 
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
@@ -43,12 +40,7 @@ export function WorkforceWizard() {
       workers.length > 0 &&
       workers.every((worker) => {
         if (!worker.assignment_instructions.trim()) return false
-        if (worker.source_type === "existing") return Boolean(worker.agent_id)
-        if (worker.source_type === "template") return Boolean(worker.template_id)
-        if (worker.source_type === "new") {
-          return Boolean(worker.agent?.name.trim() && worker.agent.instructions.trim())
-        }
-        return false
+        return Boolean(worker.agent_id)
       }),
     [workers],
   )
@@ -57,12 +49,8 @@ export function WorkforceWizard() {
     const loadAgents = async () => {
       try {
         setLoadingAgents(true)
-        const [agentData, templateData] = await Promise.all([
-          listAgentOptions(),
-          listWorkforceTemplates(),
-        ])
-        setAgents(agentData)
-        setTemplates(templateData)
+        const agentData = await listAgentOptions()
+        setAgents(agentData.filter((agent) => agent.status === "published"))
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load agents")
       } finally {
@@ -95,15 +83,6 @@ export function WorkforceWizard() {
         workers: workers.map((worker) => ({
           source_type: worker.source_type,
           agent_id: worker.agent_id,
-          template_id: worker.template_id,
-          agent: worker.agent
-            ? {
-                ...worker.agent,
-                name: worker.agent.name.trim(),
-                description: worker.agent.description.trim(),
-                instructions: worker.agent.instructions.trim(),
-              }
-            : undefined,
           alias: worker.alias.trim() || undefined,
           assignment_instructions: worker.assignment_instructions.trim(),
           enabled: worker.enabled,
@@ -191,7 +170,6 @@ export function WorkforceWizard() {
         <WorkersStep
           managerAgentId={managerAgentId}
           agents={agents}
-          templates={templates}
           workers={workers}
           onWorkersChange={setWorkers}
         />
@@ -205,7 +183,6 @@ export function WorkforceWizard() {
           managerInstructions={managerInstructions}
           workers={workers}
           agents={agents}
-          templates={templates}
         />
       ) : null}
 

--- a/frontend/src/app/workforces/components/workforce-wizard.tsx
+++ b/frontend/src/app/workforces/components/workforce-wizard.tsx
@@ -2,11 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
 import {
   createWorkforce,
   listAgentOptions,
@@ -19,10 +21,15 @@ import { ManagerStep } from "./manager-step"
 import { ReviewStep } from "./review-step"
 import { WorkersStep } from "./workers-step"
 
-const STEPS = ["Basics", "Workers", "Review"] as const
+const STEPS = [
+  "workforces.create.steps.basics",
+  "workforces.create.steps.workers",
+  "workforces.create.steps.review",
+] as const
 
 export function WorkforceWizard() {
   const router = useRouter()
+  const { t } = useI18n()
   const [step, setStep] = useState(0)
   const [loadingAgents, setLoadingAgents] = useState(true)
   const [submitting, setSubmitting] = useState(false)
@@ -52,13 +59,13 @@ export function WorkforceWizard() {
         const agentData = await listAgentOptions()
         setAgents(agentData.filter((agent) => agent.status === "published"))
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load agents")
+        setError(err instanceof Error ? err.message : t("workforces.errors.loadAgents"))
       } finally {
         setLoadingAgents(false)
       }
     }
     void loadAgents()
-  }, [])
+  }, [t])
 
   const canMoveForward = useMemo(() => {
     if (step === 0) {
@@ -91,34 +98,48 @@ export function WorkforceWizard() {
       })
       router.push(`/workforces/${workforce.id}/builder`)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create workforce")
+      setError(err instanceof Error ? err.message : t("workforces.errors.create"))
     } finally {
       setSubmitting(false)
     }
   }
 
+  const handleBack = () => {
+    if (step === 0) {
+      router.push("/workforces")
+      return
+    }
+    setStep((current) => Math.max(0, current - 1))
+  }
+
   if (loadingAgents) {
-    return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">Loading agents...</div>
+    return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.agents")}</div>
   }
 
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-4 sm:p-8">
-      <div>
-        <h1 className="text-3xl font-bold">Create Workforce</h1>
-        <p className="mt-2 text-muted-foreground">
-          Start with a manager, add workers, then review the orchestration before saving.
-        </p>
+      <div className="space-y-4">
+        <Button variant="ghost" className="w-fit gap-2 px-0" onClick={() => router.push("/workforces")}>
+          <ArrowLeft className="h-4 w-4" />
+          {t("workforces.create.backToWorkforces")}
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">{t("workforces.create.title")}</h1>
+          <p className="mt-2 text-muted-foreground">
+            {t("workforces.create.description")}
+          </p>
+        </div>
       </div>
 
       <div className="grid gap-3 md:grid-cols-3">
-        {STEPS.map((label, index) => (
-          <Card key={label} className={index === step ? "border-primary" : undefined}>
+        {STEPS.map((labelKey, index) => (
+          <Card key={labelKey} className={index === step ? "border-primary" : undefined}>
             <CardContent className="flex items-center gap-3 p-4">
               <div className="flex h-8 w-8 items-center justify-center rounded-full border text-sm font-medium">
                 {index + 1}
               </div>
-              <div className="font-medium">{label}</div>
+              <div className="font-medium">{t(labelKey)}</div>
             </CardContent>
           </Card>
         ))}
@@ -128,32 +149,32 @@ export function WorkforceWizard() {
         <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
           <Card>
             <CardHeader>
-              <CardTitle>Basics</CardTitle>
+              <CardTitle>{t("workforces.create.steps.basics")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label>Name</Label>
+                <Label>{t("workforces.fields.name")}</Label>
                 <Input
                   value={name}
                   onChange={(event) => setName(event.target.value)}
-                  placeholder="Marketing Launch Workforce"
+                  placeholder={t("workforces.create.placeholders.name")}
                 />
               </div>
               <div className="space-y-2">
-                <Label>Description</Label>
+                <Label>{t("workforces.fields.description")}</Label>
                 <Textarea
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
-                  placeholder="Coordinate research, content, and launch tasks."
+                  placeholder={t("workforces.create.placeholders.description")}
                   rows={4}
                 />
               </div>
               <div className="space-y-2">
-                <Label>Manager Instructions</Label>
+                <Label>{t("workforces.fields.managerInstructions")}</Label>
                 <Textarea
                   value={managerInstructions}
                   onChange={(event) => setManagerInstructions(event.target.value)}
-                  placeholder="Coordinate workers, reconcile conflicting outputs, and return a single answer."
+                  placeholder={t("workforces.create.placeholders.managerInstructions")}
                   rows={5}
                 />
               </div>
@@ -192,22 +213,22 @@ export function WorkforceWizard() {
       <div className="flex items-center justify-between">
         <Button
           variant="outline"
-          onClick={() => setStep((current) => Math.max(0, current - 1))}
-          disabled={step === 0 || submitting}
+          onClick={handleBack}
+          disabled={submitting}
         >
-          Back
+          {step === 0 ? t("workforces.create.backToWorkforces") : t("common.back")}
         </Button>
         <div className="flex items-center gap-3">
           {step < STEPS.length - 1 ? (
             <Button onClick={() => setStep((current) => current + 1)} disabled={!canMoveForward}>
-              Next
+              {t("common.next")}
             </Button>
           ) : (
             <Button
               onClick={handleCreate}
               disabled={submitting || !canMoveForward || !workersAreValid}
             >
-              {submitting ? "Creating..." : "Create Workforce"}
+              {submitting ? t("workforces.loading.creating") : t("workforces.actions.create")}
             </Button>
           )}
         </div>

--- a/frontend/src/app/workforces/components/workforce-wizard.tsx
+++ b/frontend/src/app/workforces/components/workforce-wizard.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  createWorkforce,
+  listAgentOptions,
+  listWorkforceTemplates,
+} from "@/lib/workforces-api"
+import type {
+  WorkforceAgentOption,
+  WorkforceTemplateOption,
+  WorkforceWorkerDraft,
+} from "@/types/workforce"
+import { ManagerStep } from "./manager-step"
+import { ReviewStep } from "./review-step"
+import { WorkersStep } from "./workers-step"
+
+const STEPS = ["Basics", "Workers", "Review"] as const
+
+export function WorkforceWizard() {
+  const router = useRouter()
+  const [step, setStep] = useState(0)
+  const [loadingAgents, setLoadingAgents] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [agents, setAgents] = useState<WorkforceAgentOption[]>([])
+  const [templates, setTemplates] = useState<WorkforceTemplateOption[]>([])
+
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [managerAgentId, setManagerAgentId] = useState("")
+  const [managerInstructions, setManagerInstructions] = useState("")
+  const [workers, setWorkers] = useState<WorkforceWorkerDraft[]>([])
+
+  const workersAreValid = useMemo(
+    () =>
+      workers.length > 0 &&
+      workers.every((worker) => {
+        if (!worker.assignment_instructions.trim()) return false
+        if (worker.source_type === "existing") return Boolean(worker.agent_id)
+        if (worker.source_type === "template") return Boolean(worker.template_id)
+        if (worker.source_type === "new") {
+          return Boolean(worker.agent?.name.trim() && worker.agent.instructions.trim())
+        }
+        return false
+      }),
+    [workers],
+  )
+
+  useEffect(() => {
+    const loadAgents = async () => {
+      try {
+        setLoadingAgents(true)
+        const [agentData, templateData] = await Promise.all([
+          listAgentOptions(),
+          listWorkforceTemplates(),
+        ])
+        setAgents(agentData)
+        setTemplates(templateData)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load agents")
+      } finally {
+        setLoadingAgents(false)
+      }
+    }
+    void loadAgents()
+  }, [])
+
+  const canMoveForward = useMemo(() => {
+    if (step === 0) {
+      return Boolean(name.trim() && managerAgentId)
+    }
+    if (step === 1) {
+      return workersAreValid
+    }
+    return true
+  }, [step, name, managerAgentId, workersAreValid])
+
+  const handleCreate = async () => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const workforce = await createWorkforce({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        manager_agent_id: Number(managerAgentId),
+        manager_instructions: managerInstructions.trim() || undefined,
+        status: "draft",
+        workers: workers.map((worker) => ({
+          source_type: worker.source_type,
+          agent_id: worker.agent_id,
+          template_id: worker.template_id,
+          agent: worker.agent
+            ? {
+                ...worker.agent,
+                name: worker.agent.name.trim(),
+                description: worker.agent.description.trim(),
+                instructions: worker.agent.instructions.trim(),
+              }
+            : undefined,
+          alias: worker.alias.trim() || undefined,
+          assignment_instructions: worker.assignment_instructions.trim(),
+          enabled: worker.enabled,
+          sort_order: worker.sort_order,
+        })),
+      })
+      router.push(`/workforces/${workforce.id}/builder`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create workforce")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loadingAgents) {
+    return <div className="p-8 text-muted-foreground">Loading agents...</div>
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-8">
+      <div>
+        <h1 className="text-3xl font-bold">Create Workforce</h1>
+        <p className="mt-2 text-muted-foreground">
+          Start with a manager, add workers, then review the orchestration before saving.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {STEPS.map((label, index) => (
+          <Card key={label} className={index === step ? "border-primary" : undefined}>
+            <CardContent className="flex items-center gap-3 p-4">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full border text-sm font-medium">
+                {index + 1}
+              </div>
+              <div className="font-medium">{label}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {step === 0 ? (
+        <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Basics</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>Name</Label>
+                <Input
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Marketing Launch Workforce"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Description</Label>
+                <Textarea
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  placeholder="Coordinate research, content, and launch tasks."
+                  rows={4}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Manager Instructions</Label>
+                <Textarea
+                  value={managerInstructions}
+                  onChange={(event) => setManagerInstructions(event.target.value)}
+                  placeholder="Coordinate workers, reconcile conflicting outputs, and return a single answer."
+                  rows={5}
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <ManagerStep
+            managerAgentId={managerAgentId}
+            onManagerAgentIdChange={setManagerAgentId}
+            agents={agents}
+          />
+        </div>
+      ) : null}
+
+      {step === 1 ? (
+        <WorkersStep
+          managerAgentId={managerAgentId}
+          agents={agents}
+          templates={templates}
+          workers={workers}
+          onWorkersChange={setWorkers}
+        />
+      ) : null}
+
+      {step === 2 ? (
+        <ReviewStep
+          name={name}
+          description={description}
+          managerAgentId={managerAgentId}
+          managerInstructions={managerInstructions}
+          workers={workers}
+          agents={agents}
+          templates={templates}
+        />
+      ) : null}
+
+      {error ? <div className="text-sm text-red-500">{error}</div> : null}
+
+      <div className="flex items-center justify-between">
+        <Button
+          variant="outline"
+          onClick={() => setStep((current) => Math.max(0, current - 1))}
+          disabled={step === 0 || submitting}
+        >
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          {step < STEPS.length - 1 ? (
+            <Button onClick={() => setStep((current) => current + 1)} disabled={!canMoveForward}>
+              Next
+            </Button>
+          ) : (
+            <Button
+              onClick={handleCreate}
+              disabled={submitting || !canMoveForward || !workersAreValid}
+            >
+              {submitting ? "Creating..." : "Create Workforce"}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/new/page.tsx
+++ b/frontend/src/app/workforces/new/page.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { WorkforceWizard } from "../components/workforce-wizard"
+
+export default function NewWorkforcePage() {
+  return <WorkforceWizard />
+}

--- a/frontend/src/app/workforces/new/page.tsx
+++ b/frontend/src/app/workforces/new/page.tsx
@@ -1,7 +1,15 @@
 "use client"
 
+import { useState } from "react"
+import { WorkforcePromptCreator } from "../components/workforce-prompt-creator"
 import { WorkforceWizard } from "../components/workforce-wizard"
 
 export default function NewWorkforcePage() {
-  return <WorkforceWizard />
+  const [mode, setMode] = useState<"prompt" | "manual">("prompt")
+
+  if (mode === "manual") {
+    return <WorkforceWizard onPromptSetup={() => setMode("prompt")} />
+  }
+
+  return <WorkforcePromptCreator onManualSetup={() => setMode("manual")} />
 }

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -40,7 +40,8 @@ export default function WorkforcesPage() {
   }, [load, page, search])
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8">
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-8">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] text-muted-foreground">
@@ -185,6 +186,7 @@ export default function WorkforcesPage() {
           </>
         )
       ) : null}
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -139,7 +139,7 @@ export default function WorkforcesPage() {
                         </div>
                         {item.last_run ? (
                           <div className="text-xs text-muted-foreground">
-                            Last run #{item.last_run.id} · task #{item.last_run.task_id} · {item.last_run.status}
+                            Last run #{item.last_run.id}{item.last_run.task_id != null ? ` · task #${item.last_run.task_id}` : ""} · {item.last_run.status}
                           </div>
                         ) : (
                           <div className="text-xs text-muted-foreground">No runs yet</div>

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useEffect, useState } from "react"
+import { ChevronLeft, ChevronRight, Layers, Play, Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { SearchInput } from "@/components/ui/search-input"
+import { listWorkforces } from "@/lib/workforces-api"
+import type { WorkforceListItem } from "@/types/workforce"
+
+export default function WorkforcesPage() {
+  const [items, setItems] = useState<WorkforceListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(1)
+  const [pages, setPages] = useState(1)
+  const [total, setTotal] = useState(0)
+  const pageSize = 10
+
+  const load = useCallback(async (nextPage: number, nextSearch: string) => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await listWorkforces({ page: nextPage, size: pageSize, search: nextSearch })
+      setItems(data.items)
+      setPages(data.pages)
+      setTotal(data.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load workforces")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load(page, search)
+  }, [load, page, search])
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+            <Layers className="h-3.5 w-3.5" />
+            Workforce
+          </div>
+          <h1 className="mt-4 text-3xl font-bold">Workforces</h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            Create manager-led multi-agent work groups, keep worker roles explicit, and
+            run them from a single entry point.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <SearchInput
+            placeholder="Search workforces..."
+            value={search}
+            onChange={(value) => {
+              setSearch(value)
+              setPage(1)
+            }}
+            containerClassName="w-full sm:w-80"
+          />
+          <Link href="/workforces/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New Workforce
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {loading ? <div className="p-8 text-muted-foreground">Loading workforces...</div> : null}
+      {error ? <div className="p-8 text-red-500">{error}</div> : null}
+
+      {!loading && !error ? (
+        items.length === 0 ? (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center gap-4 p-12 text-center">
+              <div className="text-lg font-medium">No workforces yet</div>
+              <p className="max-w-xl text-sm text-muted-foreground">
+                Start with a manager agent, add a few workers, and return here to launch
+                coordinated runs.
+              </p>
+              <Link href="/workforces/new">
+                <Button>Create your first workforce</Button>
+              </Link>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <div className="grid gap-4">
+              {items.map((item) => (
+                <Card key={item.id} className="overflow-hidden">
+                  <CardContent className="p-0">
+                    <div className="grid gap-6 p-6 lg:grid-cols-[1.4fr_0.6fr] lg:items-center">
+                      <div className="space-y-4">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Link
+                            href={`/workforces/${item.id}`}
+                            className="text-xl font-semibold hover:underline"
+                          >
+                            {item.name}
+                          </Link>
+                          <span className="rounded-full border px-2.5 py-1 text-xs capitalize text-muted-foreground">
+                            {item.status}
+                          </span>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {item.description || "No description"}
+                        </p>
+                        <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
+                          <span>Manager: {item.manager.name}</span>
+                          <span>Workers: {item.worker_count}</span>
+                          <span>
+                            Last update:{" "}
+                            {item.updated_at ? new Date(item.updated_at).toLocaleString() : "N/A"}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex flex-col gap-3 lg:items-end">
+                        <Link href={`/workforces/${item.id}/run`}>
+                          <Button className="w-full lg:w-auto">
+                            <Play className="mr-2 h-4 w-4" />
+                            Run
+                          </Button>
+                        </Link>
+                        <div className="flex gap-3">
+                          <Link href={`/workforces/${item.id}`}>
+                            <Button variant="outline">Details</Button>
+                          </Link>
+                          <Link href={`/workforces/${item.id}/builder`}>
+                            <Button variant="outline">Builder</Button>
+                          </Link>
+                          <Link href={`/workforces/${item.id}/canvas`}>
+                            <Button variant="outline">Canvas</Button>
+                          </Link>
+                        </div>
+                        {item.last_run ? (
+                          <div className="text-xs text-muted-foreground">
+                            Last run #{item.last_run.id} · task #{item.last_run.task_id} · {item.last_run.status}
+                          </div>
+                        ) : (
+                          <div className="text-xs text-muted-foreground">No runs yet</div>
+                        )}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {pages > 1 ? (
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-muted-foreground">
+                  Showing {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, total)} of {total}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((current) => current - 1)}
+                    disabled={page <= 1}
+                  >
+                    <ChevronLeft className="mr-1 h-4 w-4" />
+                    Prev
+                  </Button>
+                  <span className="text-sm text-muted-foreground">
+                    Page {page} of {pages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((current) => current + 1)}
+                    disabled={page >= pages}
+                  >
+                    Next
+                    <ChevronRight className="ml-1 h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -6,10 +6,12 @@ import { ChevronLeft, ChevronRight, Layers, Play, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { SearchInput } from "@/components/ui/search-input"
+import { useI18n } from "@/contexts/i18n-context"
 import { listWorkforces } from "@/lib/workforces-api"
 import type { WorkforceListItem } from "@/types/workforce"
 
 export default function WorkforcesPage() {
+  const { locale, t } = useI18n()
   const [items, setItems] = useState<WorkforceListItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -28,12 +30,12 @@ export default function WorkforcesPage() {
       setPages(data.pages)
       setTotal(data.total)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load workforces")
+      setError(err instanceof Error ? err.message : t("workforces.errors.loadList"))
       setItems([])
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [t])
 
   useEffect(() => {
     void load(page, search)
@@ -46,17 +48,16 @@ export default function WorkforcesPage() {
         <div>
           <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] text-muted-foreground">
             <Layers className="h-3.5 w-3.5" />
-            Workforce
+            {t("workforces.list.badge")}
           </div>
-          <h1 className="mt-4 text-3xl font-bold">Workforces</h1>
+          <h1 className="mt-4 text-3xl font-bold">{t("workforces.list.title")}</h1>
           <p className="mt-2 max-w-2xl text-muted-foreground">
-            Create manager-led multi-agent work groups, keep worker roles explicit, and
-            run them from a single entry point.
+            {t("workforces.list.description")}
           </p>
         </div>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <SearchInput
-            placeholder="Search workforces..."
+            placeholder={t("workforces.list.searchPlaceholder")}
             value={search}
             onChange={(value) => {
               setSearch(value)
@@ -67,26 +68,25 @@ export default function WorkforcesPage() {
           <Link href="/workforces/new">
             <Button>
               <Plus className="mr-2 h-4 w-4" />
-              New Workforce
+              {t("workforces.actions.new")}
             </Button>
           </Link>
         </div>
       </div>
 
-      {loading ? <div className="p-8 text-muted-foreground">Loading workforces...</div> : null}
+      {loading ? <div className="p-8 text-muted-foreground">{t("workforces.loading.list")}</div> : null}
       {error ? <div className="p-8 text-red-500">{error}</div> : null}
 
       {!loading && !error ? (
         items.length === 0 ? (
           <Card className="border-dashed">
             <CardContent className="flex flex-col items-center gap-4 p-12 text-center">
-              <div className="text-lg font-medium">No workforces yet</div>
+              <div className="text-lg font-medium">{t("workforces.list.emptyTitle")}</div>
               <p className="max-w-xl text-sm text-muted-foreground">
-                Start with a manager agent, add a few workers, and return here to launch
-                coordinated runs.
+                {t("workforces.list.emptyDescription")}
               </p>
               <Link href="/workforces/new">
-                <Button>Create your first workforce</Button>
+                <Button>{t("workforces.list.createFirst")}</Button>
               </Link>
             </CardContent>
           </Card>
@@ -106,18 +106,21 @@ export default function WorkforcesPage() {
                             {item.name}
                           </Link>
                           <span className="rounded-full border px-2.5 py-1 text-xs capitalize text-muted-foreground">
-                            {item.status}
+                            {t(`workforces.status.${item.status}`)}
                           </span>
                         </div>
                         <p className="text-sm text-muted-foreground">
-                          {item.description || "No description"}
+                          {item.description || t("workforces.common.noDescription")}
                         </p>
                         <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
-                          <span>Manager: {item.manager.name}</span>
-                          <span>Workers: {item.worker_count}</span>
+                          <span>{t("workforces.list.manager", { name: item.manager.name })}</span>
+                          <span>{t("workforces.list.workers", { count: item.worker_count })}</span>
                           <span>
-                            Last update:{" "}
-                            {item.updated_at ? new Date(item.updated_at).toLocaleString() : "N/A"}
+                            {t("workforces.list.lastUpdate", {
+                              value: item.updated_at
+                                ? new Date(item.updated_at).toLocaleString(locale)
+                                : t("workforces.common.notAvailable"),
+                            })}
                           </span>
                         </div>
                       </div>
@@ -125,26 +128,35 @@ export default function WorkforcesPage() {
                         <Link href={`/workforces/${item.id}/run`}>
                           <Button className="w-full lg:w-auto">
                             <Play className="mr-2 h-4 w-4" />
-                            Run
+                            {t("workforces.actions.run")}
                           </Button>
                         </Link>
                         <div className="flex gap-3">
                           <Link href={`/workforces/${item.id}`}>
-                            <Button variant="outline">Details</Button>
+                            <Button variant="outline">{t("workforces.actions.details")}</Button>
                           </Link>
                           <Link href={`/workforces/${item.id}/builder`}>
-                            <Button variant="outline">Builder</Button>
+                            <Button variant="outline">{t("workforces.actions.builder")}</Button>
                           </Link>
                           <Link href={`/workforces/${item.id}/canvas`}>
-                            <Button variant="outline">Canvas</Button>
+                            <Button variant="outline">{t("workforces.actions.canvas")}</Button>
                           </Link>
                         </div>
                         {item.last_run ? (
                           <div className="text-xs text-muted-foreground">
-                            Last run #{item.last_run.id}{item.last_run.task_id != null ? ` · task #${item.last_run.task_id}` : ""} · {item.last_run.status}
+                            {item.last_run.task_id != null
+                              ? t("workforces.list.lastRunWithTask", {
+                                  runId: item.last_run.id,
+                                  taskId: item.last_run.task_id,
+                                  status: item.last_run.status,
+                                })
+                              : t("workforces.list.lastRun", {
+                                  runId: item.last_run.id,
+                                  status: item.last_run.status,
+                                })}
                           </div>
                         ) : (
-                          <div className="text-xs text-muted-foreground">No runs yet</div>
+                          <div className="text-xs text-muted-foreground">{t("workforces.list.noRuns")}</div>
                         )}
                       </div>
                     </div>
@@ -156,7 +168,11 @@ export default function WorkforcesPage() {
             {pages > 1 ? (
               <div className="flex items-center justify-between">
                 <div className="text-sm text-muted-foreground">
-                  Showing {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, total)} of {total}
+                  {t("workforces.pagination.showing", {
+                    start: (page - 1) * pageSize + 1,
+                    end: Math.min(page * pageSize, total),
+                    total,
+                  })}
                 </div>
                 <div className="flex items-center gap-2">
                   <Button
@@ -166,10 +182,10 @@ export default function WorkforcesPage() {
                     disabled={page <= 1}
                   >
                     <ChevronLeft className="mr-1 h-4 w-4" />
-                    Prev
+                    {t("workforces.pagination.prev")}
                   </Button>
                   <span className="text-sm text-muted-foreground">
-                    Page {page} of {pages}
+                    {t("workforces.pagination.page", { page, pages })}
                   </span>
                   <Button
                     variant="outline"
@@ -177,7 +193,7 @@ export default function WorkforcesPage() {
                     onClick={() => setPage((current) => current + 1)}
                     disabled={page >= pages}
                   >
-                    Next
+                    {t("workforces.pagination.next")}
                     <ChevronRight className="ml-1 h-4 w-4" />
                   </Button>
                 </div>

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -29,6 +29,7 @@ export default function WorkforcesPage() {
       setTotal(data.total)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load workforces")
+      setItems([])
     } finally {
       setLoading(false)
     }

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -380,6 +380,8 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
   // Setup WebSocket connection
   useEffect(() => {
+    let shouldReconnect = true
+
     const connectWebSocket = () => {
       if (!token) {
         console.log('⏳ Waiting for token to connect to WS...')
@@ -400,6 +402,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         const ws = new WebSocket(wsUrl)
 
         ws.onopen = () => {
+          if (!shouldReconnect) {
+            ws.close()
+            return
+          }
           console.log('✅ Build preview WebSocket connected')
           setWsConnected(true)
           wsRef.current = ws
@@ -477,7 +483,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
         }
 
         ws.onerror = (error) => {
-          console.error('Build preview WebSocket error:', error)
+          if (shouldReconnect) {
+            console.warn('Build preview WebSocket error; waiting for close event to decide reconnect.', error)
+          }
           // Don't set connected false here, let onclose handle it
         }
 
@@ -487,6 +495,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           wsRef.current = null
 
           // Don't reconnect if component unmounted or token changed (handled by cleanup)
+          if (!shouldReconnect) {
+            return
+          }
+
           // Retry logic
           if (reconnectAttemptsRef.current < maxReconnectAttempts) {
             reconnectAttemptsRef.current++
@@ -510,6 +522,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     connectWebSocket()
 
     return () => {
+      shouldReconnect = false
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current)
       }

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -341,7 +341,7 @@ export function ChatMessage({
     <div className="w-full space-y-2 animate-fade-in group">
       {shouldShowProcess && !isUser && (
         <div className={cn("pl-7")}>
-          <TraceEventRenderer events={traceEvents} />
+          <TraceEventRenderer events={traceEvents} taskStatus={taskStatus} />
         </div>
       )}
 

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -108,10 +108,18 @@ interface ProcessedStep {
 
 interface TraceEventRendererProps {
   events: TraceEvent[];
+  taskStatus?: string;
+}
+
+function getTraceData(event: TraceEvent): NonNullable<TraceEvent['data']> {
+  if (event.data && typeof event.data === 'object') {
+    return event.data;
+  }
+  return event as unknown as NonNullable<TraceEvent['data']>;
 }
 
 // Process trace events into steps
-function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
+function useProcessedSteps(events: TraceEvent[], taskStatus?: string): ProcessedStep[] {
   const { t } = useI18n();
   return useMemo(() => {
     const stepsMap = new Map<string, ProcessedStep>();
@@ -132,12 +140,13 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
         return;
       }
 
+      const eventData = getTraceData(event);
       const eventId = event.event_id || `event-${index}`;
-      let stepId = event.step_id || (event.data?.step_id as string) || 'default';
+      let stepId = event.step_id || (eventData.step_id as string) || 'default';
       if (event.event_type?.startsWith('workforce_delegation_')) {
         stepId = String(
-          event.data?.worker_task_id ||
-          `workforce-${event.data?.workforce_run_id || 'run'}-${event.data?.worker_member_id || event.data?.agent_id || eventId}`
+          eventData.worker_task_id ||
+          `workforce-${eventData.workforce_run_id || 'run'}-${eventData.worker_member_id || eventData.agent_id || eventId}`
         );
       }
 
@@ -168,11 +177,11 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
       const timestamp = normalizeTimestampMs(event.timestamp);
       // Process different event types
       if (event.event_type === 'dag_step_start' || event.event_type === 'react_task_start') {
-        step.stepName = (event.data?.step_name as string) || (event.event_type === 'react_task_start' ? t('traceEventRenderer.taskExecution') : '');
-        step.description = (event.data?.description as string) || (event.data?.task as string) || '';
+        step.stepName = (eventData.step_name as string) || (event.event_type === 'react_task_start' ? t('traceEventRenderer.taskExecution') : '');
+        step.description = (eventData.description as string) || (eventData.task as string) || '';
         step.status = 'running';
 
-        const tools = event.data?.tool_names || event.data?.tools;
+        const tools = eventData.tool_names || eventData.tools;
         if (tools && Array.isArray(tools)) {
           step.tools = tools.map((toolItem: any) => {
             if (typeof toolItem === 'string') return { function: { name: toolItem } };
@@ -224,9 +233,9 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
 
       if (event.event_type === 'workforce_delegation_start') {
         const workerName = String(
-          event.data?.worker_alias ||
-          event.data?.agent_name ||
-          event.data?.tool_name ||
+          eventData.worker_alias ||
+          eventData.agent_name ||
+          eventData.tool_name ||
           t('traceEventRenderer.unknownWorker')
         );
         step.stepName = t('traceEventRenderer.workforceDelegation');
@@ -239,21 +248,21 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
           status: 'running',
           timestamp,
           data: {
-            tool: event.data?.tool_name,
-            output: event.data,
+            tool: eventData.tool_name,
+            output: eventData,
           }
         });
       }
 
       if (event.event_type === 'workforce_delegation_end') {
-        const output = event.data?.output || event.data?.response || '';
+        const output = eventData.output || eventData.response || '';
         step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
         step.description = step.description || t('traceEventRenderer.workforceDelegation');
         step.status = 'completed';
         const action = step.actions.find(a => a.type === 'info' && a.status === 'running');
         if (action) {
           action.status = 'completed';
-          action.data.output = output || event.data;
+          action.data.output = output || eventData;
         } else {
           step.actions.push({
             id: eventId,
@@ -261,13 +270,13 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
             title: t('traceEventRenderer.workerReturned'),
             status: 'completed',
             timestamp,
-            data: { output: output || event.data }
+            data: { output: output || eventData }
           });
         }
       }
 
       if (event.event_type === 'workforce_delegation_error') {
-        const errorMessage = event.data?.error || event.data?.message || t('traceEventRenderer.unknownError');
+        const errorMessage = eventData.error || eventData.message || t('traceEventRenderer.unknownError');
         step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
         step.description = step.description || t('traceEventRenderer.workforceDelegation');
         step.status = 'failed';
@@ -429,8 +438,22 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
       }
     });
 
+    if (taskStatus === 'completed' || taskStatus === 'failed') {
+      const terminalStatus = taskStatus === 'failed' ? 'failed' : 'completed';
+      stepsMap.forEach((step) => {
+        if (step.status === 'running' || step.status === 'pending') {
+          step.status = terminalStatus;
+        }
+        step.actions.forEach((action) => {
+          if (action.status === 'running') {
+            action.status = terminalStatus;
+          }
+        });
+      });
+    }
+
     return Array.from(stepsMap.values()).filter(step => step.stepName);
-  }, [events, t]);
+  }, [events, taskStatus, t]);
 }
 
 
@@ -1009,9 +1032,9 @@ function StepItem({ step, index, onOpenTerminal, onViewDetail, onFileClick, onAg
 }
 
 // Main TraceEventRenderer Component
-export function TraceEventRenderer({ events }: TraceEventRendererProps) {
+export function TraceEventRenderer({ events, taskStatus }: TraceEventRendererProps) {
   const { t } = useI18n();
-  const steps = useProcessedSteps(events);
+  const steps = useProcessedSteps(events, taskStatus);
   const router = useRouter();
 
   const { openFilePreview, dispatch } = useApp();

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   Check,
   Shield,
+  Users,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useApp } from '@/contexts/app-context-chat';
@@ -131,7 +132,14 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
         return;
       }
 
+      const eventId = event.event_id || `event-${index}`;
       let stepId = event.step_id || (event.data?.step_id as string) || 'default';
+      if (event.event_type?.startsWith('workforce_delegation_')) {
+        stepId = String(
+          event.data?.worker_task_id ||
+          `workforce-${event.data?.workforce_run_id || 'run'}-${event.data?.worker_member_id || event.data?.agent_id || eventId}`
+        );
+      }
 
       if (event.event_type === 'react_task_start' || event.event_type === 'task_start_react') {
         currentReactStepId = stepId;
@@ -158,8 +166,6 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
 
       const step = stepsMap.get(stepId)!;
       const timestamp = normalizeTimestampMs(event.timestamp);
-      const eventId = event.event_id || `event-${index}`;
-
       // Process different event types
       if (event.event_type === 'dag_step_start' || event.event_type === 'react_task_start') {
         step.stepName = (event.data?.step_name as string) || (event.event_type === 'react_task_start' ? t('traceEventRenderer.taskExecution') : '');
@@ -212,6 +218,71 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
               reasoning: event.data?.response?.reasoning,
               tool_calls: event.data?.tools
             }
+          });
+        }
+      }
+
+      if (event.event_type === 'workforce_delegation_start') {
+        const workerName = String(
+          event.data?.worker_alias ||
+          event.data?.agent_name ||
+          event.data?.tool_name ||
+          t('traceEventRenderer.unknownWorker')
+        );
+        step.stepName = t('traceEventRenderer.workforceDelegation');
+        step.description = t('traceEventRenderer.delegateToWorker', { worker: workerName });
+        step.status = 'running';
+        step.actions.push({
+          id: eventId,
+          type: 'info',
+          title: t('traceEventRenderer.delegateToWorker', { worker: workerName }),
+          status: 'running',
+          timestamp,
+          data: {
+            tool: event.data?.tool_name,
+            output: event.data,
+          }
+        });
+      }
+
+      if (event.event_type === 'workforce_delegation_end') {
+        const output = event.data?.output || event.data?.response || '';
+        step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
+        step.description = step.description || t('traceEventRenderer.workforceDelegation');
+        step.status = 'completed';
+        const action = step.actions.find(a => a.type === 'info' && a.status === 'running');
+        if (action) {
+          action.status = 'completed';
+          action.data.output = output || event.data;
+        } else {
+          step.actions.push({
+            id: eventId,
+            type: 'info',
+            title: t('traceEventRenderer.workerReturned'),
+            status: 'completed',
+            timestamp,
+            data: { output: output || event.data }
+          });
+        }
+      }
+
+      if (event.event_type === 'workforce_delegation_error') {
+        const errorMessage = event.data?.error || event.data?.message || t('traceEventRenderer.unknownError');
+        step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
+        step.description = step.description || t('traceEventRenderer.workforceDelegation');
+        step.status = 'failed';
+        const action = step.actions.find(a => a.type === 'info' && a.status === 'running');
+        if (action) {
+          action.status = 'failed';
+          action.data.error = errorMessage;
+        } else {
+          step.actions.push({
+            id: eventId,
+            type: 'error',
+            title: t('traceEventRenderer.workerFailed'),
+            status: 'failed',
+            timestamp,
+            data: { error: errorMessage }
           });
         }
       }
@@ -772,7 +843,7 @@ function StepActionItem({ action, onViewDetail, onOpenTerminal, onFileClick, onA
             <span className="flex-shrink-0 flex items-center">
               {action.type === 'tool' && <Wrench className="w-3.5 h-3.5" />}
               {action.type === 'error' && <Info className="w-3.5 h-3.5 text-red-500" />}
-              {action.type === 'info' && <Info className="w-3.5 h-3.5" />}
+              {action.type === 'info' && <Users className="w-3.5 h-3.5" />}
             </span>
 
             <span className="font-medium break-words [overflow-wrap:anywhere]">{action.title}</span>
@@ -842,6 +913,13 @@ function StepActionItem({ action, onViewDetail, onOpenTerminal, onFileClick, onA
                   <div className="text-red-400 whitespace-pre-wrap">
                     {String(action.data.error)}
                   </div>
+                )}
+
+                {action.type === 'info' && (
+                  <>
+                    <ToolErrorDisplay action={action} t={t} />
+                    <ToolOutputDisplay action={action} isRunning={isRunning} t={t} onFileClick={onFileClick} onAgentClick={onAgentClick} />
+                  </>
                 )}
               </div>
             </ScrollArea>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -45,6 +45,7 @@ import {
   Search,
   Globe,
   ChevronsUpDown,
+  Briefcase,
 } from "lucide-react"
 import {
   Dialog,
@@ -177,6 +178,13 @@ export const getNavigationGroupsForUser = (user: any): NavigationGroup[] => [
         href: "/templates",
         icon: LayoutTemplate,
         color: "text-purple-400"
+      },
+      {
+        name: "Workforces",
+        nameKey: "nav.workforces",
+        href: "/workforces",
+        icon: Briefcase,
+        color: "text-cyan-500"
       },
     ]
   },

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -7,10 +7,17 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/utils', () => ({
   getApiUrl: () => 'http://api.local',
+  cn: (...classes: Array<string | undefined | null | false>) =>
+    classes.filter(Boolean).join(' '),
 }))
 
 vi.mock('@/lib/api-wrapper', () => ({
   apiRequest: apiRequestMock,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/build/new',
 }))
 
 import { MarkdownRenderer } from '../markdown-renderer'
@@ -108,5 +115,28 @@ describe('MarkdownRenderer', () => {
     })
 
     expect(apiRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('renders agent links outside paragraph tags', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 1,
+        name: 'Research Agent',
+        description: 'Search and summarize results',
+        status: 'published',
+      }),
+    })
+
+    const { container } = render(
+      <MarkdownRenderer content={'Created [Research Agent](agent://1) for this task.'} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Research Agent')).toBeInTheDocument()
+    })
+
+    expect(container.querySelector('p div')).toBeNull()
+    expect(container.querySelector('p p')).toBeNull()
   })
 })

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -161,6 +161,25 @@ function containsAgentCardElement(children: React.ReactNode): boolean {
   })
 }
 
+function nodeContainsAgentLink(node: any): boolean {
+  if (!node) {
+    return false
+  }
+
+  if (node.type === 'element' && node.tagName === 'a') {
+    const href = node.properties?.href
+    if (typeof href === 'string' && href.startsWith('agent:')) {
+      return true
+    }
+  }
+
+  if (!Array.isArray(node.children)) {
+    return false
+  }
+
+  return node.children.some(nodeContainsAgentLink)
+}
+
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -247,8 +266,8 @@ function MarkdownFileImage({
 export function MarkdownRenderer({ content, className = '', onFileClick, onAgentClick }: MarkdownRendererProps) {
   const components = React.useMemo<Components>(
     () => ({
-      p({ node: _node, children, ...props }) {
-        if (containsAgentCardElement(children)) {
+      p({ node, children, ...props }) {
+        if (nodeContainsAgentLink(node) || containsAgentCardElement(children)) {
           return (
             <div className="my-4" {...props}>
               {children}

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -254,6 +254,7 @@ interface Task {
   executionMode?: "flash" | "balanced" | "think"
   isDag?: boolean
   agentId?: number
+  workforceId?: number
 }
 
 interface StepExecution {
@@ -1004,6 +1005,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 executionMode: taskData.execution_mode,
                 isDag: taskData.is_dag,
                 agentId: taskData.agent_id,
+                workforceId: taskData.workforce_id,
               }
             })
 
@@ -3576,6 +3578,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             executionMode: taskData.execution_mode,
             isDag: taskData.is_dag,
             agentId: taskData.agent_id,
+            workforceId: taskData.workforce_id,
           }
           dispatch({ type: "SET_CURRENT_TASK", payload: newTask })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -46,6 +46,18 @@ const generateMessageId = (prefix: string) => {
   return `${prefix}-${++messageIdCounter}-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`
 }
 
+const createNormalizedTraceEvent = (
+  message: WebSocketMessage,
+  eventType: string,
+  eventData: Record<string, unknown>,
+): TraceEvent => ({
+  event_id: message.event_id || String(eventData.event_id || generateMessageId(`trace-${eventType}`)),
+  event_type: eventType,
+  step_id: message.step_id || (typeof eventData.step_id === "string" ? eventData.step_id : undefined),
+  timestamp: message.timestamp,
+  data: eventData,
+})
+
 // Simple deduplication for all messages
 const recentMessages = new Set<string>()
 
@@ -3056,7 +3068,10 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
           // Default: add as trace event
           else {
             console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (unhandled event_type:', eventType, ')')
-            dispatch({ type: "ADD_TRACE_EVENT", payload: traceEventData })
+            dispatch({
+              type: "ADD_TRACE_EVENT",
+              payload: createNormalizedTraceEvent(message, eventType, eventData),
+            })
           }
         } else {
           console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (no event_type, direct trace event)')

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -29,6 +29,18 @@ const generateMessageId = (prefix: string) => {
   return `${prefix}-${++messageIdCounter}-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`
 }
 
+const createNormalizedTraceEvent = (
+  message: WebSocketMessage,
+  eventType: string,
+  eventData: Record<string, unknown>,
+): TraceEvent => ({
+  event_id: message.event_id || String(eventData.event_id || generateMessageId(`trace-${eventType}`)),
+  event_type: eventType,
+  step_id: message.step_id || (typeof eventData.step_id === "string" ? eventData.step_id : undefined),
+  timestamp: message.timestamp,
+  data: eventData,
+})
+
 // Simple deduplication for all messages
 const recentMessages = new Set<string>()
 
@@ -2555,7 +2567,10 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
           // Default: add as trace event
           else {
             console.trace('Raw message:', JSON.stringify(message), 'Handler: handleMessage (unhandled event_type:', eventType, ')')
-            dispatch({ type: "ADD_TRACE_EVENT", payload: traceEventData })
+            dispatch({
+              type: "ADD_TRACE_EVENT",
+              payload: createNormalizedTraceEvent(message, eventType, eventData),
+            })
           }
         } else {
           console.trace('Raw message:', JSON.stringify(message), 'Handler: handleMessage (no event_type, direct trace event)')

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3076,6 +3076,203 @@ Build when you need.`
       copied: "Copied to clipboard"
     }
   },
+  workforces: {
+    common: {
+      noDescription: "No description",
+      notAvailable: "N/A",
+      notSelected: "Not selected"
+    },
+    status: {
+      draft: "Draft",
+      active: "Active",
+      archived: "Archived",
+      published: "Published",
+      enabled: "Enabled",
+      disabled: "Disabled"
+    },
+    sourceTypes: {
+      existing: "Existing Agent"
+    },
+    actions: {
+      new: "New Workforce",
+      create: "Create Workforce",
+      run: "Run",
+      runWorkforce: "Run Workforce",
+      details: "Details",
+      builder: "Builder",
+      canvas: "Canvas",
+      saveWorkforce: "Save Workforce",
+      addWorker: "Add Worker",
+      openAgent: "Open Agent",
+      openAgentEditor: "Open Agent Editor",
+      editAgent: "Edit Agent",
+      remove: "Remove",
+      saveWorker: "Save Worker",
+      up: "Up",
+      down: "Down",
+      proposeChanges: "Propose Changes",
+      applyChanges: "Apply Changes",
+      alreadyApplied: "Already Applied"
+    },
+    fields: {
+      name: "Name",
+      description: "Description",
+      manager: "Manager",
+      managerInstructions: "Manager Instructions",
+      workers: "Workers",
+      publishedAgent: "Published Agent",
+      alias: "Alias",
+      assignmentInstructions: "Assignment Instructions",
+      enabled: "Enabled",
+      order: "Order",
+      updated: "Updated"
+    },
+    list: {
+      badge: "Workforce",
+      title: "Workforces",
+      description: "Create manager-led multi-agent work groups, keep worker roles explicit, and run them from a single entry point.",
+      searchPlaceholder: "Search workforces...",
+      emptyTitle: "No workforces yet",
+      emptyDescription: "Start with a manager agent, add a few workers, and return here to launch coordinated runs.",
+      createFirst: "Create your first workforce",
+      manager: "Manager: {name}",
+      workers: "Workers: {count}",
+      lastUpdate: "Last update: {value}",
+      lastRun: "Last run #{runId} · {status}",
+      lastRunWithTask: "Last run #{runId} · task #{taskId} · {status}",
+      noRuns: "No runs yet"
+    },
+    pagination: {
+      showing: "Showing {start}-{end} of {total}",
+      prev: "Prev",
+      page: "Page {page} of {pages}",
+      next: "Next"
+    },
+    create: {
+      backToWorkforces: "Back to Workforces",
+      title: "Create Workforce",
+      description: "Start with a manager, add workers, then review the orchestration before saving.",
+      steps: {
+        basics: "Basics",
+        workers: "Workers",
+        review: "Review"
+      },
+      placeholders: {
+        name: "Marketing Launch Workforce",
+        description: "Coordinate research, content, and launch tasks.",
+        managerInstructions: "Coordinate workers, reconcile conflicting outputs, and return a single answer."
+      },
+      manager: {
+        selectLabel: "Select the manager agent",
+        placeholder: "Choose an agent"
+      }
+    },
+    detail: {
+      description: "Review and edit the current orchestration before running it.",
+      editTitle: "Edit Workforce"
+    },
+    workers: {
+      addTitle: "Add Worker",
+      manageTitle: "Manage Workers",
+      chooseAgent: "Choose a worker agent",
+      aliasPlaceholder: "Optional display name",
+      instructionsPlaceholder: "Describe what this worker handles inside the workforce.",
+      noneSelected: "No workers selected yet.",
+      noneConfigured: "No workers configured.",
+      noneYet: "No workers yet.",
+      fallbackName: "Worker {index}",
+      aWorker: "A worker",
+      defaultDescription: "Published agent worker",
+      publishedAgent: "Published agent",
+      disabledHelp: "Disabled workers are kept in the Workforce but skipped at runtime."
+    },
+    review: {
+      potentialRisks: "Potential Risks",
+      untitled: "Untitled Workforce",
+      noManagerInstructions: "No manager instructions",
+      warnings: {
+        managerNotPublished: "Manager is not published yet.",
+        workerNotPublished: "{name} is not published yet.",
+        missingInstructions: "{name} is missing assignment instructions."
+      }
+    },
+    summary: {
+      enabledCount: "{count} enabled"
+    },
+    run: {
+      testTitle: "Test Workforce",
+      placeholder: "Describe the task you want the manager to coordinate."
+    },
+    builder: {
+      chatTitle: "Builder Chat",
+      chatDescription: "Describe the workforce change you want. The builder will turn it into a reviewable patch.",
+      emptyPrompt: "Start with something like: add worker Research Agent to handle competitor research.",
+      roleBuilder: "Builder",
+      roleYou: "You",
+      preparingPatch: "Preparing a proposed patch...",
+      messagePlaceholder: "Rename this workforce to \"Launch Crew\" and make Writer focus on launch email copy.",
+      sendHint: "Press Ctrl/Cmd + Enter to send.",
+      patchTitle: "Proposed Patch",
+      patchDescription: "Review the generated workforce changes before applying them.",
+      noProposal: "No proposal yet. Send a request in Builder Chat to generate a patch.",
+      summary: "Summary",
+      clarificationNeeded: "Clarification needed",
+      warnings: "Warnings",
+      readyToApply: "Ready to apply",
+      noDestructiveWarning: "No destructive warning was detected in this patch.",
+      operationsTitle: "Operations",
+      changeCount: "{count} change(s)",
+      noOperations: "This proposal does not contain any executable operation yet.",
+      operations: {
+        update_workforce: "Update Workforce",
+        add_existing_worker: "Add Existing Worker",
+        update_worker: "Update Worker",
+        remove_worker: "Remove Worker"
+      }
+    },
+    canvas: {
+      connections: "Connections"
+    },
+    loading: {
+      list: "Loading workforces...",
+      agents: "Loading agents...",
+      creating: "Creating...",
+      detail: "Loading workforce...",
+      saving: "Saving...",
+      starting: "Starting...",
+      builderHistory: "Loading builder history...",
+      proposing: "Proposing...",
+      applyingChanges: "Applying Changes...",
+      runView: "Loading run view...",
+      canvas: "Loading canvas...",
+      builder: "Loading builder..."
+    },
+    messages: {
+      updated: "Workforce updated",
+      workerAdded: "Worker added",
+      workerUpdated: "Worker updated",
+      workerRemoved: "Worker removed",
+      proposalCreated: "Builder proposal created",
+      changesApplied: "Workforce changes applied"
+    },
+    errors: {
+      loadList: "Failed to load workforces",
+      loadAgents: "Failed to load agents",
+      create: "Failed to create workforce",
+      load: "Failed to load workforce",
+      update: "Failed to update workforce",
+      addWorker: "Failed to add worker",
+      updateWorker: "Failed to update worker",
+      removeWorker: "Failed to remove worker",
+      run: "Failed to run workforce",
+      notFound: "Workforce not found.",
+      loadCanvas: "Failed to load workforce canvas",
+      canvasUnavailable: "Canvas unavailable.",
+      loadBuilder: "Failed to load builder",
+      proposeChanges: "Failed to propose changes",
+      applyChanges: "Failed to apply changes"
+    }
+  },
   adminMcp: {
     pageTitle: "Public MCP Configuration",
     pageDescription: "Manage OAuth providers and the public MCP apps that depend on them.",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3112,7 +3112,9 @@ Build when you need.`
       down: "Down",
       proposeChanges: "Propose Changes",
       applyChanges: "Apply Changes",
-      alreadyApplied: "Already Applied"
+      alreadyApplied: "Already Applied",
+      publish: "Publish",
+      unpublish: "Unpublish"
     },
     fields: {
       name: "Name",
@@ -3246,7 +3248,14 @@ Build when you need.`
       }
     },
     canvas: {
-      connections: "Connections"
+      backToDetails: "Back to details",
+      connections: "Connections",
+      noConnections: "No connections configured.",
+      nodeTypes: {
+        human: "Human",
+        manager: "Manager",
+        worker: "Worker"
+      }
     },
     loading: {
       list: "Loading workforces...",
@@ -3268,7 +3277,9 @@ Build when you need.`
       workerUpdated: "Worker updated",
       workerRemoved: "Worker removed",
       proposalCreated: "Builder proposal created",
-      changesApplied: "Workforce changes applied"
+      changesApplied: "Workforce changes applied",
+      published: "Workforce published",
+      unpublished: "Workforce unpublished"
     },
     errors: {
       loadList: "Failed to load workforces",
@@ -3285,7 +3296,9 @@ Build when you need.`
       canvasUnavailable: "Canvas unavailable.",
       loadBuilder: "Failed to load builder",
       proposeChanges: "Failed to propose changes",
-      applyChanges: "Failed to apply changes"
+      applyChanges: "Failed to apply changes",
+      publish: "Failed to publish workforce",
+      unpublish: "Failed to unpublish workforce"
     }
   },
   adminMcp: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -60,6 +60,7 @@ const en = {
     history: "All Tasks",
     search: "Search Tasks",
     templates: "Templates",
+    workforces: "Workforces",
     channels: "Channels",
     more: "More",
     sections: {
@@ -3016,7 +3017,12 @@ Build when you need.`
     queryPrefix: "Query:",
     pathPrefix: "Path:",
     bashPrefix: "Bash:",
-    searchPrefix: "Search:"
+    searchPrefix: "Search:",
+    workforceDelegation: "Workforce Delegation",
+    delegateToWorker: "Delegate to {worker}",
+    workerReturned: "Worker returned result",
+    workerFailed: "Worker failed",
+    unknownWorker: "Unknown Worker"
   },
   deploy_agent: {
     title: "Deploy Agent",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3152,6 +3152,21 @@ Build when you need.`
       backToWorkforces: "Back to Workforces",
       title: "Create Workforce",
       description: "Start with a manager, add workers, then review the orchestration before saving.",
+      prompt: {
+        badge: "AI setup",
+        title: "Create Workforce",
+        description: "Describe the outcome you want. The builder will create a manager, select published workers when they fit, and open a reviewable draft.",
+        cardTitle: "What should this Workforce do?",
+        cardDescription: "The generated manager is created for this Workforce. Workers are selected only from existing published agents.",
+        placeholder: "Example: Build a Workforce for weekly competitor monitoring. It should research competitor updates, summarize pricing changes, and draft a concise leadership brief.",
+        manualSetup: "Manual setup",
+        generate: "Generate Workforce"
+      },
+      manual: {
+        title: "Manual Workforce Setup",
+        description: "Choose an existing manager, add workers, then review the orchestration before saving.",
+        backToPrompt: "Back to AI setup"
+      },
       steps: {
         basics: "Basics",
         workers: "Workers",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3152,6 +3152,21 @@ Build when you need.`
       backToWorkforces: "返回 Workforces",
       title: "创建 Workforce",
       description: "先选择管理者，再添加 worker，最后在保存前检查编排配置。",
+      prompt: {
+        badge: "AI 创建",
+        title: "创建 Workforce",
+        description: "描述你想达成的目标。Builder 会创建 manager，在合适时从已发布 agents 中选择 workers，并打开一个可检查的草稿。",
+        cardTitle: "这个 Workforce 应该做什么？",
+        cardDescription: "生成的 manager 会专门用于这个 Workforce。Workers 只会从已有的已发布 agents 中选择。",
+        placeholder: "例如：创建一个用于每周竞品监控的 Workforce。它需要调研竞品动态，总结价格变化，并起草一份简洁的管理层简报。",
+        manualSetup: "手动设置",
+        generate: "生成 Workforce"
+      },
+      manual: {
+        title: "手动设置 Workforce",
+        description: "选择已有 manager，添加 workers，然后在保存前检查编排配置。",
+        backToPrompt: "返回 AI 创建"
+      },
       steps: {
         basics: "基础信息",
         workers: "Workers",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -60,6 +60,7 @@ const zh = {
     history: "全部任务",
     search: "搜索任务",
     templates: "模板",
+    workforces: "Workforces",
     channels: "渠道",
     more: "更多",
     sections: {
@@ -3016,7 +3017,12 @@ Build when you need.`
     queryPrefix: "查询:",
     pathPrefix: "路径:",
     bashPrefix: "Bash命令:",
-    searchPrefix: "搜索:"
+    searchPrefix: "搜索:",
+    workforceDelegation: "Workforce 委派",
+    delegateToWorker: "委派给 {worker}",
+    workerReturned: "Worker 已返回结果",
+    workerFailed: "Worker 执行失败",
+    unknownWorker: "未知 Worker"
   },
   deploy_agent: {
     title: "部署 Agent",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3076,6 +3076,203 @@ Build when you need.`
       copied: "已复制到剪贴板"
     }
   },
+  workforces: {
+    common: {
+      noDescription: "暂无描述",
+      notAvailable: "不可用",
+      notSelected: "未选择"
+    },
+    status: {
+      draft: "草稿",
+      active: "启用",
+      archived: "已归档",
+      published: "已发布",
+      enabled: "已启用",
+      disabled: "已禁用"
+    },
+    sourceTypes: {
+      existing: "已有 Agent"
+    },
+    actions: {
+      new: "新建 Workforce",
+      create: "创建 Workforce",
+      run: "运行",
+      runWorkforce: "运行 Workforce",
+      details: "详情",
+      builder: "Builder",
+      canvas: "画布",
+      saveWorkforce: "保存 Workforce",
+      addWorker: "添加 Worker",
+      openAgent: "打开 Agent",
+      openAgentEditor: "打开 Agent 编辑器",
+      editAgent: "编辑 Agent",
+      remove: "移除",
+      saveWorker: "保存 Worker",
+      up: "上移",
+      down: "下移",
+      proposeChanges: "生成修改建议",
+      applyChanges: "应用修改",
+      alreadyApplied: "已应用"
+    },
+    fields: {
+      name: "名称",
+      description: "描述",
+      manager: "Manager",
+      managerInstructions: "Manager 指令",
+      workers: "Workers",
+      publishedAgent: "已发布 Agent",
+      alias: "别名",
+      assignmentInstructions: "任务指令",
+      enabled: "启用",
+      order: "顺序",
+      updated: "更新时间"
+    },
+    list: {
+      badge: "Workforce",
+      title: "Workforces",
+      description: "创建由 manager 统筹的多 Agent 工作组，明确 worker 职责，并从统一入口运行。",
+      searchPlaceholder: "搜索 Workforces...",
+      emptyTitle: "还没有 Workforce",
+      emptyDescription: "先选择 manager agent，再添加几个 worker，之后可以回到这里发起协同运行。",
+      createFirst: "创建第一个 Workforce",
+      manager: "Manager: {name}",
+      workers: "Workers: {count}",
+      lastUpdate: "最后更新: {value}",
+      lastRun: "最近运行 #{runId} · {status}",
+      lastRunWithTask: "最近运行 #{runId} · 任务 #{taskId} · {status}",
+      noRuns: "还没有运行记录"
+    },
+    pagination: {
+      showing: "显示第 {start}-{end} 条，共 {total} 条",
+      prev: "上一页",
+      page: "第 {page} 页，共 {pages} 页",
+      next: "下一页"
+    },
+    create: {
+      backToWorkforces: "返回 Workforces",
+      title: "创建 Workforce",
+      description: "先选择管理者，再添加 worker，最后在保存前检查编排配置。",
+      steps: {
+        basics: "基础信息",
+        workers: "Workers",
+        review: "检查"
+      },
+      placeholders: {
+        name: "营销发布 Workforce",
+        description: "协调调研、内容和发布任务。",
+        managerInstructions: "协调 workers，处理冲突结果，并返回统一答案。"
+      },
+      manager: {
+        selectLabel: "选择 manager agent",
+        placeholder: "选择 agent"
+      }
+    },
+    detail: {
+      description: "运行前检查并编辑当前编排。",
+      editTitle: "编辑 Workforce"
+    },
+    workers: {
+      addTitle: "添加 Worker",
+      manageTitle: "管理 Workers",
+      chooseAgent: "选择 worker agent",
+      aliasPlaceholder: "可选显示名称",
+      instructionsPlaceholder: "描述这个 worker 在 workforce 中负责什么。",
+      noneSelected: "还没有选择 worker。",
+      noneConfigured: "还没有配置 worker。",
+      noneYet: "还没有 worker。",
+      fallbackName: "Worker {index}",
+      aWorker: "某个 worker",
+      defaultDescription: "已发布的 agent worker",
+      publishedAgent: "已发布 agent",
+      disabledHelp: "禁用的 worker 会保留在 Workforce 中，但运行时会跳过。"
+    },
+    review: {
+      potentialRisks: "潜在风险",
+      untitled: "未命名 Workforce",
+      noManagerInstructions: "没有 manager 指令",
+      warnings: {
+        managerNotPublished: "Manager 还没有发布。",
+        workerNotPublished: "{name} 还没有发布。",
+        missingInstructions: "{name} 缺少任务指令。"
+      }
+    },
+    summary: {
+      enabledCount: "{count} 个已启用"
+    },
+    run: {
+      testTitle: "测试 Workforce",
+      placeholder: "描述你希望 manager 协调完成的任务。"
+    },
+    builder: {
+      chatTitle: "Builder 对话",
+      chatDescription: "描述你想要的 workforce 修改，builder 会生成可检查的 patch。",
+      emptyPrompt: "可以这样开始：添加 Research Agent worker 来负责竞品调研。",
+      roleBuilder: "Builder",
+      roleYou: "你",
+      preparingPatch: "正在准备修改建议...",
+      messagePlaceholder: "把这个 workforce 改名为 \"Launch Crew\"，并让 Writer 专注发布邮件文案。",
+      sendHint: "按 Ctrl/Cmd + Enter 发送。",
+      patchTitle: "修改建议",
+      patchDescription: "应用前先检查生成的 workforce 修改。",
+      noProposal: "还没有建议。在 Builder 对话中发送请求来生成 patch。",
+      summary: "摘要",
+      clarificationNeeded: "需要澄清",
+      warnings: "警告",
+      readyToApply: "可以应用",
+      noDestructiveWarning: "这个 patch 没有检测到破坏性操作警告。",
+      operationsTitle: "操作",
+      changeCount: "{count} 项修改",
+      noOperations: "这个建议还没有包含可执行操作。",
+      operations: {
+        update_workforce: "更新 Workforce",
+        add_existing_worker: "添加已有 Worker",
+        update_worker: "更新 Worker",
+        remove_worker: "移除 Worker"
+      }
+    },
+    canvas: {
+      connections: "连接"
+    },
+    loading: {
+      list: "正在加载 Workforces...",
+      agents: "正在加载 agents...",
+      creating: "正在创建...",
+      detail: "正在加载 Workforce...",
+      saving: "正在保存...",
+      starting: "正在启动...",
+      builderHistory: "正在加载 builder 历史...",
+      proposing: "正在生成建议...",
+      applyingChanges: "正在应用修改...",
+      runView: "正在加载运行页面...",
+      canvas: "正在加载画布...",
+      builder: "正在加载 builder..."
+    },
+    messages: {
+      updated: "Workforce 已更新",
+      workerAdded: "Worker 已添加",
+      workerUpdated: "Worker 已更新",
+      workerRemoved: "Worker 已移除",
+      proposalCreated: "Builder 修改建议已创建",
+      changesApplied: "Workforce 修改已应用"
+    },
+    errors: {
+      loadList: "加载 Workforces 失败",
+      loadAgents: "加载 agents 失败",
+      create: "创建 Workforce 失败",
+      load: "加载 Workforce 失败",
+      update: "更新 Workforce 失败",
+      addWorker: "添加 worker 失败",
+      updateWorker: "更新 worker 失败",
+      removeWorker: "移除 worker 失败",
+      run: "运行 Workforce 失败",
+      notFound: "没有找到 Workforce。",
+      loadCanvas: "加载 Workforce 画布失败",
+      canvasUnavailable: "画布不可用。",
+      loadBuilder: "加载 builder 失败",
+      proposeChanges: "生成修改建议失败",
+      applyChanges: "应用修改失败"
+    }
+  },
   adminMcp: {
     pageTitle: "公共 MCP 配置",
     pageDescription: "管理 OAuth 供应商和依赖它们的公共 MCP 应用。",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3112,7 +3112,9 @@ Build when you need.`
       down: "下移",
       proposeChanges: "生成修改建议",
       applyChanges: "应用修改",
-      alreadyApplied: "已应用"
+      alreadyApplied: "已应用",
+      publish: "发布",
+      unpublish: "取消发布"
     },
     fields: {
       name: "名称",
@@ -3246,7 +3248,14 @@ Build when you need.`
       }
     },
     canvas: {
-      connections: "连接"
+      backToDetails: "返回详情",
+      connections: "连接",
+      noConnections: "暂未配置连接。",
+      nodeTypes: {
+        human: "Human",
+        manager: "Manager",
+        worker: "Worker"
+      }
     },
     loading: {
       list: "正在加载 Workforces...",
@@ -3268,7 +3277,9 @@ Build when you need.`
       workerUpdated: "Worker 已更新",
       workerRemoved: "Worker 已移除",
       proposalCreated: "Builder 修改建议已创建",
-      changesApplied: "Workforce 修改已应用"
+      changesApplied: "Workforce 修改已应用",
+      published: "Workforce 已发布",
+      unpublished: "Workforce 已取消发布"
     },
     errors: {
       loadList: "加载 Workforces 失败",
@@ -3285,7 +3296,9 @@ Build when you need.`
       canvasUnavailable: "画布不可用。",
       loadBuilder: "加载 builder 失败",
       proposeChanges: "生成修改建议失败",
-      applyChanges: "应用修改失败"
+      applyChanges: "应用修改失败",
+      publish: "发布 Workforce 失败",
+      unpublish: "取消发布 Workforce 失败"
     }
   },
   adminMcp: {

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -13,6 +13,7 @@ import type {
   WorkforceCreatePayload,
   WorkforceDetail,
   WorkforceListResponse,
+  WorkforcePromptCreatePayload,
   WorkforceRunResponse,
   WorkforceUpdatePayload,
   WorkforceWorker,
@@ -60,6 +61,22 @@ export async function getWorkforce(workforceId: number | string): Promise<Workfo
 
 export async function createWorkforce(payload: WorkforceCreatePayload): Promise<WorkforceDetail> {
   const response = await apiRequest(`${getApiUrl()}/api/workforces`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to create workforce")
+  }
+  return response.json()
+}
+
+export async function createWorkforceFromPrompt(
+  payload: WorkforcePromptCreatePayload,
+): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/from-prompt`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -1,0 +1,164 @@
+"use client"
+
+import { apiRequest } from "@/lib/api-wrapper"
+import { getApiUrl } from "@/lib/utils"
+import type {
+  WorkforceAgentOption,
+  WorkforceBuilderApplyPayload,
+  WorkforceBuilderApplyResponse,
+  WorkforceBuilderMessagesResponse,
+  WorkforceBuilderProposePayload,
+  WorkforceBuilderProposeResponse,
+  WorkforceCanvasResponse,
+  WorkforceCreatePayload,
+  WorkforceDetail,
+  WorkforceListResponse,
+  WorkforceRunResponse,
+  WorkforceTemplateOption,
+} from "@/types/workforce"
+
+async function parseApiError(response: Response, fallback: string): Promise<Error> {
+  try {
+    const data = await response.json()
+    return new Error(data?.detail || fallback)
+  } catch {
+    return new Error(fallback)
+  }
+}
+
+export async function listWorkforces(params?: {
+  page?: number
+  size?: number
+  search?: string
+  status?: string
+}): Promise<WorkforceListResponse> {
+  const searchParams = new URLSearchParams()
+  if (params?.page) searchParams.set("page", String(params.page))
+  if (params?.size) searchParams.set("size", String(params.size))
+  if (params?.search) searchParams.set("search", params.search)
+  if (params?.status) searchParams.set("status", params.status)
+
+  const suffix = searchParams.toString() ? `?${searchParams.toString()}` : ""
+  const response = await apiRequest(`${getApiUrl()}/api/workforces${suffix}`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforces")
+  }
+  return response.json()
+}
+
+export async function getWorkforce(workforceId: number | string): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforce")
+  }
+  return response.json()
+}
+
+export async function createWorkforce(payload: WorkforceCreatePayload): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to create workforce")
+  }
+  return response.json()
+}
+
+export async function runWorkforce(
+  workforceId: number | string,
+  message: string,
+): Promise<WorkforceRunResponse> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ message }),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to run workforce")
+  }
+  return response.json()
+}
+
+export async function getWorkforceBuilderMessages(
+  workforceId: number | string,
+): Promise<WorkforceBuilderMessagesResponse> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/builder/messages`,
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load builder messages")
+  }
+  return response.json()
+}
+
+export async function proposeWorkforceChanges(
+  workforceId: number | string,
+  payload: WorkforceBuilderProposePayload,
+): Promise<WorkforceBuilderProposeResponse> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/builder/propose`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to propose workforce changes")
+  }
+  return response.json()
+}
+
+export async function applyWorkforceChanges(
+  workforceId: number | string,
+  payload: WorkforceBuilderApplyPayload,
+): Promise<WorkforceBuilderApplyResponse> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/builder/apply`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to apply workforce changes")
+  }
+  return response.json()
+}
+
+export async function getWorkforceCanvas(
+  workforceId: number | string,
+): Promise<WorkforceCanvasResponse> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/canvas`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforce canvas")
+  }
+  return response.json()
+}
+
+export async function listAgentOptions(): Promise<WorkforceAgentOption[]> {
+  const response = await apiRequest(`${getApiUrl()}/api/agents`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load agents")
+  }
+  return response.json()
+}
+
+export async function listWorkforceTemplates(): Promise<WorkforceTemplateOption[]> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/templates`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load workforce templates")
+  }
+  return response.json()
+}

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -106,6 +106,30 @@ export async function updateWorkforce(
   return response.json()
 }
 
+export async function publishWorkforce(
+  workforceId: number | string,
+): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/publish`, {
+    method: "POST",
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to publish workforce")
+  }
+  return response.json()
+}
+
+export async function unpublishWorkforce(
+  workforceId: number | string,
+): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/unpublish`, {
+    method: "POST",
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to unpublish workforce")
+  }
+  return response.json()
+}
+
 export async function addWorkforceAgent(
   workforceId: number | string,
   payload: WorkforceWorkerPayload,

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -14,6 +14,10 @@ import type {
   WorkforceDetail,
   WorkforceListResponse,
   WorkforceRunResponse,
+  WorkforceUpdatePayload,
+  WorkforceWorker,
+  WorkforceWorkerPayload,
+  WorkforceWorkerUpdatePayload,
   WorkforceTemplateOption,
 } from "@/types/workforce"
 
@@ -66,6 +70,76 @@ export async function createWorkforce(payload: WorkforceCreatePayload): Promise<
     throw await parseApiError(response, "Failed to create workforce")
   }
   return response.json()
+}
+
+export async function updateWorkforce(
+  workforceId: number | string,
+  payload: WorkforceUpdatePayload,
+): Promise<WorkforceDetail> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to update workforce")
+  }
+  return response.json()
+}
+
+export async function addWorkforceAgent(
+  workforceId: number | string,
+  payload: WorkforceWorkerPayload,
+): Promise<WorkforceWorker> {
+  const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/agents`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to add workforce worker")
+  }
+  return response.json()
+}
+
+export async function updateWorkforceAgent(
+  workforceId: number | string,
+  memberId: number | string,
+  payload: WorkforceWorkerUpdatePayload,
+): Promise<WorkforceWorker> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/agents/${memberId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to update workforce worker")
+  }
+  return response.json()
+}
+
+export async function removeWorkforceAgent(
+  workforceId: number | string,
+  memberId: number | string,
+): Promise<void> {
+  const response = await apiRequest(
+    `${getApiUrl()}/api/workforces/${workforceId}/agents/${memberId}`,
+    {
+      method: "DELETE",
+    },
+  )
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to remove workforce worker")
+  }
 }
 
 export async function runWorkforce(

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -26,7 +26,7 @@ export interface WorkforceManagerListItem {
 
 export interface WorkforceRunListItem {
   id: number
-  task_id: number
+  task_id: number | null
   status: string
   created_at: string | null
 }

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -138,6 +138,7 @@ export interface WorkforceBuilderPatch {
   summary: string
   operations: WorkforceBuilderOperation[]
   warnings: string[]
+  clarification?: string | null
 }
 
 export interface WorkforceBuilderMessage {

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -118,6 +118,10 @@ export interface WorkforceCreatePayload {
   }>
 }
 
+export interface WorkforcePromptCreatePayload {
+  prompt: string
+}
+
 export interface WorkforceUpdatePayload {
   name?: string
   description?: string

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -94,10 +94,8 @@ export interface WorkforceNewAgentDraft {
 }
 
 export interface WorkforceWorkerDraft {
-  source_type: "existing" | "template" | "new"
-  agent_id?: number
-  template_id?: string
-  agent?: WorkforceNewAgentDraft
+  source_type: "existing"
+  agent_id: number
   alias: string
   assignment_instructions: string
   enabled: boolean
@@ -111,15 +109,37 @@ export interface WorkforceCreatePayload {
   manager_instructions?: string
   status?: string
   workers?: Array<{
-    source_type: "existing" | "template" | "new"
-    agent_id?: number
-    template_id?: string
-    agent?: WorkforceNewAgentDraft
+    source_type: "existing"
+    agent_id: number
     alias?: string
     assignment_instructions: string
     enabled?: boolean
     sort_order?: number
   }>
+}
+
+export interface WorkforceUpdatePayload {
+  name?: string
+  description?: string
+  manager_agent_id?: number
+  manager_instructions?: string
+  status?: string
+}
+
+export interface WorkforceWorkerPayload {
+  source_type: "existing"
+  agent_id: number
+  alias?: string
+  assignment_instructions: string
+  enabled?: boolean
+  sort_order?: number
+}
+
+export interface WorkforceWorkerUpdatePayload {
+  alias?: string
+  assignment_instructions?: string
+  enabled?: boolean
+  sort_order?: number
 }
 
 export interface WorkforceRunResponse {

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -1,0 +1,198 @@
+export interface WorkforceAgentSummary {
+  id: number
+  name: string
+  description: string | null
+  logo_url: string | null
+  status: string
+}
+
+export interface WorkforceWorker {
+  id: number
+  agent: WorkforceAgentSummary
+  alias: string | null
+  assignment_instructions: string
+  source_type: string
+  template_id: string | null
+  enabled: boolean
+  sort_order: number
+  canvas_position: Record<string, unknown> | null
+}
+
+export interface WorkforceManagerListItem {
+  id: number
+  name: string
+  logo_url: string | null
+}
+
+export interface WorkforceRunListItem {
+  id: number
+  task_id: number
+  status: string
+  created_at: string | null
+}
+
+export interface WorkforceListItem {
+  id: number
+  name: string
+  description: string | null
+  status: string
+  manager: WorkforceManagerListItem
+  worker_count: number
+  last_run: WorkforceRunListItem | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface WorkforceDetail {
+  id: number
+  name: string
+  description: string | null
+  status: string
+  manager: WorkforceAgentSummary
+  manager_instructions: string | null
+  workers: WorkforceWorker[]
+  canvas_layout: Record<string, unknown> | null
+  scope_type: string
+  scope_id: string
+  owner_user_id: number
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface WorkforceListResponse {
+  items: WorkforceListItem[]
+  total: number
+  page: number
+  size: number
+  pages: number
+}
+
+export interface WorkforceAgentOption {
+  id: number
+  name: string
+  description: string | null
+  status: string
+  logo_url: string | null
+}
+
+export interface WorkforceTemplateOption {
+  id: string
+  name: string
+  description: string | null
+}
+
+export interface WorkforceNewAgentDraft {
+  name: string
+  description: string
+  instructions: string
+  execution_mode: string
+  models?: Record<string, unknown> | null
+  knowledge_bases: string[]
+  skills: string[]
+  tool_categories: string[]
+  suggested_prompts: string[]
+}
+
+export interface WorkforceWorkerDraft {
+  source_type: "existing" | "template" | "new"
+  agent_id?: number
+  template_id?: string
+  agent?: WorkforceNewAgentDraft
+  alias: string
+  assignment_instructions: string
+  enabled: boolean
+  sort_order: number
+}
+
+export interface WorkforceCreatePayload {
+  name: string
+  description?: string
+  manager_agent_id: number
+  manager_instructions?: string
+  status?: string
+  workers?: Array<{
+    source_type: "existing" | "template" | "new"
+    agent_id?: number
+    template_id?: string
+    agent?: WorkforceNewAgentDraft
+    alias?: string
+    assignment_instructions: string
+    enabled?: boolean
+    sort_order?: number
+  }>
+}
+
+export interface WorkforceRunResponse {
+  workforce_run_id: number
+  task_id: number
+  status: string
+  redirect_url: string
+}
+
+export interface WorkforceBuilderOperation {
+  op: string
+  [key: string]: unknown
+}
+
+export interface WorkforceBuilderPatch {
+  summary: string
+  operations: WorkforceBuilderOperation[]
+  warnings: string[]
+}
+
+export interface WorkforceBuilderMessage {
+  id: number
+  role: string
+  content: string
+  status: string
+  proposed_patch: WorkforceBuilderPatch | null
+  created_at: string | null
+}
+
+export interface WorkforceBuilderMessagesResponse {
+  items: WorkforceBuilderMessage[]
+}
+
+export interface WorkforceBuilderProposePayload {
+  message: string
+  context?: Record<string, unknown>
+}
+
+export interface WorkforceBuilderProposeResponse {
+  message_id: number
+  assistant_message: string
+  proposed_patch: WorkforceBuilderPatch
+  requires_confirmation: boolean
+}
+
+export interface WorkforceBuilderApplyPayload {
+  message_id: number
+  proposed_patch: WorkforceBuilderPatch
+}
+
+export interface WorkforceBuilderApplyResponse {
+  status: string
+  message_id: number
+  workforce: WorkforceDetail
+}
+
+export interface WorkforceCanvasNode {
+  id: string
+  type: string
+  agent_id?: number
+  label: string
+  position?: Record<string, unknown> | null
+  enabled?: boolean
+}
+
+export interface WorkforceCanvasEdge {
+  id: string
+  source: string
+  target: string
+}
+
+export interface WorkforceCanvasResponse {
+  nodes: WorkforceCanvasNode[]
+  edges: WorkforceCanvasEdge[]
+  layout: Record<string, unknown>
+}

--- a/src/xagent/core/agent/pattern/dag_plan_execute/dag_plan_execute.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/dag_plan_execute.py
@@ -1378,6 +1378,7 @@ class DAGPlanExecutePattern(AgentPattern):
 
         # Add file outputs if available
         file_outputs = self._extract_file_outputs()
+        file_outputs.extend(self._extract_file_outputs_from_history(execution_history))
         if file_outputs:
             result["file_outputs"] = file_outputs
 
@@ -1441,6 +1442,60 @@ class DAGPlanExecutePattern(AgentPattern):
         logger.info(f"File outputs array: {file_outputs}")
         return file_outputs
 
+    def _extract_file_outputs_from_history(
+        self, execution_history: List[Dict[str, Any]]
+    ) -> List[Dict[str, str]]:
+        """Collect output files reported by delegated tools and completed steps."""
+        collected: List[Dict[str, str]] = []
+        seen: set[str] = set()
+
+        def add_file_output(file_info: Any) -> None:
+            if not isinstance(file_info, dict):
+                return
+            file_id = str(file_info.get("file_id") or "").strip()
+            filename = str(file_info.get("filename") or "").strip()
+            file_path = str(file_info.get("file_path") or "").strip()
+            relative_path = str(file_info.get("relative_path") or "").strip()
+            download_path = str(file_info.get("download_path") or "").strip()
+            key = file_id or file_path or relative_path or download_path
+            if not key or key in seen:
+                return
+            seen.add(key)
+
+            output: Dict[str, str] = {}
+            if file_id:
+                output["file_id"] = file_id
+            if filename:
+                output["filename"] = filename
+            if file_path:
+                output["file_path"] = file_path
+            if relative_path:
+                output["relative_path"] = relative_path
+            if download_path:
+                output["download_path"] = download_path
+            collected.append(output)
+
+        def collect_from_result(result: Any) -> None:
+            if not isinstance(result, dict):
+                return
+            file_outputs = result.get("file_outputs")
+            if isinstance(file_outputs, list):
+                for file_info in file_outputs:
+                    add_file_output(file_info)
+            nested_result = result.get("result")
+            if isinstance(nested_result, dict):
+                collect_from_result(nested_result)
+
+        for entry in execution_history:
+            collect_from_result(entry.get("result"))
+            results = entry.get("results")
+            if isinstance(results, list):
+                for step_result in results:
+                    if isinstance(step_result, dict):
+                        collect_from_result(step_result.get("result"))
+
+        return collected
+
     def _compile_continuation_result(
         self,
         additional_task: str,
@@ -1493,6 +1548,7 @@ class DAGPlanExecutePattern(AgentPattern):
 
         # Add file outputs if available
         file_outputs = self._extract_file_outputs()
+        file_outputs.extend(self._extract_file_outputs_from_history(execution_results))
         if file_outputs:
             result["file_outputs"] = file_outputs
 

--- a/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
+++ b/src/xagent/core/agent/pattern/dag_plan_execute/plan_executor.py
@@ -878,6 +878,8 @@ class PlanExecutor:
                 # Include success status
                 if "success" in result:
                     step_trace_data["success"] = result["success"]
+                if "file_outputs" in result:
+                    step_trace_data["file_outputs"] = result["file_outputs"]
 
             # Check for agent-specific trace data in the result (added by format_query_result tools)
             # This avoids circular dependencies by letting tools add data directly to results
@@ -892,6 +894,8 @@ class PlanExecutor:
                 and isinstance(result["result"], dict)
             ):
                 nested_result = result["result"]
+                if "file_outputs" in nested_result:
+                    step_trace_data["file_outputs"] = nested_result["file_outputs"]
                 if "agent_trace_data" in nested_result:
                     agent_trace_data = nested_result["agent_trace_data"]
                     if agent_trace_data:

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -148,6 +148,7 @@ class AgentService:
                 ws_config.get("base_dir", self.workspace_base_dir),
                 ws_config.get("task_id", self.id),
                 self.allowed_external_dirs,
+                db_task_id=ws_config.get("db_task_id"),
             )
         else:
             # Use provided workspace or create new one later in _setup_workspace()
@@ -429,6 +430,7 @@ class AgentService:
                         "output": normalized_output,
                         "success": result.get("success", False),
                         "chat_response": chat_response,
+                        "file_outputs": result.get("file_outputs", []),
                         "dag_status": execution_status,
                         "metadata": {
                             "agent_name": self.name,
@@ -448,6 +450,7 @@ class AgentService:
                     "output", result.get("error", "No output provided")
                 ),
                 "success": result.get("success", False),
+                "file_outputs": result.get("file_outputs", []),
                 "metadata": {
                     "agent_name": self.name,
                     "patterns_used": len(self.patterns),

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -177,6 +177,10 @@ class AgentToolResult(BaseModel):
     """Result from agent tool execution."""
 
     response: str = Field(description="The agent's response")
+    file_outputs: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Files created by the delegated agent, if any",
+    )
 
 
 class ListAvailableSkillsArgs(BaseModel):
@@ -1078,6 +1082,12 @@ class AgentTool(AbstractBaseTool):
         parent_tracer: Any | None = None,
         workforce_context: dict[str, Any] | None = None,
         agent_call_stack: list[int] | None = None,
+        user: Any | None = None,
+        is_admin: bool = False,
+        llm: Any | None = None,
+        vision_model: Any | None = None,
+        sandbox: Any | None = None,
+        allowed_external_dirs: list[str] | None = None,
     ):
         """
         Initialize an agent tool.
@@ -1103,6 +1113,12 @@ class AgentTool(AbstractBaseTool):
         self._parent_tracer = parent_tracer
         self._workforce_context = workforce_context or {}
         self._agent_call_stack = list(agent_call_stack or [])
+        self._user = user
+        self._is_admin = is_admin
+        self._llm = llm
+        self._vision_model = vision_model
+        self._sandbox = sandbox
+        self._allowed_external_dirs = allowed_external_dirs
         if workspace_base_dir is None:
             workspace_base_dir = str(get_uploads_dir())
         self._workspace_base_dir = workspace_base_dir
@@ -1144,6 +1160,7 @@ class AgentTool(AbstractBaseTool):
         execution_task_id: str | None = None,
         output: str | None = None,
         error: str | None = None,
+        file_outputs: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         data: dict[str, Any] = {
             "event_type": f"workforce_delegation_{status}",
@@ -1159,6 +1176,8 @@ class AgentTool(AbstractBaseTool):
             data["output_length"] = len(output)
         if error is not None:
             data["error"] = error
+        if file_outputs:
+            data["file_outputs"] = file_outputs
         return data
 
     async def _trace_delegation(
@@ -1167,6 +1186,7 @@ class AgentTool(AbstractBaseTool):
         execution_task_id: str | None = None,
         output: str | None = None,
         error: str | None = None,
+        file_outputs: list[dict[str, Any]] | None = None,
     ) -> None:
         if (
             self._parent_tracer is None
@@ -1195,6 +1215,7 @@ class AgentTool(AbstractBaseTool):
                     execution_task_id=execution_task_id,
                     output=output,
                     error=error,
+                    file_outputs=file_outputs,
                 ),
             )
         except Exception:
@@ -1228,6 +1249,23 @@ class AgentTool(AbstractBaseTool):
             # Generate unique task ID for this execution
             execution_task_id = f"agent_{self._agent_id}_{uuid.uuid4().hex[:8]}"
             await self._trace_delegation("start", execution_task_id=execution_task_id)
+            child_tracer = self._parent_tracer
+            if child_tracer is None:
+                from .....core.tracing.factory import create_agent_tracer
+
+                child_tracer = create_agent_tracer(
+                    task_id=execution_task_id,
+                    user_id=self._user_id,
+                    trace_name=f"xagent-agent-tool-{execution_task_id}",
+                    session_id=execution_task_id,
+                    tags=["xagent", "agent-tool", "delegation"],
+                    metadata={
+                        "source": "agent_tool",
+                        "agent_id": self._agent_id,
+                        "agent_name": self._agent_name,
+                        "parent_task_id": self._parent_task_id,
+                    },
+                )
 
             # Resolve models
             from .....core.agent.service import AgentService
@@ -1301,6 +1339,7 @@ class AgentTool(AbstractBaseTool):
 
             agent_tool_categories = ensure_list(agent.tool_categories) or []
             next_agent_call_stack = [*self._agent_call_stack, self._agent_id]
+            db_task_id = self._parent_task_id
 
             allowed_tools = None
             if agent_tool_categories:
@@ -1354,19 +1393,29 @@ class AgentTool(AbstractBaseTool):
             tool_config = WebToolConfig(
                 db=self._db,
                 request=MinimalRequest(self._user_id),
+                user=self._user,
                 user_id=self._user_id,
+                is_admin=self._is_admin,
+                llm=self._llm,
+                vision_model=self._vision_model,
                 allowed_collections=agent.knowledge_bases
                 if agent.knowledge_bases is not None
                 else None,
                 allowed_skills=agent.skills if agent.skills is not None else None,
                 allowed_tools=allowed_tools,
                 task_id=execution_task_id,
-                workspace_base_dir=self._workspace_base_dir,
+                workspace_config={
+                    "base_dir": self._workspace_base_dir,
+                    "task_id": execution_task_id,
+                    "allowed_external_dirs": self._allowed_external_dirs,
+                    "db_task_id": db_task_id,
+                },
                 allowed_agent_ids=None,
                 enable_global_agent_tools="agent" in agent_tool_categories,
                 parent_task_id=self._parent_task_id,
-                parent_tracer=self._parent_tracer,
+                parent_tracer=child_tracer,
                 agent_call_stack=next_agent_call_stack,
+                sandbox=self._sandbox,
             )
 
             # Create agent service
@@ -1384,7 +1433,7 @@ class AgentTool(AbstractBaseTool):
                 enable_workspace=True,
                 workspace_base_dir=self._workspace_base_dir,
                 task_id=execution_task_id,
-                tracer=self._parent_tracer,
+                tracer=child_tracer,
             )
 
             # Build execution context
@@ -1397,6 +1446,64 @@ class AgentTool(AbstractBaseTool):
             if prompt_parts:
                 execution_context["system_prompt"] = "\n\n".join(prompt_parts)
 
+            if self._parent_task_id is not None:
+                try:
+                    from .....web.models.task import Task
+                    from .....web.models.uploaded_file import UploadedFile
+
+                    parent_task = (
+                        self._db.query(Task)
+                        .filter(
+                            Task.id == self._parent_task_id,
+                            Task.user_id == self._user_id,
+                        )
+                        .first()
+                    )
+                    raw_selected_file_ids = (
+                        parent_task.agent_config.get("selected_file_ids")
+                        if parent_task is not None
+                        and isinstance(parent_task.agent_config, dict)
+                        else None
+                    )
+                    selected_file_ids = (
+                        [
+                            str(file_id)
+                            for file_id in raw_selected_file_ids
+                            if isinstance(file_id, str) and file_id.strip()
+                        ]
+                        if isinstance(raw_selected_file_ids, list)
+                        else []
+                    )
+                    if selected_file_ids:
+                        uploaded_files = (
+                            self._db.query(UploadedFile)
+                            .filter(
+                                UploadedFile.file_id.in_(selected_file_ids),
+                                UploadedFile.user_id == self._user_id,
+                            )
+                            .all()
+                        )
+                        file_info = [
+                            {
+                                "file_id": str(file.file_id),
+                                "filename": str(file.filename),
+                                "storage_path": str(file.storage_path),
+                                "mime_type": file.mime_type,
+                                "file_size": int(file.file_size or 0),
+                            }
+                            for file in uploaded_files
+                        ]
+                        if file_info:
+                            execution_context["uploaded_files"] = [
+                                file["file_id"] for file in file_info
+                            ]
+                            execution_context["file_info"] = file_info
+                except Exception:
+                    logger.debug(
+                        "Failed to propagate parent task file context to agent tool",
+                        exc_info=True,
+                    )
+
             # Execute task
             with UserContext(self._user_id):
                 result = await agent_service.execute_task(
@@ -1406,13 +1513,22 @@ class AgentTool(AbstractBaseTool):
                 )
 
             output = result.get("output", "No response generated")
+            file_outputs = (
+                result.get("file_outputs", []) if isinstance(result, dict) else []
+            )
             logger.info(
                 f"Agent tool {self.name} executed successfully, output length: {len(output)}"
             )
             await self._trace_delegation(
-                "end", execution_task_id=execution_task_id, output=str(output)
+                "end",
+                execution_task_id=execution_task_id,
+                output=str(output),
+                file_outputs=file_outputs if isinstance(file_outputs, list) else [],
             )
-            return AgentToolResult(response=output).model_dump()
+            return AgentToolResult(
+                response=output,
+                file_outputs=file_outputs if isinstance(file_outputs, list) else [],
+            ).model_dump()
 
         except Exception as e:
             error_msg = f"Error executing agent {self._agent_id}: {str(e)}"
@@ -1454,6 +1570,12 @@ def get_published_agents_tools(
     parent_task_id: int | None = None,
     parent_tracer: Any | None = None,
     agent_call_stack: list[int] | None = None,
+    user: Any | None = None,
+    is_admin: bool = False,
+    llm: Any | None = None,
+    vision_model: Any | None = None,
+    sandbox: Any | None = None,
+    allowed_external_dirs: list[str] | None = None,
 ) -> list[AbstractBaseTool]:
     """
     Get tools for published (and optionally draft) agents.
@@ -1576,6 +1698,12 @@ def get_published_agents_tools(
                 parent_task_id=parent_task_id,
                 parent_tracer=parent_tracer,
                 agent_call_stack=agent_call_stack,
+                user=user,
+                is_admin=is_admin,
+                llm=llm,
+                vision_model=vision_model,
+                sandbox=sandbox,
+                allowed_external_dirs=allowed_external_dirs,
                 workforce_context={
                     key: override[key]
                     for key in (
@@ -1625,12 +1753,23 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             return []
 
         excluded_agent_id = config.get_excluded_agent_id() if config else None
+        workspace_config = config.get_workspace_config() if config else None
+        workspace_base_dir = (
+            workspace_config.get("base_dir")
+            if isinstance(workspace_config, dict)
+            else None
+        )
+        allowed_external_dirs = (
+            workspace_config.get("allowed_external_dirs")
+            if isinstance(workspace_config, dict)
+            else None
+        )
 
         return get_published_agents_tools(
             db=db,
             user_id=user_id,
             task_id=config.get_task_id(),
-            workspace_base_dir=None,  # Will use get_uploads_dir() default
+            workspace_base_dir=workspace_base_dir,
             excluded_agent_id=excluded_agent_id,
             include_draft=False,  # Only PUBLISHED agents
             allowed_agent_ids=allowed_agent_ids,
@@ -1642,6 +1781,12 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             parent_task_id=getattr(config, "get_parent_task_id", lambda: None)(),
             parent_tracer=getattr(config, "get_parent_tracer", lambda: None)(),
             agent_call_stack=getattr(config, "get_agent_call_stack", lambda: [])(),
+            user=getattr(config, "_user", None),
+            is_admin=bool(getattr(config, "is_admin", lambda: False)()),
+            llm=getattr(config, "get_llm", lambda: None)(),
+            vision_model=getattr(config, "_explicit_vision_model", None),
+            sandbox=getattr(config, "get_sandbox", lambda: None)(),
+            allowed_external_dirs=allowed_external_dirs,
         )
     except Exception as e:
         logger.warning(f"Failed to create agent tools: {e}")

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -61,7 +61,9 @@ class CreateAgentToolResult(BaseModel):
 
     agent_id: int = Field(description="The ID of the created agent")
     agent_name: str = Field(description="The name of the created agent")
-    tool_name: str = Field(description="The tool name that can be used to call this agent")
+    tool_name: str = Field(
+        description="The tool name that can be used to call this agent"
+    )
     markdown_link: str = Field(
         description="Markdown link to the agent (e.g., '[Agent Name](agent://123)')"
     )
@@ -73,7 +75,9 @@ class UpdateAgentToolArgs(BaseModel):
     """Arguments for updating an existing agent."""
 
     agent_id: int = Field(description="ID of the agent to update")
-    name: str | None = Field(default=None, description="New name for the agent (optional)")
+    name: str | None = Field(
+        default=None, description="New name for the agent (optional)"
+    )
     description: str | None = Field(
         default=None,
         description="New description of when to use this agent (optional)",
@@ -114,7 +118,9 @@ class UpdateAgentToolResult(BaseModel):
 
     agent_id: int = Field(description="The ID of the updated agent")
     agent_name: str = Field(description="The name of the updated agent")
-    tool_name: str = Field(description="The tool name that can be used to call this agent")
+    tool_name: str = Field(
+        description="The tool name that can be used to call this agent"
+    )
     markdown_link: str = Field(
         description="Markdown link to the agent (e.g., '[Agent Name](agent://123)')"
     )
@@ -174,7 +180,9 @@ class AgentToolResult(BaseModel):
 
 
 class ListAvailableSkillsArgs(BaseModel):
-    query: str | None = Field(default=None, description="Optional search query to filter skills")
+    query: str | None = Field(
+        default=None, description="Optional search query to filter skills"
+    )
 
 
 class ListAvailableSkillsResult(BaseModel):
@@ -215,7 +223,9 @@ class ListAvailableSkillsTool(AbstractBaseTool):
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         import os
 
-        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
+        skills_dir = os.path.join(
+            os.path.dirname(__file__), "../../../../skills/builtin"
+        )
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -324,7 +334,9 @@ class CreateAgentTool(AbstractBaseTool):
         # Get available skills (from builtin skills directory)
         import os
 
-        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
+        skills_dir = os.path.join(
+            os.path.dirname(__file__), "../../../../skills/builtin"
+        )
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -502,7 +514,9 @@ class CreateAgentTool(AbstractBaseTool):
                     models_config[default.config_type] = default.model_id
 
             missing_types = [
-                t for t in ["general", "small_fast", "visual", "compact"] if t not in models_config
+                t
+                for t in ["general", "small_fast", "visual", "compact"]
+                if t not in models_config
             ]
             if missing_types:
                 # Fill missing with visible users' shared defaults
@@ -519,7 +533,9 @@ class CreateAgentTool(AbstractBaseTool):
                 )
                 for admin_default in admin_defaults:
                     if admin_default.config_type not in models_config:
-                        models_config[admin_default.config_type] = admin_default.model_id
+                        models_config[admin_default.config_type] = (
+                            admin_default.model_id
+                        )
 
             execution_mode = args.get("execution_mode", "balanced")
             if execution_mode not in ["flash", "balanced", "think", "auto"]:
@@ -644,7 +660,9 @@ class UpdateAgentTool(AbstractBaseTool):
         # Get available skills (from builtin skills directory)
         import os
 
-        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
+        skills_dir = os.path.join(
+            os.path.dirname(__file__), "../../../../skills/builtin"
+        )
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -782,7 +800,9 @@ class UpdateAgentTool(AbstractBaseTool):
 
             # Update instructions if provided
             new_instructions = (
-                args.get("instructions", "").strip() if args.get("instructions") else None
+                args.get("instructions", "").strip()
+                if args.get("instructions")
+                else None
             )
             if new_instructions:
                 agent.instructions = new_instructions
@@ -1003,9 +1023,13 @@ class ListAgentsTool(AbstractBaseTool):
                 agent_infos.append(agent_info.model_dump())
 
             total_count = len(agent_infos)
-            filter_msg = f" (filtered by status: {status_filter})" if status_filter else ""
+            filter_msg = (
+                f" (filtered by status: {status_filter})" if status_filter else ""
+            )
 
-            logger.info(f"Listed {total_count} agents for user {self._user_id}{filter_msg}")
+            logger.info(
+                f"Listed {total_count} agents for user {self._user_id}{filter_msg}"
+            )
 
             return ListAgentsToolResult(
                 agents=agent_infos,
@@ -1085,7 +1109,10 @@ class AgentTool(AbstractBaseTool):
     @property
     def name(self) -> str:
         """Tool name."""
-        return self._tool_name or f"call_agent_{self._agent_name.lower().replace(' ', '_')}"
+        return (
+            self._tool_name
+            or f"call_agent_{self._agent_name.lower().replace(' ', '_')}"
+        )
 
     @property
     def description(self) -> str:
@@ -1238,7 +1265,9 @@ class AgentTool(AbstractBaseTool):
 
                 if agent.models.get("visual"):
                     visual_model = (
-                        self._db.query(DBModel).filter(DBModel.id == agent.models["visual"]).first()
+                        self._db.query(DBModel)
+                        .filter(DBModel.id == agent.models["visual"])
+                        .first()
                     )
                     if visual_model:
                         vision_llm = storage.get_llm_by_name_with_access(
@@ -1567,7 +1596,9 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
     delegate_agent_ids = config.get_delegate_agent_ids() if config else None
     if allowed_agent_ids is None and delegate_agent_ids:
         allowed_agent_ids = delegate_agent_ids
-    allow_cross_user_agent_ids = getattr(config, "get_allow_cross_user_agent_ids", lambda: False)()
+    allow_cross_user_agent_ids = getattr(
+        config, "get_allow_cross_user_agent_ids", lambda: False
+    )()
     if not config.get_enable_agent_tools() and not allowed_agent_ids:
         return []
 
@@ -1587,7 +1618,9 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             excluded_agent_id=excluded_agent_id,
             include_draft=False,  # Only PUBLISHED agents
             allowed_agent_ids=allowed_agent_ids,
-            agent_tool_overrides=getattr(config, "get_agent_tool_overrides", lambda: {})(),
+            agent_tool_overrides=getattr(
+                config, "get_agent_tool_overrides", lambda: {}
+            )(),
             enable_global_agent_tools=config.get_enable_agent_tools(),
             allow_cross_user_agent_ids=allow_cross_user_agent_ids,
             parent_task_id=getattr(config, "get_parent_task_id", lambda: None)(),
@@ -1631,7 +1664,9 @@ async def create_create_agent_tool(config: "WebToolConfig") -> list[AbstractBase
             workspace_base_dir=None,
         )
 
-        logger.debug(f"Created CreateAgentTool and related list tools for user {user_id}")
+        logger.debug(
+            f"Created CreateAgentTool and related list tools for user {user_id}"
+        )
         return [tool, list_skills_tool, list_categories_tool]
     except Exception as e:
         logger.warning(f"Failed to create CreateAgentTool: {e}")

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1077,6 +1077,7 @@ class AgentTool(AbstractBaseTool):
         parent_task_id: int | None = None,
         parent_tracer: Any | None = None,
         workforce_context: dict[str, Any] | None = None,
+        agent_call_stack: list[int] | None = None,
     ):
         """
         Initialize an agent tool.
@@ -1101,6 +1102,7 @@ class AgentTool(AbstractBaseTool):
         self._parent_task_id = parent_task_id
         self._parent_tracer = parent_tracer
         self._workforce_context = workforce_context or {}
+        self._agent_call_stack = list(agent_call_stack or [])
         if workspace_base_dir is None:
             workspace_base_dir = str(get_uploads_dir())
         self._workspace_base_dir = workspace_base_dir
@@ -1297,8 +1299,11 @@ class AgentTool(AbstractBaseTool):
                 def __init__(self, user_id: int):
                     self.user = type("obj", (), {"id": user_id})()
 
+            agent_tool_categories = ensure_list(agent.tool_categories) or []
+            next_agent_call_stack = [*self._agent_call_stack, self._agent_id]
+
             allowed_tools = None
-            if agent.tool_categories is not None:
+            if agent_tool_categories:
                 from .factory import ToolFactory
 
                 temp_config = WebToolConfig(
@@ -1357,8 +1362,11 @@ class AgentTool(AbstractBaseTool):
                 allowed_tools=allowed_tools,
                 task_id=execution_task_id,
                 workspace_base_dir=self._workspace_base_dir,
-                allowed_agent_ids=[],
-                enable_global_agent_tools=False,
+                allowed_agent_ids=None,
+                enable_global_agent_tools="agent" in agent_tool_categories,
+                parent_task_id=self._parent_task_id,
+                parent_tracer=self._parent_tracer,
+                agent_call_stack=next_agent_call_stack,
             )
 
             # Create agent service
@@ -1376,7 +1384,7 @@ class AgentTool(AbstractBaseTool):
                 enable_workspace=True,
                 workspace_base_dir=self._workspace_base_dir,
                 task_id=execution_task_id,
-                tracer=None,
+                tracer=self._parent_tracer,
             )
 
             # Build execution context
@@ -1445,6 +1453,7 @@ def get_published_agents_tools(
     allow_cross_user_agent_ids: bool = False,
     parent_task_id: int | None = None,
     parent_tracer: Any | None = None,
+    agent_call_stack: list[int] | None = None,
 ) -> list[AbstractBaseTool]:
     """
     Get tools for published (and optionally draft) agents.
@@ -1500,9 +1509,15 @@ def get_published_agents_tools(
                 Agent.user_id == user_id,
             )
 
-        # Exclude the specified agent (to prevent self-calls)
+        excluded_agent_ids = set(agent_call_stack or [])
+        if excluded_agent_id is not None:
+            excluded_agent_ids.add(excluded_agent_id)
+
+        # Exclude active call-chain agents to prevent recursive AgentTool loops.
         if excluded_agent_id is not None:
             query = query.filter(Agent.id != excluded_agent_id)
+        if excluded_agent_ids:
+            query = query.filter(Agent.id.notin_(excluded_agent_ids))
 
         agents = query.all()
 
@@ -1560,6 +1575,7 @@ def get_published_agents_tools(
                 extra_system_prompt=override.get("extra_system_prompt"),
                 parent_task_id=parent_task_id,
                 parent_tracer=parent_tracer,
+                agent_call_stack=agent_call_stack,
                 workforce_context={
                     key: override[key]
                     for key in (
@@ -1625,6 +1641,7 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             allow_cross_user_agent_ids=allow_cross_user_agent_ids,
             parent_task_id=getattr(config, "get_parent_task_id", lambda: None)(),
             parent_tracer=getattr(config, "get_parent_tracer", lambda: None)(),
+            agent_call_stack=getattr(config, "get_agent_call_stack", lambda: [])(),
         )
     except Exception as e:
         logger.warning(f"Failed to create agent tools: {e}")

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -3,7 +3,8 @@ Agent Tool - Convert published agents into callable tools
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator
@@ -13,7 +14,6 @@ from .....web.services.model_service import (
     _get_visible_user_ids,
     _is_model_visible_to_user,
 )
-from ....tracing import create_agent_tracer
 from ....utils.type_check import ensure_list
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
@@ -29,19 +29,19 @@ class CreateAgentToolArgs(BaseModel):
         description="IMPORTANT: Description of when to use this agent (e.g., 'Use this agent for data analysis tasks involving CSV files'). This helps users understand the agent's purpose and when to call it."
     )
     instructions: str = Field(description="System instructions/prompt for the agent")
-    tool_categories: Optional[list[str]] = Field(
+    tool_categories: list[str] | None = Field(
         default=None,
         description="List of tool categories to allow (e.g., ['file', 'knowledge']). If None, all tools are available",
     )
-    knowledge_bases: Optional[list[str]] = Field(
+    knowledge_bases: list[str] | None = Field(
         default=None,
         description="List of knowledge base names or IDs to associate with this agent. (optional)",
     )
-    skills: Optional[list[str]] = Field(
+    skills: list[str] | None = Field(
         default=None,
         description="List of skill names to allow. If None, all skills are available",
     )
-    execution_mode: Optional[str] = Field(
+    execution_mode: str | None = Field(
         default="balanced",
         description="Execution mode for the agent: 'flash', 'balanced' (default), 'think', or 'auto'.",
     )
@@ -61,9 +61,7 @@ class CreateAgentToolResult(BaseModel):
 
     agent_id: int = Field(description="The ID of the created agent")
     agent_name: str = Field(description="The name of the created agent")
-    tool_name: str = Field(
-        description="The tool name that can be used to call this agent"
-    )
+    tool_name: str = Field(description="The tool name that can be used to call this agent")
     markdown_link: str = Field(
         description="Markdown link to the agent (e.g., '[Agent Name](agent://123)')"
     )
@@ -75,30 +73,28 @@ class UpdateAgentToolArgs(BaseModel):
     """Arguments for updating an existing agent."""
 
     agent_id: int = Field(description="ID of the agent to update")
-    name: Optional[str] = Field(
-        default=None, description="New name for the agent (optional)"
-    )
-    description: Optional[str] = Field(
+    name: str | None = Field(default=None, description="New name for the agent (optional)")
+    description: str | None = Field(
         default=None,
         description="New description of when to use this agent (optional)",
     )
-    instructions: Optional[str] = Field(
+    instructions: str | None = Field(
         default=None,
         description="New system instructions/prompt for the agent (optional)",
     )
-    tool_categories: Optional[list[str]] = Field(
+    tool_categories: list[str] | None = Field(
         default=None,
         description="New list of tool categories to allow (optional). If None, existing value is kept",
     )
-    knowledge_bases: Optional[list[str]] = Field(
+    knowledge_bases: list[str] | None = Field(
         default=None,
         description="New list of knowledge base IDs or names to associate with this agent. (optional). If None, existing value is kept",
     )
-    skills: Optional[list[str]] = Field(
+    skills: list[str] | None = Field(
         default=None,
         description="New list of skill names to allow (optional). If None, existing value is kept",
     )
-    execution_mode: Optional[str] = Field(
+    execution_mode: str | None = Field(
         default=None,
         description="New execution mode for the agent: 'flash', 'balanced', 'think', or 'auto'.",
     )
@@ -118,9 +114,7 @@ class UpdateAgentToolResult(BaseModel):
 
     agent_id: int = Field(description="The ID of the updated agent")
     agent_name: str = Field(description="The name of the updated agent")
-    tool_name: str = Field(
-        description="The tool name that can be used to call this agent"
-    )
+    tool_name: str = Field(description="The tool name that can be used to call this agent")
     markdown_link: str = Field(
         description="Markdown link to the agent (e.g., '[Agent Name](agent://123)')"
     )
@@ -131,7 +125,7 @@ class UpdateAgentToolResult(BaseModel):
 class ListAgentsToolArgs(BaseModel):
     """Arguments for listing agents."""
 
-    status_filter: Optional[str] = Field(
+    status_filter: str | None = Field(
         default=None,
         description="Filter by agent status: 'draft', 'published', or 'archived'. If None, shows all agents",
     )
@@ -149,13 +143,13 @@ class AgentInfo(BaseModel):
     execution_mode: str = Field(
         description="Execution mode: flash, balanced, think, or auto"
     )
-    knowledge_bases: Optional[list[str]] = Field(
+    knowledge_bases: list[str] | None = Field(
         default=None, description="Associated knowledge bases"
     )
-    tool_categories: Optional[list[str]] = Field(
+    tool_categories: list[str] | None = Field(
         default=None, description="Allowed tool categories"
     )
-    skills: Optional[list[str]] = Field(default=None, description="Allowed skills")
+    skills: list[str] | None = Field(default=None, description="Allowed skills")
 
 
 class ListAgentsToolResult(BaseModel):
@@ -180,9 +174,7 @@ class AgentToolResult(BaseModel):
 
 
 class ListAvailableSkillsArgs(BaseModel):
-    query: Optional[str] = Field(
-        default=None, description="Optional search query to filter skills"
-    )
+    query: str | None = Field(default=None, description="Optional search query to filter skills")
 
 
 class ListAvailableSkillsResult(BaseModel):
@@ -197,9 +189,9 @@ class ListAvailableSkillsTool(AbstractBaseTool):
     def __init__(
         self,
         db: Any = None,
-        user_id: Optional[int] = None,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        user_id: int | None = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
     ):
         self._visibility = ToolVisibility.PUBLIC
 
@@ -211,10 +203,10 @@ class ListAvailableSkillsTool(AbstractBaseTool):
     def description(self) -> str:
         return "List all available skills that can be assigned to an agent."
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         return ListAvailableSkillsArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         return ListAvailableSkillsResult
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
@@ -223,9 +215,7 @@ class ListAvailableSkillsTool(AbstractBaseTool):
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         import os
 
-        skills_dir = os.path.join(
-            os.path.dirname(__file__), "../../../../skills/builtin"
-        )
+        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -236,7 +226,7 @@ class ListAvailableSkillsTool(AbstractBaseTool):
 
 
 class ListToolCategoriesArgs(BaseModel):
-    query: Optional[str] = Field(
+    query: str | None = Field(
         default=None, description="Optional search query to filter categories"
     )
 
@@ -253,9 +243,9 @@ class ListToolCategoriesTool(AbstractBaseTool):
     def __init__(
         self,
         db: Any = None,
-        user_id: Optional[int] = None,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        user_id: int | None = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
     ):
         self._visibility = ToolVisibility.PUBLIC
 
@@ -267,10 +257,10 @@ class ListToolCategoriesTool(AbstractBaseTool):
     def description(self) -> str:
         return "List all available tool categories that can be assigned to an agent."
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         return ListToolCategoriesArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         return ListToolCategoriesResult
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
@@ -298,8 +288,8 @@ class CreateAgentTool(AbstractBaseTool):
         self,
         db: Any,
         user_id: int,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
     ):
         """
         Initialize the create agent tool.
@@ -334,9 +324,7 @@ class CreateAgentTool(AbstractBaseTool):
         # Get available skills (from builtin skills directory)
         import os
 
-        skills_dir = os.path.join(
-            os.path.dirname(__file__), "../../../../skills/builtin"
-        )
+        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -376,11 +364,11 @@ class CreateAgentTool(AbstractBaseTool):
         """Tool tags."""
         return ["agent", "create"]
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         """Argument type."""
         return CreateAgentToolArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         """Return type."""
         return CreateAgentToolResult
 
@@ -514,9 +502,7 @@ class CreateAgentTool(AbstractBaseTool):
                     models_config[default.config_type] = default.model_id
 
             missing_types = [
-                t
-                for t in ["general", "small_fast", "visual", "compact"]
-                if t not in models_config
+                t for t in ["general", "small_fast", "visual", "compact"] if t not in models_config
             ]
             if missing_types:
                 # Fill missing with visible users' shared defaults
@@ -533,9 +519,7 @@ class CreateAgentTool(AbstractBaseTool):
                 )
                 for admin_default in admin_defaults:
                     if admin_default.config_type not in models_config:
-                        models_config[admin_default.config_type] = (
-                            admin_default.model_id
-                        )
+                        models_config[admin_default.config_type] = admin_default.model_id
 
             execution_mode = args.get("execution_mode", "balanced")
             if execution_mode not in ["flash", "balanced", "think", "auto"]:
@@ -624,8 +608,8 @@ class UpdateAgentTool(AbstractBaseTool):
         self,
         db: Any,
         user_id: int,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
     ):
         """
         Initialize the update agent tool.
@@ -660,9 +644,7 @@ class UpdateAgentTool(AbstractBaseTool):
         # Get available skills (from builtin skills directory)
         import os
 
-        skills_dir = os.path.join(
-            os.path.dirname(__file__), "../../../../skills/builtin"
-        )
+        skills_dir = os.path.join(os.path.dirname(__file__), "../../../../skills/builtin")
         available_skills = []
         if os.path.exists(skills_dir):
             for skill_dir in os.listdir(skills_dir):
@@ -703,11 +685,11 @@ class UpdateAgentTool(AbstractBaseTool):
         """Tool tags."""
         return ["agent", "update"]
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         """Argument type."""
         return UpdateAgentToolArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         """Return type."""
         return UpdateAgentToolResult
 
@@ -800,9 +782,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
             # Update instructions if provided
             new_instructions = (
-                args.get("instructions", "").strip()
-                if args.get("instructions")
-                else None
+                args.get("instructions", "").strip() if args.get("instructions") else None
             )
             if new_instructions:
                 agent.instructions = new_instructions
@@ -907,8 +887,8 @@ class ListAgentsTool(AbstractBaseTool):
         self,
         db: Any,
         user_id: int,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
     ):
         """
         Initialize the list agents tool.
@@ -962,11 +942,11 @@ class ListAgentsTool(AbstractBaseTool):
         """Tool tags."""
         return ["agent", "list"]
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         """Argument type."""
         return ListAgentsToolArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         """Return type."""
         return ListAgentsToolResult
 
@@ -1023,13 +1003,9 @@ class ListAgentsTool(AbstractBaseTool):
                 agent_infos.append(agent_info.model_dump())
 
             total_count = len(agent_infos)
-            filter_msg = (
-                f" (filtered by status: {status_filter})" if status_filter else ""
-            )
+            filter_msg = f" (filtered by status: {status_filter})" if status_filter else ""
 
-            logger.info(
-                f"Listed {total_count} agents for user {self._user_id}{filter_msg}"
-            )
+            logger.info(f"Listed {total_count} agents for user {self._user_id}{filter_msg}")
 
             return ListAgentsToolResult(
                 agents=agent_infos,
@@ -1070,8 +1046,13 @@ class AgentTool(AbstractBaseTool):
         agent_description: str,
         db: Any,
         user_id: int,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
+        tool_name: str | None = None,
+        extra_system_prompt: str | None = None,
+        parent_task_id: int | None = None,
+        parent_tracer: Any | None = None,
+        workforce_context: dict[str, Any] | None = None,
     ):
         """
         Initialize an agent tool.
@@ -1091,6 +1072,11 @@ class AgentTool(AbstractBaseTool):
         self._db = db
         self._user_id = user_id
         self._task_id = task_id or f"agent_tool_{agent_id}"
+        self._tool_name = tool_name
+        self._extra_system_prompt = extra_system_prompt
+        self._parent_task_id = parent_task_id
+        self._parent_tracer = parent_tracer
+        self._workforce_context = workforce_context or {}
         if workspace_base_dir is None:
             workspace_base_dir = str(get_uploads_dir())
         self._workspace_base_dir = workspace_base_dir
@@ -1099,7 +1085,7 @@ class AgentTool(AbstractBaseTool):
     @property
     def name(self) -> str:
         """Tool name."""
-        return f"call_agent_{self._agent_name.lower().replace(' ', '_')}"
+        return self._tool_name or f"call_agent_{self._agent_name.lower().replace(' ', '_')}"
 
     @property
     def description(self) -> str:
@@ -1111,17 +1097,79 @@ class AgentTool(AbstractBaseTool):
         """Tool tags."""
         return ["agent", "delegation"]
 
-    def args_type(self) -> Type[BaseModel]:
+    def args_type(self) -> type[BaseModel]:
         """Argument type."""
         return AgentToolArgs
 
-    def return_type(self) -> Type[BaseModel]:
+    def return_type(self) -> type[BaseModel]:
         """Return type."""
         return AgentToolResult
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         """Sync execution not supported."""
         raise NotImplementedError("AgentTool only supports async execution.")
+
+    def _build_delegation_trace_data(
+        self,
+        status: str,
+        execution_task_id: str | None = None,
+        output: str | None = None,
+        error: str | None = None,
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "event_type": f"workforce_delegation_{status}",
+            "agent_id": self._agent_id,
+            "agent_name": self._agent_name,
+            "tool_name": self.name,
+        }
+        data.update(self._workforce_context)
+        if execution_task_id:
+            data["worker_task_id"] = execution_task_id
+        if output is not None:
+            data["output"] = output[:2000]
+            data["output_length"] = len(output)
+        if error is not None:
+            data["error"] = error
+        return data
+
+    async def _trace_delegation(
+        self,
+        status: str,
+        execution_task_id: str | None = None,
+        output: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        if (
+            self._parent_tracer is None
+            or self._parent_task_id is None
+            or not self._workforce_context
+        ):
+            return
+        try:
+            from .....core.agent.trace import (
+                TraceAction,
+                TraceCategory,
+                TraceEventType,
+                TraceScope,
+            )
+
+            action = {
+                "start": TraceAction.START,
+                "end": TraceAction.END,
+                "error": TraceAction.ERROR,
+            }[status]
+            await self._parent_tracer.trace_event(
+                TraceEventType(TraceScope.TASK, action, TraceCategory.GENERAL),
+                task_id=str(self._parent_task_id),
+                data=self._build_delegation_trace_data(
+                    status,
+                    execution_task_id=execution_task_id,
+                    output=output,
+                    error=error,
+                ),
+            )
+        except Exception:
+            logger.debug("Failed to emit workforce delegation trace", exc_info=True)
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Execute the agent with the given task."""
@@ -1131,6 +1179,7 @@ class AgentTool(AbstractBaseTool):
         from .....web.tools.config import WebToolConfig
         from .....web.user_isolated_memory import UserContext
 
+        execution_task_id: str | None = None
         try:
             # Load agent from database - support both PUBLISHED and DRAFT
             agent = (
@@ -1143,12 +1192,13 @@ class AgentTool(AbstractBaseTool):
             )
 
             if not agent:
-                return AgentToolResult(
-                    response=f"Error: Agent {self._agent_id} not found"
-                ).model_dump()
+                error_msg = f"Error: Agent {self._agent_id} not found"
+                await self._trace_delegation("error", error=error_msg)
+                return AgentToolResult(response=error_msg).model_dump()
 
             # Generate unique task ID for this execution
             execution_task_id = f"agent_{self._agent_id}_{uuid.uuid4().hex[:8]}"
+            await self._trace_delegation("start", execution_task_id=execution_task_id)
 
             # Resolve models
             from .....core.agent.service import AgentService
@@ -1188,9 +1238,7 @@ class AgentTool(AbstractBaseTool):
 
                 if agent.models.get("visual"):
                     visual_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["visual"])
-                        .first()
+                        self._db.query(DBModel).filter(DBModel.id == agent.models["visual"]).first()
                     )
                     if visual_model:
                         vision_llm = storage.get_llm_by_name_with_access(
@@ -1209,9 +1257,11 @@ class AgentTool(AbstractBaseTool):
                         )
 
             if not default_llm:
-                return AgentToolResult(
-                    response=f"Error: No valid model configured for agent {agent.name}"
-                ).model_dump()
+                error_msg = f"Error: No valid model configured for agent {agent.name}"
+                await self._trace_delegation(
+                    "error", execution_task_id=execution_task_id, error=error_msg
+                )
+                return AgentToolResult(response=error_msg).model_dump()
 
             # Create tool config with allowed collections, skills, and tools
             class MinimalRequest:
@@ -1278,21 +1328,8 @@ class AgentTool(AbstractBaseTool):
                 allowed_tools=allowed_tools,
                 task_id=execution_task_id,
                 workspace_base_dir=self._workspace_base_dir,
-            )
-
-            tracer = create_agent_tracer(
-                task_id=execution_task_id,
-                user_id=self._user_id,
-                trace_name=f"xagent-agent-tool-{self._agent_id}",
-                session_id=self._task_id,
-                tags=["xagent", "agent-tool", "nested-agent"],
-                metadata={
-                    "source": "xagent-agent-tool",
-                    "task_id": execution_task_id,
-                    "parent_task_id": self._task_id,
-                    "agent_id": self._agent_id,
-                    "agent_name": agent.name,
-                },
+                allowed_agent_ids=[],
+                enable_global_agent_tools=False,
             )
 
             # Create agent service
@@ -1310,13 +1347,18 @@ class AgentTool(AbstractBaseTool):
                 enable_workspace=True,
                 workspace_base_dir=self._workspace_base_dir,
                 task_id=execution_task_id,
-                tracer=tracer,
+                tracer=None,
             )
 
             # Build execution context
             execution_context: dict[str, Any] = {}
+            prompt_parts = []
             if agent.instructions:
-                execution_context["system_prompt"] = agent.instructions
+                prompt_parts.append(agent.instructions)
+            if self._extra_system_prompt:
+                prompt_parts.append(self._extra_system_prompt)
+            if prompt_parts:
+                execution_context["system_prompt"] = "\n\n".join(prompt_parts)
 
             # Execute task
             with UserContext(self._user_id):
@@ -1330,11 +1372,17 @@ class AgentTool(AbstractBaseTool):
             logger.info(
                 f"Agent tool {self.name} executed successfully, output length: {len(output)}"
             )
+            await self._trace_delegation(
+                "end", execution_task_id=execution_task_id, output=str(output)
+            )
             return AgentToolResult(response=output).model_dump()
 
         except Exception as e:
             error_msg = f"Error executing agent {self._agent_id}: {str(e)}"
             logger.error(error_msg, exc_info=True)
+            await self._trace_delegation(
+                "error", execution_task_id=execution_task_id, error=error_msg
+            )
             return AgentToolResult(response=error_msg).model_dump()
 
 
@@ -1357,12 +1405,17 @@ def gen_agent_tool_name(agent_name: str) -> str:
 def get_published_agents_tools(
     db: Any,
     user_id: int,
-    task_id: Optional[str] = None,
-    workspace_base_dir: Optional[str] = None,
-    excluded_agent_id: Optional[int] = None,
+    task_id: str | None = None,
+    workspace_base_dir: str | None = None,
+    excluded_agent_id: int | None = None,
     include_draft: bool = False,
-    draft_agent_ids_to_include: Optional[list[int]] = None,
-    allowed_agent_ids: Optional[list[int]] = None,
+    draft_agent_ids_to_include: list[int] | None = None,
+    allowed_agent_ids: list[int] | None = None,
+    agent_tool_overrides: dict[int, dict[str, Any]] | None = None,
+    enable_global_agent_tools: bool = True,
+    allow_cross_user_agent_ids: bool = False,
+    parent_task_id: int | None = None,
+    parent_tracer: Any | None = None,
 ) -> list[AbstractBaseTool]:
     """
     Get tools for published (and optionally draft) agents.
@@ -1387,6 +1440,8 @@ def get_published_agents_tools(
         workspace_base_dir = str(get_uploads_dir())
 
     tools: list[AbstractBaseTool] = []
+    if not enable_global_agent_tools and not allowed_agent_ids:
+        return tools
 
     try:
         if allowed_agent_ids is not None:
@@ -1398,10 +1453,11 @@ def get_published_agents_tools(
             if not normalized_allowed_agent_ids:
                 return []
             query = db.query(Agent).filter(
-                Agent.user_id == user_id,
                 Agent.id.in_(normalized_allowed_agent_ids),
                 Agent.status.in_(["published"]),  # type: ignore[attr-defined]
             )
+            if not allow_cross_user_agent_ids:
+                query = query.filter(Agent.user_id == user_id)
         elif include_draft:
             # Include both PUBLISHED and DRAFT agents
             query = db.query(Agent).filter(
@@ -1448,8 +1504,11 @@ def get_published_agents_tools(
 
         for agent in agents:
             # Build description
-            description = agent.description or f"Call {agent.name} agent"
-            if agent.instructions:
+            override = (agent_tool_overrides or {}).get(int(agent.id), {})
+            description = override.get("description")
+            if not description:
+                description = agent.description or f"Call {agent.name} agent"
+            if not override.get("description") and agent.instructions:
                 # Add brief instructions to description
                 instructions_preview = agent.instructions[:200]
                 if len(agent.instructions) > 200:
@@ -1457,7 +1516,7 @@ def get_published_agents_tools(
                 description += f". Instructions: {instructions_preview}"
 
             # Add status indicator for draft agents
-            if agent.status == AgentStatus.DRAFT:
+            if not override.get("description") and agent.status == AgentStatus.DRAFT:
                 description = f"[DRAFT] {description}"
 
             tool = AgentTool(
@@ -1468,6 +1527,21 @@ def get_published_agents_tools(
                 user_id=user_id,
                 task_id=task_id,
                 workspace_base_dir=workspace_base_dir,
+                tool_name=override.get("tool_name"),
+                extra_system_prompt=override.get("extra_system_prompt"),
+                parent_task_id=parent_task_id,
+                parent_tracer=parent_tracer,
+                workforce_context={
+                    key: override[key]
+                    for key in (
+                        "workforce_run_id",
+                        "workforce_id",
+                        "workforce_name",
+                        "worker_member_id",
+                        "worker_alias",
+                    )
+                    if key in override
+                },
             )
             tools.append(tool)
             logger.debug(f"Created agent tool: {tool.name}")
@@ -1489,7 +1563,12 @@ if TYPE_CHECKING:
 @register_tool
 async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
     """Create tools from published agents."""
-    if not config.get_enable_agent_tools():
+    allowed_agent_ids = getattr(config, "get_allowed_agent_ids", lambda: None)()
+    delegate_agent_ids = config.get_delegate_agent_ids() if config else None
+    if allowed_agent_ids is None and delegate_agent_ids:
+        allowed_agent_ids = delegate_agent_ids
+    allow_cross_user_agent_ids = getattr(config, "get_allow_cross_user_agent_ids", lambda: False)()
+    if not config.get_enable_agent_tools() and not allowed_agent_ids:
         return []
 
     try:
@@ -1499,9 +1578,6 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             return []
 
         excluded_agent_id = config.get_excluded_agent_id() if config else None
-        delegate_agent_ids = config.get_delegate_agent_ids() if config else None
-        if not delegate_agent_ids:
-            delegate_agent_ids = None
 
         return get_published_agents_tools(
             db=db,
@@ -1509,8 +1585,13 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
             task_id=config.get_task_id(),
             workspace_base_dir=None,  # Will use get_uploads_dir() default
             excluded_agent_id=excluded_agent_id,
-            include_draft=False,  # Only PUBLISHED agents by default
-            allowed_agent_ids=delegate_agent_ids,
+            include_draft=False,  # Only PUBLISHED agents
+            allowed_agent_ids=allowed_agent_ids,
+            agent_tool_overrides=getattr(config, "get_agent_tool_overrides", lambda: {})(),
+            enable_global_agent_tools=config.get_enable_agent_tools(),
+            allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+            parent_task_id=getattr(config, "get_parent_task_id", lambda: None)(),
+            parent_tracer=getattr(config, "get_parent_tracer", lambda: None)(),
         )
     except Exception as e:
         logger.warning(f"Failed to create agent tools: {e}")
@@ -1550,9 +1631,7 @@ async def create_create_agent_tool(config: "WebToolConfig") -> list[AbstractBase
             workspace_base_dir=None,
         )
 
-        logger.debug(
-            f"Created CreateAgentTool and related list tools for user {user_id}"
-        )
+        logger.debug(f"Created CreateAgentTool and related list tools for user {user_id}")
         return [tool, list_skills_tool, list_categories_tool]
     except Exception as e:
         logger.warning(f"Failed to create CreateAgentTool: {e}")

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -218,6 +218,7 @@ class ToolConfig(BaseToolConfig):
         )
         parent_task_id = config_dict.get("parent_task_id")
         parent_tracer = config_dict.get("parent_tracer")
+        agent_call_stack = config_dict.get("agent_call_stack")
 
         # Output limit configuration (uses environment variable as default)
         # Store custom values if provided, otherwise use None to fall back to base class defaults
@@ -288,6 +289,11 @@ class ToolConfig(BaseToolConfig):
             parent_task_id if isinstance(parent_task_id, int) else None
         )
         self.parent_tracer: Any | None = parent_tracer
+        self.agent_call_stack: list[int] = (
+            [int(agent_id) for agent_id in agent_call_stack]
+            if isinstance(agent_call_stack, list)
+            else []
+        )
 
     def get_workspace_config(self) -> dict[str, Any] | None:
         return self.workspace_config
@@ -372,6 +378,9 @@ class ToolConfig(BaseToolConfig):
 
     def get_parent_tracer(self) -> Any | None:
         return self.parent_tracer
+
+    def get_agent_call_stack(self) -> list[int]:
+        return self.agent_call_stack
 
     def get_sandbox(self) -> Any | None:
         return None  # Standalone config doesn't have sandbox

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -95,7 +95,7 @@ class BaseToolConfig(ABC):
         """Whether to include published agents as tools."""
         pass
 
-    def get_delegate_agent_ids(self) -> Optional[List[int]]:
+    def get_delegate_agent_ids(self) -> list[int] | None:
         """Get explicitly selected delegable agent IDs. None means default behavior."""
         return None
 

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -213,7 +213,9 @@ class ToolConfig(BaseToolConfig):
         tool_credentials = config_dict.get("tool_credentials", {})
         agent_tool_overrides = config_dict.get("agent_tool_overrides", {})
         enable_global_agent_tools = config_dict.get("enable_global_agent_tools", True)
-        allow_cross_user_agent_ids = config_dict.get("allow_cross_user_agent_ids", False)
+        allow_cross_user_agent_ids = config_dict.get(
+            "allow_cross_user_agent_ids", False
+        )
         parent_task_id = config_dict.get("parent_task_id")
         parent_tracer = config_dict.get("parent_tracer")
 
@@ -248,8 +250,12 @@ class ToolConfig(BaseToolConfig):
         self.image_models: dict[
             str, Any
         ] = {}  # Standalone usage typically doesn't have web context
-        self.asr_models: dict[str, Any] = {}  # Standalone usage typically doesn't have web context
-        self.tts_models: dict[str, Any] = {}  # Standalone usage typically doesn't have web context
+        self.asr_models: dict[
+            str, Any
+        ] = {}  # Standalone usage typically doesn't have web context
+        self.tts_models: dict[
+            str, Any
+        ] = {}  # Standalone usage typically doesn't have web context
         self.mcp_server_configs: list[dict[str, Any]] = mcp_server_configs
         self.file_tools_enabled: bool = bool(file_tools_enabled)
         self.basic_tools_enabled: bool = bool(basic_tools_enabled)

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -7,7 +7,7 @@ to the ToolFactory in a unified way.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from ..... import config as _root_config
 
@@ -16,32 +16,32 @@ class BaseToolConfig(ABC):
     """Abstract base class for tool configuration."""
 
     @abstractmethod
-    def get_workspace_config(self) -> Optional[Dict[str, Any]]:
+    def get_workspace_config(self) -> dict[str, Any] | None:
         """Get workspace configuration."""
         pass
 
     @abstractmethod
-    def get_vision_model(self) -> Optional[Any]:
+    def get_vision_model(self) -> Any | None:
         """Get vision model."""
         pass
 
     @abstractmethod
-    def get_image_models(self) -> Dict[str, Any]:
+    def get_image_models(self) -> dict[str, Any]:
         """Get image models."""
         pass
 
     @abstractmethod
-    def get_asr_models(self) -> Dict[str, Any]:
+    def get_asr_models(self) -> dict[str, Any]:
         """Get ASR (speech-to-text) models."""
         pass
 
     @abstractmethod
-    def get_tts_models(self) -> Dict[str, Any]:
+    def get_tts_models(self) -> dict[str, Any]:
         """Get TTS (text-to-speech) models."""
         pass
 
     @abstractmethod
-    async def get_mcp_server_configs(self) -> List[Dict[str, Any]]:
+    async def get_mcp_server_configs(self) -> list[dict[str, Any]]:
         """Get MCP server configurations."""
         pass
 
@@ -56,7 +56,7 @@ class BaseToolConfig(ABC):
         pass
 
     @abstractmethod
-    def get_embedding_model(self) -> Optional[str]:
+    def get_embedding_model(self) -> str | None:
         """Get embedding model ID."""
         pass
 
@@ -66,22 +66,22 @@ class BaseToolConfig(ABC):
         pass
 
     @abstractmethod
-    def get_task_id(self) -> Optional[str]:
+    def get_task_id(self) -> str | None:
         """Get task ID for session tracking."""
         pass
 
     @abstractmethod
-    def get_allowed_collections(self) -> Optional[List[str]]:
+    def get_allowed_collections(self) -> list[str] | None:
         """Get allowed knowledge base collections. None means all collections are allowed."""
         pass
 
     @abstractmethod
-    def get_allowed_skills(self) -> Optional[List[str]]:
+    def get_allowed_skills(self) -> list[str] | None:
         """Get allowed skill names. None means all skills are allowed."""
         pass
 
     @abstractmethod
-    def get_user_id(self) -> Optional[int]:
+    def get_user_id(self) -> int | None:
         """Get current user ID for multi-tenancy."""
         pass
 
@@ -100,50 +100,68 @@ class BaseToolConfig(ABC):
         return None
 
     @abstractmethod
-    def get_image_generate_model(self) -> Optional[Any]:
+    def get_image_generate_model(self) -> Any | None:
         """Get default image generation model."""
         pass
 
     @abstractmethod
-    def get_custom_api_configs(self) -> List[Dict[str, Any]]:
+    def get_custom_api_configs(self) -> list[dict[str, Any]]:
         """Get custom API configurations."""
         pass
 
     @abstractmethod
-    def get_image_edit_model(self) -> Optional[Any]:
+    def get_image_edit_model(self) -> Any | None:
         """Get default image editing model."""
         pass
 
     @abstractmethod
-    def get_sandbox(self) -> Optional[Any]:
+    def get_sandbox(self) -> Any | None:
         """Get sandbox instance for sandboxed executors. Returns None if not available."""
         pass
 
-    def get_tool_credential(self, tool_name: str, field_name: str) -> Optional[str]:
+    def get_tool_credential(self, tool_name: str, field_name: str) -> str | None:
         return None
 
-    def get_sql_connections(self) -> Dict[str, str]:
+    def get_sql_connections(self) -> dict[str, str]:
         return {}
 
     @abstractmethod
-    def get_db(self) -> Optional[Any]:
+    def get_db(self) -> Any | None:
         """Get database session. Returns None for standalone usage."""
         pass
 
     @abstractmethod
-    def get_asr_model(self) -> Optional[Any]:
+    def get_asr_model(self) -> Any | None:
         """Get default ASR (speech-to-text) model."""
         pass
 
     @abstractmethod
-    def get_tts_model(self) -> Optional[Any]:
+    def get_tts_model(self) -> Any | None:
         """Get default TTS (text-to-speech) model."""
         pass
 
     @abstractmethod
-    def get_llm(self) -> Optional[Any]:
+    def get_llm(self) -> Any | None:
         """Get default LLM for general tasks."""
         pass
+
+    def get_allowed_tools(self) -> list[str] | None:
+        return None
+
+    def get_allowed_agent_ids(self) -> list[int] | None:
+        return None
+
+    def get_agent_tool_overrides(self) -> dict[int, dict[str, Any]]:
+        return {}
+
+    def get_allow_cross_user_agent_ids(self) -> bool:
+        return False
+
+    def get_parent_task_id(self) -> int | None:
+        return None
+
+    def get_parent_tracer(self) -> Any | None:
+        return None
 
     def get_max_output_length(self) -> int:
         """Get maximum output length in characters.
@@ -173,7 +191,7 @@ class BaseToolConfig(ABC):
 class ToolConfig(BaseToolConfig):
     """Tool configuration that uses provided config dict for standalone usage."""
 
-    def __init__(self, config_dict: Dict[str, Any]):
+    def __init__(self, config_dict: dict[str, Any]):
         # Extract configurations from dict
         workspace_config = config_dict.get("workspace")
         config_dict.get("vision_model")  # Unused in base config
@@ -189,9 +207,15 @@ class ToolConfig(BaseToolConfig):
         allowed_collections = config_dict.get("allowed_collections")
         allowed_skills = config_dict.get("allowed_skills")
         allowed_tools = config_dict.get("allowed_tools")
+        allowed_agent_ids = config_dict.get("allowed_agent_ids")
         user_id = config_dict.get("user_id")
         is_admin = config_dict.get("is_admin", False)
         tool_credentials = config_dict.get("tool_credentials", {})
+        agent_tool_overrides = config_dict.get("agent_tool_overrides", {})
+        enable_global_agent_tools = config_dict.get("enable_global_agent_tools", True)
+        allow_cross_user_agent_ids = config_dict.get("allow_cross_user_agent_ids", False)
+        parent_task_id = config_dict.get("parent_task_id")
+        parent_tracer = config_dict.get("parent_tracer")
 
         # Output limit configuration (uses environment variable as default)
         # Store custom values if provided, otherwise use None to fall back to base class defaults
@@ -217,48 +241,64 @@ class ToolConfig(BaseToolConfig):
         except (TypeError, ValueError):
             pass
 
-        self.workspace_config: Optional[Dict[str, Any]] = workspace_config
-        self.vision_model: Optional[Any] = (
+        self.workspace_config: dict[str, Any] | None = workspace_config
+        self.vision_model: Any | None = (
             None  # Standalone usage typically doesn't have web context
         )
-        self.image_models: Dict[
+        self.image_models: dict[
             str, Any
         ] = {}  # Standalone usage typically doesn't have web context
-        self.asr_models: Dict[
-            str, Any
-        ] = {}  # Standalone usage typically doesn't have web context
-        self.tts_models: Dict[
-            str, Any
-        ] = {}  # Standalone usage typically doesn't have web context
-        self.mcp_server_configs: List[Dict[str, Any]] = mcp_server_configs
+        self.asr_models: dict[str, Any] = {}  # Standalone usage typically doesn't have web context
+        self.tts_models: dict[str, Any] = {}  # Standalone usage typically doesn't have web context
+        self.mcp_server_configs: list[dict[str, Any]] = mcp_server_configs
         self.file_tools_enabled: bool = bool(file_tools_enabled)
         self.basic_tools_enabled: bool = bool(basic_tools_enabled)
-        self.embedding_model: Optional[str] = embedding_model
+        self.embedding_model: str | None = embedding_model
         self.browser_tools_enabled: bool = bool(browser_tools_enabled)
-        self.task_id: Optional[str] = task_id
-        self.allowed_collections: Optional[List[str]] = allowed_collections
-        self.allowed_skills: Optional[List[str]] = allowed_skills
-        self.allowed_tools: Optional[List[str]] = allowed_tools
-        self.user_id: Optional[int] = user_id
+        self.task_id: str | None = task_id
+        self.allowed_collections: list[str] | None = allowed_collections
+        self.allowed_skills: list[str] | None = allowed_skills
+        self.allowed_tools: list[str] | None = allowed_tools
+        self.allowed_agent_ids: list[int] | None = (
+            [value for value in allowed_agent_ids if isinstance(value, int)]
+            if isinstance(allowed_agent_ids, list)
+            else None
+        )
+        self.user_id: int | None = user_id
         self.is_admin_value: bool = bool(is_admin)
-        self.tool_credentials: Dict[str, Dict[str, str]] = tool_credentials
+        self.tool_credentials: dict[str, dict[str, str]] = tool_credentials
+        self.agent_tool_overrides: dict[int, dict[str, Any]] = (
+            {
+                int(key): value
+                for key, value in agent_tool_overrides.items()
+                if isinstance(key, int) and isinstance(value, dict)
+            }
+            if isinstance(agent_tool_overrides, dict)
+            else {}
+        )
+        self.enable_global_agent_tools: bool = bool(enable_global_agent_tools)
+        self.allow_cross_user_agent_ids: bool = bool(allow_cross_user_agent_ids)
+        self.parent_task_id: int | None = (
+            parent_task_id if isinstance(parent_task_id, int) else None
+        )
+        self.parent_tracer: Any | None = parent_tracer
 
-    def get_workspace_config(self) -> Optional[Dict[str, Any]]:
+    def get_workspace_config(self) -> dict[str, Any] | None:
         return self.workspace_config
 
-    def get_vision_model(self) -> Optional[Any]:
+    def get_vision_model(self) -> Any | None:
         return self.vision_model
 
-    def get_image_models(self) -> Dict[str, Any]:
+    def get_image_models(self) -> dict[str, Any]:
         return self.image_models
 
-    def get_asr_models(self) -> Dict[str, Any]:
+    def get_asr_models(self) -> dict[str, Any]:
         return self.asr_models
 
-    def get_tts_models(self) -> Dict[str, Any]:
+    def get_tts_models(self) -> dict[str, Any]:
         return self.tts_models
 
-    async def get_mcp_server_configs(self) -> List[Dict[str, Any]]:
+    async def get_mcp_server_configs(self) -> list[dict[str, Any]]:
         return self.mcp_server_configs
 
     def get_file_tools_enabled(self) -> bool:
@@ -267,62 +307,77 @@ class ToolConfig(BaseToolConfig):
     def get_basic_tools_enabled(self) -> bool:
         return self.basic_tools_enabled
 
-    def get_embedding_model(self) -> Optional[str]:
+    def get_embedding_model(self) -> str | None:
         return self.embedding_model
 
     def get_browser_tools_enabled(self) -> bool:
         return self.browser_tools_enabled
 
-    def get_task_id(self) -> Optional[str]:
+    def get_task_id(self) -> str | None:
         return self.task_id
 
-    def get_allowed_collections(self) -> Optional[List[str]]:
+    def get_allowed_collections(self) -> list[str] | None:
         return self.allowed_collections
 
-    def get_allowed_skills(self) -> Optional[List[str]]:
+    def get_allowed_skills(self) -> list[str] | None:
         return self.allowed_skills
 
-    def get_user_id(self) -> Optional[int]:
+    def get_user_id(self) -> int | None:
         return self.user_id
 
     def is_admin(self) -> bool:
         return self.is_admin_value
 
     def get_enable_agent_tools(self) -> bool:
-        return True
+        return self.enable_global_agent_tools
 
-    def get_image_generate_model(self) -> Optional[Any]:
+    def get_image_generate_model(self) -> Any | None:
         return None  # Standalone config doesn't have web context
 
-    def get_custom_api_configs(self) -> List[Dict[str, Any]]:
+    def get_custom_api_configs(self) -> list[dict[str, Any]]:
         return []  # Standalone config doesn't have web context for custom APIs by default
 
-    def get_image_edit_model(self) -> Optional[Any]:
+    def get_image_edit_model(self) -> Any | None:
         return None  # Standalone config doesn't have web context
 
-    def get_asr_model(self) -> Optional[Any]:
+    def get_asr_model(self) -> Any | None:
         return None  # Standalone config doesn't have web context
 
-    def get_tts_model(self) -> Optional[Any]:
+    def get_tts_model(self) -> Any | None:
         return None  # Standalone config doesn't have web context
 
-    def get_llm(self) -> Optional[Any]:
+    def get_llm(self) -> Any | None:
         return None  # Standalone config doesn't have web context
 
-    def get_allowed_tools(self) -> Optional[List[str]]:
+    def get_allowed_tools(self) -> list[str] | None:
         return self.allowed_tools
 
-    def get_sandbox(self) -> Optional[Any]:
+    def get_allowed_agent_ids(self) -> list[int] | None:
+        return self.allowed_agent_ids
+
+    def get_agent_tool_overrides(self) -> dict[int, dict[str, Any]]:
+        return self.agent_tool_overrides
+
+    def get_allow_cross_user_agent_ids(self) -> bool:
+        return self.allow_cross_user_agent_ids
+
+    def get_parent_task_id(self) -> int | None:
+        return self.parent_task_id
+
+    def get_parent_tracer(self) -> Any | None:
+        return self.parent_tracer
+
+    def get_sandbox(self) -> Any | None:
         return None  # Standalone config doesn't have sandbox
 
-    def get_tool_credential(self, tool_name: str, field_name: str) -> Optional[str]:
+    def get_tool_credential(self, tool_name: str, field_name: str) -> str | None:
         tool_data = self.tool_credentials.get(tool_name)
         if not isinstance(tool_data, dict):
             return None
         value = tool_data.get(field_name)
         return value if isinstance(value, str) and value else None
 
-    def get_sql_connections(self) -> Dict[str, str]:
+    def get_sql_connections(self) -> dict[str, str]:
         return {}
 
     def get_max_output_length(self) -> int:
@@ -340,6 +395,6 @@ class ToolConfig(BaseToolConfig):
             return self._custom_max_recursion_depth
         return super().get_max_recursion_depth()
 
-    def get_db(self) -> Optional[Any]:
+    def get_db(self) -> Any | None:
         """ToolConfig (standalone) does not have database access."""
         return None

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -340,6 +340,7 @@ class ToolFactory:
                 workspace_config.get("base_dir") or str(get_uploads_dir()),
                 task_id or "default",
                 allowed_external_dirs=workspace_config.get("allowed_external_dirs"),
+                db_task_id=workspace_config.get("db_task_id"),
             )
             return workspace
         except Exception as e:

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -51,8 +51,10 @@ class TaskWorkspace:
         id: str,
         base_dir: Optional[str] = None,
         allowed_external_dirs: Optional[List[str]] = None,
+        db_task_id: Optional[int] = None,
     ):
         self.id = id
+        self.db_task_id = db_task_id
         if base_dir is None:
             base_dir = str(get_uploads_dir())
         self.base_dir = (
@@ -131,7 +133,7 @@ class TaskWorkspace:
         from .storage.manager import create_db_session
 
         # Use provided session or create temporary one
-        if db_session:
+        if db_session is not None:
             db = db_session
             should_close = False
         else:
@@ -149,17 +151,19 @@ class TaskWorkspace:
             if existing:
                 return
 
-            # Extract task_id from workspace id (e.g., 'web_task_265' -> 265)
-            # Handle test environment workspaces (e.g., 'test_task')
-            try:
-                task_id = int(self.id.split("_")[-1])
-            except (ValueError, IndexError):
-                # Not a valid task ID, likely a test workspace
-                # Skip database registration in test environments
-                logger.debug(
-                    f"Skipping database registration for test workspace '{self.id}', file_id={file_id}"
-                )
-                return
+            task_id = self.db_task_id
+            if task_id is None:
+                # Extract task_id from workspace id (e.g., 'web_task_265' -> 265).
+                # AgentTool workspaces use non-DB ids such as 'agent_2_abcd1234',
+                # so callers should pass db_task_id explicitly for those.
+                try:
+                    task_id = int(self.id.split("_")[-1])
+                except (ValueError, IndexError):
+                    logger.debug(
+                        f"Skipping database registration for workspace '{self.id}' "
+                        f"without db_task_id, file_id={file_id}"
+                    )
+                    return
 
             # Get user_id from task
             task = db.query(Task).filter(Task.id == task_id).first()
@@ -208,7 +212,7 @@ class TaskWorkspace:
         try:
             from ..web.models.uploaded_file import UploadedFile
 
-            if db_session:
+            if db_session is not None:
                 db = db_session
                 should_close = False
             else:
@@ -873,6 +877,7 @@ def create_workspace(
     id: str,
     base_dir: Optional[str] = None,
     allowed_external_dirs: Optional[List[str]] = None,
+    db_task_id: Optional[int] = None,
 ) -> TaskWorkspace:
     """
     Create a new workspace for the given id.
@@ -887,7 +892,7 @@ def create_workspace(
     """
     if base_dir is None:
         base_dir = str(get_uploads_dir())
-    return TaskWorkspace(id, base_dir, allowed_external_dirs)
+    return TaskWorkspace(id, base_dir, allowed_external_dirs, db_task_id=db_task_id)
 
 
 def get_workspace_output_files(
@@ -925,6 +930,7 @@ class WorkspaceManager:
         base_dir: str,
         task_id: str,
         allowed_external_dirs: Optional[List[str]] = None,
+        db_task_id: Optional[int] = None,
     ) -> TaskWorkspace:
         """
         Get existing workspace or create new one.
@@ -940,8 +946,15 @@ class WorkspaceManager:
         cache_key = f"{base_dir}:{task_id}"
 
         if cache_key not in self._workspaces:
-            workspace = TaskWorkspace(task_id, base_dir, allowed_external_dirs)
+            workspace = TaskWorkspace(
+                task_id,
+                base_dir,
+                allowed_external_dirs,
+                db_task_id=db_task_id,
+            )
             self._workspaces[cache_key] = workspace
+        elif db_task_id is not None and self._workspaces[cache_key].db_task_id is None:
+            self._workspaces[cache_key].db_task_id = db_task_id
 
         return self._workspaces[cache_key]
 

--- a/src/xagent/migrations/versions/20260511_add_workforces_core.py
+++ b/src/xagent/migrations/versions/20260511_add_workforces_core.py
@@ -8,7 +8,6 @@ Create Date: 2026-05-11
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "20260511_add_workforces_core"
@@ -40,18 +39,33 @@ def upgrade() -> None:
             sa.Column("manager_instructions", sa.Text(), nullable=True),
             sa.Column("status", sa.String(length=20), nullable=False),
             sa.Column("canvas_layout", sa.JSON(), nullable=True),
-            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
-            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
-            sa.ForeignKeyConstraint(["manager_agent_id"], ["agents.id"], ondelete="RESTRICT"),
-            sa.ForeignKeyConstraint(["owner_user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.Column(
+                "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
+            sa.Column(
+                "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
+            sa.ForeignKeyConstraint(
+                ["manager_agent_id"], ["agents.id"], ondelete="RESTRICT"
+            ),
+            sa.ForeignKeyConstraint(
+                ["owner_user_id"], ["users.id"], ondelete="CASCADE"
+            ),
             sa.PrimaryKeyConstraint("id"),
-            sa.UniqueConstraint("scope_type", "scope_id", "name", name="uq_workforce_scope_name"),
+            sa.UniqueConstraint(
+                "scope_type", "scope_id", "name", name="uq_workforce_scope_name"
+            ),
         )
         op.create_index(op.f("ix_workforces_id"), "workforces", ["id"], unique=False)
         op.create_index(
-            op.f("ix_workforces_owner_user_id"), "workforces", ["owner_user_id"], unique=False
+            op.f("ix_workforces_owner_user_id"),
+            "workforces",
+            ["owner_user_id"],
+            unique=False,
         )
-        op.create_index(op.f("ix_workforces_scope_id"), "workforces", ["scope_id"], unique=False)
+        op.create_index(
+            op.f("ix_workforces_scope_id"), "workforces", ["scope_id"], unique=False
+        )
         op.create_index(
             op.f("ix_workforces_scope_type"), "workforces", ["scope_type"], unique=False
         )
@@ -61,7 +75,9 @@ def upgrade() -> None:
             ["manager_agent_id"],
             unique=False,
         )
-        op.create_index(op.f("ix_workforces_status"), "workforces", ["status"], unique=False)
+        op.create_index(
+            op.f("ix_workforces_status"), "workforces", ["status"], unique=False
+        )
 
     if not _table_exists(inspector, "workforce_agents"):
         op.create_table(
@@ -76,14 +92,22 @@ def upgrade() -> None:
             sa.Column("enabled", sa.Boolean(), nullable=False),
             sa.Column("sort_order", sa.Integer(), nullable=False),
             sa.Column("canvas_position", sa.JSON(), nullable=True),
-            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
-            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column(
+                "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
+            sa.Column(
+                "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
             sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="RESTRICT"),
-            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
         )
-        op.create_index(op.f("ix_workforce_agents_id"), "workforce_agents", ["id"], unique=False)
+        op.create_index(
+            op.f("ix_workforce_agents_id"), "workforce_agents", ["id"], unique=False
+        )
         op.create_index(
             op.f("ix_workforce_agents_workforce_id"),
             "workforce_agents",
@@ -106,15 +130,21 @@ def upgrade() -> None:
             sa.Column("user_id", sa.Integer(), nullable=False),
             sa.Column("status", sa.String(length=20), nullable=False),
             sa.Column("snapshot", sa.JSON(), nullable=False),
-            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column(
+                "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
             sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
             sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="SET NULL"),
             sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("task_id"),
         )
-        op.create_index(op.f("ix_workforce_runs_id"), "workforce_runs", ["id"], unique=False)
+        op.create_index(
+            op.f("ix_workforce_runs_id"), "workforce_runs", ["id"], unique=False
+        )
         op.create_index(
             op.f("ix_workforce_runs_workforce_id"),
             "workforce_runs",
@@ -122,7 +152,10 @@ def upgrade() -> None:
             unique=False,
         )
         op.create_index(
-            op.f("ix_workforce_runs_user_id"), "workforce_runs", ["user_id"], unique=False
+            op.f("ix_workforce_runs_user_id"),
+            "workforce_runs",
+            ["user_id"],
+            unique=False,
         )
         op.create_index(
             op.f("ix_workforce_runs_status"), "workforce_runs", ["status"], unique=False
@@ -138,9 +171,13 @@ def upgrade() -> None:
             sa.Column("content", sa.Text(), nullable=False),
             sa.Column("proposed_patch", sa.JSON(), nullable=True),
             sa.Column("status", sa.String(length=20), nullable=False),
-            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column(
+                "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+            ),
             sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
             sa.PrimaryKeyConstraint("id"),
         )
         op.create_index(
@@ -187,12 +224,16 @@ def downgrade() -> None:
     if _table_exists(inspector, "workforce_runs"):
         op.drop_index(op.f("ix_workforce_runs_status"), table_name="workforce_runs")
         op.drop_index(op.f("ix_workforce_runs_user_id"), table_name="workforce_runs")
-        op.drop_index(op.f("ix_workforce_runs_workforce_id"), table_name="workforce_runs")
+        op.drop_index(
+            op.f("ix_workforce_runs_workforce_id"), table_name="workforce_runs"
+        )
         op.drop_index(op.f("ix_workforce_runs_id"), table_name="workforce_runs")
         op.drop_table("workforce_runs")
 
     if _table_exists(inspector, "workforce_agents"):
-        op.drop_index(op.f("ix_workforce_agents_agent_id"), table_name="workforce_agents")
+        op.drop_index(
+            op.f("ix_workforce_agents_agent_id"), table_name="workforce_agents"
+        )
         op.drop_index(
             op.f("ix_workforce_agents_workforce_id"),
             table_name="workforce_agents",

--- a/src/xagent/migrations/versions/20260511_add_workforces_core.py
+++ b/src/xagent/migrations/versions/20260511_add_workforces_core.py
@@ -1,7 +1,7 @@
 """add workforce core tables
 
 Revision ID: 20260511_add_workforces_core
-Revises: b2c517a02b3b
+Revises: 7f4d2c9a1b58
 Create Date: 2026-05-11
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260511_add_workforces_core"
-down_revision: str | None = "b2c517a02b3b"
+down_revision: str | None = "7f4d2c9a1b58"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/xagent/migrations/versions/20260511_add_workforces_core.py
+++ b/src/xagent/migrations/versions/20260511_add_workforces_core.py
@@ -1,0 +1,210 @@
+"""add workforce core tables
+
+Revision ID: 20260511_add_workforces_core
+Revises: b2c517a02b3b
+Create Date: 2026-05-11
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260511_add_workforces_core"
+down_revision: str | None = "b2c517a02b3b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _table_exists(inspector, "workforces"):
+        op.create_table(
+            "workforces",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("owner_user_id", sa.Integer(), nullable=False),
+            sa.Column("scope_type", sa.String(length=50), nullable=False),
+            sa.Column("scope_id", sa.String(length=200), nullable=False),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("manager_agent_id", sa.Integer(), nullable=False),
+            sa.Column("manager_instructions", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("canvas_layout", sa.JSON(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.ForeignKeyConstraint(["manager_agent_id"], ["agents.id"], ondelete="RESTRICT"),
+            sa.ForeignKeyConstraint(["owner_user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("scope_type", "scope_id", "name", name="uq_workforce_scope_name"),
+        )
+        op.create_index(op.f("ix_workforces_id"), "workforces", ["id"], unique=False)
+        op.create_index(
+            op.f("ix_workforces_owner_user_id"), "workforces", ["owner_user_id"], unique=False
+        )
+        op.create_index(op.f("ix_workforces_scope_id"), "workforces", ["scope_id"], unique=False)
+        op.create_index(
+            op.f("ix_workforces_scope_type"), "workforces", ["scope_type"], unique=False
+        )
+        op.create_index(
+            op.f("ix_workforces_manager_agent_id"),
+            "workforces",
+            ["manager_agent_id"],
+            unique=False,
+        )
+        op.create_index(op.f("ix_workforces_status"), "workforces", ["status"], unique=False)
+
+    if not _table_exists(inspector, "workforce_agents"):
+        op.create_table(
+            "workforce_agents",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("agent_id", sa.Integer(), nullable=False),
+            sa.Column("alias", sa.String(length=200), nullable=True),
+            sa.Column("assignment_instructions", sa.Text(), nullable=False),
+            sa.Column("source_type", sa.String(length=20), nullable=False),
+            sa.Column("template_id", sa.String(length=200), nullable=True),
+            sa.Column("enabled", sa.Boolean(), nullable=False),
+            sa.Column("sort_order", sa.Integer(), nullable=False),
+            sa.Column("canvas_position", sa.JSON(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="RESTRICT"),
+            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
+        )
+        op.create_index(op.f("ix_workforce_agents_id"), "workforce_agents", ["id"], unique=False)
+        op.create_index(
+            op.f("ix_workforce_agents_workforce_id"),
+            "workforce_agents",
+            ["workforce_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f("ix_workforce_agents_agent_id"),
+            "workforce_agents",
+            ["agent_id"],
+            unique=False,
+        )
+
+    if not _table_exists(inspector, "workforce_runs"):
+        op.create_table(
+            "workforce_runs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("task_id", sa.Integer(), nullable=True),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("snapshot", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("task_id"),
+        )
+        op.create_index(op.f("ix_workforce_runs_id"), "workforce_runs", ["id"], unique=False)
+        op.create_index(
+            op.f("ix_workforce_runs_workforce_id"),
+            "workforce_runs",
+            ["workforce_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f("ix_workforce_runs_user_id"), "workforce_runs", ["user_id"], unique=False
+        )
+        op.create_index(
+            op.f("ix_workforce_runs_status"), "workforce_runs", ["status"], unique=False
+        )
+
+    if not _table_exists(inspector, "workforce_builder_messages"):
+        op.create_table(
+            "workforce_builder_messages",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("role", sa.String(length=20), nullable=False),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("proposed_patch", sa.JSON(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["workforce_id"], ["workforces.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            op.f("ix_workforce_builder_messages_id"),
+            "workforce_builder_messages",
+            ["id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f("ix_workforce_builder_messages_workforce_id"),
+            "workforce_builder_messages",
+            ["workforce_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f("ix_workforce_builder_messages_user_id"),
+            "workforce_builder_messages",
+            ["user_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _table_exists(inspector, "workforce_builder_messages"):
+        op.drop_index(
+            op.f("ix_workforce_builder_messages_user_id"),
+            table_name="workforce_builder_messages",
+        )
+        op.drop_index(
+            op.f("ix_workforce_builder_messages_workforce_id"),
+            table_name="workforce_builder_messages",
+        )
+        op.drop_index(
+            op.f("ix_workforce_builder_messages_id"),
+            table_name="workforce_builder_messages",
+        )
+        op.drop_table("workforce_builder_messages")
+
+    if _table_exists(inspector, "workforce_runs"):
+        op.drop_index(op.f("ix_workforce_runs_status"), table_name="workforce_runs")
+        op.drop_index(op.f("ix_workforce_runs_user_id"), table_name="workforce_runs")
+        op.drop_index(op.f("ix_workforce_runs_workforce_id"), table_name="workforce_runs")
+        op.drop_index(op.f("ix_workforce_runs_id"), table_name="workforce_runs")
+        op.drop_table("workforce_runs")
+
+    if _table_exists(inspector, "workforce_agents"):
+        op.drop_index(op.f("ix_workforce_agents_agent_id"), table_name="workforce_agents")
+        op.drop_index(
+            op.f("ix_workforce_agents_workforce_id"),
+            table_name="workforce_agents",
+        )
+        op.drop_index(op.f("ix_workforce_agents_id"), table_name="workforce_agents")
+        op.drop_table("workforce_agents")
+
+    if _table_exists(inspector, "workforces"):
+        op.drop_index(op.f("ix_workforces_status"), table_name="workforces")
+        op.drop_index(op.f("ix_workforces_manager_agent_id"), table_name="workforces")
+        op.drop_index(op.f("ix_workforces_scope_type"), table_name="workforces")
+        op.drop_index(op.f("ix_workforces_scope_id"), table_name="workforces")
+        op.drop_index(op.f("ix_workforces_owner_user_id"), table_name="workforces")
+        op.drop_index(op.f("ix_workforces_id"), table_name="workforces")
+        op.drop_table("workforces")

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -44,9 +44,13 @@ class AgentCreateRequest(BaseModel):
     models: dict | None = Field(
         None, description="Model config: {general, small_fast, visual, compact}"
     )
-    knowledge_bases: list[str] = Field(default_factory=list, description="Knowledge base names")
+    knowledge_bases: list[str] = Field(
+        default_factory=list, description="Knowledge base names"
+    )
     skills: list[str] = Field(default_factory=list, description="Skill names")
-    tool_categories: list[str] = Field(default_factory=list, description="Tool category names")
+    tool_categories: list[str] = Field(
+        default_factory=list, description="Tool category names"
+    )
     suggested_prompts: list[str] = Field(
         default_factory=list, description="Suggested prompt examples for users"
     )
@@ -162,7 +166,9 @@ def enhance_system_prompt_with_kb(
 # ===== Helper Functions =====
 
 
-def _validate_knowledge_base_tools(knowledge_bases: list[str], tool_categories: list[str]) -> None:
+def _validate_knowledge_base_tools(
+    knowledge_bases: list[str], tool_categories: list[str]
+) -> None:
     """Raise HTTPException if knowledge bases are selected without the knowledge tool category."""
     if knowledge_bases and KNOWLEDGE_TOOL_CATEGORY not in tool_categories:
         raise HTTPException(
@@ -282,7 +288,9 @@ async def optimize_instructions(
             llm = default_llm
 
         if not llm:
-            raise HTTPException(status_code=400, detail="No LLM available for optimization")
+            raise HTTPException(
+                status_code=400, detail="No LLM available for optimization"
+            )
 
         # Construct prompt
         system_prompt = (
@@ -292,9 +300,7 @@ async def optimize_instructions(
             "Do not include any conversational filler. Just output the optimized instructions."
         )
 
-        user_prompt = (
-            f"Draft instructions:\n{request.instructions}\n\nPlease optimize these instructions."
-        )
+        user_prompt = f"Draft instructions:\n{request.instructions}\n\nPlease optimize these instructions."
 
         # Call LLM
         response = await llm.chat(
@@ -331,9 +337,13 @@ async def create_agent(
             .first()
         )
         if existing:
-            raise HTTPException(status_code=400, detail="Agent with this name already exists")
+            raise HTTPException(
+                status_code=400, detail="Agent with this name already exists"
+            )
 
-        _validate_knowledge_base_tools(agent_data.knowledge_bases, agent_data.tool_categories)
+        _validate_knowledge_base_tools(
+            agent_data.knowledge_bases, agent_data.tool_categories
+        )
 
         # Create agent
         agent = Agent(
@@ -420,7 +430,9 @@ async def get_agent(
     """Get agent details."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -445,7 +457,9 @@ async def update_agent(
     """Update an existing agent."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -477,7 +491,9 @@ async def update_agent(
                 .first()
             )
             if existing:
-                raise HTTPException(status_code=400, detail="Agent with this name already exists")
+                raise HTTPException(
+                    status_code=400, detail="Agent with this name already exists"
+                )
             agent.name = agent_data.name  # type: ignore[assignment]
 
         if agent_data.description is not None:
@@ -534,7 +550,9 @@ async def delete_agent(
     """Delete an agent."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -598,7 +616,9 @@ async def publish_agent(
     """Publish an agent (make it publicly accessible)."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -637,7 +657,9 @@ async def unpublish_agent(
     """Unpublish an agent (revert to draft status)."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -677,7 +699,9 @@ async def upload_agent_logo(
     """Upload or update agent logo."""
     try:
         agent = (
-            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
+            db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+            .first()
         )
 
         if not agent:
@@ -719,9 +743,13 @@ class AgentPreviewRequest(BaseModel):
     models: dict | None = Field(
         None, description="Model config: {general, small_fast, visual, compact}"
     )
-    knowledge_bases: list[str] = Field(default_factory=list, description="Knowledge base names")
+    knowledge_bases: list[str] = Field(
+        default_factory=list, description="Knowledge base names"
+    )
     skills: list[str] = Field(default_factory=list, description="Skill names")
-    tool_categories: list[str] = Field(default_factory=list, description="Tool category names")
+    tool_categories: list[str] = Field(
+        default_factory=list, description="Tool category names"
+    )
     message: str = Field(..., description="User message to preview")
 
 
@@ -755,7 +783,9 @@ async def preview_agent(
 
             if model_config.get("general"):
                 general_model = (
-                    db.query(DBModel).filter(DBModel.id == model_config["general"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == model_config["general"])
+                    .first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -763,7 +793,9 @@ async def preview_agent(
                     )
             if model_config.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel).filter(DBModel.id == model_config["small_fast"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == model_config["small_fast"])
+                    .first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -771,7 +803,9 @@ async def preview_agent(
                     )
             if model_config.get("visual"):
                 visual_model = (
-                    db.query(DBModel).filter(DBModel.id == model_config["visual"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == model_config["visual"])
+                    .first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -779,7 +813,9 @@ async def preview_agent(
                     )
             if model_config.get("compact"):
                 compact_model = (
-                    db.query(DBModel).filter(DBModel.id == model_config["compact"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == model_config["compact"])
+                    .first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -787,7 +823,9 @@ async def preview_agent(
                     )
 
         if not default_llm:
-            raise HTTPException(status_code=400, detail="General model is required for preview")
+            raise HTTPException(
+                status_code=400, detail="General model is required for preview"
+            )
 
         # Create tool config with allowed collections, skills, and tools
         # WebToolConfig expects db and request, pass a minimal dict-like request object

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -4,6 +4,7 @@ import logging
 import os
 import uuid
 from datetime import datetime
+from typing import Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -257,6 +258,27 @@ def _agent_to_response(agent: Agent, db: Session) -> AgentResponse:
     )
 
 
+def _exclude_workforce_manager_agents(query: Any, db: Session) -> Any:
+    """Exclude agents that are internal managers for a Workforce."""
+    workforce_manager_ids = db.query(Workforce.manager_agent_id).filter(
+        Workforce.manager_agent_id.isnot(None)
+    )
+    return query.filter(~Agent.id.in_(workforce_manager_ids))
+
+
+def _is_workforce_manager_agent(db: Session, agent_id: int) -> bool:
+    """Return whether an agent is managed internally by a Workforce."""
+    return (
+        db.query(Workforce.id).filter(Workforce.manager_agent_id == agent_id).first()
+        is not None
+    )
+
+
+def _raise_if_workforce_manager_agent(db: Session, agent_id: int) -> None:
+    if _is_workforce_manager_agent(db, agent_id):
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+
 # ===== Endpoints =====
 
 
@@ -393,8 +415,10 @@ async def list_agents(
     """List all agents for the current user."""
     try:
         agents = (
-            db.query(Agent)
-            .filter(Agent.user_id == current_user.id)
+            _exclude_workforce_manager_agents(
+                db.query(Agent).filter(Agent.user_id == current_user.id),
+                db,
+            )
             .order_by(Agent.created_at.desc())
             .all()
         )
@@ -437,6 +461,7 @@ async def get_agent(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+        _raise_if_workforce_manager_agent(db, int(agent.id))
 
         return _agent_to_response(agent, db)
 
@@ -464,6 +489,7 @@ async def update_agent(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+        _raise_if_workforce_manager_agent(db, int(agent.id))
 
         # Validate knowledge base + tool category consistency
         effective_kb = (
@@ -623,6 +649,7 @@ async def publish_agent(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+        _raise_if_workforce_manager_agent(db, int(agent.id))
 
         if agent.status == AgentStatus.PUBLISHED:
             return PublishResponse(
@@ -664,6 +691,7 @@ async def unpublish_agent(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+        _raise_if_workforce_manager_agent(db, int(agent.id))
 
         if agent.status != AgentStatus.PUBLISHED:
             return PublishResponse(
@@ -706,6 +734,7 @@ async def upload_agent_logo(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+        _raise_if_workforce_manager_agent(db, int(agent.id))
 
         # Delete old logo
         if agent.logo_url:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -4,7 +4,6 @@ import logging
 import os
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -20,6 +19,7 @@ from ..models.agent import Agent, AgentStatus
 from ..models.database import get_db
 from ..models.model import Model as DBModel
 from ..models.user import User
+from ..models.workforce import Workforce, WorkforceAgent
 from ..services.llm_utils import UserAwareModelStorage
 from ..tools.config import WebToolConfig
 from ..user_isolated_memory import UserContext
@@ -36,48 +36,42 @@ class AgentCreateRequest(BaseModel):
     """Request model for creating a new agent."""
 
     name: str = Field(..., min_length=1, max_length=200, description="Agent name")
-    description: Optional[str] = Field(None, description="Agent description")
-    instructions: Optional[str] = Field(None, description="System instructions/prompt")
-    execution_mode: Optional[str] = Field(
+    description: str | None = Field(None, description="Agent description")
+    instructions: str | None = Field(None, description="System instructions/prompt")
+    execution_mode: str | None = Field(
         "balanced", description="Execution mode: flash, balanced, think, or auto"
     )
-    models: Optional[dict] = Field(
+    models: dict | None = Field(
         None, description="Model config: {general, small_fast, visual, compact}"
     )
-    knowledge_bases: List[str] = Field(
-        default_factory=list, description="Knowledge base names"
-    )
-    skills: List[str] = Field(default_factory=list, description="Skill names")
-    tool_categories: List[str] = Field(
-        default_factory=list, description="Tool category names"
-    )
-    suggested_prompts: List[str] = Field(
+    knowledge_bases: list[str] = Field(default_factory=list, description="Knowledge base names")
+    skills: list[str] = Field(default_factory=list, description="Skill names")
+    tool_categories: list[str] = Field(default_factory=list, description="Tool category names")
+    suggested_prompts: list[str] = Field(
         default_factory=list, description="Suggested prompt examples for users"
     )
-    logo_base64: Optional[str] = Field(
-        None, description="Logo image as base64 data URL"
-    )
+    logo_base64: str | None = Field(None, description="Logo image as base64 data URL")
 
 
 class AgentUpdateRequest(BaseModel):
     """Request model for updating an agent."""
 
-    name: Optional[str] = Field(None, min_length=1, max_length=200)
-    description: Optional[str] = None
-    instructions: Optional[str] = None
-    execution_mode: Optional[str] = Field(
+    name: str | None = Field(None, min_length=1, max_length=200)
+    description: str | None = None
+    instructions: str | None = None
+    execution_mode: str | None = Field(
         None, description="Execution mode: flash, balanced, think, or auto"
     )
-    models: Optional[dict] = None
-    knowledge_bases: Optional[List[str]] = None
-    skills: Optional[List[str]] = None
-    tool_categories: Optional[List[str]] = None
-    suggested_prompts: Optional[List[str]] = Field(
+    models: dict | None = None
+    knowledge_bases: list[str] | None = None
+    skills: list[str] | None = None
+    tool_categories: list[str] | None = None
+    suggested_prompts: list[str] | None = Field(
         None, description="Suggested prompt examples for users"
     )
-    logo_base64: Optional[str] = None
-    widget_enabled: Optional[bool] = None
-    allowed_domains: Optional[List[str]] = None
+    logo_base64: str | None = None
+    widget_enabled: bool | None = None
+    allowed_domains: list[str] | None = None
 
 
 class AgentResponse(BaseModel):
@@ -86,21 +80,21 @@ class AgentResponse(BaseModel):
     id: int
     user_id: int
     name: str
-    description: Optional[str]
-    instructions: Optional[str]
+    description: str | None
+    instructions: str | None
     execution_mode: str
-    models: Optional[dict]
-    knowledge_bases: List[str]
-    skills: List[str]
-    tool_categories: List[str]
-    suggested_prompts: List[str]
-    logo_url: Optional[str]
+    models: dict | None
+    knowledge_bases: list[str]
+    skills: list[str]
+    tool_categories: list[str]
+    suggested_prompts: list[str]
+    logo_url: str | None
     status: str
-    published_at: Optional[str]
+    published_at: str | None
     created_at: str
     updated_at: str
     widget_enabled: bool
-    allowed_domains: List[str]
+    allowed_domains: list[str]
 
 
 class AgentListItem(BaseModel):
@@ -108,13 +102,13 @@ class AgentListItem(BaseModel):
 
     id: int
     name: str
-    description: Optional[str]
-    logo_url: Optional[str]
+    description: str | None
+    logo_url: str | None
     status: str
     created_at: str
     updated_at: str
     widget_enabled: bool
-    allowed_domains: List[str]
+    allowed_domains: list[str]
 
 
 class PublishResponse(BaseModel):
@@ -128,9 +122,7 @@ class OptimizeInstructionsRequest(BaseModel):
     """Request model for optimizing agent instructions."""
 
     instructions: str = Field(..., description="Draft instructions to optimize")
-    model_id: Optional[int] = Field(
-        None, description="Model ID to use for optimization"
-    )
+    model_id: int | None = Field(None, description="Model ID to use for optimization")
 
 
 KNOWLEDGE_TOOL_CATEGORY = "knowledge"
@@ -148,8 +140,8 @@ KB_PRIORITY_PROMPT = (
 
 
 def enhance_system_prompt_with_kb(
-    system_prompt: Optional[str], knowledge_bases: Optional[List[str]]
-) -> Optional[str]:
+    system_prompt: str | None, knowledge_bases: list[str] | None
+) -> str | None:
     """Append knowledge-base priority instructions when KBs are configured."""
     if not knowledge_bases:
         return system_prompt
@@ -170,9 +162,7 @@ def enhance_system_prompt_with_kb(
 # ===== Helper Functions =====
 
 
-def _validate_knowledge_base_tools(
-    knowledge_bases: List[str], tool_categories: List[str]
-) -> None:
+def _validate_knowledge_base_tools(knowledge_bases: list[str], tool_categories: list[str]) -> None:
     """Raise HTTPException if knowledge bases are selected without the knowledge tool category."""
     if knowledge_bases and KNOWLEDGE_TOOL_CATEGORY not in tool_categories:
         raise HTTPException(
@@ -181,7 +171,7 @@ def _validate_knowledge_base_tools(
         )
 
 
-def _save_logo(base64_data: Optional[str], agent_id: int) -> Optional[str]:
+def _save_logo(base64_data: str | None, agent_id: int) -> str | None:
     """Save logo image and return URL."""
     if not base64_data:
         return None
@@ -269,7 +259,7 @@ async def optimize_instructions(
     request: OptimizeInstructionsRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Optimize agent instructions using an LLM."""
     try:
         # Get model storage
@@ -292,9 +282,7 @@ async def optimize_instructions(
             llm = default_llm
 
         if not llm:
-            raise HTTPException(
-                status_code=400, detail="No LLM available for optimization"
-            )
+            raise HTTPException(status_code=400, detail="No LLM available for optimization")
 
         # Construct prompt
         system_prompt = (
@@ -304,7 +292,9 @@ async def optimize_instructions(
             "Do not include any conversational filler. Just output the optimized instructions."
         )
 
-        user_prompt = f"Draft instructions:\n{request.instructions}\n\nPlease optimize these instructions."
+        user_prompt = (
+            f"Draft instructions:\n{request.instructions}\n\nPlease optimize these instructions."
+        )
 
         # Call LLM
         response = await llm.chat(
@@ -341,13 +331,9 @@ async def create_agent(
             .first()
         )
         if existing:
-            raise HTTPException(
-                status_code=400, detail="Agent with this name already exists"
-            )
+            raise HTTPException(status_code=400, detail="Agent with this name already exists")
 
-        _validate_knowledge_base_tools(
-            agent_data.knowledge_bases, agent_data.tool_categories
-        )
+        _validate_knowledge_base_tools(agent_data.knowledge_bases, agent_data.tool_categories)
 
         # Create agent
         agent = Agent(
@@ -389,11 +375,11 @@ async def create_agent(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("", response_model=List[AgentListItem])
+@router.get("", response_model=list[AgentListItem])
 async def list_agents(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
-) -> List[AgentListItem]:
+) -> list[AgentListItem]:
     """List all agents for the current user."""
     try:
         agents = (
@@ -434,9 +420,7 @@ async def get_agent(
     """Get agent details."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
@@ -461,9 +445,7 @@ async def update_agent(
     """Update an existing agent."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
@@ -495,9 +477,7 @@ async def update_agent(
                 .first()
             )
             if existing:
-                raise HTTPException(
-                    status_code=400, detail="Agent with this name already exists"
-                )
+                raise HTTPException(status_code=400, detail="Agent with this name already exists")
             agent.name = agent_data.name  # type: ignore[assignment]
 
         if agent_data.description is not None:
@@ -554,13 +534,42 @@ async def delete_agent(
     """Delete an agent."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+
+        manager_reference = (
+            db.query(Workforce)
+            .filter(Workforce.manager_agent_id == agent.id)
+            .order_by(Workforce.id.asc())
+            .first()
+        )
+        if manager_reference:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Cannot delete agent because it is used as the manager agent "
+                    f"by workforce '{manager_reference.name}'"
+                ),
+            )
+
+        worker_reference = (
+            db.query(Workforce)
+            .join(WorkforceAgent, WorkforceAgent.workforce_id == Workforce.id)
+            .filter(WorkforceAgent.agent_id == agent.id)
+            .order_by(Workforce.id.asc(), WorkforceAgent.id.asc())
+            .first()
+        )
+        if worker_reference:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Cannot delete agent because it is used as a worker agent "
+                    f"by workforce '{worker_reference.name}'"
+                ),
+            )
 
         # Delete logo if exists
         if agent.logo_url:
@@ -589,9 +598,7 @@ async def publish_agent(
     """Publish an agent (make it publicly accessible)."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
@@ -630,9 +637,7 @@ async def unpublish_agent(
     """Unpublish an agent (revert to draft status)."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
@@ -672,9 +677,7 @@ async def upload_agent_logo(
     """Upload or update agent logo."""
     try:
         agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
+            db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == current_user.id).first()
         )
 
         if not agent:
@@ -709,20 +712,16 @@ async def upload_agent_logo(
 class AgentPreviewRequest(BaseModel):
     """Request model for agent preview."""
 
-    instructions: Optional[str] = Field(None, description="System instructions/prompt")
-    execution_mode: Optional[str] = Field(
+    instructions: str | None = Field(None, description="System instructions/prompt")
+    execution_mode: str | None = Field(
         "balanced", description="Execution mode: flash, balanced, think, or auto"
     )
-    models: Optional[dict] = Field(
+    models: dict | None = Field(
         None, description="Model config: {general, small_fast, visual, compact}"
     )
-    knowledge_bases: List[str] = Field(
-        default_factory=list, description="Knowledge base names"
-    )
-    skills: List[str] = Field(default_factory=list, description="Skill names")
-    tool_categories: List[str] = Field(
-        default_factory=list, description="Tool category names"
-    )
+    knowledge_bases: list[str] = Field(default_factory=list, description="Knowledge base names")
+    skills: list[str] = Field(default_factory=list, description="Skill names")
+    tool_categories: list[str] = Field(default_factory=list, description="Tool category names")
     message: str = Field(..., description="User message to preview")
 
 
@@ -756,9 +755,7 @@ async def preview_agent(
 
             if model_config.get("general"):
                 general_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == model_config["general"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == model_config["general"]).first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -766,9 +763,7 @@ async def preview_agent(
                     )
             if model_config.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == model_config["small_fast"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == model_config["small_fast"]).first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -776,9 +771,7 @@ async def preview_agent(
                     )
             if model_config.get("visual"):
                 visual_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == model_config["visual"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == model_config["visual"]).first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -786,9 +779,7 @@ async def preview_agent(
                     )
             if model_config.get("compact"):
                 compact_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == model_config["compact"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == model_config["compact"]).first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -796,9 +787,7 @@ async def preview_agent(
                     )
 
         if not default_llm:
-            raise HTTPException(
-                status_code=400, detail="General model is required for preview"
-            )
+            raise HTTPException(status_code=400, detail="General model is required for preview")
 
         # Create tool config with allowed collections, skills, and tools
         # WebToolConfig expects db and request, pass a minimal dict-like request object

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -573,19 +573,19 @@ async def delete_agent(
                 ),
             )
 
-        worker_reference = (
+        workforce_reference = (
             db.query(Workforce)
             .join(WorkforceAgent, WorkforceAgent.workforce_id == Workforce.id)
             .filter(WorkforceAgent.agent_id == agent.id)
             .order_by(Workforce.id.asc(), WorkforceAgent.id.asc())
             .first()
         )
-        if worker_reference:
+        if workforce_reference:
             raise HTTPException(
                 status_code=409,
                 detail=(
                     "Cannot delete agent because it is used as a worker agent "
-                    f"by workforce '{worker_reference.name}'"
+                    f"by workforce '{workforce_reference.name}'"
                 ),
             )
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -30,6 +30,7 @@ from ..models.database import get_db
 from ..models.model import Model as DBModel
 from ..models.task import AgentType, Task, TaskStatus
 from ..models.user import User
+from ..models.workforce import Workforce
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.chat_history_service import (
     get_latest_waiting_question,
@@ -47,7 +48,10 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
-from ..services.workforce_runtime import is_verified_workforce_task
+from ..services.workforce_runtime import (
+    is_verified_workforce_task,
+    sync_workforce_run_status,
+)
 from ..tools.config import WebToolConfig
 from ..tracing import create_task_tracer
 from ..user_isolated_memory import UserContext
@@ -57,6 +61,13 @@ logger = logging.getLogger(__name__)
 
 # Create router
 chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+def _is_workforce_manager_agent(db: Session, agent_id: int) -> bool:
+    return (
+        db.query(Workforce.id).filter(Workforce.manager_agent_id == agent_id).first()
+        is not None
+    )
 
 
 def create_default_llm() -> BaseLLM | None:
@@ -219,6 +230,7 @@ async def create_default_tools(
             "base_dir": str(get_uploads_dir() / f"user_{user.id}"),
             "task_id": task_id,
             "allowed_external_dirs": allowed_external_dirs,
+            "db_task_id": parent_task_id,
         },
         include_mcp_tools=bool(
             allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)
@@ -1306,6 +1318,22 @@ class AgentServiceManager:
                     "status": "running_elsewhere",
                     "error": "Task is already running on another worker.",
                 }
+            try:
+                task_for_sync = (
+                    db_session.query(Task)
+                    .filter(Task.id == int(tracker_task_id))
+                    .first()
+                )
+                if task_for_sync is not None:
+                    sync_workforce_run_status(
+                        db_session, task_for_sync, TaskStatus.RUNNING
+                    )
+                    db_session.commit()
+            except Exception:
+                logger.debug(
+                    "Failed to sync workforce run status after lease acquisition",
+                    exc_info=True,
+                )
             lease_stop_event = asyncio.Event()
             lease_heartbeat_task = asyncio.create_task(
                 run_task_lease_heartbeat(lease, lease_stop_event)
@@ -1360,6 +1388,20 @@ class AgentServiceManager:
                     else:
                         final_status = TaskStatus.FAILED
                 release_task_lease(db_session, lease, status=final_status)
+                try:
+                    task_for_sync = (
+                        db_session.query(Task).filter(Task.id == lease.task_id).first()
+                    )
+                    if task_for_sync is not None:
+                        sync_workforce_run_status(
+                            db_session, task_for_sync, final_status
+                        )
+                        db_session.commit()
+                except Exception:
+                    logger.debug(
+                        "Failed to sync workforce run status after lease release",
+                        exc_info=True,
+                    )
             # Complete tracking if it was started
             if tracker:
                 try:
@@ -1872,6 +1914,12 @@ async def create_task(
     """Create new chat task"""
     try:
         from ..models.agent import Agent as AgentModel
+
+        if request.agent_id and _is_workforce_manager_agent(db, int(request.agent_id)):
+            raise HTTPException(
+                status_code=400,
+                detail="Workforce manager agents can only be run through Workforce",
+            )
 
         # Build task description with file information
         task_description = request.description or ""

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
@@ -47,6 +47,7 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
+from ..services.workforce_runtime import is_verified_workforce_task
 from ..tools.config import WebToolConfig
 from ..tracing import create_task_tracer
 from ..user_isolated_memory import UserContext
@@ -58,7 +59,7 @@ logger = logging.getLogger(__name__)
 chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
 
 
-def create_default_llm() -> Optional[BaseLLM]:
+def create_default_llm() -> BaseLLM | None:
     """Create a default LLM instance based on environment configuration"""
     try:
         # For OpenAI: allow empty string API key (use is not None check)
@@ -94,22 +95,16 @@ def create_default_llm() -> Optional[BaseLLM]:
         is_zhipu = (
             zhipu_base_url
             and any(
-                domain in zhipu_base_url.lower()
-                for domain in {"zhipu", "bigmodel.cn", "api.z.ai"}
+                domain in zhipu_base_url.lower() for domain in {"zhipu", "bigmodel.cn", "api.z.ai"}
             )
-        ) or (
-            zhipu_model
-            and any(zhipu_model.lower().strip() in x.lower() for x in zhipu_models)
-        )
+        ) or (zhipu_model and any(zhipu_model.lower().strip() in x.lower() for x in zhipu_models))
 
         if is_zhipu:
             if zhipu_api_key:
                 logger.info(f"Using Zhipu LLM with model: {zhipu_model}")
                 # Use automatic thinking mode (None) by default
                 thinking_mode_env = os.getenv("ZHIPU_THINKING_MODE", "auto").lower()
-                thinking_mode = (
-                    None if thinking_mode_env == "auto" else thinking_mode_env == "true"
-                )
+                thinking_mode = None if thinking_mode_env == "auto" else thinking_mode_env == "true"
                 return ZhipuLLM(
                     model_name=zhipu_model or "glm-4.7-flash",
                     api_key=zhipu_api_key,
@@ -150,7 +145,7 @@ def create_default_llm() -> Optional[BaseLLM]:
 
 
 def _build_allowed_external_dirs(
-    user_id: Optional[int], *, only_existing: bool = False
+    user_id: int | None, *, only_existing: bool = False
 ) -> list[str]:
     """Build the allowed_external_dirs list for AgentService / tool
     workspace_config.
@@ -177,16 +172,22 @@ def _build_allowed_external_dirs(
 async def create_default_tools(
     db: Session,
     request: Any = None,
-    user: Optional[User] = None,
-    task_id: Optional[str] = None,
-    allowed_collections: Optional[List[str]] = None,
-    allowed_skills: Optional[List[str]] = None,
-    allowed_tools: Optional[List[str]] = None,
-    excluded_agent_id: Optional[int] = None,
-    delegate_agent_ids: Optional[List[int]] = None,
-    vision_model: Optional[Any] = None,
-    sandbox: Optional[Any] = None,
-    llm: Optional[Any] = None,
+    user: User | None = None,
+    task_id: str | None = None,
+    allowed_collections: list[str] | None = None,
+    allowed_skills: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    excluded_agent_id: int | None = None,
+    delegate_agent_ids: list[int] | None = None,
+    vision_model: Any | None = None,
+    sandbox: Any | None = None,
+    llm: Any | None = None,
+    allowed_agent_ids: list[int] | None = None,
+    agent_tool_overrides: dict[int, dict[str, Any]] | None = None,
+    enable_global_agent_tools: bool = True,
+    allow_cross_user_agent_ids: bool = False,
+    parent_task_id: int | None = None,
+    parent_tracer: Any | None = None,
 ) -> tuple[list[Any], Any]:
     """Create default tools and tool_config for AgentService using ToolFactory"""
     if not user:
@@ -213,15 +214,19 @@ async def create_default_tools(
             "task_id": task_id,
             "allowed_external_dirs": allowed_external_dirs,
         },
-        include_mcp_tools=bool(
-            allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)
-        ),
+        include_mcp_tools=bool(allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)),
         task_id=task_id,  # Pass task_id for browser session tracking
         browser_tools_enabled=True,  # Enable browser automation tools
         allowed_collections=allowed_collections,  # Agent Builder knowledge bases
         allowed_skills=allowed_skills,  # Agent Builder skills
         allowed_tools=allowed_tools,  # Agent Builder tool categories
         vision_model=vision_model,  # Pass task-specific vision model
+        allowed_agent_ids=allowed_agent_ids,
+        agent_tool_overrides=agent_tool_overrides,
+        enable_global_agent_tools=enable_global_agent_tools,
+        allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+        parent_task_id=parent_task_id,
+        parent_tracer=parent_tracer,
     )
 
     # Store excluded_agent_id in tool_config for agent tool filtering
@@ -286,31 +291,27 @@ async def update_task_title_from_agent(
             old_title = task_record.title
             task_record.title = task_name
             db.commit()
-            logger.info(
-                f"Updated task {task_id} title from '{old_title}' to '{task_name}'"
-            )
+            logger.info(f"Updated task {task_id} title from '{old_title}' to '{task_name}'")
             return True
         else:
             logger.debug(f"Task title already matches: '{task_record.title}'")
             return False
 
     except Exception as e:
-        logger.error(
-            f"Failed to update task title for task {task_id}: {e}", exc_info=True
-        )
+        logger.error(f"Failed to update task title for task {task_id}: {e}", exc_info=True)
         return False
 
 
 class AgentServiceManager:
     """Manage AgentService instances for different tasks"""
 
-    def __init__(self, request: Optional[Any] = None) -> None:
-        self._agents: Dict[int, AgentService] = {}
-        self._sandboxes: Dict[int, Any] = {}  # user_id -> Sandbox instance
+    def __init__(self, request: Any | None = None) -> None:
+        self._agents: dict[int, AgentService] = {}
+        self._sandboxes: dict[int, Any] = {}  # user_id -> Sandbox instance
         self._default_llm = create_default_llm()
         self.request = request
 
-    def _get_task_llm_ids(self, task: Task, db: Session) -> List[Optional[str]]:
+    def _get_task_llm_ids(self, task: Task, db: Session) -> list[str | None]:
         """Return internal model_id identifiers for a task (never provider model_name)."""
         from ..services.llm_utils import CoreStorage, make_normalize_model_id
 
@@ -319,9 +320,7 @@ class AgentServiceManager:
         _normalize = make_normalize_model_id(core_storage)
 
         return [
-            _normalize(
-                getattr(task, "model_id", None), getattr(task, "model_name", None)
-            ),
+            _normalize(getattr(task, "model_id", None), getattr(task, "model_name", None)),
             _normalize(
                 getattr(task, "small_fast_model_id", None),
                 getattr(task, "small_fast_model_name", None),
@@ -337,7 +336,7 @@ class AgentServiceManager:
         ]
 
     def set_task_llms(
-        self, task_id: int, llm_ids: Optional[List[Optional[str]]], db: Session
+        self, task_id: int, llm_ids: list[str | None] | None, db: Session
     ) -> None:
         """Set LLM configuration for a specific task (configuration now stored in Task table)"""
         logger.info(f"set_task_llms called for task {task_id} with llm_ids: {llm_ids}")
@@ -358,15 +357,13 @@ class AgentServiceManager:
             )
 
     def set_task_memory_similarity_threshold(
-        self, task_id: int, threshold: Optional[float]
+        self, task_id: int, threshold: float | None
     ) -> None:
         """Set memory similarity threshold for a specific task's agent"""
         if task_id in self._agents:
             agent = self._agents[task_id]
             agent.memory_similarity_threshold = threshold
-            logger.info(
-                f"Set memory similarity threshold for task {task_id}: {threshold}"
-            )
+            logger.info(f"Set memory similarity threshold for task {task_id}: {threshold}")
         else:
             logger.warning(
                 f"Cannot set memory similarity threshold for non-existent task {task_id}"
@@ -387,9 +384,7 @@ class AgentServiceManager:
             f"Loaded {len(conversation_history)} persisted chat messages for task {task_id}"
         )
 
-    async def _load_persisted_execution_context(
-        self, task_id: int, db: Session
-    ) -> None:
+    async def _load_persisted_execution_context(self, task_id: int, db: Session) -> None:
         """Hydrate an agent with persisted reusable execution context."""
         agent = self._agents.get(task_id)
         if agent is None:
@@ -409,9 +404,7 @@ class AgentServiceManager:
         if skill_context:
             logger.info(f"Loaded recovered skill context for task {task_id}")
 
-    def _load_agent_builder_config(
-        self, agent: Agent, db: Session, user_id: int
-    ) -> dict:
+    def _load_agent_builder_config(self, agent: Agent, db: Session, user_id: int) -> dict:
         """Load all Agent Builder configuration.
 
         Returns dict with:
@@ -434,9 +427,7 @@ class AgentServiceManager:
         if agent.models:
             if agent.models.get("general"):
                 general_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == agent.models["general"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == agent.models["general"]).first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -445,9 +436,7 @@ class AgentServiceManager:
 
             if agent.models.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == agent.models["small_fast"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == agent.models["small_fast"]).first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -456,9 +445,7 @@ class AgentServiceManager:
 
             if agent.models.get("visual"):
                 visual_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == agent.models["visual"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == agent.models["visual"]).first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -467,9 +454,7 @@ class AgentServiceManager:
 
             if agent.models.get("compact"):
                 compact_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == agent.models["compact"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == agent.models["compact"]).first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -653,8 +638,8 @@ class AgentServiceManager:
     async def get_agent_for_task(
         self,
         task_id: int,
-        db: Optional[Session] = None,
-        user: Optional[User] = None,
+        db: Session | None = None,
+        user: User | None = None,
     ) -> AgentService:
         """Get or create AgentService instance for specific task"""
         if task_id not in self._agents:
@@ -666,9 +651,7 @@ class AgentServiceManager:
                     task = db.query(Task).filter(Task.id == task_id).first()
                     task_exists = task is not None
                 except Exception as e:
-                    logger.warning(
-                        f"Failed to check task existence for task {task_id}: {e}"
-                    )
+                    logger.warning(f"Failed to check task existence for task {task_id}: {e}")
                     task_exists = False
                     task = None
 
@@ -689,9 +672,7 @@ class AgentServiceManager:
                             f"Created new task record for task {task_id} with user_id={user.id}"
                         )
                     except Exception as e:
-                        logger.error(
-                            f"Failed to create task record for task {task_id}: {e}"
-                        )
+                        logger.error(f"Failed to create task record for task {task_id}: {e}")
             else:
                 should_reconstruct = task is not None and task.status in [
                     TaskStatus.RUNNING,
@@ -744,13 +725,9 @@ class AgentServiceManager:
                     if task.agent_type_enum == AgentType.TEXT2SQL:
                         logger.info(f"🎯 Creating Text2SQL agent for task {task.id}")
                         if user is not None:
-                            return await self._create_text2sql_agent(
-                                task, db, user, tracer
-                            )
+                            return await self._create_text2sql_agent(task, db, user, tracer)
                         else:
-                            raise ValueError(
-                                "User context is required for Text2SQL agent creation"
-                            )
+                            raise ValueError("User context is required for Text2SQL agent creation")
                     else:
                         logger.info(
                             f"❌ Task {task.id} is not Text2SQL, using standard agent creation"
@@ -771,11 +748,9 @@ class AgentServiceManager:
                     )
 
                     llm_ids = self._get_task_llm_ids(task, db)
-                    logger.info(
-                        f"Loading LLM configuration from task {task_id}: {llm_ids}"
-                    )
+                    logger.info(f"Loading LLM configuration from task {task_id}: {llm_ids}")
                     # Use user_id for model resolution if available
-                    user_id_for_resolution: Optional[int] = (
+                    user_id_for_resolution: int | None = (
                         int(user.id) if user and user.id is not None else None
                     )
                     task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
@@ -784,16 +759,10 @@ class AgentServiceManager:
 
                     # Override with Agent Builder configuration if task.agent_id exists
                     if task and task.agent_id and user:
-                        agent = (
-                            db.query(Agent).filter(Agent.id == task.agent_id).first()
-                        )
+                        agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
                         if agent:
-                            logger.info(
-                                f"Task {task_id} using Agent Builder config: {agent.name}"
-                            )
-                            agent_config = self._load_agent_builder_config(
-                                agent, db, int(user.id)
-                            )
+                            logger.info(f"Task {task_id} using Agent Builder config: {agent.name}")
+                            agent_config = self._load_agent_builder_config(agent, db, int(user.id))
                             (
                                 task_llm,
                                 task_fast_llm,
@@ -829,9 +798,7 @@ class AgentServiceManager:
                     task_vision_llm = None
                     task_compact_llm = None
             except Exception as e:
-                logger.error(
-                    f"Failed to load LLM configuration from task {task_id} database: {e}"
-                )
+                logger.error(f"Failed to load LLM configuration from task {task_id} database: {e}")
                 # Fallback to defaults
                 task_llm = self._default_llm
                 task_fast_llm = None
@@ -845,19 +812,75 @@ class AgentServiceManager:
                     raise ValueError("User context is required for agent creation")
 
                 if not db:
-                    raise ValueError(
-                        "Database connection is required for agent creation"
-                    )
+                    raise ValueError("Database connection is required for agent creation")
 
                 # Check if task has an associated published agent that should be excluded from agent tools
                 excluded_agent_id = None
+                workforce_allowed_agent_ids: list[int] | None = None
+                workforce_agent_tool_overrides: dict[int, dict[str, Any]] | None = None
+                workforce_tool_names: set[str] = set()
+                workforce_manager_prompt: str | None = None
+                enable_global_agent_tools = True
+                allow_cross_user_agent_ids = False
+                if task and isinstance(task.agent_config, dict):
+                    raw_snapshot = task.agent_config.get("workforce_snapshot")
+                    workforce_run_id = task.agent_config.get("workforce_run_id")
+                    if isinstance(raw_snapshot, dict) and is_verified_workforce_task(
+                        db, task, workforce_run_id
+                    ):
+                        workers = raw_snapshot.get("workers", [])
+                        workforce_allowed_agent_ids = []
+                        workforce_agent_tool_overrides = {}
+                        allow_cross_user_agent_ids = True
+                        workforce = raw_snapshot.get("workforce", {}) or {}
+                        workforce_name = workforce.get("name", "Workforce")
+                        for worker in workers:
+                            if not isinstance(worker, dict):
+                                continue
+                            agent_id = worker.get("agent_id")
+                            if not isinstance(agent_id, int):
+                                continue
+                            if not worker.get("enabled", True):
+                                continue
+                            workforce_allowed_agent_ids.append(agent_id)
+                            alias = worker.get("alias") or worker.get("name")
+                            assignment_instructions = worker.get("assignment_instructions")
+                            description_parts = []
+                            if worker.get("description"):
+                                description_parts.append(str(worker["description"]))
+                            if alias:
+                                description_parts.append(f"Workforce role: {alias}.")
+                            if assignment_instructions:
+                                description_parts.append(f"Assignment: {assignment_instructions}")
+                            worker_prompt_parts = [
+                                f'You are being called as part of Workforce "{workforce_name}".',
+                                "",
+                                "Your assignment in this Workforce:",
+                                str(assignment_instructions or ""),
+                                "",
+                                "Stay within this assignment. Return your result to the Workforce Manager. Do not address the end user directly unless asked.",
+                            ]
+                            workforce_agent_tool_overrides[agent_id] = {
+                                "tool_name": worker.get("tool_name"),
+                                "description": " ".join(description_parts),
+                                "extra_system_prompt": "\n".join(worker_prompt_parts),
+                                "workforce_run_id": workforce_run_id,
+                                "workforce_id": workforce.get("id"),
+                                "workforce_name": workforce_name,
+                                "worker_member_id": worker.get("member_id"),
+                                "worker_alias": alias,
+                            }
+                            if isinstance(worker.get("tool_name"), str):
+                                workforce_tool_names.add(str(worker["tool_name"]))
+                        workforce_manager_prompt = (raw_snapshot.get("manager", {}) or {}).get(
+                            "runtime_prompt"
+                        )
+                        enable_global_agent_tools = False
                 if task and task.agent_id:
                     # Get the current agent to check if it's published
                     from ..models.agent import AgentStatus
 
-                    current_agent = (
-                        db.query(Agent).filter(Agent.id == task.agent_id).first()
-                    )
+                    current_agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
                     if current_agent and current_agent.status == AgentStatus.PUBLISHED:
                         excluded_agent_id = int(current_agent.id)
                         logger.info(
@@ -873,9 +896,7 @@ class AgentServiceManager:
                     sandbox_mgr = get_sandbox_manager()
                     if sandbox_mgr:
                         try:
-                            sandbox = await sandbox_mgr.get_or_create_sandbox(
-                                "user", str(user_id)
-                            )
+                            sandbox = await sandbox_mgr.get_or_create_sandbox("user", str(user_id))
                             self._sandboxes[user_id] = sandbox
                         except Exception as e:
                             # Graceful degradation: tools will run locally without sandbox
@@ -915,9 +936,7 @@ class AgentServiceManager:
                     allowed_tools = []
 
                     for tool in all_tools:
-                        if hasattr(tool, "metadata") and hasattr(
-                            tool.metadata, "category"
-                        ):
+                        if hasattr(tool, "metadata") and hasattr(tool.metadata, "category"):
                             category = str(tool.metadata.category.value)
                             tool_name = getattr(tool, "name", None)
 
@@ -932,9 +951,7 @@ class AgentServiceManager:
                                         # Use the exact raw server name for prefix comparison, just replace spaces with underscores
                                         # as done in mcp_adapter.py (e.g. "LinkedIn" -> "LinkedIn", "Google Drive" -> "Google_Drive")
                                         server_name = (
-                                            tc.split(":", 1)[1]
-                                            .replace(" ", "_")
-                                            .replace("-", "_")
+                                            tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
                                         )
 
                                         # mcp_adapter prefix is f"mcp_{server_name}_" where server_name preserves original case
@@ -947,23 +964,20 @@ class AgentServiceManager:
                                 for tc in tool_categories:
                                     if tc.startswith("mcp:"):
                                         server_name = (
-                                            tc.split(":", 1)[1]
-                                            .replace(" ", "_")
-                                            .replace("-", "_")
+                                            tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
                                         )
                                         logger.info(
                                             f"Checking Custom API tool: '{tool_name}' vs 'api_{server_name}_call'"
                                         )
-                                        if (
-                                            tool_name.lower()
-                                            == f"api_{server_name.lower()}_call"
-                                        ):
+                                        if tool_name.lower() == f"api_{server_name.lower()}_call":
                                             allowed_tools.append(tool_name)
                                             break
 
                     logger.info(
                         f"Tool categories {tool_categories} mapped to {len(allowed_tools)} tools for task {task_id}"
                     )
+                if workforce_tool_names:
+                    allowed_tools = list(set(allowed_tools or []) | workforce_tool_names)
 
                 delegate_agent_ids = self._get_delegate_agent_ids(task)
 
@@ -973,9 +987,7 @@ class AgentServiceManager:
                     request=self.request,
                     user=user,
                     task_id=f"web_task_{task_id}",
-                    allowed_collections=agent_config["knowledge_bases"]
-                    if agent_config
-                    else None,
+                    allowed_collections=agent_config["knowledge_bases"] if agent_config else None,
                     allowed_skills=agent_config["skills"] if agent_config else None,
                     allowed_tools=allowed_tools,
                     excluded_agent_id=excluded_agent_id,
@@ -983,6 +995,12 @@ class AgentServiceManager:
                     vision_model=task_vision_llm,  # Pass task-specific vision model
                     sandbox=sandbox,
                     llm=task_llm,  # Pass task-specific LLM
+                    allowed_agent_ids=workforce_allowed_agent_ids,
+                    agent_tool_overrides=workforce_agent_tool_overrides,
+                    enable_global_agent_tools=enable_global_agent_tools,
+                    allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+                    parent_task_id=task_id,
+                    parent_tracer=tracer,
                 )
 
                 with UserContext(int(user.id)):
@@ -990,13 +1008,9 @@ class AgentServiceManager:
                     agent_kwargs = {}
                     if task and task.agent_type == "text2sql" and task.agent_config:
                         config: dict[str, Any] = (
-                            task.agent_config
-                            if isinstance(task.agent_config, dict)
-                            else {}
+                            task.agent_config if isinstance(task.agent_config, dict) else {}
                         )
-                        logger.info(
-                            f"Extracting Text2SQL config: {list(config.keys())}"
-                        )
+                        logger.info(f"Extracting Text2SQL config: {list(config.keys())}")
                         agent_kwargs.update(
                             {
                                 "database_url": config.get("database_url"),
@@ -1008,12 +1022,8 @@ class AgentServiceManager:
                                 "available_tables": config.get("available_tables"),
                             }
                         )
-                        logger.info(
-                            f"Text2SQL kwargs prepared: {list(agent_kwargs.keys())}"
-                        )
-                        logger.info(
-                            f"Database URL: {config.get('database_url', 'NOT FOUND')}"
-                        )
+                        logger.info(f"Text2SQL kwargs prepared: {list(agent_kwargs.keys())}")
+                        logger.info(f"Database URL: {config.get('database_url', 'NOT FOUND')}")
 
                     # Unpack tools and tool_config from create_default_tools
                     tools_list, tool_config = tools
@@ -1021,15 +1031,15 @@ class AgentServiceManager:
                     # Get system prompt from agent config (if available)
                     from .agents import enhance_system_prompt_with_kb
 
-                    system_prompt = (
-                        agent_config.get("instructions") if agent_config else None
-                    )
-                    kb_list = (
-                        agent_config.get("knowledge_bases") if agent_config else None
-                    )
-                    system_prompt = enhance_system_prompt_with_kb(
-                        system_prompt, kb_list
-                    )
+                    system_prompt = agent_config.get("instructions") if agent_config else None
+                    kb_list = agent_config.get("knowledge_bases") if agent_config else None
+                    system_prompt = enhance_system_prompt_with_kb(system_prompt, kb_list)
+                    if workforce_manager_prompt:
+                        system_prompt = (
+                            f"{system_prompt}\n\n{workforce_manager_prompt}"
+                            if system_prompt
+                            else workforce_manager_prompt
+                        )
 
                     system_prompt = self._apply_delegate_prompt(
                         db=db,
@@ -1041,9 +1051,7 @@ class AgentServiceManager:
                     # Extract memory similarity threshold from agent config
                     memory_similarity_threshold = None
                     if agent_config and "memory_similarity_threshold" in agent_config:
-                        memory_similarity_threshold = agent_config[
-                            "memory_similarity_threshold"
-                        ]
+                        memory_similarity_threshold = agent_config["memory_similarity_threshold"]
 
                     # Build allowed external directories (user's upload directory for knowledge base files)
                     allowed_external_dirs = _build_allowed_external_dirs(
@@ -1063,9 +1071,7 @@ class AgentServiceManager:
                         memory=get_memory_store(),  # Use dynamic memory store for auto-switching
                         pattern=task_pattern,  # Use pattern instead of use_dag_pattern
                         tracer=tracer,
-                        agent_type=str(task.agent_type)
-                        if task and task.agent_type
-                        else "standard",
+                        agent_type=str(task.agent_type) if task and task.agent_type else "standard",
                         enable_workspace=True,  # Enable workspace functionality
                         workspace_base_dir=str(
                             get_uploads_dir() / f"user_{user.id}"
@@ -1079,9 +1085,7 @@ class AgentServiceManager:
 
                     selected_file_ids: list[str] = []
                     if task and isinstance(task.agent_config, dict):
-                        raw_selected_file_ids = task.agent_config.get(
-                            "selected_file_ids"
-                        )
+                        raw_selected_file_ids = task.agent_config.get("selected_file_ids")
                         if isinstance(raw_selected_file_ids, list):
                             selected_file_ids = [
                                 str(item)
@@ -1111,18 +1115,14 @@ class AgentServiceManager:
 
                             # Use the source file directly (user's upload directory) instead of copying
                             # This avoids duplicate files across the system
-                            workspace.register_file(
-                                str(source_path), file_id=selected_file_id
-                            )
+                            workspace.register_file(str(source_path), file_id=selected_file_id)
 
                 pattern_info = (
                     f"with DAG pattern and workspace using {llm_info}"
                     if use_dag
                     else "with workspace (no LLM configured)"
                 )
-                logger.info(
-                    f"Created new AgentService for task {task_id} {pattern_info}"
-                )
+                logger.info(f"Created new AgentService for task {task_id} {pattern_info}")
 
                 if task_exists and db is not None:
                     self._load_persisted_conversation_history(task_id, db)
@@ -1135,7 +1135,7 @@ class AgentServiceManager:
 
         return self._agents[task_id]
 
-    def remove_agent(self, task_id: int, user_id: Optional[int] = None) -> None:
+    def remove_agent(self, task_id: int, user_id: int | None = None) -> None:
         """Remove AgentService instance for completed task"""
         if task_id in self._agents:
             # Log workspace path before cleanup
@@ -1145,9 +1145,7 @@ class AgentServiceManager:
             else:
                 workspace_path = None
             if workspace_path:
-                logger.info(
-                    f"Deleting workspace path for task {task_id}: {workspace_path}"
-                )
+                logger.info(f"Deleting workspace path for task {task_id}: {workspace_path}")
 
             # Clean up workspace before removing agent
             self._agents[task_id].cleanup_workspace()
@@ -1165,11 +1163,11 @@ class AgentServiceManager:
         self,
         agent_service: "AgentService",
         task: str,
-        context: Optional[Dict[str, Any]] = None,
-        task_id: Optional[str] = None,
-        tracking_task_id: Optional[str] = None,
-        db_session: Optional[Any] = None,
-    ) -> Dict[str, Any]:
+        context: dict[str, Any] | None = None,
+        task_id: str | None = None,
+        tracking_task_id: str | None = None,
+        db_session: Any | None = None,
+    ) -> dict[str, Any]:
         """
         Execute task with automatic token tracking.
 
@@ -1215,9 +1213,7 @@ class AgentServiceManager:
                 await tracker.start_tracking()
                 logger.info(f"Started token tracking for task {tracker_task_id}")
             except Exception as e:
-                logger.warning(
-                    f"Failed to start token tracking for task {tracker_task_id}: {e}"
-                )
+                logger.warning(f"Failed to start token tracking for task {tracker_task_id}: {e}")
                 tracker = None
 
         try:
@@ -1226,17 +1222,13 @@ class AgentServiceManager:
             )
 
             # Execute the task
-            result = await agent_service.execute_task(
-                task=task, context=context, task_id=task_id
-            )
+            result = await agent_service.execute_task(task=task, context=context, task_id=task_id)
 
             logger.info("=== Task executed successfully, updating title if needed ===")
 
             # Update task title with generated task_name (clean architecture: Core provides API, Web handles DB)
             if db_session and task_id and result and result.get("success"):
-                await update_task_title_from_agent(
-                    agent_service, int(task_id), db_session
-                )
+                await update_task_title_from_agent(agent_service, int(task_id), db_session)
 
             return result
         finally:
@@ -1265,9 +1257,7 @@ class AgentServiceManager:
                         f"Failed to complete token tracking for task {tracker_task_id}: {e}"
                     )
 
-    def _cleanup_workspace_directory(
-        self, task_id: int, user_id: Optional[int] = None
-    ) -> None:
+    def _cleanup_workspace_directory(self, task_id: int, user_id: int | None = None) -> None:
         """Clean up workspace directory for a task when agent is not in memory"""
         from ...core.workspace import TaskWorkspace
 
@@ -1301,9 +1291,7 @@ class AgentServiceManager:
                 )
                 break
         else:
-            logger.info(
-                f"No workspace directory found for task {task_id} (user {user_id})"
-            )
+            logger.info(f"No workspace directory found for task {task_id} (user {user_id})")
 
     async def _create_text2sql_agent(
         self, task: Task, db: Session, user: User, tracer: Tracer
@@ -1326,21 +1314,17 @@ class AgentServiceManager:
 
             # Validate required configuration
             if not config.get("database_url"):
-                raise ValueError(
-                    "Text2SQL agent configuration must include 'database_url'"
-                )
+                raise ValueError("Text2SQL agent configuration must include 'database_url'")
 
             # Log configuration for debugging
-            logger.info(
-                f"Creating Text2SQL agent for task {task.id} with config: {config}"
-            )
+            logger.info(f"Creating Text2SQL agent for task {task.id} with config: {config}")
 
             llm_ids = self._get_task_llm_ids(task, db)
 
             # Use user_id for model resolution if available
             user_id_for_resolution = int(user.id) if user else None
-            task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
-                resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
+            task_llm, task_fast_llm, task_vision_llm, task_compact_llm = resolve_llms_from_names(
+                llm_ids, db, user_id_for_resolution
             )
 
             # Use default LLM if no specific LLM configured
@@ -1422,22 +1406,18 @@ class AgentServiceManager:
         """Infer database type from connection URL"""
         if database_url.startswith("mysql://") or database_url.startswith("mysql2://"):
             return "MySQL"
-        elif database_url.startswith("postgresql://") or database_url.startswith(
-            "postgres://"
-        ):
+        elif database_url.startswith("postgresql://") or database_url.startswith("postgres://"):
             return "PostgreSQL"
         elif database_url.startswith("sqlite://"):
             return "SQLite"
-        elif database_url.startswith("sqlserver://") or database_url.startswith(
-            "mssql://"
-        ):
+        elif database_url.startswith("sqlserver://") or database_url.startswith("mssql://"):
             return "SQL Server"
         else:
             return "Unknown"
 
     async def _execute_text2sql_agent_directly(
         self, agent: Any, task: str, tracer: Any, task_id: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Execute Text2SQL agent directly using its own execute method.
 
@@ -1451,9 +1431,7 @@ class AgentServiceManager:
             # Normalize return format to match AgentService format
             return {
                 "status": "completed" if result.get("success") else "failed",
-                "output": result.get(
-                    "output", result.get("error", "No output provided")
-                ),
+                "output": result.get("output", result.get("error", "No output provided")),
                 "success": result.get("success", False),
                 "metadata": result.get(
                     "metadata",
@@ -1513,23 +1491,17 @@ class AgentServiceManager:
                         "event_type": event.event_type,
                         "task_id": str(event.task_id),
                         "step_id": event.step_id,
-                        "timestamp": event.timestamp.timestamp()
-                        if event.timestamp
-                        else None,
+                        "timestamp": event.timestamp.timestamp() if event.timestamp else None,
                         "data": event.data,
                         "parent_id": event.parent_event_id,
                     }
                 )
 
             # Get DAG execution data
-            dag_execution = (
-                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
-            )
+            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
             if dag_execution and dag_execution.current_plan:
                 plan_state = (
-                    dict(dag_execution.current_plan)
-                    if dag_execution.current_plan
-                    else None
+                    dict(dag_execution.current_plan) if dag_execution.current_plan else None
                 )
 
             if tracer_events or plan_state:
@@ -1564,9 +1536,7 @@ class AgentServiceManager:
                         )
                         llm_ids = self._get_task_llm_ids(task, db)
                         # Use user_id for model resolution if available
-                        user_id_for_resolution = (
-                            int(task.user_id) if task.user_id else None
-                        )
+                        user_id_for_resolution = int(task.user_id) if task.user_id else None
                         task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
                             resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
                         )
@@ -1680,9 +1650,7 @@ class AgentServiceManager:
                             memory_similarity_threshold=memory_similarity_threshold,
                         )
                 else:
-                    raise ValueError(
-                        "User context is required for agent reconstruction"
-                    )
+                    raise ValueError("User context is required for agent reconstruction")
 
                 await self._agents[task_id].reconstruct_from_history(
                     str(task_id), tracer_events, plan_state
@@ -1690,31 +1658,25 @@ class AgentServiceManager:
                 self._load_persisted_conversation_history(task_id, db)
                 await self._load_persisted_execution_context(task_id, db)
 
-                logger.info(
-                    f"Successfully reconstructed agent for task {task_id} from history"
-                )
+                logger.info(f"Successfully reconstructed agent for task {task_id} from history")
             else:
-                logger.info(
-                    f"No historical data found for task {task_id}, will create new agent"
-                )
+                logger.info(f"No historical data found for task {task_id}, will create new agent")
                 # Don't create agent here, let the normal flow handle it
                 # Raise an exception to indicate reconstruction is not possible
                 raise ValueError(f"No historical data found for task {task_id}")
 
         except Exception as e:
-            logger.error(
-                f"Failed to reconstruct agent from history for task {task_id}: {e}"
-            )
+            logger.error(f"Failed to reconstruct agent from history for task {task_id}: {e}")
             raise
 
-    def get_agent_workspace_files(self, task_id: int) -> Dict[str, Any]:
+    def get_agent_workspace_files(self, task_id: int) -> dict[str, Any]:
         """Get workspace files for a task"""
         if task_id not in self._agents:
             raise ValueError(f"No agent found for task {task_id}")
 
         return self._agents[task_id].get_workspace_files()
 
-    def get_agent_output_files(self, task_id: int) -> List[Dict[str, Any]]:
+    def get_agent_output_files(self, task_id: int) -> list[dict[str, Any]]:
         """Get output files for a task"""
         if task_id not in self._agents:
             raise ValueError(f"No agent found for task {task_id}")
@@ -1795,25 +1757,17 @@ async def create_task(
                 file_paths.append(str(file_path))
 
                 if file_path.exists():
-                    file_info_list.append(
-                        f"File: {uploaded_file.filename} (Path: {file_path})"
-                    )
+                    file_info_list.append(f"File: {uploaded_file.filename} (Path: {file_path})")
                 else:
-                    file_info_list.append(
-                        f"File: {uploaded_file.filename} (File does not exist)"
-                    )
+                    file_info_list.append(f"File: {uploaded_file.filename} (File does not exist)")
 
             if file_info_list:
                 if task_description:
-                    task_description += "\n\nUploaded files:\n" + "\n".join(
-                        file_info_list
-                    )
+                    task_description += "\n\nUploaded files:\n" + "\n".join(file_info_list)
                 else:
-                    task_description = "File processing task:\n" + "\n".join(
-                        file_info_list
-                    )
+                    task_description = "File processing task:\n" + "\n".join(file_info_list)
 
-        delegate_agent_ids: Optional[list[int]] = None
+        delegate_agent_ids: list[int] | None = None
         if request.delegate_agent_ids:
             requested_delegate_ids = [
                 int(agent_id)
@@ -1848,8 +1802,8 @@ async def create_task(
         core_storage = CoreStorage(db, DBModel)
 
         def _to_internal_model_id_if_accessible(
-            model_ref: Optional[Any],
-        ) -> Optional[str]:
+            model_ref: Any | None,
+        ) -> str | None:
             if model_ref is None:
                 return None
             if isinstance(model_ref, str):
@@ -1888,16 +1842,14 @@ async def create_task(
 
             return str(db_model.model_id)
 
-        def _normalize_llm_refs(llm_refs: List[Optional[Any]]) -> List[Optional[str]]:
-            return [
-                _to_internal_model_id_if_accessible(model_ref) for model_ref in llm_refs
-            ]
+        def _normalize_llm_refs(llm_refs: list[Any | None]) -> list[str | None]:
+            return [_to_internal_model_id_if_accessible(model_ref) for model_ref in llm_refs]
 
-        def _get_default_internal_model_ids() -> Dict[str, Optional[str]]:
+        def _get_default_internal_model_ids() -> dict[str, str | None]:
             from ..models.model import Model as DBModel
 
             config_types = ["general", "small_fast", "visual", "compact"]
-            defaults: Dict[str, Optional[str]] = {ct: None for ct in config_types}
+            defaults: dict[str, str | None] = dict.fromkeys(config_types)
 
             # User-specific defaults (Mode A: use DBModel JOIN).
             user_defaults = (
@@ -1943,9 +1895,7 @@ async def create_task(
             # Fetch model configuration from agent
             agent_db = (
                 db.query(AgentModel)
-                .filter(
-                    AgentModel.id == request.agent_id, AgentModel.user_id == user.id
-                )
+                .filter(AgentModel.id == request.agent_id, AgentModel.user_id == user.id)
                 .first()
             )
             if agent_db and agent_db.models:
@@ -1982,10 +1932,10 @@ async def create_task(
         # Persist both:
         # - *_model_id: internal stable identifier (preferred for selection)
         # - *_model_name: provider-facing model name (useful for display/audit)
-        default_model_id: Optional[str] = None
-        fast_model_id: Optional[str] = None
-        visual_model_id: Optional[str] = None
-        compact_model_id: Optional[str] = None
+        default_model_id: str | None = None
+        fast_model_id: str | None = None
+        visual_model_id: str | None = None
+        compact_model_id: str | None = None
 
         if llm_ids_to_use and len(llm_ids_to_use) == 4:
             default_model_id = llm_ids_to_use[0]
@@ -2011,19 +1961,15 @@ async def create_task(
             try:
                 agent_type_enum = AgentType(request.agent_type)
             except ValueError:
-                logger.warning(
-                    f"Unknown agent_type '{request.agent_type}', using STANDARD"
-                )
+                logger.warning(f"Unknown agent_type '{request.agent_type}', using STANDARD")
                 agent_type_enum = AgentType.STANDARD
 
         # Convert examples to list of dicts if provided
         examples_data = None
         if request.examples:
-            examples_data = [
-                {"input": ex.input, "output": ex.output} for ex in request.examples
-            ]
+            examples_data = [{"input": ex.input, "output": ex.output} for ex in request.examples]
 
-        task_agent_config: Dict[str, Any] = {}
+        task_agent_config: dict[str, Any] = {}
         if isinstance(request.agent_config, dict):
             task_agent_config.update(request.agent_config)
         if selected_file_ids:
@@ -2086,9 +2032,7 @@ async def create_task(
             task_id=task.id,
             title=task.title,
             status=task.status.value,
-            created_at=format_datetime_for_api(task.created_at)
-            if task.created_at
-            else None,
+            created_at=format_datetime_for_api(task.created_at) if task.created_at else None,
             model_id=task.model_id,
             small_fast_model_id=task.small_fast_model_id,
             visual_model_id=task.visual_model_id,
@@ -2113,18 +2057,18 @@ async def create_task(
 async def get_tasks(
     page: int = 1,
     per_page: int = 10,
-    search: Optional[str] = None,
-    agent_type: Optional[str] = None,
-    exclude_agent_type: Optional[str] = None,
-    execution_mode: Optional[str] = None,
-    exclude_execution_mode: Optional[str] = None,
+    search: str | None = None,
+    agent_type: str | None = None,
+    exclude_agent_type: str | None = None,
+    execution_mode: str | None = None,
+    exclude_execution_mode: str | None = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get tasks list with pagination"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
-        def _get_tasks_sync() -> Dict[str, Any]:
+        def _get_tasks_sync() -> dict[str, Any]:
             # Build base query - filter by current user, unless admin
             if user.is_admin:
                 # Admin can see all tasks - include user relationship for admin
@@ -2148,8 +2092,7 @@ async def get_tasks(
                     if agent_type_enum.value == AgentType.STANDARD.value:
                         # For STANDARD agent type, include both 'standard' and NULL values
                         query = query.filter(
-                            (Task.agent_type == agent_type_enum.value)
-                            | (Task.agent_type.is_(None))
+                            (Task.agent_type == agent_type_enum.value) | (Task.agent_type.is_(None))
                         )
                     else:
                         # For other agent types, filter by exact value
@@ -2188,9 +2131,7 @@ async def get_tasks(
 
             # Apply pagination
             offset = (page - 1) * per_page
-            query = (
-                query.order_by(Task.created_at.desc()).offset(offset).limit(per_page)
-            )
+            query = query.order_by(Task.created_at.desc()).offset(offset).limit(per_page)
             tasks_query = query.all()
 
             # Batch fetch agents for tasks with agent_id
@@ -2242,9 +2183,7 @@ async def get_tasks(
                     # Include user information for admin users
                     if user.is_admin:
                         task_data["user_id"] = task.user_id
-                        task_data["username"] = (
-                            task.user.username if task.user else "Unknown"
-                        )
+                        task_data["username"] = task.user.username if task.user else "Unknown"
 
                     tasks.append(task_data)
                 except Exception as e:
@@ -2278,20 +2217,16 @@ async def get_tasks(
 @chat_router.get("/task/{task_id}")
 async def get_task(
     task_id: int, db: Session = Depends(get_db), user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get task details"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
-        def _get_task_sync() -> Dict[str, Any]:
+        def _get_task_sync() -> dict[str, Any]:
             # Admin can see any task, regular users can only see their own
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2311,9 +2246,7 @@ async def get_task(
             dag_data = None
             from ..models.task import DAGExecution
 
-            dag_execution = (
-                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
-            )
+            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
             if dag_execution:
                 dag_data = {
                     "phase": dag_execution.phase.value if dag_execution.phase else None,
@@ -2376,20 +2309,16 @@ async def get_task(
 @chat_router.get("/task/{task_id}/status")
 async def get_task_status(
     task_id: int, db: Session = Depends(get_db), user: User = Depends(get_current_user)
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get task status"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
-        def _get_task_status_sync() -> Dict[str, Any]:
+        def _get_task_status_sync() -> dict[str, Any]:
             # Admin can see any task, regular users can only see their own
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2464,11 +2393,7 @@ async def update_task(
         if user.is_admin:
             task = db.query(Task).filter(Task.id == task_id).first()
         else:
-            task = (
-                db.query(Task)
-                .filter(Task.id == task_id, Task.user_id == user.id)
-                .first()
-            )
+            task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
 
         if not task:
             raise HTTPException(status_code=404, detail="Task not found")
@@ -2490,7 +2415,7 @@ async def delete_task(
     request: Any = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Delete a task and all related data"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
@@ -2499,11 +2424,7 @@ async def delete_task(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2513,9 +2434,7 @@ async def delete_task(
             # Delete DAG execution (if any)
             from ..models.task import DAGExecution
 
-            dag_execution = (
-                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
-            )
+            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
             if dag_execution:
                 db.delete(dag_execution)
 
@@ -2579,7 +2498,7 @@ async def get_task_workspace_files(
     request: Any = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get all workspace files for a task"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
@@ -2588,11 +2507,7 @@ async def get_task_workspace_files(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
             return task
@@ -2621,7 +2536,7 @@ async def get_task_output_files(
     request: Any = None,
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get output files for a task"""
     try:
         # Run synchronous database queries in thread pool to avoid blocking event loop
@@ -2630,11 +2545,7 @@ async def get_task_output_files(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
             return task

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -813,16 +813,28 @@ class AgentServiceManager:
                                 task_vision_llm,
                                 task_compact_llm,
                             ) = agent_config["llms"]
-                            # Agent Builder execution_mode overrides task pattern.
-                            agent_execution_mode = agent_config.get(
-                                "execution_mode", "balanced"
+                            # For workforce tasks, keep the task's own
+                            # execution_mode (validated at run creation).
+                            # For regular Agent Builder tasks, override with
+                            # the agent's current execution_mode.
+                            is_workforce = (
+                                isinstance(task.agent_config, dict)
+                                and "workforce_snapshot" in task.agent_config
                             )
-                            task_pattern = get_agent_pattern_for_execution_mode(
-                                agent_execution_mode
-                            )
-                            logger.info(
-                                f"Task {task_id} using Agent Builder execution mode: {agent.execution_mode} -> pattern={task_pattern}"
-                            )
+                            if not is_workforce:
+                                agent_execution_mode = agent_config.get(
+                                    "execution_mode", "balanced"
+                                )
+                                task_pattern = get_agent_pattern_for_execution_mode(
+                                    agent_execution_mode
+                                )
+                                logger.info(
+                                    f"Task {task_id} using Agent Builder execution mode: {agent.execution_mode} -> pattern={task_pattern}"
+                                )
+                            else:
+                                logger.info(
+                                    f"Workforce task {task_id} keeping task execution_mode: {task.execution_mode} -> pattern={task_pattern}"
+                                )
 
                     # If no models were resolved, use defaults
                     if not task_llm:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Dict, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
@@ -95,16 +95,22 @@ def create_default_llm() -> BaseLLM | None:
         is_zhipu = (
             zhipu_base_url
             and any(
-                domain in zhipu_base_url.lower() for domain in {"zhipu", "bigmodel.cn", "api.z.ai"}
+                domain in zhipu_base_url.lower()
+                for domain in {"zhipu", "bigmodel.cn", "api.z.ai"}
             )
-        ) or (zhipu_model and any(zhipu_model.lower().strip() in x.lower() for x in zhipu_models))
+        ) or (
+            zhipu_model
+            and any(zhipu_model.lower().strip() in x.lower() for x in zhipu_models)
+        )
 
         if is_zhipu:
             if zhipu_api_key:
                 logger.info(f"Using Zhipu LLM with model: {zhipu_model}")
                 # Use automatic thinking mode (None) by default
                 thinking_mode_env = os.getenv("ZHIPU_THINKING_MODE", "auto").lower()
-                thinking_mode = None if thinking_mode_env == "auto" else thinking_mode_env == "true"
+                thinking_mode = (
+                    None if thinking_mode_env == "auto" else thinking_mode_env == "true"
+                )
                 return ZhipuLLM(
                     model_name=zhipu_model or "glm-4.7-flash",
                     api_key=zhipu_api_key,
@@ -214,7 +220,9 @@ async def create_default_tools(
             "task_id": task_id,
             "allowed_external_dirs": allowed_external_dirs,
         },
-        include_mcp_tools=bool(allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)),
+        include_mcp_tools=bool(
+            allowed_tools and any(t.startswith("mcp_") for t in allowed_tools)
+        ),
         task_id=task_id,  # Pass task_id for browser session tracking
         browser_tools_enabled=True,  # Enable browser automation tools
         allowed_collections=allowed_collections,  # Agent Builder knowledge bases
@@ -291,14 +299,18 @@ async def update_task_title_from_agent(
             old_title = task_record.title
             task_record.title = task_name
             db.commit()
-            logger.info(f"Updated task {task_id} title from '{old_title}' to '{task_name}'")
+            logger.info(
+                f"Updated task {task_id} title from '{old_title}' to '{task_name}'"
+            )
             return True
         else:
             logger.debug(f"Task title already matches: '{task_record.title}'")
             return False
 
     except Exception as e:
-        logger.error(f"Failed to update task title for task {task_id}: {e}", exc_info=True)
+        logger.error(
+            f"Failed to update task title for task {task_id}: {e}", exc_info=True
+        )
         return False
 
 
@@ -320,7 +332,9 @@ class AgentServiceManager:
         _normalize = make_normalize_model_id(core_storage)
 
         return [
-            _normalize(getattr(task, "model_id", None), getattr(task, "model_name", None)),
+            _normalize(
+                getattr(task, "model_id", None), getattr(task, "model_name", None)
+            ),
             _normalize(
                 getattr(task, "small_fast_model_id", None),
                 getattr(task, "small_fast_model_name", None),
@@ -363,7 +377,9 @@ class AgentServiceManager:
         if task_id in self._agents:
             agent = self._agents[task_id]
             agent.memory_similarity_threshold = threshold
-            logger.info(f"Set memory similarity threshold for task {task_id}: {threshold}")
+            logger.info(
+                f"Set memory similarity threshold for task {task_id}: {threshold}"
+            )
         else:
             logger.warning(
                 f"Cannot set memory similarity threshold for non-existent task {task_id}"
@@ -384,7 +400,9 @@ class AgentServiceManager:
             f"Loaded {len(conversation_history)} persisted chat messages for task {task_id}"
         )
 
-    async def _load_persisted_execution_context(self, task_id: int, db: Session) -> None:
+    async def _load_persisted_execution_context(
+        self, task_id: int, db: Session
+    ) -> None:
         """Hydrate an agent with persisted reusable execution context."""
         agent = self._agents.get(task_id)
         if agent is None:
@@ -404,7 +422,9 @@ class AgentServiceManager:
         if skill_context:
             logger.info(f"Loaded recovered skill context for task {task_id}")
 
-    def _load_agent_builder_config(self, agent: Agent, db: Session, user_id: int) -> dict:
+    def _load_agent_builder_config(
+        self, agent: Agent, db: Session, user_id: int
+    ) -> dict:
         """Load all Agent Builder configuration.
 
         Returns dict with:
@@ -427,7 +447,9 @@ class AgentServiceManager:
         if agent.models:
             if agent.models.get("general"):
                 general_model = (
-                    db.query(DBModel).filter(DBModel.id == agent.models["general"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == agent.models["general"])
+                    .first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -436,7 +458,9 @@ class AgentServiceManager:
 
             if agent.models.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel).filter(DBModel.id == agent.models["small_fast"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == agent.models["small_fast"])
+                    .first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -445,7 +469,9 @@ class AgentServiceManager:
 
             if agent.models.get("visual"):
                 visual_model = (
-                    db.query(DBModel).filter(DBModel.id == agent.models["visual"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == agent.models["visual"])
+                    .first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -454,7 +480,9 @@ class AgentServiceManager:
 
             if agent.models.get("compact"):
                 compact_model = (
-                    db.query(DBModel).filter(DBModel.id == agent.models["compact"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == agent.models["compact"])
+                    .first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -651,7 +679,9 @@ class AgentServiceManager:
                     task = db.query(Task).filter(Task.id == task_id).first()
                     task_exists = task is not None
                 except Exception as e:
-                    logger.warning(f"Failed to check task existence for task {task_id}: {e}")
+                    logger.warning(
+                        f"Failed to check task existence for task {task_id}: {e}"
+                    )
                     task_exists = False
                     task = None
 
@@ -672,7 +702,9 @@ class AgentServiceManager:
                             f"Created new task record for task {task_id} with user_id={user.id}"
                         )
                     except Exception as e:
-                        logger.error(f"Failed to create task record for task {task_id}: {e}")
+                        logger.error(
+                            f"Failed to create task record for task {task_id}: {e}"
+                        )
             else:
                 should_reconstruct = task is not None and task.status in [
                     TaskStatus.RUNNING,
@@ -725,9 +757,13 @@ class AgentServiceManager:
                     if task.agent_type_enum == AgentType.TEXT2SQL:
                         logger.info(f"🎯 Creating Text2SQL agent for task {task.id}")
                         if user is not None:
-                            return await self._create_text2sql_agent(task, db, user, tracer)
+                            return await self._create_text2sql_agent(
+                                task, db, user, tracer
+                            )
                         else:
-                            raise ValueError("User context is required for Text2SQL agent creation")
+                            raise ValueError(
+                                "User context is required for Text2SQL agent creation"
+                            )
                     else:
                         logger.info(
                             f"❌ Task {task.id} is not Text2SQL, using standard agent creation"
@@ -748,7 +784,9 @@ class AgentServiceManager:
                     )
 
                     llm_ids = self._get_task_llm_ids(task, db)
-                    logger.info(f"Loading LLM configuration from task {task_id}: {llm_ids}")
+                    logger.info(
+                        f"Loading LLM configuration from task {task_id}: {llm_ids}"
+                    )
                     # Use user_id for model resolution if available
                     user_id_for_resolution: int | None = (
                         int(user.id) if user and user.id is not None else None
@@ -759,10 +797,16 @@ class AgentServiceManager:
 
                     # Override with Agent Builder configuration if task.agent_id exists
                     if task and task.agent_id and user:
-                        agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+                        agent = (
+                            db.query(Agent).filter(Agent.id == task.agent_id).first()
+                        )
                         if agent:
-                            logger.info(f"Task {task_id} using Agent Builder config: {agent.name}")
-                            agent_config = self._load_agent_builder_config(agent, db, int(user.id))
+                            logger.info(
+                                f"Task {task_id} using Agent Builder config: {agent.name}"
+                            )
+                            agent_config = self._load_agent_builder_config(
+                                agent, db, int(user.id)
+                            )
                             (
                                 task_llm,
                                 task_fast_llm,
@@ -798,7 +842,9 @@ class AgentServiceManager:
                     task_vision_llm = None
                     task_compact_llm = None
             except Exception as e:
-                logger.error(f"Failed to load LLM configuration from task {task_id} database: {e}")
+                logger.error(
+                    f"Failed to load LLM configuration from task {task_id} database: {e}"
+                )
                 # Fallback to defaults
                 task_llm = self._default_llm
                 task_fast_llm = None
@@ -812,7 +858,9 @@ class AgentServiceManager:
                     raise ValueError("User context is required for agent creation")
 
                 if not db:
-                    raise ValueError("Database connection is required for agent creation")
+                    raise ValueError(
+                        "Database connection is required for agent creation"
+                    )
 
                 # Check if task has an associated published agent that should be excluded from agent tools
                 excluded_agent_id = None
@@ -844,14 +892,18 @@ class AgentServiceManager:
                                 continue
                             workforce_allowed_agent_ids.append(agent_id)
                             alias = worker.get("alias") or worker.get("name")
-                            assignment_instructions = worker.get("assignment_instructions")
+                            assignment_instructions = worker.get(
+                                "assignment_instructions"
+                            )
                             description_parts = []
                             if worker.get("description"):
                                 description_parts.append(str(worker["description"]))
                             if alias:
                                 description_parts.append(f"Workforce role: {alias}.")
                             if assignment_instructions:
-                                description_parts.append(f"Assignment: {assignment_instructions}")
+                                description_parts.append(
+                                    f"Assignment: {assignment_instructions}"
+                                )
                             worker_prompt_parts = [
                                 f'You are being called as part of Workforce "{workforce_name}".',
                                 "",
@@ -872,15 +924,17 @@ class AgentServiceManager:
                             }
                             if isinstance(worker.get("tool_name"), str):
                                 workforce_tool_names.add(str(worker["tool_name"]))
-                        workforce_manager_prompt = (raw_snapshot.get("manager", {}) or {}).get(
-                            "runtime_prompt"
-                        )
+                        workforce_manager_prompt = (
+                            raw_snapshot.get("manager", {}) or {}
+                        ).get("runtime_prompt")
                         enable_global_agent_tools = False
                 if task and task.agent_id:
                     # Get the current agent to check if it's published
                     from ..models.agent import AgentStatus
 
-                    current_agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+                    current_agent = (
+                        db.query(Agent).filter(Agent.id == task.agent_id).first()
+                    )
                     if current_agent and current_agent.status == AgentStatus.PUBLISHED:
                         excluded_agent_id = int(current_agent.id)
                         logger.info(
@@ -896,7 +950,9 @@ class AgentServiceManager:
                     sandbox_mgr = get_sandbox_manager()
                     if sandbox_mgr:
                         try:
-                            sandbox = await sandbox_mgr.get_or_create_sandbox("user", str(user_id))
+                            sandbox = await sandbox_mgr.get_or_create_sandbox(
+                                "user", str(user_id)
+                            )
                             self._sandboxes[user_id] = sandbox
                         except Exception as e:
                             # Graceful degradation: tools will run locally without sandbox
@@ -936,7 +992,9 @@ class AgentServiceManager:
                     allowed_tools = []
 
                     for tool in all_tools:
-                        if hasattr(tool, "metadata") and hasattr(tool.metadata, "category"):
+                        if hasattr(tool, "metadata") and hasattr(
+                            tool.metadata, "category"
+                        ):
                             category = str(tool.metadata.category.value)
                             tool_name = getattr(tool, "name", None)
 
@@ -951,7 +1009,9 @@ class AgentServiceManager:
                                         # Use the exact raw server name for prefix comparison, just replace spaces with underscores
                                         # as done in mcp_adapter.py (e.g. "LinkedIn" -> "LinkedIn", "Google Drive" -> "Google_Drive")
                                         server_name = (
-                                            tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
+                                            tc.split(":", 1)[1]
+                                            .replace(" ", "_")
+                                            .replace("-", "_")
                                         )
 
                                         # mcp_adapter prefix is f"mcp_{server_name}_" where server_name preserves original case
@@ -964,12 +1024,17 @@ class AgentServiceManager:
                                 for tc in tool_categories:
                                     if tc.startswith("mcp:"):
                                         server_name = (
-                                            tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
+                                            tc.split(":", 1)[1]
+                                            .replace(" ", "_")
+                                            .replace("-", "_")
                                         )
                                         logger.info(
                                             f"Checking Custom API tool: '{tool_name}' vs 'api_{server_name}_call'"
                                         )
-                                        if tool_name.lower() == f"api_{server_name.lower()}_call":
+                                        if (
+                                            tool_name.lower()
+                                            == f"api_{server_name.lower()}_call"
+                                        ):
                                             allowed_tools.append(tool_name)
                                             break
 
@@ -977,7 +1042,9 @@ class AgentServiceManager:
                         f"Tool categories {tool_categories} mapped to {len(allowed_tools)} tools for task {task_id}"
                     )
                 if workforce_tool_names:
-                    allowed_tools = list(set(allowed_tools or []) | workforce_tool_names)
+                    allowed_tools = list(
+                        set(allowed_tools or []) | workforce_tool_names
+                    )
 
                 delegate_agent_ids = self._get_delegate_agent_ids(task)
 
@@ -987,7 +1054,9 @@ class AgentServiceManager:
                     request=self.request,
                     user=user,
                     task_id=f"web_task_{task_id}",
-                    allowed_collections=agent_config["knowledge_bases"] if agent_config else None,
+                    allowed_collections=agent_config["knowledge_bases"]
+                    if agent_config
+                    else None,
                     allowed_skills=agent_config["skills"] if agent_config else None,
                     allowed_tools=allowed_tools,
                     excluded_agent_id=excluded_agent_id,
@@ -1008,9 +1077,13 @@ class AgentServiceManager:
                     agent_kwargs = {}
                     if task and task.agent_type == "text2sql" and task.agent_config:
                         config: dict[str, Any] = (
-                            task.agent_config if isinstance(task.agent_config, dict) else {}
+                            task.agent_config
+                            if isinstance(task.agent_config, dict)
+                            else {}
                         )
-                        logger.info(f"Extracting Text2SQL config: {list(config.keys())}")
+                        logger.info(
+                            f"Extracting Text2SQL config: {list(config.keys())}"
+                        )
                         agent_kwargs.update(
                             {
                                 "database_url": config.get("database_url"),
@@ -1022,8 +1095,12 @@ class AgentServiceManager:
                                 "available_tables": config.get("available_tables"),
                             }
                         )
-                        logger.info(f"Text2SQL kwargs prepared: {list(agent_kwargs.keys())}")
-                        logger.info(f"Database URL: {config.get('database_url', 'NOT FOUND')}")
+                        logger.info(
+                            f"Text2SQL kwargs prepared: {list(agent_kwargs.keys())}"
+                        )
+                        logger.info(
+                            f"Database URL: {config.get('database_url', 'NOT FOUND')}"
+                        )
 
                     # Unpack tools and tool_config from create_default_tools
                     tools_list, tool_config = tools
@@ -1031,9 +1108,15 @@ class AgentServiceManager:
                     # Get system prompt from agent config (if available)
                     from .agents import enhance_system_prompt_with_kb
 
-                    system_prompt = agent_config.get("instructions") if agent_config else None
-                    kb_list = agent_config.get("knowledge_bases") if agent_config else None
-                    system_prompt = enhance_system_prompt_with_kb(system_prompt, kb_list)
+                    system_prompt = (
+                        agent_config.get("instructions") if agent_config else None
+                    )
+                    kb_list = (
+                        agent_config.get("knowledge_bases") if agent_config else None
+                    )
+                    system_prompt = enhance_system_prompt_with_kb(
+                        system_prompt, kb_list
+                    )
                     if workforce_manager_prompt:
                         system_prompt = (
                             f"{system_prompt}\n\n{workforce_manager_prompt}"
@@ -1051,7 +1134,9 @@ class AgentServiceManager:
                     # Extract memory similarity threshold from agent config
                     memory_similarity_threshold = None
                     if agent_config and "memory_similarity_threshold" in agent_config:
-                        memory_similarity_threshold = agent_config["memory_similarity_threshold"]
+                        memory_similarity_threshold = agent_config[
+                            "memory_similarity_threshold"
+                        ]
 
                     # Build allowed external directories (user's upload directory for knowledge base files)
                     allowed_external_dirs = _build_allowed_external_dirs(
@@ -1071,7 +1156,9 @@ class AgentServiceManager:
                         memory=get_memory_store(),  # Use dynamic memory store for auto-switching
                         pattern=task_pattern,  # Use pattern instead of use_dag_pattern
                         tracer=tracer,
-                        agent_type=str(task.agent_type) if task and task.agent_type else "standard",
+                        agent_type=str(task.agent_type)
+                        if task and task.agent_type
+                        else "standard",
                         enable_workspace=True,  # Enable workspace functionality
                         workspace_base_dir=str(
                             get_uploads_dir() / f"user_{user.id}"
@@ -1085,7 +1172,9 @@ class AgentServiceManager:
 
                     selected_file_ids: list[str] = []
                     if task and isinstance(task.agent_config, dict):
-                        raw_selected_file_ids = task.agent_config.get("selected_file_ids")
+                        raw_selected_file_ids = task.agent_config.get(
+                            "selected_file_ids"
+                        )
                         if isinstance(raw_selected_file_ids, list):
                             selected_file_ids = [
                                 str(item)
@@ -1115,14 +1204,18 @@ class AgentServiceManager:
 
                             # Use the source file directly (user's upload directory) instead of copying
                             # This avoids duplicate files across the system
-                            workspace.register_file(str(source_path), file_id=selected_file_id)
+                            workspace.register_file(
+                                str(source_path), file_id=selected_file_id
+                            )
 
                 pattern_info = (
                     f"with DAG pattern and workspace using {llm_info}"
                     if use_dag
                     else "with workspace (no LLM configured)"
                 )
-                logger.info(f"Created new AgentService for task {task_id} {pattern_info}")
+                logger.info(
+                    f"Created new AgentService for task {task_id} {pattern_info}"
+                )
 
                 if task_exists and db is not None:
                     self._load_persisted_conversation_history(task_id, db)
@@ -1145,7 +1238,9 @@ class AgentServiceManager:
             else:
                 workspace_path = None
             if workspace_path:
-                logger.info(f"Deleting workspace path for task {task_id}: {workspace_path}")
+                logger.info(
+                    f"Deleting workspace path for task {task_id}: {workspace_path}"
+                )
 
             # Clean up workspace before removing agent
             self._agents[task_id].cleanup_workspace()
@@ -1213,7 +1308,9 @@ class AgentServiceManager:
                 await tracker.start_tracking()
                 logger.info(f"Started token tracking for task {tracker_task_id}")
             except Exception as e:
-                logger.warning(f"Failed to start token tracking for task {tracker_task_id}: {e}")
+                logger.warning(
+                    f"Failed to start token tracking for task {tracker_task_id}: {e}"
+                )
                 tracker = None
 
         try:
@@ -1222,13 +1319,17 @@ class AgentServiceManager:
             )
 
             # Execute the task
-            result = await agent_service.execute_task(task=task, context=context, task_id=task_id)
+            result = await agent_service.execute_task(
+                task=task, context=context, task_id=task_id
+            )
 
             logger.info("=== Task executed successfully, updating title if needed ===")
 
             # Update task title with generated task_name (clean architecture: Core provides API, Web handles DB)
             if db_session and task_id and result and result.get("success"):
-                await update_task_title_from_agent(agent_service, int(task_id), db_session)
+                await update_task_title_from_agent(
+                    agent_service, int(task_id), db_session
+                )
 
             return result
         finally:
@@ -1257,7 +1358,9 @@ class AgentServiceManager:
                         f"Failed to complete token tracking for task {tracker_task_id}: {e}"
                     )
 
-    def _cleanup_workspace_directory(self, task_id: int, user_id: int | None = None) -> None:
+    def _cleanup_workspace_directory(
+        self, task_id: int, user_id: int | None = None
+    ) -> None:
         """Clean up workspace directory for a task when agent is not in memory"""
         from ...core.workspace import TaskWorkspace
 
@@ -1291,7 +1394,9 @@ class AgentServiceManager:
                 )
                 break
         else:
-            logger.info(f"No workspace directory found for task {task_id} (user {user_id})")
+            logger.info(
+                f"No workspace directory found for task {task_id} (user {user_id})"
+            )
 
     async def _create_text2sql_agent(
         self, task: Task, db: Session, user: User, tracer: Tracer
@@ -1314,17 +1419,21 @@ class AgentServiceManager:
 
             # Validate required configuration
             if not config.get("database_url"):
-                raise ValueError("Text2SQL agent configuration must include 'database_url'")
+                raise ValueError(
+                    "Text2SQL agent configuration must include 'database_url'"
+                )
 
             # Log configuration for debugging
-            logger.info(f"Creating Text2SQL agent for task {task.id} with config: {config}")
+            logger.info(
+                f"Creating Text2SQL agent for task {task.id} with config: {config}"
+            )
 
             llm_ids = self._get_task_llm_ids(task, db)
 
             # Use user_id for model resolution if available
             user_id_for_resolution = int(user.id) if user else None
-            task_llm, task_fast_llm, task_vision_llm, task_compact_llm = resolve_llms_from_names(
-                llm_ids, db, user_id_for_resolution
+            task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
+                resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
             )
 
             # Use default LLM if no specific LLM configured
@@ -1379,15 +1488,19 @@ class AgentServiceManager:
                 ):
                     # Save original method
 
-                    async def wrapped_execute(task, context=None, task_id=None):
+                    async def wrapped_execute(
+                        task_message: str,
+                        context: Optional[Dict[str, Any]] = None,
+                        task_id: Optional[str] = None,
+                    ) -> Dict[str, Any]:
                         return await self._execute_text2sql_agent_directly(
                             agent_service.agent,
-                            task,
+                            task_message,
                             tracer,
                             task_id if task_id else str(task.id),
                         )
 
-                    agent_service.execute_task = wrapped_execute
+                    setattr(agent_service, "execute_task", wrapped_execute)
 
                 # Store in manager
                 self._agents[int(task.id)] = agent_service
@@ -1406,11 +1519,15 @@ class AgentServiceManager:
         """Infer database type from connection URL"""
         if database_url.startswith("mysql://") or database_url.startswith("mysql2://"):
             return "MySQL"
-        elif database_url.startswith("postgresql://") or database_url.startswith("postgres://"):
+        elif database_url.startswith("postgresql://") or database_url.startswith(
+            "postgres://"
+        ):
             return "PostgreSQL"
         elif database_url.startswith("sqlite://"):
             return "SQLite"
-        elif database_url.startswith("sqlserver://") or database_url.startswith("mssql://"):
+        elif database_url.startswith("sqlserver://") or database_url.startswith(
+            "mssql://"
+        ):
             return "SQL Server"
         else:
             return "Unknown"
@@ -1431,7 +1548,9 @@ class AgentServiceManager:
             # Normalize return format to match AgentService format
             return {
                 "status": "completed" if result.get("success") else "failed",
-                "output": result.get("output", result.get("error", "No output provided")),
+                "output": result.get(
+                    "output", result.get("error", "No output provided")
+                ),
                 "success": result.get("success", False),
                 "metadata": result.get(
                     "metadata",
@@ -1491,17 +1610,23 @@ class AgentServiceManager:
                         "event_type": event.event_type,
                         "task_id": str(event.task_id),
                         "step_id": event.step_id,
-                        "timestamp": event.timestamp.timestamp() if event.timestamp else None,
+                        "timestamp": event.timestamp.timestamp()
+                        if event.timestamp
+                        else None,
                         "data": event.data,
                         "parent_id": event.parent_event_id,
                     }
                 )
 
             # Get DAG execution data
-            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            dag_execution = (
+                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            )
             if dag_execution and dag_execution.current_plan:
                 plan_state = (
-                    dict(dag_execution.current_plan) if dag_execution.current_plan else None
+                    dict(dag_execution.current_plan)
+                    if dag_execution.current_plan
+                    else None
                 )
 
             if tracer_events or plan_state:
@@ -1536,7 +1661,9 @@ class AgentServiceManager:
                         )
                         llm_ids = self._get_task_llm_ids(task, db)
                         # Use user_id for model resolution if available
-                        user_id_for_resolution = int(task.user_id) if task.user_id else None
+                        user_id_for_resolution = (
+                            int(task.user_id) if task.user_id else None
+                        )
                         task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
                             resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
                         )
@@ -1650,7 +1777,9 @@ class AgentServiceManager:
                             memory_similarity_threshold=memory_similarity_threshold,
                         )
                 else:
-                    raise ValueError("User context is required for agent reconstruction")
+                    raise ValueError(
+                        "User context is required for agent reconstruction"
+                    )
 
                 await self._agents[task_id].reconstruct_from_history(
                     str(task_id), tracer_events, plan_state
@@ -1658,15 +1787,21 @@ class AgentServiceManager:
                 self._load_persisted_conversation_history(task_id, db)
                 await self._load_persisted_execution_context(task_id, db)
 
-                logger.info(f"Successfully reconstructed agent for task {task_id} from history")
+                logger.info(
+                    f"Successfully reconstructed agent for task {task_id} from history"
+                )
             else:
-                logger.info(f"No historical data found for task {task_id}, will create new agent")
+                logger.info(
+                    f"No historical data found for task {task_id}, will create new agent"
+                )
                 # Don't create agent here, let the normal flow handle it
                 # Raise an exception to indicate reconstruction is not possible
                 raise ValueError(f"No historical data found for task {task_id}")
 
         except Exception as e:
-            logger.error(f"Failed to reconstruct agent from history for task {task_id}: {e}")
+            logger.error(
+                f"Failed to reconstruct agent from history for task {task_id}: {e}"
+            )
             raise
 
     def get_agent_workspace_files(self, task_id: int) -> dict[str, Any]:
@@ -1757,15 +1892,23 @@ async def create_task(
                 file_paths.append(str(file_path))
 
                 if file_path.exists():
-                    file_info_list.append(f"File: {uploaded_file.filename} (Path: {file_path})")
+                    file_info_list.append(
+                        f"File: {uploaded_file.filename} (Path: {file_path})"
+                    )
                 else:
-                    file_info_list.append(f"File: {uploaded_file.filename} (File does not exist)")
+                    file_info_list.append(
+                        f"File: {uploaded_file.filename} (File does not exist)"
+                    )
 
             if file_info_list:
                 if task_description:
-                    task_description += "\n\nUploaded files:\n" + "\n".join(file_info_list)
+                    task_description += "\n\nUploaded files:\n" + "\n".join(
+                        file_info_list
+                    )
                 else:
-                    task_description = "File processing task:\n" + "\n".join(file_info_list)
+                    task_description = "File processing task:\n" + "\n".join(
+                        file_info_list
+                    )
 
         delegate_agent_ids: list[int] | None = None
         if request.delegate_agent_ids:
@@ -1843,7 +1986,9 @@ async def create_task(
             return str(db_model.model_id)
 
         def _normalize_llm_refs(llm_refs: list[Any | None]) -> list[str | None]:
-            return [_to_internal_model_id_if_accessible(model_ref) for model_ref in llm_refs]
+            return [
+                _to_internal_model_id_if_accessible(model_ref) for model_ref in llm_refs
+            ]
 
         def _get_default_internal_model_ids() -> dict[str, str | None]:
             from ..models.model import Model as DBModel
@@ -1895,7 +2040,9 @@ async def create_task(
             # Fetch model configuration from agent
             agent_db = (
                 db.query(AgentModel)
-                .filter(AgentModel.id == request.agent_id, AgentModel.user_id == user.id)
+                .filter(
+                    AgentModel.id == request.agent_id, AgentModel.user_id == user.id
+                )
                 .first()
             )
             if agent_db and agent_db.models:
@@ -1961,13 +2108,17 @@ async def create_task(
             try:
                 agent_type_enum = AgentType(request.agent_type)
             except ValueError:
-                logger.warning(f"Unknown agent_type '{request.agent_type}', using STANDARD")
+                logger.warning(
+                    f"Unknown agent_type '{request.agent_type}', using STANDARD"
+                )
                 agent_type_enum = AgentType.STANDARD
 
         # Convert examples to list of dicts if provided
         examples_data = None
         if request.examples:
-            examples_data = [{"input": ex.input, "output": ex.output} for ex in request.examples]
+            examples_data = [
+                {"input": ex.input, "output": ex.output} for ex in request.examples
+            ]
 
         task_agent_config: dict[str, Any] = {}
         if isinstance(request.agent_config, dict):
@@ -2032,7 +2183,9 @@ async def create_task(
             task_id=task.id,
             title=task.title,
             status=task.status.value,
-            created_at=format_datetime_for_api(task.created_at) if task.created_at else None,
+            created_at=format_datetime_for_api(task.created_at)
+            if task.created_at
+            else None,
             model_id=task.model_id,
             small_fast_model_id=task.small_fast_model_id,
             visual_model_id=task.visual_model_id,
@@ -2092,7 +2245,8 @@ async def get_tasks(
                     if agent_type_enum.value == AgentType.STANDARD.value:
                         # For STANDARD agent type, include both 'standard' and NULL values
                         query = query.filter(
-                            (Task.agent_type == agent_type_enum.value) | (Task.agent_type.is_(None))
+                            (Task.agent_type == agent_type_enum.value)
+                            | (Task.agent_type.is_(None))
                         )
                     else:
                         # For other agent types, filter by exact value
@@ -2131,7 +2285,9 @@ async def get_tasks(
 
             # Apply pagination
             offset = (page - 1) * per_page
-            query = query.order_by(Task.created_at.desc()).offset(offset).limit(per_page)
+            query = (
+                query.order_by(Task.created_at.desc()).offset(offset).limit(per_page)
+            )
             tasks_query = query.all()
 
             # Batch fetch agents for tasks with agent_id
@@ -2183,7 +2339,9 @@ async def get_tasks(
                     # Include user information for admin users
                     if user.is_admin:
                         task_data["user_id"] = task.user_id
-                        task_data["username"] = task.user.username if task.user else "Unknown"
+                        task_data["username"] = (
+                            task.user.username if task.user else "Unknown"
+                        )
 
                     tasks.append(task_data)
                 except Exception as e:
@@ -2226,7 +2384,11 @@ async def get_task(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2246,7 +2408,9 @@ async def get_task(
             dag_data = None
             from ..models.task import DAGExecution
 
-            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            dag_execution = (
+                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            )
             if dag_execution:
                 dag_data = {
                     "phase": dag_execution.phase.value if dag_execution.phase else None,
@@ -2318,7 +2482,11 @@ async def get_task_status(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2393,7 +2561,11 @@ async def update_task(
         if user.is_admin:
             task = db.query(Task).filter(Task.id == task_id).first()
         else:
-            task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+            task = (
+                db.query(Task)
+                .filter(Task.id == task_id, Task.user_id == user.id)
+                .first()
+            )
 
         if not task:
             raise HTTPException(status_code=404, detail="Task not found")
@@ -2424,7 +2596,11 @@ async def delete_task(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
@@ -2434,7 +2610,9 @@ async def delete_task(
             # Delete DAG execution (if any)
             from ..models.task import DAGExecution
 
-            dag_execution = db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            dag_execution = (
+                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            )
             if dag_execution:
                 db.delete(dag_execution)
 
@@ -2507,7 +2685,11 @@ async def get_task_workspace_files(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
             return task
@@ -2545,7 +2727,11 @@ async def get_task_output_files(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
             return task

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -4,6 +4,7 @@ import mimetypes
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional, Tuple
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
@@ -115,6 +116,10 @@ def _guess_media_type(filename: str) -> str:
     return media_type or "application/octet-stream"
 
 
+def _content_disposition(disposition: str, filename: str) -> str:
+    return f"{disposition}; filename*=utf-8''{quote(filename)}"
+
+
 def _build_unique_file_path(path: Path) -> Path:
     if not path.exists():
         return path
@@ -141,10 +146,25 @@ def _ensure_under_uploads(path: Path, user_id: int) -> None:
         raise HTTPException(status_code=403, detail="Access denied") from exc
 
 
+def _ensure_under_uploads_root(path: Path) -> None:
+    resolved_path = path.resolve()
+    uploads_root = get_uploads_dir().resolve()
+    try:
+        resolved_path.relative_to(uploads_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Access denied") from exc
+
+
 def _resolve_public_preview_target(
-    base_path: Path, relative_path: Optional[str], user_id: int
+    base_path: Path,
+    relative_path: Optional[str],
+    user_id: int,
+    require_user_root: bool = True,
 ) -> Path:
-    _ensure_under_uploads(base_path, user_id)
+    if require_user_root:
+        _ensure_under_uploads(base_path, user_id)
+    else:
+        _ensure_under_uploads_root(base_path)
     if not relative_path:
         return base_path
 
@@ -156,7 +176,10 @@ def _resolve_public_preview_target(
     except ValueError as exc:
         raise HTTPException(status_code=403, detail="Access denied") from exc
 
-    _ensure_under_uploads(candidate, user_id)
+    if require_user_root:
+        _ensure_under_uploads(candidate, user_id)
+    else:
+        _ensure_under_uploads_root(candidate)
     return candidate
 
 
@@ -736,7 +759,10 @@ async def download_file(
         file_name = full_path.name
         media_type = _guess_media_type(file_name)
 
-    _ensure_under_uploads(full_path, owner_user_id)
+    if file_record:
+        _ensure_under_uploads_root(full_path)
+    else:
+        _ensure_under_uploads(full_path, owner_user_id)
 
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
@@ -754,7 +780,10 @@ async def download_file(
         filename=file_name,
         media_type=media_type,
         headers={
-            "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
+            "Content-Disposition": _content_disposition(
+                content_disposition,
+                file_name,
+            )
         },
     )
 
@@ -781,7 +810,10 @@ async def preview_file(
         file_name = full_path.name
         media_type = _guess_media_type(file_name)
 
-    _ensure_under_uploads(full_path, owner_user_id)
+    if file_record:
+        _ensure_under_uploads_root(full_path)
+    else:
+        _ensure_under_uploads(full_path, owner_user_id)
 
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
@@ -836,6 +868,7 @@ async def public_preview_file(
         base_path,
         relative_path,
         owner_user_id,
+        require_user_root=file_record is None,
     )
 
     if not target_path.exists() or not target_path.is_file():
@@ -900,7 +933,10 @@ async def delete_file(
             raise HTTPException(status_code=403, detail="Access denied")
         file_name = file_path.name
 
-    _ensure_under_uploads(file_path, owner_user_id)
+    if file_record:
+        _ensure_under_uploads_root(file_path)
+    else:
+        _ensure_under_uploads(file_path, owner_user_id)
 
     if file_path.exists() and file_path.is_file():
         file_path.unlink()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -8,7 +8,7 @@ import unicodedata
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, cast
 from urllib.parse import unquote
 
 from fastapi import (
@@ -44,6 +44,7 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
+from ..services.workforce_runtime import sync_workforce_run_status
 from ..tools.config import WebToolConfig
 from ..tracing import create_ephemeral_tracer
 from ..user_isolated_memory import UserContext
@@ -54,7 +55,7 @@ logger = logging.getLogger(__name__)
 
 def _resolve_task_llm_ids(
     task: Any, db: Session
-) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None, str | None, str | None]:
     """Best-effort resolve internal model_id identifiers for a task."""
     from ..models.model import Model as DBModel
     from ..services.llm_utils import CoreStorage, make_normalize_model_id
@@ -194,10 +195,10 @@ def _append_uploaded_files_context_to_message(
 
 def create_stream_event(
     event_type: str,
-    task_id: Union[int, str],
-    data: Dict[str, Any],
-    timestamp: Optional[Any] = None,
-) -> Dict[str, Any]:
+    task_id: int | str,
+    data: dict[str, Any],
+    timestamp: Any | None = None,
+) -> dict[str, Any]:
     """Create unified stream event format"""
     # Convert timestamp to Unix timestamp if it's a datetime
     if timestamp is None:
@@ -337,7 +338,7 @@ def _build_output_file_id(relative_path: str) -> str:
     return str(uuid.uuid4())
 
 
-def _resolve_output_storage_path(raw_path: str) -> Optional[tuple[Any, str]]:
+def _resolve_output_storage_path(raw_path: str) -> tuple[Any, str] | None:
     if not raw_path:
         return None
 
@@ -358,7 +359,7 @@ def _resolve_output_storage_path(raw_path: str) -> Optional[tuple[Any, str]]:
     return resolved, relative_path
 
 
-def _resolve_legacy_preview_storage_path(raw_path: str) -> Optional[tuple[Path, str]]:
+def _resolve_legacy_preview_storage_path(raw_path: str) -> tuple[Path, str] | None:
     candidates: list[str] = []
 
     def _append_candidate(value: str) -> None:
@@ -396,13 +397,13 @@ def _resolve_legacy_preview_storage_path(raw_path: str) -> Optional[tuple[Path, 
 
 def _infer_owner_from_relative_path(
     db: Session, relative_path: str
-) -> Optional[tuple[int, Optional[int]]]:
+) -> tuple[int, int | None] | None:
     path_parts = Path(relative_path).parts
     if not path_parts:
         return None
 
-    user_id: Optional[int] = None
-    task_id: Optional[int] = None
+    user_id: int | None = None
+    task_id: int | None = None
 
     first = path_parts[0]
     remaining = path_parts[1:] if len(path_parts) > 1 else []
@@ -440,14 +441,12 @@ def _infer_owner_from_relative_path(
     if task_id is not None:
         task_row = db.query(Task).filter(Task.id == task_id).first()
         if task_row and getattr(task_row, "user_id", None) is not None:
-            return int(getattr(task_row, "user_id")), task_id
+            return int(task_row.user_id), task_id
 
     return None
 
 
-def _map_link_token_to_file_id(
-    token: str, path_to_file_id: Dict[str, str]
-) -> Optional[str]:
+def _map_link_token_to_file_id(token: str, path_to_file_id: dict[str, str]) -> str | None:
     raw = token.strip()
     if not raw:
         return None
@@ -482,9 +481,7 @@ def _map_link_token_to_file_id(
     return None
 
 
-def _rewrite_file_links_to_file_id(
-    output_text: Any, path_to_file_id: Dict[str, str]
-) -> Any:
+def _rewrite_file_links_to_file_id(output_text: Any, path_to_file_id: dict[str, str]) -> Any:
     if not isinstance(output_text, str) or not output_text:
         return output_text
 
@@ -557,7 +554,7 @@ def _normalize_file_outputs(
     task_id: int,
     task_user_id: int,
     file_outputs: Any,
-) -> tuple[list[Dict[str, str]], Dict[str, str]]:
+) -> tuple[list[dict[str, str]], dict[str, str]]:
     from ..models.uploaded_file import UploadedFile
 
     if isinstance(file_outputs, str):
@@ -565,8 +562,8 @@ def _normalize_file_outputs(
     if not isinstance(file_outputs, list):
         return [], {}
 
-    normalized_outputs: list[Dict[str, str]] = []
-    path_to_file_id: Dict[str, str] = {}
+    normalized_outputs: list[dict[str, str]] = []
+    path_to_file_id: dict[str, str] = {}
     changed = False
 
     for item in file_outputs:
@@ -606,20 +603,14 @@ def _normalize_file_outputs(
 
         resolved_path, relative_path = resolved_info
         normalized_relative_path = relative_path.lstrip("/")
-        expected_file_id = item_file_id or _build_output_file_id(
-            normalized_relative_path
-        )
+        expected_file_id = item_file_id or _build_output_file_id(normalized_relative_path)
 
         file_record = (
-            db.query(UploadedFile)
-            .filter(UploadedFile.storage_path == str(resolved_path))
-            .first()
+            db.query(UploadedFile).filter(UploadedFile.storage_path == str(resolved_path)).first()
         )
         if file_record is None and item_file_id:
             file_record = (
-                db.query(UploadedFile)
-                .filter(UploadedFile.file_id == item_file_id)
-                .first()
+                db.query(UploadedFile).filter(UploadedFile.file_id == item_file_id).first()
             )
 
         if file_record is None:
@@ -662,15 +653,14 @@ def _normalize_file_outputs(
     return normalized_outputs, path_to_file_id
 
 
-def _rewrite_links_in_payload(payload: Any, path_to_file_id: Dict[str, str]) -> Any:
+def _rewrite_links_in_payload(payload: Any, path_to_file_id: dict[str, str]) -> Any:
     if isinstance(payload, str):
         return _rewrite_file_links_to_file_id(payload, path_to_file_id)
     if isinstance(payload, list):
         return [_rewrite_links_in_payload(item, path_to_file_id) for item in payload]
     if isinstance(payload, dict):
         return {
-            key: _rewrite_links_in_payload(value, path_to_file_id)
-            for key, value in payload.items()
+            key: _rewrite_links_in_payload(value, path_to_file_id) for key, value in payload.items()
         }
     return payload
 
@@ -685,7 +675,7 @@ def _task_user_id(task: Any) -> int | None:
 async def execute_task_background(
     task_id: int,
     user_message: str,
-    context: Dict[str, Any],
+    context: dict[str, Any],
     agent_manager: Any,
     user: Any,
     task: Any,
@@ -742,9 +732,7 @@ async def execute_task_background(
         # Get AI response
         chat_response = result.get("chat_response")
         if isinstance(chat_response, dict):
-            ai_response = chat_response.get("message") or result.get(
-                "output", "Task completed"
-            )
+            ai_response = chat_response.get("message") or result.get("output", "Task completed")
         else:
             ai_response = result.get("output", "Task completed")
 
@@ -798,6 +786,8 @@ async def execute_task_background(
                             db_new, task_id, status=TaskStatus.FAILED
                         )
                     db_new.refresh(task_updated)
+                    sync_workforce_run_status(db_new, task_updated, task_updated.status)
+                    db_new.commit()
                     logger.info(
                         f"Updated task {task_id} status to {task_updated.status.value}"
                     )
@@ -862,9 +852,7 @@ async def execute_task_background(
                 "output": ai_response,
                 "file_outputs": normalized_outputs,
                 "success": result.get("success", False),
-                "chat_response": chat_response
-                if isinstance(chat_response, dict)
-                else None,
+                "chat_response": chat_response if isinstance(chat_response, dict) else None,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
             task_id,
@@ -897,7 +885,7 @@ async def execute_task_background(
 async def execute_continuation_background(
     task_id: int,
     user_message: str,
-    context: Dict[str, Any],
+    context: dict[str, Any],
     agent_service: Any,
     dag_pattern: Any,
     user: Any,
@@ -971,10 +959,9 @@ async def execute_continuation_background(
                         task_updated.status = TaskStatus.COMPLETED
                     else:
                         task_updated.status = TaskStatus.FAILED
+                    sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     db_new.commit()
-                    logger.info(
-                        f"Updated task {task_id} status to {task_updated.status.value}"
-                    )
+                    logger.info(f"Updated task {task_id} status to {task_updated.status.value}")
                 else:
                     logger.info(f"Task {task_id} is paused, not updating status")
 
@@ -1005,9 +992,7 @@ async def execute_continuation_background(
                 "result": ai_response,
                 "output": ai_response,
                 "success": result.get("success", False),
-                "chat_response": chat_response
-                if isinstance(chat_response, dict)
-                else None,
+                "chat_response": chat_response if isinstance(chat_response, dict) else None,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
             task_id,
@@ -1015,9 +1000,7 @@ async def execute_continuation_background(
         logger.info(f"Background continuation for task {task_id} completed")
 
     except Exception as e:
-        logger.error(
-            f"Background continuation for task {task_id} failed: {e}", exc_info=True
-        )
+        logger.error(f"Background continuation for task {task_id} failed: {e}", exc_info=True)
         # Send error event
         try:
             await manager.broadcast_to_task(
@@ -1211,7 +1194,7 @@ class BackgroundTaskManager:
 
     def __init__(self) -> None:
         # task_id -> asyncio.Task
-        self.running_tasks: Dict[int, asyncio.Task] = {}
+        self.running_tasks: dict[int, asyncio.Task] = {}
 
     async def wait_for_previous(self, task_id: int) -> None:
         """Wait for previous background task of this task to complete"""
@@ -1221,16 +1204,12 @@ class BackgroundTaskManager:
             if current_task is not None and old_task is current_task:
                 return
             if not old_task.done():
-                logger.info(
-                    f"Waiting for previous background task {task_id} to complete..."
-                )
+                logger.info(f"Waiting for previous background task {task_id} to complete...")
                 try:
                     await old_task
                     logger.info(f"Previous background task {task_id} completed")
                 except Exception as e:
-                    logger.warning(
-                        f"Previous background task {task_id} ended with error: {e}"
-                    )
+                    logger.warning(f"Previous background task {task_id} ended with error: {e}")
 
     def register_task(self, task_id: int, task: asyncio.Task) -> None:
         """Register new background task"""
@@ -1257,17 +1236,11 @@ class BackgroundTaskManager:
             except asyncio.CancelledError:
                 logger.info(f"Cancelled background task for task {task_id}")
             except asyncio.TimeoutError:
-                logger.info(
-                    f"Cancellation timeout for task {task_id}; continuing cleanup"
-                )
+                logger.info(f"Cancellation timeout for task {task_id}; continuing cleanup")
             except RuntimeError as e:
-                logger.warning(
-                    f"Background task {task_id} cancellation runtime warning: {e}"
-                )
+                logger.warning(f"Background task {task_id} cancellation runtime warning: {e}")
             except Exception as e:
-                logger.warning(
-                    f"Background task {task_id} raised during cancellation: {e}"
-                )
+                logger.warning(f"Background task {task_id} raised during cancellation: {e}")
 
         self.running_tasks.pop(task_id, None)
 
@@ -1285,7 +1258,7 @@ class SharedWebSocketTracer(TraceHandler):
         self.is_preview = is_preview
         self._closed = False
 
-    def _serialize_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _serialize_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively serialize data to ensure JSON compatibility."""
         import json
         from datetime import datetime, timezone
@@ -1294,9 +1267,7 @@ class SharedWebSocketTracer(TraceHandler):
             if not isinstance(value, str):
                 return value
             cleaned = value.replace("\x00", "").replace("\u0000", "")
-            cleaned = "".join(
-                char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
-            )
+            cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\n\r\t")
             return cleaned
 
         def serialize_value(value: Any) -> Any:
@@ -1325,7 +1296,7 @@ class SharedWebSocketTracer(TraceHandler):
                 return value
 
         try:
-            cleaned_data = cast(Dict[str, Any], serialize_value(data))
+            cleaned_data = cast(dict[str, Any], serialize_value(data))
             json.dumps(cleaned_data)
             return cleaned_data
         except Exception as e:
@@ -1363,10 +1334,7 @@ class SharedWebSocketTracer(TraceHandler):
 
         except (RuntimeError, ConnectionError) as e:
             error_msg = str(e)
-            if (
-                "close" in error_msg.lower()
-                or "response already completed" in error_msg.lower()
-            ):
+            if "close" in error_msg.lower() or "response already completed" in error_msg.lower():
                 self._closed = True
                 logger.debug(f"WebSocket connection closed: {e}")
             else:
@@ -1390,9 +1358,7 @@ async def redirect_legacy_preview(
 
     resolved_path, relative_path = resolved_info
     file_record = (
-        db.query(UploadedFile)
-        .filter(UploadedFile.storage_path == str(resolved_path))
-        .first()
+        db.query(UploadedFile).filter(UploadedFile.storage_path == str(resolved_path)).first()
     )
 
     if file_record is None:
@@ -1426,7 +1392,7 @@ async def redirect_legacy_preview(
 class ConnectionManager:
     def __init__(self) -> None:
         # task_id -> List[WebSocket]
-        self.active_connections: Dict[int, List[WebSocket]] = {}
+        self.active_connections: dict[int, list[WebSocket]] = {}
 
     async def connect(self, websocket: WebSocket, task_id: int) -> None:
         await websocket.accept()
@@ -1443,9 +1409,7 @@ class ConnectionManager:
             except ValueError:
                 pass
 
-    def move_connection(
-        self, websocket: WebSocket, old_task_id: int, new_task_id: int
-    ) -> None:
+    def move_connection(self, websocket: WebSocket, old_task_id: int, new_task_id: int) -> None:
         """Move a WebSocket connection from one task_id to another"""
         if old_task_id in self.active_connections:
             try:
@@ -1458,9 +1422,7 @@ class ConnectionManager:
         if new_task_id not in self.active_connections:
             self.active_connections[new_task_id] = []
         self.active_connections[new_task_id].append(websocket)
-        logger.info(
-            f"Moved WebSocket connection from task {old_task_id} to {new_task_id}"
-        )
+        logger.info(f"Moved WebSocket connection from task {old_task_id} to {new_task_id}")
 
     async def send_personal_message(self, message: dict, websocket: WebSocket) -> None:
         await websocket.send_text(json.dumps(message))
@@ -1476,9 +1438,7 @@ class ConnectionManager:
                     self.disconnect(connection, task_id)
                 except Exception as e:
                     # Other errors should not be silently handled, log and re-raise
-                    logger.error(
-                        f"Unexpected error broadcasting to task {task_id}: {e}"
-                    )
+                    logger.error(f"Unexpected error broadcasting to task {task_id}: {e}")
                     # Remove disconnected connection but preserve error propagation
                     self.disconnect(connection, task_id)
                     raise
@@ -1489,7 +1449,7 @@ manager = ConnectionManager()
 
 
 async def handle_file_upload_for_task(
-    task_id: int, files: list, db: Session, user: Optional[User] = None
+    task_id: int, files: list, db: Session, user: User | None = None
 ) -> dict:
     """Handle file upload for task"""
     try:
@@ -1504,9 +1464,7 @@ async def handle_file_upload_for_task(
         logger.info(f"📁 Starting file upload for task {task_id}, files: {len(files)}")
 
         # Get agent
-        agent_service = await get_agent_manager().get_agent_for_task(
-            task_id, db, user=user
-        )
+        agent_service = await get_agent_manager().get_agent_for_task(task_id, db, user=user)
         logger.info(f"🤖 Got agent service for task {task_id}")
 
         for file_info in files:
@@ -1515,9 +1473,7 @@ async def handle_file_upload_for_task(
                 logger.warning(f"No file_id provided in file info: {file_info}")
                 continue
 
-            file_record = (
-                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
-            )
+            file_record = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
             if not file_record:
                 logger.warning(f"File record not found for file_id: {file_id}")
                 continue
@@ -1586,8 +1542,8 @@ async def handle_file_upload_for_task(
 
 
 async def get_authenticated_user(
-    websocket: WebSocket, token: Optional[str] = None
-) -> Optional[User]:
+    websocket: WebSocket, token: str | None = None
+) -> User | None:
     """
     Get authenticated user from WebSocket connection
 
@@ -1616,9 +1572,7 @@ async def get_authenticated_user(
         return None
 
 
-async def handle_chat_message(
-    websocket: WebSocket, task_id: int, message_data: dict
-) -> None:
+async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: dict) -> None:
     """Handle chat message"""
     try:
         user_message = message_data.get("message", "")
@@ -1665,9 +1619,7 @@ async def handle_chat_message(
                     task = db.query(Task).filter(Task.id == task_id).first()
                 else:
                     task = (
-                        db.query(Task)
-                        .filter(Task.id == task_id, Task.user_id == user.id)
-                        .first()
+                        db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
                     )
 
                 if not task:
@@ -1678,9 +1630,7 @@ async def handle_chat_message(
                         logger.warning(
                             f"User {user.id} attempted to access task {task_id} belonging to user {existing_task.user_id}"
                         )
-                        raise ValueError(
-                            f"Access denied: Task {task_id} does not belong to you"
-                        )
+                        raise ValueError(f"Access denied: Task {task_id} does not belong to you")
                     else:
                         # Task doesn't exist (may have been deleted), create new task
                         # This is a fresh start, don't use continuation logic
@@ -1734,11 +1684,7 @@ async def handle_chat_message(
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent = (
-                                db.query(Agent)
-                                .filter(Agent.id == task.agent_id)
-                                .first()
-                            )
+                            agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
                             if agent:
                                 is_dag = agent.execution_mode == "think"
 
@@ -1786,9 +1732,7 @@ async def handle_chat_message(
                 uploaded_files_context = ""
                 if files:
                     # Process file upload
-                    upload_result = await handle_file_upload_for_task(
-                        task_id, files, db, user
-                    )
+                    upload_result = await handle_file_upload_for_task(task_id, files, db, user)
                     uploaded_file_paths = upload_result.get("uploaded_files", [])
                     file_info_list = upload_result.get("file_info_list", [])
 
@@ -1804,21 +1748,14 @@ async def handle_chat_message(
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent_record = (
-                                db.query(Agent)
-                                .filter(Agent.id == task.agent_id)
-                                .first()
-                            )
+                            agent_record = db.query(Agent).filter(Agent.id == task.agent_id).first()
                             if agent_record and agent_record.skills:
                                 if isinstance(agent_record.skills, list):
                                     is_agent_builder = any(
-                                        s == "agent-builder"
-                                        for s in agent_record.skills
+                                        s == "agent-builder" for s in agent_record.skills
                                     )
                                 elif isinstance(agent_record.skills, str):
-                                    is_agent_builder = (
-                                        "agent-builder" in agent_record.skills
-                                    )
+                                    is_agent_builder = "agent-builder" in agent_record.skills
 
                         uploaded_files_context = _build_uploaded_files_context(
                             file_info_list,
@@ -1847,9 +1784,7 @@ async def handle_chat_message(
 
                         existing_prompt = context.get("system_prompt")
                         if existing_prompt:
-                            context["system_prompt"] = (
-                                f"{existing_prompt}\n\n{file_prompt}"
-                            )
+                            context["system_prompt"] = f"{existing_prompt}\n\n{file_prompt}"
                         else:
                             context["system_prompt"] = file_prompt
 
@@ -1903,9 +1838,7 @@ async def handle_chat_message(
                     assert dag_pattern is not None  # for mypy type checking
 
                     # Immediately send trace_user_message to display user message on interface
-                    if hasattr(dag_pattern, "tracer") and hasattr(
-                        dag_pattern, "task_id"
-                    ):
+                    if hasattr(dag_pattern, "tracer") and hasattr(dag_pattern, "task_id"):
                         from ...core.agent.trace import trace_user_message
 
                         trace_data = {
@@ -1936,6 +1869,8 @@ async def handle_chat_message(
                             )
                             return
                         db.refresh(task)
+                        sync_workforce_run_status(db, task, task.status)
+                        db.commit()
 
                         (
                             model_id,
@@ -2028,16 +1963,10 @@ async def handle_chat_message(
                             before_message_id=int(persisted_user_message.id),
                         )
                         agent_service.set_conversation_history(conversation_history)
-                    recovery_state = await load_task_execution_recovery_state(
-                        db, task_id
-                    )
+                    recovery_state = await load_task_execution_recovery_state(db, task_id)
                     execution_context_messages = recovery_state.get("messages", [])
-                    agent_service.set_execution_context_messages(
-                        execution_context_messages
-                    )
-                    agent_service.set_recovered_skill_context(
-                        recovery_state.get("skill_context")
-                    )
+                    agent_service.set_execution_context_messages(execution_context_messages)
+                    agent_service.set_recovered_skill_context(recovery_state.get("skill_context"))
 
                     # IMPORTANT: Check if task was completed/failed BEFORE updating status
                     # This is needed to force fresh execution instead of continuation
@@ -2063,11 +1992,7 @@ async def handle_chat_message(
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent = (
-                                db.query(Agent)
-                                .filter(Agent.id == task.agent_id)
-                                .first()
-                            )
+                            agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
                             if agent:
                                 is_dag = agent.execution_mode == "think"
 
@@ -2112,10 +2037,7 @@ async def handle_chat_message(
                     # Build context with vibe mode information if available
                     if hasattr(task, "execution_mode") and task.execution_mode:
                         context["execution_mode"] = task.execution_mode
-                    if (
-                        hasattr(task, "process_description")
-                        and task.process_description
-                    ):
+                    if hasattr(task, "process_description") and task.process_description:
                         context["process_description"] = task.process_description
                     if hasattr(task, "examples") and task.examples:
                         context["examples"] = task.examples
@@ -2193,9 +2115,7 @@ async def handle_chat_message(
         raise
 
 
-async def handle_execute_task(
-    websocket: WebSocket, task_id: int, message_data: dict
-) -> None:
+async def handle_execute_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
     """Handle task execution request"""
     try:
         user = message_data.get("user")
@@ -2228,11 +2148,7 @@ async def handle_execute_task(
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = (
-                    db.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
-                    .first()
-                )
+                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
             if not task:
                 raise Exception(f"Task {task_id} not found or access denied")
 
@@ -2288,12 +2204,8 @@ async def handle_execute_task(
                     make_agent_v2_outbound_handler(task_id)
                 )
             recovery_state = await load_task_execution_recovery_state(db, task_id)
-            agent_service.set_execution_context_messages(
-                recovery_state.get("messages", [])
-            )
-            agent_service.set_recovered_skill_context(
-                recovery_state.get("skill_context")
-            )
+            agent_service.set_execution_context_messages(recovery_state.get("messages", []))
+            agent_service.set_recovered_skill_context(recovery_state.get("skill_context"))
 
             # Set up user context
             with UserContext(user.id):
@@ -2325,6 +2237,8 @@ async def handle_execute_task(
                         db, task_id, status=TaskStatus.FAILED
                     )
                 db.refresh(task)
+                sync_workforce_run_status(db, task, task.status)
+                db.commit()
 
                 # Send task completion event (don't duplicate result as trace system already sent)
 
@@ -2400,9 +2314,7 @@ async def handle_execute_task(
         raise
 
 
-async def send_historical_data_as_stream(
-    websocket: WebSocket, task_id: int, user: User
-) -> None:
+async def send_historical_data_as_stream(websocket: WebSocket, task_id: int, user: User) -> None:
     """Send historical data as stream messages - using unified trace event format"""
     try:
         # Load historical data directly from database
@@ -2511,8 +2423,8 @@ async def send_historical_data_as_stream(
             # Merge all time-sensitive events and sort by timestamp
             historical_events: list[dict[str, Any]] = []
 
-            historical_path_to_file_id: Dict[str, str] = {}
-            normalized_trace_data_by_event_id: Dict[str, Any] = {}
+            historical_path_to_file_id: dict[str, str] = {}
+            normalized_trace_data_by_event_id: dict[str, Any] = {}
             task_user_id = int(cast(Any, task.user_id))
             trace_message_keys: set[tuple[str, str]] = set()
 
@@ -2742,21 +2654,15 @@ async def send_historical_data_as_stream(
 
         except (ValueError, KeyError, TypeError) as e:
             # Data format error
-            logger.error(
-                f"Data format error loading historical data for task {task_id}: {e}"
-            )
+            logger.error(f"Data format error loading historical data for task {task_id}: {e}")
             raise
         except RuntimeError as e:
             # Runtime error
-            logger.error(
-                f"Runtime error loading historical data for task {task_id}: {e}"
-            )
+            logger.error(f"Runtime error loading historical data for task {task_id}: {e}")
             raise
         except Exception as e:
             # Other unknown errors, re-raise
-            logger.error(
-                f"Unexpected error loading historical data for task {task_id}: {e}"
-            )
+            logger.error(f"Unexpected error loading historical data for task {task_id}: {e}")
             raise
         finally:
             db.close()
@@ -2792,7 +2698,7 @@ async def handle_status_request(websocket: WebSocket, task_id: int, user: User) 
 async def websocket_chat_endpoint(
     websocket: WebSocket,
     task_id: int,
-    token: Optional[str] = Query(None, description="Authentication token"),
+    token: str | None = Query(None, description="Authentication token"),
 ) -> None:
     """WebSocket unified endpoint - handle chat, execution status, and DAG intervention"""
     # Verify user identity
@@ -2851,9 +2757,7 @@ async def websocket_chat_endpoint(
         raise
 
 
-async def handle_intervention(
-    websocket: WebSocket, task_id: int, message_data: dict
-) -> None:
+async def handle_intervention(websocket: WebSocket, task_id: int, message_data: dict) -> None:
     """Handle manual intervention"""
     try:
         intervention_data = {
@@ -2868,9 +2772,7 @@ async def handle_intervention(
                 "type": "intervention_processed",
                 "message": f"Manual intervention processed: {intervention_data['action']}",
                 "intervention_id": intervention_data["step_id"],
-                "timestamp": datetime.now(
-                    timezone.utc
-                ).isoformat(),  # Send UTC timestamp directly
+                "timestamp": datetime.now(timezone.utc).isoformat(),  # Send UTC timestamp directly
             },
             task_id,
         )
@@ -2893,9 +2795,7 @@ async def handle_intervention(
         raise
 
 
-async def handle_pause_task(
-    websocket: WebSocket, task_id: int, message_data: dict
-) -> None:
+async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
     """Handle task pause request"""
     try:
         logger.info(f"🔘 handle_pause_task called for task {task_id}")
@@ -2916,9 +2816,7 @@ async def handle_pause_task(
         from .chat import get_agent_manager
 
         logger.info(f"Getting agent service for task {task_id}")
-        agent_service = await get_agent_manager().get_agent_for_task(
-            task_id, db, user=user
-        )
+        agent_service = await get_agent_manager().get_agent_for_task(task_id, db, user=user)
         logger.info(f"Agent service obtained: {type(agent_service).__name__}")
 
         # Check if agent supports pause functionality
@@ -2936,6 +2834,31 @@ async def handle_pause_task(
                 logger.warning(f"No live execution found to pause for task {task_id}")
                 return
             logger.info("Agent pause_execution completed")
+
+            # Update task status in database
+            from ..models.task import Task, TaskStatus
+
+            db_gen = get_db()
+            db_update = next(db_gen)
+            try:
+                # Admin can pause any task, regular users can only pause their own tasks
+                if user.is_admin:
+                    task = db_update.query(Task).filter(Task.id == task_id).first()
+                else:
+                    task = (
+                        db_update.query(Task)
+                        .filter(Task.id == task_id, Task.user_id == user.id)
+                        .first()
+                    )
+                if task:
+                    task.status = TaskStatus.PAUSED
+                    sync_workforce_run_status(db_update, task, task.status)
+                    db_update.commit()
+                    logger.info(f"Updated task {task_id} status to PAUSED in database")
+                else:
+                    logger.warning(f"Task {task_id} not found or access denied for user {user.id}")
+            finally:
+                db_update.close()
 
             # Send pause confirmation
             await manager.broadcast_to_task(
@@ -2957,9 +2880,7 @@ async def handle_pause_task(
                 },
                 websocket,
             )
-            logger.warning(
-                f"Agent for task {task_id} does not support pause functionality"
-            )
+            logger.warning(f"Agent for task {task_id} does not support pause functionality")
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
@@ -2979,9 +2900,7 @@ async def handle_pause_task(
         raise
 
 
-async def handle_resume_task(
-    websocket: WebSocket, task_id: int, message_data: dict
-) -> None:
+async def handle_resume_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
     """Handle task resume request"""
     try:
         user = message_data.get("user")
@@ -3060,6 +2979,27 @@ async def handle_resume_task(
         if hasattr(agent_service, "resume_execution"):
             await agent_service.resume_execution()
 
+            db_update_gen = get_db()
+            db_update = next(db_update_gen)
+            try:
+                if user.is_admin:
+                    task = db_update.query(Task).filter(Task.id == task_id).first()
+                else:
+                    task = (
+                        db_update.query(Task)
+                        .filter(Task.id == task_id, Task.user_id == user.id)
+                        .first()
+                    )
+                if task:
+                    task.status = TaskStatus.RUNNING
+                    sync_workforce_run_status(db_update, task, task.status)
+                    db_update.commit()
+                    logger.info(f"Updated task {task_id} status to RUNNING in database")
+                else:
+                    logger.warning(f"Task {task_id} not found or access denied for user {user.id}")
+            finally:
+                db_update.close()
+
             # Send resume confirmation
             await manager.broadcast_to_task(
                 {
@@ -3080,9 +3020,7 @@ async def handle_resume_task(
                 },
                 websocket,
             )
-            logger.warning(
-                f"Agent for task {task_id} does not support resume functionality"
-            )
+            logger.warning(f"Agent for task {task_id} does not support resume functionality")
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
@@ -3105,7 +3043,7 @@ async def handle_resume_task(
 @ws_router.websocket("/ws/build/chat")
 async def websocket_builder_chat_endpoint(
     websocket: WebSocket,
-    token: Optional[str] = Query(None, description="Authentication token"),
+    token: str | None = Query(None, description="Authentication token"),
 ) -> None:
     """WebSocket endpoint for AI Agent Builder Assistant chat."""
     user = await get_authenticated_user(websocket, token)
@@ -3180,9 +3118,7 @@ async def handle_builder_chat(
 
     builder_tracer = create_ephemeral_tracer(
         task_id=builder_task_id,
-        websocket_handler=SharedWebSocketTracer(
-            websocket, builder_task_id, is_preview=False
-        ),
+        websocket_handler=SharedWebSocketTracer(websocket, builder_task_id, is_preview=False),
         user=user,
         is_preview=False,
     )
@@ -3297,18 +3233,14 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
             )
 
         if not llm:
-            default_llm, fast_llm, vision_llm, compact_llm = (
-                resolver.get_configured_defaults(
-                    user_id=user.id  # type: ignore[arg-type]
-                )
+            default_llm, fast_llm, vision_llm, compact_llm = resolver.get_configured_defaults(
+                user_id=user.id  # type: ignore[arg-type]
             )
             llm = default_llm
 
         if not llm:
             await websocket.send_text(
-                json.dumps(
-                    {"type": "error", "message": "No LLM configured for builder chat"}
-                )
+                json.dumps({"type": "error", "message": "No LLM configured for builder chat"})
             )
             return
 
@@ -3401,9 +3333,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
 
             # Save agent service to websocket state for reuse
             websocket.state.builder_agent_service = agent_service
-            logger.info(
-                f"Created new builder chat agent service with task_id: {builder_task_id}"
-            )
+            logger.info(f"Created new builder chat agent service with task_id: {builder_task_id}")
         else:
             agent_service = websocket.state.builder_agent_service
             # Update tracer to the new connection
@@ -3413,9 +3343,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                 websocket.state.builder_chat_history = []
             if not hasattr(websocket.state, "builder_memory"):
                 websocket.state.builder_memory = InMemoryMemoryStore()
-            if hasattr(agent_service, "agent") and hasattr(
-                agent_service.agent, "patterns"
-            ):
+            if hasattr(agent_service, "agent") and hasattr(agent_service.agent, "patterns"):
                 for pattern in agent_service.agent.patterns:
                     if hasattr(pattern, "tracer"):
                         pattern.tracer = builder_tracer
@@ -3434,9 +3362,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
             if hasattr(websocket.state, "builder_chat_history") and hasattr(
                 agent_service, "set_conversation_history"
             ):
-                agent_service.set_conversation_history(
-                    websocket.state.builder_chat_history
-                )
+                agent_service.set_conversation_history(websocket.state.builder_chat_history)
 
             # Execute task with the agent
             with UserContext(int(user.id)):
@@ -3481,9 +3407,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                         )
                         output_content = f"```json\n{structured_content}\n```"
                     except Exception as e:
-                        logger.warning(
-                            f"Failed to serialize chat_response for history: {e}"
-                        )
+                        logger.warning(f"Failed to serialize chat_response for history: {e}")
 
                 if output_content:
                     websocket.state.builder_chat_history.append(
@@ -3499,9 +3423,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                     )
 
                 # Keep history size manageable (e.g. last 20 messages)
-                websocket.state.builder_chat_history = (
-                    websocket.state.builder_chat_history[-20:]
-                )
+                websocket.state.builder_chat_history = websocket.state.builder_chat_history[-20:]
 
             # Send task_completed event to match the preview flow behavior
             # which relies on Trace events but might need a final completion indicator
@@ -3510,9 +3432,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                 # so the frontend can receive the structured data instead of trying to parse markdown
                 task_completion_result = {"content": result.get("output", "")}
                 if result.get("chat_response"):
-                    task_completion_result["chat_response"] = result.get(
-                        "chat_response"
-                    )
+                    task_completion_result["chat_response"] = result.get("chat_response")
 
                 await websocket.send_text(
                     json.dumps(
@@ -3538,7 +3458,7 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
 @ws_router.websocket("/ws/build/preview")
 async def websocket_build_preview_endpoint(
     websocket: WebSocket,
-    token: Optional[str] = Query(None, description="Authentication token"),
+    token: str | None = Query(None, description="Authentication token"),
 ) -> None:
     """WebSocket endpoint for build page agent preview - no database storage, real-time execution only."""
     # Verify user identity
@@ -3577,9 +3497,7 @@ async def websocket_build_preview_endpoint(
                     hasattr(websocket.state, "preview_agent_service")
                     and websocket.state.preview_agent_service
                 ):
-                    if hasattr(
-                        websocket.state.preview_agent_service, "pause_execution"
-                    ):
+                    if hasattr(websocket.state.preview_agent_service, "pause_execution"):
                         await websocket.state.preview_agent_service.pause_execution()
                         await websocket.send_text(
                             json.dumps(
@@ -3604,9 +3522,7 @@ async def websocket_build_preview_endpoint(
                     hasattr(websocket.state, "preview_agent_service")
                     and websocket.state.preview_agent_service
                 ):
-                    if hasattr(
-                        websocket.state.preview_agent_service, "resume_execution"
-                    ):
+                    if hasattr(websocket.state.preview_agent_service, "resume_execution"):
                         await websocket.state.preview_agent_service.resume_execution()
                         await websocket.send_text(
                             json.dumps(
@@ -3699,9 +3615,7 @@ async def handle_build_preview_execution(
 
     preview_tracer = create_ephemeral_tracer(
         task_id=preview_task_id,
-        websocket_handler=SharedWebSocketTracer(
-            websocket, preview_task_id, is_preview=True
-        ),
+        websocket_handler=SharedWebSocketTracer(websocket, preview_task_id, is_preview=True),
         user=user,
         is_preview=True,
     )
@@ -3722,9 +3636,7 @@ async def handle_build_preview_execution(
 
             if models_config.get("general"):
                 general_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == models_config["general"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == models_config["general"]).first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -3733,9 +3645,7 @@ async def handle_build_preview_execution(
 
             if models_config.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == models_config["small_fast"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == models_config["small_fast"]).first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -3744,9 +3654,7 @@ async def handle_build_preview_execution(
 
             if models_config.get("visual"):
                 visual_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == models_config["visual"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == models_config["visual"]).first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -3755,9 +3663,7 @@ async def handle_build_preview_execution(
 
             if models_config.get("compact"):
                 compact_model = (
-                    db.query(DBModel)
-                    .filter(DBModel.id == models_config["compact"])
-                    .first()
+                    db.query(DBModel).filter(DBModel.id == models_config["compact"]).first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -3789,9 +3695,7 @@ async def handle_build_preview_execution(
         if sandbox_manager:
             user_id = int(user.id)
             try:
-                sandbox = await sandbox_manager.get_or_create_sandbox(
-                    "user", str(user_id)
-                )
+                sandbox = await sandbox_manager.get_or_create_sandbox("user", str(user_id))
             except Exception as e:
                 logger.error(f"Failed to create sandbox for user {user_id}: {e}")
 
@@ -3802,9 +3706,7 @@ async def handle_build_preview_execution(
             # Get all tools and filter by category using metadata
             from ...core.tools.adapters.vibe.factory import ToolFactory
 
-            has_mcp = bool(
-                tool_categories and any(tc.startswith("mcp:") for tc in tool_categories)
-            )
+            has_mcp = bool(tool_categories and any(tc.startswith("mcp:") for tc in tool_categories))
             temp_config = WebToolConfig(
                 db=db,
                 request=MinimalRequest(int(user.id)),
@@ -3825,8 +3727,7 @@ async def handle_build_preview_execution(
 
                 # Check if we also need custom APIs
                 has_custom_api = bool(
-                    tool_categories
-                    and any(tc.startswith("mcp:") for tc in tool_categories)
+                    tool_categories and any(tc.startswith("mcp:") for tc in tool_categories)
                 )
                 if has_custom_api:
                     # Manually add custom APIs since temp_config might not load them properly
@@ -3851,17 +3752,13 @@ async def handle_build_preview_execution(
                             for tc in tool_categories:
                                 if tc.startswith("mcp:"):
                                     server_name = (
-                                        tc.split(":", 1)[1]
-                                        .replace(" ", "_")
-                                        .replace("-", "_")
+                                        tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
                                     )
                                     logger.info(
                                         f"Checking MCP tool: '{tool_name}' vs 'mcp_{server_name}_'"
                                     )
                                     # Use case-insensitive matching for MCP server prefix
-                                    if tool_name.lower().startswith(
-                                        f"mcp_{server_name.lower()}_"
-                                    ):
+                                    if tool_name.lower().startswith(f"mcp_{server_name.lower()}_"):
                                         allowed_tools.append(tool_name)
                                         break
                         elif category == "other":
@@ -3869,18 +3766,13 @@ async def handle_build_preview_execution(
                             for tc in tool_categories:
                                 if tc.startswith("mcp:"):
                                     server_name = (
-                                        tc.split(":", 1)[1]
-                                        .replace(" ", "_")
-                                        .replace("-", "_")
+                                        tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
                                     )
                                     logger.info(
                                         f"Checking Custom API tool: '{tool_name}' vs 'api_{server_name}_call'"
                                     )
                                     # Custom APIs are now prefixed with api_ and suffixed with _call
-                                    if (
-                                        tool_name.lower()
-                                        == f"api_{server_name.lower()}_call"
-                                    ):
+                                    if tool_name.lower() == f"api_{server_name.lower()}_call":
                                         allowed_tools.append(tool_name)
                                         break
 
@@ -3895,9 +3787,7 @@ async def handle_build_preview_execution(
             llm=default_llm,
             user_id=int(user.id),
             is_admin=bool(user.is_admin),
-            allowed_collections=knowledge_bases
-            if knowledge_bases is not None
-            else None,
+            allowed_collections=knowledge_bases if knowledge_bases is not None else None,
             allowed_skills=skills if skills is not None else None,
             allowed_tools=allowed_tools,
             task_id=preview_task_id,
@@ -3915,9 +3805,7 @@ async def handle_build_preview_execution(
             from ..models.agent import Agent as AgentModel
             from ..models.agent import AgentStatus
 
-            preview_agent = (
-                db.query(AgentModel).filter(AgentModel.id == preview_agent_id).first()
-            )
+            preview_agent = db.query(AgentModel).filter(AgentModel.id == preview_agent_id).first()
             if preview_agent and preview_agent.status == AgentStatus.PUBLISHED:
                 tool_config._excluded_agent_id = int(preview_agent.id)
                 logger.info(
@@ -3988,15 +3876,11 @@ async def handle_build_preview_execution(
                 for file_info in files_data:
                     file_id = file_info.get("file_id")
                     if not file_id:
-                        logger.warning(
-                            f"No file_id provided in preview file info: {file_info}"
-                        )
+                        logger.warning(f"No file_id provided in preview file info: {file_info}")
                         continue
 
                     file_record = (
-                        db.query(UploadedFile)
-                        .filter(UploadedFile.file_id == file_id)
-                        .first()
+                        db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
                     )
                     if not file_record:
                         logger.warning(f"File record not found for file_id: {file_id}")
@@ -4048,9 +3932,7 @@ async def handle_build_preview_execution(
                         )
 
                     except Exception as e:
-                        logger.error(
-                            f"Error handling file {file_info.get('name')}: {e}"
-                        )
+                        logger.error(f"Error handling file {file_info.get('name')}: {e}")
                         continue
 
                 if file_info_list:
@@ -4065,15 +3947,11 @@ async def handle_build_preview_execution(
                         f"{file_summary}"
                     )
 
-                logger.info(
-                    f"🎉 File upload completed, uploaded {len(uploaded_files)} files"
-                )
+                logger.info(f"🎉 File upload completed, uploaded {len(uploaded_files)} files")
                 db.commit()
 
             except Exception as e:
-                logger.error(
-                    f"Error handling file upload for build preview: {e}", exc_info=True
-                )
+                logger.error(f"Error handling file upload for build preview: {e}", exc_info=True)
                 await websocket.send_text(
                     json.dumps(
                         {
@@ -4117,13 +3995,9 @@ async def handle_build_preview_execution(
             )
 
         # Append the new interaction to the history
-        websocket.state.preview_history.append(
-            {"role": "user", "content": user_message}
-        )
+        websocket.state.preview_history.append({"role": "user", "content": user_message})
         assistant_output = result.get("output", "")
-        websocket.state.preview_history.append(
-            {"role": "assistant", "content": assistant_output}
-        )
+        websocket.state.preview_history.append({"role": "assistant", "content": assistant_output})
 
         # Send preview completion event
         await websocket.send_text(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -81,6 +81,14 @@ def _resolve_task_llm_ids(
     )
 
 
+def _extract_task_workforce_id(task: Any) -> int | None:
+    agent_config = getattr(task, "agent_config", None)
+    if not isinstance(agent_config, dict):
+        return None
+    workforce_id = agent_config.get("workforce_id")
+    return workforce_id if isinstance(workforce_id, int) else None
+
+
 def normalize_filename(filename: str) -> str:
     """
     Normalize filename by removing special characters and spaces.
@@ -843,6 +851,7 @@ async def execute_task_background(
                         "description": task.description,
                         "status": final_task_status,
                         "execution_mode": task.execution_mode,
+                        "workforce_id": _extract_task_workforce_id(task),
                     },
                     task.updated_at if task.updated_at else None,
                 ),
@@ -1159,6 +1168,7 @@ async def execute_v2_resume_background(
                         "description": task.description,
                         "status": final_status,
                         "execution_mode": task.execution_mode,
+                        "workforce_id": _extract_task_workforce_id(task),
                     },
                 ),
                 task_id,
@@ -1771,6 +1781,7 @@ async def handle_chat_message(
                                 "compact_model_name": task.compact_model_name,
                                 "execution_mode": task.execution_mode,
                                 "agent_id": task.agent_id,
+                                "workforce_id": _extract_task_workforce_id(task),
                                 "is_dag": is_dag,
                                 "created_at": safe_timestamp_to_unix(task.created_at)
                                 if task.created_at
@@ -1968,6 +1979,7 @@ async def handle_chat_message(
                                 "visual_model_name": task.visual_model_name,
                                 "compact_model_name": task.compact_model_name,
                                 "execution_mode": task.execution_mode,
+                                "workforce_id": _extract_task_workforce_id(task),
                                 "created_at": safe_timestamp_to_unix(task.created_at)
                                 if task.created_at
                                 else None,
@@ -2102,6 +2114,7 @@ async def handle_chat_message(
                                 "compact_model_name": task.compact_model_name,
                                 "execution_mode": task.execution_mode,
                                 "agent_id": task.agent_id,
+                                "workforce_id": _extract_task_workforce_id(task),
                                 "is_dag": is_dag,
                                 "created_at": safe_timestamp_to_unix(task.created_at)
                                 if task.created_at
@@ -2267,6 +2280,7 @@ async def handle_execute_task(
                     "visual_model_name": task.visual_model_name,
                     "compact_model_name": task.compact_model_name,
                     "execution_mode": task.execution_mode,
+                    "workforce_id": _extract_task_workforce_id(task),
                     "created_at": safe_timestamp_to_unix(task.created_at)
                     if task.created_at
                     else None,
@@ -2483,6 +2497,7 @@ async def send_historical_data_as_stream(
                     "compact_model_name": task.compact_model_name,
                     "execution_mode": task.execution_mode,
                     "agent_id": task.agent_id,
+                    "workforce_id": _extract_task_workforce_id(task),
                     "is_dag": is_dag,
                     "waiting_question": waiting_question,
                     "waiting_interactions": waiting_interactions,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -446,7 +446,9 @@ def _infer_owner_from_relative_path(
     return None
 
 
-def _map_link_token_to_file_id(token: str, path_to_file_id: dict[str, str]) -> str | None:
+def _map_link_token_to_file_id(
+    token: str, path_to_file_id: dict[str, str]
+) -> str | None:
     raw = token.strip()
     if not raw:
         return None
@@ -481,7 +483,9 @@ def _map_link_token_to_file_id(token: str, path_to_file_id: dict[str, str]) -> s
     return None
 
 
-def _rewrite_file_links_to_file_id(output_text: Any, path_to_file_id: dict[str, str]) -> Any:
+def _rewrite_file_links_to_file_id(
+    output_text: Any, path_to_file_id: dict[str, str]
+) -> Any:
     if not isinstance(output_text, str) or not output_text:
         return output_text
 
@@ -603,14 +607,20 @@ def _normalize_file_outputs(
 
         resolved_path, relative_path = resolved_info
         normalized_relative_path = relative_path.lstrip("/")
-        expected_file_id = item_file_id or _build_output_file_id(normalized_relative_path)
+        expected_file_id = item_file_id or _build_output_file_id(
+            normalized_relative_path
+        )
 
         file_record = (
-            db.query(UploadedFile).filter(UploadedFile.storage_path == str(resolved_path)).first()
+            db.query(UploadedFile)
+            .filter(UploadedFile.storage_path == str(resolved_path))
+            .first()
         )
         if file_record is None and item_file_id:
             file_record = (
-                db.query(UploadedFile).filter(UploadedFile.file_id == item_file_id).first()
+                db.query(UploadedFile)
+                .filter(UploadedFile.file_id == item_file_id)
+                .first()
             )
 
         if file_record is None:
@@ -660,7 +670,8 @@ def _rewrite_links_in_payload(payload: Any, path_to_file_id: dict[str, str]) -> 
         return [_rewrite_links_in_payload(item, path_to_file_id) for item in payload]
     if isinstance(payload, dict):
         return {
-            key: _rewrite_links_in_payload(value, path_to_file_id) for key, value in payload.items()
+            key: _rewrite_links_in_payload(value, path_to_file_id)
+            for key, value in payload.items()
         }
     return payload
 
@@ -732,7 +743,9 @@ async def execute_task_background(
         # Get AI response
         chat_response = result.get("chat_response")
         if isinstance(chat_response, dict):
-            ai_response = chat_response.get("message") or result.get("output", "Task completed")
+            ai_response = chat_response.get("message") or result.get(
+                "output", "Task completed"
+            )
         else:
             ai_response = result.get("output", "Task completed")
 
@@ -852,7 +865,9 @@ async def execute_task_background(
                 "output": ai_response,
                 "file_outputs": normalized_outputs,
                 "success": result.get("success", False),
-                "chat_response": chat_response if isinstance(chat_response, dict) else None,
+                "chat_response": chat_response
+                if isinstance(chat_response, dict)
+                else None,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
             task_id,
@@ -961,7 +976,9 @@ async def execute_continuation_background(
                         task_updated.status = TaskStatus.FAILED
                     sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     db_new.commit()
-                    logger.info(f"Updated task {task_id} status to {task_updated.status.value}")
+                    logger.info(
+                        f"Updated task {task_id} status to {task_updated.status.value}"
+                    )
                 else:
                     logger.info(f"Task {task_id} is paused, not updating status")
 
@@ -992,7 +1009,9 @@ async def execute_continuation_background(
                 "result": ai_response,
                 "output": ai_response,
                 "success": result.get("success", False),
-                "chat_response": chat_response if isinstance(chat_response, dict) else None,
+                "chat_response": chat_response
+                if isinstance(chat_response, dict)
+                else None,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
             task_id,
@@ -1000,7 +1019,9 @@ async def execute_continuation_background(
         logger.info(f"Background continuation for task {task_id} completed")
 
     except Exception as e:
-        logger.error(f"Background continuation for task {task_id} failed: {e}", exc_info=True)
+        logger.error(
+            f"Background continuation for task {task_id} failed: {e}", exc_info=True
+        )
         # Send error event
         try:
             await manager.broadcast_to_task(
@@ -1204,12 +1225,16 @@ class BackgroundTaskManager:
             if current_task is not None and old_task is current_task:
                 return
             if not old_task.done():
-                logger.info(f"Waiting for previous background task {task_id} to complete...")
+                logger.info(
+                    f"Waiting for previous background task {task_id} to complete..."
+                )
                 try:
                     await old_task
                     logger.info(f"Previous background task {task_id} completed")
                 except Exception as e:
-                    logger.warning(f"Previous background task {task_id} ended with error: {e}")
+                    logger.warning(
+                        f"Previous background task {task_id} ended with error: {e}"
+                    )
 
     def register_task(self, task_id: int, task: asyncio.Task) -> None:
         """Register new background task"""
@@ -1236,11 +1261,17 @@ class BackgroundTaskManager:
             except asyncio.CancelledError:
                 logger.info(f"Cancelled background task for task {task_id}")
             except asyncio.TimeoutError:
-                logger.info(f"Cancellation timeout for task {task_id}; continuing cleanup")
+                logger.info(
+                    f"Cancellation timeout for task {task_id}; continuing cleanup"
+                )
             except RuntimeError as e:
-                logger.warning(f"Background task {task_id} cancellation runtime warning: {e}")
+                logger.warning(
+                    f"Background task {task_id} cancellation runtime warning: {e}"
+                )
             except Exception as e:
-                logger.warning(f"Background task {task_id} raised during cancellation: {e}")
+                logger.warning(
+                    f"Background task {task_id} raised during cancellation: {e}"
+                )
 
         self.running_tasks.pop(task_id, None)
 
@@ -1267,7 +1298,9 @@ class SharedWebSocketTracer(TraceHandler):
             if not isinstance(value, str):
                 return value
             cleaned = value.replace("\x00", "").replace("\u0000", "")
-            cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\n\r\t")
+            cleaned = "".join(
+                char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
+            )
             return cleaned
 
         def serialize_value(value: Any) -> Any:
@@ -1334,7 +1367,10 @@ class SharedWebSocketTracer(TraceHandler):
 
         except (RuntimeError, ConnectionError) as e:
             error_msg = str(e)
-            if "close" in error_msg.lower() or "response already completed" in error_msg.lower():
+            if (
+                "close" in error_msg.lower()
+                or "response already completed" in error_msg.lower()
+            ):
                 self._closed = True
                 logger.debug(f"WebSocket connection closed: {e}")
             else:
@@ -1358,7 +1394,9 @@ async def redirect_legacy_preview(
 
     resolved_path, relative_path = resolved_info
     file_record = (
-        db.query(UploadedFile).filter(UploadedFile.storage_path == str(resolved_path)).first()
+        db.query(UploadedFile)
+        .filter(UploadedFile.storage_path == str(resolved_path))
+        .first()
     )
 
     if file_record is None:
@@ -1409,7 +1447,9 @@ class ConnectionManager:
             except ValueError:
                 pass
 
-    def move_connection(self, websocket: WebSocket, old_task_id: int, new_task_id: int) -> None:
+    def move_connection(
+        self, websocket: WebSocket, old_task_id: int, new_task_id: int
+    ) -> None:
         """Move a WebSocket connection from one task_id to another"""
         if old_task_id in self.active_connections:
             try:
@@ -1422,7 +1462,9 @@ class ConnectionManager:
         if new_task_id not in self.active_connections:
             self.active_connections[new_task_id] = []
         self.active_connections[new_task_id].append(websocket)
-        logger.info(f"Moved WebSocket connection from task {old_task_id} to {new_task_id}")
+        logger.info(
+            f"Moved WebSocket connection from task {old_task_id} to {new_task_id}"
+        )
 
     async def send_personal_message(self, message: dict, websocket: WebSocket) -> None:
         await websocket.send_text(json.dumps(message))
@@ -1438,7 +1480,9 @@ class ConnectionManager:
                     self.disconnect(connection, task_id)
                 except Exception as e:
                     # Other errors should not be silently handled, log and re-raise
-                    logger.error(f"Unexpected error broadcasting to task {task_id}: {e}")
+                    logger.error(
+                        f"Unexpected error broadcasting to task {task_id}: {e}"
+                    )
                     # Remove disconnected connection but preserve error propagation
                     self.disconnect(connection, task_id)
                     raise
@@ -1464,7 +1508,9 @@ async def handle_file_upload_for_task(
         logger.info(f"📁 Starting file upload for task {task_id}, files: {len(files)}")
 
         # Get agent
-        agent_service = await get_agent_manager().get_agent_for_task(task_id, db, user=user)
+        agent_service = await get_agent_manager().get_agent_for_task(
+            task_id, db, user=user
+        )
         logger.info(f"🤖 Got agent service for task {task_id}")
 
         for file_info in files:
@@ -1473,7 +1519,9 @@ async def handle_file_upload_for_task(
                 logger.warning(f"No file_id provided in file info: {file_info}")
                 continue
 
-            file_record = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+            file_record = (
+                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+            )
             if not file_record:
                 logger.warning(f"File record not found for file_id: {file_id}")
                 continue
@@ -1572,7 +1620,9 @@ async def get_authenticated_user(
         return None
 
 
-async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: dict) -> None:
+async def handle_chat_message(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle chat message"""
     try:
         user_message = message_data.get("message", "")
@@ -1619,7 +1669,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                     task = db.query(Task).filter(Task.id == task_id).first()
                 else:
                     task = (
-                        db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                        db.query(Task)
+                        .filter(Task.id == task_id, Task.user_id == user.id)
+                        .first()
                     )
 
                 if not task:
@@ -1630,7 +1682,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                         logger.warning(
                             f"User {user.id} attempted to access task {task_id} belonging to user {existing_task.user_id}"
                         )
-                        raise ValueError(f"Access denied: Task {task_id} does not belong to you")
+                        raise ValueError(
+                            f"Access denied: Task {task_id} does not belong to you"
+                        )
                     else:
                         # Task doesn't exist (may have been deleted), create new task
                         # This is a fresh start, don't use continuation logic
@@ -1684,7 +1738,11 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+                            agent = (
+                                db.query(Agent)
+                                .filter(Agent.id == task.agent_id)
+                                .first()
+                            )
                             if agent:
                                 is_dag = agent.execution_mode == "think"
 
@@ -1732,7 +1790,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                 uploaded_files_context = ""
                 if files:
                     # Process file upload
-                    upload_result = await handle_file_upload_for_task(task_id, files, db, user)
+                    upload_result = await handle_file_upload_for_task(
+                        task_id, files, db, user
+                    )
                     uploaded_file_paths = upload_result.get("uploaded_files", [])
                     file_info_list = upload_result.get("file_info_list", [])
 
@@ -1748,14 +1808,21 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent_record = db.query(Agent).filter(Agent.id == task.agent_id).first()
+                            agent_record = (
+                                db.query(Agent)
+                                .filter(Agent.id == task.agent_id)
+                                .first()
+                            )
                             if agent_record and agent_record.skills:
                                 if isinstance(agent_record.skills, list):
                                     is_agent_builder = any(
-                                        s == "agent-builder" for s in agent_record.skills
+                                        s == "agent-builder"
+                                        for s in agent_record.skills
                                     )
                                 elif isinstance(agent_record.skills, str):
-                                    is_agent_builder = "agent-builder" in agent_record.skills
+                                    is_agent_builder = (
+                                        "agent-builder" in agent_record.skills
+                                    )
 
                         uploaded_files_context = _build_uploaded_files_context(
                             file_info_list,
@@ -1784,7 +1851,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
 
                         existing_prompt = context.get("system_prompt")
                         if existing_prompt:
-                            context["system_prompt"] = f"{existing_prompt}\n\n{file_prompt}"
+                            context["system_prompt"] = (
+                                f"{existing_prompt}\n\n{file_prompt}"
+                            )
                         else:
                             context["system_prompt"] = file_prompt
 
@@ -1838,7 +1907,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                     assert dag_pattern is not None  # for mypy type checking
 
                     # Immediately send trace_user_message to display user message on interface
-                    if hasattr(dag_pattern, "tracer") and hasattr(dag_pattern, "task_id"):
+                    if hasattr(dag_pattern, "tracer") and hasattr(
+                        dag_pattern, "task_id"
+                    ):
                         from ...core.agent.trace import trace_user_message
 
                         trace_data = {
@@ -1963,10 +2034,16 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                             before_message_id=int(persisted_user_message.id),
                         )
                         agent_service.set_conversation_history(conversation_history)
-                    recovery_state = await load_task_execution_recovery_state(db, task_id)
+                    recovery_state = await load_task_execution_recovery_state(
+                        db, task_id
+                    )
                     execution_context_messages = recovery_state.get("messages", [])
-                    agent_service.set_execution_context_messages(execution_context_messages)
-                    agent_service.set_recovered_skill_context(recovery_state.get("skill_context"))
+                    agent_service.set_execution_context_messages(
+                        execution_context_messages
+                    )
+                    agent_service.set_recovered_skill_context(
+                        recovery_state.get("skill_context")
+                    )
 
                     # IMPORTANT: Check if task was completed/failed BEFORE updating status
                     # This is needed to force fresh execution instead of continuation
@@ -1992,7 +2069,11 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                         if task.agent_id:
                             from ..models.agent import Agent
 
-                            agent = db.query(Agent).filter(Agent.id == task.agent_id).first()
+                            agent = (
+                                db.query(Agent)
+                                .filter(Agent.id == task.agent_id)
+                                .first()
+                            )
                             if agent:
                                 is_dag = agent.execution_mode == "think"
 
@@ -2037,7 +2118,10 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
                     # Build context with vibe mode information if available
                     if hasattr(task, "execution_mode") and task.execution_mode:
                         context["execution_mode"] = task.execution_mode
-                    if hasattr(task, "process_description") and task.process_description:
+                    if (
+                        hasattr(task, "process_description")
+                        and task.process_description
+                    ):
                         context["process_description"] = task.process_description
                     if hasattr(task, "examples") and task.examples:
                         context["examples"] = task.examples
@@ -2115,7 +2199,9 @@ async def handle_chat_message(websocket: WebSocket, task_id: int, message_data: 
         raise
 
 
-async def handle_execute_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
+async def handle_execute_task(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle task execution request"""
     try:
         user = message_data.get("user")
@@ -2148,7 +2234,11 @@ async def handle_execute_task(websocket: WebSocket, task_id: int, message_data: 
             if user.is_admin:
                 task = db.query(Task).filter(Task.id == task_id).first()
             else:
-                task = db.query(Task).filter(Task.id == task_id, Task.user_id == user.id).first()
+                task = (
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    .first()
+                )
             if not task:
                 raise Exception(f"Task {task_id} not found or access denied")
 
@@ -2204,8 +2294,12 @@ async def handle_execute_task(websocket: WebSocket, task_id: int, message_data: 
                     make_agent_v2_outbound_handler(task_id)
                 )
             recovery_state = await load_task_execution_recovery_state(db, task_id)
-            agent_service.set_execution_context_messages(recovery_state.get("messages", []))
-            agent_service.set_recovered_skill_context(recovery_state.get("skill_context"))
+            agent_service.set_execution_context_messages(
+                recovery_state.get("messages", [])
+            )
+            agent_service.set_recovered_skill_context(
+                recovery_state.get("skill_context")
+            )
 
             # Set up user context
             with UserContext(user.id):
@@ -2314,7 +2408,9 @@ async def handle_execute_task(websocket: WebSocket, task_id: int, message_data: 
         raise
 
 
-async def send_historical_data_as_stream(websocket: WebSocket, task_id: int, user: User) -> None:
+async def send_historical_data_as_stream(
+    websocket: WebSocket, task_id: int, user: User
+) -> None:
     """Send historical data as stream messages - using unified trace event format"""
     try:
         # Load historical data directly from database
@@ -2654,15 +2750,21 @@ async def send_historical_data_as_stream(websocket: WebSocket, task_id: int, use
 
         except (ValueError, KeyError, TypeError) as e:
             # Data format error
-            logger.error(f"Data format error loading historical data for task {task_id}: {e}")
+            logger.error(
+                f"Data format error loading historical data for task {task_id}: {e}"
+            )
             raise
         except RuntimeError as e:
             # Runtime error
-            logger.error(f"Runtime error loading historical data for task {task_id}: {e}")
+            logger.error(
+                f"Runtime error loading historical data for task {task_id}: {e}"
+            )
             raise
         except Exception as e:
             # Other unknown errors, re-raise
-            logger.error(f"Unexpected error loading historical data for task {task_id}: {e}")
+            logger.error(
+                f"Unexpected error loading historical data for task {task_id}: {e}"
+            )
             raise
         finally:
             db.close()
@@ -2757,7 +2859,9 @@ async def websocket_chat_endpoint(
         raise
 
 
-async def handle_intervention(websocket: WebSocket, task_id: int, message_data: dict) -> None:
+async def handle_intervention(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle manual intervention"""
     try:
         intervention_data = {
@@ -2772,7 +2876,9 @@ async def handle_intervention(websocket: WebSocket, task_id: int, message_data: 
                 "type": "intervention_processed",
                 "message": f"Manual intervention processed: {intervention_data['action']}",
                 "intervention_id": intervention_data["step_id"],
-                "timestamp": datetime.now(timezone.utc).isoformat(),  # Send UTC timestamp directly
+                "timestamp": datetime.now(
+                    timezone.utc
+                ).isoformat(),  # Send UTC timestamp directly
             },
             task_id,
         )
@@ -2795,7 +2901,9 @@ async def handle_intervention(websocket: WebSocket, task_id: int, message_data: 
         raise
 
 
-async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
+async def handle_pause_task(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle task pause request"""
     try:
         logger.info(f"🔘 handle_pause_task called for task {task_id}")
@@ -2816,7 +2924,9 @@ async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: di
         from .chat import get_agent_manager
 
         logger.info(f"Getting agent service for task {task_id}")
-        agent_service = await get_agent_manager().get_agent_for_task(task_id, db, user=user)
+        agent_service = await get_agent_manager().get_agent_for_task(
+            task_id, db, user=user
+        )
         logger.info(f"Agent service obtained: {type(agent_service).__name__}")
 
         # Check if agent supports pause functionality
@@ -2856,7 +2966,9 @@ async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: di
                     db_update.commit()
                     logger.info(f"Updated task {task_id} status to PAUSED in database")
                 else:
-                    logger.warning(f"Task {task_id} not found or access denied for user {user.id}")
+                    logger.warning(
+                        f"Task {task_id} not found or access denied for user {user.id}"
+                    )
             finally:
                 db_update.close()
 
@@ -2880,7 +2992,9 @@ async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: di
                 },
                 websocket,
             )
-            logger.warning(f"Agent for task {task_id} does not support pause functionality")
+            logger.warning(
+                f"Agent for task {task_id} does not support pause functionality"
+            )
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
@@ -2900,7 +3014,9 @@ async def handle_pause_task(websocket: WebSocket, task_id: int, message_data: di
         raise
 
 
-async def handle_resume_task(websocket: WebSocket, task_id: int, message_data: dict) -> None:
+async def handle_resume_task(
+    websocket: WebSocket, task_id: int, message_data: dict
+) -> None:
     """Handle task resume request"""
     try:
         user = message_data.get("user")
@@ -2996,7 +3112,9 @@ async def handle_resume_task(websocket: WebSocket, task_id: int, message_data: d
                     db_update.commit()
                     logger.info(f"Updated task {task_id} status to RUNNING in database")
                 else:
-                    logger.warning(f"Task {task_id} not found or access denied for user {user.id}")
+                    logger.warning(
+                        f"Task {task_id} not found or access denied for user {user.id}"
+                    )
             finally:
                 db_update.close()
 
@@ -3020,7 +3138,9 @@ async def handle_resume_task(websocket: WebSocket, task_id: int, message_data: d
                 },
                 websocket,
             )
-            logger.warning(f"Agent for task {task_id} does not support resume functionality")
+            logger.warning(
+                f"Agent for task {task_id} does not support resume functionality"
+            )
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
@@ -3118,7 +3238,9 @@ async def handle_builder_chat(
 
     builder_tracer = create_ephemeral_tracer(
         task_id=builder_task_id,
-        websocket_handler=SharedWebSocketTracer(websocket, builder_task_id, is_preview=False),
+        websocket_handler=SharedWebSocketTracer(
+            websocket, builder_task_id, is_preview=False
+        ),
         user=user,
         is_preview=False,
     )
@@ -3233,14 +3355,18 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
             )
 
         if not llm:
-            default_llm, fast_llm, vision_llm, compact_llm = resolver.get_configured_defaults(
-                user_id=user.id  # type: ignore[arg-type]
+            default_llm, fast_llm, vision_llm, compact_llm = (
+                resolver.get_configured_defaults(
+                    user_id=user.id  # type: ignore[arg-type]
+                )
             )
             llm = default_llm
 
         if not llm:
             await websocket.send_text(
-                json.dumps({"type": "error", "message": "No LLM configured for builder chat"})
+                json.dumps(
+                    {"type": "error", "message": "No LLM configured for builder chat"}
+                )
             )
             return
 
@@ -3333,7 +3459,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
 
             # Save agent service to websocket state for reuse
             websocket.state.builder_agent_service = agent_service
-            logger.info(f"Created new builder chat agent service with task_id: {builder_task_id}")
+            logger.info(
+                f"Created new builder chat agent service with task_id: {builder_task_id}"
+            )
         else:
             agent_service = websocket.state.builder_agent_service
             # Update tracer to the new connection
@@ -3343,7 +3471,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                 websocket.state.builder_chat_history = []
             if not hasattr(websocket.state, "builder_memory"):
                 websocket.state.builder_memory = InMemoryMemoryStore()
-            if hasattr(agent_service, "agent") and hasattr(agent_service.agent, "patterns"):
+            if hasattr(agent_service, "agent") and hasattr(
+                agent_service.agent, "patterns"
+            ):
                 for pattern in agent_service.agent.patterns:
                     if hasattr(pattern, "tracer"):
                         pattern.tracer = builder_tracer
@@ -3362,7 +3492,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
             if hasattr(websocket.state, "builder_chat_history") and hasattr(
                 agent_service, "set_conversation_history"
             ):
-                agent_service.set_conversation_history(websocket.state.builder_chat_history)
+                agent_service.set_conversation_history(
+                    websocket.state.builder_chat_history
+                )
 
             # Execute task with the agent
             with UserContext(int(user.id)):
@@ -3407,7 +3539,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                         )
                         output_content = f"```json\n{structured_content}\n```"
                     except Exception as e:
-                        logger.warning(f"Failed to serialize chat_response for history: {e}")
+                        logger.warning(
+                            f"Failed to serialize chat_response for history: {e}"
+                        )
 
                 if output_content:
                     websocket.state.builder_chat_history.append(
@@ -3423,7 +3557,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                     )
 
                 # Keep history size manageable (e.g. last 20 messages)
-                websocket.state.builder_chat_history = websocket.state.builder_chat_history[-20:]
+                websocket.state.builder_chat_history = (
+                    websocket.state.builder_chat_history[-20:]
+                )
 
             # Send task_completed event to match the preview flow behavior
             # which relies on Trace events but might need a final completion indicator
@@ -3432,7 +3568,9 @@ If the user wants to add skills, tool categories, or knowledge bases but you are
                 # so the frontend can receive the structured data instead of trying to parse markdown
                 task_completion_result = {"content": result.get("output", "")}
                 if result.get("chat_response"):
-                    task_completion_result["chat_response"] = result.get("chat_response")
+                    task_completion_result["chat_response"] = result.get(
+                        "chat_response"
+                    )
 
                 await websocket.send_text(
                     json.dumps(
@@ -3497,7 +3635,9 @@ async def websocket_build_preview_endpoint(
                     hasattr(websocket.state, "preview_agent_service")
                     and websocket.state.preview_agent_service
                 ):
-                    if hasattr(websocket.state.preview_agent_service, "pause_execution"):
+                    if hasattr(
+                        websocket.state.preview_agent_service, "pause_execution"
+                    ):
                         await websocket.state.preview_agent_service.pause_execution()
                         await websocket.send_text(
                             json.dumps(
@@ -3522,7 +3662,9 @@ async def websocket_build_preview_endpoint(
                     hasattr(websocket.state, "preview_agent_service")
                     and websocket.state.preview_agent_service
                 ):
-                    if hasattr(websocket.state.preview_agent_service, "resume_execution"):
+                    if hasattr(
+                        websocket.state.preview_agent_service, "resume_execution"
+                    ):
                         await websocket.state.preview_agent_service.resume_execution()
                         await websocket.send_text(
                             json.dumps(
@@ -3615,7 +3757,9 @@ async def handle_build_preview_execution(
 
     preview_tracer = create_ephemeral_tracer(
         task_id=preview_task_id,
-        websocket_handler=SharedWebSocketTracer(websocket, preview_task_id, is_preview=True),
+        websocket_handler=SharedWebSocketTracer(
+            websocket, preview_task_id, is_preview=True
+        ),
         user=user,
         is_preview=True,
     )
@@ -3636,7 +3780,9 @@ async def handle_build_preview_execution(
 
             if models_config.get("general"):
                 general_model = (
-                    db.query(DBModel).filter(DBModel.id == models_config["general"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == models_config["general"])
+                    .first()
                 )
                 if general_model:
                     default_llm = storage.get_llm_by_name_with_access(
@@ -3645,7 +3791,9 @@ async def handle_build_preview_execution(
 
             if models_config.get("small_fast"):
                 fast_model = (
-                    db.query(DBModel).filter(DBModel.id == models_config["small_fast"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == models_config["small_fast"])
+                    .first()
                 )
                 if fast_model:
                     fast_llm = storage.get_llm_by_name_with_access(
@@ -3654,7 +3802,9 @@ async def handle_build_preview_execution(
 
             if models_config.get("visual"):
                 visual_model = (
-                    db.query(DBModel).filter(DBModel.id == models_config["visual"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == models_config["visual"])
+                    .first()
                 )
                 if visual_model:
                     vision_llm = storage.get_llm_by_name_with_access(
@@ -3663,7 +3813,9 @@ async def handle_build_preview_execution(
 
             if models_config.get("compact"):
                 compact_model = (
-                    db.query(DBModel).filter(DBModel.id == models_config["compact"]).first()
+                    db.query(DBModel)
+                    .filter(DBModel.id == models_config["compact"])
+                    .first()
                 )
                 if compact_model:
                     compact_llm = storage.get_llm_by_name_with_access(
@@ -3695,7 +3847,9 @@ async def handle_build_preview_execution(
         if sandbox_manager:
             user_id = int(user.id)
             try:
-                sandbox = await sandbox_manager.get_or_create_sandbox("user", str(user_id))
+                sandbox = await sandbox_manager.get_or_create_sandbox(
+                    "user", str(user_id)
+                )
             except Exception as e:
                 logger.error(f"Failed to create sandbox for user {user_id}: {e}")
 
@@ -3706,7 +3860,9 @@ async def handle_build_preview_execution(
             # Get all tools and filter by category using metadata
             from ...core.tools.adapters.vibe.factory import ToolFactory
 
-            has_mcp = bool(tool_categories and any(tc.startswith("mcp:") for tc in tool_categories))
+            has_mcp = bool(
+                tool_categories and any(tc.startswith("mcp:") for tc in tool_categories)
+            )
             temp_config = WebToolConfig(
                 db=db,
                 request=MinimalRequest(int(user.id)),
@@ -3727,7 +3883,8 @@ async def handle_build_preview_execution(
 
                 # Check if we also need custom APIs
                 has_custom_api = bool(
-                    tool_categories and any(tc.startswith("mcp:") for tc in tool_categories)
+                    tool_categories
+                    and any(tc.startswith("mcp:") for tc in tool_categories)
                 )
                 if has_custom_api:
                     # Manually add custom APIs since temp_config might not load them properly
@@ -3752,13 +3909,17 @@ async def handle_build_preview_execution(
                             for tc in tool_categories:
                                 if tc.startswith("mcp:"):
                                     server_name = (
-                                        tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
+                                        tc.split(":", 1)[1]
+                                        .replace(" ", "_")
+                                        .replace("-", "_")
                                     )
                                     logger.info(
                                         f"Checking MCP tool: '{tool_name}' vs 'mcp_{server_name}_'"
                                     )
                                     # Use case-insensitive matching for MCP server prefix
-                                    if tool_name.lower().startswith(f"mcp_{server_name.lower()}_"):
+                                    if tool_name.lower().startswith(
+                                        f"mcp_{server_name.lower()}_"
+                                    ):
                                         allowed_tools.append(tool_name)
                                         break
                         elif category == "other":
@@ -3766,13 +3927,18 @@ async def handle_build_preview_execution(
                             for tc in tool_categories:
                                 if tc.startswith("mcp:"):
                                     server_name = (
-                                        tc.split(":", 1)[1].replace(" ", "_").replace("-", "_")
+                                        tc.split(":", 1)[1]
+                                        .replace(" ", "_")
+                                        .replace("-", "_")
                                     )
                                     logger.info(
                                         f"Checking Custom API tool: '{tool_name}' vs 'api_{server_name}_call'"
                                     )
                                     # Custom APIs are now prefixed with api_ and suffixed with _call
-                                    if tool_name.lower() == f"api_{server_name.lower()}_call":
+                                    if (
+                                        tool_name.lower()
+                                        == f"api_{server_name.lower()}_call"
+                                    ):
                                         allowed_tools.append(tool_name)
                                         break
 
@@ -3787,7 +3953,9 @@ async def handle_build_preview_execution(
             llm=default_llm,
             user_id=int(user.id),
             is_admin=bool(user.is_admin),
-            allowed_collections=knowledge_bases if knowledge_bases is not None else None,
+            allowed_collections=knowledge_bases
+            if knowledge_bases is not None
+            else None,
             allowed_skills=skills if skills is not None else None,
             allowed_tools=allowed_tools,
             task_id=preview_task_id,
@@ -3805,7 +3973,9 @@ async def handle_build_preview_execution(
             from ..models.agent import Agent as AgentModel
             from ..models.agent import AgentStatus
 
-            preview_agent = db.query(AgentModel).filter(AgentModel.id == preview_agent_id).first()
+            preview_agent = (
+                db.query(AgentModel).filter(AgentModel.id == preview_agent_id).first()
+            )
             if preview_agent and preview_agent.status == AgentStatus.PUBLISHED:
                 tool_config._excluded_agent_id = int(preview_agent.id)
                 logger.info(
@@ -3876,11 +4046,15 @@ async def handle_build_preview_execution(
                 for file_info in files_data:
                     file_id = file_info.get("file_id")
                     if not file_id:
-                        logger.warning(f"No file_id provided in preview file info: {file_info}")
+                        logger.warning(
+                            f"No file_id provided in preview file info: {file_info}"
+                        )
                         continue
 
                     file_record = (
-                        db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+                        db.query(UploadedFile)
+                        .filter(UploadedFile.file_id == file_id)
+                        .first()
                     )
                     if not file_record:
                         logger.warning(f"File record not found for file_id: {file_id}")
@@ -3932,7 +4106,9 @@ async def handle_build_preview_execution(
                         )
 
                     except Exception as e:
-                        logger.error(f"Error handling file {file_info.get('name')}: {e}")
+                        logger.error(
+                            f"Error handling file {file_info.get('name')}: {e}"
+                        )
                         continue
 
                 if file_info_list:
@@ -3947,11 +4123,15 @@ async def handle_build_preview_execution(
                         f"{file_summary}"
                     )
 
-                logger.info(f"🎉 File upload completed, uploaded {len(uploaded_files)} files")
+                logger.info(
+                    f"🎉 File upload completed, uploaded {len(uploaded_files)} files"
+                )
                 db.commit()
 
             except Exception as e:
-                logger.error(f"Error handling file upload for build preview: {e}", exc_info=True)
+                logger.error(
+                    f"Error handling file upload for build preview: {e}", exc_info=True
+                )
                 await websocket.send_text(
                     json.dumps(
                         {
@@ -3995,9 +4175,13 @@ async def handle_build_preview_execution(
             )
 
         # Append the new interaction to the history
-        websocket.state.preview_history.append({"role": "user", "content": user_message})
+        websocket.state.preview_history.append(
+            {"role": "user", "content": user_message}
+        )
         assistant_output = result.get("output", "")
-        websocket.state.preview_history.append({"role": "assistant", "content": assistant_output})
+        websocket.state.preview_history.append(
+            {"role": "assistant", "content": assistant_output}
+        )
 
         # Send preview completion event
         await websocket.send_text(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -8,7 +8,7 @@ import unicodedata
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Dict, List, Optional, cast
 from urllib.parse import unquote
 
 from fastapi import (
@@ -32,7 +32,7 @@ from ...config import (
 from ...core.agent.trace import TraceEvent, TraceHandler
 from ..auth_dependencies import get_user_from_websocket_token
 from ..models.database import get_db
-from ..models.task import Task
+from ..models.task import Task, TaskStatus
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..services.chat_history_service import get_latest_waiting_question

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1085,6 +1085,13 @@ async def execute_v2_resume_background(
         db_lease = next(db_gen)
         try:
             lease = acquire_task_lease(db_lease, task_id)
+            if lease is not None:
+                task_for_sync = db_lease.query(Task).filter(Task.id == task_id).first()
+                if task_for_sync is not None:
+                    sync_workforce_run_status(
+                        db_lease, task_for_sync, TaskStatus.RUNNING
+                    )
+                    db_lease.commit()
         finally:
             db_lease.close()
         if lease is None:
@@ -1151,6 +1158,8 @@ async def execute_v2_resume_background(
                         db_new, task_id, status=TaskStatus.FAILED
                     )
                     db_new.refresh(task_updated)
+                sync_workforce_run_status(db_new, task_updated, task_updated.status)
+                db_new.commit()
                 final_status = task_updated.status.value
             else:
                 final_status = task.status.value

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
+
 from xagent.web.auth_dependencies import get_current_user
 from xagent.web.models.agent import Agent
 from xagent.web.models.database import get_db
@@ -145,7 +146,9 @@ def _serialize_worker(worker: WorkforceAgent) -> dict[str, Any]:
 
 
 def _serialize_workforce_detail(workforce: Workforce) -> dict[str, Any]:
-    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    workers = sorted(
+        workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0)
+    )
     return {
         "id": workforce.id,
         "name": workforce.name,
@@ -158,8 +161,12 @@ def _serialize_workforce_detail(workforce: Workforce) -> dict[str, Any]:
         "scope_type": workforce.scope_type,
         "scope_id": workforce.scope_id,
         "owner_user_id": workforce.owner_user_id,
-        "created_at": workforce.created_at.isoformat() if workforce.created_at else None,
-        "updated_at": workforce.updated_at.isoformat() if workforce.updated_at else None,
+        "created_at": workforce.created_at.isoformat()
+        if workforce.created_at
+        else None,
+        "updated_at": workforce.updated_at.isoformat()
+        if workforce.updated_at
+        else None,
     }
 
 
@@ -186,13 +193,19 @@ def _serialize_workforce_list_item(db: Session, workforce: Workforce) -> dict[st
                 "id": last_run.id,
                 "task_id": last_run.task_id,
                 "status": last_run.status,
-                "created_at": last_run.created_at.isoformat() if last_run.created_at else None,
+                "created_at": last_run.created_at.isoformat()
+                if last_run.created_at
+                else None,
             }
             if last_run
             else None
         ),
-        "created_at": workforce.created_at.isoformat() if workforce.created_at else None,
-        "updated_at": workforce.updated_at.isoformat() if workforce.updated_at else None,
+        "created_at": workforce.created_at.isoformat()
+        if workforce.created_at
+        else None,
+        "updated_at": workforce.updated_at.isoformat()
+        if workforce.updated_at
+        else None,
     }
 
 
@@ -214,7 +227,9 @@ def _check_duplicate_workforce_name(
         raise HTTPException(status_code=409, detail="Workforce name already exists")
 
 
-def _validate_worker_agent_ids(workers: list[WorkforceWorkerInput], manager_agent_id: int) -> None:
+def _validate_worker_agent_ids(
+    workers: list[WorkforceWorkerInput], manager_agent_id: int
+) -> None:
     seen_agent_ids: set[int] = set()
     for worker in workers:
         ensure_supported_source_type(worker.source_type)
@@ -222,9 +237,13 @@ def _validate_worker_agent_ids(workers: list[WorkforceWorkerInput], manager_agen
             if worker.agent_id is None:
                 raise HTTPException(status_code=400, detail="agent_id is required")
             if worker.agent_id == manager_agent_id:
-                raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+                raise HTTPException(
+                    status_code=400, detail="Manager agent cannot also be a worker"
+                )
             if worker.agent_id in seen_agent_ids:
-                raise HTTPException(status_code=409, detail="Duplicate worker agent in workforce")
+                raise HTTPException(
+                    status_code=409, detail="Duplicate worker agent in workforce"
+                )
             seen_agent_ids.add(worker.agent_id)
         elif worker.source_type == "template":
             if not worker.template_id:
@@ -234,12 +253,16 @@ def _validate_worker_agent_ids(workers: list[WorkforceWorkerInput], manager_agen
                 raise HTTPException(
                     status_code=400, detail="agent is required for source_type='new'"
                 )
-            new_agent_name = normalize_text(worker.agent.name, "agent.name", required=True)
+            new_agent_name = normalize_text(
+                worker.agent.name, "agent.name", required=True
+            )
             if new_agent_name is None:
                 raise HTTPException(status_code=400, detail="agent.name is required")
 
 
-def _ensure_can_activate(status: str, workforce: Workforce | None, workers: list[Any]) -> None:
+def _ensure_can_activate(
+    status: str, workforce: Workforce | None, workers: list[Any]
+) -> None:
     if status != "active":
         return
     enabled_count = 0
@@ -249,7 +272,8 @@ def _ensure_can_activate(status: str, workforce: Workforce | None, workers: list
         enabled_count = sum(1 for worker in workers if getattr(worker, "enabled", True))
     if enabled_count == 0:
         raise HTTPException(
-            status_code=400, detail="Active workforce requires at least one enabled worker"
+            status_code=400,
+            detail="Active workforce requires at least one enabled worker",
         )
 
 
@@ -290,18 +314,25 @@ async def list_workforces(
     query = db.query(Workforce)
     if search:
         query = query.filter(
-            or_(Workforce.name.ilike(f"%{search}%"), Workforce.description.ilike(f"%{search}%"))
+            or_(
+                Workforce.name.ilike(f"%{search}%"),
+                Workforce.description.ilike(f"%{search}%"),
+            )
         )
     if status:
         query = query.filter(Workforce.status == normalize_workforce_status(status))
 
     items = query.order_by(Workforce.updated_at.desc(), Workforce.id.desc()).all()
     if not user.is_admin:
-        items = [workforce for workforce in items if can_view_workforce(db, user, workforce)]
+        items = [
+            workforce for workforce in items if can_view_workforce(db, user, workforce)
+        ]
     total = len(items)
     paged_items = items[(page - 1) * size : (page - 1) * size + size]
     return {
-        "items": [_serialize_workforce_list_item(db, workforce) for workforce in paged_items],
+        "items": [
+            _serialize_workforce_list_item(db, workforce) for workforce in paged_items
+        ],
         "total": total,
         "page": page,
         "size": size,
@@ -336,8 +367,9 @@ async def create_workforce(
         user,
         db,
     )
+    manager_agent_id = cast(int, manager_agent.id)
     _check_duplicate_workforce_name(db, scope_type, scope_id, name)
-    _validate_worker_agent_ids(request.workers, manager_agent.id)
+    _validate_worker_agent_ids(request.workers, manager_agent_id)
     status = normalize_workforce_status(request.status)
     _ensure_can_activate(status, None, request.workers)
 
@@ -347,8 +379,10 @@ async def create_workforce(
         scope_id=scope_id,
         name=name,
         description=normalize_text(request.description, "description"),
-        manager_agent_id=manager_agent.id,
-        manager_instructions=normalize_text(request.manager_instructions, "manager_instructions"),
+        manager_agent_id=manager_agent_id,
+        manager_instructions=normalize_text(
+            request.manager_instructions, "manager_instructions"
+        ),
         status=status,
         canvas_layout=request.canvas_layout,
     )
@@ -395,6 +429,7 @@ async def update_workforce(
 ) -> dict[str, Any]:
     workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    workforce_row = cast(Any, workforce)
 
     if request.name is not None:
         name = normalize_text(request.name, "name", required=True)
@@ -408,30 +443,33 @@ async def update_workforce(
                 name,
                 cast(int, workforce.id),
             )
-            workforce.name = name
+            workforce_row.name = name
 
     if request.description is not None:
-        workforce.description = normalize_text(request.description, "description")
+        workforce_row.description = normalize_text(request.description, "description")
     if request.manager_instructions is not None:
-        workforce.manager_instructions = normalize_text(
+        workforce_row.manager_instructions = normalize_text(
             request.manager_instructions,
             "manager_instructions",
         )
     if request.canvas_layout is not None:
-        workforce.canvas_layout = request.canvas_layout
+        workforce_row.canvas_layout = request.canvas_layout
     if request.manager_agent_id is not None:
         manager_agent = ensure_agent_access(
             db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
             user,
             db,
         )
+        manager_agent_id = cast(int, manager_agent.id)
         if any(worker.agent_id == manager_agent.id for worker in workforce.workers):
-            raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
-        workforce.manager_agent_id = manager_agent.id
+            raise HTTPException(
+                status_code=400, detail="Manager agent cannot also be a worker"
+            )
+        workforce_row.manager_agent_id = manager_agent_id
     if request.status is not None:
         status = normalize_workforce_status(request.status)
         _ensure_can_activate(status, workforce, [])
-        workforce.status = status
+        workforce_row.status = status
 
     db.commit()
     db.refresh(workforce)
@@ -446,7 +484,8 @@ async def archive_workforce(
 ) -> dict[str, Any]:
     workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
-    workforce.status = "archived"
+    workforce_row = cast(Any, workforce)
+    workforce_row.status = "archived"
     db.commit()
     return {"id": workforce.id, "status": workforce.status}
 
@@ -481,16 +520,19 @@ async def update_workforce_agent(
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
     worker = (
         db.query(WorkforceAgent)
-        .filter(WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id)
+        .filter(
+            WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id
+        )
         .first()
     )
     if worker is None:
         raise HTTPException(status_code=404, detail="Workforce worker not found")
+    worker_row = cast(Any, worker)
 
     if request.alias is not None:
-        worker.alias = normalize_text(request.alias, "alias")
+        worker_row.alias = normalize_text(request.alias, "alias")
     if request.assignment_instructions is not None:
-        worker.assignment_instructions = (
+        worker_row.assignment_instructions = (
             normalize_text(
                 request.assignment_instructions,
                 "assignment_instructions",
@@ -499,11 +541,11 @@ async def update_workforce_agent(
             or ""
         )
     if request.enabled is not None:
-        worker.enabled = bool(request.enabled)
+        worker_row.enabled = bool(request.enabled)
     if request.sort_order is not None:
-        worker.sort_order = request.sort_order
+        worker_row.sort_order = request.sort_order
     if request.canvas_position is not None:
-        worker.canvas_position = request.canvas_position
+        worker_row.canvas_position = request.canvas_position
 
     _ensure_can_activate(cast(str, workforce.status), workforce, [])
     db.commit()
@@ -522,7 +564,9 @@ async def remove_workforce_agent(
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
     worker = (
         db.query(WorkforceAgent)
-        .filter(WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id)
+        .filter(
+            WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id
+        )
         .first()
     )
     if worker is None:
@@ -561,7 +605,9 @@ async def create_workforce_run(
         description=message,
         status=TaskStatus.PENDING,
         agent_id=workforce.manager_agent_id,
-        agent_config=build_workforce_task_config(snapshot, selected_file_ids=request.files),
+        agent_config=build_workforce_task_config(
+            snapshot, selected_file_ids=request.files
+        ),
         execution_mode=request.execution_mode
         or workforce.manager_agent.execution_mode
         or "balanced",
@@ -578,11 +624,12 @@ async def create_workforce_run(
     )
     db.add(workforce_run)
     db.flush()
+    workforce_run_id = cast(int, workforce_run.id)
 
     task.agent_config = build_workforce_task_config(
         snapshot,
         selected_file_ids=request.files,
-        workforce_run_id=cast(int, workforce_run.id),
+        workforce_run_id=workforce_run_id,
     )
     get_workforce_policy().after_workforce_run_created(
         db,
@@ -625,7 +672,9 @@ async def propose_workforce_changes(
             status="message",
         )
     )
-    assistant_message, patch = await generate_builder_patch(db, user, workforce, user_message)
+    assistant_message, patch = await generate_builder_patch(
+        db, user, workforce, user_message
+    )
     assistant_row = WorkforceBuilderMessage(
         workforce_id=workforce.id,
         user_id=user.id,
@@ -641,7 +690,7 @@ async def propose_workforce_changes(
     return {
         "message_id": assistant_row.id,
         "assistant_message": assistant_row.content,
-        "proposed_patch": assistant_row.proposed_patch,
+        "proposed_patch": cast(dict[str, Any], assistant_row.proposed_patch),
         "requires_confirmation": True,
     }
 
@@ -668,9 +717,13 @@ async def apply_workforce_changes(
     if message.role != "assistant":
         raise HTTPException(status_code=400, detail="Builder message is not applicable")
     if message.status != "proposed" or not isinstance(message.proposed_patch, dict):
-        raise HTTPException(status_code=400, detail="Builder message has no pending patch")
+        raise HTTPException(
+            status_code=400, detail="Builder message has no pending patch"
+        )
     if request.proposed_patch != message.proposed_patch:
-        raise HTTPException(status_code=400, detail="Proposed patch does not match message")
+        raise HTTPException(
+            status_code=400, detail="Proposed patch does not match message"
+        )
 
     workforce = apply_builder_patch(db, user, workforce, request.proposed_patch)
     message.status = "applied"
@@ -693,7 +746,9 @@ async def get_workforce_canvas(
 ) -> dict[str, Any]:
     workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
     workforce = ensure_workforce_access(db, user, workforce, action="view")
-    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    workers = sorted(
+        workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0)
+    )
 
     nodes = [
         {"id": "human", "type": "human", "label": "Human"},

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from xagent.web.auth_dependencies import get_current_user
-from xagent.web.models.agent import Agent
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import get_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
@@ -31,6 +31,7 @@ from ..services.workforce_builder import (
     list_builder_messages,
     serialize_builder_message,
 )
+from ..services.workforce_creator import generate_workforce_creation_plan
 from ..services.workforce_snapshot import (
     build_workforce_snapshot,
     build_workforce_task_config,
@@ -38,6 +39,7 @@ from ..services.workforce_snapshot import (
     normalize_workforce_status,
 )
 from ..services.workforce_workers import (
+    create_agent_record,
     create_workforce_worker,
     ensure_supported_source_type,
     list_template_summaries,
@@ -79,6 +81,10 @@ class WorkforceCreateRequest(BaseModel):
     status: str | None = "draft"
     canvas_layout: dict[str, Any] | None = None
     workers: list[WorkforceWorkerInput] = Field(default_factory=list)
+
+
+class WorkforcePromptCreateRequest(BaseModel):
+    prompt: str = Field(..., min_length=1)
 
 
 class WorkforceUpdateRequest(BaseModel):
@@ -226,6 +232,47 @@ def _check_duplicate_workforce_name(
         query = query.filter(Workforce.id != exclude_workforce_id)
     if query.first():
         raise HTTPException(status_code=409, detail="Workforce name already exists")
+
+
+def _resolve_unique_workforce_name(
+    db: Session,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    if normalized_name is None:
+        raise HTTPException(status_code=400, detail="name is required")
+    existing = (
+        db.query(Workforce)
+        .filter(
+            Workforce.scope_type == scope_type,
+            Workforce.scope_id == scope_id,
+            Workforce.name == normalized_name,
+        )
+        .first()
+    )
+    if existing is None:
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        conflict = (
+            db.query(Workforce)
+            .filter(
+                Workforce.scope_type == scope_type,
+                Workforce.scope_id == scope_id,
+                Workforce.name == candidate,
+            )
+            .first()
+        )
+        if conflict is None:
+            return candidate
+        suffix += 1
 
 
 def _validate_worker_agent_ids(
@@ -380,6 +427,96 @@ async def create_workforce(
 
     for worker_input in request.workers:
         _create_worker_row(db, workforce, worker_input, user)
+
+    db.commit()
+    db.refresh(workforce)
+    return _serialize_workforce_detail(workforce)
+
+
+@router.post("/from-prompt")
+async def create_workforce_from_prompt(
+    request: WorkforcePromptCreateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    prompt = normalize_text(request.prompt, "prompt", required=True)
+    if prompt is None:
+        raise HTTPException(status_code=400, detail="prompt is required")
+
+    scope_type, scope_id = resolve_create_scope(db, user)
+    if not can_create_workforce(db, user, scope_type, scope_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    plan = await generate_workforce_creation_plan(db, user, prompt)
+    name = _resolve_unique_workforce_name(db, scope_type, scope_id, str(plan["name"]))
+    manager_plan = cast(dict[str, Any], plan["manager"])
+    manager_agent = create_agent_record(
+        db,
+        user,
+        name=str(manager_plan.get("name") or f"{name} Manager"),
+        description=manager_plan.get("description"),
+        instructions=manager_plan.get("instructions"),
+        execution_mode="think",
+        ensure_unique_name=True,
+        status=AgentStatus.PUBLISHED,
+    )
+
+    workforce = Workforce(
+        owner_user_id=user.id,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        name=name,
+        description=normalize_text(plan.get("description"), "description"),
+        manager_agent_id=cast(int, manager_agent.id),
+        manager_instructions=normalize_text(
+            plan.get("manager_instructions"), "manager_instructions"
+        ),
+        status="draft",
+    )
+    db.add(workforce)
+    db.flush()
+
+    for index, worker in enumerate(
+        cast(list[dict[str, Any]], plan.get("workers") or [])
+    ):
+        _create_worker_row(
+            db,
+            workforce,
+            WorkforceWorkerInput(
+                source_type="existing",
+                agent_id=cast(int, worker["agent_id"]),
+                alias=cast(str | None, worker.get("alias")),
+                assignment_instructions=str(worker["assignment_instructions"]),
+                enabled=bool(worker.get("enabled", True)),
+                sort_order=index + 1,
+            ),
+            user,
+        )
+
+    db.add(
+        WorkforceBuilderMessage(
+            workforce_id=workforce.id,
+            user_id=user.id,
+            role="user",
+            content=prompt,
+            status="message",
+        )
+    )
+    warnings = cast(list[str], plan.get("warnings") or [])
+    assistant_content = "Created an initial Workforce draft from your prompt."
+    if warnings:
+        assistant_content = f"{assistant_content}\n\n" + "\n".join(
+            f"- {warning}" for warning in warnings
+        )
+    db.add(
+        WorkforceBuilderMessage(
+            workforce_id=workforce.id,
+            user_id=user.id,
+            role="assistant",
+            content=assistant_content,
+            status="message",
+        )
+    )
 
     db.commit()
     db.refresh(workforce)

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -1,0 +1,735 @@
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+from xagent.web.auth_dependencies import get_current_user
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import get_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+
+from ..models.workforce import (
+    Workforce,
+    WorkforceAgent,
+    WorkforceBuilderMessage,
+    WorkforceRun,
+)
+from ..services.workforce_access import (
+    can_create_workforce,
+    can_view_workforce,
+    ensure_agent_access,
+    ensure_workforce_access,
+    get_workforce_policy,
+    resolve_create_scope,
+)
+from ..services.workforce_builder import (
+    apply_builder_patch,
+    generate_builder_patch,
+    list_builder_messages,
+    serialize_builder_message,
+)
+from ..services.workforce_snapshot import (
+    build_workforce_snapshot,
+    build_workforce_task_config,
+    normalize_text,
+    normalize_workforce_status,
+)
+from ..services.workforce_workers import (
+    create_workforce_worker,
+    ensure_supported_source_type,
+    list_template_summaries,
+)
+
+router = APIRouter(prefix="/api/workforces", tags=["workforces"])
+
+
+class WorkforceNewAgentInput(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    instructions: str | None = None
+    execution_mode: str | None = "balanced"
+    models: dict[str, Any] | None = None
+    knowledge_bases: list[str] = Field(default_factory=list)
+    skills: list[str] = Field(default_factory=list)
+    tool_categories: list[str] = Field(default_factory=list)
+    suggested_prompts: list[str] = Field(default_factory=list)
+
+
+class WorkforceWorkerInput(BaseModel):
+    source_type: str = Field(default="existing")
+    agent_id: int | None = None
+    alias: str | None = None
+    assignment_instructions: str = Field(..., min_length=1)
+    template_id: str | None = None
+    agent: WorkforceNewAgentInput | None = None
+    enabled: bool = True
+    sort_order: int | None = None
+    canvas_position: dict[str, Any] | None = None
+
+
+class WorkforceCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    manager_agent_id: int
+    manager_instructions: str | None = None
+    status: str | None = "draft"
+    canvas_layout: dict[str, Any] | None = None
+    workers: list[WorkforceWorkerInput] = Field(default_factory=list)
+
+
+class WorkforceUpdateRequest(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=200)
+    description: str | None = None
+    manager_agent_id: int | None = None
+    manager_instructions: str | None = None
+    status: str | None = None
+    canvas_layout: dict[str, Any] | None = None
+
+
+class WorkforceWorkerUpdateRequest(BaseModel):
+    alias: str | None = None
+    assignment_instructions: str | None = None
+    enabled: bool | None = None
+    sort_order: int | None = None
+    canvas_position: dict[str, Any] | None = None
+
+
+class WorkforceRunRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+    files: list[str] = Field(default_factory=list)
+    execution_mode: str | None = None
+
+
+class WorkforceBuilderProposeRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+    context: dict[str, Any] | None = None
+
+
+class WorkforceBuilderApplyRequest(BaseModel):
+    message_id: int
+    proposed_patch: dict[str, Any]
+
+
+def _agent_status_value(agent: Agent) -> str:
+    status = getattr(agent, "status", None)
+    value = getattr(status, "value", None)
+    if isinstance(value, str):
+        return value
+    return str(status or "")
+
+
+def _serialize_agent(agent: Agent) -> dict[str, Any]:
+    return {
+        "id": agent.id,
+        "name": agent.name,
+        "description": agent.description,
+        "logo_url": agent.logo_url,
+        "status": _agent_status_value(agent),
+    }
+
+
+def _serialize_worker(worker: WorkforceAgent) -> dict[str, Any]:
+    return {
+        "id": worker.id,
+        "agent": _serialize_agent(worker.agent),
+        "alias": worker.alias,
+        "assignment_instructions": worker.assignment_instructions,
+        "source_type": worker.source_type,
+        "template_id": worker.template_id,
+        "enabled": worker.enabled,
+        "sort_order": worker.sort_order,
+        "canvas_position": worker.canvas_position,
+    }
+
+
+def _serialize_workforce_detail(workforce: Workforce) -> dict[str, Any]:
+    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    return {
+        "id": workforce.id,
+        "name": workforce.name,
+        "description": workforce.description,
+        "status": workforce.status,
+        "manager": _serialize_agent(workforce.manager_agent),
+        "manager_instructions": workforce.manager_instructions,
+        "workers": [_serialize_worker(worker) for worker in workers],
+        "canvas_layout": workforce.canvas_layout,
+        "scope_type": workforce.scope_type,
+        "scope_id": workforce.scope_id,
+        "owner_user_id": workforce.owner_user_id,
+        "created_at": workforce.created_at.isoformat() if workforce.created_at else None,
+        "updated_at": workforce.updated_at.isoformat() if workforce.updated_at else None,
+    }
+
+
+def _serialize_workforce_list_item(db: Session, workforce: Workforce) -> dict[str, Any]:
+    last_run = (
+        db.query(WorkforceRun)
+        .filter(WorkforceRun.workforce_id == workforce.id)
+        .order_by(WorkforceRun.created_at.desc(), WorkforceRun.id.desc())
+        .first()
+    )
+    return {
+        "id": workforce.id,
+        "name": workforce.name,
+        "description": workforce.description,
+        "status": workforce.status,
+        "manager": {
+            "id": workforce.manager_agent.id,
+            "name": workforce.manager_agent.name,
+            "logo_url": workforce.manager_agent.logo_url,
+        },
+        "worker_count": len(workforce.workers),
+        "last_run": (
+            {
+                "id": last_run.id,
+                "task_id": last_run.task_id,
+                "status": last_run.status,
+                "created_at": last_run.created_at.isoformat() if last_run.created_at else None,
+            }
+            if last_run
+            else None
+        ),
+        "created_at": workforce.created_at.isoformat() if workforce.created_at else None,
+        "updated_at": workforce.updated_at.isoformat() if workforce.updated_at else None,
+    }
+
+
+def _check_duplicate_workforce_name(
+    db: Session,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+    exclude_workforce_id: int | None = None,
+) -> None:
+    query = db.query(Workforce).filter(
+        Workforce.scope_type == scope_type,
+        Workforce.scope_id == scope_id,
+        Workforce.name == name,
+    )
+    if exclude_workforce_id is not None:
+        query = query.filter(Workforce.id != exclude_workforce_id)
+    if query.first():
+        raise HTTPException(status_code=409, detail="Workforce name already exists")
+
+
+def _validate_worker_agent_ids(workers: list[WorkforceWorkerInput], manager_agent_id: int) -> None:
+    seen_agent_ids: set[int] = set()
+    for worker in workers:
+        ensure_supported_source_type(worker.source_type)
+        if worker.source_type == "existing":
+            if worker.agent_id is None:
+                raise HTTPException(status_code=400, detail="agent_id is required")
+            if worker.agent_id == manager_agent_id:
+                raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+            if worker.agent_id in seen_agent_ids:
+                raise HTTPException(status_code=409, detail="Duplicate worker agent in workforce")
+            seen_agent_ids.add(worker.agent_id)
+        elif worker.source_type == "template":
+            if not worker.template_id:
+                raise HTTPException(status_code=400, detail="template_id is required")
+        elif worker.source_type == "new":
+            if worker.agent is None:
+                raise HTTPException(
+                    status_code=400, detail="agent is required for source_type='new'"
+                )
+            new_agent_name = normalize_text(worker.agent.name, "agent.name", required=True)
+            if new_agent_name is None:
+                raise HTTPException(status_code=400, detail="agent.name is required")
+
+
+def _ensure_can_activate(status: str, workforce: Workforce | None, workers: list[Any]) -> None:
+    if status != "active":
+        return
+    enabled_count = 0
+    if workforce is not None:
+        enabled_count = sum(1 for worker in workforce.workers if worker.enabled)
+    else:
+        enabled_count = sum(1 for worker in workers if getattr(worker, "enabled", True))
+    if enabled_count == 0:
+        raise HTTPException(
+            status_code=400, detail="Active workforce requires at least one enabled worker"
+        )
+
+
+def _create_worker_row(
+    db: Session,
+    workforce: Workforce,
+    worker_input: WorkforceWorkerInput,
+    user: User,
+) -> WorkforceAgent:
+    return create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type=worker_input.source_type,
+        assignment_instructions=worker_input.assignment_instructions,
+        alias=worker_input.alias,
+        agent_id=worker_input.agent_id,
+        template_id=worker_input.template_id,
+        agent_payload=worker_input.agent.model_dump() if worker_input.agent else None,
+        enabled=worker_input.enabled,
+        sort_order=worker_input.sort_order,
+        canvas_position=worker_input.canvas_position,
+    )
+
+
+@router.get("")
+async def list_workforces(
+    search: str = "",
+    page: int = 1,
+    size: int = 20,
+    status: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    if page < 1 or size < 1 or size > 100:
+        raise HTTPException(status_code=400, detail="Invalid pagination parameters")
+
+    query = db.query(Workforce)
+    if search:
+        query = query.filter(
+            or_(Workforce.name.ilike(f"%{search}%"), Workforce.description.ilike(f"%{search}%"))
+        )
+    if status:
+        query = query.filter(Workforce.status == normalize_workforce_status(status))
+
+    items = query.order_by(Workforce.updated_at.desc(), Workforce.id.desc()).all()
+    if not user.is_admin:
+        items = [workforce for workforce in items if can_view_workforce(db, user, workforce)]
+    total = len(items)
+    paged_items = items[(page - 1) * size : (page - 1) * size + size]
+    return {
+        "items": [_serialize_workforce_list_item(db, workforce) for workforce in paged_items],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": (total + size - 1) // size,
+    }
+
+
+@router.get("/templates")
+async def list_workforce_templates(
+    user: User = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    _ = user
+    return list_template_summaries()
+
+
+@router.post("")
+async def create_workforce(
+    request: WorkforceCreateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    name = normalize_text(request.name, "name", required=True)
+    if name is None:
+        raise HTTPException(status_code=400, detail="name is required")
+
+    scope_type, scope_id = resolve_create_scope(db, user)
+    if not can_create_workforce(db, user, scope_type, scope_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    manager_agent = ensure_agent_access(
+        db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
+        user,
+        db,
+    )
+    _check_duplicate_workforce_name(db, scope_type, scope_id, name)
+    _validate_worker_agent_ids(request.workers, manager_agent.id)
+    status = normalize_workforce_status(request.status)
+    _ensure_can_activate(status, None, request.workers)
+
+    workforce = Workforce(
+        owner_user_id=user.id,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        name=name,
+        description=normalize_text(request.description, "description"),
+        manager_agent_id=manager_agent.id,
+        manager_instructions=normalize_text(request.manager_instructions, "manager_instructions"),
+        status=status,
+        canvas_layout=request.canvas_layout,
+    )
+    db.add(workforce)
+    db.flush()
+
+    for worker_input in request.workers:
+        _create_worker_row(db, workforce, worker_input, user)
+
+    db.commit()
+    db.refresh(workforce)
+    return _serialize_workforce_detail(workforce)
+
+
+@router.get("/{workforce_id}")
+async def get_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="view")
+    return _serialize_workforce_detail(workforce)
+
+
+@router.get("/{workforce_id}/builder/messages")
+async def get_workforce_builder_messages(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="view")
+    messages = list_builder_messages(db, cast(int, workforce.id))
+    return {"items": [serialize_builder_message(message) for message in messages]}
+
+
+@router.patch("/{workforce_id}")
+async def update_workforce(
+    workforce_id: int,
+    request: WorkforceUpdateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+
+    if request.name is not None:
+        name = normalize_text(request.name, "name", required=True)
+        if name is None:
+            raise HTTPException(status_code=400, detail="name is required")
+        if name != workforce.name:
+            _check_duplicate_workforce_name(
+                db,
+                cast(str, workforce.scope_type),
+                cast(str, workforce.scope_id),
+                name,
+                cast(int, workforce.id),
+            )
+            workforce.name = name
+
+    if request.description is not None:
+        workforce.description = normalize_text(request.description, "description")
+    if request.manager_instructions is not None:
+        workforce.manager_instructions = normalize_text(
+            request.manager_instructions,
+            "manager_instructions",
+        )
+    if request.canvas_layout is not None:
+        workforce.canvas_layout = request.canvas_layout
+    if request.manager_agent_id is not None:
+        manager_agent = ensure_agent_access(
+            db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
+            user,
+            db,
+        )
+        if any(worker.agent_id == manager_agent.id for worker in workforce.workers):
+            raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+        workforce.manager_agent_id = manager_agent.id
+    if request.status is not None:
+        status = normalize_workforce_status(request.status)
+        _ensure_can_activate(status, workforce, [])
+        workforce.status = status
+
+    db.commit()
+    db.refresh(workforce)
+    return _serialize_workforce_detail(workforce)
+
+
+@router.delete("/{workforce_id}")
+async def archive_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    workforce.status = "archived"
+    db.commit()
+    return {"id": workforce.id, "status": workforce.status}
+
+
+@router.post("/{workforce_id}/agents")
+async def add_workforce_agent(
+    workforce_id: int,
+    request: WorkforceWorkerInput,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    worker = _create_worker_row(db, workforce, request, user)
+    workforce_status = cast(str, workforce.status)
+    if workforce_status == "active" and not worker.enabled:
+        _ensure_can_activate(workforce_status, workforce, [])
+    db.commit()
+    db.refresh(worker)
+    return _serialize_worker(worker)
+
+
+@router.patch("/{workforce_id}/agents/{member_id}")
+async def update_workforce_agent(
+    workforce_id: int,
+    member_id: int,
+    request: WorkforceWorkerUpdateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id)
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+
+    if request.alias is not None:
+        worker.alias = normalize_text(request.alias, "alias")
+    if request.assignment_instructions is not None:
+        worker.assignment_instructions = (
+            normalize_text(
+                request.assignment_instructions,
+                "assignment_instructions",
+                required=True,
+            )
+            or ""
+        )
+    if request.enabled is not None:
+        worker.enabled = bool(request.enabled)
+    if request.sort_order is not None:
+        worker.sort_order = request.sort_order
+    if request.canvas_position is not None:
+        worker.canvas_position = request.canvas_position
+
+    _ensure_can_activate(cast(str, workforce.status), workforce, [])
+    db.commit()
+    db.refresh(worker)
+    return _serialize_worker(worker)
+
+
+@router.delete("/{workforce_id}/agents/{member_id}")
+async def remove_workforce_agent(
+    workforce_id: int,
+    member_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(WorkforceAgent.id == member_id, WorkforceAgent.workforce_id == workforce.id)
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+
+    db.delete(worker)
+    db.flush()
+    _ensure_can_activate(cast(str, workforce.status), workforce, [])
+    db.commit()
+    return {"status": "deleted"}
+
+
+@router.post("/{workforce_id}/runs")
+async def create_workforce_run(
+    workforce_id: int,
+    request: WorkforceRunRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="run")
+    get_workforce_policy().before_workforce_run(db, user, workforce)
+
+    snapshot = build_workforce_snapshot(db, user, workforce)
+    message = normalize_text(request.message, "message", required=True)
+    if message is None:
+        raise HTTPException(status_code=400, detail="message is required")
+
+    task_title = f"{workforce.name}: {message}"
+    if len(task_title) > 50:
+        task_title = task_title[:50] + "..."
+
+    task = Task(
+        user_id=user.id,
+        title=task_title,
+        description=message,
+        status=TaskStatus.PENDING,
+        agent_id=workforce.manager_agent_id,
+        agent_config=build_workforce_task_config(snapshot, selected_file_ids=request.files),
+        execution_mode=request.execution_mode
+        or workforce.manager_agent.execution_mode
+        or "balanced",
+    )
+    db.add(task)
+    db.flush()
+
+    workforce_run = WorkforceRun(
+        workforce_id=workforce.id,
+        task_id=task.id,
+        user_id=user.id,
+        status="pending",
+        snapshot=snapshot,
+    )
+    db.add(workforce_run)
+    db.flush()
+
+    task.agent_config = build_workforce_task_config(
+        snapshot,
+        selected_file_ids=request.files,
+        workforce_run_id=cast(int, workforce_run.id),
+    )
+    get_workforce_policy().after_workforce_run_created(
+        db,
+        user,
+        workforce,
+        workforce_run,
+        task,
+    )
+    db.commit()
+    db.refresh(workforce_run)
+    db.refresh(task)
+
+    return {
+        "workforce_run_id": workforce_run.id,
+        "task_id": task.id,
+        "status": workforce_run.status,
+        "redirect_url": f"/task/{task.id}",
+    }
+
+
+@router.post("/{workforce_id}/builder/propose")
+async def propose_workforce_changes(
+    workforce_id: int,
+    request: WorkforceBuilderProposeRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    user_message = normalize_text(request.message, "message", required=True)
+    if user_message is None:
+        raise HTTPException(status_code=400, detail="message is required")
+
+    db.add(
+        WorkforceBuilderMessage(
+            workforce_id=workforce.id,
+            user_id=user.id,
+            role="user",
+            content=user_message,
+            status="message",
+        )
+    )
+    assistant_message, patch = await generate_builder_patch(db, user, workforce, user_message)
+    assistant_row = WorkforceBuilderMessage(
+        workforce_id=workforce.id,
+        user_id=user.id,
+        role="assistant",
+        content=assistant_message,
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db.add(assistant_row)
+    db.commit()
+    db.refresh(assistant_row)
+
+    return {
+        "message_id": assistant_row.id,
+        "assistant_message": assistant_row.content,
+        "proposed_patch": assistant_row.proposed_patch,
+        "requires_confirmation": True,
+    }
+
+
+@router.post("/{workforce_id}/builder/apply")
+async def apply_workforce_changes(
+    workforce_id: int,
+    request: WorkforceBuilderApplyRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    message = (
+        db.query(WorkforceBuilderMessage)
+        .filter(
+            WorkforceBuilderMessage.id == request.message_id,
+            WorkforceBuilderMessage.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if message is None:
+        raise HTTPException(status_code=404, detail="Builder message not found")
+    if message.role != "assistant":
+        raise HTTPException(status_code=400, detail="Builder message is not applicable")
+    if message.status != "proposed" or not isinstance(message.proposed_patch, dict):
+        raise HTTPException(status_code=400, detail="Builder message has no pending patch")
+    if request.proposed_patch != message.proposed_patch:
+        raise HTTPException(status_code=400, detail="Proposed patch does not match message")
+
+    workforce = apply_builder_patch(db, user, workforce, request.proposed_patch)
+    message.status = "applied"
+    message.proposed_patch = request.proposed_patch
+    db.commit()
+    db.refresh(workforce)
+    db.refresh(message)
+    return {
+        "status": "applied",
+        "message_id": message.id,
+        "workforce": _serialize_workforce_detail(workforce),
+    }
+
+
+@router.get("/{workforce_id}/canvas")
+async def get_workforce_canvas(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="view")
+    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+
+    nodes = [
+        {"id": "human", "type": "human", "label": "Human"},
+        {
+            "id": f"manager-{workforce.manager_agent.id}",
+            "type": "manager",
+            "agent_id": workforce.manager_agent.id,
+            "label": workforce.manager_agent.name,
+        },
+    ]
+    edges = [
+        {
+            "id": "human-manager",
+            "source": "human",
+            "target": f"manager-{workforce.manager_agent.id}",
+        }
+    ]
+
+    for worker in workers:
+        label = worker.alias or worker.agent.name
+        nodes.append(
+            {
+                "id": f"worker-{worker.id}",
+                "type": "worker",
+                "agent_id": worker.agent_id,
+                "label": label,
+                "position": worker.canvas_position,
+                "enabled": worker.enabled,
+            }
+        )
+        edges.append(
+            {
+                "id": f"manager-worker-{worker.id}",
+                "source": f"manager-{workforce.manager_agent.id}",
+                "target": f"worker-{worker.id}",
+            }
+        )
+
+    return {"nodes": nodes, "edges": edges, "layout": workforce.canvas_layout or {}}

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -41,6 +41,7 @@ from ..services.workforce_workers import (
     create_workforce_worker,
     ensure_supported_source_type,
     list_template_summaries,
+    normalize_execution_mode,
 )
 
 router = APIRouter(prefix="/api/workforces", tags=["workforces"])
@@ -600,6 +601,10 @@ async def create_workforce_run(
     if len(task_title) > 50:
         task_title = task_title[:50] + "..."
 
+    execution_mode = normalize_execution_mode(
+        request.execution_mode or workforce.manager_agent.execution_mode or "balanced"
+    )
+
     task = Task(
         user_id=user.id,
         title=task_title,
@@ -609,9 +614,7 @@ async def create_workforce_run(
         agent_config=build_workforce_task_config(
             snapshot, selected_file_ids=request.files
         ),
-        execution_mode=request.execution_mode
-        or workforce.manager_agent.execution_mode
-        or "balanced",
+        execution_mode=execution_mode,
     )
     db.add(task)
     db.flush()

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -574,6 +574,7 @@ async def remove_workforce_agent(
 
     db.delete(worker)
     db.flush()
+    db.expire(workforce, ["workers"])
     _ensure_can_activate(cast(str, workforce.status), workforce, [])
     db.commit()
     return {"status": "deleted"}

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -312,6 +312,30 @@ def _ensure_can_activate(
         )
 
 
+def _set_workforce_status(
+    db: Session,
+    user: User,
+    workforce_id: int,
+    status: str,
+) -> Workforce:
+    workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    current_status = cast(str, workforce.status)
+    if current_status == "archived":
+        raise HTTPException(
+            status_code=409,
+            detail="Archived workforce cannot change publish state",
+        )
+
+    normalized_status = normalize_workforce_status(status)
+    _ensure_can_activate(normalized_status, workforce, [])
+    workforce_row = cast(Any, workforce)
+    workforce_row.status = normalized_status
+    db.commit()
+    db.refresh(workforce)
+    return workforce
+
+
 def _create_worker_row(
     db: Session,
     workforce: Workforce,
@@ -531,6 +555,26 @@ async def get_workforce(
 ) -> dict[str, Any]:
     workforce = db.query(Workforce).filter(Workforce.id == workforce_id).first()
     workforce = ensure_workforce_access(db, user, workforce, action="view")
+    return _serialize_workforce_detail(workforce)
+
+
+@router.post("/{workforce_id}/publish")
+async def publish_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = _set_workforce_status(db, user, workforce_id, "active")
+    return _serialize_workforce_detail(workforce)
+
+
+@router.post("/{workforce_id}/unpublish")
+async def unpublish_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = _set_workforce_status(db, user, workforce_id, "draft")
     return _serialize_workforce_detail(workforce)
 
 

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -246,19 +246,6 @@ def _validate_worker_agent_ids(
                     status_code=409, detail="Duplicate worker agent in workforce"
                 )
             seen_agent_ids.add(worker.agent_id)
-        elif worker.source_type == "template":
-            if not worker.template_id:
-                raise HTTPException(status_code=400, detail="template_id is required")
-        elif worker.source_type == "new":
-            if worker.agent is None:
-                raise HTTPException(
-                    status_code=400, detail="agent is required for source_type='new'"
-                )
-            new_agent_name = normalize_text(
-                worker.agent.name, "agent.name", required=True
-            )
-            if new_agent_name is None:
-                raise HTTPException(status_code=400, detail="agent.name is required")
 
 
 def _ensure_can_activate(
@@ -367,6 +354,7 @@ async def create_workforce(
         db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
         user,
         db,
+        require_published=True,
     )
     manager_agent_id = cast(int, manager_agent.id)
     _check_duplicate_workforce_name(db, scope_type, scope_id, name)
@@ -460,6 +448,7 @@ async def update_workforce(
             db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
             user,
             db,
+            require_published=True,
         )
         manager_agent_id = cast(int, manager_agent.id)
         if any(worker.agent_id == manager_agent.id for worker in workforce.workers):

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ...core.agent.trace import (
     TraceAction,
@@ -18,6 +18,14 @@ from .websocket import create_stream_event, manager
 # Helper function to map new event types to old-style handling for compatibility
 def get_event_type_mapping(event: TraceEvent) -> str:
     """Map new trace event types to old-style string identifiers for compatibility."""
+    data_event_type = event.data.get("event_type") if isinstance(event.data, dict) else None
+    if data_event_type in {
+        "workforce_delegation_start",
+        "workforce_delegation_end",
+        "workforce_delegation_error",
+    }:
+        return str(data_event_type)
+
     scope = event.event_type.scope
     action = event.event_type.action
     category = event.event_type.category
@@ -35,47 +43,23 @@ def get_event_type_mapping(event: TraceEvent) -> str:
         and category == TraceCategory.DAG_PLAN
     ):
         return "dag_plan_end"
-    elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.START
-        and category == TraceCategory.DAG
-    ):
+    elif scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.DAG:
         return "dag_execute_start"
     elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.UPDATE
-        and category == TraceCategory.DAG
+        scope == TraceScope.TASK and action == TraceAction.UPDATE and category == TraceCategory.DAG
     ):
         return "dag_execution"
-    elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.END
-        and category == TraceCategory.DAG
-    ):
+    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.DAG:
         return "dag_execute_end"
-    elif (
-        scope == TraceScope.STEP
-        and action == TraceAction.START
-        and category == TraceCategory.DAG
-    ):
+    elif scope == TraceScope.STEP and action == TraceAction.START and category == TraceCategory.DAG:
         return "dag_step_start"
-    elif (
-        scope == TraceScope.STEP
-        and action == TraceAction.END
-        and category == TraceCategory.DAG
-    ):
+    elif scope == TraceScope.STEP and action == TraceAction.END and category == TraceCategory.DAG:
         return "dag_step_end"
     elif (
-        scope == TraceScope.ACTION
-        and action == TraceAction.START
-        and category == TraceCategory.LLM
+        scope == TraceScope.ACTION and action == TraceAction.START and category == TraceCategory.LLM
     ):
         return "llm_call_start"
-    elif (
-        scope == TraceScope.ACTION
-        and action == TraceAction.END
-        and category == TraceCategory.LLM
-    ):
+    elif scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.LLM:
         return "llm_call_end"
     elif (
         scope == TraceScope.ACTION
@@ -90,9 +74,7 @@ def get_event_type_mapping(event: TraceEvent) -> str:
     ):
         return "tool_execution_start"
     elif (
-        scope == TraceScope.ACTION
-        and action == TraceAction.END
-        and category == TraceCategory.TOOL
+        scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.TOOL
     ):
         return "tool_execution_end"
     elif (
@@ -132,54 +114,32 @@ def get_event_type_mapping(event: TraceEvent) -> str:
         )
         return "user_message"
     elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.END
-        and category == TraceCategory.MESSAGE
+        scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.MESSAGE
     ):
         return "ai_message"
     elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.END
-        and category == TraceCategory.GENERAL
+        scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.GENERAL
     ):
         return "task_completion"
     # Skill selection events
     elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.START
-        and category == TraceCategory.SKILL
+        scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.SKILL
     ):
         return "skill_select_start"
-    elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.END
-        and category == TraceCategory.SKILL
-    ):
+    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.SKILL:
         return "skill_select_end"
     # ReAct pattern events (for BUILD phase)
     elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.START
-        and category == TraceCategory.REACT
+        scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.REACT
     ):
         return "react_task_start"
-    elif (
-        scope == TraceScope.TASK
-        and action == TraceAction.END
-        and category == TraceCategory.REACT
-    ):
+    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.REACT:
         return "react_task_end"
     elif (
-        scope == TraceScope.STEP
-        and action == TraceAction.START
-        and category == TraceCategory.REACT
+        scope == TraceScope.STEP and action == TraceAction.START and category == TraceCategory.REACT
     ):
         return "react_step_start"
-    elif (
-        scope == TraceScope.STEP
-        and action == TraceAction.END
-        and category == TraceCategory.REACT
-    ):
+    elif scope == TraceScope.STEP and action == TraceAction.END and category == TraceCategory.REACT:
         return "react_step_end"
     elif (
         scope == TraceScope.ACTION
@@ -188,9 +148,7 @@ def get_event_type_mapping(event: TraceEvent) -> str:
     ):
         return "react_action_start"
     elif (
-        scope == TraceScope.ACTION
-        and action == TraceAction.END
-        and category == TraceCategory.REACT
+        scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.REACT
     ):
         return "react_action_end"
     else:
@@ -240,7 +198,7 @@ class WebSocketTraceHandler(TraceHandler):
 
     def __init__(self, task_id: int):
         self.task_id = task_id
-        self._task_description: Optional[str] = None
+        self._task_description: str | None = None
         self._task_description_loaded = False
 
     async def handle_event(self, event: TraceEvent) -> None:
@@ -269,9 +227,7 @@ class WebSocketTraceHandler(TraceHandler):
                 )
 
         except Exception as e:
-            logger.warning(
-                f"Failed to send trace event to WebSocket for task {self.task_id}: {e}"
-            )
+            logger.warning(f"Failed to send trace event to WebSocket for task {self.task_id}: {e}")
 
     async def _load_task_description(self) -> None:
         """Load task description from database."""
@@ -282,9 +238,7 @@ class WebSocketTraceHandler(TraceHandler):
             # Run synchronous database operations in a thread pool to avoid blocking event loop
             await asyncio.to_thread(self._sync_load_task_description)
         except Exception as e:
-            logger.warning(
-                f"Failed to load task description for task {self.task_id}: {e}"
-            )
+            logger.warning(f"Failed to load task description for task {self.task_id}: {e}")
 
         self._task_description_loaded = True
 
@@ -301,9 +255,7 @@ class WebSocketTraceHandler(TraceHandler):
         try:
             task = db.query(Task).filter(Task.id == self.task_id).first()
             if task:
-                self._task_description = (
-                    str(task.description) if task.description else None
-                )
+                self._task_description = str(task.description) if task.description else None
                 logger.info(
                     f"Loaded task description for task {self.task_id}: {task.description[:50]}..."
                 )
@@ -312,9 +264,7 @@ class WebSocketTraceHandler(TraceHandler):
         finally:
             db.close()
 
-    def _convert_trace_event_to_stream_event(
-        self, event: TraceEvent
-    ) -> Optional[Dict[str, Any]]:
+    def _convert_trace_event_to_stream_event(self, event: TraceEvent) -> dict[str, Any]:
         """Convert trace event to unified stream format."""
         event_type_str = get_event_type_mapping(event)
         logger.debug(
@@ -327,9 +277,7 @@ class WebSocketTraceHandler(TraceHandler):
             return None
 
         # Create the base stream event
-        stream_event = create_stream_event(
-            event_type_str, self.task_id, data, event.timestamp
-        )
+        stream_event = create_stream_event(event_type_str, self.task_id, data, event.timestamp)
 
         # Add step_id if present (required for tool/LLM events)
         if event.step_id:
@@ -345,7 +293,7 @@ class WebSocketTraceHandler(TraceHandler):
 
         return stream_event
 
-    def _serialize_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _serialize_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively serialize data to ensure JSON compatibility."""
         import json
         from datetime import datetime
@@ -359,9 +307,7 @@ class WebSocketTraceHandler(TraceHandler):
             cleaned = value.replace("\x00", "")  # Remove NULL character
             cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
             # Remove other control characters that might cause issues
-            cleaned = "".join(
-                char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
-            )
+            cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\n\r\t")
             return cleaned
 
         def serialize_value(value: Any) -> Any:
@@ -399,9 +345,7 @@ class WebSocketTraceHandler(TraceHandler):
             return cleaned_data  # type: ignore[no-any-return]
         except (TypeError, ValueError) as e:
             # If still not serializable, return a safe fallback
-            logger.warning(
-                f"Failed to serialize data for JSON: {e}, data type: {type(data)}"
-            )
+            logger.warning(f"Failed to serialize data for JSON: {e}, data type: {type(data)}")
             return {
                 "_serialization_error": f"Failed to serialize {type(data).__name__}",
                 "_original_type": type(data).__name__,

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -322,7 +322,9 @@ class WebSocketTraceHandler(TraceHandler):
         finally:
             db.close()
 
-    def _convert_trace_event_to_stream_event(self, event: TraceEvent) -> dict[str, Any]:
+    def _convert_trace_event_to_stream_event(
+        self, event: TraceEvent
+    ) -> dict[str, Any] | None:
         """Convert trace event to unified stream format."""
         event_type_str = get_event_type_mapping(event)
         logger.debug(

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -18,7 +18,9 @@ from .websocket import create_stream_event, manager
 # Helper function to map new event types to old-style handling for compatibility
 def get_event_type_mapping(event: TraceEvent) -> str:
     """Map new trace event types to old-style string identifiers for compatibility."""
-    data_event_type = event.data.get("event_type") if isinstance(event.data, dict) else None
+    data_event_type = (
+        event.data.get("event_type") if isinstance(event.data, dict) else None
+    )
     if data_event_type in {
         "workforce_delegation_start",
         "workforce_delegation_end",
@@ -43,23 +45,47 @@ def get_event_type_mapping(event: TraceEvent) -> str:
         and category == TraceCategory.DAG_PLAN
     ):
         return "dag_plan_end"
-    elif scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.DAG:
+    elif (
+        scope == TraceScope.TASK
+        and action == TraceAction.START
+        and category == TraceCategory.DAG
+    ):
         return "dag_execute_start"
     elif (
-        scope == TraceScope.TASK and action == TraceAction.UPDATE and category == TraceCategory.DAG
+        scope == TraceScope.TASK
+        and action == TraceAction.UPDATE
+        and category == TraceCategory.DAG
     ):
         return "dag_execution"
-    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.DAG:
+    elif (
+        scope == TraceScope.TASK
+        and action == TraceAction.END
+        and category == TraceCategory.DAG
+    ):
         return "dag_execute_end"
-    elif scope == TraceScope.STEP and action == TraceAction.START and category == TraceCategory.DAG:
+    elif (
+        scope == TraceScope.STEP
+        and action == TraceAction.START
+        and category == TraceCategory.DAG
+    ):
         return "dag_step_start"
-    elif scope == TraceScope.STEP and action == TraceAction.END and category == TraceCategory.DAG:
+    elif (
+        scope == TraceScope.STEP
+        and action == TraceAction.END
+        and category == TraceCategory.DAG
+    ):
         return "dag_step_end"
     elif (
-        scope == TraceScope.ACTION and action == TraceAction.START and category == TraceCategory.LLM
+        scope == TraceScope.ACTION
+        and action == TraceAction.START
+        and category == TraceCategory.LLM
     ):
         return "llm_call_start"
-    elif scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.LLM:
+    elif (
+        scope == TraceScope.ACTION
+        and action == TraceAction.END
+        and category == TraceCategory.LLM
+    ):
         return "llm_call_end"
     elif (
         scope == TraceScope.ACTION
@@ -74,7 +100,9 @@ def get_event_type_mapping(event: TraceEvent) -> str:
     ):
         return "tool_execution_start"
     elif (
-        scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.TOOL
+        scope == TraceScope.ACTION
+        and action == TraceAction.END
+        and category == TraceCategory.TOOL
     ):
         return "tool_execution_end"
     elif (
@@ -114,32 +142,54 @@ def get_event_type_mapping(event: TraceEvent) -> str:
         )
         return "user_message"
     elif (
-        scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.MESSAGE
+        scope == TraceScope.TASK
+        and action == TraceAction.END
+        and category == TraceCategory.MESSAGE
     ):
         return "ai_message"
     elif (
-        scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.GENERAL
+        scope == TraceScope.TASK
+        and action == TraceAction.END
+        and category == TraceCategory.GENERAL
     ):
         return "task_completion"
     # Skill selection events
     elif (
-        scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.SKILL
+        scope == TraceScope.TASK
+        and action == TraceAction.START
+        and category == TraceCategory.SKILL
     ):
         return "skill_select_start"
-    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.SKILL:
+    elif (
+        scope == TraceScope.TASK
+        and action == TraceAction.END
+        and category == TraceCategory.SKILL
+    ):
         return "skill_select_end"
     # ReAct pattern events (for BUILD phase)
     elif (
-        scope == TraceScope.TASK and action == TraceAction.START and category == TraceCategory.REACT
+        scope == TraceScope.TASK
+        and action == TraceAction.START
+        and category == TraceCategory.REACT
     ):
         return "react_task_start"
-    elif scope == TraceScope.TASK and action == TraceAction.END and category == TraceCategory.REACT:
+    elif (
+        scope == TraceScope.TASK
+        and action == TraceAction.END
+        and category == TraceCategory.REACT
+    ):
         return "react_task_end"
     elif (
-        scope == TraceScope.STEP and action == TraceAction.START and category == TraceCategory.REACT
+        scope == TraceScope.STEP
+        and action == TraceAction.START
+        and category == TraceCategory.REACT
     ):
         return "react_step_start"
-    elif scope == TraceScope.STEP and action == TraceAction.END and category == TraceCategory.REACT:
+    elif (
+        scope == TraceScope.STEP
+        and action == TraceAction.END
+        and category == TraceCategory.REACT
+    ):
         return "react_step_end"
     elif (
         scope == TraceScope.ACTION
@@ -148,7 +198,9 @@ def get_event_type_mapping(event: TraceEvent) -> str:
     ):
         return "react_action_start"
     elif (
-        scope == TraceScope.ACTION and action == TraceAction.END and category == TraceCategory.REACT
+        scope == TraceScope.ACTION
+        and action == TraceAction.END
+        and category == TraceCategory.REACT
     ):
         return "react_action_end"
     else:
@@ -227,7 +279,9 @@ class WebSocketTraceHandler(TraceHandler):
                 )
 
         except Exception as e:
-            logger.warning(f"Failed to send trace event to WebSocket for task {self.task_id}: {e}")
+            logger.warning(
+                f"Failed to send trace event to WebSocket for task {self.task_id}: {e}"
+            )
 
     async def _load_task_description(self) -> None:
         """Load task description from database."""
@@ -238,7 +292,9 @@ class WebSocketTraceHandler(TraceHandler):
             # Run synchronous database operations in a thread pool to avoid blocking event loop
             await asyncio.to_thread(self._sync_load_task_description)
         except Exception as e:
-            logger.warning(f"Failed to load task description for task {self.task_id}: {e}")
+            logger.warning(
+                f"Failed to load task description for task {self.task_id}: {e}"
+            )
 
         self._task_description_loaded = True
 
@@ -255,7 +311,9 @@ class WebSocketTraceHandler(TraceHandler):
         try:
             task = db.query(Task).filter(Task.id == self.task_id).first()
             if task:
-                self._task_description = str(task.description) if task.description else None
+                self._task_description = (
+                    str(task.description) if task.description else None
+                )
                 logger.info(
                     f"Loaded task description for task {self.task_id}: {task.description[:50]}..."
                 )
@@ -277,7 +335,9 @@ class WebSocketTraceHandler(TraceHandler):
             return None
 
         # Create the base stream event
-        stream_event = create_stream_event(event_type_str, self.task_id, data, event.timestamp)
+        stream_event = create_stream_event(
+            event_type_str, self.task_id, data, event.timestamp
+        )
 
         # Add step_id if present (required for tool/LLM events)
         if event.step_id:
@@ -307,7 +367,9 @@ class WebSocketTraceHandler(TraceHandler):
             cleaned = value.replace("\x00", "")  # Remove NULL character
             cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
             # Remove other control characters that might cause issues
-            cleaned = "".join(char for char in cleaned if ord(char) >= 32 or char in "\n\r\t")
+            cleaned = "".join(
+                char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
+            )
             return cleaned
 
         def serialize_value(value: Any) -> Any:
@@ -345,7 +407,9 @@ class WebSocketTraceHandler(TraceHandler):
             return cleaned_data  # type: ignore[no-any-return]
         except (TypeError, ValueError) as e:
             # If still not serializable, return a safe fallback
-            logger.warning(f"Failed to serialize data for JSON: {e}, data type: {type(data)}")
+            logger.warning(
+                f"Failed to serialize data for JSON: {e}, data type: {type(data)}"
+            )
             return {
                 "_serialization_error": f"Failed to serialize {type(data).__name__}",
                 "_original_type": type(data).__name__,

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -34,6 +34,7 @@ from .api.text2sql import text2sql_router
 from .api.tools import tools_router
 from .api.websocket import ws_router
 from .api.widget import widget_router
+from .api.workforces import router as workforces_router
 from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
@@ -53,9 +54,7 @@ uploads_dir.mkdir(parents=True, exist_ok=True)
 
 
 # FastAPI app creation here
-app = FastAPI(
-    title="xagent", description="The Agent Operating System", redirect_slashes=False
-)
+app = FastAPI(title="xagent", description="The Agent Operating System", redirect_slashes=False)
 
 # Track background migration task for graceful shutdown cleanup.
 _migration_task: asyncio.Task[None] | None = None
@@ -165,6 +164,7 @@ app.include_router(skills_router)
 app.include_router(system_router)
 app.include_router(templates_router)
 app.include_router(agents_router)
+app.include_router(workforces_router)
 app.include_router(channel_router, prefix="/api/channels", tags=["Channels"])
 app.include_router(widget_router)
 
@@ -186,9 +186,7 @@ async def startup_event() -> None:
     skill_manager = create_skill_manager()
     await skill_manager.initialize()
     app.state.skill_manager = skill_manager
-    logger.info(
-        f"Skill manager initialized with {len(await skill_manager.list_skills())} skills"
-    )
+    logger.info(f"Skill manager initialized with {len(await skill_manager.list_skills())} skills")
 
     # Initialize template manager
     from ..templates.utils import create_template_manager
@@ -212,9 +210,7 @@ async def startup_event() -> None:
     else:
         logger.info("Using in-memory store (no vector search capabilities)")
 
-    logger.info(
-        f"Memory store similarity threshold: {store_info['similarity_threshold']}"
-    )
+    logger.info(f"Memory store similarity threshold: {store_info['similarity_threshold']}")
 
     # Auto-migrate LanceDB tables if needed (for multi-tenancy support)
     # Controlled by LANCEDB_AUTO_MIGRATE environment variable (default: true)
@@ -299,9 +295,7 @@ async def startup_event() -> None:
 
                         # Log any skipped records
                         chunks_skipped = result.get("chunks", {}).get("skipped", 0)
-                        embeddings_skipped = result.get("embeddings", {}).get(
-                            "skipped", 0
-                        )
+                        embeddings_skipped = result.get("embeddings", {}).get("skipped", 0)
                         if chunks_skipped > 0 or embeddings_skipped > 0:
                             logger.warning(
                                 "Some records were skipped (no matching document): chunks=%s, embeddings=%s",
@@ -355,9 +349,7 @@ async def startup_event() -> None:
 
                 fix_result = fix_file_id_nullable(dry_run=False, conn=conn)
                 if fix_result.get("fixed"):
-                    logger.info(
-                        "Auto-fixed file_id column to nullable in documents table"
-                    )
+                    logger.info("Auto-fixed file_id column to nullable in documents table")
             except Exception as e:
                 logger.warning("Could not fix file_id nullability: %s", e)
 
@@ -375,16 +367,12 @@ async def startup_event() -> None:
 
                 # Check for empty string file_id values
                 empty_file_id_count = len(
-                    query_to_list(
-                        documents_table.search().where("file_id = ''").limit(1)
-                    )
+                    query_to_list(documents_table.search().where("file_id = ''").limit(1))
                 )
 
                 # Check for NULL user_id values
                 null_user_id_count = len(
-                    query_to_list(
-                        documents_table.search().where("user_id IS NULL").limit(1)
-                    )
+                    query_to_list(documents_table.search().where("user_id IS NULL").limit(1))
                 )
 
                 if empty_file_id_count > 0 or null_user_id_count > 0:
@@ -402,9 +390,7 @@ async def startup_event() -> None:
                         )
 
                         try:
-                            result = await asyncio.to_thread(
-                                backfill_all, dry_run=False, conn=conn
-                            )
+                            result = await asyncio.to_thread(backfill_all, dry_run=False, conn=conn)
                             logger.info("=" * 60)
                             logger.info("DOCUMENTS TABLE BACKFILL COMPLETED")
                             logger.info("=" * 60)
@@ -444,9 +430,7 @@ async def startup_event() -> None:
                             )
 
                     # Start background task
-                    _migration_task = asyncio.create_task(
-                        run_documents_backfill_background()
-                    )
+                    _migration_task = asyncio.create_task(run_documents_backfill_background())
                 else:
                     logger.info("Documents table backfill not needed")
             except Exception as e:
@@ -456,8 +440,7 @@ async def startup_event() -> None:
                 _safe_close_table(documents_table)
         except Exception as e:
             logger.warning(
-                "Could not check documents table backfill status: %s. "
-                "Application will continue.",
+                "Could not check documents table backfill status: %s. Application will continue.",
                 e,
             )
 
@@ -480,9 +463,7 @@ async def startup_event() -> None:
                 logger.warning("Collection metadata rebuild failed: %s", e)
 
     if not os.getenv("PYTEST_CURRENT_TEST"):
-        app.state.metadata_rebuild_task = asyncio.create_task(
-            run_metadata_rebuild_background()
-        )
+        app.state.metadata_rebuild_task = asyncio.create_task(run_metadata_rebuild_background())
         logger.info(
             "Started background collection metadata rebuild task (interval=%sh)",
             os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"),

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -54,7 +54,9 @@ uploads_dir.mkdir(parents=True, exist_ok=True)
 
 
 # FastAPI app creation here
-app = FastAPI(title="xagent", description="The Agent Operating System", redirect_slashes=False)
+app = FastAPI(
+    title="xagent", description="The Agent Operating System", redirect_slashes=False
+)
 
 # Track background migration task for graceful shutdown cleanup.
 _migration_task: asyncio.Task[None] | None = None
@@ -186,7 +188,9 @@ async def startup_event() -> None:
     skill_manager = create_skill_manager()
     await skill_manager.initialize()
     app.state.skill_manager = skill_manager
-    logger.info(f"Skill manager initialized with {len(await skill_manager.list_skills())} skills")
+    logger.info(
+        f"Skill manager initialized with {len(await skill_manager.list_skills())} skills"
+    )
 
     # Initialize template manager
     from ..templates.utils import create_template_manager
@@ -210,7 +214,9 @@ async def startup_event() -> None:
     else:
         logger.info("Using in-memory store (no vector search capabilities)")
 
-    logger.info(f"Memory store similarity threshold: {store_info['similarity_threshold']}")
+    logger.info(
+        f"Memory store similarity threshold: {store_info['similarity_threshold']}"
+    )
 
     # Auto-migrate LanceDB tables if needed (for multi-tenancy support)
     # Controlled by LANCEDB_AUTO_MIGRATE environment variable (default: true)
@@ -295,7 +301,9 @@ async def startup_event() -> None:
 
                         # Log any skipped records
                         chunks_skipped = result.get("chunks", {}).get("skipped", 0)
-                        embeddings_skipped = result.get("embeddings", {}).get("skipped", 0)
+                        embeddings_skipped = result.get("embeddings", {}).get(
+                            "skipped", 0
+                        )
                         if chunks_skipped > 0 or embeddings_skipped > 0:
                             logger.warning(
                                 "Some records were skipped (no matching document): chunks=%s, embeddings=%s",
@@ -349,7 +357,9 @@ async def startup_event() -> None:
 
                 fix_result = fix_file_id_nullable(dry_run=False, conn=conn)
                 if fix_result.get("fixed"):
-                    logger.info("Auto-fixed file_id column to nullable in documents table")
+                    logger.info(
+                        "Auto-fixed file_id column to nullable in documents table"
+                    )
             except Exception as e:
                 logger.warning("Could not fix file_id nullability: %s", e)
 
@@ -367,12 +377,16 @@ async def startup_event() -> None:
 
                 # Check for empty string file_id values
                 empty_file_id_count = len(
-                    query_to_list(documents_table.search().where("file_id = ''").limit(1))
+                    query_to_list(
+                        documents_table.search().where("file_id = ''").limit(1)
+                    )
                 )
 
                 # Check for NULL user_id values
                 null_user_id_count = len(
-                    query_to_list(documents_table.search().where("user_id IS NULL").limit(1))
+                    query_to_list(
+                        documents_table.search().where("user_id IS NULL").limit(1)
+                    )
                 )
 
                 if empty_file_id_count > 0 or null_user_id_count > 0:
@@ -390,7 +404,9 @@ async def startup_event() -> None:
                         )
 
                         try:
-                            result = await asyncio.to_thread(backfill_all, dry_run=False, conn=conn)
+                            result = await asyncio.to_thread(
+                                backfill_all, dry_run=False, conn=conn
+                            )
                             logger.info("=" * 60)
                             logger.info("DOCUMENTS TABLE BACKFILL COMPLETED")
                             logger.info("=" * 60)
@@ -430,7 +446,9 @@ async def startup_event() -> None:
                             )
 
                     # Start background task
-                    _migration_task = asyncio.create_task(run_documents_backfill_background())
+                    _migration_task = asyncio.create_task(
+                        run_documents_backfill_background()
+                    )
                 else:
                     logger.info("Documents table backfill not needed")
             except Exception as e:
@@ -463,7 +481,9 @@ async def startup_event() -> None:
                 logger.warning("Collection metadata rebuild failed: %s", e)
 
     if not os.getenv("PYTEST_CURRENT_TEST"):
-        app.state.metadata_rebuild_task = asyncio.create_task(run_metadata_rebuild_background())
+        app.state.metadata_rebuild_task = asyncio.create_task(
+            run_metadata_rebuild_background()
+        )
         logger.info(
             "Started background collection metadata rebuild task (interval=%sh)",
             os.getenv("XAGENT_METADATA_REBUILD_INTERVAL_HOURS", "6"),

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -16,6 +16,7 @@ from .uploaded_file import UploadedFile
 from .user import User, UserDefaultModel, UserModel
 from .user_channel import UserChannel
 from .user_oauth import UserOAuth
+from .workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage, WorkforceRun
 
 __all__ = [
     "Base",
@@ -46,4 +47,8 @@ __all__ = [
     "SandboxSnapshot",
     "OAuthProvider",
     "PublicMCPApp",
+    "Workforce",
+    "WorkforceAgent",
+    "WorkforceRun",
+    "WorkforceBuilderMessage",
 ]

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -58,6 +59,10 @@ def init_db(db_url: str | None = None) -> None:
         User,
         UserDefaultModel,
         UserModel,
+        Workforce,
+        WorkforceAgent,
+        WorkforceBuilderMessage,
+        WorkforceRun,
     )
     from .agent import Agent  # noqa: F401
     from .sandbox import SandboxInfo, SandboxSnapshot  # noqa: F401

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from .database import Base
@@ -111,7 +111,11 @@ class Task(Base):  # type: ignore
     agent_type = Column(
         String(20), default=AgentType.STANDARD.value, nullable=True
     )  # SQLite compatible
-    agent_config = Column(JSON, nullable=True)  # Agent-specific configuration
+    agent_config: Mapped[dict[str, Any] | None] = (
+        mapped_column(  # Agent-specific configuration
+            JSON, nullable=True
+        )
+    )
 
     # Execution mode configuration
     execution_mode = Column(

--- a/src/xagent/web/models/workforce.py
+++ b/src/xagent/web/models/workforce.py
@@ -1,0 +1,120 @@
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from xagent.web.models.database import Base
+
+
+class Workforce(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforces"
+    __table_args__ = (
+        UniqueConstraint("scope_type", "scope_id", "name", name="uq_workforce_scope_name"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    owner_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scope_type = Column(String(50), nullable=False, default="user", index=True)
+    scope_id = Column(String(200), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    description = Column(Text, nullable=True)
+    manager_agent_id = Column(
+        Integer, ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    manager_instructions = Column(Text, nullable=True)
+    status = Column(String(20), nullable=False, default="draft", index=True)
+    canvas_layout = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    owner = relationship("User", foreign_keys=[owner_user_id])
+    manager_agent = relationship("Agent", foreign_keys=[manager_agent_id])
+    workers = relationship(
+        "WorkforceAgent",
+        back_populates="workforce",
+        cascade="all, delete-orphan",
+    )
+    runs = relationship("WorkforceRun", back_populates="workforce")
+    builder_messages = relationship(
+        "WorkforceBuilderMessage",
+        back_populates="workforce",
+        cascade="all, delete-orphan",
+    )
+
+
+class WorkforceAgent(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_agents"
+    __table_args__ = (UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    agent_id = Column(
+        Integer, ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    alias = Column(String(200), nullable=True)
+    assignment_instructions = Column(Text, nullable=False)
+    source_type = Column(String(20), nullable=False, default="existing")
+    template_id = Column(String(200), nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+    sort_order = Column(Integer, nullable=False, default=0)
+    canvas_position = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    workforce = relationship("Workforce", back_populates="workers")
+    agent = relationship("Agent", foreign_keys=[agent_id])
+
+
+class WorkforceRun(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    task_id = Column(
+        Integer, ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True, unique=True
+    )
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status = Column(String(20), nullable=False, default="pending", index=True)
+    snapshot = Column(JSON, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    workforce = relationship("Workforce", back_populates="runs")
+    task = relationship("Task")
+    user = relationship("User", foreign_keys=[user_id])
+
+
+class WorkforceBuilderMessage(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_builder_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    role = Column(String(20), nullable=False)
+    content = Column(Text, nullable=False)
+    proposed_patch = Column(JSON, nullable=True)
+    status = Column(String(20), nullable=False, default="message")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    workforce = relationship("Workforce", back_populates="builder_messages")
+    user = relationship("User", foreign_keys=[user_id])

--- a/src/xagent/web/models/workforce.py
+++ b/src/xagent/web/models/workforce.py
@@ -11,13 +11,16 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from xagent.web.models.database import Base
 
 
 class Workforce(Base):  # type: ignore[no-any-unimported]
     __tablename__ = "workforces"
     __table_args__ = (
-        UniqueConstraint("scope_type", "scope_id", "name", name="uq_workforce_scope_name"),
+        UniqueConstraint(
+            "scope_type", "scope_id", "name", name="uq_workforce_scope_name"
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -29,13 +32,18 @@ class Workforce(Base):  # type: ignore[no-any-unimported]
     name = Column(String(200), nullable=False)
     description = Column(Text, nullable=True)
     manager_agent_id = Column(
-        Integer, ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False, index=True
+        Integer,
+        ForeignKey("agents.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
     )
     manager_instructions = Column(Text, nullable=True)
     status = Column(String(20), nullable=False, default="draft", index=True)
     canvas_layout = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
     owner = relationship("User", foreign_keys=[owner_user_id])
     manager_agent = relationship("Agent", foreign_keys=[manager_agent_id])
@@ -54,14 +62,22 @@ class Workforce(Base):  # type: ignore[no-any-unimported]
 
 class WorkforceAgent(Base):  # type: ignore[no-any-unimported]
     __tablename__ = "workforce_agents"
-    __table_args__ = (UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),)
+    __table_args__ = (
+        UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     workforce_id = Column(
-        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     agent_id = Column(
-        Integer, ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False, index=True
+        Integer,
+        ForeignKey("agents.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
     )
     alias = Column(String(200), nullable=True)
     assignment_instructions = Column(Text, nullable=False)
@@ -71,7 +87,9 @@ class WorkforceAgent(Base):  # type: ignore[no-any-unimported]
     sort_order = Column(Integer, nullable=False, default=0)
     canvas_position = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
     workforce = relationship("Workforce", back_populates="workers")
     agent = relationship("Agent", foreign_keys=[agent_id])
@@ -82,7 +100,10 @@ class WorkforceRun(Base):  # type: ignore[no-any-unimported]
 
     id = Column(Integer, primary_key=True, index=True)
     workforce_id = Column(
-        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     task_id = Column(
         Integer, ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True, unique=True
@@ -105,7 +126,10 @@ class WorkforceBuilderMessage(Base):  # type: ignore[no-any-unimported]
 
     id = Column(Integer, primary_key=True, index=True)
     workforce_id = Column(
-        Integer, ForeignKey("workforces.id", ondelete="CASCADE"), nullable=False, index=True
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     user_id = Column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -151,13 +151,24 @@ def ensure_agent_access(
     user: User,
     db: Session,
     purpose: str = "workforce_select",
+    require_published: bool = False,
 ) -> Agent:
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
     if user.is_admin or int(agent.user_id) == int(user.id):
+        if require_published and agent.status != AgentStatus.PUBLISHED:
+            raise HTTPException(
+                status_code=400,
+                detail="Workforce agents must be published",
+            )
         return agent
     visible_agent_ids = get_visible_agent_ids(db, user, purpose)
     if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
+        if require_published and agent.status != AgentStatus.PUBLISHED:
+            raise HTTPException(
+                status_code=400,
+                detail="Workforce agents must be published",
+            )
         return agent
     raise HTTPException(status_code=403, detail="Access denied to agent")
 
@@ -167,9 +178,13 @@ def ensure_workforce_agent_run_access(
     user: User,
     db: Session,
 ) -> Agent:
-    """Allow Workforce runs to reference published or policy-visible agents."""
+    """Allow Workforce runs to reference only published accessible agents."""
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.status != AgentStatus.PUBLISHED:
+        raise HTTPException(
+            status_code=400, detail="Workforce agents must be published"
+        )
     if user.is_admin or int(agent.user_id) == int(user.id):
         return agent
     visible_agent_ids = get_visible_agent_ids(db, user, "workforce_run")

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -1,0 +1,177 @@
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce
+
+
+class WorkforcePolicy:
+    def resolve_create_scope(self, db: Session, user: User) -> tuple[str, str]:
+        del db
+        return ("user", str(user.id))
+
+    def can_create_workforce(
+        self,
+        db: Session,
+        user: User,
+        scope_type: str,
+        scope_id: str,
+    ) -> bool:
+        del db, scope_type, scope_id
+        return bool(user.id)
+
+    def can_view_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        del db
+        return bool(user.is_admin or int(workforce.owner_user_id) == int(user.id))
+
+    def can_run_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        return self.can_view_workforce(db, user, workforce)
+
+    def can_edit_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        del db
+        return bool(user.is_admin or int(workforce.owner_user_id) == int(user.id))
+
+    def get_visible_agent_ids(
+        self,
+        db: Session,
+        user: User,
+        purpose: str,
+    ) -> set[int] | None:
+        del db, user, purpose
+        return None
+
+    def before_workforce_run(self, db: Session, user: User, workforce: Workforce) -> None:
+        del db, user, workforce
+
+    def after_workforce_run_created(
+        self,
+        db: Session,
+        user: User,
+        workforce: Workforce,
+        run: Any,
+        task: Any,
+    ) -> None:
+        del db, user, workforce, run, task
+
+    def record_workforce_event(
+        self,
+        db: Session,
+        user: User,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        del db, user, event_type, payload
+
+
+_workforce_policy: WorkforcePolicy = WorkforcePolicy()
+
+
+def set_workforce_policy(policy: WorkforcePolicy) -> None:
+    global _workforce_policy
+    _workforce_policy = policy
+
+
+def get_workforce_policy() -> WorkforcePolicy:
+    return _workforce_policy
+
+
+def resolve_create_scope(db: Session, user: User) -> tuple[str, str]:
+    return get_workforce_policy().resolve_create_scope(db, user)
+
+
+def can_create_workforce(
+    db: Session,
+    user: User,
+    scope_type: str,
+    scope_id: str,
+) -> bool:
+    return get_workforce_policy().can_create_workforce(db, user, scope_type, scope_id)
+
+
+def _normalize_visible_agent_ids(values: Iterable[int] | None) -> set[int] | None:
+    if values is None:
+        return None
+    normalized: set[int] = set()
+    for value in values:
+        if isinstance(value, int):
+            normalized.add(value)
+    return normalized
+
+
+def get_visible_agent_ids(db: Session, user: User, purpose: str) -> set[int] | None:
+    visible_agent_ids = get_workforce_policy().get_visible_agent_ids(db, user, purpose)
+    return _normalize_visible_agent_ids(visible_agent_ids)
+
+
+def can_view_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_view_workforce(db, user, workforce)
+
+
+def can_run_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_run_workforce(db, user, workforce)
+
+
+def can_edit_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_edit_workforce(db, user, workforce)
+
+
+def ensure_workforce_access(
+    db: Session,
+    user: User,
+    workforce: Workforce | None,
+    action: str = "view",
+) -> Workforce:
+    if workforce is None:
+        raise HTTPException(status_code=404, detail="Workforce not found")
+
+    allowed = False
+    if action == "view":
+        allowed = can_view_workforce(db, user, workforce)
+    elif action == "run":
+        allowed = can_run_workforce(db, user, workforce)
+    elif action == "edit":
+        allowed = can_edit_workforce(db, user, workforce)
+    else:
+        raise ValueError(f"Unsupported workforce access action: {action}")
+
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Access denied")
+    return workforce
+
+
+def ensure_agent_access(
+    agent: Agent | None,
+    user: User,
+    db: Session,
+    purpose: str = "workforce_select",
+) -> Agent:
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if user.is_admin or int(agent.user_id) == int(user.id):
+        return agent
+    visible_agent_ids = get_visible_agent_ids(db, user, purpose)
+    if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
+        return agent
+    raise HTTPException(status_code=403, detail="Access denied to agent")
+
+
+def ensure_workforce_agent_run_access(
+    agent: Agent | None,
+    user: User,
+    db: Session,
+) -> Agent:
+    """Allow Workforce runs to reference published or policy-visible agents."""
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if user.is_admin or int(agent.user_id) == int(user.id):
+        return agent
+    visible_agent_ids = get_visible_agent_ids(db, user, "workforce_run")
+    if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
+        return agent
+    if agent.status == AgentStatus.PUBLISHED:
+        return agent
+    raise HTTPException(status_code=403, detail="Access denied to agent")

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -190,6 +190,4 @@ def ensure_workforce_agent_run_access(
     visible_agent_ids = get_visible_agent_ids(db, user, "workforce_run")
     if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
         return agent
-    if agent.status == AgentStatus.PUBLISHED:
-        return agent
     raise HTTPException(status_code=403, detail="Access denied to agent")

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
 
@@ -44,7 +45,9 @@ class WorkforcePolicy:
         del db, user, purpose
         return None
 
-    def before_workforce_run(self, db: Session, user: User, workforce: Workforce) -> None:
+    def before_workforce_run(
+        self, db: Session, user: User, workforce: Workforce
+    ) -> None:
         del db, user, workforce
 
     def after_workforce_run_created(

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -1,0 +1,712 @@
+import json
+import logging
+import os
+import re
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from xagent.web.models.agent import Agent
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import UserAwareModelStorage
+
+from ..models.workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage
+from .workforce_access import ensure_agent_access, ensure_workforce_access
+from .workforce_snapshot import (
+    normalize_text,
+    normalize_workforce_status,
+)
+from .workforce_workers import create_workforce_worker, list_template_summaries
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_BUILDER_OPS = {
+    "update_workforce",
+    "add_existing_worker",
+    "add_worker_from_template",
+    "create_worker_agent",
+    "update_worker",
+    "remove_worker",
+}
+
+PLACEHOLDER_PATCH_WARNING = (
+    "Could not confidently infer a structured change. "
+    "Please refine the instruction or edit manually."
+)
+
+
+def serialize_builder_message(message: WorkforceBuilderMessage) -> dict[str, Any]:
+    return {
+        "id": message.id,
+        "role": message.role,
+        "content": message.content,
+        "status": message.status,
+        "proposed_patch": message.proposed_patch,
+        "created_at": message.created_at.isoformat() if message.created_at else None,
+    }
+
+
+def list_builder_messages(db: Session, workforce_id: int) -> list[WorkforceBuilderMessage]:
+    return (
+        db.query(WorkforceBuilderMessage)
+        .filter(WorkforceBuilderMessage.workforce_id == workforce_id)
+        .order_by(WorkforceBuilderMessage.id.asc())
+        .all()
+    )
+
+
+def _serialize_workers_for_prompt(workforce: Workforce) -> list[dict[str, Any]]:
+    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    return [
+        {
+            "member_id": worker.id,
+            "agent_id": worker.agent_id,
+            "agent_name": worker.agent.name,
+            "alias": worker.alias,
+            "assignment_instructions": worker.assignment_instructions,
+            "enabled": worker.enabled,
+            "sort_order": worker.sort_order,
+        }
+        for worker in workers
+    ]
+
+
+def _make_builder_context(workforce: Workforce) -> dict[str, Any]:
+    return {
+        "workforce": {
+            "id": workforce.id,
+            "name": workforce.name,
+            "description": workforce.description,
+            "status": workforce.status,
+            "manager_agent_id": workforce.manager_agent_id,
+            "manager_agent_name": workforce.manager_agent.name if workforce.manager_agent else None,
+            "manager_instructions": workforce.manager_instructions,
+        },
+        "workers": _serialize_workers_for_prompt(workforce),
+    }
+
+
+def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
+    summary = str(candidate.get("summary") or "").strip() or "Update workforce configuration."
+    warnings = candidate.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    clean_warnings = [str(item).strip() for item in warnings if str(item).strip()]
+
+    operations = candidate.get("operations")
+    if not isinstance(operations, list):
+        operations = []
+
+    clean_operations: list[dict[str, Any]] = []
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        op_name = str(operation.get("op") or "").strip()
+        if op_name not in SUPPORTED_BUILDER_OPS:
+            continue
+        clean_operations.append(operation)
+
+    return {
+        "summary": summary,
+        "operations": clean_operations,
+        "warnings": clean_warnings,
+    }
+
+
+def _has_meaningful_operations(patch: dict[str, Any]) -> bool:
+    operations = patch.get("operations")
+    if not isinstance(operations, list) or not operations:
+        return False
+    if len(operations) != 1:
+        return True
+
+    only_operation = operations[0]
+    if only_operation.get("op") != "update_workforce":
+        return True
+
+    fields = only_operation.get("fields")
+    return isinstance(fields, dict) and bool(fields)
+
+
+def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str, Any]:
+    text = message.strip()
+    lower = text.lower()
+    operations: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    summary_parts: list[str] = []
+
+    quoted_texts = re.findall(r'"([^"]+)"', text)
+    workforce_name_target = quoted_texts[0].strip() if quoted_texts else None
+
+    rename_match = re.search(r"\brename\b|\brenamed\b|\bname it\b|\bcall it\b", lower)
+    if rename_match and workforce_name_target:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {"name": workforce_name_target},
+            }
+        )
+        summary_parts.append(f'Rename workforce to "{workforce_name_target}"')
+
+    if (
+        ("description" in lower or "desc" in lower)
+        and workforce_name_target
+        and len(quoted_texts) >= 2
+    ):
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {"description": quoted_texts[1].strip()},
+            }
+        )
+        summary_parts.append("Update workforce description")
+
+    manager_instructions_match = re.search(
+        r"(manager instructions?|manager prompt)\s*(?:to|as|=)?\s*\"([^\"]+)\"",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if manager_instructions_match:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {"manager_instructions": manager_instructions_match.group(2).strip()},
+            }
+        )
+        summary_parts.append("Update manager instructions")
+
+    remove_match = re.search(r"\bremove\b\s+([a-zA-Z0-9 _-]+)", text, flags=re.IGNORECASE)
+    if remove_match:
+        raw_target = remove_match.group(1).strip().rstrip(".")
+        matched_worker = _find_worker_by_name(workforce, raw_target)
+        if matched_worker is not None:
+            operations.append({"op": "remove_worker", "member_id": matched_worker.id})
+            warnings.append(
+                f'Removing worker "{matched_worker.alias or matched_worker.agent.name}".'
+            )
+            summary_parts.append(
+                f'Remove worker "{matched_worker.alias or matched_worker.agent.name}"'
+            )
+
+    update_match = re.search(
+        (
+            r"(?:make|update|change)\s+([a-zA-Z0-9 _-]+?)\s+"
+            r"(?:focus on|to handle|to work on|to)\s+(.+)"
+        ),
+        text,
+        flags=re.IGNORECASE,
+    )
+    if update_match:
+        target_name = update_match.group(1).strip()
+        instructions = update_match.group(2).strip().rstrip(".")
+        matched_worker = _find_worker_by_name(workforce, target_name)
+        if matched_worker is not None and instructions:
+            operations.append(
+                {
+                    "op": "update_worker",
+                    "member_id": matched_worker.id,
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(
+                f'Update worker "{matched_worker.alias or matched_worker.agent.name}"'
+            )
+
+    if "add" in lower and "worker" in lower and ("template" in lower or "based on" in lower):
+        template = _find_template_candidate_for_message(text)
+        instructions = _extract_assignment_instructions(text)
+        if template is not None and instructions:
+            alias = _extract_alias_after_add_worker(text)
+            operations.append(
+                {
+                    "op": "add_worker_from_template",
+                    "template_id": template["id"],
+                    "alias": alias or template["name"],
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(f'Add worker from template "{template["name"]}"')
+
+    if "add" in lower and "worker" in lower and ("new agent" in lower or "create agent" in lower):
+        instructions = _extract_assignment_instructions(text)
+        agent_name = _extract_new_agent_name(text)
+        if agent_name and instructions:
+            operations.append(
+                {
+                    "op": "create_worker_agent",
+                    "agent": {
+                        "name": agent_name,
+                        "description": f"{agent_name} created by Workforce Builder.",
+                        "instructions": instructions,
+                        "execution_mode": "balanced",
+                        "tool_categories": ["basic"],
+                    },
+                    "alias": agent_name,
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(f'Create new worker agent "{agent_name}"')
+
+    if "add" in lower and "worker" in lower:
+        agent = _find_agent_candidate_for_message(workforce, text)
+        instructions = _extract_assignment_instructions(text)
+        if agent is not None and instructions:
+            operations.append(
+                {
+                    "op": "add_existing_worker",
+                    "agent_id": agent.id,
+                    "alias": agent.name,
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(f'Add worker "{agent.name}"')
+
+    if not operations:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {},
+            }
+        )
+        warnings.append(PLACEHOLDER_PATCH_WARNING)
+        summary_parts.append("No safe structured changes inferred")
+
+    return {
+        "summary": ". ".join(summary_parts) + ".",
+        "operations": operations,
+        "warnings": warnings,
+    }
+
+
+def _find_worker_by_name(workforce: Workforce, raw_name: str) -> WorkforceAgent | None:
+    target = raw_name.strip().lower()
+    if not target:
+        return None
+    for raw_worker in workforce.workers:
+        worker = cast(WorkforceAgent, raw_worker)
+        candidates = [
+            worker.alias or "",
+            worker.agent.name if worker.agent else "",
+        ]
+        for candidate in candidates:
+            if candidate and candidate.lower() == target:
+                return worker
+    for raw_worker in workforce.workers:
+        worker = cast(WorkforceAgent, raw_worker)
+        candidates = [
+            worker.alias or "",
+            worker.agent.name if worker.agent else "",
+        ]
+        for candidate in candidates:
+            if candidate and target in candidate.lower():
+                return worker
+    return None
+
+
+def _find_agent_candidate_for_message(workforce: Workforce, message: str) -> Agent | None:
+    lower = message.lower()
+    owner_id = workforce.owner_user_id
+    db = workforce._sa_instance_state.session
+    if db is None:
+        return None
+    agents = db.query(Agent).filter(Agent.user_id == owner_id).order_by(Agent.id.asc()).all()
+    existing_agent_ids = {worker.agent_id for worker in workforce.workers}
+    manager_id = workforce.manager_agent_id
+    for agent in agents:
+        if agent.id in existing_agent_ids or agent.id == manager_id:
+            continue
+        if agent.name.lower() in lower:
+            return agent
+    return None
+
+
+def _find_template_candidate_for_message(message: str) -> dict[str, Any] | None:
+    lower = message.lower()
+    for template in list_template_summaries():
+        template_name = str(template.get("name") or "")
+        template_id = str(template.get("id") or "")
+        if template_name.lower() in lower or template_id.lower() in lower:
+            return template
+    return None
+
+
+def _extract_alias_after_add_worker(message: str) -> str | None:
+    match = re.search(
+        r"add\s+(?:a\s+)?worker\s+(?:named|called)\s+\"?([a-zA-Z0-9 _-]+)\"?",
+        message,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        alias = match.group(1).strip()
+        return alias or None
+    return None
+
+
+def _extract_new_agent_name(message: str) -> str | None:
+    quoted = [str(item).strip() for item in re.findall(r'"([^"]+)"', message)]
+    if quoted:
+        return quoted[0] or None
+    match = re.search(
+        r"(?:new agent|create agent)\s+([a-zA-Z0-9 _-]+?)(?:\s+to\s+|\s+for\s+|$)",
+        message,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        candidate = match.group(1).strip()
+        return candidate or None
+    return None
+
+
+def _extract_assignment_instructions(message: str) -> str | None:
+    quoted = [str(item).strip() for item in re.findall(r'"([^"]+)"', message)]
+    if quoted:
+        return quoted[-1] or None
+
+    match = re.search(
+        r"(?:to|for)\s+(?:handle|focus on|work on|cover)\s+(.+)$",
+        message,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip().rstrip(".")
+    return None
+
+
+async def _llm_generate_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> dict[str, Any] | None:
+    try:
+        storage = UserAwareModelStorage(db)
+        user_id = int(user.id)
+        llm = None
+        default_llm, _, _, _ = storage.get_configured_defaults(user_id)
+        llm = default_llm
+        if not llm:
+            default_llm, _, _, _ = storage.get_configured_defaults(None)
+            llm = default_llm
+        if not llm:
+            return None
+
+        system_prompt = (
+            "You are a Workforce Builder assistant. "
+            "Team means human organization and must never be modified. "
+            "Workforce means AI orchestration and may be modified only at the relationship layer. "
+            "You may only output JSON for a proposed patch. "
+            "You can modify workforce name, description, manager instructions, "
+            "worker membership, worker alias, worker assignment instructions, "
+            "and worker order. "
+            "Do not modify underlying agent instructions, models, tools, skills, "
+            "or knowledge bases. "
+            "Supported operations are: update_workforce, add_existing_worker, "
+            "add_worker_from_template, create_worker_agent, update_worker, remove_worker. "
+            "For destructive operations like remove_worker, include a warning. "
+            "Return a JSON object with keys summary, operations, warnings. No markdown fences."
+        )
+        user_prompt = json.dumps(
+            {
+                "request": message,
+                "current_state": _make_builder_context(workforce),
+            },
+            ensure_ascii=False,
+        )
+        response = await llm.chat(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        content = (
+            response["content"]
+            if isinstance(response, dict) and "content" in response
+            else response
+        )
+        if not isinstance(content, str):
+            content = str(content)
+        parsed = json.loads(content)
+        if not isinstance(parsed, dict):
+            return None
+        return _clean_patch(parsed)
+    except Exception as exc:
+        logger.warning("Failed to generate builder patch with LLM: %s", exc)
+        return None
+
+
+async def generate_builder_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> tuple[str, dict[str, Any]]:
+    normalized_message = normalize_text(message, "message", required=True)
+    if normalized_message is None:
+        raise HTTPException(status_code=400, detail="message is required")
+
+    fallback_patch = _clean_patch(_fallback_patch_from_message(workforce, normalized_message))
+    if _has_meaningful_operations(fallback_patch):
+        return (
+            f"I prepared {len(fallback_patch['operations'])} change(s) using rule-based parsing.",
+            fallback_patch,
+        )
+
+    if os.getenv("XAGENT_WORKFORCE_BUILDER_ENABLE_LLM") == "1":
+        llm_patch = await _llm_generate_patch(db, user, workforce, normalized_message)
+        if llm_patch is not None and _has_meaningful_operations(llm_patch):
+            return (
+                f"I prepared {len(llm_patch['operations'])} change(s) for review.",
+                llm_patch,
+            )
+
+    return (
+        "I could not confidently translate the request into a safe structured change. "
+        "Review the warning and refine the prompt if needed.",
+        fallback_patch,
+    )
+
+
+def _apply_update_workforce(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+    fields = operation.get("fields")
+    if not isinstance(fields, dict):
+        return
+    if "name" in fields:
+        name = normalize_text(fields.get("name"), "name", required=True)
+        if name:
+            duplicate = (
+                db.query(Workforce)
+                .filter(
+                    Workforce.id != workforce.id,
+                    Workforce.scope_type == workforce.scope_type,
+                    Workforce.scope_id == workforce.scope_id,
+                    Workforce.name == name,
+                )
+                .first()
+            )
+            if duplicate:
+                raise HTTPException(status_code=409, detail="Workforce name already exists")
+            workforce.name = name
+    if "description" in fields:
+        workforce.description = normalize_text(fields.get("description"), "description")
+    if "manager_instructions" in fields:
+        workforce.manager_instructions = normalize_text(
+            fields.get("manager_instructions"),
+            "manager_instructions",
+        )
+    if "status" in fields:
+        workforce.status = normalize_workforce_status(fields.get("status"))
+
+
+def _apply_add_existing_worker(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+    user: User,
+) -> None:
+    agent_id = operation.get("agent_id")
+    if not isinstance(agent_id, int):
+        raise HTTPException(status_code=400, detail="agent_id is required for add_existing_worker")
+
+    agent = ensure_agent_access(
+        db.query(Agent).filter(Agent.id == agent_id).first(),
+        user,
+        db,
+    )
+    if agent.id == workforce.manager_agent_id:
+        raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+    existing = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.workforce_id == workforce.id,
+            WorkforceAgent.agent_id == agent.id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="Agent already added to workforce")
+
+    assignment_instructions = normalize_text(
+        operation.get("assignment_instructions"),
+        "assignment_instructions",
+        required=True,
+    )
+    if assignment_instructions is None:
+        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+
+    create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type="existing",
+        assignment_instructions=assignment_instructions,
+        alias=operation.get("alias"),
+        agent_id=agent.id,
+        enabled=bool(operation.get("enabled", True)),
+        sort_order=operation.get("sort_order")
+        if isinstance(operation.get("sort_order"), int)
+        else None,
+    )
+
+
+def _apply_add_worker_from_template(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+    user: User,
+) -> None:
+    template_id = operation.get("template_id")
+    if not isinstance(template_id, str) or not template_id.strip():
+        raise HTTPException(
+            status_code=400, detail="template_id is required for add_worker_from_template"
+        )
+
+    assignment_instructions = normalize_text(
+        operation.get("assignment_instructions"),
+        "assignment_instructions",
+        required=True,
+    )
+    if assignment_instructions is None:
+        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+
+    create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type="template",
+        assignment_instructions=assignment_instructions,
+        alias=operation.get("alias"),
+        template_id=template_id.strip(),
+        enabled=bool(operation.get("enabled", True)),
+        sort_order=operation.get("sort_order")
+        if isinstance(operation.get("sort_order"), int)
+        else None,
+    )
+
+
+def _apply_create_worker_agent(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+    user: User,
+) -> None:
+    agent_payload = operation.get("agent")
+    if not isinstance(agent_payload, dict):
+        raise HTTPException(status_code=400, detail="agent is required for create_worker_agent")
+
+    assignment_instructions = normalize_text(
+        operation.get("assignment_instructions"),
+        "assignment_instructions",
+        required=True,
+    )
+    if assignment_instructions is None:
+        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+
+    create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type="new",
+        assignment_instructions=assignment_instructions,
+        alias=operation.get("alias"),
+        agent_payload=agent_payload,
+        enabled=bool(operation.get("enabled", True)),
+        sort_order=operation.get("sort_order")
+        if isinstance(operation.get("sort_order"), int)
+        else None,
+    )
+
+
+def _apply_update_worker(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+    member_id = operation.get("member_id")
+    if not isinstance(member_id, int):
+        raise HTTPException(status_code=400, detail="member_id is required for update_worker")
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.id == member_id,
+            WorkforceAgent.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+
+    if "alias" in operation:
+        worker.alias = normalize_text(operation.get("alias"), "alias")
+    if "assignment_instructions" in operation:
+        assignment_instructions = normalize_text(
+            operation.get("assignment_instructions"),
+            "assignment_instructions",
+            required=True,
+        )
+        if assignment_instructions is None:
+            raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        worker.assignment_instructions = assignment_instructions
+    if "enabled" in operation:
+        worker.enabled = bool(operation.get("enabled"))
+    if "sort_order" in operation and isinstance(operation.get("sort_order"), int):
+        worker.sort_order = int(operation["sort_order"])
+
+
+def _apply_remove_worker(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+    member_id = operation.get("member_id")
+    if not isinstance(member_id, int):
+        raise HTTPException(status_code=400, detail="member_id is required for remove_worker")
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.id == member_id,
+            WorkforceAgent.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+    db.delete(worker)
+    db.flush()
+
+
+def apply_builder_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    patch: dict[str, Any],
+) -> Workforce:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    clean_patch = _clean_patch(patch)
+    operations = clean_patch["operations"]
+
+    for operation in operations:
+        op_name = operation["op"]
+        if op_name == "update_workforce":
+            _apply_update_workforce(workforce, operation, db)
+        elif op_name == "add_existing_worker":
+            _apply_add_existing_worker(workforce, operation, db, user)
+        elif op_name == "add_worker_from_template":
+            _apply_add_worker_from_template(workforce, operation, db, user)
+        elif op_name == "create_worker_agent":
+            _apply_create_worker_agent(workforce, operation, db, user)
+        elif op_name == "update_worker":
+            _apply_update_worker(workforce, operation, db)
+        elif op_name == "remove_worker":
+            _apply_remove_worker(workforce, operation, db)
+        else:
+            raise HTTPException(status_code=400, detail=f"Unsupported builder operation: {op_name}")
+
+    db.flush()
+    if workforce.status == "active":
+        enabled_count = (
+            db.query(WorkforceAgent)
+            .filter(
+                WorkforceAgent.workforce_id == workforce.id,
+                WorkforceAgent.enabled.is_(True),
+            )
+            .count()
+        )
+        if enabled_count == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Active workforce requires at least one enabled worker",
+            )
+    return workforce

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+
 from xagent.web.models.agent import Agent
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
@@ -46,7 +47,9 @@ def serialize_builder_message(message: WorkforceBuilderMessage) -> dict[str, Any
     }
 
 
-def list_builder_messages(db: Session, workforce_id: int) -> list[WorkforceBuilderMessage]:
+def list_builder_messages(
+    db: Session, workforce_id: int
+) -> list[WorkforceBuilderMessage]:
     return (
         db.query(WorkforceBuilderMessage)
         .filter(WorkforceBuilderMessage.workforce_id == workforce_id)
@@ -56,7 +59,9 @@ def list_builder_messages(db: Session, workforce_id: int) -> list[WorkforceBuild
 
 
 def _serialize_workers_for_prompt(workforce: Workforce) -> list[dict[str, Any]]:
-    workers = sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    workers = sorted(
+        workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0)
+    )
     return [
         {
             "member_id": worker.id,
@@ -79,7 +84,9 @@ def _make_builder_context(workforce: Workforce) -> dict[str, Any]:
             "description": workforce.description,
             "status": workforce.status,
             "manager_agent_id": workforce.manager_agent_id,
-            "manager_agent_name": workforce.manager_agent.name if workforce.manager_agent else None,
+            "manager_agent_name": workforce.manager_agent.name
+            if workforce.manager_agent
+            else None,
             "manager_instructions": workforce.manager_instructions,
         },
         "workers": _serialize_workers_for_prompt(workforce),
@@ -87,7 +94,9 @@ def _make_builder_context(workforce: Workforce) -> dict[str, Any]:
 
 
 def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
-    summary = str(candidate.get("summary") or "").strip() or "Update workforce configuration."
+    summary = (
+        str(candidate.get("summary") or "").strip() or "Update workforce configuration."
+    )
     warnings = candidate.get("warnings")
     if not isinstance(warnings, list):
         warnings = []
@@ -170,12 +179,16 @@ def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str
         operations.append(
             {
                 "op": "update_workforce",
-                "fields": {"manager_instructions": manager_instructions_match.group(2).strip()},
+                "fields": {
+                    "manager_instructions": manager_instructions_match.group(2).strip()
+                },
             }
         )
         summary_parts.append("Update manager instructions")
 
-    remove_match = re.search(r"\bremove\b\s+([a-zA-Z0-9 _-]+)", text, flags=re.IGNORECASE)
+    remove_match = re.search(
+        r"\bremove\b\s+([a-zA-Z0-9 _-]+)", text, flags=re.IGNORECASE
+    )
     if remove_match:
         raw_target = remove_match.group(1).strip().rstrip(".")
         matched_worker = _find_worker_by_name(workforce, raw_target)
@@ -212,7 +225,11 @@ def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str
                 f'Update worker "{matched_worker.alias or matched_worker.agent.name}"'
             )
 
-    if "add" in lower and "worker" in lower and ("template" in lower or "based on" in lower):
+    if (
+        "add" in lower
+        and "worker" in lower
+        and ("template" in lower or "based on" in lower)
+    ):
         template = _find_template_candidate_for_message(text)
         instructions = _extract_assignment_instructions(text)
         if template is not None and instructions:
@@ -227,7 +244,11 @@ def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str
             )
             summary_parts.append(f'Add worker from template "{template["name"]}"')
 
-    if "add" in lower and "worker" in lower and ("new agent" in lower or "create agent" in lower):
+    if (
+        "add" in lower
+        and "worker" in lower
+        and ("new agent" in lower or "create agent" in lower)
+    ):
         instructions = _extract_assignment_instructions(text)
         agent_name = _extract_new_agent_name(text)
         if agent_name and instructions:
@@ -303,16 +324,21 @@ def _find_worker_by_name(workforce: Workforce, raw_name: str) -> WorkforceAgent 
     return None
 
 
-def _find_agent_candidate_for_message(workforce: Workforce, message: str) -> Agent | None:
+def _find_agent_candidate_for_message(
+    workforce: Workforce, message: str
+) -> Agent | None:
     lower = message.lower()
     owner_id = workforce.owner_user_id
     db = workforce._sa_instance_state.session
     if db is None:
         return None
-    agents = db.query(Agent).filter(Agent.user_id == owner_id).order_by(Agent.id.asc()).all()
+    agents = (
+        db.query(Agent).filter(Agent.user_id == owner_id).order_by(Agent.id.asc()).all()
+    )
     existing_agent_ids = {worker.agent_id for worker in workforce.workers}
     manager_id = workforce.manager_agent_id
-    for agent in agents:
+    for raw_agent in agents:
+        agent = cast(Agent, raw_agent)
         if agent.id in existing_agent_ids or agent.id == manager_id:
             continue
         if agent.name.lower() in lower:
@@ -445,7 +471,9 @@ async def generate_builder_patch(
     if normalized_message is None:
         raise HTTPException(status_code=400, detail="message is required")
 
-    fallback_patch = _clean_patch(_fallback_patch_from_message(workforce, normalized_message))
+    fallback_patch = _clean_patch(
+        _fallback_patch_from_message(workforce, normalized_message)
+    )
     if _has_meaningful_operations(fallback_patch):
         return (
             f"I prepared {len(fallback_patch['operations'])} change(s) using rule-based parsing.",
@@ -467,7 +495,10 @@ async def generate_builder_patch(
     )
 
 
-def _apply_update_workforce(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+def _apply_update_workforce(
+    workforce: Workforce, operation: dict[str, Any], db: Session
+) -> None:
+    workforce_row = cast(Any, workforce)
     fields = operation.get("fields")
     if not isinstance(fields, dict):
         return
@@ -485,17 +516,21 @@ def _apply_update_workforce(workforce: Workforce, operation: dict[str, Any], db:
                 .first()
             )
             if duplicate:
-                raise HTTPException(status_code=409, detail="Workforce name already exists")
-            workforce.name = name
+                raise HTTPException(
+                    status_code=409, detail="Workforce name already exists"
+                )
+            workforce_row.name = name
     if "description" in fields:
-        workforce.description = normalize_text(fields.get("description"), "description")
+        workforce_row.description = normalize_text(
+            fields.get("description"), "description"
+        )
     if "manager_instructions" in fields:
-        workforce.manager_instructions = normalize_text(
+        workforce_row.manager_instructions = normalize_text(
             fields.get("manager_instructions"),
             "manager_instructions",
         )
     if "status" in fields:
-        workforce.status = normalize_workforce_status(fields.get("status"))
+        workforce_row.status = normalize_workforce_status(fields.get("status"))
 
 
 def _apply_add_existing_worker(
@@ -506,15 +541,20 @@ def _apply_add_existing_worker(
 ) -> None:
     agent_id = operation.get("agent_id")
     if not isinstance(agent_id, int):
-        raise HTTPException(status_code=400, detail="agent_id is required for add_existing_worker")
+        raise HTTPException(
+            status_code=400, detail="agent_id is required for add_existing_worker"
+        )
 
     agent = ensure_agent_access(
         db.query(Agent).filter(Agent.id == agent_id).first(),
         user,
         db,
     )
-    if agent.id == workforce.manager_agent_id:
-        raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+    agent_id_value = cast(int, agent.id)
+    if agent_id_value == cast(int, workforce.manager_agent_id):
+        raise HTTPException(
+            status_code=400, detail="Manager agent cannot also be a worker"
+        )
     existing = (
         db.query(WorkforceAgent)
         .filter(
@@ -532,7 +572,9 @@ def _apply_add_existing_worker(
         required=True,
     )
     if assignment_instructions is None:
-        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        raise HTTPException(
+            status_code=400, detail="assignment_instructions is required"
+        )
 
     create_workforce_worker(
         db,
@@ -541,7 +583,7 @@ def _apply_add_existing_worker(
         source_type="existing",
         assignment_instructions=assignment_instructions,
         alias=operation.get("alias"),
-        agent_id=agent.id,
+        agent_id=agent_id_value,
         enabled=bool(operation.get("enabled", True)),
         sort_order=operation.get("sort_order")
         if isinstance(operation.get("sort_order"), int)
@@ -558,7 +600,8 @@ def _apply_add_worker_from_template(
     template_id = operation.get("template_id")
     if not isinstance(template_id, str) or not template_id.strip():
         raise HTTPException(
-            status_code=400, detail="template_id is required for add_worker_from_template"
+            status_code=400,
+            detail="template_id is required for add_worker_from_template",
         )
 
     assignment_instructions = normalize_text(
@@ -567,7 +610,9 @@ def _apply_add_worker_from_template(
         required=True,
     )
     if assignment_instructions is None:
-        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        raise HTTPException(
+            status_code=400, detail="assignment_instructions is required"
+        )
 
     create_workforce_worker(
         db,
@@ -592,7 +637,9 @@ def _apply_create_worker_agent(
 ) -> None:
     agent_payload = operation.get("agent")
     if not isinstance(agent_payload, dict):
-        raise HTTPException(status_code=400, detail="agent is required for create_worker_agent")
+        raise HTTPException(
+            status_code=400, detail="agent is required for create_worker_agent"
+        )
 
     assignment_instructions = normalize_text(
         operation.get("assignment_instructions"),
@@ -600,7 +647,9 @@ def _apply_create_worker_agent(
         required=True,
     )
     if assignment_instructions is None:
-        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        raise HTTPException(
+            status_code=400, detail="assignment_instructions is required"
+        )
 
     create_workforce_worker(
         db,
@@ -617,10 +666,14 @@ def _apply_create_worker_agent(
     )
 
 
-def _apply_update_worker(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+def _apply_update_worker(
+    workforce: Workforce, operation: dict[str, Any], db: Session
+) -> None:
     member_id = operation.get("member_id")
     if not isinstance(member_id, int):
-        raise HTTPException(status_code=400, detail="member_id is required for update_worker")
+        raise HTTPException(
+            status_code=400, detail="member_id is required for update_worker"
+        )
     worker = (
         db.query(WorkforceAgent)
         .filter(
@@ -631,9 +684,10 @@ def _apply_update_worker(workforce: Workforce, operation: dict[str, Any], db: Se
     )
     if worker is None:
         raise HTTPException(status_code=404, detail="Workforce worker not found")
+    worker_row = cast(Any, worker)
 
     if "alias" in operation:
-        worker.alias = normalize_text(operation.get("alias"), "alias")
+        worker_row.alias = normalize_text(operation.get("alias"), "alias")
     if "assignment_instructions" in operation:
         assignment_instructions = normalize_text(
             operation.get("assignment_instructions"),
@@ -641,18 +695,24 @@ def _apply_update_worker(workforce: Workforce, operation: dict[str, Any], db: Se
             required=True,
         )
         if assignment_instructions is None:
-            raise HTTPException(status_code=400, detail="assignment_instructions is required")
-        worker.assignment_instructions = assignment_instructions
+            raise HTTPException(
+                status_code=400, detail="assignment_instructions is required"
+            )
+        worker_row.assignment_instructions = assignment_instructions
     if "enabled" in operation:
-        worker.enabled = bool(operation.get("enabled"))
+        worker_row.enabled = bool(operation.get("enabled"))
     if "sort_order" in operation and isinstance(operation.get("sort_order"), int):
-        worker.sort_order = int(operation["sort_order"])
+        worker_row.sort_order = int(operation["sort_order"])
 
 
-def _apply_remove_worker(workforce: Workforce, operation: dict[str, Any], db: Session) -> None:
+def _apply_remove_worker(
+    workforce: Workforce, operation: dict[str, Any], db: Session
+) -> None:
     member_id = operation.get("member_id")
     if not isinstance(member_id, int):
-        raise HTTPException(status_code=400, detail="member_id is required for remove_worker")
+        raise HTTPException(
+            status_code=400, detail="member_id is required for remove_worker"
+        )
     worker = (
         db.query(WorkforceAgent)
         .filter(
@@ -692,7 +752,9 @@ def apply_builder_patch(
         elif op_name == "remove_worker":
             _apply_remove_worker(workforce, operation, db)
         else:
-            raise HTTPException(status_code=400, detail=f"Unsupported builder operation: {op_name}")
+            raise HTTPException(
+                status_code=400, detail=f"Unsupported builder operation: {op_name}"
+            )
 
     db.flush()
     if workforce.status == "active":

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -1,13 +1,12 @@
 import json
 import logging
-import os
 import re
 from typing import Any, cast
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from xagent.web.models.agent import Agent
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
@@ -17,15 +16,13 @@ from .workforce_snapshot import (
     normalize_text,
     normalize_workforce_status,
 )
-from .workforce_workers import create_workforce_worker, list_template_summaries
+from .workforce_workers import create_workforce_worker
 
 logger = logging.getLogger(__name__)
 
 SUPPORTED_BUILDER_OPS = {
     "update_workforce",
     "add_existing_worker",
-    "add_worker_from_template",
-    "create_worker_agent",
     "update_worker",
     "remove_worker",
 }
@@ -93,6 +90,32 @@ def _make_builder_context(workforce: Workforce) -> dict[str, Any]:
     }
 
 
+def _serialize_available_agents_for_prompt(
+    db: Session, user: User, workforce: Workforce
+) -> list[dict[str, Any]]:
+    existing_agent_ids = {worker.agent_id for worker in workforce.workers}
+    manager_id = workforce.manager_agent_id
+    query = db.query(Agent).filter(cast(Any, Agent.status) == AgentStatus.PUBLISHED)
+    if not user.is_admin:
+        query = query.filter(Agent.user_id == user.id)
+
+    agents = query.order_by(Agent.id.asc()).all()
+    results: list[dict[str, Any]] = []
+    for raw_agent in agents:
+        agent = cast(Agent, raw_agent)
+        if agent.id in existing_agent_ids or agent.id == manager_id:
+            continue
+        results.append(
+            {
+                "agent_id": agent.id,
+                "name": agent.name,
+                "description": agent.description,
+                "status": getattr(agent.status, "value", str(agent.status)),
+            }
+        )
+    return results
+
+
 def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
     summary = (
         str(candidate.get("summary") or "").strip() or "Update workforce configuration."
@@ -101,6 +124,7 @@ def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(warnings, list):
         warnings = []
     clean_warnings = [str(item).strip() for item in warnings if str(item).strip()]
+    clarification = str(candidate.get("clarification") or "").strip() or None
 
     operations = candidate.get("operations")
     if not isinstance(operations, list):
@@ -119,6 +143,7 @@ def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
         "summary": summary,
         "operations": clean_operations,
         "warnings": clean_warnings,
+        "clarification": clarification,
     }
 
 
@@ -225,49 +250,6 @@ def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str
                 f'Update worker "{matched_worker.alias or matched_worker.agent.name}"'
             )
 
-    if (
-        "add" in lower
-        and "worker" in lower
-        and ("template" in lower or "based on" in lower)
-    ):
-        template = _find_template_candidate_for_message(text)
-        instructions = _extract_assignment_instructions(text)
-        if template is not None and instructions:
-            alias = _extract_alias_after_add_worker(text)
-            operations.append(
-                {
-                    "op": "add_worker_from_template",
-                    "template_id": template["id"],
-                    "alias": alias or template["name"],
-                    "assignment_instructions": instructions,
-                }
-            )
-            summary_parts.append(f'Add worker from template "{template["name"]}"')
-
-    if (
-        "add" in lower
-        and "worker" in lower
-        and ("new agent" in lower or "create agent" in lower)
-    ):
-        instructions = _extract_assignment_instructions(text)
-        agent_name = _extract_new_agent_name(text)
-        if agent_name and instructions:
-            operations.append(
-                {
-                    "op": "create_worker_agent",
-                    "agent": {
-                        "name": agent_name,
-                        "description": f"{agent_name} created by Workforce Builder.",
-                        "instructions": instructions,
-                        "execution_mode": "balanced",
-                        "tool_categories": ["basic"],
-                    },
-                    "alias": agent_name,
-                    "assignment_instructions": instructions,
-                }
-            )
-            summary_parts.append(f'Create new worker agent "{agent_name}"')
-
     if "add" in lower and "worker" in lower:
         agent = _find_agent_candidate_for_message(workforce, text)
         instructions = _extract_assignment_instructions(text)
@@ -296,6 +278,7 @@ def _fallback_patch_from_message(workforce: Workforce, message: str) -> dict[str
         "summary": ". ".join(summary_parts) + ".",
         "operations": operations,
         "warnings": warnings,
+        "clarification": None,
     }
 
 
@@ -346,16 +329,6 @@ def _find_agent_candidate_for_message(
     return None
 
 
-def _find_template_candidate_for_message(message: str) -> dict[str, Any] | None:
-    lower = message.lower()
-    for template in list_template_summaries():
-        template_name = str(template.get("name") or "")
-        template_id = str(template.get("id") or "")
-        if template_name.lower() in lower or template_id.lower() in lower:
-            return template
-    return None
-
-
 def _extract_alias_after_add_worker(message: str) -> str | None:
     match = re.search(
         r"add\s+(?:a\s+)?worker\s+(?:named|called)\s+\"?([a-zA-Z0-9 _-]+)\"?",
@@ -365,21 +338,6 @@ def _extract_alias_after_add_worker(message: str) -> str | None:
     if match:
         alias = match.group(1).strip()
         return alias or None
-    return None
-
-
-def _extract_new_agent_name(message: str) -> str | None:
-    quoted = [str(item).strip() for item in re.findall(r'"([^"]+)"', message)]
-    if quoted:
-        return quoted[0] or None
-    match = re.search(
-        r"(?:new agent|create agent)\s+([a-zA-Z0-9 _-]+?)(?:\s+to\s+|\s+for\s+|$)",
-        message,
-        flags=re.IGNORECASE,
-    )
-    if match:
-        candidate = match.group(1).strip()
-        return candidate or None
     return None
 
 
@@ -427,14 +385,22 @@ async def _llm_generate_patch(
             "Do not modify underlying agent instructions, models, tools, skills, "
             "or knowledge bases. "
             "Supported operations are: update_workforce, add_existing_worker, "
-            "add_worker_from_template, create_worker_agent, update_worker, remove_worker. "
+            "update_worker, remove_worker. "
+            "Workers must be existing published agents from available_published_agents. "
+            "Do not create new agents or add workers from templates. "
             "For destructive operations like remove_worker, include a warning. "
-            "Return a JSON object with keys summary, operations, warnings. No markdown fences."
+            "If the user's intent is unclear, return no operations and include a "
+            "clarification question. "
+            "Return a JSON object with keys summary, operations, warnings, "
+            "clarification. No markdown fences."
         )
         user_prompt = json.dumps(
             {
                 "request": message,
                 "current_state": _make_builder_context(workforce),
+                "available_published_agents": _serialize_available_agents_for_prompt(
+                    db, user, workforce
+                ),
             },
             ensure_ascii=False,
         )
@@ -471,22 +437,30 @@ async def generate_builder_patch(
     if normalized_message is None:
         raise HTTPException(status_code=400, detail="message is required")
 
+    llm_patch = await _llm_generate_patch(db, user, workforce, normalized_message)
+    if llm_patch is not None:
+        if _has_meaningful_operations(llm_patch):
+            return (
+                f"I prepared {len(llm_patch['operations'])} change(s) for review.",
+                llm_patch,
+            )
+        clarification = llm_patch.get("clarification")
+        if clarification:
+            return (str(clarification), llm_patch)
+        return (
+            "I could not translate the request into an executable Workforce change. "
+            "Review the proposal details and refine the prompt if needed.",
+            llm_patch,
+        )
+
     fallback_patch = _clean_patch(
         _fallback_patch_from_message(workforce, normalized_message)
     )
     if _has_meaningful_operations(fallback_patch):
         return (
-            f"I prepared {len(fallback_patch['operations'])} change(s) using rule-based parsing.",
+            f"I prepared {len(fallback_patch['operations'])} change(s) using rule-based parsing because no LLM was available.",
             fallback_patch,
         )
-
-    if os.getenv("XAGENT_WORKFORCE_BUILDER_ENABLE_LLM") == "1":
-        llm_patch = await _llm_generate_patch(db, user, workforce, normalized_message)
-        if llm_patch is not None and _has_meaningful_operations(llm_patch):
-            return (
-                f"I prepared {len(llm_patch['operations'])} change(s) for review.",
-                llm_patch,
-            )
 
     return (
         "I could not confidently translate the request into a safe structured change. "
@@ -592,81 +566,6 @@ def _apply_add_existing_worker(
     )
 
 
-def _apply_add_worker_from_template(
-    workforce: Workforce,
-    operation: dict[str, Any],
-    db: Session,
-    user: User,
-) -> None:
-    template_id = operation.get("template_id")
-    if not isinstance(template_id, str) or not template_id.strip():
-        raise HTTPException(
-            status_code=400,
-            detail="template_id is required for add_worker_from_template",
-        )
-
-    assignment_instructions = normalize_text(
-        operation.get("assignment_instructions"),
-        "assignment_instructions",
-        required=True,
-    )
-    if assignment_instructions is None:
-        raise HTTPException(
-            status_code=400, detail="assignment_instructions is required"
-        )
-
-    create_workforce_worker(
-        db,
-        workforce,
-        user,
-        source_type="template",
-        assignment_instructions=assignment_instructions,
-        alias=operation.get("alias"),
-        template_id=template_id.strip(),
-        enabled=bool(operation.get("enabled", True)),
-        sort_order=operation.get("sort_order")
-        if isinstance(operation.get("sort_order"), int)
-        else None,
-    )
-
-
-def _apply_create_worker_agent(
-    workforce: Workforce,
-    operation: dict[str, Any],
-    db: Session,
-    user: User,
-) -> None:
-    agent_payload = operation.get("agent")
-    if not isinstance(agent_payload, dict):
-        raise HTTPException(
-            status_code=400, detail="agent is required for create_worker_agent"
-        )
-
-    assignment_instructions = normalize_text(
-        operation.get("assignment_instructions"),
-        "assignment_instructions",
-        required=True,
-    )
-    if assignment_instructions is None:
-        raise HTTPException(
-            status_code=400, detail="assignment_instructions is required"
-        )
-
-    create_workforce_worker(
-        db,
-        workforce,
-        user,
-        source_type="new",
-        assignment_instructions=assignment_instructions,
-        alias=operation.get("alias"),
-        agent_payload=agent_payload,
-        enabled=bool(operation.get("enabled", True)),
-        sort_order=operation.get("sort_order")
-        if isinstance(operation.get("sort_order"), int)
-        else None,
-    )
-
-
 def _apply_update_worker(
     workforce: Workforce, operation: dict[str, Any], db: Session
 ) -> None:
@@ -744,10 +643,6 @@ def apply_builder_patch(
             _apply_update_workforce(workforce, operation, db)
         elif op_name == "add_existing_worker":
             _apply_add_existing_worker(workforce, operation, db, user)
-        elif op_name == "add_worker_from_template":
-            _apply_add_worker_from_template(workforce, operation, db, user)
-        elif op_name == "create_worker_agent":
-            _apply_create_worker_agent(workforce, operation, db, user)
         elif op_name == "update_worker":
             _apply_update_worker(workforce, operation, db)
         elif op_name == "remove_worker":

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -549,6 +549,7 @@ def _apply_add_existing_worker(
         db.query(Agent).filter(Agent.id == agent_id).first(),
         user,
         db,
+        require_published=True,
     )
     agent_id_value = cast(int, agent.id)
     if agent_id_value == cast(int, workforce.manager_agent_id):

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -1,0 +1,219 @@
+import json
+import logging
+import re
+from typing import Any, cast
+
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import UserAwareModelStorage
+
+logger = logging.getLogger(__name__)
+
+
+def _available_published_agents(db: Session, user: User) -> list[Agent]:
+    query = db.query(Agent).filter(cast(Any, Agent.status) == AgentStatus.PUBLISHED)
+    if not user.is_admin:
+        query = query.filter(Agent.user_id == user.id)
+    return [cast(Agent, item) for item in query.order_by(Agent.id.asc()).all()]
+
+
+def _serialize_available_agents(agents: list[Agent]) -> list[dict[str, Any]]:
+    return [
+        {
+            "agent_id": agent.id,
+            "name": agent.name,
+            "description": agent.description,
+            "status": getattr(agent.status, "value", str(agent.status)),
+        }
+        for agent in agents
+    ]
+
+
+def _short_name_from_prompt(prompt: str) -> str:
+    words = re.findall(r"[\w-]+", prompt, flags=re.UNICODE)
+    if not words:
+        return "New Workforce"
+    name = " ".join(words[:6]).strip()
+    if len(name) > 80:
+        name = name[:80].rstrip()
+    return f"{name} Workforce" if "workforce" not in name.lower() else name
+
+
+def _clean_creation_plan(
+    candidate: dict[str, Any],
+    available_agent_ids: set[int],
+    prompt: str,
+) -> dict[str, Any]:
+    name = str(candidate.get("name") or "").strip() or _short_name_from_prompt(prompt)
+    description = str(candidate.get("description") or "").strip() or prompt.strip()
+
+    manager = candidate.get("manager")
+    if not isinstance(manager, dict):
+        manager = {}
+    manager_name = str(manager.get("name") or "").strip() or f"{name} Manager"
+    manager_description = (
+        str(manager.get("description") or "").strip()
+        or "Coordinates this Workforce and synthesizes worker outputs."
+    )
+    manager_instructions = (
+        str(manager.get("instructions") or "").strip()
+        or (
+            "Understand the user's goal, delegate focused work to the available "
+            "workers, compare their outputs, and return one coherent final answer."
+        )
+    )
+
+    workers = candidate.get("workers")
+    if not isinstance(workers, list):
+        workers = []
+    clean_workers: list[dict[str, Any]] = []
+    seen_agent_ids: set[int] = set()
+    for item in workers:
+        if not isinstance(item, dict):
+            continue
+        agent_id = item.get("agent_id")
+        if not isinstance(agent_id, int):
+            continue
+        if agent_id not in available_agent_ids or agent_id in seen_agent_ids:
+            continue
+        instructions = str(item.get("assignment_instructions") or "").strip()
+        if not instructions:
+            continue
+        clean_workers.append(
+            {
+                "agent_id": agent_id,
+                "alias": str(item.get("alias") or "").strip() or None,
+                "assignment_instructions": instructions,
+                "enabled": bool(item.get("enabled", True)),
+            }
+        )
+        seen_agent_ids.add(agent_id)
+
+    warnings = candidate.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    clean_warnings = [str(item).strip() for item in warnings if str(item).strip()]
+    if not clean_workers:
+        clean_warnings.append(
+            "No published worker agents were selected. Add workers before running."
+        )
+
+    return {
+        "name": name[:200],
+        "description": description,
+        "manager": {
+            "name": manager_name[:200],
+            "description": manager_description,
+            "instructions": manager_instructions,
+        },
+        "manager_instructions": manager_instructions,
+        "workers": clean_workers,
+        "warnings": clean_warnings,
+    }
+
+
+def _fallback_creation_plan(prompt: str, agents: list[Agent]) -> dict[str, Any]:
+    lower_prompt = prompt.lower()
+    selected: list[Agent] = []
+    for agent in agents:
+        haystack = f"{agent.name} {agent.description or ''}".lower()
+        if any(token and token in haystack for token in re.findall(r"[a-z0-9]+", lower_prompt)):
+            selected.append(agent)
+        if len(selected) >= 3:
+            break
+    if not selected:
+        selected = agents[: min(3, len(agents))]
+
+    name = _short_name_from_prompt(prompt)
+    return _clean_creation_plan(
+        {
+            "name": name,
+            "description": prompt,
+            "manager": {
+                "name": f"{name} Manager",
+                "description": "Coordinates this Workforce and synthesizes worker outputs.",
+                "instructions": (
+                    "Break the user request into worker assignments, call the "
+                    "right workers, reconcile their outputs, and provide a concise final answer."
+                ),
+            },
+            "workers": [
+                {
+                    "agent_id": cast(int, agent.id),
+                    "alias": agent.name,
+                    "assignment_instructions": (
+                        f"Contribute to the Workforce goal using the strengths of {agent.name}."
+                    ),
+                    "enabled": True,
+                }
+                for agent in selected
+            ],
+            "warnings": [
+                "Created from a rule-based fallback because no LLM plan was available."
+            ],
+        },
+        {cast(int, agent.id) for agent in agents},
+        prompt,
+    )
+
+
+async def generate_workforce_creation_plan(
+    db: Session,
+    user: User,
+    prompt: str,
+) -> dict[str, Any]:
+    agents = _available_published_agents(db, user)
+    available_agent_ids = {cast(int, agent.id) for agent in agents}
+
+    try:
+        storage = UserAwareModelStorage(db)
+        user_id = int(user.id)
+        default_llm, _, _, _ = storage.get_configured_defaults(user_id)
+        llm = default_llm
+        if not llm:
+            default_llm, _, _, _ = storage.get_configured_defaults(None)
+            llm = default_llm
+        if not llm:
+            return _fallback_creation_plan(prompt, agents)
+
+        system_prompt = (
+            "You create initial AI Workforce drafts from a user's goal. "
+            "A Workforce is AI orchestration, not a human team. "
+            "Create a manager spec that can coordinate workers and synthesize results. "
+            "Select workers only from available_published_agents. "
+            "Do not create worker agents. If no worker fits, return no workers and add a warning. "
+            "Return JSON only with keys: name, description, manager, manager_instructions, workers, warnings. "
+            "manager has name, description, instructions. "
+            "Each worker has agent_id, alias, assignment_instructions, enabled. "
+            "Keep instructions concrete and task-oriented."
+        )
+        user_prompt = json.dumps(
+            {
+                "request": prompt,
+                "available_published_agents": _serialize_available_agents(agents),
+            },
+            ensure_ascii=False,
+        )
+        response = await llm.chat(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        content = (
+            response["content"]
+            if isinstance(response, dict) and "content" in response
+            else response
+        )
+        if not isinstance(content, str):
+            content = str(content)
+        parsed = json.loads(content)
+        if not isinstance(parsed, dict):
+            return _fallback_creation_plan(prompt, agents)
+        return _clean_creation_plan(parsed, available_agent_ids, prompt)
+    except Exception as exc:
+        logger.warning("Failed to generate Workforce creation plan with LLM: %s", exc)
+        return _fallback_creation_plan(prompt, agents)

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -57,12 +57,9 @@ def _clean_creation_plan(
         str(manager.get("description") or "").strip()
         or "Coordinates this Workforce and synthesizes worker outputs."
     )
-    manager_instructions = (
-        str(manager.get("instructions") or "").strip()
-        or (
-            "Understand the user's goal, delegate focused work to the available "
-            "workers, compare their outputs, and return one coherent final answer."
-        )
+    manager_instructions = str(manager.get("instructions") or "").strip() or (
+        "Understand the user's goal, delegate focused work to the available "
+        "workers, compare their outputs, and return one coherent final answer."
     )
 
     workers = candidate.get("workers")
@@ -119,7 +116,10 @@ def _fallback_creation_plan(prompt: str, agents: list[Agent]) -> dict[str, Any]:
     selected: list[Agent] = []
     for agent in agents:
         haystack = f"{agent.name} {agent.description or ''}".lower()
-        if any(token and token in haystack for token in re.findall(r"[a-z0-9]+", lower_prompt)):
+        if any(
+            token and token in haystack
+            for token in re.findall(r"[a-z0-9]+", lower_prompt)
+        ):
             selected.append(agent)
         if len(selected) >= 3:
             break

--- a/src/xagent/web/services/workforce_runtime.py
+++ b/src/xagent/web/services/workforce_runtime.py
@@ -50,6 +50,8 @@ def _map_task_status(status: Any) -> str | None:
         return "pending"
     if status == TaskStatus.RUNNING:
         return "running"
+    if status == TaskStatus.PAUSED:
+        return "paused"
     if status == TaskStatus.COMPLETED:
         return "completed"
     if status == TaskStatus.FAILED:

--- a/src/xagent/web/services/workforce_runtime.py
+++ b/src/xagent/web/services/workforce_runtime.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+
 from xagent.web.models.task import TaskStatus
 
 

--- a/src/xagent/web/services/workforce_runtime.py
+++ b/src/xagent/web/services/workforce_runtime.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import inspect, text
+from sqlalchemy.orm import Session
+from xagent.web.models.task import TaskStatus
+
+
+def extract_workforce_run_id(task: Any) -> int | None:
+    agent_config = getattr(task, "agent_config", None)
+    if not isinstance(agent_config, dict):
+        return None
+    workforce_run_id = agent_config.get("workforce_run_id")
+    return workforce_run_id if isinstance(workforce_run_id, int) else None
+
+
+def has_workforce_runs_table(db: Session) -> bool:
+    try:
+        inspector = inspect(db.bind)
+        return bool(inspector is not None and inspector.has_table("workforce_runs"))
+    except Exception:
+        return False
+
+
+def is_verified_workforce_task(db: Session, task: Any, workforce_run_id: Any) -> bool:
+    if not isinstance(workforce_run_id, int):
+        return False
+    if not has_workforce_runs_table(db):
+        return False
+    try:
+        row = db.execute(
+            text(
+                "SELECT 1 FROM workforce_runs "
+                "WHERE id = :run_id AND task_id = :task_id AND user_id = :user_id"
+            ),
+            {
+                "run_id": workforce_run_id,
+                "task_id": int(task.id),
+                "user_id": int(task.user_id),
+            },
+        ).first()
+        return row is not None
+    except Exception:
+        return False
+
+
+def _map_task_status(status: Any) -> str | None:
+    if status == TaskStatus.PENDING:
+        return "pending"
+    if status == TaskStatus.RUNNING:
+        return "running"
+    if status == TaskStatus.COMPLETED:
+        return "completed"
+    if status == TaskStatus.FAILED:
+        return "failed"
+    return None
+
+
+def sync_workforce_run_status(db: Session, task: Any, status: Any) -> None:
+    workforce_run_id = extract_workforce_run_id(task)
+    mapped_status = _map_task_status(status)
+    if workforce_run_id is None or mapped_status is None:
+        return
+    if not has_workforce_runs_table(db):
+        return
+
+    completed_at = None
+    if mapped_status in {"completed", "failed"}:
+        completed_at = datetime.now(timezone.utc)
+
+    db.execute(
+        text(
+            "UPDATE workforce_runs "
+            "SET status = :status, completed_at = :completed_at "
+            "WHERE id = :run_id AND task_id = :task_id"
+        ),
+        {
+            "status": mapped_status,
+            "completed_at": completed_at,
+            "run_id": workforce_run_id,
+            "task_id": int(task.id),
+        },
+    )

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -78,6 +78,8 @@ def validate_workforce_for_run(
     workforce = ensure_workforce_access(db, user, workforce, action="run")
     if workforce.status == "archived":
         raise HTTPException(status_code=400, detail="Archived workforce cannot run")
+    if workforce.status != "active":
+        raise HTTPException(status_code=400, detail="Workforce must be active to run")
 
     manager_agent = ensure_workforce_agent_run_access(workforce.manager_agent, user, db)
     workers = _sorted_workers(workforce)

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+
 from xagent.web.models.agent import Agent
 from xagent.web.models.user import User
 
@@ -19,7 +20,9 @@ def normalize_workforce_status(status: str | None) -> str:
     return normalized
 
 
-def normalize_text(value: str | None, field_name: str, required: bool = False) -> str | None:
+def normalize_text(
+    value: str | None, field_name: str, required: bool = False
+) -> str | None:
     if value is None:
         if required:
             raise HTTPException(status_code=400, detail=f"{field_name} is required")
@@ -37,7 +40,9 @@ def slugify_name(value: str | None, fallback: str = "worker") -> str:
 
 
 def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
-    return sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+    return sorted(
+        workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0)
+    )
 
 
 def validate_workforce_for_run(
@@ -65,9 +70,13 @@ def validate_workforce_for_run(
             required=True,
         )
         if instructions is None:
-            raise HTTPException(status_code=400, detail="assignment_instructions is required")
+            raise HTTPException(
+                status_code=400, detail="assignment_instructions is required"
+            )
         if int(worker.agent_id) == int(workforce.manager_agent_id):
-            raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+            raise HTTPException(
+                status_code=400, detail="Manager agent cannot also be a worker"
+            )
 
     return manager_agent, enabled_workers
 
@@ -96,11 +105,15 @@ def build_manager_system_prompt(snapshot: dict[str, Any]) -> str:
 
     manager_instructions = snapshot.get("manager", {}).get("workforce_instructions")
     if manager_instructions:
-        lines.extend(["", "Workforce-specific manager instructions:", manager_instructions])
+        lines.extend(
+            ["", "Workforce-specific manager instructions:", manager_instructions]
+        )
     return "\n".join(lines)
 
 
-def build_worker_system_prompt(workforce_name: str, assignment_instructions: str) -> str:
+def build_worker_system_prompt(
+    workforce_name: str, assignment_instructions: str
+) -> str:
     return "\n".join(
         [
             f'You are being called as part of Workforce "{workforce_name}".',
@@ -142,18 +155,24 @@ def build_agent_tool_overrides(
     return overrides
 
 
-def build_workforce_snapshot(db: Session, user: User, workforce: Workforce) -> dict[str, Any]:
+def build_workforce_snapshot(
+    db: Session, user: User, workforce: Workforce
+) -> dict[str, Any]:
     manager_agent, enabled_workers = validate_workforce_for_run(db, user, workforce)
     snapshot_workers: list[dict[str, Any]] = []
     for worker in enabled_workers:
-        alias = normalize_text(cast(str | None, worker.alias), "alias") or worker.agent.name
+        alias = (
+            normalize_text(cast(str | None, worker.alias), "alias") or worker.agent.name
+        )
         assignment_instructions = normalize_text(
             cast(str | None, worker.assignment_instructions),
             "assignment_instructions",
             required=True,
         )
         if assignment_instructions is None:
-            raise HTTPException(status_code=400, detail="assignment_instructions is required")
+            raise HTTPException(
+                status_code=400, detail="assignment_instructions is required"
+            )
 
         snapshot_workers.append(
             {

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -1,0 +1,211 @@
+import re
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from xagent.web.models.agent import Agent
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce, WorkforceAgent
+from .workforce_access import ensure_workforce_access, ensure_workforce_agent_run_access
+
+WORKFORCE_STATUSES = {"draft", "active", "archived"}
+
+
+def normalize_workforce_status(status: str | None) -> str:
+    normalized = (status or "draft").strip().lower()
+    if normalized not in WORKFORCE_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid workforce status")
+    return normalized
+
+
+def normalize_text(value: str | None, field_name: str, required: bool = False) -> str | None:
+    if value is None:
+        if required:
+            raise HTTPException(status_code=400, detail=f"{field_name} is required")
+        return None
+    normalized = value.strip()
+    if required and not normalized:
+        raise HTTPException(status_code=400, detail=f"{field_name} is required")
+    return normalized or None
+
+
+def slugify_name(value: str | None, fallback: str = "worker") -> str:
+    base = (value or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "_", base).strip("_")
+    return slug or fallback
+
+
+def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
+    return sorted(workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0))
+
+
+def validate_workforce_for_run(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+) -> tuple[Agent, list[WorkforceAgent]]:
+    workforce = ensure_workforce_access(db, user, workforce, action="run")
+    if workforce.status == "archived":
+        raise HTTPException(status_code=400, detail="Archived workforce cannot run")
+
+    manager_agent = ensure_workforce_agent_run_access(workforce.manager_agent, user, db)
+    workers = _sorted_workers(workforce)
+    enabled_workers = [worker for worker in workers if worker.enabled]
+    if not enabled_workers:
+        raise HTTPException(
+            status_code=400, detail="Workforce requires at least one enabled worker"
+        )
+
+    for worker in enabled_workers:
+        ensure_workforce_agent_run_access(worker.agent, user, db)
+        instructions = normalize_text(
+            cast(str | None, worker.assignment_instructions),
+            "assignment_instructions",
+            required=True,
+        )
+        if instructions is None:
+            raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        if int(worker.agent_id) == int(workforce.manager_agent_id):
+            raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+
+    return manager_agent, enabled_workers
+
+
+def build_manager_system_prompt(snapshot: dict[str, Any]) -> str:
+    workforce = snapshot["workforce"]
+    workers = snapshot["workers"]
+    lines = [
+        f'You are the Workforce Manager for "{workforce["name"]}".',
+        "",
+        "You are the only agent that talks to the user. You may delegate work only to the Worker Agents exposed as tools in this Workforce.",
+        "",
+        "Rules:",
+        "1. Decide which Worker Agents are needed for the user's request.",
+        "2. Give each Worker Agent a focused task with enough context.",
+        "3. Do not delegate outside this Workforce.",
+        "4. Consolidate Worker results into one final answer.",
+        "5. If Worker outputs conflict, resolve the conflict or explain uncertainty.",
+        "6. Do not expose internal tool names unless necessary.",
+        "",
+        "Available Worker Agents:",
+    ]
+    for worker in workers:
+        alias = worker.get("alias") or worker["name"]
+        lines.append(f"- {alias}: {worker['assignment_instructions']}")
+
+    manager_instructions = snapshot.get("manager", {}).get("workforce_instructions")
+    if manager_instructions:
+        lines.extend(["", "Workforce-specific manager instructions:", manager_instructions])
+    return "\n".join(lines)
+
+
+def build_worker_system_prompt(workforce_name: str, assignment_instructions: str) -> str:
+    return "\n".join(
+        [
+            f'You are being called as part of Workforce "{workforce_name}".',
+            "",
+            "Your assignment in this Workforce:",
+            assignment_instructions,
+            "",
+            "Stay within this assignment. Return your result to the Workforce Manager. Do not address the end user directly unless asked.",
+        ]
+    )
+
+
+def build_agent_tool_overrides(
+    snapshot: dict[str, Any],
+    workforce_run_id: int | None = None,
+) -> dict[int, dict[str, Any]]:
+    workforce_name = snapshot["workforce"]["name"]
+    workforce_id = snapshot["workforce"]["id"]
+    overrides: dict[int, dict[str, Any]] = {}
+    for worker in snapshot["workers"]:
+        alias = worker.get("alias") or worker["name"]
+        description_parts = []
+        if worker.get("description"):
+            description_parts.append(worker["description"])
+        description_parts.append(f"Workforce role: {alias}.")
+        description_parts.append(f"Assignment: {worker['assignment_instructions']}")
+        overrides[int(worker["agent_id"])] = {
+            "tool_name": worker["tool_name"],
+            "description": " ".join(description_parts),
+            "extra_system_prompt": build_worker_system_prompt(
+                workforce_name, worker["assignment_instructions"]
+            ),
+            "workforce_run_id": workforce_run_id,
+            "workforce_id": workforce_id,
+            "workforce_name": workforce_name,
+            "worker_member_id": worker.get("member_id"),
+            "worker_alias": alias,
+        }
+    return overrides
+
+
+def build_workforce_snapshot(db: Session, user: User, workforce: Workforce) -> dict[str, Any]:
+    manager_agent, enabled_workers = validate_workforce_for_run(db, user, workforce)
+    snapshot_workers: list[dict[str, Any]] = []
+    for worker in enabled_workers:
+        alias = normalize_text(cast(str | None, worker.alias), "alias") or worker.agent.name
+        assignment_instructions = normalize_text(
+            cast(str | None, worker.assignment_instructions),
+            "assignment_instructions",
+            required=True,
+        )
+        if assignment_instructions is None:
+            raise HTTPException(status_code=400, detail="assignment_instructions is required")
+
+        snapshot_workers.append(
+            {
+                "member_id": worker.id,
+                "agent_id": worker.agent_id,
+                "name": worker.agent.name,
+                "alias": alias,
+                "description": worker.agent.description,
+                "assignment_instructions": assignment_instructions,
+                "execution_mode": worker.agent.execution_mode,
+                "tool_name": f"call_workforce_worker_{worker.id}_{slugify_name(alias)}",
+                "enabled": bool(worker.enabled),
+            }
+        )
+
+    snapshot: dict[str, Any] = {
+        "version": 1,
+        "workforce": {
+            "id": workforce.id,
+            "name": workforce.name,
+            "description": workforce.description,
+            "status": workforce.status,
+            "scope_type": workforce.scope_type,
+            "scope_id": workforce.scope_id,
+            "owner_user_id": workforce.owner_user_id,
+        },
+        "manager": {
+            "agent_id": manager_agent.id,
+            "name": manager_agent.name,
+            "description": manager_agent.description,
+            "instructions": manager_agent.instructions,
+            "workforce_instructions": workforce.manager_instructions,
+            "execution_mode": manager_agent.execution_mode,
+            "models": manager_agent.models or {},
+        },
+        "workers": snapshot_workers,
+    }
+    snapshot["manager"]["runtime_prompt"] = build_manager_system_prompt(snapshot)
+    return snapshot
+
+
+def build_workforce_task_config(
+    snapshot: dict[str, Any],
+    selected_file_ids: list[str] | None = None,
+    workforce_run_id: int | None = None,
+) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "workforce_id": snapshot["workforce"]["id"],
+        "workforce_snapshot": snapshot,
+    }
+    if workforce_run_id is not None:
+        config["workforce_run_id"] = workforce_run_id
+    if selected_file_ids:
+        config["selected_file_ids"] = selected_file_ids
+    return config

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 from typing import Any, cast
 
@@ -37,6 +38,30 @@ def slugify_name(value: str | None, fallback: str = "worker") -> str:
     base = (value or "").strip().lower()
     slug = re.sub(r"[^a-z0-9]+", "_", base).strip("_")
     return slug or fallback
+
+
+_MAX_TOOL_NAME_LENGTH = 64
+_TOOL_NAME_PREFIX = "call_workforce_worker_"
+
+
+def _build_worker_tool_name(worker_id: int, alias: str) -> str:
+    slug = slugify_name(alias)
+    raw = f"{_TOOL_NAME_PREFIX}{worker_id}_{slug}"
+    if len(raw) <= _MAX_TOOL_NAME_LENGTH:
+        return raw
+    worker_id_str = str(worker_id)
+    hash_suffix = "_" + hashlib.md5(slug.encode()).hexdigest()[:6]
+    available = (
+        _MAX_TOOL_NAME_LENGTH
+        - len(_TOOL_NAME_PREFIX)
+        - len(worker_id_str)
+        - len(hash_suffix)
+        - 1
+    )
+    if available < 4:
+        available = 4
+    truncated_slug = slug[:available]
+    return f"{_TOOL_NAME_PREFIX}{worker_id_str}_{truncated_slug}{hash_suffix}"
 
 
 def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
@@ -183,7 +208,7 @@ def build_workforce_snapshot(
                 "description": worker.agent.description,
                 "assignment_instructions": assignment_instructions,
                 "execution_mode": worker.agent.execution_mode,
-                "tool_name": f"call_workforce_worker_{worker.id}_{slugify_name(alias)}",
+                "tool_name": _build_worker_tool_name(cast(int, worker.id), alias),
                 "enabled": bool(worker.enabled),
             }
         )

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -16,10 +16,13 @@ from .workforce_snapshot import normalize_text
 _TEMPLATE_MANAGER = create_template_manager()
 
 _SAFE_TEMPLATE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+_MAX_TEMPLATE_ID_LENGTH = 200
 
 
 def _validate_template_id(template_id: str) -> None:
-    if not _SAFE_TEMPLATE_ID_RE.match(template_id):
+    if len(template_id) > _MAX_TEMPLATE_ID_LENGTH:
+        raise HTTPException(status_code=400, detail="template_id too long")
+    if not _SAFE_TEMPLATE_ID_RE.fullmatch(template_id):
         raise HTTPException(
             status_code=400, detail=f"Invalid template_id: {template_id}"
         )

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -97,6 +97,7 @@ def create_agent_record(
     tool_categories: list[str] | None = None,
     suggested_prompts: list[str] | None = None,
     ensure_unique_name: bool = False,
+    status: AgentStatus = AgentStatus.DRAFT,
 ) -> Agent:
     normalized_name = normalize_text(name, "name", required=True)
     if normalized_name is None:
@@ -127,7 +128,7 @@ def create_agent_record(
         skills=normalize_string_list(skills),
         tool_categories=normalize_string_list(tool_categories),
         suggested_prompts=normalize_string_list(suggested_prompts),
-        status=AgentStatus.DRAFT,
+        status=status,
         widget_enabled=True,
         allowed_domains=[],
     )

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+
 from xagent.templates.utils import create_template_manager
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
@@ -46,7 +47,9 @@ def _resolve_unique_agent_name(db: Session, user: User, name: str) -> str:
         raise HTTPException(status_code=400, detail="name is required")
 
     existing = (
-        db.query(Agent).filter(Agent.user_id == user.id, Agent.name == normalized_name).first()
+        db.query(Agent)
+        .filter(Agent.user_id == user.id, Agent.name == normalized_name)
+        .first()
     )
     if existing is None:
         return normalized_name
@@ -57,7 +60,11 @@ def _resolve_unique_agent_name(db: Session, user: User, name: str) -> str:
         suffix_text = f" {suffix}"
         candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
         candidate = f"{candidate_base}{suffix_text}"
-        conflict = db.query(Agent).filter(Agent.user_id == user.id, Agent.name == candidate).first()
+        conflict = (
+            db.query(Agent)
+            .filter(Agent.user_id == user.id, Agent.name == candidate)
+            .first()
+        )
         if conflict is None:
             return candidate
         suffix += 1
@@ -86,10 +93,14 @@ def create_agent_record(
         final_name = _resolve_unique_agent_name(db, user, normalized_name)
     else:
         existing = (
-            db.query(Agent).filter(Agent.user_id == user.id, Agent.name == normalized_name).first()
+            db.query(Agent)
+            .filter(Agent.user_id == user.id, Agent.name == normalized_name)
+            .first()
         )
         if existing:
-            raise HTTPException(status_code=409, detail="Agent with this name already exists")
+            raise HTTPException(
+                status_code=409, detail="Agent with this name already exists"
+            )
         final_name = normalized_name
 
     agent = Agent(
@@ -139,7 +150,9 @@ def list_template_summaries() -> list[dict[str, Any]]:
         enriched = _TEMPLATE_MANAGER._enrich_template(template)
         descriptions = enriched.get("descriptions") or {}
         if isinstance(descriptions, dict):
-            description = descriptions.get("en") or next(iter(descriptions.values()), None)
+            description = descriptions.get("en") or next(
+                iter(descriptions.values()), None
+            )
         else:
             description = descriptions
         results.append(
@@ -182,7 +195,11 @@ def next_worker_sort_order(db: Session, workforce_id: int) -> int:
         .order_by(WorkforceAgent.sort_order.desc(), WorkforceAgent.id.desc())
         .first()
     )
-    return int(max_sort_order[0]) + 1 if max_sort_order and max_sort_order[0] is not None else 1
+    return (
+        int(max_sort_order[0]) + 1
+        if max_sort_order and max_sort_order[0] is not None
+        else 1
+    )
 
 
 def create_workforce_worker(
@@ -208,7 +225,9 @@ def create_workforce_worker(
         required=True,
     )
     if normalized_assignment is None:
-        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+        raise HTTPException(
+            status_code=400, detail="assignment_instructions is required"
+        )
 
     if source_type == "existing":
         if agent_id is None:
@@ -227,14 +246,18 @@ def create_workforce_worker(
             .first()
         )
         if existing:
-            raise HTTPException(status_code=409, detail="Agent already added to workforce")
+            raise HTTPException(
+                status_code=409, detail="Agent already added to workforce"
+            )
     elif source_type == "template":
         if not template_id:
             raise HTTPException(status_code=400, detail="template_id is required")
         agent = create_agent_from_template(db, user, template_id)
     else:
         if not isinstance(agent_payload, dict):
-            raise HTTPException(status_code=400, detail="agent is required for source_type='new'")
+            raise HTTPException(
+                status_code=400, detail="agent is required for source_type='new'"
+            )
         agent = create_agent_record(
             db,
             user,
@@ -253,7 +276,9 @@ def create_workforce_worker(
     agent_id_value = cast(int, agent.id)
     workforce_manager_id = cast(int, workforce.manager_agent_id)
     if agent_id_value == workforce_manager_id:
-        raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+        raise HTTPException(
+            status_code=400, detail="Manager agent cannot also be a worker"
+        )
 
     workforce_id = cast(int, workforce.id)
     worker = WorkforceAgent(

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -13,6 +14,15 @@ from .workforce_access import ensure_agent_access
 from .workforce_snapshot import normalize_text
 
 _TEMPLATE_MANAGER = create_template_manager()
+
+_SAFE_TEMPLATE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _validate_template_id(template_id: str) -> None:
+    if not _SAFE_TEMPLATE_ID_RE.match(template_id):
+        raise HTTPException(
+            status_code=400, detail=f"Invalid template_id: {template_id}"
+        )
 
 
 def ensure_supported_source_type(source_type: str) -> None:
@@ -124,6 +134,7 @@ def create_agent_record(
 
 
 def load_template_detail(template_id: str) -> dict[str, Any]:
+    _validate_template_id(template_id)
     yaml_path = Path(_TEMPLATE_MANAGER.templates_root) / f"{template_id}.yaml"
     if not yaml_path.exists():
         raise HTTPException(status_code=404, detail="Template not found")

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -29,10 +29,10 @@ def _validate_template_id(template_id: str) -> None:
 
 
 def ensure_supported_source_type(source_type: str) -> None:
-    if source_type not in {"existing", "template", "new"}:
+    if source_type != "existing":
         raise HTTPException(
             status_code=400,
-            detail="source_type must be one of: existing, template, new",
+            detail="source_type must be existing; publish an agent before adding it to a workforce",
         )
 
 
@@ -250,6 +250,7 @@ def create_workforce_worker(
             db.query(Agent).filter(Agent.id == agent_id).first(),
             user,
             db,
+            require_published=True,
         )
         existing = (
             db.query(WorkforceAgent)

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -1,0 +1,274 @@
+from pathlib import Path
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from xagent.templates.utils import create_template_manager
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce, WorkforceAgent
+from .workforce_access import ensure_agent_access
+from .workforce_snapshot import normalize_text
+
+_TEMPLATE_MANAGER = create_template_manager()
+
+
+def ensure_supported_source_type(source_type: str) -> None:
+    if source_type not in {"existing", "template", "new"}:
+        raise HTTPException(
+            status_code=400,
+            detail="source_type must be one of: existing, template, new",
+        )
+
+
+def normalize_execution_mode(value: str | None) -> str:
+    normalized = str(value or "balanced").strip().lower()
+    if normalized not in {"flash", "balanced", "think"}:
+        raise HTTPException(
+            status_code=400, detail="execution_mode must be flash, balanced, or think"
+        )
+    return normalized
+
+
+def normalize_string_list(values: list[str] | None) -> list[str]:
+    normalized: list[str] = []
+    for value in values or []:
+        text = str(value or "").strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _resolve_unique_agent_name(db: Session, user: User, name: str) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    if normalized_name is None:
+        raise HTTPException(status_code=400, detail="name is required")
+
+    existing = (
+        db.query(Agent).filter(Agent.user_id == user.id, Agent.name == normalized_name).first()
+    )
+    if existing is None:
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        conflict = db.query(Agent).filter(Agent.user_id == user.id, Agent.name == candidate).first()
+        if conflict is None:
+            return candidate
+        suffix += 1
+
+
+def create_agent_record(
+    db: Session,
+    user: User,
+    *,
+    name: str,
+    description: str | None = None,
+    instructions: str | None = None,
+    execution_mode: str | None = "balanced",
+    models: dict[str, Any] | None = None,
+    knowledge_bases: list[str] | None = None,
+    skills: list[str] | None = None,
+    tool_categories: list[str] | None = None,
+    suggested_prompts: list[str] | None = None,
+    ensure_unique_name: bool = False,
+) -> Agent:
+    normalized_name = normalize_text(name, "name", required=True)
+    if normalized_name is None:
+        raise HTTPException(status_code=400, detail="name is required")
+
+    if ensure_unique_name:
+        final_name = _resolve_unique_agent_name(db, user, normalized_name)
+    else:
+        existing = (
+            db.query(Agent).filter(Agent.user_id == user.id, Agent.name == normalized_name).first()
+        )
+        if existing:
+            raise HTTPException(status_code=409, detail="Agent with this name already exists")
+        final_name = normalized_name
+
+    agent = Agent(
+        user_id=user.id,
+        name=final_name,
+        description=normalize_text(description, "description"),
+        instructions=normalize_text(instructions, "instructions"),
+        execution_mode=normalize_execution_mode(execution_mode),
+        models=models,
+        knowledge_bases=normalize_string_list(knowledge_bases),
+        skills=normalize_string_list(skills),
+        tool_categories=normalize_string_list(tool_categories),
+        suggested_prompts=normalize_string_list(suggested_prompts),
+        status=AgentStatus.DRAFT,
+        widget_enabled=True,
+        allowed_domains=[],
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def load_template_detail(template_id: str) -> dict[str, Any]:
+    yaml_path = Path(_TEMPLATE_MANAGER.templates_root) / f"{template_id}.yaml"
+    if not yaml_path.exists():
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    template = _TEMPLATE_MANAGER._parse_yaml_file(yaml_path)
+    enriched = _TEMPLATE_MANAGER._enrich_template(template)
+    descriptions = enriched.get("descriptions") or {}
+    if isinstance(descriptions, dict):
+        description = descriptions.get("en") or next(iter(descriptions.values()), None)
+    else:
+        description = descriptions
+
+    return {
+        **enriched,
+        "description": normalize_text(description, "description"),
+    }
+
+
+def list_template_summaries() -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    templates_root = Path(_TEMPLATE_MANAGER.templates_root)
+    for yaml_path in sorted(templates_root.glob("*.yaml")):
+        template = _TEMPLATE_MANAGER._parse_yaml_file(yaml_path)
+        enriched = _TEMPLATE_MANAGER._enrich_template(template)
+        descriptions = enriched.get("descriptions") or {}
+        if isinstance(descriptions, dict):
+            description = descriptions.get("en") or next(iter(descriptions.values()), None)
+        else:
+            description = descriptions
+        results.append(
+            {
+                "id": enriched.get("id"),
+                "name": enriched.get("name"),
+                "description": normalize_text(description, "description"),
+            }
+        )
+    return results
+
+
+def create_agent_from_template(
+    db: Session,
+    user: User,
+    template_id: str,
+) -> Agent:
+    template = load_template_detail(template_id)
+    agent_config = template.get("agent_config") or {}
+    return create_agent_record(
+        db,
+        user,
+        name=template.get("name") or template_id,
+        description=template.get("description"),
+        instructions=agent_config.get("instructions"),
+        execution_mode=agent_config.get("execution_mode"),
+        models=agent_config.get("models"),
+        knowledge_bases=agent_config.get("knowledge_bases") or [],
+        skills=agent_config.get("skills") or [],
+        tool_categories=agent_config.get("tool_categories") or [],
+        suggested_prompts=agent_config.get("suggested_prompts") or [],
+        ensure_unique_name=True,
+    )
+
+
+def next_worker_sort_order(db: Session, workforce_id: int) -> int:
+    max_sort_order = (
+        db.query(WorkforceAgent.sort_order)
+        .filter(WorkforceAgent.workforce_id == workforce_id)
+        .order_by(WorkforceAgent.sort_order.desc(), WorkforceAgent.id.desc())
+        .first()
+    )
+    return int(max_sort_order[0]) + 1 if max_sort_order and max_sort_order[0] is not None else 1
+
+
+def create_workforce_worker(
+    db: Session,
+    workforce: Workforce,
+    user: User,
+    *,
+    source_type: str,
+    assignment_instructions: str,
+    alias: str | None = None,
+    agent_id: int | None = None,
+    template_id: str | None = None,
+    agent_payload: dict[str, Any] | None = None,
+    enabled: bool = True,
+    sort_order: int | None = None,
+    canvas_position: dict[str, Any] | None = None,
+) -> WorkforceAgent:
+    ensure_supported_source_type(source_type)
+
+    normalized_assignment = normalize_text(
+        assignment_instructions,
+        "assignment_instructions",
+        required=True,
+    )
+    if normalized_assignment is None:
+        raise HTTPException(status_code=400, detail="assignment_instructions is required")
+
+    if source_type == "existing":
+        if agent_id is None:
+            raise HTTPException(status_code=400, detail="agent_id is required")
+        agent = ensure_agent_access(
+            db.query(Agent).filter(Agent.id == agent_id).first(),
+            user,
+            db,
+        )
+        existing = (
+            db.query(WorkforceAgent)
+            .filter(
+                WorkforceAgent.workforce_id == workforce.id,
+                WorkforceAgent.agent_id == agent.id,
+            )
+            .first()
+        )
+        if existing:
+            raise HTTPException(status_code=409, detail="Agent already added to workforce")
+    elif source_type == "template":
+        if not template_id:
+            raise HTTPException(status_code=400, detail="template_id is required")
+        agent = create_agent_from_template(db, user, template_id)
+    else:
+        if not isinstance(agent_payload, dict):
+            raise HTTPException(status_code=400, detail="agent is required for source_type='new'")
+        agent = create_agent_record(
+            db,
+            user,
+            name=str(agent_payload.get("name") or ""),
+            description=agent_payload.get("description"),
+            instructions=agent_payload.get("instructions"),
+            execution_mode=agent_payload.get("execution_mode"),
+            models=agent_payload.get("models"),
+            knowledge_bases=agent_payload.get("knowledge_bases"),
+            skills=agent_payload.get("skills"),
+            tool_categories=agent_payload.get("tool_categories"),
+            suggested_prompts=agent_payload.get("suggested_prompts"),
+            ensure_unique_name=True,
+        )
+
+    agent_id_value = cast(int, agent.id)
+    workforce_manager_id = cast(int, workforce.manager_agent_id)
+    if agent_id_value == workforce_manager_id:
+        raise HTTPException(status_code=400, detail="Manager agent cannot also be a worker")
+
+    workforce_id = cast(int, workforce.id)
+    worker = WorkforceAgent(
+        workforce_id=workforce_id,
+        agent_id=agent_id_value,
+        alias=normalize_text(alias, "alias"),
+        assignment_instructions=normalized_assignment,
+        source_type=source_type,
+        template_id=template_id,
+        enabled=bool(enabled),
+        sort_order=sort_order
+        if sort_order is not None
+        else next_worker_sort_order(db, workforce_id),
+        canvas_position=canvas_position,
+    )
+    db.add(worker)
+    db.flush()
+    return worker

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -8,7 +8,7 @@ and other web-specific sources.
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import httpx
 
@@ -23,9 +23,7 @@ from ..services.tool_credentials import (
 logger = logging.getLogger(__name__)
 
 
-async def refresh_oauth_token_if_needed(
-    db: Any, oauth_account: Any, provider_name: str
-) -> bool:
+async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_name: str) -> bool:
     """Check if token is expired (or close to expiring) and refresh if needed."""
     if not oauth_account.expires_at:
         return True  # Assume valid if no expiration is set
@@ -42,9 +40,7 @@ async def refresh_oauth_token_if_needed(
         return True  # Token is still valid
 
     if not oauth_account.refresh_token:
-        logger.warning(
-            f"Token expired for {provider_name} but no refresh_token available."
-        )
+        logger.warning(f"Token expired for {provider_name} but no refresh_token available.")
         return False
 
     logger.info(f"Token expired for {provider_name}, attempting to refresh...")
@@ -53,9 +49,7 @@ async def refresh_oauth_token_if_needed(
         from ..models.oauth_provider import OAuthProvider
 
         provider_config = (
-            db.query(OAuthProvider)
-            .filter(OAuthProvider.provider_name == provider_name)
-            .first()
+            db.query(OAuthProvider).filter(OAuthProvider.provider_name == provider_name).first()
         )
         if not provider_config:
             logger.warning(f"Unknown provider for refresh: {provider_name}")
@@ -65,9 +59,7 @@ async def refresh_oauth_token_if_needed(
         client_secret = decrypt_value(provider_config.client_secret)
 
         if not client_id or not client_secret:
-            logger.warning(
-                f"{provider_name} OAuth not configured (missing CLIENT_ID or SECRET)."
-            )
+            logger.warning(f"{provider_name} OAuth not configured (missing CLIENT_ID or SECRET).")
             return False
 
         data = {
@@ -105,9 +97,7 @@ async def refresh_oauth_token_if_needed(
             logger.error(f"Failed to refresh {provider_name} token: {response.text}")
 
     except Exception as e:
-        logger.error(
-            f"Exception refreshing token for {provider_name}: {e}", exc_info=True
-        )
+        logger.error(f"Exception refreshing token for {provider_name}: {e}", exc_info=True)
 
     return False
 
@@ -116,33 +106,37 @@ class WebToolConfig(BaseToolConfig):
     """Web-specific tool configuration that loads from database."""
 
     @staticmethod
-    def _coerce_user_id(value: Any) -> Optional[int]:
+    def _coerce_user_id(value: Any) -> int | None:
         return value if isinstance(value, int) else None
 
     def __init__(
         self,
         db: Any,
         request: Any,
-        user_id: Optional[int] = None,
+        user_id: int | None = None,
         is_admin: bool = False,
-        user: Optional[Any] = None,
-        workspace_config: Optional[Dict[str, Any]] = None,
-        vision_model: Optional[Any] = None,
-        llm: Optional[Any] = None,
+        user: Any | None = None,
+        workspace_config: dict[str, Any] | None = None,
+        vision_model: Any | None = None,
+        llm: Any | None = None,
         include_mcp_tools: bool = True,
-        task_id: Optional[str] = None,
-        workspace_base_dir: Optional[str] = None,
+        task_id: str | None = None,
+        workspace_base_dir: str | None = None,
         browser_tools_enabled: bool = True,
-        allowed_collections: Optional[List[str]] = None,
-        allowed_skills: Optional[List[str]] = None,
-        allowed_tools: Optional[List[str]] = None,
-        sandbox: Optional[Any] = None,
+        allowed_collections: list[str] | None = None,
+        allowed_skills: list[str] | None = None,
+        allowed_tools: list[str] | None = None,
+        allowed_agent_ids: list[int] | None = None,
+        agent_tool_overrides: dict[int, dict[str, Any]] | None = None,
+        enable_global_agent_tools: bool = True,
+        allow_cross_user_agent_ids: bool = False,
+        parent_task_id: int | None = None,
+        parent_tracer: Any | None = None,
+        sandbox: Any | None = None,
     ):
         self.db = db
         self.request = request
-        self._user_id = (
-            user_id if user_id is not None else self._get_user_id_from_request(request)
-        )
+        self._user_id = user_id if user_id is not None else self._get_user_id_from_request(request)
         self._is_admin_value = is_admin or self._get_is_admin_from_request(request)
         # Initialize workspace_config with base_dir and task_id if provided
         if workspace_config is None:
@@ -164,28 +158,34 @@ class WebToolConfig(BaseToolConfig):
         self._allowed_collections = allowed_collections
         self._allowed_skills = allowed_skills
         self._allowed_tools = allowed_tools
-        self._delegate_agent_ids: Optional[List[int]] = None
-        self._excluded_agent_id: Optional[int] = None
+        self._delegate_agent_ids: list[int] | None = None
+        self._allowed_agent_ids = allowed_agent_ids
+        self._agent_tool_overrides = agent_tool_overrides or {}
+        self._enable_global_agent_tools = enable_global_agent_tools
+        self._allow_cross_user_agent_ids = allow_cross_user_agent_ids
+        self._parent_task_id = parent_task_id
+        self._parent_tracer = parent_tracer
+        self._excluded_agent_id: int | None = None
 
         # Cache user object for hook queries.
         # Use explicit user param first; fall back to request.user.
         self._user = user if user is not None else getattr(request, "user", None)
-        self._cached_tool_overrides: Optional[dict] = None
+        self._cached_tool_overrides: dict | None = None
 
         # Sandbox instance - only store reference, lifecycle managed by upper layer
-        self._sandbox: Optional[Any] = sandbox
+        self._sandbox: Any | None = sandbox
 
         # Cache for loaded configurations
-        self._cached_vision_config: Optional[Any] = None
-        self._cached_image_configs: Optional[Dict[str, Any]] = None
-        self._cached_image_generate_model: Optional[Any] = None
-        self._cached_image_edit_model: Optional[Any] = None
-        self._cached_asr_models: Optional[Dict[str, Any]] = None
-        self._cached_asr_model: Optional[Any] = None
-        self._cached_tts_models: Optional[Dict[str, Any]] = None
-        self._cached_tts_model: Optional[Any] = None
-        self._cached_mcp_configs: Optional[List[Dict[str, Any]]] = None
-        self._cached_embedding_model: Optional[str] = None
+        self._cached_vision_config: Any | None = None
+        self._cached_image_configs: dict[str, Any] | None = None
+        self._cached_image_generate_model: Any | None = None
+        self._cached_image_edit_model: Any | None = None
+        self._cached_asr_models: dict[str, Any] | None = None
+        self._cached_asr_model: Any | None = None
+        self._cached_tts_models: dict[str, Any] | None = None
+        self._cached_tts_model: Any | None = None
+        self._cached_mcp_configs: list[dict[str, Any]] | None = None
+        self._cached_embedding_model: str | None = None
 
     def _get_user_id_from_request(self, request: Any) -> int:
         """Extract user ID from request using JWT authentication."""
@@ -233,7 +233,7 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to get is_admin from request: {e}")
             return False
 
-    def get_workspace_config(self) -> Optional[Dict[str, Any]]:
+    def get_workspace_config(self) -> dict[str, Any] | None:
         """Get workspace configuration."""
         return self._workspace_config
 
@@ -245,7 +245,7 @@ class WebToolConfig(BaseToolConfig):
         """Whether to include basic tools."""
         return True
 
-    def get_vision_model(self) -> Optional[Any]:
+    def get_vision_model(self) -> Any | None:
         """Get vision model, prioritizing explicitly provided model over database."""
         if hasattr(self, "_explicit_vision_model") and self._explicit_vision_model:
             return self._explicit_vision_model
@@ -254,25 +254,25 @@ class WebToolConfig(BaseToolConfig):
             self._cached_vision_config = self._load_vision_model()
         return self._cached_vision_config
 
-    def get_image_models(self) -> Dict[str, Any]:
+    def get_image_models(self) -> dict[str, Any]:
         """Load image models from database."""
         if self._cached_image_configs is None:
             self._cached_image_configs = self._load_image_models()
         return self._cached_image_configs
 
-    def get_image_generate_model(self) -> Optional[Any]:
+    def get_image_generate_model(self) -> Any | None:
         """Get default image generation model from database."""
         if self._cached_image_generate_model is None:
             self._cached_image_generate_model = self._load_image_generate_model()
         return self._cached_image_generate_model
 
-    def get_image_edit_model(self) -> Optional[Any]:
+    def get_image_edit_model(self) -> Any | None:
         """Get default image editing model from database."""
         if self._cached_image_edit_model is None:
             self._cached_image_edit_model = self._load_image_edit_model()
         return self._cached_image_edit_model
 
-    async def get_mcp_server_configs(self) -> List[Dict[str, Any]]:
+    async def get_mcp_server_configs(self) -> list[dict[str, Any]]:
         """Load MCP server configurations from database."""
         if not self._include_mcp_tools:
             return []
@@ -281,7 +281,7 @@ class WebToolConfig(BaseToolConfig):
             self._cached_mcp_configs = await self._load_mcp_server_configs()
         return self._cached_mcp_configs
 
-    def get_embedding_model(self) -> Optional[str]:
+    def get_embedding_model(self) -> str | None:
         """Load default embedding model ID from database."""
         if self._cached_embedding_model is None:
             self._cached_embedding_model = self._load_embedding_model()
@@ -291,19 +291,19 @@ class WebToolConfig(BaseToolConfig):
         """Whether to include browser automation tools."""
         return self._browser_tools_enabled
 
-    def get_task_id(self) -> Optional[str]:
+    def get_task_id(self) -> str | None:
         """Get task ID for session tracking."""
         return self._task_id
 
-    def get_allowed_collections(self) -> Optional[List[str]]:
+    def get_allowed_collections(self) -> list[str] | None:
         """Get allowed knowledge base collections. None means all collections are allowed."""
         return self._allowed_collections
 
-    def get_allowed_skills(self) -> Optional[List[str]]:
+    def get_allowed_skills(self) -> list[str] | None:
         """Get allowed skill names. None means all skills are allowed."""
         return self._allowed_skills
 
-    def get_allowed_tools(self) -> Optional[List[str]]:
+    def get_allowed_tools(self) -> list[str] | None:
         """Get allowed tool names. None means all tools are allowed."""
         return self._allowed_tools
 
@@ -325,15 +325,15 @@ class WebToolConfig(BaseToolConfig):
             self._cached_tool_overrides = {}
         return self._cached_tool_overrides
 
-    def get_excluded_agent_id(self) -> Optional[int]:
+    def get_excluded_agent_id(self) -> int | None:
         """Get agent ID to exclude from agent tools (to prevent self-calls)."""
         return getattr(self, "_excluded_agent_id", None)
 
-    def get_delegate_agent_ids(self) -> Optional[List[int]]:
+    def get_delegate_agent_ids(self) -> list[int] | None:
         """Get explicitly selected delegable agent IDs."""
         return getattr(self, "_delegate_agent_ids", None)
 
-    def get_user_id(self) -> Optional[int]:
+    def get_user_id(self) -> int | None:
         """Get current user ID for multi-tenancy."""
         return self._user_id
 
@@ -347,29 +347,44 @@ class WebToolConfig(BaseToolConfig):
 
     def get_enable_agent_tools(self) -> bool:
         """Whether to include published agents as tools."""
-        return True
+        return self._enable_global_agent_tools
 
-    def get_sandbox(self) -> Optional[Any]:
+    def get_allowed_agent_ids(self) -> list[int] | None:
+        return self._allowed_agent_ids
+
+    def get_agent_tool_overrides(self) -> dict[int, dict[str, Any]]:
+        return self._agent_tool_overrides
+
+    def get_allow_cross_user_agent_ids(self) -> bool:
+        return self._allow_cross_user_agent_ids
+
+    def get_parent_task_id(self) -> int | None:
+        return self._parent_task_id
+
+    def get_parent_tracer(self) -> Any | None:
+        return self._parent_tracer
+
+    def get_sandbox(self) -> Any | None:
         """Get sandbox instance. Returns None if not available."""
         return self._sandbox
 
-    def get_tool_credential(self, tool_name: str, field_name: str) -> Optional[str]:
+    def get_tool_credential(self, tool_name: str, field_name: str) -> str | None:
         return resolve_tool_credential(self.db, tool_name, field_name)
 
-    def get_sql_connections(self) -> Dict[str, str]:
+    def get_sql_connections(self) -> dict[str, str]:
         return get_sql_connection_map(self.db, self._user_id)
 
     def set_sandbox(self, sandbox: Any) -> None:
         """Set sandbox instance for this config."""
         self._sandbox = sandbox
 
-    def _load_embedding_model(self) -> Optional[str]:
+    def _load_embedding_model(self) -> str | None:
         """Load embedding model ID from database via model service."""
         from ...web.services.model_service import get_default_embedding_model
 
         return get_default_embedding_model(self._user_id)
 
-    def _load_vision_model(self) -> Optional[Any]:
+    def _load_vision_model(self) -> Any | None:
         """Load vision model from database via model service."""
         try:
             from ...web.services.model_service import get_default_vision_model
@@ -381,7 +396,7 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load vision model: {e}")
             return None
 
-    def _load_image_models(self) -> Dict[str, Any]:
+    def _load_image_models(self) -> dict[str, Any]:
         """Load image models from database via model service."""
         try:
             from ...web.services.model_service import get_image_models
@@ -394,7 +409,7 @@ class WebToolConfig(BaseToolConfig):
 
             return {}
 
-    def _load_image_generate_model(self) -> Optional[Any]:
+    def _load_image_generate_model(self) -> Any | None:
         """Load default image generation model from database via model service."""
         try:
             from ...web.services.model_service import get_default_image_generate_model
@@ -406,7 +421,7 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default image generation model: {e}")
             return None
 
-    def _load_image_edit_model(self) -> Optional[Any]:
+    def _load_image_edit_model(self) -> Any | None:
         """Load default image editing model from database via model service."""
         try:
             from ...web.services.model_service import get_default_image_edit_model
@@ -418,13 +433,13 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default image editing model: {e}")
             return None
 
-    def get_asr_models(self) -> Dict[str, Any]:
+    def get_asr_models(self) -> dict[str, Any]:
         """Load ASR models from database."""
         if self._cached_asr_models is None:
             self._cached_asr_models = self._load_asr_models()
         return self._cached_asr_models
 
-    def _load_asr_models(self) -> Dict[str, Any]:
+    def _load_asr_models(self) -> dict[str, Any]:
         """Load ASR models from database via model service."""
         try:
             from ...web.services.model_service import get_asr_models
@@ -436,13 +451,13 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load ASR models: {e}")
             return {}
 
-    def get_asr_model(self) -> Optional[Any]:
+    def get_asr_model(self) -> Any | None:
         """Get default ASR model from database."""
         if self._cached_asr_model is None:
             self._cached_asr_model = self._load_asr_model()
         return self._cached_asr_model
 
-    def _load_asr_model(self) -> Optional[Any]:
+    def _load_asr_model(self) -> Any | None:
         """Load default ASR model from database via model service."""
         try:
             from ...web.services.model_service import get_default_asr_model
@@ -454,13 +469,13 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default ASR model: {e}")
             return None
 
-    def get_tts_models(self) -> Dict[str, Any]:
+    def get_tts_models(self) -> dict[str, Any]:
         """Load TTS models from database."""
         if self._cached_tts_models is None:
             self._cached_tts_models = self._load_tts_models()
         return self._cached_tts_models
 
-    def _load_tts_models(self) -> Dict[str, Any]:
+    def _load_tts_models(self) -> dict[str, Any]:
         """Load TTS models from database via model service."""
         try:
             from ...web.services.model_service import get_tts_models
@@ -472,17 +487,17 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load TTS models: {e}")
             return {}
 
-    def get_tts_model(self) -> Optional[Any]:
+    def get_tts_model(self) -> Any | None:
         """Get default TTS model from database."""
         if self._cached_tts_model is None:
             self._cached_tts_model = self._load_tts_model()
         return self._cached_tts_model
 
-    def get_llm(self) -> Optional[Any]:
+    def get_llm(self) -> Any | None:
         """Get LLM from constructor parameter."""
         return self._explicit_llm
 
-    def _load_tts_model(self) -> Optional[Any]:
+    def _load_tts_model(self) -> Any | None:
         """Load default TTS model from database via model service."""
         try:
             from ...web.services.model_service import get_default_tts_model
@@ -494,7 +509,7 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default TTS model: {e}")
             return None
 
-    async def _load_mcp_server_configs(self) -> List[Dict[str, Any]]:
+    async def _load_mcp_server_configs(self) -> list[dict[str, Any]]:
         """Load MCP server configurations from database with user context."""
         logger = logging.getLogger(__name__)
         configs = []
@@ -510,9 +525,7 @@ class WebToolConfig(BaseToolConfig):
                 .all()
             )
 
-            logger.info(
-                f"Found {len(servers)} active MCP servers for user {self._user_id}"
-            )
+            logger.info(f"Found {len(servers)} active MCP servers for user {self._user_id}")
 
             for server in servers:
                 # Build config dict from server model
@@ -533,9 +546,7 @@ class WebToolConfig(BaseToolConfig):
                     from ...web.models.user_oauth import UserOAuth
 
                     app_info = get_app_by_name(self.db, str(server.name))
-                    provider_name = (
-                        app_info.get("provider") if app_info else server.name.lower()
-                    )
+                    provider_name = app_info.get("provider") if app_info else server.name.lower()
 
                     # Some oauth records might be saved with the app_id as provider instead of the general provider_name
                     # For example, "google-drive" instead of "google"
@@ -590,18 +601,14 @@ class WebToolConfig(BaseToolConfig):
 
                         if is_valid and app_info:
                             app_id = app_info.get("id")
-                            logger.info(
-                                f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
-                            )
+                            logger.info(f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy")
 
                             launch_config = app_info.get("launch_config")
                             if launch_config:
                                 config["transport"] = "stdio"
                                 transport_config["transport"] = "stdio"
                                 transport_config["command"] = launch_config["command"]
-                                transport_config["args"] = launch_config.get(
-                                    "args", []
-                                ).copy()
+                                transport_config["args"] = launch_config.get("args", []).copy()
 
                                 env = {}
                                 for env_key, token_type in launch_config.get(
@@ -612,13 +619,9 @@ class WebToolConfig(BaseToolConfig):
 
                                 env.update(
                                     {
-                                        "HTTPS_PROXY": os.environ.get(
-                                            "HTTPS_PROXY", ""
-                                        ),
+                                        "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
                                         "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
-                                        "https_proxy": os.environ.get(
-                                            "https_proxy", ""
-                                        ),
+                                        "https_proxy": os.environ.get("https_proxy", ""),
                                         "http_proxy": os.environ.get("http_proxy", ""),
                                     }
                                 )
@@ -640,9 +643,7 @@ class WebToolConfig(BaseToolConfig):
                                 }
 
                     else:
-                        logger.info(
-                            f"OAUTH CONFIG: No valid token found for '{provider_name}'."
-                        )
+                        logger.info(f"OAUTH CONFIG: No valid token found for '{provider_name}'.")
 
                 if server.transport == "stdio":
                     if server.command:
@@ -677,13 +678,9 @@ class WebToolConfig(BaseToolConfig):
                     if server.docker_image:
                         transport_config["docker_image"] = server.docker_image
                     if server.docker_environment:
-                        transport_config["docker_environment"] = (
-                            server.docker_environment
-                        )
+                        transport_config["docker_environment"] = server.docker_environment
                     if server.docker_working_dir:
-                        transport_config["docker_working_dir"] = (
-                            server.docker_working_dir
-                        )
+                        transport_config["docker_working_dir"] = server.docker_working_dir
                     if server.volumes:
                         transport_config["volumes"] = server.volumes
                     if server.bind_ports:
@@ -700,9 +697,7 @@ class WebToolConfig(BaseToolConfig):
                 config["allow_users"] = [str(self._user_id)]  # Only allow current user
 
                 configs.append(config)
-                logger.debug(
-                    f"Loaded MCP server config: {server.name} ({server.transport})"
-                )
+                logger.debug(f"Loaded MCP server config: {server.name} ({server.transport})")
 
         except Exception as e:
             logger.warning(f"Failed to load MCP server configs: {e}", exc_info=True)
@@ -710,7 +705,7 @@ class WebToolConfig(BaseToolConfig):
         logger.info(f"Loaded {len(configs)} MCP server configurations")
         return configs
 
-    def get_custom_api_configs(self) -> List[Dict[str, Any]]:
+    def get_custom_api_configs(self) -> list[dict[str, Any]]:
         """Get custom API configurations."""
         if not self._user_id:
             return []
@@ -748,7 +743,5 @@ class WebToolConfig(BaseToolConfig):
             return custom_api_configs
 
         except Exception as e:
-            logger.error(
-                f"Failed to get Custom API configs from database: {e}", exc_info=True
-            )
+            logger.error(f"Failed to get Custom API configs from database: {e}", exc_info=True)
             return []

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -142,6 +142,7 @@ class WebToolConfig(BaseToolConfig):
         allow_cross_user_agent_ids: bool = False,
         parent_task_id: int | None = None,
         parent_tracer: Any | None = None,
+        agent_call_stack: list[int] | None = None,
         sandbox: Any | None = None,
     ):
         self.db = db
@@ -177,6 +178,7 @@ class WebToolConfig(BaseToolConfig):
         self._allow_cross_user_agent_ids = allow_cross_user_agent_ids
         self._parent_task_id = parent_task_id
         self._parent_tracer = parent_tracer
+        self._agent_call_stack = list(agent_call_stack or [])
         self._excluded_agent_id: int | None = None
 
         # Cache user object for hook queries.
@@ -375,6 +377,9 @@ class WebToolConfig(BaseToolConfig):
 
     def get_parent_tracer(self) -> Any | None:
         return self._parent_tracer
+
+    def get_agent_call_stack(self) -> list[int]:
+        return self._agent_call_stack
 
     def get_sandbox(self) -> Any | None:
         """Get sandbox instance. Returns None if not available."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -23,7 +23,9 @@ from ..services.tool_credentials import (
 logger = logging.getLogger(__name__)
 
 
-async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_name: str) -> bool:
+async def refresh_oauth_token_if_needed(
+    db: Any, oauth_account: Any, provider_name: str
+) -> bool:
     """Check if token is expired (or close to expiring) and refresh if needed."""
     if not oauth_account.expires_at:
         return True  # Assume valid if no expiration is set
@@ -40,7 +42,9 @@ async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_na
         return True  # Token is still valid
 
     if not oauth_account.refresh_token:
-        logger.warning(f"Token expired for {provider_name} but no refresh_token available.")
+        logger.warning(
+            f"Token expired for {provider_name} but no refresh_token available."
+        )
         return False
 
     logger.info(f"Token expired for {provider_name}, attempting to refresh...")
@@ -49,7 +53,9 @@ async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_na
         from ..models.oauth_provider import OAuthProvider
 
         provider_config = (
-            db.query(OAuthProvider).filter(OAuthProvider.provider_name == provider_name).first()
+            db.query(OAuthProvider)
+            .filter(OAuthProvider.provider_name == provider_name)
+            .first()
         )
         if not provider_config:
             logger.warning(f"Unknown provider for refresh: {provider_name}")
@@ -59,7 +65,9 @@ async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_na
         client_secret = decrypt_value(provider_config.client_secret)
 
         if not client_id or not client_secret:
-            logger.warning(f"{provider_name} OAuth not configured (missing CLIENT_ID or SECRET).")
+            logger.warning(
+                f"{provider_name} OAuth not configured (missing CLIENT_ID or SECRET)."
+            )
             return False
 
         data = {
@@ -97,7 +105,9 @@ async def refresh_oauth_token_if_needed(db: Any, oauth_account: Any, provider_na
             logger.error(f"Failed to refresh {provider_name} token: {response.text}")
 
     except Exception as e:
-        logger.error(f"Exception refreshing token for {provider_name}: {e}", exc_info=True)
+        logger.error(
+            f"Exception refreshing token for {provider_name}: {e}", exc_info=True
+        )
 
     return False
 
@@ -136,7 +146,9 @@ class WebToolConfig(BaseToolConfig):
     ):
         self.db = db
         self.request = request
-        self._user_id = user_id if user_id is not None else self._get_user_id_from_request(request)
+        self._user_id = (
+            user_id if user_id is not None else self._get_user_id_from_request(request)
+        )
         self._is_admin_value = is_admin or self._get_is_admin_from_request(request)
         # Initialize workspace_config with base_dir and task_id if provided
         if workspace_config is None:
@@ -525,7 +537,9 @@ class WebToolConfig(BaseToolConfig):
                 .all()
             )
 
-            logger.info(f"Found {len(servers)} active MCP servers for user {self._user_id}")
+            logger.info(
+                f"Found {len(servers)} active MCP servers for user {self._user_id}"
+            )
 
             for server in servers:
                 # Build config dict from server model
@@ -546,7 +560,9 @@ class WebToolConfig(BaseToolConfig):
                     from ...web.models.user_oauth import UserOAuth
 
                     app_info = get_app_by_name(self.db, str(server.name))
-                    provider_name = app_info.get("provider") if app_info else server.name.lower()
+                    provider_name = (
+                        app_info.get("provider") if app_info else server.name.lower()
+                    )
 
                     # Some oauth records might be saved with the app_id as provider instead of the general provider_name
                     # For example, "google-drive" instead of "google"
@@ -601,14 +617,18 @@ class WebToolConfig(BaseToolConfig):
 
                         if is_valid and app_info:
                             app_id = app_info.get("id")
-                            logger.info(f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy")
+                            logger.info(
+                                f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
+                            )
 
                             launch_config = app_info.get("launch_config")
                             if launch_config:
                                 config["transport"] = "stdio"
                                 transport_config["transport"] = "stdio"
                                 transport_config["command"] = launch_config["command"]
-                                transport_config["args"] = launch_config.get("args", []).copy()
+                                transport_config["args"] = launch_config.get(
+                                    "args", []
+                                ).copy()
 
                                 env = {}
                                 for env_key, token_type in launch_config.get(
@@ -619,9 +639,13 @@ class WebToolConfig(BaseToolConfig):
 
                                 env.update(
                                     {
-                                        "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
+                                        "HTTPS_PROXY": os.environ.get(
+                                            "HTTPS_PROXY", ""
+                                        ),
                                         "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
-                                        "https_proxy": os.environ.get("https_proxy", ""),
+                                        "https_proxy": os.environ.get(
+                                            "https_proxy", ""
+                                        ),
                                         "http_proxy": os.environ.get("http_proxy", ""),
                                     }
                                 )
@@ -643,7 +667,9 @@ class WebToolConfig(BaseToolConfig):
                                 }
 
                     else:
-                        logger.info(f"OAUTH CONFIG: No valid token found for '{provider_name}'.")
+                        logger.info(
+                            f"OAUTH CONFIG: No valid token found for '{provider_name}'."
+                        )
 
                 if server.transport == "stdio":
                     if server.command:
@@ -678,9 +704,13 @@ class WebToolConfig(BaseToolConfig):
                     if server.docker_image:
                         transport_config["docker_image"] = server.docker_image
                     if server.docker_environment:
-                        transport_config["docker_environment"] = server.docker_environment
+                        transport_config["docker_environment"] = (
+                            server.docker_environment
+                        )
                     if server.docker_working_dir:
-                        transport_config["docker_working_dir"] = server.docker_working_dir
+                        transport_config["docker_working_dir"] = (
+                            server.docker_working_dir
+                        )
                     if server.volumes:
                         transport_config["volumes"] = server.volumes
                     if server.bind_ports:
@@ -697,7 +727,9 @@ class WebToolConfig(BaseToolConfig):
                 config["allow_users"] = [str(self._user_id)]  # Only allow current user
 
                 configs.append(config)
-                logger.debug(f"Loaded MCP server config: {server.name} ({server.transport})")
+                logger.debug(
+                    f"Loaded MCP server config: {server.name} ({server.transport})"
+                )
 
         except Exception as e:
             logger.warning(f"Failed to load MCP server configs: {e}", exc_info=True)
@@ -743,5 +775,7 @@ class WebToolConfig(BaseToolConfig):
             return custom_api_configs
 
         except Exception as e:
-            logger.error(f"Failed to get Custom API configs from database: {e}", exc_info=True)
+            logger.error(
+                f"Failed to get Custom API configs from database: {e}", exc_info=True
+            )
             return []

--- a/tests/core/agent/pattern/test_dag_file_outputs.py
+++ b/tests/core/agent/pattern/test_dag_file_outputs.py
@@ -106,6 +106,47 @@ class TestDAGFileOutputs:
         # Should be empty
         assert file_outputs == []
 
+    def test_extract_file_outputs_from_nested_step_history(self):
+        """Test that delegated tool file outputs are collected from step history."""
+        mock_llm = Mock(spec=OpenAILLM)
+        workspace = Mock()
+        workspace.get_output_files.return_value = []
+        dag_pattern = DAGPlanExecutePattern(llm=mock_llm, workspace=workspace)
+
+        file_outputs = dag_pattern._extract_file_outputs_from_history(
+            [
+                {
+                    "iteration": 1,
+                    "results": [
+                        {
+                            "step_id": "generate_file",
+                            "result": {
+                                "success": True,
+                                "result": {
+                                    "response": "created file",
+                                    "file_outputs": [
+                                        {
+                                            "file_id": "worker-file-id",
+                                            "filename": "worker.xlsx",
+                                            "file_path": "/tmp/worker.xlsx",
+                                        }
+                                    ],
+                                },
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+
+        assert file_outputs == [
+            {
+                "file_id": "worker-file-id",
+                "filename": "worker.xlsx",
+                "file_path": "/tmp/worker.xlsx",
+            }
+        ]
+
     @pytest.mark.usefixtures("mock_workspace_db")
     def test_extract_file_outputs_mixed_sources(self, tmp_path):
         """Test that workspace files take precedence over execution results."""

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -227,6 +227,50 @@ async def test_create_agent_tools_treats_empty_delegate_allowlist_as_unrestricte
         _remove_db(db_path)
 
 
+def test_agent_call_stack_excludes_recursive_agent_tools() -> None:
+    db, db_path = _create_session()
+    try:
+        owner = User(username="stack-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.commit()
+        db.refresh(owner)
+
+        agent_a = Agent(
+            user_id=owner.id,
+            name="Agent A",
+            status=AgentStatus.PUBLISHED,
+        )
+        agent_b = Agent(
+            user_id=owner.id,
+            name="Agent B",
+            status=AgentStatus.PUBLISHED,
+        )
+        agent_c = Agent(
+            user_id=owner.id,
+            name="Agent C",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add_all([agent_a, agent_b, agent_c])
+        db.commit()
+        db.refresh(agent_a)
+        db.refresh(agent_b)
+        db.refresh(agent_c)
+
+        tools = get_published_agents_tools(
+            db=db,
+            user_id=owner.id,
+            agent_call_stack=[agent_a.id, agent_b.id],
+        )
+        tool_names = {tool.name for tool in tools}
+
+        assert "call_agent_agent_a" not in tool_names
+        assert "call_agent_agent_b" not in tool_names
+        assert "call_agent_agent_c" in tool_names
+    finally:
+        db.close()
+        _remove_db(db_path)
+
+
 @pytest.mark.asyncio
 async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -> None:
     db, db_path = _create_session()
@@ -265,8 +309,10 @@ async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -
                 return object()
 
         class FakeAgentService:
+            init_kwargs = None
+
             def __init__(self, *args, **kwargs):
-                pass
+                self.__class__.init_kwargs = kwargs
 
             async def execute_task(self, task, context=None, task_id=None):
                 return {"output": "worker output"}
@@ -313,6 +359,11 @@ async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -
         result = await tool.run_json_async({"task": "research"})
 
         assert result["response"] == "worker output"
+        assert FakeAgentService.init_kwargs["tracer"] is tracer
+        nested_tool_config = FakeAgentService.init_kwargs["tool_config"]
+        assert nested_tool_config.get_parent_tracer() is tracer
+        assert nested_tool_config.get_parent_task_id() == 123
+        assert nested_tool_config.get_agent_call_stack() == [agent.id]
         assert [event["data"]["event_type"] for event in tracer.events] == [
             "workforce_delegation_start",
             "workforce_delegation_end",

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -315,7 +315,16 @@ async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -
                 self.__class__.init_kwargs = kwargs
 
             async def execute_task(self, task, context=None, task_id=None):
-                return {"output": "worker output"}
+                return {
+                    "output": "worker output",
+                    "file_outputs": [
+                        {
+                            "file_id": "worker-file-id",
+                            "filename": "worker.xlsx",
+                            "file_path": "/tmp/worker.xlsx",
+                        }
+                    ],
+                }
 
         class FakeTracer:
             def __init__(self):
@@ -359,11 +368,19 @@ async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -
         result = await tool.run_json_async({"task": "research"})
 
         assert result["response"] == "worker output"
+        assert result["file_outputs"] == [
+            {
+                "file_id": "worker-file-id",
+                "filename": "worker.xlsx",
+                "file_path": "/tmp/worker.xlsx",
+            }
+        ]
         assert FakeAgentService.init_kwargs["tracer"] is tracer
         nested_tool_config = FakeAgentService.init_kwargs["tool_config"]
         assert nested_tool_config.get_parent_tracer() is tracer
         assert nested_tool_config.get_parent_task_id() == 123
         assert nested_tool_config.get_agent_call_stack() == [agent.id]
+        assert nested_tool_config.get_workspace_config()["db_task_id"] == 123
         assert [event["data"]["event_type"] for event in tracer.events] == [
             "workforce_delegation_start",
             "workforce_delegation_end",
@@ -372,6 +389,13 @@ async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -
         assert tracer.events[0]["data"]["workforce_run_id"] == 456
         assert tracer.events[0]["data"]["worker_alias"] == "Researcher"
         assert tracer.events[1]["data"]["output"] == "worker output"
+        assert tracer.events[1]["data"]["file_outputs"] == [
+            {
+                "file_id": "worker-file-id",
+                "filename": "worker.xlsx",
+                "file_path": "/tmp/worker.xlsx",
+            }
+        ]
     finally:
         db.close()
         _remove_db(db_path)

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -5,11 +6,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.core.tools.adapters.vibe.agent_tool import (
+    AgentTool,
     create_agent_tools,
     get_published_agents_tools,
 )
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
+from xagent.web.models.model import Model
 from xagent.web.models.user import User
 from xagent.web.tools.config import WebToolConfig
 
@@ -22,6 +25,13 @@ def _create_session() -> tuple[Session, str]:
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     return SessionLocal(), temp_db.name
+
+
+def _remove_db(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
 
 
 def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
@@ -48,12 +58,7 @@ def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
         assert "call_agent_owner_published_agent" not in tool_names
     finally:
         db.close()
-        try:
-            import os
-
-            os.remove(db_path)
-        except OSError:
-            pass
+        _remove_db(db_path)
 
 
 def test_owner_sees_only_own_published_agents_not_drafts() -> None:
@@ -84,12 +89,7 @@ def test_owner_sees_only_own_published_agents_not_drafts() -> None:
         assert "call_agent_owner_draft_agent" not in tool_names
     finally:
         db.close()
-        try:
-            import os
-
-            os.remove(db_path)
-        except OSError:
-            pass
+        _remove_db(db_path)
 
 
 def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None:
@@ -149,12 +149,51 @@ def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None
         assert "call_agent_other_users_agent" not in tool_names
     finally:
         db.close()
-        try:
-            import os
+        _remove_db(db_path)
 
-            os.remove(db_path)
-        except OSError:
-            pass
+
+def test_allowed_agent_ids_can_cross_users_only_when_explicitly_enabled() -> None:
+    db, db_path = _create_session()
+    try:
+        owner = User(username="owner_cross", password_hash="x", is_admin=False)
+        runner = User(username="runner", password_hash="x", is_admin=False)
+        db.add_all([owner, runner])
+        db.commit()
+        db.refresh(owner)
+        db.refresh(runner)
+
+        published_agent = Agent(
+            user_id=owner.id,
+            name="Shared Workforce Worker",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(published_agent)
+        db.commit()
+        db.refresh(published_agent)
+
+        blocked_tools = get_published_agents_tools(
+            db=db,
+            user_id=runner.id,
+            allowed_agent_ids=[published_agent.id],
+            enable_global_agent_tools=False,
+        )
+        assert "call_agent_shared_workforce_worker" not in {
+            tool.name for tool in blocked_tools
+        }
+
+        allowed_tools = get_published_agents_tools(
+            db=db,
+            user_id=runner.id,
+            allowed_agent_ids=[published_agent.id],
+            enable_global_agent_tools=False,
+            allow_cross_user_agent_ids=True,
+        )
+        assert "call_agent_shared_workforce_worker" in {
+            tool.name for tool in allowed_tools
+        }
+    finally:
+        db.close()
+        _remove_db(db_path)
 
 
 @pytest.mark.asyncio
@@ -185,9 +224,103 @@ async def test_create_agent_tools_treats_empty_delegate_allowlist_as_unrestricte
         assert "call_agent_default_published_agent" in tool_names
     finally:
         db.close()
-        try:
-            import os
+        _remove_db(db_path)
 
-            os.remove(db_path)
-        except OSError:
-            pass
+
+@pytest.mark.asyncio
+async def test_agent_tool_emits_workforce_delegation_trace_events(monkeypatch) -> None:
+    db, db_path = _create_session()
+    try:
+        user = User(username="trace-user", password_hash="x", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        model = Model(
+            model_id="fake-general",
+            model_provider="openai",
+            model_name="fake-general",
+            category="llm",
+        )
+        model.api_key = "fake-key"
+        db.add(model)
+        db.commit()
+        db.refresh(model)
+
+        agent = Agent(
+            user_id=user.id,
+            name="Trace Worker",
+            status=AgentStatus.PUBLISHED,
+            models={"general": model.id},
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+
+        class FakeStorage:
+            def __init__(self, db):
+                self.db = db
+
+            def get_llm_by_name_with_access(self, model_id, user_id):
+                return object()
+
+        class FakeAgentService:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def execute_task(self, task, context=None, task_id=None):
+                return {"output": "worker output"}
+
+        class FakeTracer:
+            def __init__(self):
+                self.events = []
+
+            async def trace_event(
+                self, event_type, task_id=None, step_id=None, data=None, parent_id=None
+            ):
+                self.events.append(
+                    {
+                        "event_type": event_type.value,
+                        "task_id": task_id,
+                        "data": data or {},
+                    }
+                )
+
+        monkeypatch.setattr(
+            "xagent.web.services.llm_utils.UserAwareModelStorage",
+            FakeStorage,
+        )
+        monkeypatch.setattr(
+            "xagent.core.agent.service.AgentService",
+            FakeAgentService,
+        )
+
+        tracer = FakeTracer()
+        tool = AgentTool(
+            agent_id=agent.id,
+            agent_name=agent.name,
+            agent_description="Trace worker",
+            db=db,
+            user_id=user.id,
+            parent_task_id=123,
+            parent_tracer=tracer,
+            workforce_context={
+                "workforce_run_id": 456,
+                "worker_alias": "Researcher",
+            },
+        )
+
+        result = await tool.run_json_async({"task": "research"})
+
+        assert result["response"] == "worker output"
+        assert [event["data"]["event_type"] for event in tracer.events] == [
+            "workforce_delegation_start",
+            "workforce_delegation_end",
+        ]
+        assert tracer.events[0]["task_id"] == "123"
+        assert tracer.events[0]["data"]["workforce_run_id"] == 456
+        assert tracer.events[0]["data"]["worker_alias"] == "Researcher"
+        assert tracer.events[1]["data"]["output"] == "worker output"
+    finally:
+        db.close()
+        _remove_db(db_path)

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -1,0 +1,371 @@
+import tempfile
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from xagent.web.api.agents import delete_agent
+from xagent.web.api.workforces import (
+    WorkforceBuilderApplyRequest,
+    WorkforceBuilderProposeRequest,
+    WorkforceCreateRequest,
+    WorkforceRunRequest,
+    WorkforceUpdateRequest,
+    WorkforceWorkerInput,
+    WorkforceWorkerUpdateRequest,
+    add_workforce_agent,
+    apply_workforce_changes,
+    create_workforce,
+    create_workforce_run,
+    get_workforce,
+    get_workforce_canvas,
+    list_workforces,
+    propose_workforce_changes,
+    update_workforce,
+    update_workforce_agent,
+)
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+
+
+def _create_session() -> tuple[Session, str]:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as temp_db:
+        db_path = temp_db.name
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return session_local(), db_path
+
+
+def _create_user(db_session: Session, username: str, is_admin: bool = False) -> User:
+    user = User(username=username, password_hash="x", is_admin=is_admin)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _create_agent(
+    db_session: Session, user: User, name: str, execution_mode: str = "balanced"
+) -> Agent:
+    agent = Agent(
+        user_id=user.id,
+        name=name,
+        description=f"{name} description",
+        instructions=f"{name} instructions",
+        execution_mode=execution_mode,
+        models={"general": 1},
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_workforce() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "regular-user")
+        manager = _create_agent(db_session, regular_user, "Manager")
+        worker = _create_agent(db_session, regular_user, "Research Agent")
+
+        result = await create_workforce(
+            WorkforceCreateRequest(
+                name="Launch Workforce",
+                description="Coordinate launch",
+                manager_agent_id=manager.id,
+                manager_instructions="Coordinate workers.",
+                status="active",
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        alias="Researcher",
+                        assignment_instructions="Research competitors.",
+                        sort_order=1,
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+        assert result["name"] == "Launch Workforce"
+        assert result["status"] == "active"
+        assert result["manager"]["id"] == manager.id
+        assert result["scope_type"] == "user"
+        assert result["scope_id"] == str(regular_user.id)
+        assert len(result["workers"]) == 1
+        workforce_id = result["id"]
+
+        detail = await get_workforce(workforce_id, db_session, regular_user)
+        assert detail["manager_instructions"] == "Coordinate workers."
+        assert detail["workers"][0]["alias"] == "Researcher"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_list_workforces_filters_to_visible_items() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "owner-user")
+        other_user = _create_user(db_session, "other-user")
+        manager_a = _create_agent(db_session, regular_user, "Manager A")
+        worker_a = _create_agent(db_session, regular_user, "Worker A")
+        manager_b = _create_agent(db_session, other_user, "Manager B")
+        worker_b = _create_agent(db_session, other_user, "Worker B")
+
+        await create_workforce(
+            WorkforceCreateRequest(
+                name="Visible Workforce",
+                manager_agent_id=manager_a.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker_a.id,
+                        alias="Writer",
+                        assignment_instructions="Write copy.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        await create_workforce(
+            WorkforceCreateRequest(
+                name="Hidden Workforce",
+                manager_agent_id=manager_b.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker_b.id,
+                        alias="Analyst",
+                        assignment_instructions="Analyze data.",
+                    )
+                ],
+            ),
+            db_session,
+            other_user,
+        )
+
+        owner_result = await list_workforces(db=db_session, user=regular_user)
+        assert owner_result["total"] == 1
+        assert owner_result["items"][0]["name"] == "Visible Workforce"
+
+        other_result = await list_workforces(db=db_session, user=other_user)
+        assert other_result["total"] == 1
+        assert other_result["items"][0]["name"] == "Hidden Workforce"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_update_worker_and_canvas() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "edit-user")
+        manager = _create_agent(db_session, regular_user, "Manager Three")
+        worker = _create_agent(db_session, regular_user, "Researcher Agent")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Editable Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        alias="Researcher",
+                        assignment_instructions="Research market.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        updated = await update_workforce(
+            created["id"],
+            WorkforceUpdateRequest(
+                name="Editable Workforce V2",
+                description="Updated description",
+                manager_instructions="Use worker results carefully.",
+                canvas_layout={"zoom": 1.2},
+            ),
+            db_session,
+            regular_user,
+        )
+        assert updated["name"] == "Editable Workforce V2"
+        assert updated["canvas_layout"] == {"zoom": 1.2}
+
+        member_id = updated["workers"][0]["id"]
+        worker_updated = await update_workforce_agent(
+            created["id"],
+            member_id,
+            WorkforceWorkerUpdateRequest(
+                alias="Market Researcher",
+                assignment_instructions="Focus on pricing.",
+                sort_order=3,
+                canvas_position={"x": 20, "y": 30},
+            ),
+            db_session,
+            regular_user,
+        )
+        assert worker_updated["alias"] == "Market Researcher"
+        assert worker_updated["assignment_instructions"] == "Focus on pricing."
+        assert worker_updated["sort_order"] == 3
+
+        canvas = await get_workforce_canvas(created["id"], db_session, regular_user)
+        worker_node = next(node for node in canvas["nodes"] if node["type"] == "worker")
+        assert worker_node["position"] == {"x": 20, "y": 30}
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_builder_apply_and_run_workforce() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "builder-user")
+        manager = _create_agent(db_session, regular_user, "Manager Four")
+        worker = _create_agent(db_session, regular_user, "Analyst Agent")
+        extra_worker = _create_agent(db_session, regular_user, "Writer Agent")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Builder Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        alias="Analyst",
+                        assignment_instructions="Analyze data.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        propose = await propose_workforce_changes(
+            created["id"],
+            WorkforceBuilderProposeRequest(
+                message='Rename this workforce to "Launch Crew".',
+            ),
+            db_session,
+            regular_user,
+        )
+        proposed_patch = propose["proposed_patch"]
+        assert proposed_patch["operations"]
+
+        applied = await apply_workforce_changes(
+            created["id"],
+            WorkforceBuilderApplyRequest(
+                message_id=propose["message_id"],
+                proposed_patch=proposed_patch,
+            ),
+            db_session,
+            regular_user,
+        )
+        assert applied["workforce"]["name"] == "Launch Crew"
+
+        added_worker = await add_workforce_agent(
+            created["id"],
+            WorkforceWorkerInput(
+                agent_id=extra_worker.id,
+                alias="Writer",
+                assignment_instructions="Draft the summary.",
+            ),
+            db_session,
+            regular_user,
+        )
+        assert added_worker["alias"] == "Writer"
+
+        canvas = await get_workforce_canvas(created["id"], db_session, regular_user)
+        assert len(canvas["nodes"]) == 4
+        assert len(canvas["edges"]) == 3
+
+        run_response = await create_workforce_run(
+            created["id"],
+            WorkforceRunRequest(message="Coordinate a launch brief"),
+            db_session,
+            regular_user,
+        )
+        assert run_response["status"] == "pending"
+        assert run_response["redirect_url"].startswith("/task/")
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_blocked_when_referenced_by_workforce() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "delete-user")
+        manager = _create_agent(db_session, regular_user, "Manager Five")
+        worker = _create_agent(db_session, regular_user, "Worker Five")
+
+        await create_workforce(
+            WorkforceCreateRequest(
+                name="Protected Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        alias="Worker",
+                        assignment_instructions="Handle analysis.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        try:
+            await delete_agent(manager.id, regular_user, db_session)
+        except HTTPException as exc:
+            assert exc.status_code == 409
+            assert "manager agent" in exc.detail
+        else:
+            raise AssertionError("Expected manager delete to fail")
+
+        try:
+            await delete_agent(worker.id, regular_user, db_session)
+        except HTTPException as exc:
+            assert exc.status_code == 409
+            assert "worker agent" in exc.detail
+        else:
+            raise AssertionError("Expected worker delete to fail")
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -31,6 +31,7 @@ from xagent.web.models.database import Base
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceAgent
 from xagent.web.services import workforce_builder as workforce_builder_service
+from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 
 
 def _create_session() -> tuple[Session, str]:
@@ -502,6 +503,123 @@ async def test_builder_apply_and_run_workforce() -> None:
         assert run_response["status"] == "pending"
         assert run_response["redirect_url"].startswith("/task/")
     finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_workforce_run_revalidates_policy_visible_agents() -> None:
+    class RunOnlyPolicy(WorkforcePolicy):
+        def can_view_workforce(self, db, user, workforce):
+            del db, user, workforce
+            return True
+
+        def can_run_workforce(self, db, user, workforce):
+            del db, user, workforce
+            return True
+
+        def get_visible_agent_ids(self, db, user, purpose):
+            del db, user, purpose
+            return set()
+
+    db_session, db_path = _create_session()
+    try:
+        owner = _create_user(db_session, "policy-owner")
+        runner = _create_user(db_session, "policy-runner")
+        manager = _create_agent(db_session, owner, "Policy Manager")
+        worker = _create_agent(db_session, owner, "Policy Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Policy Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle policy work.",
+                    )
+                ],
+            ),
+            db_session,
+            owner,
+        )
+
+        set_workforce_policy(RunOnlyPolicy())
+        with pytest.raises(HTTPException) as run_error:
+            await create_workforce_run(
+                created["id"],
+                WorkforceRunRequest(message="Run with no visible agents"),
+                db_session,
+                runner,
+            )
+        assert run_error.value.status_code == 403
+        assert run_error.value.detail == "Access denied to agent"
+    finally:
+        set_workforce_policy(WorkforcePolicy())
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_workforce_run_allows_policy_visible_agents() -> None:
+    class VisibleRunPolicy(WorkforcePolicy):
+        def __init__(self, visible_ids):
+            self.visible_ids = visible_ids
+
+        def can_view_workforce(self, db, user, workforce):
+            del db, user, workforce
+            return True
+
+        def can_run_workforce(self, db, user, workforce):
+            del db, user, workforce
+            return True
+
+        def get_visible_agent_ids(self, db, user, purpose):
+            del db, user, purpose
+            return self.visible_ids
+
+    db_session, db_path = _create_session()
+    try:
+        owner = _create_user(db_session, "visible-policy-owner")
+        runner = _create_user(db_session, "visible-policy-runner")
+        manager = _create_agent(db_session, owner, "Visible Policy Manager")
+        worker = _create_agent(db_session, owner, "Visible Policy Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Visible Policy Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle visible policy work.",
+                    )
+                ],
+            ),
+            db_session,
+            owner,
+        )
+
+        set_workforce_policy(VisibleRunPolicy({manager.id, worker.id}))
+        response = await create_workforce_run(
+            created["id"],
+            WorkforceRunRequest(message="Run with visible agents"),
+            db_session,
+            runner,
+        )
+        assert response["status"] == "pending"
+    finally:
+        set_workforce_policy(WorkforcePolicy())
         db_session.close()
         try:
             import os

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -51,7 +51,11 @@ def _create_user(db_session: Session, username: str, is_admin: bool = False) -> 
 
 
 def _create_agent(
-    db_session: Session, user: User, name: str, execution_mode: str = "balanced"
+    db_session: Session,
+    user: User,
+    name: str,
+    execution_mode: str = "balanced",
+    status: AgentStatus = AgentStatus.PUBLISHED,
 ) -> Agent:
     agent = Agent(
         user_id=user.id,
@@ -60,12 +64,193 @@ def _create_agent(
         instructions=f"{name} instructions",
         execution_mode=execution_mode,
         models={"general": 1},
-        status=AgentStatus.PUBLISHED,
+        status=status,
     )
     db_session.add(agent)
     db_session.commit()
     db_session.refresh(agent)
     return agent
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_requires_published_manager_and_workers() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "published-required-user")
+        published_manager = _create_agent(db_session, regular_user, "Published Manager")
+        draft_manager = _create_agent(
+            db_session,
+            regular_user,
+            "Draft Manager",
+            status=AgentStatus.DRAFT,
+        )
+        draft_worker = _create_agent(
+            db_session,
+            regular_user,
+            "Draft Worker",
+            status=AgentStatus.DRAFT,
+        )
+
+        with pytest.raises(HTTPException) as manager_error:
+            await create_workforce(
+                WorkforceCreateRequest(
+                    name="Draft Manager Workforce",
+                    manager_agent_id=draft_manager.id,
+                    workers=[
+                        WorkforceWorkerInput(
+                            agent_id=draft_worker.id,
+                            assignment_instructions="Draft should not run.",
+                        )
+                    ],
+                ),
+                db_session,
+                regular_user,
+            )
+        assert manager_error.value.status_code == 400
+        assert manager_error.value.detail == "Workforce agents must be published"
+
+        with pytest.raises(HTTPException) as worker_error:
+            await create_workforce(
+                WorkforceCreateRequest(
+                    name="Draft Worker Workforce",
+                    manager_agent_id=published_manager.id,
+                    workers=[
+                        WorkforceWorkerInput(
+                            agent_id=draft_worker.id,
+                            assignment_instructions="Draft should not run.",
+                        )
+                    ],
+                ),
+                db_session,
+                regular_user,
+            )
+        assert worker_error.value.status_code == 400
+        assert worker_error.value.detail == "Workforce agents must be published"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_workforce_rejects_template_and_new_workers() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "source-type-user")
+        manager = _create_agent(db_session, regular_user, "Source Type Manager")
+
+        for source_type in ("template", "new"):
+            with pytest.raises(HTTPException) as source_error:
+                await create_workforce(
+                    WorkforceCreateRequest(
+                        name=f"{source_type} Workforce",
+                        manager_agent_id=manager.id,
+                        workers=[
+                            WorkforceWorkerInput(
+                                source_type=source_type,
+                                template_id="researcher-template"
+                                if source_type == "template"
+                                else None,
+                                agent={"name": "New Worker"}
+                                if source_type == "new"
+                                else None,
+                                assignment_instructions="Do the work.",
+                            )
+                        ],
+                    ),
+                    db_session,
+                    regular_user,
+                )
+            assert source_error.value.status_code == 400
+            assert "source_type must be existing" in str(source_error.value.detail)
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_workforce_rejects_draft_agent_on_update_add_and_run() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "draft-lifecycle-user")
+        manager = _create_agent(db_session, regular_user, "Lifecycle Manager")
+        worker = _create_agent(db_session, regular_user, "Lifecycle Worker")
+        extra_worker = _create_agent(db_session, regular_user, "Lifecycle Extra")
+        draft_manager = _create_agent(
+            db_session,
+            regular_user,
+            "Lifecycle Draft Manager",
+            status=AgentStatus.DRAFT,
+        )
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Lifecycle Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle lifecycle work.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        with pytest.raises(HTTPException) as update_error:
+            await update_workforce(
+                created["id"],
+                WorkforceUpdateRequest(manager_agent_id=draft_manager.id),
+                db_session,
+                regular_user,
+            )
+        assert update_error.value.status_code == 400
+        assert update_error.value.detail == "Workforce agents must be published"
+
+        extra_worker.status = AgentStatus.DRAFT
+        db_session.commit()
+        with pytest.raises(HTTPException) as add_error:
+            await add_workforce_agent(
+                created["id"],
+                WorkforceWorkerInput(
+                    agent_id=extra_worker.id,
+                    assignment_instructions="Draft add should fail.",
+                ),
+                db_session,
+                regular_user,
+            )
+        assert add_error.value.status_code == 400
+        assert add_error.value.detail == "Workforce agents must be published"
+
+        worker.status = AgentStatus.DRAFT
+        db_session.commit()
+        with pytest.raises(HTTPException) as run_error:
+            await create_workforce_run(
+                created["id"],
+                WorkforceRunRequest(message="Run with stale draft worker"),
+                db_session,
+                regular_user,
+            )
+        assert run_error.value.status_code == 400
+        assert run_error.value.detail == "Workforce agents must be published"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -5,7 +5,8 @@ from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from xagent.web.api.agents import delete_agent
+from xagent.web.api.agents import delete_agent, get_agent, list_agents
+from xagent.web.api.chat import create_task
 from xagent.web.api.workforces import (
     WorkforceBuilderApplyRequest,
     WorkforceBuilderProposeRequest,
@@ -25,7 +26,9 @@ from xagent.web.api.workforces import (
     get_workforce_canvas,
     list_workforces,
     propose_workforce_changes,
+    publish_workforce,
     remove_workforce_agent,
+    unpublish_workforce,
     update_workforce,
     update_workforce_agent,
 )
@@ -33,6 +36,7 @@ from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceAgent
+from xagent.web.schemas.chat import TaskCreateRequest
 from xagent.web.services import workforce_builder as workforce_builder_service
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 
@@ -75,6 +79,210 @@ def _create_agent(
     db_session.commit()
     db_session.refresh(agent)
     return agent
+
+
+@pytest.mark.asyncio
+async def test_list_agents_hides_workforce_managers() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "agent-list-user")
+        manager = _create_agent(db_session, regular_user, "Internal Manager")
+        worker = _create_agent(db_session, regular_user, "Worker Agent")
+        normal_agent = _create_agent(db_session, regular_user, "Regular Agent")
+
+        await create_workforce(
+            WorkforceCreateRequest(
+                name="Managed Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle assigned work.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        listed_agents = await list_agents(regular_user, db_session)
+        listed_agent_ids = {agent.id for agent in listed_agents}
+
+        assert manager.id not in listed_agent_ids
+        assert worker.id in listed_agent_ids
+        assert normal_agent.id in listed_agent_ids
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_workforce_manager_is_hidden_from_direct_agent_access() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "manager-hidden-user")
+        manager = _create_agent(db_session, regular_user, "Internal Manager")
+        worker = _create_agent(db_session, regular_user, "Worker Agent")
+
+        await create_workforce(
+            WorkforceCreateRequest(
+                name="Managed Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle assigned work.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        with pytest.raises(HTTPException) as detail_error:
+            await get_agent(manager.id, regular_user, db_session)
+        assert detail_error.value.status_code == 404
+
+        with pytest.raises(HTTPException) as task_error:
+            await create_task(
+                TaskCreateRequest(
+                    title="Run internal manager",
+                    description="Run the internal manager directly.",
+                    agent_id=manager.id,
+                ),
+                db_session,
+                regular_user,
+            )
+        assert task_error.value.status_code == 400
+        assert task_error.value.detail == (
+            "Workforce manager agents can only be run through Workforce"
+        )
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_publish_and_unpublish_workforce() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "publish-workforce-user")
+        manager = _create_agent(db_session, regular_user, "Manager")
+        worker = _create_agent(db_session, regular_user, "Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Publishable Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle assigned work.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+        assert created["status"] == "draft"
+
+        published = await publish_workforce(created["id"], db_session, regular_user)
+        assert published["status"] == "active"
+
+        unpublished = await unpublish_workforce(created["id"], db_session, regular_user)
+        assert unpublished["status"] == "draft"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_publish_workforce_requires_enabled_worker() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "publish-invalid-user")
+        manager = _create_agent(db_session, regular_user, "Manager")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="No Workers Workforce",
+                manager_agent_id=manager.id,
+            ),
+            db_session,
+            regular_user,
+        )
+
+        with pytest.raises(HTTPException) as error:
+            await publish_workforce(created["id"], db_session, regular_user)
+        assert error.value.status_code == 400
+        assert error.value.detail == (
+            "Active workforce requires at least one enabled worker"
+        )
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_draft_workforce_cannot_run() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "draft-run-user")
+        manager = _create_agent(db_session, regular_user, "Draft Run Manager")
+        worker = _create_agent(db_session, regular_user, "Draft Run Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Draft Run Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle draft run work.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        with pytest.raises(HTTPException) as run_error:
+            await create_workforce_run(
+                created["id"],
+                WorkforceRunRequest(message="Try to run a draft workforce"),
+                db_session,
+                regular_user,
+            )
+        assert run_error.value.status_code == 400
+        assert run_error.value.detail == "Workforce must be active to run"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
 
 
 @pytest.mark.asyncio
@@ -279,6 +487,7 @@ async def test_workforce_rejects_draft_agent_on_update_add_and_run() -> None:
             WorkforceCreateRequest(
                 name="Lifecycle Workforce",
                 manager_agent_id=manager.id,
+                status="active",
                 workers=[
                     WorkforceWorkerInput(
                         agent_id=worker.id,
@@ -513,7 +722,17 @@ async def test_update_worker_and_canvas() -> None:
 
 
 @pytest.mark.asyncio
-async def test_builder_apply_and_run_workforce() -> None:
+async def test_builder_apply_and_run_workforce(monkeypatch) -> None:
+    async def no_llm_patch(db, user, workforce, message):
+        del db, user, workforce, message
+        return None
+
+    monkeypatch.setattr(
+        workforce_builder_service,
+        "_llm_generate_patch",
+        no_llm_patch,
+    )
+
     db_session, db_path = _create_session()
     try:
         regular_user = _create_user(db_session, "builder-user")
@@ -525,6 +744,7 @@ async def test_builder_apply_and_run_workforce() -> None:
             WorkforceCreateRequest(
                 name="Builder Workforce",
                 manager_agent_id=manager.id,
+                status="active",
                 workers=[
                     WorkforceWorkerInput(
                         agent_id=worker.id,
@@ -619,6 +839,7 @@ async def test_workforce_run_revalidates_policy_visible_agents() -> None:
             WorkforceCreateRequest(
                 name="Policy Workforce",
                 manager_agent_id=manager.id,
+                status="active",
                 workers=[
                     WorkforceWorkerInput(
                         agent_id=worker.id,
@@ -680,6 +901,7 @@ async def test_workforce_run_allows_policy_visible_agents() -> None:
             WorkforceCreateRequest(
                 name="Visible Policy Workforce",
                 manager_agent_id=manager.id,
+                status="active",
                 workers=[
                     WorkforceWorkerInput(
                         agent_id=worker.id,

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -22,12 +22,14 @@ from xagent.web.api.workforces import (
     get_workforce_canvas,
     list_workforces,
     propose_workforce_changes,
+    remove_workforce_agent,
     update_workforce,
     update_workforce_agent,
 )
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
+from xagent.web.models.workforce import Workforce, WorkforceAgent
 
 
 def _create_session() -> tuple[Session, str]:
@@ -362,6 +364,61 @@ async def test_delete_agent_blocked_when_referenced_by_workforce() -> None:
             assert "worker agent" in exc.detail
         else:
             raise AssertionError("Expected worker delete to fail")
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_delete_last_enabled_worker_from_active_workforce_fails() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "delete-worker-user")
+        manager = _create_agent(db_session, regular_user, "Manager")
+        worker = _create_agent(db_session, regular_user, "Solo Worker")
+
+        workforce = Workforce(
+            scope_type="user",
+            scope_id=str(regular_user.id),
+            owner_user_id=regular_user.id,
+            name="Solo Workforce",
+            manager_agent_id=manager.id,
+            status="active",
+        )
+        db_session.add(workforce)
+        db_session.commit()
+        db_session.refresh(workforce)
+
+        worker_link = WorkforceAgent(
+            workforce_id=workforce.id,
+            agent_id=worker.id,
+            alias="Solo",
+            assignment_instructions="Do everything.",
+            enabled=True,
+        )
+        db_session.add(worker_link)
+        db_session.commit()
+        db_session.refresh(worker_link)
+
+        try:
+            await remove_workforce_agent(
+                workforce_id=workforce.id,
+                member_id=worker_link.id,
+                db=db_session,
+                user=regular_user,
+            )
+        except HTTPException as exc:
+            assert exc.status_code == 400
+            assert "enabled worker" in exc.detail.lower()
+            return
+        raise AssertionError(
+            "Expected HTTPException when deleting last enabled worker from active workforce"
+        )
     finally:
         db_session.close()
         try:

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+
 from xagent.web.api.agents import delete_agent
 from xagent.web.api.workforces import (
     WorkforceBuilderApplyRequest,

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -10,6 +10,7 @@ from xagent.web.api.workforces import (
     WorkforceBuilderApplyRequest,
     WorkforceBuilderProposeRequest,
     WorkforceCreateRequest,
+    WorkforcePromptCreateRequest,
     WorkforceRunRequest,
     WorkforceUpdateRequest,
     WorkforceWorkerInput,
@@ -17,8 +18,10 @@ from xagent.web.api.workforces import (
     add_workforce_agent,
     apply_workforce_changes,
     create_workforce,
+    create_workforce_from_prompt,
     create_workforce_run,
     get_workforce,
+    get_workforce_builder_messages,
     get_workforce_canvas,
     list_workforces,
     propose_workforce_changes,
@@ -72,6 +75,84 @@ def _create_agent(
     db_session.commit()
     db_session.refresh(agent)
     return agent
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_from_prompt_creates_manager_and_selects_published_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "prompt-create-user")
+        worker = _create_agent(db_session, regular_user, "Research Agent")
+        draft_worker = _create_agent(
+            db_session,
+            regular_user,
+            "Draft Research Agent",
+            status=AgentStatus.DRAFT,
+        )
+
+        async def fake_creation_plan(*args, **kwargs):
+            return {
+                "name": "Competitor Research Workforce",
+                "description": "Track competitor updates.",
+                "manager": {
+                    "name": "Competitor Research Manager",
+                    "description": "Coordinates competitor research.",
+                    "instructions": "Delegate research and synthesize a weekly brief.",
+                },
+                "manager_instructions": "Delegate research and synthesize a weekly brief.",
+                "workers": [
+                    {
+                        "agent_id": worker.id,
+                        "alias": "Researcher",
+                        "assignment_instructions": "Research competitor updates.",
+                        "enabled": True,
+                    }
+                ],
+                "warnings": [],
+            }
+
+        monkeypatch.setattr(
+            "xagent.web.api.workforces.generate_workforce_creation_plan",
+            fake_creation_plan,
+        )
+
+        created = await create_workforce_from_prompt(
+            WorkforcePromptCreateRequest(
+                prompt="Create a workforce for competitor research and weekly briefings."
+            ),
+            db_session,
+            regular_user,
+        )
+
+        assert created["name"]
+        assert created["status"] == "draft"
+        assert created["manager"]["id"] not in {worker.id, draft_worker.id}
+        manager = (
+            db_session.query(Agent).filter(Agent.id == created["manager"]["id"]).one()
+        )
+        assert manager.status == AgentStatus.PUBLISHED
+        assert manager.execution_mode == "think"
+        assert draft_worker.id not in {
+            item["agent"]["id"] for item in created["workers"]
+        }
+        assert all(
+            item["agent"]["status"] == "published" for item in created["workers"]
+        )
+
+        messages = await get_workforce_builder_messages(
+            created["id"], db_session, regular_user
+        )
+        assert [item["role"] for item in messages["items"]] == ["user", "assistant"]
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -30,6 +30,7 @@ from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceAgent
+from xagent.web.services import workforce_builder as workforce_builder_service
 
 
 def _create_session() -> tuple[Session, str]:
@@ -500,6 +501,144 @@ async def test_builder_apply_and_run_workforce() -> None:
         )
         assert run_response["status"] == "pending"
         assert run_response["redirect_url"].startswith("/task/")
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_builder_uses_llm_before_rule_based_fallback(monkeypatch) -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "llm-builder-user")
+        manager = _create_agent(db_session, regular_user, "LLM Manager")
+        worker = _create_agent(db_session, regular_user, "LLM Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Original Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle analysis.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        async def fake_llm_generate_patch(*args, **kwargs):
+            del args, kwargs
+            return {
+                "summary": "Rename from the LLM.",
+                "operations": [
+                    {
+                        "op": "update_workforce",
+                        "fields": {"name": "LLM Renamed Workforce"},
+                    }
+                ],
+                "warnings": [],
+            }
+
+        monkeypatch.setattr(
+            workforce_builder_service,
+            "_llm_generate_patch",
+            fake_llm_generate_patch,
+        )
+
+        propose = await propose_workforce_changes(
+            created["id"],
+            WorkforceBuilderProposeRequest(
+                message='Rename this workforce to "Rule Based Name".',
+            ),
+            db_session,
+            regular_user,
+        )
+
+        operation = propose["proposed_patch"]["operations"][0]
+        assert operation["fields"]["name"] == "LLM Renamed Workforce"
+        assert "using rule-based parsing" not in propose["assistant_message"]
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_builder_filters_template_and_new_worker_operations(monkeypatch) -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "llm-builder-filter-user")
+        manager = _create_agent(db_session, regular_user, "Filter Manager")
+        worker = _create_agent(db_session, regular_user, "Filter Worker")
+
+        created = await create_workforce(
+            WorkforceCreateRequest(
+                name="Filter Workforce",
+                manager_agent_id=manager.id,
+                workers=[
+                    WorkforceWorkerInput(
+                        agent_id=worker.id,
+                        assignment_instructions="Handle analysis.",
+                    )
+                ],
+            ),
+            db_session,
+            regular_user,
+        )
+
+        async def fake_llm_generate_patch(*args, **kwargs):
+            del args, kwargs
+            return workforce_builder_service._clean_patch(
+                {
+                    "summary": "Unsupported worker creation.",
+                    "operations": [
+                        {
+                            "op": "add_worker_from_template",
+                            "template_id": "researcher-template",
+                            "assignment_instructions": "Research.",
+                        },
+                        {
+                            "op": "create_worker_agent",
+                            "agent": {"name": "Draft Worker"},
+                            "assignment_instructions": "Draft.",
+                        },
+                    ],
+                    "warnings": [],
+                    "clarification": "Choose an existing published agent.",
+                }
+            )
+
+        monkeypatch.setattr(
+            workforce_builder_service,
+            "_llm_generate_patch",
+            fake_llm_generate_patch,
+        )
+
+        propose = await propose_workforce_changes(
+            created["id"],
+            WorkforceBuilderProposeRequest(message="Add a brand new worker."),
+            db_session,
+            regular_user,
+        )
+
+        assert propose["proposed_patch"]["operations"] == []
+        assert (
+            propose["proposed_patch"]["clarification"]
+            == "Choose an existing published agent."
+        )
+        assert propose["assistant_message"] == "Choose an existing published agent."
     finally:
         db_session.close()
         try:

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from asyncio import run
 from pathlib import Path
 from typing import Any, cast
 
@@ -9,13 +10,16 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.workspace import TaskWorkspace
 from xagent.web.api.auth import hash_password
-from xagent.web.api.files import file_router
+from xagent.web.api.files import download_file, file_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.database import Base, get_db
 from xagent.web.models.task import Task
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
+
+_ORIGINAL_CREATE_FILE_RECORD = TaskWorkspace._create_file_record
 
 
 @pytest.fixture(scope="function")
@@ -183,6 +187,89 @@ class TestAdminFileAccess:
 
         assert response.status_code == 200
         assert response.content == b"my content"
+
+    def test_registered_agent_workspace_file_download(self, test_db, temp_uploads_dir):
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=85,
+            user_id=regular_user_id,
+            title="Agent Workspace File",
+            description="Agent workspace output file",
+        )
+        session.add(task)
+        session.commit()
+
+        workspace_output_dir = temp_uploads_dir / "agent_2_99ea8e11" / "output"
+        workspace_output_dir.mkdir(parents=True, exist_ok=True)
+        file_path = workspace_output_dir / "世界杯报告.txt"
+        file_path.write_text("agent output")
+
+        uploaded_file = UploadedFile(
+            user_id=regular_user_id,
+            task_id=int(cast(Any, task.id)),
+            filename=file_path.name,
+            storage_path=str(file_path),
+            mime_type="text/plain",
+            file_size=len("agent output"),
+        )
+        session.add(uploaded_file)
+        session.commit()
+        session.refresh(uploaded_file)
+
+        del test_app
+        response = run(
+            download_file(
+                str(uploaded_file.file_id),
+                user=regular_user,
+                db=session,
+            )
+        )
+
+        assert response.path == str(file_path)
+        assert response.filename == "世界杯报告.txt"
+        assert (
+            "filename*=utf-8''%E4%B8%96%E7%95%8C%E6%9D%AF%E6%8A%A5%E5%91%8A.txt"
+            in response.headers["content-disposition"]
+        )
+
+    def test_agent_workspace_registration_uses_db_task_id(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user, test_app
+        monkeypatch.setattr(
+            TaskWorkspace,
+            "_create_file_record",
+            _ORIGINAL_CREATE_FILE_RECORD,
+        )
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=86,
+            user_id=regular_user_id,
+            title="Agent Workspace Registration",
+            description="worker output registration",
+        )
+        session.add(task)
+        session.commit()
+
+        workspace = TaskWorkspace(
+            "agent_2_99ea8e11",
+            str(temp_uploads_dir),
+            db_task_id=int(cast(Any, task.id)),
+        )
+        output_file = workspace.output_dir / "report.txt"
+        output_file.write_text("registered output")
+
+        file_id = workspace.register_file(str(output_file), db_session=session)
+
+        uploaded_file = (
+            session.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        )
+        assert uploaded_file.task_id == int(cast(Any, task.id))
+        assert uploaded_file.user_id == regular_user_id
+        assert uploaded_file.storage_path == str(output_file)
 
     def test_regular_user_access_other_user_file_denied(
         self, test_db, temp_uploads_dir

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -3,6 +3,7 @@ import tempfile
 from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
@@ -51,7 +52,9 @@ def test_build_workforce_snapshot():
     db_session, db_path = _create_session()
     try:
         regular_user = _create_user(db_session, "snapshot-user")
-        manager = _create_agent(db_session, regular_user, "Manager", execution_mode="think")
+        manager = _create_agent(
+            db_session, regular_user, "Manager", execution_mode="think"
+        )
         worker = _create_agent(db_session, regular_user, "Research Agent")
 
         workforce = Workforce(

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -6,10 +6,13 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
-from xagent.web.models.task import TaskStatus
+from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
-from xagent.web.models.workforce import Workforce, WorkforceAgent
-from xagent.web.services.workforce_runtime import _map_task_status
+from xagent.web.models.workforce import Workforce, WorkforceAgent, WorkforceRun
+from xagent.web.services.workforce_runtime import (
+    _map_task_status,
+    sync_workforce_run_status,
+)
 from xagent.web.services.workforce_snapshot import (
     _build_worker_tool_name,
     build_agent_tool_overrides,
@@ -125,7 +128,7 @@ def test_build_workforce_snapshot_requires_enabled_worker():
             owner_user_id=regular_user.id,
             name="No Enabled Workers",
             manager_agent_id=manager.id,
-            status="draft",
+            status="active",
         )
         db_session.add(workforce)
         db_session.commit()
@@ -167,6 +170,64 @@ def test_map_task_status_maps_paused() -> None:
     assert _map_task_status(TaskStatus.FAILED) == "failed"
     assert _map_task_status(None) is None
     assert _map_task_status("unknown") is None
+
+
+def test_sync_workforce_run_status_tracks_task_lifecycle() -> None:
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "run-sync-user")
+        manager = _create_agent(db_session, regular_user, "Run Sync Manager")
+        workforce = Workforce(
+            scope_type="user",
+            scope_id=str(regular_user.id),
+            owner_user_id=regular_user.id,
+            name="Run Sync Workforce",
+            manager_agent_id=manager.id,
+            status="active",
+        )
+        db_session.add(workforce)
+        db_session.flush()
+        task = Task(
+            user_id=regular_user.id,
+            title="Run sync task",
+            description="Run sync task",
+            status=TaskStatus.PENDING,
+            agent_id=manager.id,
+            agent_config={},
+        )
+        db_session.add(task)
+        db_session.flush()
+        run = WorkforceRun(
+            workforce_id=workforce.id,
+            task_id=task.id,
+            user_id=regular_user.id,
+            status="pending",
+            snapshot={"version": 1},
+        )
+        db_session.add(run)
+        db_session.flush()
+        task.agent_config = {"workforce_run_id": run.id}
+        db_session.commit()
+
+        sync_workforce_run_status(db_session, task, TaskStatus.RUNNING)
+        db_session.commit()
+        db_session.refresh(run)
+        assert run.status == "running"
+        assert run.completed_at is None
+
+        sync_workforce_run_status(db_session, task, TaskStatus.COMPLETED)
+        db_session.commit()
+        db_session.refresh(run)
+        assert run.status == "completed"
+        assert run.completed_at is not None
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
 
 
 def test_build_worker_tool_name_truncates_long_alias() -> None:

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -11,9 +11,11 @@ from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceAgent
 from xagent.web.services.workforce_runtime import _map_task_status
 from xagent.web.services.workforce_snapshot import (
+    _build_worker_tool_name,
     build_agent_tool_overrides,
     build_workforce_snapshot,
 )
+from xagent.web.services.workforce_workers import load_template_detail
 
 
 def _create_session() -> tuple[Session, str]:
@@ -165,3 +167,48 @@ def test_map_task_status_maps_paused() -> None:
     assert _map_task_status(TaskStatus.FAILED) == "failed"
     assert _map_task_status(None) is None
     assert _map_task_status("unknown") is None
+
+
+def test_build_worker_tool_name_truncates_long_alias() -> None:
+    normal = _build_worker_tool_name(1, "researcher")
+    assert normal == "call_workforce_worker_1_researcher"
+    assert len(normal) <= 64
+
+    long_alias = "a" * 100
+    truncated = _build_worker_tool_name(1, long_alias)
+    assert len(truncated) <= 64
+    assert truncated.startswith("call_workforce_worker_1_")
+
+    same_alias_second = _build_worker_tool_name(2, long_alias)
+    assert same_alias_second != truncated
+    assert same_alias_second.startswith("call_workforce_worker_2_")
+
+
+def test_load_template_detail_rejects_path_traversal() -> None:
+    traversal_ids = [
+        "../archived/foo",
+        "foo/bar",
+        "../../etc/passwd",
+        "foo\\bar",
+    ]
+    safe_ids = [
+        "valid_name",
+        "valid.name",
+    ]
+    for tid in traversal_ids:
+        try:
+            load_template_detail(tid)
+        except HTTPException as exc:
+            assert exc.status_code == 400, (
+                f"Expected 400 for {tid}, got {exc.status_code}"
+            )
+        else:
+            raise AssertionError(f"Expected HTTPException for template_id={tid}")
+
+    for tid in safe_ids:
+        try:
+            load_template_detail(tid)
+        except HTTPException as exc:
+            if exc.status_code == 400:
+                raise AssertionError(f"Safe template_id {tid} was rejected with 400")
+            # 404 is expected for non-existent template files

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -212,3 +212,13 @@ def test_load_template_detail_rejects_path_traversal() -> None:
             if exc.status_code == 400:
                 raise AssertionError(f"Safe template_id {tid} was rejected with 400")
             # 404 is expected for non-existent template files
+
+
+def test_load_template_detail_rejects_overly_long_id() -> None:
+    long_id = "a" * 255
+    try:
+        load_template_detail(long_id)
+    except HTTPException as exc:
+        assert exc.status_code == 400
+    else:
+        raise AssertionError("Expected HTTPException for overly long template_id")

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -1,0 +1,152 @@
+import tempfile
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+from xagent.web.models.workforce import Workforce, WorkforceAgent
+from xagent.web.services.workforce_snapshot import (
+    build_agent_tool_overrides,
+    build_workforce_snapshot,
+)
+
+
+def _create_session() -> tuple[Session, str]:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as temp_db:
+        db_path = temp_db.name
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return session_local(), db_path
+
+
+def _create_user(db_session: Session, username: str) -> User:
+    user = User(username=username, password_hash="x", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _create_agent(db_session, user, name, execution_mode="balanced"):
+    agent = Agent(
+        user_id=user.id,
+        name=name,
+        description=f"{name} description",
+        instructions=f"{name} instructions",
+        execution_mode=execution_mode,
+        models={"general": 1},
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(agent)
+    db_session.commit()
+    db_session.refresh(agent)
+    return agent
+
+
+def test_build_workforce_snapshot():
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "snapshot-user")
+        manager = _create_agent(db_session, regular_user, "Manager", execution_mode="think")
+        worker = _create_agent(db_session, regular_user, "Research Agent")
+
+        workforce = Workforce(
+            scope_type="user",
+            scope_id=str(regular_user.id),
+            owner_user_id=regular_user.id,
+            name="Launch Workforce",
+            description="Coordinate launch tasks",
+            manager_agent_id=manager.id,
+            manager_instructions="Keep the answer concise.",
+            status="active",
+        )
+        db_session.add(workforce)
+        db_session.commit()
+        db_session.refresh(workforce)
+
+        db_session.add(
+            WorkforceAgent(
+                workforce_id=workforce.id,
+                agent_id=worker.id,
+                alias="Researcher",
+                assignment_instructions="Research competitors.",
+                enabled=True,
+                sort_order=1,
+            )
+        )
+        db_session.commit()
+        db_session.refresh(workforce)
+
+        snapshot = build_workforce_snapshot(db_session, regular_user, workforce)
+        assert snapshot["workforce"]["name"] == "Launch Workforce"
+        assert snapshot["workforce"]["scope_type"] == "user"
+        assert snapshot["workforce"]["scope_id"] == str(regular_user.id)
+        assert snapshot["manager"]["agent_id"] == manager.id
+        assert snapshot["workers"][0]["alias"] == "Researcher"
+        assert snapshot["workers"][0]["tool_name"].startswith("call_workforce_worker_")
+        assert "You are the Workforce Manager" in snapshot["manager"]["runtime_prompt"]
+
+        overrides = build_agent_tool_overrides(snapshot, workforce_run_id=88)
+        assert overrides[worker.id]["tool_name"] == snapshot["workers"][0]["tool_name"]
+        assert "Research competitors." in overrides[worker.id]["extra_system_prompt"]
+        assert overrides[worker.id]["workforce_run_id"] == 88
+        assert overrides[worker.id]["worker_alias"] == "Researcher"
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+def test_build_workforce_snapshot_requires_enabled_worker():
+    db_session, db_path = _create_session()
+    try:
+        regular_user = _create_user(db_session, "snapshot-user-2")
+        manager = _create_agent(db_session, regular_user, "Manager Two")
+        worker = _create_agent(db_session, regular_user, "Writer Agent")
+
+        workforce = Workforce(
+            scope_type="user",
+            scope_id=str(regular_user.id),
+            owner_user_id=regular_user.id,
+            name="No Enabled Workers",
+            manager_agent_id=manager.id,
+            status="draft",
+        )
+        db_session.add(workforce)
+        db_session.commit()
+        db_session.refresh(workforce)
+        db_session.add(
+            WorkforceAgent(
+                workforce_id=workforce.id,
+                agent_id=worker.id,
+                alias="Writer",
+                assignment_instructions="Write copy.",
+                enabled=False,
+            )
+        )
+        db_session.commit()
+        db_session.refresh(workforce)
+
+        try:
+            build_workforce_snapshot(db_session, regular_user, workforce)
+        except HTTPException as exc:
+            assert exc.status_code == 400
+            assert "enabled worker" in exc.detail
+            return
+        raise AssertionError("Expected HTTPException")
+    finally:
+        db_session.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass

--- a/tests/web/test_workforce_snapshot.py
+++ b/tests/web/test_workforce_snapshot.py
@@ -6,8 +6,10 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
+from xagent.web.models.task import TaskStatus
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceAgent
+from xagent.web.services.workforce_runtime import _map_task_status
 from xagent.web.services.workforce_snapshot import (
     build_agent_tool_overrides,
     build_workforce_snapshot,
@@ -153,3 +155,13 @@ def test_build_workforce_snapshot_requires_enabled_worker():
             os.remove(db_path)
         except OSError:
             pass
+
+
+def test_map_task_status_maps_paused() -> None:
+    assert _map_task_status(TaskStatus.PENDING) == "pending"
+    assert _map_task_status(TaskStatus.RUNNING) == "running"
+    assert _map_task_status(TaskStatus.PAUSED) == "paused"
+    assert _map_task_status(TaskStatus.COMPLETED) == "completed"
+    assert _map_task_status(TaskStatus.FAILED) == "failed"
+    assert _map_task_status(None) is None
+    assert _map_task_status("unknown") is None


### PR DESCRIPTION
## Summary

- Add the Workforce backend model, snapshot, run, publish, builder, and task execution flow.
- Add the frontend Workforce create/edit/run loop with localized pages, worker management, canvas improvements, and task-page integration.
- Wire Workforce runtime delegation through AgentTool, including nested trace propagation, run status synchronization, file output registration, and file download handling.
- Keep internal Workforce manager agents hidden from normal agent lists and require published workers for runnable Workforce membership.

## Validation

- `pre-commit run --all-files`
- Workforce-focused pytest coverage was run during development, including `tests/web/test_workforce_snapshot.py`, `tests/web/api/test_workforces_api.py`, and `tests/core/tools/test_agent_tool_publish_status.py`.
