### PR TITLE
fix: preserve agent attachment context

### DIFF
--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -10,6 +10,33 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+DISPLAY_USER_MESSAGE_KEY = "display_user_message"
+
+
+def get_display_user_message(context: Any, fallback: str) -> str:
+    """Return the user-visible message for trace/UI events."""
+    candidates: list[dict[str, Any]] = []
+    if isinstance(context, dict):
+        candidates.append(context)
+
+    state = getattr(context, "state", None)
+    if isinstance(state, dict):
+        candidates.append(state)
+
+    metadata = getattr(context, "metadata", None)
+    if isinstance(metadata, dict):
+        request_context = metadata.get("request_context")
+        if isinstance(request_context, dict):
+            candidates.append(request_context)
+        candidates.append(metadata)
+
+    for candidate in candidates:
+        display_message = candidate.get(DISPLAY_USER_MESSAGE_KEY)
+        if isinstance(display_message, str) and display_message.strip():
+            return display_message
+
+    return fallback
+
 
 class TraceScope(Enum):
     """Defines the scope of trace events for clear task/step attribution."""

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .result import extract_assistant_message
 from .trace import (
+    get_display_user_message,
     trace_ai_message,
     trace_error,
     trace_task_completion,
@@ -35,7 +36,7 @@ class TraceEventCallback:
             await trace_user_message(
                 tracer,
                 execution_id,
-                task,
+                get_display_user_message(context, task),
                 {"context": self._context_payload(context)},
             )
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -54,6 +55,20 @@ logger = logging.getLogger(__name__)
 
 # Create router
 chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+def _build_task_agent_config(
+    request_agent_config: Optional[Dict[str, Any]],
+    selected_file_ids: list[str],
+) -> Optional[Dict[str, Any]]:
+    """Build task agent_config with server-owned selected file ids."""
+    task_agent_config: Dict[str, Any] = {}
+    if isinstance(request_agent_config, dict):
+        task_agent_config.update(request_agent_config)
+        task_agent_config.pop("selected_file_ids", None)
+    if selected_file_ids:
+        task_agent_config["selected_file_ids"] = selected_file_ids
+    return task_agent_config or None
 
 
 def create_default_llm() -> Optional[BaseLLM]:
@@ -177,6 +192,7 @@ async def create_default_tools(
     request: Any = None,
     user: Optional[User] = None,
     task_id: Optional[str] = None,
+    workspace_owner_id: Optional[int] = None,
     allowed_collections: Optional[List[str]] = None,
     allowed_skills: Optional[List[str]] = None,
     allowed_tools: Optional[List[str]] = None,
@@ -194,9 +210,13 @@ async def create_default_tools(
     # Create a WebToolConfig to properly initialize tools
     from ..tools.config import WebToolConfig
 
-    # Build allowed external directories so file tools can reach the user's
+    owner_id = (
+        int(workspace_owner_id) if workspace_owner_id is not None else int(user.id)
+    )
+
+    # Build allowed external directories so file tools can reach the task owner's
     # uploads (see _build_allowed_external_dirs docstring).
-    allowed_external_dirs = _build_allowed_external_dirs(int(user.id))
+    allowed_external_dirs = _build_allowed_external_dirs(owner_id)
 
     tool_config = WebToolConfig(
         db=db,
@@ -206,7 +226,7 @@ async def create_default_tools(
         user_id=int(user.id),
         is_admin=bool(user.is_admin),
         workspace_config={
-            "base_dir": str(get_uploads_dir() / f"user_{user.id}"),
+            "base_dir": str(get_uploads_dir() / f"user_{owner_id}"),
             "task_id": task_id,
             "allowed_external_dirs": allowed_external_dirs,
         },
@@ -587,6 +607,7 @@ class AgentServiceManager:
             request=self.request,
             user=user,
             task_id=f"web_task_{task_id}",
+            workspace_owner_id=int(task.user_id),
             allowed_collections=agent_config["knowledge_bases"]
             if agent_config
             else None,
@@ -901,12 +922,19 @@ class AgentServiceManager:
                         f"Tool categories {tool_categories} mapped to {len(allowed_tools)} tools for task {task_id}"
                     )
 
+                workspace_owner_id = (
+                    int(task.user_id)
+                    if task and task.user_id is not None
+                    else int(user.id)
+                )
+
                 # Create tools using ToolFactory
                 tools = await create_default_tools(
                     db,
                     request=self.request,
                     user=user,
                     task_id=f"web_task_{task_id}",
+                    workspace_owner_id=workspace_owner_id,
                     allowed_collections=agent_config["knowledge_bases"]
                     if agent_config
                     else None,
@@ -945,9 +973,9 @@ class AgentServiceManager:
                     # disabled until the product exposes an explicit opt-in.
                     agent_builder_memory_enabled = not bool(task and task.agent_id)
 
-                    # Build allowed external directories (user's upload directory for knowledge base files)
+                    # Build allowed external directories for the task owner's uploads.
                     allowed_external_dirs = _build_allowed_external_dirs(
-                        int(user.id) if user and user.id else None
+                        workspace_owner_id,
                     )
 
                     # Create AgentService first (this creates the workspace)
@@ -965,7 +993,7 @@ class AgentServiceManager:
                         tracer=tracer,
                         enable_workspace=True,  # Enable workspace functionality
                         workspace_base_dir=str(
-                            get_uploads_dir() / f"user_{user.id}"
+                            get_uploads_dir() / f"user_{workspace_owner_id}"
                         ),  # Use user-isolated base directory
                         allowed_external_dirs=allowed_external_dirs,  # Add allowed external directories
                         task_id=str(task_id),  # Pass task_id for proper tracing
@@ -991,11 +1019,16 @@ class AgentServiceManager:
                         from ..models.uploaded_file import UploadedFile
 
                         for selected_file_id in selected_file_ids:
+                            task_owner_id = int(task.user_id) if task else int(user.id)
                             uploaded_file = (
                                 db.query(UploadedFile)
                                 .filter(
                                     UploadedFile.file_id == selected_file_id,
-                                    UploadedFile.user_id == int(user.id),
+                                    UploadedFile.user_id == task_owner_id,
+                                    or_(
+                                        UploadedFile.task_id == int(task_id),
+                                        UploadedFile.task_id.is_(None),
+                                    ),
                                 )
                                 .first()
                             )
@@ -1005,6 +1038,10 @@ class AgentServiceManager:
                             source_path = Path(str(uploaded_file.storage_path))
                             if not source_path.exists() or not source_path.is_file():
                                 continue
+
+                            if uploaded_file.task_id is None:
+                                uploaded_file.task_id = int(task_id)
+                                db.flush()
 
                             # Use the source file directly (user's upload directory) instead of copying
                             # This avoids duplicate files across the system.
@@ -1498,6 +1535,7 @@ async def create_task(
                     .filter(
                         UploadedFile.file_id == file_id,
                         UploadedFile.user_id == int(user.id),
+                        UploadedFile.task_id.is_(None),
                     )
                     .first()
                 )
@@ -1724,11 +1762,10 @@ async def create_task(
                 {"input": ex.input, "output": ex.output} for ex in request.examples
             ]
 
-        task_agent_config: Dict[str, Any] = {}
-        if isinstance(request.agent_config, dict):
-            task_agent_config.update(request.agent_config)
-        if selected_file_ids:
-            task_agent_config["selected_file_ids"] = selected_file_ids
+        task_agent_config = _build_task_agent_config(
+            request.agent_config,
+            selected_file_ids,
+        )
 
         task_execution_mode = request.execution_mode
         if not task_execution_mode:
@@ -1754,7 +1791,7 @@ async def create_task(
             small_fast_model_name=fast_model_name,
             visual_model_name=visual_model_name,
             compact_model_name=compact_model_name,
-            agent_config=task_agent_config or None,
+            agent_config=task_agent_config,
             execution_mode=task_execution_mode,
             process_description=request.process_description,
             examples=examples_data,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1764,8 +1764,7 @@ async def create_task(
         # Set agent_type using the property to avoid Column type issues
         task.agent_type_enum = agent_type_enum
         db.add(task)
-        db.commit()
-        db.refresh(task)
+        db.flush()
 
         # Set LLM configuration for this task in agent manager
         task_llm_ids_to_set = [
@@ -1794,7 +1793,9 @@ async def create_task(
                     synchronize_session=False,
                 )
             )
-            db.commit()
+
+        db.commit()
+        db.refresh(task)
 
         return TaskCreateResponse(
             task_id=task.id,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1779,6 +1779,23 @@ async def create_task(
         )
         get_agent_manager(request).set_task_llms(int(task.id), task_llm_ids_to_set, db)
 
+        if selected_file_ids:
+            from ..models.uploaded_file import UploadedFile
+
+            (
+                db.query(UploadedFile)
+                .filter(
+                    UploadedFile.file_id.in_(selected_file_ids),
+                    UploadedFile.user_id == int(user.id),
+                    UploadedFile.task_id.is_(None),
+                )
+                .update(
+                    {UploadedFile.task_id: int(task.id)},
+                    synchronize_session=False,
+                )
+            )
+            db.commit()
+
         return TaskCreateResponse(
             task_id=task.id,
             title=task.title,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -22,6 +22,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import RedirectResponse
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -202,8 +203,8 @@ def _display_message_for_user(user_message: str, has_files: bool) -> str:
     return user_message
 
 
-def _selected_file_refs_from_task(task: Any) -> list[dict[str, str]]:
-    """Return file refs stored during task creation for the initial turn."""
+def _selected_file_ids_from_task_config(task: Any) -> list[str]:
+    """Return unique selected file ids stored during task creation."""
     agent_config = getattr(task, "agent_config", None)
     if not isinstance(agent_config, dict):
         return []
@@ -212,13 +213,65 @@ def _selected_file_refs_from_task(task: Any) -> list[dict[str, str]]:
     if not isinstance(raw_file_ids, list):
         return []
 
-    refs = []
+    file_ids = []
+    seen = set()
     for raw_file_id in raw_file_ids:
         if not isinstance(raw_file_id, str):
             continue
         file_id = raw_file_id.strip()
-        if file_id:
-            refs.append({"file_id": file_id})
+        if file_id and file_id not in seen:
+            seen.add(file_id)
+            file_ids.append(file_id)
+    return file_ids
+
+
+def _uploaded_file_ref(file_record: UploadedFile) -> dict[str, Any]:
+    """Build a websocket file ref from an authorized UploadedFile record."""
+    return {
+        "file_id": str(file_record.file_id),
+        "name": str(file_record.filename),
+        "size": int(file_record.file_size or 0),
+        "type": file_record.mime_type,
+    }
+
+
+def _selected_file_refs_from_task(task: Any, db: Session) -> list[dict[str, Any]]:
+    """Recover task-selected file refs after revalidating DB ownership/binding."""
+    selected_file_ids = _selected_file_ids_from_task_config(task)
+    if not selected_file_ids:
+        return []
+
+    task_id = getattr(task, "id", None)
+    task_owner_id = getattr(task, "user_id", None)
+    if task_id is None or task_owner_id is None:
+        logger.warning("Cannot recover selected files without task id and owner id")
+        return []
+
+    task_id_int = int(task_id)
+    task_owner_id_int = int(task_owner_id)
+    records = (
+        db.query(UploadedFile)
+        .filter(
+            UploadedFile.file_id.in_(selected_file_ids),
+            UploadedFile.user_id == task_owner_id_int,
+            or_(UploadedFile.task_id == task_id_int, UploadedFile.task_id.is_(None)),
+        )
+        .all()
+    )
+    records_by_file_id = {str(record.file_id): record for record in records}
+
+    refs: list[dict[str, Any]] = []
+    for file_id in selected_file_ids:
+        record = records_by_file_id.get(file_id)
+        if record is None:
+            logger.warning(
+                "Skipping selected file %s for task %s: not found, wrong owner, "
+                "or bound to another task",
+                file_id,
+                task_id_int,
+            )
+            continue
+        refs.append(_uploaded_file_ref(record))
     return refs
 
 
@@ -1522,7 +1575,11 @@ manager = ConnectionManager()
 
 
 async def handle_file_upload_for_task(
-    task_id: int, files: list, db: Session, user: Optional[User] = None
+    task_id: int,
+    files: list,
+    db: Session,
+    user: Optional[User] = None,
+    task_owner_id: Optional[int] = None,
 ) -> dict:
     """Handle file upload for task"""
     try:
@@ -1535,6 +1592,16 @@ async def handle_file_upload_for_task(
         file_info_list = []
 
         logger.info(f"📁 Starting file upload for task {task_id}, files: {len(files)}")
+
+        authorized_owner_id = task_owner_id
+        if authorized_owner_id is None and user is not None:
+            authorized_owner_id = int(user.id)
+        if authorized_owner_id is None:
+            logger.warning(
+                "Cannot handle uploaded files for task %s without an authorized owner",
+                task_id,
+            )
+            return {"uploaded_files": [], "file_info_list": []}
 
         # Get agent
         agent_service = await get_agent_manager().get_agent_for_task(
@@ -1549,10 +1616,23 @@ async def handle_file_upload_for_task(
                 continue
 
             file_record = (
-                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+                db.query(UploadedFile)
+                .filter(
+                    UploadedFile.file_id == file_id,
+                    UploadedFile.user_id == int(authorized_owner_id),
+                    or_(
+                        UploadedFile.task_id == int(task_id),
+                        UploadedFile.task_id.is_(None),
+                    ),
+                )
+                .first()
             )
             if not file_record:
-                logger.warning(f"File record not found for file_id: {file_id}")
+                logger.warning(
+                    "File record not accessible for task %s: %s",
+                    task_id,
+                    file_id,
+                )
                 continue
 
             file_name = file_record.filename
@@ -1898,7 +1978,7 @@ async def handle_chat_message(
                         logger.info(f"task_info event sent for task {task_id}")
 
                 if not files and task.status == TaskStatus.PENDING:
-                    files = _selected_file_refs_from_task(task)
+                    files = _selected_file_refs_from_task(task, db)
                     if files:
                         logger.info(
                             f"📁 Recovered {len(files)} selected file(s) from task "
@@ -1918,7 +1998,11 @@ async def handle_chat_message(
                 if files:
                     # Process file upload
                     upload_result = await handle_file_upload_for_task(
-                        task_id, files, db, user
+                        task_id,
+                        files,
+                        db,
+                        user,
+                        task_owner_id=int(task.user_id),
                     )
                     uploaded_file_paths = upload_result.get("uploaded_files", [])
                     file_info_list = upload_result.get("file_info_list", [])

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1757,11 +1757,7 @@ async def handle_chat_message(
         logger.info(f"Received chat message for task {task_id}")
         logger.info(f"👤 User: {user.id if user else 'unknown'}")
         logger.info(f"📄 Message: {user_message}")
-        logger.info(f"📁 Files received: {len(files)}")
-        for i, file_info in enumerate(files):
-            logger.info(
-                f"📄 File {i}: {file_info.get('name', 'unknown')} ({file_info.get('size', 0)} bytes)"
-            )
+        logger.info(f"📁 Files received from websocket/fallback: {len(files)}")
 
         # Call Agent to handle - use same agent manager as chat API
         try:
@@ -1908,6 +1904,12 @@ async def handle_chat_message(
                             f"📁 Recovered {len(files)} selected file(s) from task "
                             f"{task_id} for initial chat turn"
                         )
+
+                logger.info(f"📁 Files used for execution: {len(files)}")
+                for i, file_info in enumerate(files):
+                    logger.info(
+                        f"📄 File {i}: {file_info.get('name', 'unknown')} ({file_info.get('size', 0)} bytes)"
+                    )
 
                 # Handle file upload if files present
                 uploaded_file_paths = []

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -193,6 +193,35 @@ def _append_uploaded_files_context_to_message(
     return f"{message.rstrip()}\n\n{uploaded_files_context}"
 
 
+def _display_message_for_user(user_message: str, has_files: bool) -> str:
+    """Return the user-visible message for chat history and trace events."""
+    if user_message.strip():
+        return user_message
+    if has_files:
+        return "Uploaded file(s)"
+    return user_message
+
+
+def _selected_file_refs_from_task(task: Any) -> list[dict[str, str]]:
+    """Return file refs stored during task creation for the initial turn."""
+    agent_config = getattr(task, "agent_config", None)
+    if not isinstance(agent_config, dict):
+        return []
+
+    raw_file_ids = agent_config.get("selected_file_ids")
+    if not isinstance(raw_file_ids, list):
+        return []
+
+    refs = []
+    for raw_file_id in raw_file_ids:
+        if not isinstance(raw_file_id, str):
+            continue
+        file_id = raw_file_id.strip()
+        if file_id:
+            refs.append({"file_id": file_id})
+    return refs
+
+
 def create_stream_event(
     event_type: str,
     task_id: Union[int, str],
@@ -695,6 +724,7 @@ async def execute_task_background(
     task: Any,
     db: Session,
     force_fresh_execution: bool = False,
+    llm_user_message: Optional[str] = None,
 ) -> None:
     """Execute task in background without blocking WebSocket message loop"""
     from ..models.task import Task, TaskStatus
@@ -721,9 +751,10 @@ async def execute_task_background(
 
             # Execute task with automatic token tracking
             actual_task_id = None if force_fresh_execution else str(task_id)
+            task_for_agent = llm_user_message or user_message
             result = await agent_manager.execute_task(
                 agent_service=agent_service,
-                task=user_message,
+                task=task_for_agent,
                 context=context,
                 task_id=actual_task_id,
                 tracking_task_id=str(task_id),
@@ -1870,6 +1901,14 @@ async def handle_chat_message(
                         await manager.broadcast_to_task(task_event, task_id)
                         logger.info(f"task_info event sent for task {task_id}")
 
+                if not files and task.status == TaskStatus.PENDING:
+                    files = _selected_file_refs_from_task(task)
+                    if files:
+                        logger.info(
+                            f"📁 Recovered {len(files)} selected file(s) from task "
+                            f"{task_id} for initial chat turn"
+                        )
+
                 # Handle file upload if files present
                 uploaded_file_paths = []
                 file_info_list = []
@@ -1947,6 +1986,10 @@ async def handle_chat_message(
                     user_message,
                     uploaded_files_context,
                 )
+                display_user_message = _display_message_for_user(
+                    user_message,
+                    bool(file_info_list),
+                )
 
                 # DAG plan-execute will automatically send user_message trace event
 
@@ -1963,7 +2006,7 @@ async def handle_chat_message(
                     db,
                     task_id=task_id,
                     user_id=int(user.id),
-                    content=user_message_for_llm,
+                    content=display_user_message,
                 )
 
                 # Check if there's an old task running (PAUSED, WAITING_FOR_USER, or RUNNING status)
@@ -2006,7 +2049,7 @@ async def handle_chat_message(
                         await trace_user_message(
                             dag_pattern.tracer,
                             str(dag_pattern.task_id),
-                            user_message,
+                            display_user_message,
                             trace_data,
                         )
 
@@ -2200,6 +2243,7 @@ async def handle_chat_message(
                         logger.info(f"task_info event sent for existing task {task_id}")
 
                     # Build context with vibe mode information if available
+                    context["display_user_message"] = display_user_message
                     if hasattr(task, "execution_mode") and task.execution_mode:
                         context["execution_mode"] = task.execution_mode
                     if (
@@ -2222,13 +2266,14 @@ async def handle_chat_message(
                     bg_task = asyncio.create_task(
                         execute_task_background(
                             task_id=task_id,
-                            user_message=user_message,
+                            user_message=display_user_message,
                             context=context,
                             agent_manager=get_agent_manager(),
                             user=user,
                             task=task,
                             db=db,
                             force_fresh_execution=force_fresh_execution,
+                            llm_user_message=user_message_for_llm,
                         )
                     )
 

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -54,6 +54,22 @@ async def test_trace_callback_success_emits_user_assistant_and_completion() -> N
 
 
 @pytest.mark.asyncio
+async def test_trace_callback_uses_display_user_message_when_present() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Read file\n\n## UPLOADED FILES\nfile_id=file-123"
+    context.metadata["request_context"] = {
+        "display_user_message": "Read file",
+    }
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert tracer.events[0]["data"]["message"] == "Read file"
+
+
+@pytest.mark.asyncio
 async def test_trace_callback_failed_run_emits_error() -> None:
     tracer = TraceRecorder()
     callback = TraceEventCallback()

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -202,6 +202,57 @@ class TestAgentServiceManagerReconstruction:
         assert agent_manager._agents[1] == mock_agent_service
 
     @pytest.mark.asyncio
+    async def test_admin_task_uses_task_owner_workspace_dirs(
+        self, agent_manager, mock_db, tmp_path
+    ):
+        """Admin executing another user's task should use the task owner's workspace."""
+        owner_task = Task(
+            id=1,
+            user_id=7,
+            title="Owner Task",
+            description="Task owned by another user",
+            status=TaskStatus.PENDING,
+            agent_type="standard",
+        )
+        admin_user = User(
+            id=1,
+            username="admin",
+            password_hash="hashed_password",
+            is_admin=True,
+        )
+        uploads_dir = tmp_path / "uploads"
+
+        with (
+            patch("xagent.web.api.chat.AgentService") as mock_agent_service_class,
+            patch("xagent.web.api.chat.resolve_llms_from_names") as mock_resolve_llms,
+            patch("xagent.web.api.chat.get_memory_store") as mock_get_memory,
+            patch("xagent.web.api.chat.get_uploads_dir", return_value=uploads_dir),
+            patch(
+                "xagent.core.tools.adapters.vibe.factory.ToolFactory"
+            ) as mock_tool_factory,
+        ):
+            mock_resolve_llms.return_value = (MagicMock(), None, None, None)
+            mock_get_memory.return_value = MagicMock()
+            mock_tool_factory.create_all_tools = AsyncMock(return_value=[])
+            mock_agent_service = MagicMock()
+            mock_agent_service_class.return_value = mock_agent_service
+
+            mock_task_query = MagicMock()
+            mock_task_query.filter.return_value = mock_task_query
+            mock_task_query.first.return_value = owner_task
+            mock_db.query.return_value = mock_task_query
+
+            await agent_manager.get_agent_for_task(1, mock_db, user=admin_user)
+
+        kwargs = mock_agent_service_class.call_args.kwargs
+        assert kwargs["workspace_base_dir"] == str(uploads_dir / "user_7")
+        assert str(uploads_dir / "user_7") in kwargs["allowed_external_dirs"]
+        tool_config = kwargs["tool_config"]
+        workspace_config = tool_config.get_workspace_config()
+        assert workspace_config["base_dir"] == str(uploads_dir / "user_7")
+        assert str(uploads_dir / "user_7") in workspace_config["allowed_external_dirs"]
+
+    @pytest.mark.asyncio
     async def test_get_agent_for_task_existing_task_with_reconstruction(
         self,
         agent_manager,

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -1,12 +1,95 @@
 from types import SimpleNamespace
 
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from xagent.core.agent.trace import get_display_user_message
+from xagent.web.api.chat import _build_task_agent_config
 from xagent.web.api.websocket import (
     _append_uploaded_files_context_to_message,
     _build_uploaded_files_context,
     _display_message_for_user,
     _selected_file_refs_from_task,
+    handle_file_upload_for_task,
 )
+from xagent.web.models import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.models.user import User
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'test.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _create_user(db, user_id: int, username: str) -> User:
+    user = User(id=user_id, username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_task(
+    db,
+    *,
+    task_id: int,
+    user_id: int,
+    selected_file_ids: list[str] | None = None,
+) -> Task:
+    task = Task(
+        id=task_id,
+        user_id=user_id,
+        title=f"task-{task_id}",
+        description="task",
+        status=TaskStatus.PENDING,
+        agent_config=(
+            {"selected_file_ids": selected_file_ids}
+            if selected_file_ids is not None
+            else None
+        ),
+    )
+    db.add(task)
+    db.flush()
+    return task
+
+
+def _create_uploaded_file(
+    db,
+    tmp_path,
+    *,
+    file_id: str,
+    user_id: int,
+    task_id: int | None,
+    filename: str,
+) -> UploadedFile:
+    path = tmp_path / f"{file_id}-{filename}"
+    path.write_text("file content")
+    file_record = UploadedFile(
+        file_id=file_id,
+        user_id=user_id,
+        task_id=task_id,
+        filename=filename,
+        storage_path=str(path),
+        mime_type="text/plain",
+        file_size=len("file content"),
+    )
+    db.add(file_record)
+    db.flush()
+    return file_record
 
 
 def test_build_uploaded_files_context_includes_agent_builder_kb_instruction():
@@ -38,23 +121,193 @@ def test_append_uploaded_files_context_to_message_is_idempotent():
     assert _append_uploaded_files_context_to_message(message, context) == message
 
 
-def test_selected_file_refs_from_task_uses_task_create_file_ids():
-    class Task:
-        agent_config = {
-            "selected_file_ids": [" file-123 ", "", 42, "file-456"],
-        }
+def test_build_task_agent_config_ignores_client_selected_file_ids():
+    assert _build_task_agent_config(
+        {"selected_file_ids": ["forged"], "tools": ["search"]},
+        [],
+    ) == {"tools": ["search"]}
+    assert _build_task_agent_config({"selected_file_ids": ["forged"]}, []) is None
+    assert _build_task_agent_config(
+        {"selected_file_ids": ["forged"], "tools": ["search"]},
+        ["valid-file"],
+    ) == {"tools": ["search"], "selected_file_ids": ["valid-file"]}
 
-    assert _selected_file_refs_from_task(Task()) == [
-        {"file_id": "file-123"},
-        {"file_id": "file-456"},
+
+def test_create_task_file_selection_requires_unbound_files(db_session, tmp_path):
+    _create_user(db_session, 1, "owner")
+    _create_task(db_session, task_id=10, user_id=1)
+    bound_file = _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="bound-file",
+        user_id=1,
+        task_id=10,
+        filename="bound.txt",
+    )
+
+    selected_file_ids = []
+    uploaded_file = (
+        db_session.query(UploadedFile)
+        .filter(
+            UploadedFile.file_id == "bound-file",
+            UploadedFile.user_id == 1,
+            UploadedFile.task_id.is_(None),
+        )
+        .first()
+    )
+    if uploaded_file is not None:
+        selected_file_ids.append(str(uploaded_file.file_id))
+
+    assert selected_file_ids == []
+    db_session.refresh(bound_file)
+    assert bound_file.task_id == 10
+
+
+def test_selected_file_refs_from_task_revalidates_owner_and_task_binding(
+    db_session,
+    tmp_path,
+):
+    _create_user(db_session, 1, "owner")
+    _create_user(db_session, 2, "other")
+    task = _create_task(
+        db_session,
+        task_id=10,
+        user_id=1,
+        selected_file_ids=[
+            "task-file",
+            "unbound-file",
+            "other-user-file",
+            "other-task-file",
+            "missing-file",
+            "task-file",
+        ],
+    )
+    _create_task(db_session, task_id=11, user_id=1)
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="task-file",
+        user_id=1,
+        task_id=10,
+        filename="task.txt",
+    )
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="unbound-file",
+        user_id=1,
+        task_id=None,
+        filename="unbound.txt",
+    )
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="other-user-file",
+        user_id=2,
+        task_id=None,
+        filename="other-user.txt",
+    )
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="other-task-file",
+        user_id=1,
+        task_id=11,
+        filename="other-task.txt",
+    )
+
+    assert _selected_file_refs_from_task(task, db_session) == [
+        {
+            "file_id": "task-file",
+            "name": "task.txt",
+            "size": len("file content"),
+            "type": "text/plain",
+        },
+        {
+            "file_id": "unbound-file",
+            "name": "unbound.txt",
+            "size": len("file content"),
+            "type": "text/plain",
+        },
     ]
 
 
-def test_selected_file_refs_from_task_ignores_missing_config():
-    class Task:
-        agent_config = None
+def test_selected_file_refs_from_task_ignores_missing_config(db_session):
+    _create_user(db_session, 1, "owner")
+    task = _create_task(db_session, task_id=10, user_id=1)
 
-    assert _selected_file_refs_from_task(Task()) == []
+    assert _selected_file_refs_from_task(task, db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_handle_file_upload_for_task_rejects_unowned_and_wrong_task_files(
+    db_session,
+    tmp_path,
+    monkeypatch,
+):
+    _create_user(db_session, 1, "owner")
+    _create_user(db_session, 2, "other")
+    _create_task(db_session, task_id=10, user_id=1)
+    _create_task(db_session, task_id=11, user_id=1)
+    valid_file = _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="valid-file",
+        user_id=1,
+        task_id=None,
+        filename="valid.txt",
+    )
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="other-user-file",
+        user_id=2,
+        task_id=None,
+        filename="other-user.txt",
+    )
+    _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="other-task-file",
+        user_id=1,
+        task_id=11,
+        filename="other-task.txt",
+    )
+
+    class Workspace:
+        def __init__(self):
+            self.input_dir = str(tmp_path / "workspace" / "input")
+            self.registered_files = []
+
+        def register_file(self, path, file_id, db_session=None):
+            self.registered_files.append((path, file_id, db_session))
+
+    workspace = Workspace()
+
+    class Manager:
+        async def get_agent_for_task(self, task_id, db, user=None):
+            return SimpleNamespace(workspace=workspace)
+
+    import xagent.web.api.chat as chat_api
+
+    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: Manager())
+
+    result = await handle_file_upload_for_task(
+        10,
+        [
+            {"file_id": "other-user-file"},
+            {"file_id": "other-task-file"},
+            {"file_id": "valid-file"},
+        ],
+        db_session,
+        SimpleNamespace(id=1, is_admin=False),
+        task_owner_id=1,
+    )
+
+    assert [item["file_id"] for item in result["file_info_list"]] == ["valid-file"]
+    assert [item[1] for item in workspace.registered_files] == ["valid-file"]
+    db_session.refresh(valid_file)
+    assert valid_file.task_id == 10
 
 
 def test_get_display_user_message_reads_agent_context_state():

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -1,6 +1,11 @@
+from types import SimpleNamespace
+
+from xagent.core.agent.trace import get_display_user_message
 from xagent.web.api.websocket import (
     _append_uploaded_files_context_to_message,
     _build_uploaded_files_context,
+    _display_message_for_user,
+    _selected_file_refs_from_task,
 )
 
 
@@ -31,3 +36,46 @@ def test_append_uploaded_files_context_to_message_is_idempotent():
     message = _append_uploaded_files_context_to_message("Upload File", context)
     assert message.startswith("Upload File\n\n## UPLOADED FILES")
     assert _append_uploaded_files_context_to_message(message, context) == message
+
+
+def test_selected_file_refs_from_task_uses_task_create_file_ids():
+    class Task:
+        agent_config = {
+            "selected_file_ids": [" file-123 ", "", 42, "file-456"],
+        }
+
+    assert _selected_file_refs_from_task(Task()) == [
+        {"file_id": "file-123"},
+        {"file_id": "file-456"},
+    ]
+
+
+def test_selected_file_refs_from_task_ignores_missing_config():
+    class Task:
+        agent_config = None
+
+    assert _selected_file_refs_from_task(Task()) == []
+
+
+def test_get_display_user_message_reads_agent_context_state():
+    context = SimpleNamespace(
+        state={
+            "display_user_message": "Summarize this document",
+        }
+    )
+
+    assert (
+        get_display_user_message(
+            context,
+            "Summarize this document\n\n## UPLOADED FILES\nfile_id=file-123",
+        )
+        == "Summarize this document"
+    )
+
+
+def test_display_message_for_file_only_turn_uses_placeholder():
+    assert _display_message_for_user("", has_files=True) == "Uploaded file(s)"
+    assert (
+        _display_message_for_user("Summarize this document", has_files=True)
+        == "Summarize this document"
+    )


### PR DESCRIPTION
## Summary
- Recover selected file IDs for the initial using-agent chat turn when the WebSocket message does not include `files`.
- Split user-visible chat text from the enriched LLM input so internal `## UPLOADED FILES` context stays out of trace/UI/history.
- Bind task-created uploads to the task and add trace coverage for display-message overrides.

## Root Cause
Using-agent task creation persisted `selected_file_ids`, but the first WebSocket chat message could arrive without `files`, so the execution turn did not register the attachment. The existing enriched message helper was also not safely separated from user-visible trace/history paths.

## Validation
- `uv run pytest tests/web/test_websocket_uploaded_files_context.py tests/core/agent_v2/test_tracing.py`
- `uv run ruff check src/xagent/core/agent/trace.py src/xagent/core/agent/pattern/react.py src/xagent/core/agent/pattern/single_call.py src/xagent/core/agent/pattern/dag_plan_execute/dag_plan_execute.py src/xagent/core/agent_v2/tracing.py src/xagent/web/api/websocket.py src/xagent/web/api/chat.py tests/web/test_websocket_uploaded_files_context.py tests/core/agent_v2/test_tracing.py`
- pre-commit hooks during commit
