### PR TITLE
fix: improve agent execution recovery

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -429,11 +429,14 @@ export function ChatInput({
     setAgentConfig(config);
   };
 
+  const allowsInterruptedInput = taskStatus === 'paused' || taskStatus === 'waiting_for_user';
+  const isInputBusy = !!isLoading && !allowsInterruptedInput;
+
   const canSubmit = () => {
     const hasText = message.trim().length > 0;
     const hasFiles = files.length > 0;
     const isUploadingFiles = uploadingFiles.size > 0;
-    return (hasText || hasFiles) && !isLoading && !isUploadingFiles;
+    return (hasText || hasFiles) && !isInputBusy && !isUploadingFiles;
   };
   const canPauseTask =
     taskStatus === 'running' ||
@@ -690,7 +693,7 @@ export function ChatInput({
               className={cn(
                 "w-full rounded-md border-0 bg-transparent text-[15px] outline-none placeholder:text-muted-foreground/60 overflow-y-auto resize-none focus-visible:ring-0 focus-visible:ring-offset-0 whitespace-pre-wrap break-words text-left",
                 compact ? "min-h-[44px] px-3 py-3 pr-12 max-h-[150px]" : cn(minHeightClass, "px-4 py-3 pb-16 max-h-[400px]"),
-                isLoading ? "opacity-50 pointer-events-none" : ""
+                isInputBusy ? "opacity-50 pointer-events-none" : ""
               )}
               onInput={handleInput}
               onKeyDown={handleKeyDown}
@@ -719,7 +722,7 @@ export function ChatInput({
                   !canSubmit() && "bg-muted text-muted-foreground/50"
                 )}
               >
-                {isLoading ? (
+                {isInputBusy ? (
                   <Sparkles className="h-4 w-4 animate-pulse" />
                 ) : (
                   <ArrowUp className="h-4 w-4" />
@@ -756,7 +759,7 @@ export function ChatInput({
                             variant="ghost"
                             size="sm"
                             className="h-9 px-3 text-muted-foreground hover:text-foreground hover:bg-secondary/80 rounded-xl gap-2"
-                            disabled={isLoading}
+                            disabled={isInputBusy}
                             title={t('agent.input.actions.config')}
                           >
                             <Globe className="h-4 w-4" />
@@ -786,7 +789,7 @@ export function ChatInput({
                       size="sm"
                       className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground hover:bg-secondary/80 rounded-full"
                       onClick={() => fileInputRef.current?.click()}
-                      disabled={isLoading}
+                      disabled={isInputBusy}
                       title={t("chatPage.input.actions.upload")}
                     >
                       <Paperclip className="h-4 w-4" />
@@ -805,15 +808,6 @@ export function ChatInput({
                   >
                     <Pause className="h-4 w-4" />
                   </Button>
-                ) : taskStatus === 'paused' ? (
-                  <Button
-                    type="button"
-                    size="icon"
-                    onClick={onResume}
-                    className="h-8 w-8 rounded-full transition-all duration-300 bg-green-500 hover:bg-green-600 text-white"
-                  >
-                    <Play className="h-4 w-4" />
-                  </Button>
                 ) : (
                   <div className="flex items-center gap-2">
                     <span className="text-[13px] font-medium text-muted-foreground/50 select-none mr-1">
@@ -828,12 +822,23 @@ export function ChatInput({
                         !canSubmit() && "bg-muted text-muted-foreground/50"
                       )}
                     >
-                      {isLoading ? (
+                      {isInputBusy ? (
                         <Sparkles className="h-4 w-4 animate-pulse" />
                       ) : (
                         <ArrowUp className="h-4 w-4" />
                       )}
                     </Button>
+                    {taskStatus === 'paused' && onResume && (
+                      <Button
+                        type="button"
+                        size="icon"
+                        onClick={onResume}
+                        className="h-8 w-8 rounded-full transition-all duration-300 bg-green-500 hover:bg-green-600 text-white"
+                        title={t('agent.input.actions.resumeTask')}
+                      >
+                        <Play className="h-4 w-4" />
+                      </Button>
+                    )}
                   </div>
                 )}
               </div>

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -39,6 +39,7 @@ import { getApiUrl, getUploadApiUrl } from "@/lib/utils"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
+import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 
 // Unique ID generator for messages
 let messageIdCounter = 0
@@ -1229,7 +1230,11 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
           // Agent-to-user messages, including ask_user_question prompts.
           else if (eventType === "agent_message" || eventType === "ai_message") {
-            const messageContent = eventData.message || eventData.content || ""
+            const rawMessageContent = eventData.message || eventData.content || ""
+            const messageContent =
+              typeof rawMessageContent === "string"
+                ? unwrapFinalAnswerContent(rawMessageContent)
+                : rawMessageContent
             if (!messageContent) {
               return
             }
@@ -2166,7 +2171,11 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               && (resultData as any).content
               && !(resultData as any).output
             ) {
-              resultData = { ...resultData, output: (resultData as any).content }
+              const content = (resultData as any).content
+              resultData = {
+                ...resultData,
+                output: typeof content === "string" ? unwrapFinalAnswerContent(content) : content,
+              }
             }
 
             // 1. Output meta info (excluding output, file_outputs, and history)

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -22,6 +22,7 @@ import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl, getUploadApiUrl } from "@/lib/utils"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
+import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 
 // Unique ID generator for messages
 let messageIdCounter = 0
@@ -1738,7 +1739,11 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               && (resultData as any).content
               && !(resultData as any).output
             ) {
-              resultData = { ...resultData, output: (resultData as any).content }
+              const content = (resultData as any).content
+              resultData = {
+                ...resultData,
+                output: typeof content === "string" ? unwrapFinalAnswerContent(content) : content,
+              }
             }
 
             // 1. Output meta info (exclude output, file_outputs and history)
@@ -2081,7 +2086,10 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               payload: {
                 id: generateMessageId("msg-ai"),
                 role: "assistant",
-                content: eventData.content || "",
+                content:
+                  typeof eventData.content === "string"
+                    ? unwrapFinalAnswerContent(eventData.content)
+                    : eventData.content || "",
                 timestamp: message.timestamp,
                 status: "completed",
               }

--- a/frontend/src/lib/final-answer.ts
+++ b/frontend/src/lib/final-answer.ts
@@ -1,0 +1,47 @@
+export function unwrapFinalAnswerContent(content: string): string {
+  const text = stripCodeFence(content.trim())
+  if (!text.startsWith("{") || !text.endsWith("}")) {
+    return content
+  }
+
+  try {
+    const parsed = JSON.parse(text)
+    if (!parsed || typeof parsed !== "object") {
+      return content
+    }
+
+    if (parsed.action === "final_answer") {
+      return stringifyAnswerValue(
+        Object.prototype.hasOwnProperty.call(parsed, "action_input")
+          ? parsed.action_input
+          : parsed.answer
+      )
+    }
+
+    if (Object.prototype.hasOwnProperty.call(parsed, "final_answer")) {
+      return stringifyAnswerValue(parsed.final_answer)
+    }
+  } catch {
+    return content
+  }
+
+  return content
+}
+
+function stripCodeFence(content: string): string {
+  const lines = content.split(/\r?\n/)
+  if (lines.length >= 2 && lines[0].trim().startsWith("```")) {
+    const closing = lines[lines.length - 1].trim()
+    if (closing === "```" || closing.startsWith("```")) {
+      return lines.slice(1, -1).join("\n").trim()
+    }
+  }
+  return content
+}
+
+function stringifyAnswerValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value
+  }
+  return JSON.stringify(value, null, 2)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ source = "vcs"
 addopts = "-ra -q"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+pythonpath = ["tests/_stubs"]
 markers = [
   "integration: marks tests as integration tests",
   "slow: marks tests as slow running tests",

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -877,6 +877,11 @@ class AutoPattern(AgentPattern):
         arguments: str,
         original_error: json.JSONDecodeError,
     ) -> Any:
+        if not self._is_structurally_complete_json_object(arguments):
+            raise AutoDecisionArgumentsError(
+                "Tool call arguments appear truncated and must be retried.",
+                arguments=arguments,
+            ) from original_error
         try:
             return repair_json_loads(arguments, logging=False)
         except Exception as exc:
@@ -884,6 +889,35 @@ class AutoPattern(AgentPattern):
                 "Tool call arguments must be valid JSON.",
                 arguments=arguments,
             ) from original_error or exc
+
+    def _is_structurally_complete_json_object(self, arguments: str) -> bool:
+        stripped = arguments.strip()
+        if not stripped.startswith("{") or not stripped.endswith("}"):
+            return False
+
+        pairs = {"}": "{", "]": "["}
+        stack: list[str] = []
+        in_string = False
+        escaped = False
+        for char in stripped:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+            elif char in "{[":
+                stack.append(char)
+            elif char in pairs:
+                if not stack or stack.pop() != pairs[char]:
+                    return False
+
+        return not in_string and not escaped and not stack
 
     def _selected_child(self) -> AgentPattern:
         if self.decision is None:

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -132,6 +132,9 @@ class _AutoChildRuntime:
     async def should_interrupt(self) -> bool:
         return await self.parent.should_interrupt()
 
+    def clear_interrupt(self) -> None:
+        self.parent.clear_interrupt()
+
     async def run_llm_call(self, llm: Any, **kwargs: Any) -> Any:
         return await self.parent.run_llm_call(llm, **kwargs)
 

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+
+from json_repair import loads as repair_json_loads
 
 from ...context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
@@ -85,6 +86,15 @@ class AutoDecision:
 
 
 DECISION_TOOL_NAME = "select_execution_pattern"
+MAX_DECISION_PARSE_ATTEMPTS = 2
+
+
+class AutoDecisionArgumentsError(ValueError):
+    """Raised when the routing tool call arguments cannot be parsed."""
+
+    def __init__(self, message: str, *, arguments: str | None = None) -> None:
+        super().__init__(message)
+        self.arguments = arguments
 
 
 def _coerce_bool(value: Any, *, default: bool) -> bool:
@@ -590,30 +600,84 @@ class AutoPattern(AgentPattern):
             metadata={"phase": "auto_decision"},
         )
 
-        messages = context.get_messages_for_llm()
+        base_messages = context.get_messages_for_llm()
         decision_prompt = self._decision_prompt(tools)
-        messages.append({"role": "user", "content": decision_prompt})
         decision_tools = [self._decision_tool_schema()]
-        metadata = {"phase": "auto_decision"}
-        await runtime.on_llm_start(
-            context=context,
-            messages=messages,
-            tools=decision_tools,
-            metadata=metadata,
-        )
-        try:
-            response = await runtime.run_llm_call(
-                llm,
+        retry_feedback: str | None = None
+        for attempt in range(MAX_DECISION_PARSE_ATTEMPTS):
+            messages = list(base_messages)
+            messages.append({"role": "user", "content": decision_prompt})
+            if retry_feedback:
+                messages.append({"role": "user", "content": retry_feedback})
+            metadata: dict[str, Any] = {"phase": "auto_decision"}
+            if attempt:
+                metadata["attempt"] = attempt + 1
+            await runtime.on_llm_start(
+                context=context,
                 messages=messages,
                 tools=decision_tools,
-                tool_choice="required",
-                thinking={"type": "disabled", "enable": False},
+                metadata=metadata,
             )
-        except Exception as exc:
-            await runtime.on_llm_error(context=context, error=exc, metadata=metadata)
-            raise
-        await runtime.on_llm_end(context=context, response=response, metadata=metadata)
-        return self._parse_decision(response)
+            try:
+                response = await runtime.run_llm_call(
+                    llm,
+                    messages=messages,
+                    tools=decision_tools,
+                    tool_choice="required",
+                    thinking={"type": "disabled", "enable": False},
+                )
+            except Exception as exc:
+                await runtime.on_llm_error(
+                    context=context, error=exc, metadata=metadata
+                )
+                raise
+            await runtime.on_llm_end(
+                context=context, response=response, metadata=metadata
+            )
+            try:
+                return self._parse_decision(response)
+            except AutoDecisionArgumentsError as exc:
+                if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
+                    raise
+                retry_feedback = self._decision_retry_feedback(exc)
+                logger.warning(
+                    "AutoPattern decision arguments were invalid JSON; retrying "
+                    "decision parse. execution_id=%s error=%s",
+                    getattr(context, "execution_id", None),
+                    exc,
+                )
+                await runtime.checkpoint(
+                    "auto_decision_retry",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "attempt": attempt + 1,
+                        "error": str(exc),
+                    },
+                )
+        raise RuntimeError("AutoPattern decision retry loop exited unexpectedly.")
+
+    def _decision_retry_feedback(self, error: AutoDecisionArgumentsError) -> str:
+        argument_preview = self._truncate_retry_preview(error.arguments or "")
+        return (
+            f"The previous {DECISION_TOOL_NAME} tool call could not be used "
+            f"because its arguments were invalid JSON: {error}. Call "
+            f"{DECISION_TOOL_NAME} again exactly once. The tool arguments must be "
+            "one complete valid JSON object. Do not truncate string values. If "
+            "action is final_answer, include the complete non-empty answer field "
+            "inside the same tool call."
+            + (
+                f"\nInvalid arguments preview:\n```json\n{argument_preview}\n```"
+                if argument_preview
+                else ""
+            )
+        )
+
+    def _truncate_retry_preview(self, value: str, *, limit: int = 1200) -> str:
+        stripped = value.strip()
+        if len(stripped) <= limit:
+            return stripped
+        return f"{stripped[:limit]}... [truncated]"
 
     def _decision_prompt(self, tools: list[Any]) -> str:
         tool_count = len(tools)
@@ -796,28 +860,30 @@ class AutoPattern(AgentPattern):
         try:
             payload = json.loads(arguments)
         except json.JSONDecodeError as exc:
-            repaired_arguments = self._repair_empty_string_arguments(arguments)
-            if repaired_arguments == arguments:
-                raise ValueError("Tool call arguments must be valid JSON.") from exc
-            try:
-                payload = json.loads(repaired_arguments)
-            except json.JSONDecodeError:
-                raise ValueError("Tool call arguments must be valid JSON.") from exc
+            payload = self._repair_json_arguments(
+                arguments=arguments,
+                original_error=exc,
+            )
         if not isinstance(payload, dict):
-            raise TypeError("Tool call arguments must decode to an object.")
+            raise AutoDecisionArgumentsError(
+                "Tool call arguments must decode to an object.",
+                arguments=arguments,
+            )
         return payload
 
-    def _repair_empty_string_arguments(self, arguments: str) -> str:
-        """Repair common model omission of an empty string value in tool JSON."""
-        empty_string_fields = ("missing_verification",)
-        repaired = arguments
-        for field in empty_string_fields:
-            repaired = re.sub(
-                rf'("{re.escape(field)}"\s*:\s*)(?=[,}}])',
-                r'\1""',
-                repaired,
-            )
-        return repaired
+    def _repair_json_arguments(
+        self,
+        *,
+        arguments: str,
+        original_error: json.JSONDecodeError,
+    ) -> Any:
+        try:
+            return repair_json_loads(arguments, logging=False)
+        except Exception as exc:
+            raise AutoDecisionArgumentsError(
+                "Tool call arguments must be valid JSON.",
+                arguments=arguments,
+            ) from original_error or exc
 
     def _selected_child(self) -> AgentPattern:
         if self.decision is None:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -631,7 +631,11 @@ class DAGPattern(AgentPattern):
                             )
                         return result
                     failed_step = next(
-                        (step for step in steps if step.status == "failed"),
+                        (
+                            step
+                            for step in steps_by_id.values()
+                            if step.status == "failed"
+                        ),
                         None,
                     )
                     if failed_step is not None:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -565,6 +565,40 @@ class DAGPattern(AgentPattern):
         }
         steps_by_id = {step.id: step for step in steps}
         pending = set(tasks)
+        scheduled_step_ids = set(steps_by_id)
+
+        def schedule_ready_steps() -> None:
+            if self.plan is None:
+                return
+            available_slots = self.max_concurrency - len(pending)
+            if available_slots <= 0:
+                return
+            for ready_step in self._pending_ready_steps():
+                if ready_step.id in scheduled_step_ids:
+                    continue
+                self._mark_step_active(ready_step.id)
+                ready_step.status = "running"
+                task = asyncio.create_task(
+                    self._execute_step(
+                        step=ready_step,
+                        root_context=root_context,
+                        tools=tools,
+                        llm=llm,
+                        runtime=runtime,
+                        memory_store=memory_store,
+                        memory_similarity_threshold=memory_similarity_threshold,
+                        skill_manager=skill_manager,
+                        allowed_skills=allowed_skills,
+                    )
+                )
+                tasks[task] = ready_step.id
+                steps_by_id[ready_step.id] = ready_step
+                pending.add(task)
+                scheduled_step_ids.add(ready_step.id)
+                available_slots -= 1
+                if available_slots <= 0:
+                    break
+
         try:
             while pending:
                 done, pending = await asyncio.wait(
@@ -629,6 +663,7 @@ class DAGPattern(AgentPattern):
                             steps_by_id=steps_by_id,
                         )
                         return None
+                schedule_ready_steps()
         except Exception:
             try:
                 await self._cancel_pending_steps(
@@ -980,6 +1015,16 @@ class DAGPattern(AgentPattern):
                 ready.append(step)
         return ready
 
+    def _pending_ready_steps(self) -> list[PlanStep]:
+        if self.plan is None:
+            return []
+        return [
+            step
+            for step in self.plan.steps
+            if step.status == "pending"
+            and all(dep in self.step_results for dep in step.dependencies)
+        ]
+
     def _all_steps_completed(self) -> bool:
         return self.plan is not None and all(
             step.status == "completed" for step in self.plan.steps
@@ -1036,6 +1081,10 @@ class DAGPattern(AgentPattern):
             else "This step has no dependencies."
         )
         suggested_tools = ", ".join(step.tool_names) if step.tool_names else "(none)"
+        termination_condition = (
+            step.termination_condition
+            or "Return final_answer when the current step description is satisfied."
+        )
         return (
             "DAG STEP EXECUTION BOUNDARY\n"
             "The overall user goal is background context only. Do not execute it "
@@ -1047,9 +1096,17 @@ class DAGPattern(AgentPattern):
             f"Current DAG step description: {step.description or step.task}\n"
             f"Current DAG step dependencies: {list(step.dependencies)}\n"
             f"Suggested tools for this step: {suggested_tools}\n\n"
+            "TERMINATION CONDITION - AUTHORITATIVE STOP RULE\n"
+            f"{termination_condition}\n"
+            "Treat this termination condition as authoritative for this step. "
+            "Once it is satisfied, your next action must be final_answer for this "
+            "step. Do not inspect, verify, revise, optimize, regenerate, or perform "
+            "downstream work unless the termination condition explicitly requires "
+            "that work.\n\n"
             f"{dependency_note}\n\n"
             "Execute only the current DAG step. The current step title and "
-            "description define the entire actionable goal for this ReAct run. "
+            "description plus the termination condition define the entire "
+            "actionable goal for this ReAct run. "
             "Do not infer extra work from the overall user goal. Do not complete "
             "downstream, sibling, final synthesis, rendering, screenshots, visual "
             "inspection, export, or delivery work unless that work is explicitly "

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -522,7 +522,8 @@ class DAGPattern(AgentPattern):
         if not steps:
             return None
         if len(steps) == 1:
-            return await self._execute_step(
+            step = steps[0]
+            result = await self._execute_step(
                 step=steps[0],
                 root_context=root_context,
                 tools=tools,
@@ -533,6 +534,18 @@ class DAGPattern(AgentPattern):
                 skill_manager=skill_manager,
                 allowed_skills=allowed_skills,
             )
+            if result is not None:
+                return result
+            if step.status == "failed":
+                return await self._fail(
+                    context=root_context,
+                    runtime=runtime,
+                    error=step.error or f"Step {step.id} failed.",
+                    failure_reason="step_failed",
+                    checkpoint_label="dag_failed",
+                    failed_step_id=step.id,
+                )
+            return None
 
         self.status = "running"
         for step in steps:
@@ -560,7 +573,8 @@ class DAGPattern(AgentPattern):
                     memory_similarity_threshold=memory_similarity_threshold,
                     skill_manager=skill_manager,
                     allowed_skills=allowed_skills,
-                )
+                ),
+                name=f"dag_step_{step.id}",
             ): step.id
             for step in steps
         }
@@ -590,7 +604,8 @@ class DAGPattern(AgentPattern):
                         memory_similarity_threshold=memory_similarity_threshold,
                         skill_manager=skill_manager,
                         allowed_skills=allowed_skills,
-                    )
+                    ),
+                    name=f"dag_step_{ready_step.id}",
                 )
                 tasks[task] = ready_step.id
                 steps_by_id[ready_step.id] = ready_step

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -12,6 +12,7 @@ from ...context.enrichment import (
     latest_user_text,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult
 from ..react import ReActPattern, ReActReasoningMode
@@ -719,16 +720,22 @@ class DAGPattern(AgentPattern):
                 metadata={
                     "kind": "dag_step_instruction",
                     "dag_step_id": step.id,
+                    "dag_completion_evidence": step.completion_evidence or "",
                 },
             )
 
+        finalize_after_tool_result = bool(
+            step.completion_evidence and len(step.tool_names) == 1
+        )
         react_pattern = ReActPattern(
             max_iterations=self.react_max_iterations,
             reasoning_mode=self.react_reasoning_mode,
+            finalize_after_tool_result=finalize_after_tool_result,
         )
         active_pattern_state = self.active_step_pattern_states.get(step.id)
         if active_pattern_state is not None:
             react_pattern.load_state(active_pattern_state)
+            react_pattern.finalize_after_tool_result = finalize_after_tool_result
 
         step_runtime = _DAGStepRuntime(
             parent=runtime,
@@ -1051,7 +1058,7 @@ class DAGPattern(AgentPattern):
 
     def _display_output(self, result: Any) -> str:
         if isinstance(result, str):
-            return result
+            return unwrap_final_answer_content(result)
         return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
     def _terminal_steps(self) -> list[PlanStep]:
@@ -1085,6 +1092,7 @@ class DAGPattern(AgentPattern):
             step.termination_condition
             or "Return final_answer when the current step description is satisfied."
         )
+        completion_evidence = step.completion_evidence or "(none)"
         return (
             "DAG STEP EXECUTION BOUNDARY\n"
             "The overall user goal is background context only. Do not execute it "
@@ -1098,6 +1106,7 @@ class DAGPattern(AgentPattern):
             f"Suggested tools for this step: {suggested_tools}\n\n"
             "TERMINATION CONDITION - AUTHORITATIVE STOP RULE\n"
             f"{termination_condition}\n"
+            f"Completion evidence: {completion_evidence}\n"
             "Treat this termination condition as authoritative for this step. "
             "Once it is satisfied, your next action must be final_answer for this "
             "step. Do not inspect, verify, revise, optimize, regenerate, or perform "

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -743,18 +743,15 @@ class DAGPattern(AgentPattern):
                 },
             )
 
-        finalize_after_tool_result = bool(
-            step.completion_evidence and len(step.tool_names) == 1
-        )
         react_pattern = ReActPattern(
             max_iterations=self.react_max_iterations,
             reasoning_mode=self.react_reasoning_mode,
-            finalize_after_tool_result=finalize_after_tool_result,
+            finalize_after_tool_result=False,
         )
         active_pattern_state = self.active_step_pattern_states.get(step.id)
         if active_pattern_state is not None:
             react_pattern.load_state(active_pattern_state)
-            react_pattern.finalize_after_tool_result = finalize_after_tool_result
+            react_pattern.finalize_after_tool_result = False
 
         step_runtime = _DAGStepRuntime(
             parent=runtime,

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -23,6 +23,7 @@ class PlanStep:
     dependencies: list[str] = field(default_factory=list)
     description: str | None = None
     termination_condition: str | None = None
+    completion_evidence: str | None = None
     tool_names: list[str] = field(default_factory=list)
     status: str = "pending"
     result: Any = None
@@ -35,6 +36,7 @@ class PlanStep:
             "dependencies": list(self.dependencies),
             "description": self.description,
             "termination_condition": self.termination_condition,
+            "completion_evidence": self.completion_evidence,
             "tool_names": list(self.tool_names),
             "status": self.status,
             "result": self.result,
@@ -58,6 +60,7 @@ class PlanStep:
                 if data.get("termination_condition") is not None
                 else None
             ),
+            completion_evidence=normalize_completion_evidence(data),
             tool_names=tool_names,
             status=str(data.get("status", "pending")),
             result=data.get("result"),
@@ -206,8 +209,8 @@ class LLMPlanGenerator(PlanGenerator):
                         "Generate a DAG execution plan by calling the "
                         f"{self.PLAN_TOOL_NAME} tool exactly once. Each step requires "
                         '"id", "task", "dependencies", "termination_condition", '
-                        'and "tool_names"; "description" is optional but strongly '
-                        "recommended. "
+                        '"completion_evidence", and "tool_names"; "description" is '
+                        "optional but strongly recommended. "
                         "dependencies is required for every step; "
                         "use an empty array only for true entry steps that do not "
                         "need any prior output. If a step uses data, files, decisions, "
@@ -223,12 +226,26 @@ class LLMPlanGenerator(PlanGenerator):
                         "step executor when this step is done and what it must report. "
                         "The termination_condition must be concrete and action-specific; "
                         "do not use vague wording such as 'when complete' or 'when the "
-                        "task is done'. For artifact-producing steps, name the exact "
-                        "artifact or path and state that the step must call final_answer "
-                        "after the artifact is successfully produced. Put review, "
+                        "task is done'. For artifact-producing steps, name an exact path "
+                        "only when the user requires that path or the tool accepts it as "
+                        "an argument; otherwise refer to the artifact returned by the "
+                        "tool. State that the step must call final_answer after the "
+                        "condition is satisfied. Put review, "
                         "verification, rendering, optimization, and final synthesis in "
                         "separate dependent steps unless this step explicitly owns that "
-                        "work. tool_names "
+                        "work. Use completion_evidence for a short natural-language "
+                        "proof that this specific step is done, usually naming the "
+                        "successful tool result fields to check. Do not use global "
+                        "effect labels or invented fixed filenames. For auto-named "
+                        "outputs, say that the tool returned a usable path. Keep "
+                        "completion_evidence under 160 characters. If a workflow needs "
+                        "several tool actions and only the last one proves completion, "
+                        "split those actions into dependent steps. Few-shot examples: "
+                        "auto-named output evidence: 'The generator returned success=true "
+                        "and a non-empty path or URL for the created asset.' explicit "
+                        "path evidence: 'The writer returned success=true for the "
+                        "requested output path.' non-file evidence: 'The tool returned "
+                        "the requested answer data successfully.' tool_names "
                         "must only contain exact names from available_tool_names. "
                         "Include the best matching available tools for every step "
                         "that needs tool use. Leave tool_names empty only for pure "
@@ -333,12 +350,24 @@ class LLMPlanGenerator(PlanGenerator):
                                             "be completed without tools."
                                         ),
                                     },
