### PR TITLE
chore: update docker compose images to 0.4.0

### DIFF
--- a/docker-compose-sandbox.yml
+++ b/docker-compose-sandbox.yml
@@ -16,7 +16,7 @@ services:
 
   # Xagent Frontend (Next.js)
   frontend:
-    image: xprobe/xagent-frontend:0.3.4
+    image: xprobe/xagent-frontend:0.4.0
     container_name: xagent_frontend
     restart: unless-stopped
     networks:
@@ -30,7 +30,7 @@ services:
 
   # Xagent Backend (FastAPI)
   backend:
-    image: xprobe/xagent-backend:0.3.4
+    image: xprobe/xagent-backend:0.4.0
     container_name: xagent_backend
     restart: unless-stopped
     # Don't expose ports, only accessible through nginx
@@ -41,7 +41,7 @@ services:
       - XAGENT_UPLOADS_DIR=/root/.xagent/uploads
       - XAGENT_MAX_UPLOAD_SIZE=${XAGENT_MAX_UPLOAD_SIZE:-100M}
       - SANDBOX_ENABLED=true
-      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.3.4 # pinned version (`latest` may lead to caching problems)
+      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.4.0 # pinned version (`latest` may lead to caching problems)
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - BOXLITE_HOME_DIR=/root/.xagent/boxlite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # Xagent Frontend (Next.js)
   frontend:
-    image: xprobe/xagent-frontend:0.3.4
+    image: xprobe/xagent-frontend:0.4.0
     container_name: xagent_frontend
     restart: unless-stopped
     networks:
@@ -30,7 +30,7 @@ services:
 
   # Xagent Backend (FastAPI)
   backend:
-    image: xprobe/xagent-backend:0.3.4
+    image: xprobe/xagent-backend:0.4.0
     container_name: xagent_backend
     restart: unless-stopped
     # Don't expose ports, only accessible through nginx


### PR DESCRIPTION
## Summary
- Update docker-compose frontend/backend images to `xprobe/xagent-frontend:0.4.0` and `xprobe/xagent-backend:0.4.0`
- Update sandbox compose `SANDBOX_IMAGE` to `xprobe/xagent-sandbox:0.4.0`

## Verification
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose-sandbox.yml config`
- pre-commit checks from `git commit`