+                                    "completion_evidence": {
+                                        "type": "string",
+                                        "description": (
+                                            "Short natural-language proof that this "
+                                            "step is finished. Do not use global effect "
+                                            "labels. For tool steps, describe the "
+                                            "successful tool result fields that prove "
+                                            "completion; avoid invented fixed filenames "
+                                            "for auto-named outputs."
+                                        ),
+                                    },
                                 },
                                 "required": [
                                     "id",
                                     "task",
                                     "dependencies",
                                     "termination_condition",
+                                    "completion_evidence",
                                     "tool_names",
                                 ],
                                 "additionalProperties": False,
@@ -452,6 +481,23 @@ def normalize_tool_names(data: dict[str, Any]) -> list[str]:
             seen.add(stripped)
             names.append(stripped)
     return names
+
+
+def normalize_completion_evidence(data: dict[str, Any]) -> str | None:
+    raw_evidence = data.get("completion_evidence")
+    if raw_evidence is not None:
+        evidence = str(raw_evidence).strip()
+        return evidence or None
+
+    legacy_effects = data.get("expected_effects")
+    if isinstance(legacy_effects, str):
+        evidence = legacy_effects.strip()
+        return evidence or None
+    if isinstance(legacy_effects, list):
+        parts = [item.strip() for item in legacy_effects if isinstance(item, str)]
+        evidence = "; ".join(part for part in parts if part)
+        return evidence or None
+    return None
 
 
 def coerce_execution_plan(payload: Any) -> ExecutionPlan:

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -22,6 +22,7 @@ class PlanStep:
     task: str
     dependencies: list[str] = field(default_factory=list)
     description: str | None = None
+    termination_condition: str | None = None
     tool_names: list[str] = field(default_factory=list)
     status: str = "pending"
     result: Any = None
@@ -33,6 +34,7 @@ class PlanStep:
             "task": self.task,
             "dependencies": list(self.dependencies),
             "description": self.description,
+            "termination_condition": self.termination_condition,
             "tool_names": list(self.tool_names),
             "status": self.status,
             "result": self.result,
@@ -49,6 +51,11 @@ class PlanStep:
             description=(
                 str(data["description"])
                 if data.get("description") is not None
+                else None
+            ),
+            termination_condition=(
+                str(data["termination_condition"])
+                if data.get("termination_condition") is not None
                 else None
             ),
             tool_names=tool_names,
@@ -198,8 +205,9 @@ class LLMPlanGenerator(PlanGenerator):
                     "content": (
                         "Generate a DAG execution plan by calling the "
                         f"{self.PLAN_TOOL_NAME} tool exactly once. Each step requires "
-                        '"id", "task", "dependencies", and "tool_names"; '
-                        '"description" is optional but strongly recommended. '
+                        '"id", "task", "dependencies", "termination_condition", '
+                        'and "tool_names"; "description" is optional but strongly '
+                        "recommended. "
                         "dependencies is required for every step; "
                         "use an empty array only for true entry steps that do not "
                         "need any prior output. If a step uses data, files, decisions, "
@@ -210,7 +218,17 @@ class LLMPlanGenerator(PlanGenerator):
                         "on the research or build steps they summarize. Use task as "
                         "the short node title, "
                         "description for the concrete work to perform, and tool_names "
-                        "for the step's suggested execution tool scope. tool_names "
+                        "for the step's suggested execution tool scope. Use "
+                        "termination_condition for the exact stop rule that tells the "
+                        "step executor when this step is done and what it must report. "
+                        "The termination_condition must be concrete and action-specific; "
+                        "do not use vague wording such as 'when complete' or 'when the "
+                        "task is done'. For artifact-producing steps, name the exact "
+                        "artifact or path and state that the step must call final_answer "
+                        "after the artifact is successfully produced. Put review, "
+                        "verification, rendering, optimization, and final synthesis in "
+                        "separate dependent steps unless this step explicitly owns that "
+                        "work. tool_names "
                         "must only contain exact names from available_tool_names. "
                         "Include the best matching available tools for every step "
                         "that needs tool use. Leave tool_names empty only for pure "
@@ -294,6 +312,16 @@ class LLMPlanGenerator(PlanGenerator):
                                             "execution plan."
                                         ),
                                     },
+                                    "termination_condition": {
+                                        "type": "string",
+                                        "description": (
+                                            "Concrete stop rule for this step. It must "
+                                            "state the exact condition that means this "
+                                            "step is finished and what final_answer "
+                                            "should report. Avoid vague conditions such "
+                                            "as 'when complete'."
+                                        ),
+                                    },
                                     "tool_names": {
                                         "type": "array",
                                         "items": {"type": "string"},
@@ -310,6 +338,7 @@ class LLMPlanGenerator(PlanGenerator):
                                     "id",
                                     "task",
                                     "dependencies",
+                                    "termination_condition",
                                     "tool_names",
                                 ],
                                 "additionalProperties": False,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -14,6 +14,7 @@ from ...context.enrichment import (
     generate_and_store_react_memory,
     latest_user_text,
 )
+from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult
 
@@ -260,7 +261,12 @@ class ReActPattern(AgentPattern):
                 self.status = "thinking"
                 continue
 
-            tool_schemas = [] if self.force_final_answer_next else base_tool_schemas
+            force_final_answer_now = self.force_final_answer_next or (
+                self.finalize_after_tool_result
+                and not self.pending_tool_calls
+                and self._latest_tool_result_success(context)
+            )
+            tool_schemas = [] if force_final_answer_now else base_tool_schemas
             interrupted = await self._interrupt_if_requested(
                 runtime=runtime,
                 context=context,
@@ -278,7 +284,7 @@ class ReActPattern(AgentPattern):
             messages = self._messages_for_llm(
                 context,
                 has_tools=bool(tool_schemas),
-                force_final_answer=self.force_final_answer_next,
+                force_final_answer=force_final_answer_now,
                 tool_names=self._schema_tool_names(tool_schemas),
             )
             await runtime.checkpoint("before_llm", context=context, pattern=self)
@@ -311,7 +317,7 @@ class ReActPattern(AgentPattern):
             )
             self.last_response = response
             normalized = self._normalize_llm_response(response)
-            if self.force_final_answer_next and not normalized.get("tool_calls"):
+            if force_final_answer_now and not normalized.get("tool_calls"):
                 normalized["done"] = True
 
             assistant_content = normalized.get("content")
@@ -411,6 +417,9 @@ class ReActPattern(AgentPattern):
             )
         else:
             return messages
+        completion_instruction = self._completion_evidence_instruction(context)
+        if completion_instruction:
+            instruction = f"{instruction}\n\n{completion_instruction}"
         if messages and messages[0].get("role") == "system":
             return [
                 {
@@ -549,32 +558,35 @@ class ReActPattern(AgentPattern):
 
     def _normalize_llm_response(self, response: Any) -> dict[str, Any]:
         if isinstance(response, str):
+            content = unwrap_final_answer_content(response)
             return {
-                "content": response,
+                "content": content,
                 "tool_calls": [],
                 "done": True,
                 "raw": response,
             }
 
         if not isinstance(response, dict):
-            text = str(response)
+            text = unwrap_final_answer_content(str(response))
             return {"content": text, "tool_calls": [], "done": True, "raw": response}
 
         tool_calls = self._normalize_tool_calls(response.get("tool_calls", []))
-        content = response.get("content")
-        if content is None:
-            content = (
+        content_value: Any = response.get("content")
+        if content_value is None:
+            content_value = (
                 response.get("answer")
                 or response.get("output")
                 or response.get("message")
             )
+        if isinstance(content_value, str):
+            content_value = unwrap_final_answer_content(content_value)
 
         done = response.get("done")
         if done is None:
             done = not tool_calls
 
         return {
-            "content": content,
+            "content": content_value,
             "tool_calls": tool_calls,
             "raw_tool_calls": response.get("tool_calls", []),
             "done": bool(done),
@@ -1068,6 +1080,32 @@ class ReActPattern(AgentPattern):
             return False
         status = result.get("status")
         return not (isinstance(status, str) and status.lower() == "error")
+
+    def _latest_tool_result_success(self, context: Any) -> bool:
+        for message in reversed(getattr(context, "messages", [])):
+            if getattr(message, "role", None) != "tool":
+                continue
+            metadata = getattr(message, "metadata", {}) or {}
+            return self._tool_result_success(metadata.get("raw_result"))
+        return False
+
+    def _completion_evidence_instruction(self, context: Any) -> str:
+        for message in reversed(getattr(context, "messages", [])):
+            metadata = getattr(message, "metadata", {}) or {}
+            evidence = metadata.get("dag_completion_evidence")
+            if not isinstance(evidence, str):
+                continue
+            evidence = evidence.strip()
+            if evidence:
+                return (
+                    "Step completion evidence: "
+                    f"{evidence} "
+                    "When the latest tool result or response satisfies this evidence "
+                    "and the termination condition, call final_answer for this step. "
+                    "Do not repeat the same work for a nicer variant unless the result "
+                    "failed or the user explicitly requested a revision."
+                )
+        return ""
 
     async def _interrupt_if_requested(
         self,

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 
@@ -9,5 +10,50 @@ def extract_assistant_message(result: dict[str, Any]) -> str | None:
     for key in ("response", "answer", "output", "content", "message"):
         value = result.get(key)
         if isinstance(value, str) and value:
-            return value
+            return unwrap_final_answer_content(value)
     return None
+
+
+def unwrap_final_answer_content(content: str) -> str:
+    """Unwrap textual legacy final_answer JSON into display-ready content."""
+    parsed = _parse_json_like_text(content)
+    if not isinstance(parsed, dict):
+        return content
+
+    action = str(parsed.get("action") or "").strip()
+    if action == "final_answer":
+        return _stringify_answer_value(
+            parsed.get("action_input")
+            if "action_input" in parsed
+            else parsed.get("answer", content)
+        )
+
+    if "final_answer" in parsed:
+        return _stringify_answer_value(parsed["final_answer"])
+
+    return content
+
+
+def _parse_json_like_text(content: str) -> Any | None:
+    text = _strip_code_fence(content.strip())
+    if not text or not (text.startswith("{") and text.endswith("}")):
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _strip_code_fence(text: str) -> str:
+    lines = text.splitlines()
+    if len(lines) >= 2 and lines[0].strip().startswith("```"):
+        closing = lines[-1].strip()
+        if closing == "```" or closing.startswith("```"):
+            return "\n".join(lines[1:-1]).strip()
+    return text
+
+
+def _stringify_answer_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, indent=2, default=str)

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -649,6 +649,11 @@ class AgentRunner:
         normalized.setdefault("pattern", pattern.__class__.__name__)
 
         assistant_message = extract_assistant_message(normalized)
+        if assistant_message:
+            for key in ("response", "answer", "output", "content", "message"):
+                if isinstance(normalized.get(key), str):
+                    normalized[key] = assistant_message
+                    break
         if assistant_message and not self._has_assistant_message(
             context, assistant_message
         ):

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -653,7 +653,6 @@ class AgentRunner:
             for key in ("response", "answer", "output", "content", "message"):
                 if isinstance(normalized.get(key), str):
                     normalized[key] = assistant_message
-                    break
         if assistant_message and not self._has_assistant_message(
             context, assistant_message
         ):

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -51,11 +51,10 @@ class TraceEventCallback:
         )
         status = str(result.get("status") or "")
         output = extract_assistant_message(result)
-        data = {
+        data: dict[str, Any] = {
             "execution_id": execution_id,
             "status": status or ("completed" if result.get("success") else "failed"),
             "pattern": result.get("pattern"),
-            "context": self._context_payload(context),
         }
 
         if result.get("success"):
@@ -85,7 +84,7 @@ class TraceEventCallback:
             execution_id,
             error_type="agent_error",
             error_message=str(result.get("error") or "agent execution failed"),
-            data=data,
+            data={**data, "context": self._context_payload(context)},
         )
 
     def _context_payload(self, context: Any) -> dict[str, Any] | None:

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -31,6 +31,16 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 logger = logging.getLogger(__name__)
 
 
+class BrowserTaskSessionMixin:
+    """Keeps browser tool default sessions aligned during task setup."""
+
+    _task_id: Optional[str]
+
+    async def setup(self, task_id: Optional[str] = None) -> None:
+        if task_id:
+            self._task_id = task_id
+
+
 # ============== Input/Output Schemas ==============
 
 
@@ -238,7 +248,7 @@ class BrowserPdfResult(BaseModel):
 # ============== Tool Implementations ==============
 
 
-class BrowserNavigateTool(AbstractBaseTool):
+class BrowserNavigateTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Navigate to a URL in a browser session."""
 
@@ -423,7 +433,7 @@ class BrowserNavigateTool(AbstractBaseTool):
                     )
 
 
-class BrowserClickTool(AbstractBaseTool):
+class BrowserClickTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Click an element on the current page."""
 
@@ -474,7 +484,7 @@ class BrowserClickTool(AbstractBaseTool):
         return BrowserClickResult(**result).model_dump()
 
 
-class BrowserFillTool(AbstractBaseTool):
+class BrowserFillTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Fill an input field with text."""
 
@@ -525,7 +535,7 @@ class BrowserFillTool(AbstractBaseTool):
         return BrowserFillResult(**result).model_dump()
 
 
-class BrowserScreenshotTool(AbstractBaseTool):
+class BrowserScreenshotTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Take a screenshot of the current page."""
 
@@ -638,7 +648,7 @@ class BrowserScreenshotTool(AbstractBaseTool):
         return BrowserScreenshotResult(**result).model_dump()
 
 
-class BrowserExtractTextTool(AbstractBaseTool):
+class BrowserExtractTextTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Extract text content from the page."""
 
@@ -688,7 +698,7 @@ class BrowserExtractTextTool(AbstractBaseTool):
         return BrowserExtractTextResult(**result).model_dump()
 
 
-class BrowserEvaluateTool(AbstractBaseTool):
+class BrowserEvaluateTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Execute JavaScript code in the browser."""
 
@@ -798,7 +808,7 @@ class BrowserListSessionsTool(AbstractBaseTool):
         return result
 
 
-class BrowserSelectOptionTool(AbstractBaseTool):
+class BrowserSelectOptionTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Select an option from a dropdown."""
 
@@ -850,7 +860,7 @@ class BrowserSelectOptionTool(AbstractBaseTool):
         return BrowserSelectOptionResult(**result).model_dump()
 
 
-class BrowserWaitForSelectorTool(AbstractBaseTool):
+class BrowserWaitForSelectorTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Wait for an element to appear on the page."""
 
@@ -901,7 +911,7 @@ class BrowserWaitForSelectorTool(AbstractBaseTool):
         return BrowserWaitForSelectorResult(**result).model_dump()
 
 
-class BrowserCloseTool(AbstractBaseTool):
+class BrowserCloseTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Close a browser session and free resources."""
 
@@ -947,7 +957,7 @@ class BrowserCloseTool(AbstractBaseTool):
         return BrowserCloseResult(**result).model_dump()
 
 
-class BrowserPdfTool(AbstractBaseTool):
+class BrowserPdfTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Save current page as PDF."""
 

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -257,6 +257,14 @@ class BrowserNavigateTool(AbstractBaseTool):
     def description(self) -> str:
         return """Navigate to URL. Browser session auto-created.
 
+        This tool only opens a page and reports navigation success. It does not inspect
+        page content, validate visual rendering, take screenshots, export images, or
+        prove that a page meets the user's request. After a successful navigation to the
+        intended URL, do not call browser_navigate again for the same URL unless the
+        previous navigation failed or the URL changed. Use browser_screenshot when visual
+        inspection or rendered output is required, and use browser_extract_text when page
+        text is required.
+
         Workspace files: Use filename (e.g., "poster.html") - auto-searches input/output/temp dirs.
 
         Default: headless=False (shows browser window for debugging/interaction).

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 class BrowserTaskSessionMixin:
     """Keeps browser tool default sessions aligned during task setup."""
 
-    _task_id: Optional[str]
+    _task_id: Optional[str] = None
 
     async def setup(self, task_id: Optional[str] = None) -> None:
         if task_id:

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -399,7 +399,15 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
             "session_id": session_id,
             "url": url,
             "title": title,
-            "message": f"Navigated to {url}. IMPORTANT: Session ID is '{session_id}'. You MUST use this exact session_id='{session_id}' in all subsequent browser calls (browser_click, browser_extract_text, etc.) to continue using this browser.",
+            "message": (
+                f"Navigation complete: opened {url}. This only confirms the page "
+                "loaded; it does not inspect content, validate visual rendering, "
+                "or create an image export. Do not call browser_navigate again for "
+                "this same URL unless navigation failed or the target URL changed. "
+                "Use browser_screenshot for visual inspection/rendered output, "
+                "or browser_extract_text for page text. "
+                f"Session ID: '{session_id}'."
+            ),
         }
     except Exception as e:
         import logging

--- a/src/xagent/web/services/task_execution_context_service.py
+++ b/src/xagent/web/services/task_execution_context_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
@@ -58,15 +59,19 @@ def load_task_execution_context_messages(
         seen_summaries.add(summary)
         tool_summaries.append(summary)
 
-    if not tool_summaries:
+    failure_summary = load_latest_execution_failure_summary(db, task_id)
+    if not tool_summaries and not failure_summary:
         return []
 
     tool_summaries.reverse()
+    context_lines = []
+    if failure_summary:
+        context_lines.append(failure_summary)
+    context_lines.extend(tool_summaries)
     content = (
         "=== Previous Execution Context ===\n"
-        "These are reusable results discovered in earlier rounds of this same task.\n"
-        "Use them when handling follow-up requests, and only rerun tools if fresher data is needed.\n"
-        + "\n".join(tool_summaries)
+        "Prior execution context for this task. Reuse when relevant; rerun only if needed.\n"
+        + "\n".join(context_lines)
     )
     return [{"role": "system", "content": content}]
 
@@ -94,6 +99,17 @@ async def load_task_recovered_skill_context(db: Session, task_id: int) -> Option
     return await _load_skill_context_by_name(skill_name)
 
 
+_BINARY_MAGIC_PREFIXES = (
+    "\x89PNG",
+    "\xff\xd8\xff",
+    "GIF87a",
+    "GIF89a",
+    "%PDF",
+    "PK\x03\x04",
+)
+_DATA_URL_RE = re.compile(r"^data:[^;]+;base64,", re.IGNORECASE)
+
+
 def summarize_tool_event(data: Dict[str, Any]) -> Optional[str]:
     """Summarize a persisted tool execution event into reusable context text."""
     tool_name = str(data.get("tool_name") or "").strip()
@@ -107,25 +123,131 @@ def summarize_tool_event(data: Dict[str, Any]) -> Optional[str]:
     summary = _summarize_generic_result(result)
     if not summary:
         return None
+    if "payload omitted" in summary:
+        params_summary = _summarize_generic_result(
+            data.get("tool_params"), max_length=120
+        )
+        if params_summary:
+            summary = f"{summary} (tool_params: {params_summary})"
     return f"- Tool {tool_name} previously returned: {summary}"
+
+
+def load_latest_execution_failure_summary(
+    db: Session,
+    task_id: int,
+) -> Optional[str]:
+    """Load a concise anchor for the latest failed execution, if any."""
+    trace_event = (
+        db.query(TraceEvent)
+        .filter(
+            TraceEvent.task_id == task_id,
+            TraceEvent.build_id.is_(None),
+            TraceEvent.event_type.in_(("dag_execute_end", "trace_error")),
+        )
+        .order_by(TraceEvent.timestamp.desc(), TraceEvent.id.desc())
+        .first()
+    )
+    if trace_event is None or not isinstance(trace_event.data, dict):
+        return None
+    return summarize_execution_failure_event(trace_event.data)
+
+
+def summarize_execution_failure_event(data: Dict[str, Any]) -> Optional[str]:
+    result = data.get("result") if isinstance(data.get("result"), dict) else data
+    if not isinstance(result, dict):
+        return None
+
+    success = result.get("success")
+    status = str(result.get("status") or data.get("status") or "").strip()
+    if success is not False and status not in {"failed", "error"}:
+        return None
+
+    error = str(result.get("error") or data.get("error_message") or "").strip()
+    failure_reason = str(result.get("failure_reason") or "").strip()
+    failed_step_id = str(result.get("failed_step_id") or "").strip()
+
+    details: list[str] = []
+    if failed_step_id:
+        details.append(f"step={failed_step_id}")
+    if failure_reason:
+        details.append(f"reason={failure_reason}")
+    if error:
+        details.append(f"error={_compact_preview_string(error, max_string_length=180)}")
+
+    if not details:
+        return None
+    return "- Previous execution failed: " + "; ".join(details)
 
 
 def _summarize_generic_result(result: Any, max_length: int = 240) -> Optional[str]:
     if result is None:
         return None
-    if isinstance(result, str):
-        preview = result.strip()
+    compact_result = _compact_preview_value(result)
+    if isinstance(compact_result, str):
+        preview = compact_result.strip()
     else:
         try:
-            preview = json.dumps(result, ensure_ascii=False)
+            preview = json.dumps(compact_result, ensure_ascii=False)
         except Exception:
-            preview = str(result).strip()
+            preview = str(compact_result).strip()
 
     if not preview:
         return None
     if len(preview) > max_length:
         return preview[: max_length - 3] + "..."
     return preview
+
+
+def _compact_preview_value(value: Any, *, max_string_length: int = 160) -> Any:
+    if isinstance(value, str):
+        return _compact_preview_string(value, max_string_length=max_string_length)
+    if isinstance(value, list):
+        return [
+            _compact_preview_value(item, max_string_length=max_string_length)
+            for item in value[:20]
+        ]
+    if isinstance(value, dict):
+        compact: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            compact[key_text] = _compact_preview_value(
+                item,
+                max_string_length=max_string_length,
+            )
+        return compact
+    return value
+
+
+def _compact_preview_string(value: str, *, max_string_length: int) -> str:
+    text = value.strip()
+    if not text:
+        return text
+    if _looks_like_binary_or_encoded_payload(text):
+        return f"[non-text payload omitted; {len(value)} characters]"
+    if len(text) > max_string_length:
+        return text[: max_string_length - 3] + "..."
+    return text
+
+
+def _looks_like_binary_or_encoded_payload(value: str) -> bool:
+    if value.startswith(_BINARY_MAGIC_PREFIXES):
+        return True
+    if _DATA_URL_RE.match(value):
+        return True
+
+    sample = value[:4096]
+    if not sample:
+        return False
+
+    control_chars = 0
+    for char in sample:
+        codepoint = ord(char)
+        if char in "\n\r\t":
+            continue
+        if codepoint < 32 or 0x80 <= codepoint <= 0x9F:
+            control_chars += 1
+
+    return control_chars / max(len(sample), 1) > 0.02
 
 
 async def _load_skill_context_by_name(skill_name: str) -> Optional[str]:

--- a/tests/_stubs/readline.py
+++ b/tests/_stubs/readline.py
@@ -1,0 +1,102 @@
+"""Test-only readline stub.
+
+Some local macOS/Codex Python environments segfault while importing the native
+readline extension. Pytest and pdb can import readline opportunistically, so the
+test runner uses this stub through pytest's pythonpath setting.
+"""
+
+
+def parse_and_bind(_: str) -> None:
+    return None
+
+
+def set_completer(_: object | None) -> None:
+    return None
+
+
+def get_completer() -> None:
+    return None
+
+
+def set_completer_delims(_: str) -> None:
+    return None
+
+
+def get_completer_delims() -> str:
+    return ""
+
+
+def set_history_length(_: int) -> None:
+    return None
+
+
+def get_history_length() -> int:
+    return 0
+
+
+def read_history_file(_: str | None = None) -> None:
+    return None
+
+
+def write_history_file(_: str | None = None) -> None:
+    return None
+
+
+def clear_history() -> None:
+    return None
+
+
+def add_history(_: str) -> None:
+    return None
+
+
+def get_current_history_length() -> int:
+    return 0
+
+
+def get_history_item(_: int) -> None:
+    return None
+
+
+def remove_history_item(_: int) -> None:
+    return None
+
+
+def replace_history_item(_: int, __: str) -> None:
+    return None
+
+
+def set_startup_hook(_: object | None = None) -> None:
+    return None
+
+
+def set_pre_input_hook(_: object | None = None) -> None:
+    return None
+
+
+def redisplay() -> None:
+    return None
+
+
+def insert_text(_: str) -> None:
+    return None
+
+
+def get_line_buffer() -> str:
+    return ""
+
+
+def get_begidx() -> int:
+    return 0
+
+
+def get_endidx() -> int:
+    return 0
+
+
+def __getattr__(_: str) -> object:
+    def noop(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        return None
+
+    return noop

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -17,7 +17,7 @@ from xagent.core.agent import (
     PatternRuntime,
     ReActPattern,
 )
-from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME
+from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRuntime
 
 
 class FakeWorkspace:
@@ -132,6 +132,22 @@ class CapturingChildPattern:
 
     def get_state(self) -> dict[str, Any]:
         return {"captured": True}
+
+
+def test_auto_child_runtime_forwards_clear_interrupt() -> None:
+    parent_runtime = PatternRuntime()
+    parent_runtime.request_interrupt("resume with user guidance")
+
+    child_runtime = _AutoChildRuntime(
+        parent=parent_runtime,
+        auto_pattern=AutoPattern(),
+        root_context=ExecutionContext(execution_id="auto-clear-interrupt"),
+    )
+
+    child_runtime.clear_interrupt()
+
+    assert parent_runtime._interrupt_requested is False
+    assert parent_runtime.interrupt_reason is None
 
 
 def decision_tool_response(

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -204,6 +204,43 @@ def malformed_empty_missing_verification_decision_tool_response() -> dict[str, A
     }
 
 
+def truncated_final_answer_decision_tool_response() -> dict[str, Any]:
+    return {
+        "tool_calls": [
+            {
+                "id": f"call_{DECISION_TOOL_NAME}",
+                "type": "function",
+                "function": {
+                    "name": DECISION_TOOL_NAME,
+                    "arguments": (
+                        '{"action":"final_answer","reason":"simple reply",'
+                        '"requires_current_or_external_facts":false,'
+                        '"existing_context_sufficient":true,'
+                        '"evidence_basis":"current conversation",'
+                        '"missing_verification":"",'
+                        '"answer":"Recovered answer'
+                    ),
+                },
+            }
+        ]
+    }
+
+
+def unrepairable_decision_tool_response() -> dict[str, Any]:
+    return {
+        "tool_calls": [
+            {
+                "id": f"call_{DECISION_TOOL_NAME}",
+                "type": "function",
+                "function": {
+                    "name": DECISION_TOOL_NAME,
+                    "arguments": "not json at all",
+                },
+            }
+        ]
+    }
+
+
 @pytest.mark.asyncio
 async def test_auto_decision_sees_memory_and_skill_context() -> None:
     llm = FakeLLM(
@@ -663,6 +700,59 @@ async def test_auto_pattern_repairs_empty_missing_verification_argument() -> Non
     assert result["success"] is True
     assert result["auto_decision"]["action"] == "plan_execute"
     assert result["auto_decision"]["missing_verification"] == ""
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_repairs_truncated_final_answer_arguments() -> None:
+    llm = FakeLLM([truncated_final_answer_decision_tool_response()])
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["success"] is True
+    assert result["output"] == "Recovered answer"
+    assert result["auto_decision"]["action"] == "final_answer"
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_retries_unrepairable_decision_arguments() -> None:
+    llm = FakeLLM(
+        [
+            unrepairable_decision_tool_response(),
+            decision_tool_response(
+                "final_answer",
+                "Retry produced valid arguments.",
+                answer="after retry",
+            ),
+        ]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+    runtime = RecordingRuntime()
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["output"] == "after retry"
+    assert len(llm.calls) == 2
+    retry_messages = llm.calls[1]["messages"]
+    assert "invalid JSON" in retry_messages[-1]["content"]
+    assert "not json at all" in retry_messages[-1]["content"]
+    llm_start_metadata = [
+        hook[1]["metadata"] for hook in runtime.hooks if hook[0] == "llm_start"
+    ]
+    assert llm_start_metadata == [
+        {"phase": "auto_decision"},
+        {"phase": "auto_decision", "attempt": 2},
+    ]
+    assert any(
+        checkpoint["label"] == "auto_decision_retry"
+        for checkpoint in runtime.checkpoints
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -703,18 +703,35 @@ async def test_auto_pattern_repairs_empty_missing_verification_argument() -> Non
 
 
 @pytest.mark.asyncio
-async def test_auto_pattern_repairs_truncated_final_answer_arguments() -> None:
-    llm = FakeLLM([truncated_final_answer_decision_tool_response()])
+async def test_auto_pattern_retries_truncated_final_answer_arguments() -> None:
+    llm = FakeLLM(
+        [
+            truncated_final_answer_decision_tool_response(),
+            decision_tool_response(
+                "final_answer",
+                "Retry produced the full answer.",
+                answer="Complete answer after retry.",
+            ),
+        ]
+    )
     pattern = AutoPattern()
     context = ExecutionContext()
     context.add_user_message("Continue")
+    runtime = RecordingRuntime()
 
-    result = await pattern.run(context=context, tools=[], llm=llm)
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
 
     assert result["success"] is True
-    assert result["output"] == "Recovered answer"
+    assert result["output"] == "Complete answer after retry."
     assert result["auto_decision"]["action"] == "final_answer"
-    assert len(llm.calls) == 1
+    assert len(llm.calls) == 2
+    retry_messages = llm.calls[1]["messages"]
+    assert "truncated" in retry_messages[-1]["content"]
+    assert "Recovered answer" in retry_messages[-1]["content"]
+    assert any(
+        checkpoint["label"] == "auto_decision_retry"
+        for checkpoint in runtime.checkpoints
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_browser_tools.py
+++ b/tests/core/agent/test_browser_tools.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.browser_use import create_browser_tools
+
+
+@pytest.mark.asyncio
+async def test_browser_tools_share_runtime_task_session_after_setup() -> None:
+    tools = create_browser_tools(task_id="workspace-task")
+
+    for tool in tools:
+        setup = getattr(tool, "setup", None)
+        if not callable(setup):
+            continue
+        result = setup(task_id="runtime-task")
+        if inspect.isawaitable(result):
+            await result
+
+    session_tools = [
+        tool
+        for tool in tools
+        if getattr(tool, "name", "") != "browser_list_sessions"
+        and hasattr(tool, "_task_id")
+    ]
+
+    assert session_tools
+    assert {tool._task_id for tool in session_tools} == {"runtime-task"}

--- a/tests/core/agent/test_browser_tools.py
+++ b/tests/core/agent/test_browser_tools.py
@@ -4,7 +4,21 @@ import inspect
 
 import pytest
 
-from xagent.core.tools.adapters.vibe.browser_use import create_browser_tools
+from xagent.core.tools.adapters.vibe.browser_use import (
+    BrowserTaskSessionMixin,
+    create_browser_tools,
+)
+
+
+@pytest.mark.asyncio
+async def test_browser_task_session_mixin_defaults_to_no_task() -> None:
+    tool = BrowserTaskSessionMixin()
+
+    assert tool._task_id is None
+
+    await tool.setup(task_id=None)
+
+    assert tool._task_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -619,6 +619,46 @@ async def test_dag_pattern_executes_independent_ready_steps_concurrently() -> No
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_names_concurrent_step_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_task_names: list[str | None] = []
+    real_create_task = asyncio.create_task
+
+    def record_create_task(coro: Any, *, name: str | None = None) -> asyncio.Task[Any]:
+        created_task_names.append(name)
+        return real_create_task(coro, name=name)
+
+    monkeypatch.setattr(asyncio, "create_task", record_create_task)
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="first", task="First task"),
+            PlanStep(id="second", task="Second task", dependencies=["first"]),
+            PlanStep(id="slow", task="Slow task"),
+        ),
+        max_concurrency=2,
+    )
+
+    result = await pattern.run(
+        context=ExecutionContext(execution_id="dag-task-names"),
+        tools=[],
+        llm=SequenceLLM(
+            [
+                "first done",
+                "slow done",
+                "second done",
+            ]
+        ),
+    )
+
+    assert result["success"] is True
+    assert "dag_step_first" in created_task_names
+    assert "dag_step_slow" in created_task_names
+    assert "dag_step_second" in created_task_names
+
+
+@pytest.mark.asyncio
 async def test_dag_pattern_schedules_newly_ready_step_before_sibling_finishes() -> None:
     class PartialBlockingLLM:
         def __init__(self) -> None:
@@ -727,6 +767,47 @@ async def test_dag_pattern_catches_dynamically_scheduled_step_failure() -> None:
     assert result["failure_reason"] == "step_failed"
     assert result["failed_step_id"] == "render_zh"
     assert "Create English HTML" in llm.cancelled_tasks
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_single_step_failure_stops_independent_steps() -> None:
+    class FailThenRecordLLM:
+        def __init__(self) -> None:
+            self.tasks: list[str] = []
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            messages = list(kwargs.get("messages", []))
+            task = current_step_task(messages)
+            self.tasks.append(task)
+            if task == "Fail task":
+                return {"content": "not done", "done": False}
+            return {"content": f"{task} done", "done": True}
+
+    llm = FailThenRecordLLM()
+    runtime = PatternRuntime(execution_id="dag-single-failure")
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="fail", task="Fail task"),
+            PlanStep(id="next", task="Should not run"),
+        ),
+        max_concurrency=1,
+        react_max_iterations=1,
+    )
+
+    result = await pattern.run(
+        context=ExecutionContext(execution_id="dag-single-failure"),
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "step_failed"
+    assert result["failed_step_id"] == "fail"
+    assert llm.tasks == ["Fail task"]
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["label"] == "dag_failed"
 
 
 @pytest.mark.parametrize("max_concurrency", [0, -1])

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -674,6 +674,61 @@ async def test_dag_pattern_schedules_newly_ready_step_before_sibling_finishes() 
     }
 
 
+@pytest.mark.asyncio
+async def test_dag_pattern_catches_dynamically_scheduled_step_failure() -> None:
+    class DynamicFailureLLM:
+        def __init__(self) -> None:
+            self.started_by_task: dict[str, asyncio.Event] = {}
+            self.cancelled_tasks: list[str] = []
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            messages = list(kwargs.get("messages", []))
+            task = current_step_task(messages)
+            self.started_by_task.setdefault(task, asyncio.Event()).set()
+            if task == "Create English HTML":
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    self.cancelled_tasks.append(task)
+                    raise
+            if task == "Render Chinese poster":
+                await self.wait_started("Create English HTML")
+                raise RuntimeError("render failed")
+            return {"content": f"{task} done", "done": True}
+
+        async def wait_started(self, task: str) -> None:
+            await asyncio.wait_for(
+                self.started_by_task.setdefault(task, asyncio.Event()).wait(),
+                timeout=1,
+            )
+
+    llm = DynamicFailureLLM()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="zh", task="Create Chinese HTML"),
+            PlanStep(id="en", task="Create English HTML"),
+            PlanStep(id="render_zh", task="Render Chinese poster", dependencies=["zh"]),
+            PlanStep(id="render_en", task="Render English poster", dependencies=["en"]),
+        ),
+        max_concurrency=2,
+    )
+
+    result = await asyncio.wait_for(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-dynamic-failure"),
+            tools=[],
+            llm=llm,
+        ),
+        timeout=1,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "step_failed"
+    assert result["failed_step_id"] == "render_zh"
+    assert "Create English HTML" in llm.cancelled_tasks
+
+
 @pytest.mark.parametrize("max_concurrency", [0, -1])
 def test_dag_pattern_clamps_non_positive_max_concurrency(
     max_concurrency: int,

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -84,6 +84,38 @@ class FakeTool:
         return {"result": eval(args["expression"])}  # noqa: S307
 
 
+class FakeWriteFileTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.metadata = type(
+            "Metadata",
+            (),
+            {
+                "name": "write_file",
+                "description": "Write file content in the workspace.",
+            },
+        )()
+
+    def args_type(self) -> type:
+        class Args:
+            @staticmethod
+            def model_json_schema() -> dict[str, Any]:
+                return {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["file_path", "content"],
+                }
+
+        return Args
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {"success": True, "file_path": args["file_path"]}
+
+
 class SequenceLLM:
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = responses
@@ -808,6 +840,91 @@ async def test_dag_pattern_single_step_failure_stops_independent_steps() -> None
     assert llm.tasks == ["Fail task"]
     assert runtime.last_checkpoint is not None
     assert runtime.last_checkpoint["label"] == "dag_failed"
+
+
+@pytest.mark.asyncio
+async def test_dag_completion_evidence_keeps_tools_for_multi_call_step() -> None:
+    class MultiWriteLLM:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(kwargs)
+            tools = kwargs.get("tools") or []
+            tool_names = {
+                schema.get("function", {}).get("name")
+                for schema in tools
+                if isinstance(schema, dict)
+            }
+            if len(self.calls) == 1:
+                assert "write_file" in tool_names
+                return {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "write-index",
+                            "function": {
+                                "name": "write_file",
+                                "arguments": json.dumps(
+                                    {
+                                        "file_path": "index.html",
+                                        "content": "<html></html>",
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                    "done": False,
+                }
+            if len(self.calls) == 2:
+                assert "write_file" in tool_names
+                return {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "write-style",
+                            "function": {
+                                "name": "write_file",
+                                "arguments": json.dumps(
+                                    {
+                                        "file_path": "style.css",
+                                        "content": "body { color: black; }",
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                    "done": False,
+                }
+            return {"content": "Both files were written.", "done": True}
+
+    llm = MultiWriteLLM()
+    tool = FakeWriteFileTool()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(
+                id="write_files",
+                task="Write landing page files",
+                termination_condition=(
+                    "Stop after both index.html and style.css have been written."
+                ),
+                completion_evidence="Both file writes returned success=true.",
+                tool_names=["write_file"],
+            )
+        ),
+        react_max_iterations=4,
+    )
+
+    result = await pattern.run(
+        context=ExecutionContext(execution_id="dag-multi-write"),
+        tools=[tool],
+        llm=llm,
+    )
+
+    assert result["success"] is True
+    assert result["step_results"]["write_files"] == "Both files were written."
+    assert [call["file_path"] for call in tool.calls] == ["index.html", "style.css"]
+    assert len(llm.calls) == 3
 
 
 @pytest.mark.parametrize("max_concurrency", [0, -1])

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -221,6 +221,26 @@ async def run_invalid_plan(plan: ExecutionPlan) -> dict[str, Any]:
     )
 
 
+def test_plan_step_serializes_termination_condition() -> None:
+    step = PlanStep(
+        id="write_html",
+        task="Write HTML",
+        dependencies=["extract"],
+        description="Create the poster HTML file.",
+        termination_condition=(
+            "Stop after output/poster.html has been successfully written once."
+        ),
+        tool_names=["write_file"],
+    )
+
+    restored = PlanStep.from_dict(step.to_dict())
+
+    assert restored.termination_condition == (
+        "Stop after output/poster.html has been successfully written once."
+    )
+    assert restored.to_dict()["termination_condition"] == restored.termination_condition
+
+
 @pytest.mark.asyncio
 async def test_dag_pattern_interrupt_before_plan_skips_plan_generation() -> None:
     plan_calls: list[dict[str, Any]] = []
@@ -418,6 +438,9 @@ async def test_dag_step_appends_current_step_boundary_after_parent_context() -> 
             id="extract",
             task="Extract release highlights",
             description="Extract version, date, features, bug fixes, and contributors.",
+            termination_condition=(
+                "Stop after the release highlights have been extracted and reported."
+            ),
         )
     )
     pattern = DAGPattern(lambda **_: plan)
@@ -437,6 +460,12 @@ async def test_dag_step_appends_current_step_boundary_after_parent_context() -> 
     assert "DAG STEP EXECUTION BOUNDARY" in messages[-1]["content"]
     assert "Current DAG step id: extract" in messages[-1]["content"]
     assert "CURRENT STEP - ONLY EXECUTABLE GOAL" in messages[-1]["content"]
+    assert "TERMINATION CONDITION - AUTHORITATIVE STOP RULE" in messages[-1]["content"]
+    assert (
+        "Stop after the release highlights have been extracted and reported."
+        in messages[-1]["content"]
+    )
+    assert "your next action must be final_answer" in messages[-1]["content"]
     assert "Execute only the current DAG step" in messages[-1]["content"]
     assert (
         "Do not infer extra work from the overall user goal" in messages[-1]["content"]
@@ -579,6 +608,62 @@ async def test_dag_pattern_executes_independent_ready_steps_concurrently() -> No
         "step_3": "Task 3 done",
         "step_4": "Task 4 done",
         "step_5": "Task 5 done",
+    }
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_schedules_newly_ready_step_before_sibling_finishes() -> None:
+    class PartialBlockingLLM:
+        def __init__(self) -> None:
+            self.release_slow = asyncio.Event()
+            self.started_by_task: dict[str, asyncio.Event] = {}
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            messages = list(kwargs.get("messages", []))
+            task = current_step_task(messages)
+            self.started_by_task.setdefault(task, asyncio.Event()).set()
+            if task == "Create English HTML":
+                await self.release_slow.wait()
+            return {"content": f"{task} done", "done": True}
+
+        async def wait_started(self, task: str) -> None:
+            await asyncio.wait_for(
+                self.started_by_task.setdefault(task, asyncio.Event()).wait(),
+                timeout=1,
+            )
+
+    llm = PartialBlockingLLM()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="zh", task="Create Chinese HTML"),
+            PlanStep(id="en", task="Create English HTML"),
+            PlanStep(id="render_zh", task="Render Chinese poster", dependencies=["zh"]),
+            PlanStep(id="render_en", task="Render English poster", dependencies=["en"]),
+        ),
+        max_concurrency=2,
+    )
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-dynamic-ready"),
+            tools=[],
+            llm=llm,
+        )
+    )
+
+    await llm.wait_started("Create English HTML")
+    await llm.wait_started("Render Chinese poster")
+    assert "Render English poster" not in llm.started_by_task
+
+    llm.release_slow.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["success"] is True
+    assert result["step_results"] == {
+        "zh": "Create Chinese HTML done",
+        "en": "Create English HTML done",
+        "render_zh": "Render Chinese poster done",
+        "render_en": "Render English poster done",
     }
 
 
@@ -765,6 +850,9 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
                     "id": "final",
                     "task": "Finalize answer",
                     "description": "Write the final answer from the draft.",
+                    "termination_condition": (
+                        "Stop after the final answer has been written once."
+                    ),
                     "tool_names": ["calculator"],
                     "dependencies": ["draft"],
                 },
@@ -784,23 +872,30 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     assert [step.id for step in plan.steps] == ["draft", "final"]
     assert plan.steps[1].dependencies == ["draft"]
     assert plan.steps[1].description == "Write the final answer from the draft."
+    assert (
+        plan.steps[1].termination_condition
+        == "Stop after the final answer has been written once."
+    )
     assert plan.steps[1].tool_names == ["calculator"]
     assert llm.calls[0]["tools"][0]["function"]["name"] == "generate_execution_plan"
     step_schema = llm.calls[0]["tools"][0]["function"]["parameters"]["properties"][
         "steps"
     ]["items"]["properties"]
     assert "description" in step_schema
+    assert "termination_condition" in step_schema
     assert "tool_names" in step_schema
     assert "dependencies" in step_schema
     step_required = llm.calls[0]["tools"][0]["function"]["parameters"]["properties"][
         "steps"
     ]["items"]["required"]
     assert "dependencies" in step_required
+    assert "termination_condition" in step_required
     assert "tool_names" in step_required
     system_prompt = llm.calls[0]["messages"][0]["content"]
     assert "dependencies is required for every step" in system_prompt
     assert "screenshot or render steps must depend" in system_prompt
-    assert 'tool_names"; "description" is optional' in system_prompt
+    assert '"termination_condition"' in system_prompt
+    assert "must be concrete and action-specific" in system_prompt
     assert "suggested execution tool scope" in system_prompt
     assert llm.calls[0]["tool_choice"] == "required"
     assert llm.calls[0]["thinking"] == {"type": "disabled", "enable": False}

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -230,6 +230,9 @@ def test_plan_step_serializes_termination_condition() -> None:
         termination_condition=(
             "Stop after output/poster.html has been successfully written once."
         ),
+        completion_evidence=(
+            "The writer returned success=true for the requested output path."
+        ),
         tool_names=["write_file"],
     )
 
@@ -239,6 +242,10 @@ def test_plan_step_serializes_termination_condition() -> None:
         "Stop after output/poster.html has been successfully written once."
     )
     assert restored.to_dict()["termination_condition"] == restored.termination_condition
+    assert restored.completion_evidence == (
+        "The writer returned success=true for the requested output path."
+    )
+    assert restored.to_dict()["completion_evidence"] == restored.completion_evidence
 
 
 @pytest.mark.asyncio
@@ -845,13 +852,23 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     llm = PlanLLM(
         plan_tool_response(
             [
-                {"id": "draft", "task": "Draft answer"},
+                {
+                    "id": "draft",
+                    "task": "Draft answer",
+                    "dependencies": [],
+                    "termination_condition": "Stop after the draft is written.",
+                    "completion_evidence": "The draft has been returned in final_answer.",
+                    "tool_names": [],
+                },
                 {
                     "id": "final",
                     "task": "Finalize answer",
                     "description": "Write the final answer from the draft.",
                     "termination_condition": (
                         "Stop after the final answer has been written once."
+                    ),
+                    "completion_evidence": (
+                        "The final answer has been returned successfully."
                     ),
                     "tool_names": ["calculator"],
                     "dependencies": ["draft"],
@@ -883,6 +900,7 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     ]["items"]["properties"]
     assert "description" in step_schema
     assert "termination_condition" in step_schema
+    assert "completion_evidence" in step_schema
     assert "tool_names" in step_schema
     assert "dependencies" in step_schema
     step_required = llm.calls[0]["tools"][0]["function"]["parameters"]["properties"][
@@ -890,11 +908,14 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     ]["items"]["required"]
     assert "dependencies" in step_required
     assert "termination_condition" in step_required
+    assert "completion_evidence" in step_required
     assert "tool_names" in step_required
     system_prompt = llm.calls[0]["messages"][0]["content"]
     assert "dependencies is required for every step" in system_prompt
     assert "screenshot or render steps must depend" in system_prompt
     assert '"termination_condition"' in system_prompt
+    assert '"completion_evidence"' in system_prompt
+    assert "Few-shot examples" in system_prompt
     assert "must be concrete and action-specific" in system_prompt
     assert "suggested execution tool scope" in system_prompt
     assert llm.calls[0]["tool_choice"] == "required"

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -24,6 +24,11 @@ class CalculatorArgs(BaseModel):
     expression: str
 
 
+class WriteFileArgs(BaseModel):
+    file_path: str
+    content: str
+
+
 class FakeTool:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -41,6 +46,30 @@ class FakeTool:
         self.calls.append(args)
         expression = args["expression"]
         return {"result": eval(expression), "expression": expression}  # noqa: S307
+
+
+class FakeWriteFileTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "write_file"
+            description = "Write file content in workspace."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return WriteFileArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        path = args["file_path"]
+        return {
+            "success": True,
+            "filename": path.split("/")[-1],
+            "relative_path": f"output/{path.split('/')[-1]}",
+            "file_path": f"/workspace/output/{path.split('/')[-1]}",
+        }
 
 
 class BrokenTool:
@@ -266,6 +295,72 @@ async def test_react_pattern_runs_tool_call_then_final_answer() -> None:
     assert "use this date when forming search queries" in system_prompt
     assert "not supported by the conversation" in system_prompt
     assert "available context is insufficient" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_unwraps_textual_final_answer_json() -> None:
+    llm = FakeLLM(
+        responses=[
+            '```json\n{"action":"final_answer","action_input":"Done cleanly."}\n```'
+        ]
+    )
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Finish")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Done cleanly."
+    assert context.messages[-1].content == "Done cleanly."
+    assert "action_input" not in context.messages[-1].content
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_finalizes_with_completion_evidence() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_write",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": (
+                                '{"file_path":"en_poster.html","content":"<html></html>"}'
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "Created output/en_poster.html."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3, finalize_after_tool_result=True)
+    tool = FakeWriteFileTool()
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message(
+        "Create the English poster HTML.",
+        metadata={
+            "dag_completion_evidence": (
+                "The writer returned success=true for the requested output path."
+            )
+        },
+    )
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Created output/en_poster.html."
+    assert tool.calls == [{"file_path": "en_poster.html", "content": "<html></html>"}]
+    assert llm.calls[1]["tools"] is None
+    assert (
+        "Step completion evidence: The writer returned success=true"
+        in (llm.calls[1]["messages"][0]["content"])
+    )
+    assert "Do not repeat the same work" in llm.calls[1]["messages"][0]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -694,6 +694,10 @@ async def test_trace_callback_unwraps_final_answer_and_omits_success_context(
                         '```json\n{"action":"final_answer",'
                         '"action_input":"Done cleanly."}\n```'
                     ),
+                    "message": (
+                        '```json\n{"action":"final_answer",'
+                        '"action_input":"Done cleanly."}\n```'
+                    ),
                 }
             )
         ],
@@ -708,6 +712,7 @@ async def test_trace_callback_unwraps_final_answer_and_omits_success_context(
     result = await runner.run(task="Finish", execution_id="exec-success")
 
     assert result["output"] == "Done cleanly."
+    assert result["message"] == "Done cleanly."
     ai_event = next(
         event for event in tracer.events if event["event_type"] == "task_end_message"
     )

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -677,3 +677,39 @@ async def test_trace_callback_does_not_emit_completion_for_interrupted_run(
     event_types = [event["event_type"] for event in tracer.events]
     assert event_types == ["task_start_message"]
     assert "task_end_general" not in event_types
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_unwraps_final_answer_and_omits_success_context(
+    tmp_path: Path,
+) -> None:
+    tracer = RecordingTraceEventTracer()
+    agent = Agent(
+        name="writer",
+        patterns=[
+            FakePattern(
+                {
+                    "success": True,
+                    "output": (
+                        '```json\n{"action":"final_answer",'
+                        '"action_input":"Done cleanly."}\n```'
+                    ),
+                }
+            )
+        ],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        callbacks=[TraceEventCallback()],
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    result = await runner.run(task="Finish", execution_id="exec-success")
+
+    assert result["output"] == "Done cleanly."
+    ai_event = next(
+        event for event in tracer.events if event["event_type"] == "task_end_message"
+    )
+    assert ai_event["data"]["content"] == "Done cleanly."
+    assert "context" not in ai_event["data"]

--- a/tests/web/test_task_execution_context_service.py
+++ b/tests/web/test_task_execution_context_service.py
@@ -10,6 +10,7 @@ from xagent.web.models.user import User
 from xagent.web.services.task_execution_context_service import (
     load_task_execution_context_messages,
     load_task_execution_recovery_state,
+    summarize_execution_failure_event,
     summarize_tool_event,
 )
 
@@ -93,6 +94,95 @@ def test_summarize_tool_event_uses_generic_fallback_for_unknown_tools():
     assert summary is not None
     assert summary.startswith("- Tool web_search previously returned: ")
     assert "top_result" in summary
+
+
+def test_summarize_tool_event_omits_binary_payloads():
+    summary = summarize_tool_event(
+        {
+            "tool_name": "read_file",
+            "success": True,
+            "tool_params": {"file_path": "logo.png"},
+            "result": "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + ("\x80" * 100),
+        }
+    )
+
+    assert summary is not None
+    assert "non-text payload omitted" in summary
+    assert "logo.png" in summary
+    assert "PNG" not in summary
+    assert "IHDR" not in summary
+
+
+def test_summarize_tool_event_compacts_nested_large_strings():
+    summary = summarize_tool_event(
+        {
+            "tool_name": "write_file",
+            "success": True,
+            "result": {
+                "success": True,
+                "file_path": "/tmp/report.html",
+                "content": "<html>" + ("a" * 300) + "</html>",
+            },
+        }
+    )
+
+    assert summary is not None
+    assert "/tmp/report.html" in summary
+    assert "a" * 200 not in summary
+
+
+def test_summarize_execution_failure_event_includes_step_anchor():
+    summary = summarize_execution_failure_event(
+        {
+            "status": "failed",
+            "result": {
+                "success": False,
+                "error": "Gemini SDK API error: connection reset by peer",
+                "failure_reason": "step_failed",
+                "failed_step_id": "write_html",
+            },
+        }
+    )
+
+    assert summary is not None
+    assert "step=write_html" in summary
+    assert "reason=step_failed" in summary
+    assert "connection reset" in summary
+
+
+def test_load_task_execution_context_messages_includes_latest_failure_anchor():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        db_session.add(
+            TraceEvent(
+                task_id=int(task.id),
+                build_id=None,
+                event_id="failure-event-1",
+                event_type="dag_execute_end",
+                timestamp=datetime.now(timezone.utc),
+                step_id=str(task.id),
+                parent_event_id=None,
+                data={
+                    "status": "failed",
+                    "result": {
+                        "success": False,
+                        "error": "network reset",
+                        "failure_reason": "step_failed",
+                        "failed_step_id": "render_poster",
+                    },
+                },
+            )
+        )
+        db_session.commit()
+
+        messages = load_task_execution_context_messages(db_session, int(task.id))
+
+        assert len(messages) == 1
+        assert "Previous execution failed" in messages[0]["content"]
+        assert "step=render_poster" in messages[0]["content"]
+    finally:
+        db_session.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add DAG step completion evidence and ReAct finalization handling to reduce repeated tool calls
- keep browser tools on the task session and sanitize reusable execution context
- unwrap legacy textual final_answer payloads so final results render cleanly

## Tests
- pytest tests/core/agent/test_react.py tests/core/agent/test_runner.py tests/core/agent/test_dag.py tests/web/test_task_execution_context_service.py -q
- pytest tests/core/agent/test_auto.py tests/core/agent/test_browser_tools.py -q
- npm run type-check