### PR TITLE
feat: improve file_id contract for model file handling

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1139,6 +1139,7 @@ class ReActPattern(AgentPattern):
         tools: list[Any],
         runtime: PatternRuntime,
     ) -> Any:
+        tool_call = self._with_runtime_step(tool_call, runtime)
         self._record_tool_call(tool_call, status="running")
         await runtime.on_tool_start(tool_call=tool_call)
         try:
@@ -1178,6 +1179,22 @@ class ReActPattern(AgentPattern):
         self._record_tool_call(tool_call, status="completed", result=result)
         await runtime.on_tool_end(tool_call=tool_call, result=result)
         return result
+
+    def _with_runtime_step(
+        self, tool_call: dict[str, Any], runtime: PatternRuntime
+    ) -> dict[str, Any]:
+        if tool_call.get("step_id") or tool_call.get("dag_step_id"):
+            return tool_call
+
+        step_id = getattr(runtime, "active_react_step_id", None)
+        if not step_id:
+            return tool_call
+
+        return {
+            **tool_call,
+            "step_id": str(step_id),
+            "dag_step_id": str(step_id),
+        }
 
     def _record_tool_call(
         self,
@@ -1289,7 +1306,7 @@ class ReActPattern(AgentPattern):
 
     async def _execute_tool(self, tool_call: dict[str, Any], tools: list[Any]) -> Any:
         tool = self._find_tool(tool_call["name"], tools)
-        args = tool_call.get("args", {})
+        args = self._tool_args_for_execution(tool_call, tool)
 
         execute = getattr(tool, "execute", None)
         if callable(execute):
@@ -1310,6 +1327,19 @@ class ReActPattern(AgentPattern):
         raise ValueError(
             f"Tool {tool_call['name']} does not expose a supported executor."
         )
+
+    def _tool_args_for_execution(
+        self, tool_call: dict[str, Any], tool: Any
+    ) -> dict[str, Any]:
+        args = dict(tool_call.get("args", {}))
+        tool_name = self._tool_name(tool)
+        if not tool_name.startswith("browser_"):
+            return args
+
+        step_id = tool_call.get("dag_step_id") or tool_call.get("step_id")
+        if step_id and not args.get("session_id"):
+            args.setdefault("_xagent_step_id", str(step_id))
+        return args
 
     def _find_tool(self, name: str, tools: list[Any]) -> Any:
         for tool in tools:

--- a/src/xagent/core/agent/utils/context_builder.py
+++ b/src/xagent/core/agent/utils/context_builder.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS
 from ...model.chat.basic.base import BaseLLM
 from ..trace import Tracer, trace_compact_end, trace_compact_start
 from .compact import CompactConfig, CompactUtils
@@ -127,7 +128,11 @@ class ContextBuilder:
             file_list_str = "\n".join(file_list_lines)
 
             # Build content message that supports both generic file processing and KB creation
-            content_msg = f"## UPLOADED FILES: {len(file_info)} files available for processing:\n{file_list_str}\n\n"
+            content_msg = (
+                f"## UPLOADED FILES: {len(file_info)} files available for processing:\n"
+                f"{file_list_str}\n\n"
+                f"{FILE_REF_MODEL_INSTRUCTIONS}\n\n"
+            )
 
             if is_builder_context:
                 content_msg += (

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -11,7 +11,7 @@ Files are referenced by FileRef objects. Treat file_id as the canonical file han
 Rules:
 - Use file_id when reading files or passing files to tools.
 - Do not guess storage paths such as /uploads/... or user_id/... paths.
-- For HTML assets, call prepare_html_asset(file_id, alias) first.
+- For HTML assets, call prepare_html_asset(file_id, html_path, alias) first.
 - Use the returned html_src inside HTML, CSS, script, or image references.
 - For user-visible output links, use markdown_link or file:{file_id}."""
 
@@ -44,7 +44,6 @@ def build_file_ref(
             {
                 "preview_url": f"/api/files/preview/{encoded_file_id}",
                 "download_url": f"/api/files/download/{encoded_file_id}",
-                "public_preview_url": f"/api/files/public/preview/{encoded_file_id}",
                 "markdown_link": f"[{filename}](file:{file_id})",
             }
         )
@@ -53,7 +52,6 @@ def build_file_ref(
             {
                 "preview_url": None,
                 "download_url": None,
-                "public_preview_url": None,
                 "markdown_link": None,
             }
         )

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -58,6 +58,43 @@ def build_file_ref(
     return result
 
 
+def build_workspace_file_ref(
+    *,
+    workspace: Any,
+    file_path: str | Path,
+    file_id: str | None = None,
+    mime_type: str | None = None,
+) -> dict[str, Any]:
+    """Register a workspace file and build the model/API-facing FileRef."""
+    resolved_path = Path(file_path).resolve()
+    if not resolved_path.exists() or not resolved_path.is_file():
+        raise FileNotFoundError(f"File not found for FileRef: {file_path}")
+    if not hasattr(workspace, "workspace_dir"):
+        raise ValueError("Workspace does not expose workspace_dir")
+
+    final_file_id = file_id or workspace.get_file_id_from_path(str(resolved_path))
+    if not final_file_id:
+        final_file_id = workspace.register_file(str(resolved_path))
+
+    workspace_root = workspace.workspace_dir.resolve()
+    file_ref = build_file_ref(
+        file_id=final_file_id,
+        filename=resolved_path.name,
+        mime_type=mime_type,
+        size=resolved_path.stat().st_size,
+    )
+    try:
+        relative_path = str(resolved_path.relative_to(workspace_root))
+    except ValueError:
+        relative_path = str(resolved_path)
+
+    return {
+        **file_ref,
+        "relative_path": relative_path,
+        "file_path": str(resolved_path),
+    }
+
+
 def safe_asset_filename(filename: str) -> str:
     """Return a browser-safe basename for HTML bundle assets."""
     name = Path(filename).name.strip()

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+FILE_REF_MODEL_INSTRUCTIONS = """## FILE REFERENCES
+Files are referenced by FileRef objects. Treat file_id as the canonical file handle.
+
+Rules:
+- Use file_id when reading files or passing files to tools.
+- Do not guess storage paths such as /uploads/... or user_id/... paths.
+- For HTML assets, call prepare_html_asset(file_id, alias) first.
+- Use the returned html_src inside HTML, CSS, script, or image references.
+- For user-visible output links, use markdown_link or file:{file_id}."""
+
+
+def guess_mime_type(filename: str) -> str:
+    media_type, _ = mimetypes.guess_type(filename)
+    return media_type or "application/octet-stream"
+
+
+def build_file_ref(
+    *,
+    file_id: str | None,
+    filename: str,
+    mime_type: str | None = None,
+    size: int | None = None,
+) -> dict[str, Any]:
+    """Build the model/API-facing file reference for a registered file."""
+    resolved_mime_type = mime_type or guess_mime_type(filename)
+    result: dict[str, Any] = {
+        "file_id": file_id,
+        "filename": filename,
+        "mime_type": resolved_mime_type,
+    }
+    if size is not None:
+        result["size"] = int(size)
+
+    if file_id:
+        encoded_file_id = quote(file_id, safe="")
+        result.update(
+            {
+                "preview_url": f"/api/files/preview/{encoded_file_id}",
+                "download_url": f"/api/files/download/{encoded_file_id}",
+                "public_preview_url": f"/api/files/public/preview/{encoded_file_id}",
+                "markdown_link": f"[{filename}](file:{file_id})",
+            }
+        )
+    else:
+        result.update(
+            {
+                "preview_url": None,
+                "download_url": None,
+                "public_preview_url": None,
+                "markdown_link": None,
+            }
+        )
+    return result
+
+
+def safe_asset_filename(filename: str) -> str:
+    """Return a browser-safe basename for HTML bundle assets."""
+    name = Path(filename).name.strip()
+    if not name or name in {".", ".."}:
+        return "asset"
+    return name

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Optional, Type
 
 from pydantic import BaseModel, Field
 
+from ....file_ref import build_workspace_file_ref
 from ....tools.core.browser_use import (
     browser_click,
     browser_close,
@@ -190,6 +191,13 @@ class BrowserScreenshotResult(BaseModel):
     wait_for_lazy_load: bool = Field(description="Whether lazy loading was enabled")
     message: str = Field(description="Result message")
     error: str = Field(default="", description="Error message if failed")
+    file_id: Optional[str] = Field(default=None, description="Registered file ID")
+    file_ref: Optional[dict[str, Any]] = Field(
+        default=None, description="Registered FileRef for the saved screenshot"
+    )
+    preview_url: Optional[str] = Field(default=None, description="Preview URL")
+    download_url: Optional[str] = Field(default=None, description="Download URL")
+    markdown_link: Optional[str] = Field(default=None, description="Markdown file link")
 
 
 class BrowserExtractTextArgs(BaseModel):
@@ -302,6 +310,13 @@ class BrowserPdfResult(BaseModel):
     size: int = Field(default=0, description="PDF file size in bytes")
     message: str = Field(description="Result message")
     error: str = Field(default="", description="Error message if failed")
+    file_id: Optional[str] = Field(default=None, description="Registered file ID")
+    file_ref: Optional[dict[str, Any]] = Field(
+        default=None, description="Registered FileRef for the saved PDF"
+    )
+    preview_url: Optional[str] = Field(default=None, description="Preview URL")
+    download_url: Optional[str] = Field(default=None, description="Download URL")
+    markdown_link: Optional[str] = Field(default=None, description="Markdown file link")
 
 
 # ============== Tool Implementations ==============
@@ -666,8 +681,18 @@ class BrowserScreenshotTool(BrowserTaskSessionMixin, AbstractBaseTool):
                 relative_path = str(
                     file_path.relative_to(self._workspace.workspace_dir)
                 )
+                file_ref = build_workspace_file_ref(
+                    workspace=self._workspace,
+                    file_path=file_path,
+                    mime_type="image/png",
+                )
                 result["screenshot"] = relative_path
                 result["format"] = "file"
+                result["file_id"] = file_ref["file_id"]
+                result["file_ref"] = file_ref
+                result["preview_url"] = file_ref["preview_url"]
+                result["download_url"] = file_ref["download_url"]
+                result["markdown_link"] = file_ref["markdown_link"]
                 result["message"] = f"Screenshot saved to {relative_path}"
             except Exception as e:
                 logger.error(
@@ -1067,8 +1092,18 @@ class BrowserPdfTool(BrowserTaskSessionMixin, AbstractBaseTool):
                 relative_path = str(
                     file_path.relative_to(self._workspace.workspace_dir)
                 )
+                file_ref = build_workspace_file_ref(
+                    workspace=self._workspace,
+                    file_path=file_path,
+                    mime_type="application/pdf",
+                )
                 result["output_path"] = relative_path
                 result["format"] = "file"
+                result["file_id"] = file_ref["file_id"]
+                result["file_ref"] = file_ref
+                result["preview_url"] = file_ref["preview_url"]
+                result["download_url"] = file_ref["download_url"]
+                result["markdown_link"] = file_ref["markdown_link"]
                 result["message"] = f"PDF saved to {relative_path}"
             except Exception as e:
                 logger.error(f"Failed to save PDF to workspace: {e}", exc_info=True)

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -30,6 +30,8 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
 logger = logging.getLogger(__name__)
 
+_STEP_SESSION_ARG = "_xagent_step_id"
+
 
 class BrowserTaskSessionMixin:
     """Keeps browser tool default sessions aligned during task setup."""
@@ -39,6 +41,63 @@ class BrowserTaskSessionMixin:
     async def setup(self, task_id: Optional[str] = None) -> None:
         if task_id:
             self._task_id = task_id
+
+    async def teardown(self, task_id: Optional[str] = None) -> None:
+        await self._close_task_sessions(task_id)
+
+    def _with_default_session(self, args: Mapping[str, Any]) -> dict[str, Any]:
+        updated = dict(args)
+        step_id = updated.pop(_STEP_SESSION_ARG, None)
+        if not updated.get("session_id") and self._task_id:
+            updated["session_id"] = self._default_session_id(step_id)
+        return updated
+
+    def _default_session_id(self, step_id: Any = None) -> str:
+        task_id = str(self._task_id or "").strip()
+        step_part = self._safe_session_part(step_id)
+        if step_part:
+            return f"{task_id}:{step_part}"
+        return task_id
+
+    @staticmethod
+    def _safe_session_part(value: Any = None) -> str:
+        if value is None:
+            return ""
+        safe = "".join(
+            char if char.isalnum() or char in {"-", "_", "."} else "_"
+            for char in str(value).strip()
+        ).strip("_")
+        return safe
+
+    async def _close_task_sessions(self, task_id: Optional[str] = None) -> None:
+        target_task_id = str(task_id or self._task_id or "").strip()
+        if not target_task_id:
+            return
+
+        try:
+            manager = get_browser_manager()
+            async with manager._lock:
+                session_ids = [
+                    session_id
+                    for session_id in manager._sessions
+                    if session_id == target_task_id
+                    or session_id.startswith(f"{target_task_id}:")
+                ]
+                for session_id in session_ids:
+                    await manager._sessions[session_id].close()
+                    del manager._sessions[session_id]
+            logger.info(
+                "Cleaned up %d browser session(s) for task %s",
+                len(session_ids),
+                target_task_id,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to cleanup browser sessions for task %s: %s",
+                target_task_id,
+                e,
+                exc_info=True,
+            )
 
 
 # ============== Input/Output Schemas ==============
@@ -307,10 +366,7 @@ class BrowserNavigateTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         # Convert workspace-relative paths to file:// URLs
         url = args.get("url", "")
@@ -415,22 +471,7 @@ class BrowserNavigateTool(BrowserTaskSessionMixin, AbstractBaseTool):
 
     async def teardown(self, task_id: Optional[str] = None) -> None:
         """Cleanup browser sessions when task completes."""
-        if self._task_id or task_id:
-            target_task_id = self._task_id or task_id
-            if target_task_id:  # Type guard for mypy
-                try:
-                    manager = get_browser_manager()
-                    # Close the session associated with this task
-                    # Session ID is typically the same as task_id in our pattern
-                    await manager.close(target_task_id)
-                    logger.info(
-                        f"Cleaned up browser session for task {target_task_id} via teardown"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to cleanup browser session for task {target_task_id}: {e}",
-                        exc_info=True,
-                    )
+        await self._close_task_sessions(task_id)
 
 
 class BrowserClickTool(BrowserTaskSessionMixin, AbstractBaseTool):
@@ -475,10 +516,7 @@ class BrowserClickTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_click(**args)
         return BrowserClickResult(**result).model_dump()
@@ -526,10 +564,7 @@ class BrowserFillTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_fill(**args)
         return BrowserFillResult(**result).model_dump()
@@ -583,10 +618,7 @@ class BrowserScreenshotTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         # Call async version directly
         import traceback
@@ -689,10 +721,7 @@ class BrowserExtractTextTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_extract_text(**args)
         return BrowserExtractTextResult(**result).model_dump()
@@ -749,10 +778,7 @@ class BrowserEvaluateTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_evaluate(**args)
         return BrowserEvaluateResult(**result).model_dump()
@@ -851,10 +877,7 @@ class BrowserSelectOptionTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_select_option(**args)
         return BrowserSelectOptionResult(**result).model_dump()
@@ -902,10 +925,7 @@ class BrowserWaitForSelectorTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_wait_for_selector(**args)
         return BrowserWaitForSelectorResult(**result).model_dump()
@@ -948,10 +968,7 @@ class BrowserCloseTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         result = await browser_close(**args)
         return BrowserCloseResult(**result).model_dump()
@@ -1009,10 +1026,7 @@ class BrowserPdfTool(BrowserTaskSessionMixin, AbstractBaseTool):
         )
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        # Use task_id as default session_id if not provided
-        if not args.get("session_id") and self._task_id:
-            args = dict(args)  # Make a mutable copy
-            args["session_id"] = self._task_id
+        args = self._with_default_session(args)
 
         # Call core function to get PDF data (base64 encoded)
         result = await browser_pdf(**args)

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -341,6 +341,9 @@ class ToolFactory:
                 task_id or "default",
                 allowed_external_dirs=workspace_config.get("allowed_external_dirs"),
             )
+            user_id = workspace_config.get("user_id")
+            if isinstance(user_id, int):
+                workspace.owner_user_id = user_id
             return workspace
         except Exception as e:
             logger.warning(f"Failed to create workspace: {e}")

--- a/src/xagent/core/tools/adapters/vibe/logo_overlay.py
+++ b/src/xagent/core/tools/adapters/vibe/logo_overlay.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Optional, Type
 from pydantic import BaseModel, Field
 
 from .....config import get_uploads_dir
+from ....file_ref import build_workspace_file_ref
 from ....workspace import TaskWorkspace
 from ...core.logo_overlay import LogoOverlayCore
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
@@ -51,6 +52,10 @@ class LogoOverlayResult(BaseModel):
     output_path: str = Field(description="Path to the output image")
     message: str = Field(description="Operation message")
     error: Optional[str] = Field(description="Error message if any")
+    file_id: Optional[str] = Field(default=None, description="Registered file ID")
+    file_ref: Optional[dict[str, Any]] = Field(
+        default=None, description="Registered FileRef for the output image"
+    )
 
 
 class LogoOverlayTool(AbstractBaseTool):
@@ -127,6 +132,18 @@ class LogoOverlayTool(AbstractBaseTool):
                 padding=overlay_args.padding,
                 output_filename=overlay_args.output_filename,
             )
+
+        if self._workspace and result.get("success") and result.get("output_path"):
+            try:
+                file_ref = build_workspace_file_ref(
+                    workspace=self._workspace,
+                    file_path=result["output_path"],
+                )
+                result["file_id"] = file_ref["file_id"]
+                result["file_ref"] = file_ref
+            except Exception as e:
+                logger.warning("Failed to build logo overlay FileRef: %s", e)
+                result["file_ref_warning"] = str(e)
 
         return LogoOverlayResult(**result).model_dump()
 

--- a/src/xagent/core/tools/adapters/vibe/vision_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/vision_tool.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from xagent.core.workspace import TaskWorkspace
 
+from ....file_ref import build_workspace_file_ref
 from ....model.chat.basic.base import BaseLLM
 from ...core.vision_tool import DetectObjectsResult, UnderstandImagesResult, VisionCore
 from .base import ToolCategory
@@ -229,6 +230,26 @@ class VisionTool:
                 temperature,
                 max_tokens,
             )
+
+        if (
+            mark_objects
+            and self.workspace
+            and result.success
+            and result.marked_image_path
+        ):
+            try:
+                file_ref = build_workspace_file_ref(
+                    workspace=self.workspace,
+                    file_path=result.marked_image_path,
+                )
+                result = result.model_copy(
+                    update={
+                        "file_id": file_ref["file_id"],
+                        "file_ref": file_ref,
+                    }
+                )
+            except Exception as e:
+                logger.warning("Failed to build marked image FileRef: %s", e)
 
         return result
 

--- a/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
@@ -61,6 +61,15 @@ class WorkspaceFileTools(WorkspaceFileOperations):
             raise ValueError("content is required")
         return self.inner.write_file(file_path, content, encoding, create_dirs)
 
+    def prepare_html_asset(
+        self,
+        file_id: str,
+        alias: str | None = None,
+        assets_dir: str = "assets",
+    ) -> Dict[str, Any]:
+        """Copy a file_id-referenced asset into the current output bundle."""
+        return self.inner.prepare_html_asset(file_id, alias, assets_dir)
+
     def append_file(
         self,
         file_path: str,
@@ -162,7 +171,12 @@ class WorkspaceFileTools(WorkspaceFileOperations):
             FileTool(
                 self.write_file,
                 name="write_file",
-                description="Write file content in workspace. Use relative paths (e.g., 'filename.txt'), not absolute paths.\n\nImportant: For HTML files, when referencing resources in the same directory (CSS, JS, images), only use filenames (e.g., '1.png'), not absolute paths (e.g., '/uploads/xxx/1.png'). All files are in the workspace, and browsers will automatically resolve relative paths.",
+                description="Write file content in workspace. Use relative paths (e.g., 'filename.txt'), not absolute paths. Returns a FileRef with file_id, preview_url, download_url, and markdown_link.\n\nImportant: For HTML files, do not guess paths to uploaded files or files from other tasks. First call prepare_html_asset(file_id, alias) for every external image/CSS/JS asset, then use the returned html_src in the HTML.",
+            ),
+            FileTool(
+                self.prepare_html_asset,
+                name="prepare_html_asset",
+                description="Prepare an uploaded or registered file for use inside an HTML artifact. Pass the source file_id and an optional alias such as 'logo.png'. The tool copies the asset into the current output/assets bundle and returns html_src (for example 'assets/logo.png'). Use html_src in <img src>, <link href>, <script src>, or CSS url(). Do not compute ../ paths yourself.",
             ),
             FileTool(
                 self.append_file,

--- a/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
@@ -64,11 +64,12 @@ class WorkspaceFileTools(WorkspaceFileOperations):
     def prepare_html_asset(
         self,
         file_id: str,
+        html_path: str,
         alias: str | None = None,
-        assets_dir: str = "assets",
+        assets_subdir: str = "assets",
     ) -> Dict[str, Any]:
         """Copy a file_id-referenced asset into the current output bundle."""
-        return self.inner.prepare_html_asset(file_id, alias, assets_dir)
+        return self.inner.prepare_html_asset(file_id, html_path, alias, assets_subdir)
 
     def append_file(
         self,
@@ -171,12 +172,12 @@ class WorkspaceFileTools(WorkspaceFileOperations):
             FileTool(
                 self.write_file,
                 name="write_file",
-                description="Write file content in workspace. Use relative paths (e.g., 'filename.txt'), not absolute paths. Returns a FileRef with file_id, preview_url, download_url, and markdown_link.\n\nImportant: For HTML files, do not guess paths to uploaded files or files from other tasks. First call prepare_html_asset(file_id, alias) for every external image/CSS/JS asset, then use the returned html_src in the HTML.",
+                description="Write file content in workspace. Use relative paths (e.g., 'filename.txt'), not absolute paths. Returns a FileRef with file_id, preview_url, download_url, and markdown_link.\n\nImportant: For HTML files, do not guess paths to uploaded files or files from other tasks. First call prepare_html_asset(file_id, html_path, alias) for every external image/CSS/JS asset, then use the returned html_src in the HTML.",
             ),
             FileTool(
                 self.prepare_html_asset,
                 name="prepare_html_asset",
-                description="Prepare an uploaded or registered file for use inside an HTML artifact. Pass the source file_id and an optional alias such as 'logo.png'. The tool copies the asset into the current output/assets bundle and returns html_src (for example 'assets/logo.png'). Use html_src in <img src>, <link href>, <script src>, or CSS url(). Do not compute ../ paths yourself.",
+                description="Prepare an uploaded or registered file for use inside an HTML artifact. Pass the source file_id, the target HTML output path such as 'index.html' or 'reports/index.html', and an optional alias such as 'logo.png'. The tool copies the asset next to that HTML file under assets_subdir and returns html_src relative to the HTML file. Use html_src in <img src>, <link href>, <script src>, or CSS url(). Do not compute ../ paths yourself.",
             ),
             FileTool(
                 self.append_file,

--- a/src/xagent/core/tools/core/audio_tool.py
+++ b/src/xagent/core/tools/core/audio_tool.py
@@ -14,6 +14,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ...file_ref import build_workspace_file_ref
 from ...model.asr.base import ASRResult, BaseASR
 from ...model.tts.base import BaseTTS, TTSResult
 from ...workspace import TaskWorkspace
@@ -370,6 +371,7 @@ class AudioToolCore:
 
             # Save transcription to JSON file if workspace is available
             file_id: Optional[str] = None
+            file_ref: Optional[dict[str, Any]] = None
             transcription_path = None
 
             if text and self._workspace:
@@ -406,9 +408,11 @@ class AudioToolCore:
 
                     # Get file ID from workspace after registration
                     if transcription_path:
-                        file_id = self._workspace.get_file_id_from_path(
-                            transcription_path
+                        file_ref = build_workspace_file_ref(
+                            workspace=self._workspace,
+                            file_path=transcription_path,
                         )
+                        file_id = file_ref["file_id"]
 
                 except Exception as e:
                     logger.warning(f"Failed to save transcription to workspace: {e}")
@@ -420,6 +424,7 @@ class AudioToolCore:
             return {
                 "success": True,
                 "file_id": file_id,
+                "file_ref": file_ref,
                 "transcription_path": transcription_path,
                 "segments": segments,
                 "language": language_detected,
@@ -517,6 +522,7 @@ class AudioToolCore:
             # Save audio file to workspace if available
             audio_path = None
             audio_file_id: Optional[str] = None
+            file_ref: Optional[dict[str, Any]] = None
 
             if audio_data and self._workspace:
                 try:
@@ -536,9 +542,11 @@ class AudioToolCore:
 
                     # Get file ID from workspace after registration
                     if audio_path:
-                        audio_file_id = self._workspace.get_file_id_from_path(
-                            audio_path
+                        file_ref = build_workspace_file_ref(
+                            workspace=self._workspace,
+                            file_path=audio_path,
                         )
+                        audio_file_id = file_ref["file_id"]
 
                 except Exception as e:
                     logger.warning(f"Failed to save audio to workspace: {e}")
@@ -550,6 +558,7 @@ class AudioToolCore:
                 "success": True,
                 "audio_path": audio_path,
                 "file_id": audio_file_id,
+                "file_ref": file_ref,
                 "format": result_audio_format,
                 "sample_rate": sample_rate,
                 "language": language_detected,
@@ -1084,6 +1093,7 @@ class AudioToolCore:
             # Save to workspace if available
             audio_path = None
             audio_file_id = None
+            file_ref: Optional[dict[str, Any]] = None
 
             if self._workspace:
                 try:
@@ -1100,9 +1110,11 @@ class AudioToolCore:
 
                     # Get file ID
                     if audio_path:
-                        audio_file_id = self._workspace.get_file_id_from_path(
-                            audio_path
+                        file_ref = build_workspace_file_ref(
+                            workspace=self._workspace,
+                            file_path=audio_path,
                         )
+                        audio_file_id = file_ref["file_id"]
 
                 except Exception as e:
                     logger.warning(f"Failed to save audio to workspace: {e}")
@@ -1114,6 +1126,7 @@ class AudioToolCore:
                 "voice": voice,
                 "audio_path": audio_path,
                 "file_id": audio_file_id,
+                "file_ref": file_ref,
                 "format": audio_format,
                 "saved_to_workspace": audio_path is not None,
             }

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -16,6 +16,7 @@ from urllib import parse
 
 import aiohttp
 
+from ...file_ref import build_workspace_file_ref
 from ...model.image.base import BaseImageModel
 from ...workspace import TaskWorkspace
 
@@ -537,6 +538,7 @@ Images are automatically saved to workspace.
             image_url = result.get("image_url")
             image_path = None
             image_file_id: Optional[str] = None
+            file_ref: Optional[dict[str, Any]] = None
 
             # Download image to workspace if workspace is available
             if image_url and self._workspace:
@@ -544,9 +546,19 @@ Images are automatically saved to workspace.
                     with self._workspace.auto_register_files():
                         image_path = await self._download_image(image_url)
                     if image_path:
-                        image_file_id = self._workspace.get_file_id_from_path(
-                            image_path
-                        )
+                        try:
+                            file_ref = build_workspace_file_ref(
+                                workspace=self._workspace,
+                                file_path=image_path,
+                            )
+                            image_file_id = file_ref["file_id"]
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to build generated image FileRef: %s", e
+                            )
+                            image_file_id = self._workspace.get_file_id_from_path(
+                                image_path
+                            )
                 except Exception as e:
                     logger.warning(f"Failed to download image to workspace: {e}")
                     # Continue execution even if download fails
@@ -558,6 +570,7 @@ Images are automatically saved to workspace.
                 "image_path": image_path,
                 "file_id": image_file_id,
                 "artifacts": self._build_image_artifacts(image_path, image_file_id),
+                "file_ref": file_ref,
                 "usage": result.get("usage", {}),
                 "task_metric": result.get("task_metric", {}),
                 "request_id": result.get("request_id"),
@@ -661,6 +674,7 @@ Images are automatically saved to workspace.
             edited_image_url = result.get("image_url")
             image_path = None
             image_file_id: Optional[str] = None
+            file_ref: Optional[dict[str, Any]] = None
 
             # Download image to workspace if workspace is available
             if edited_image_url and self._workspace:
@@ -672,9 +686,19 @@ Images are automatically saved to workspace.
                             edited_image_url, filename
                         )
                     if image_path:
-                        image_file_id = self._workspace.get_file_id_from_path(
-                            image_path
-                        )
+                        try:
+                            file_ref = build_workspace_file_ref(
+                                workspace=self._workspace,
+                                file_path=image_path,
+                            )
+                            image_file_id = file_ref["file_id"]
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to build edited image FileRef: %s", e
+                            )
+                            image_file_id = self._workspace.get_file_id_from_path(
+                                image_path
+                            )
                 except Exception as e:
                     logger.warning(f"Failed to download edited image to workspace: {e}")
                     # Continue execution even if download fails
@@ -686,6 +710,7 @@ Images are automatically saved to workspace.
                 "image_path": image_path,
                 "file_id": image_file_id,
                 "artifacts": self._build_image_artifacts(image_path, image_file_id),
+                "file_ref": file_ref,
                 "usage": result.get("usage", {}),
                 "task_metric": result.get("task_metric", {}),
                 "request_id": result.get("request_id"),

--- a/src/xagent/core/tools/core/pptx_tool.py
+++ b/src/xagent/core/tools/core/pptx_tool.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 from xml.etree import ElementTree as ET
 
+from ...file_ref import build_workspace_file_ref
 from ...workspace import TaskWorkspace
 
 # PPTX namespaces
@@ -1922,9 +1923,16 @@ def generate_pptx(
             if result.get("success"):
                 output_file_str = result.get("output")
                 if output_file_str:
-                    file_id = workspace.get_file_id_from_path(output_file_str)
-                    if file_id:
-                        result["file_id"] = file_id
+                    try:
+                        file_ref = build_workspace_file_ref(
+                            workspace=workspace,
+                            file_path=output_file_str,
+                        )
+                        result["file_id"] = file_ref["file_id"]
+                        result["file_ref"] = file_ref
+                    except Exception as e:
+                        logger.warning("Failed to build generated PPTX FileRef: %s", e)
+                        result["file_ref_warning"] = str(e)
             return result
     else:
         return gen.generate(
@@ -1986,9 +1994,16 @@ def pack_pptx(
             if result.get("success"):
                 output_path_str = result.get("output_path")
                 if output_path_str:
-                    file_id = workspace.get_file_id_from_path(output_path_str)
-                    if file_id:
-                        result["file_id"] = file_id
+                    try:
+                        file_ref = build_workspace_file_ref(
+                            workspace=workspace,
+                            file_path=output_path_str,
+                        )
+                        result["file_id"] = file_ref["file_id"]
+                        result["file_ref"] = file_ref
+                    except Exception as e:
+                        logger.warning("Failed to build packed PPTX FileRef: %s", e)
+                        result["file_ref_warning"] = str(e)
             return result
     else:
         return reader.pack(str(output_file), validate=validate)

--- a/src/xagent/core/tools/core/translate_json_tool.py
+++ b/src/xagent/core/tools/core/translate_json_tool.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 from tqdm import tqdm as tqdm_std  # type: ignore[import-untyped]
 from tqdm.asyncio import tqdm as tqdm_async  # type: ignore[import-untyped]
 
+from ...file_ref import build_workspace_file_ref
+
 logger = logging.getLogger(__name__)
 
 
@@ -427,6 +429,7 @@ Translations:"""
 
         # Save translation to JSON file if workspace is available
         file_id: Optional[str] = None
+        file_ref: Optional[dict[str, Any]] = None
         translation_path = None
         saved_to_workspace = False
 
@@ -464,7 +467,11 @@ Translations:"""
 
                 # Get file ID from workspace after registration
                 if translation_path:
-                    file_id = self._workspace.get_file_id_from_path(translation_path)
+                    file_ref = build_workspace_file_ref(
+                        workspace=self._workspace,
+                        file_path=translation_path,
+                    )
+                    file_id = file_ref["file_id"]
                     saved_to_workspace = True
 
             except Exception as e:
@@ -477,6 +484,7 @@ Translations:"""
             "fields_translated": len(translated_texts),
             "target_lang": target_lang,
             "file_id": file_id,
+            "file_ref": file_ref,
             "translation_path": translation_path,
             "saved_to_workspace": saved_to_workspace,
         }

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -46,6 +46,8 @@ class DetectObjectsResult(BaseModel):
     confidence_threshold: float = 0.5
     prompt_sent: Optional[str] = None
     marked_image_path: Optional[str] = None
+    file_id: Optional[str] = None
+    file_ref: Optional[Dict[str, Any]] = None
     box_color: Optional[str] = None
     raw_response: Optional[str] = None
     parsing_method: Optional[str] = None

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -8,6 +8,7 @@ It focuses on pure file operations without tool framework dependencies.
 import asyncio
 import csv
 import logging
+import os
 import shutil
 import time
 from pathlib import Path
@@ -327,28 +328,30 @@ class WorkspaceFileOperations:
     def prepare_html_asset(
         self,
         file_id: str,
+        html_path: str,
         alias: str | None = None,
-        assets_dir: str = "assets",
+        assets_subdir: str = "assets",
     ) -> Dict[str, Any]:
-        """Copy an existing file into output/assets and return the HTML src."""
+        """Copy an existing file next to an HTML output and return the HTML src."""
         source_ref = self._normalize_file_ref(file_id)
         source_path = self.workspace.resolve_path_with_search(source_ref)
         if not source_path.exists() or not source_path.is_file():
             raise FileNotFoundError(f"File not found: {file_id}")
 
-        assets_path = Path(assets_dir)
+        html_output_path = self._resolve_html_output_path(html_path)
+        assets_path = Path(assets_subdir)
         if assets_path.is_absolute() or ".." in assets_path.parts:
-            raise ValueError("assets_dir must be a relative path inside output")
+            raise ValueError("assets_subdir must be a relative path inside output")
 
         asset_name = safe_asset_filename(alias or source_path.name)
-        target_dir = self._resolve_path(str(assets_path), "output")
+        target_dir = html_output_path.parent / assets_path
         output_root = self.workspace.output_dir.resolve()
         resolved_target_dir = target_dir.resolve()
         if (
             resolved_target_dir != output_root
             and not resolved_target_dir.is_relative_to(output_root)
         ):
-            raise ValueError("assets_dir must resolve inside output")
+            raise ValueError("assets_subdir must resolve inside output")
 
         target_dir.mkdir(parents=True, exist_ok=True)
         target_path = self._build_unique_asset_path(target_dir / asset_name)
@@ -361,7 +364,9 @@ class WorkspaceFileOperations:
             asset_file_id = self.workspace.register_file(str(target_path))
 
         workspace_root = self.workspace.workspace_dir.resolve()
-        html_src = target_path.resolve().relative_to(output_root).as_posix()
+        html_src = Path(
+            os.path.relpath(target_path.resolve(), start=html_output_path.parent)
+        ).as_posix()
         file_ref = build_file_ref(
             file_id=asset_file_id,
             filename=target_path.name,
@@ -376,6 +381,22 @@ class WorkspaceFileOperations:
             "relative_path": str(target_path.resolve().relative_to(workspace_root)),
             "file_path": str(target_path.resolve()),
         }
+
+    def _resolve_html_output_path(self, html_path: str) -> Path:
+        path = Path(str(html_path).strip())
+        if not str(path) or path.is_absolute() or ".." in path.parts:
+            raise ValueError("html_path must be a relative path inside output")
+        if path.parts and path.parts[0] in {"input", "temp"}:
+            raise ValueError("html_path must be inside output")
+
+        resolved_path = self._resolve_path(str(path), "output")
+        output_root = self.workspace.output_dir.resolve()
+        resolved_path = resolved_path.resolve()
+        if resolved_path != output_root and not resolved_path.is_relative_to(
+            output_root
+        ):
+            raise ValueError("html_path must resolve inside output")
+        return resolved_path
 
     @staticmethod
     def _normalize_file_ref(file_ref: str | None) -> str:

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -378,7 +378,9 @@ class WorkspaceFileOperations:
         }
 
     @staticmethod
-    def _normalize_file_ref(file_ref: str) -> str:
+    def _normalize_file_ref(file_ref: str | None) -> str:
+        if file_ref is None:
+            return ""
         value = str(file_ref).strip()
         if value.startswith("file://"):
             return value[7:]

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -8,12 +8,14 @@ It focuses on pure file operations without tool framework dependencies.
 import asyncio
 import csv
 import logging
+import shutil
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
+from ...file_ref import build_file_ref, safe_asset_filename
 from ...workspace import TaskWorkspace
 from .document_parser import DocumentCapabilities, DocumentParseArgs, parse_document
 from .file_tool import EditOperation, EditResult, get_image_metadata
@@ -310,13 +312,86 @@ class WorkspaceFileOperations:
         # Use resolved workspace_dir so relative_to works on macOS where
         # /var can be symlink to /private/var (resolved_path has /private, raw dir may not).
         workspace_root = self.workspace.workspace_dir.resolve()
+        file_ref = build_file_ref(
+            file_id=file_id,
+            filename=resolved_path.name,
+            size=resolved_path.stat().st_size,
+        )
         return {
             "success": True,
-            "file_id": file_id,
-            "filename": resolved_path.name,
+            **file_ref,
             "relative_path": str(resolved_path.relative_to(workspace_root)),
             "file_path": str(resolved_path),
         }
+
+    def prepare_html_asset(
+        self,
+        file_id: str,
+        alias: str | None = None,
+        assets_dir: str = "assets",
+    ) -> Dict[str, Any]:
+        """Copy an existing file into output/assets and return the HTML src."""
+        source_ref = self._normalize_file_ref(file_id)
+        source_path = self.workspace.resolve_path_with_search(source_ref)
+        if not source_path.exists() or not source_path.is_file():
+            raise FileNotFoundError(f"File not found: {file_id}")
+
+        assets_path = Path(assets_dir)
+        if assets_path.is_absolute() or ".." in assets_path.parts:
+            raise ValueError("assets_dir must be a relative path inside output")
+
+        asset_name = safe_asset_filename(alias or source_path.name)
+        target_dir = self._resolve_path(str(assets_path), "output")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = self._build_unique_asset_path(target_dir / asset_name)
+
+        with self.workspace.auto_register_files():
+            shutil.copy2(source_path, target_path)
+
+        asset_file_id = self.workspace.get_file_id_from_path(str(target_path))
+        if not asset_file_id:
+            asset_file_id = self.workspace.register_file(str(target_path))
+
+        output_root = self.workspace.output_dir.resolve()
+        workspace_root = self.workspace.workspace_dir.resolve()
+        html_src = target_path.resolve().relative_to(output_root).as_posix()
+        file_ref = build_file_ref(
+            file_id=asset_file_id,
+            filename=target_path.name,
+            size=target_path.stat().st_size,
+        )
+        return {
+            "success": True,
+            "source_file_id": source_ref,
+            "asset_file_id": asset_file_id,
+            "html_src": html_src,
+            **file_ref,
+            "relative_path": str(target_path.resolve().relative_to(workspace_root)),
+            "file_path": str(target_path.resolve()),
+        }
+
+    @staticmethod
+    def _normalize_file_ref(file_ref: str) -> str:
+        value = str(file_ref).strip()
+        if value.startswith("file://"):
+            return value[7:]
+        if value.startswith("file:"):
+            return value[5:]
+        return value
+
+    @staticmethod
+    def _build_unique_asset_path(path: Path) -> Path:
+        if not path.exists():
+            return path
+        stem = path.stem
+        suffix = path.suffix
+        parent = path.parent
+        index = 1
+        while True:
+            candidate = parent / f"{stem}_{index}{suffix}"
+            if not candidate.exists():
+                return candidate
+            index += 1
 
     def append_file(
         self,

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
-from ...file_ref import build_file_ref, safe_asset_filename
+from ...file_ref import build_workspace_file_ref, safe_asset_filename
 from ...workspace import TaskWorkspace
 from .document_parser import DocumentCapabilities, DocumentParseArgs, parse_document
 from .file_tool import EditOperation, EditResult, get_image_metadata
@@ -305,24 +305,20 @@ class WorkspaceFileOperations:
             with open(resolved_path, "w", encoding=encoding) as f:
                 f.write(content)
 
-        file_id = self.workspace.get_file_id_from_path(str(resolved_path))
+        file_ref = build_workspace_file_ref(
+            workspace=self.workspace,
+            file_path=resolved_path,
+        )
 
         logger.debug(
-            "Successfully wrote file: %s with file_id: %s", resolved_path, file_id
-        )
-        # Use resolved workspace_dir so relative_to works on macOS where
-        # /var can be symlink to /private/var (resolved_path has /private, raw dir may not).
-        workspace_root = self.workspace.workspace_dir.resolve()
-        file_ref = build_file_ref(
-            file_id=file_id,
-            filename=resolved_path.name,
-            size=resolved_path.stat().st_size,
+            "Successfully wrote file: %s with file_id: %s",
+            resolved_path,
+            file_ref["file_id"],
         )
         return {
             "success": True,
             **file_ref,
-            "relative_path": str(resolved_path.relative_to(workspace_root)),
-            "file_path": str(resolved_path),
+            "file_ref": file_ref,
         }
 
     def prepare_html_asset(
@@ -359,27 +355,20 @@ class WorkspaceFileOperations:
         with self.workspace.auto_register_files():
             shutil.copy2(source_path, target_path)
 
-        asset_file_id = self.workspace.get_file_id_from_path(str(target_path))
-        if not asset_file_id:
-            asset_file_id = self.workspace.register_file(str(target_path))
-
-        workspace_root = self.workspace.workspace_dir.resolve()
         html_src = Path(
             os.path.relpath(target_path.resolve(), start=html_output_path.parent)
         ).as_posix()
-        file_ref = build_file_ref(
-            file_id=asset_file_id,
-            filename=target_path.name,
-            size=target_path.stat().st_size,
+        file_ref = build_workspace_file_ref(
+            workspace=self.workspace,
+            file_path=target_path,
         )
         return {
             "success": True,
             "source_file_id": source_ref,
-            "asset_file_id": asset_file_id,
+            "asset_file_id": file_ref["file_id"],
             "html_src": html_src,
             **file_ref,
-            "relative_path": str(target_path.resolve().relative_to(workspace_root)),
-            "file_path": str(target_path.resolve()),
+            "file_ref": file_ref,
         }
 
     def _resolve_html_output_path(self, html_path: str) -> Path:

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -342,6 +342,14 @@ class WorkspaceFileOperations:
 
         asset_name = safe_asset_filename(alias or source_path.name)
         target_dir = self._resolve_path(str(assets_path), "output")
+        output_root = self.workspace.output_dir.resolve()
+        resolved_target_dir = target_dir.resolve()
+        if (
+            resolved_target_dir != output_root
+            and not resolved_target_dir.is_relative_to(output_root)
+        ):
+            raise ValueError("assets_dir must resolve inside output")
+
         target_dir.mkdir(parents=True, exist_ok=True)
         target_path = self._build_unique_asset_path(target_dir / asset_name)
 
@@ -352,7 +360,6 @@ class WorkspaceFileOperations:
         if not asset_file_id:
             asset_file_id = self.workspace.register_file(str(target_path))
 
-        output_root = self.workspace.output_dir.resolve()
         workspace_root = self.workspace.workspace_dir.resolve()
         html_src = target_path.resolve().relative_to(output_root).as_posix()
         file_ref = build_file_ref(

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -61,6 +61,8 @@ class TaskWorkspace:
         self.db_session = None  # Optional database session for file registration
         self._recently_registered_files: Dict[str, str] = {}  # path -> file_id mapping
         self._file_id_to_path: Dict[str, Path] = {}  # file_id -> path reverse mapping
+        self.owner_user_id: Optional[int] = None
+        self.current_task_id: Optional[int] = self._parse_task_id_from_workspace_id(id)
 
         # Create workspace directory
         self.workspace_dir = self.base_dir / id
@@ -238,6 +240,36 @@ class TaskWorkspace:
         except Exception:
             return None
 
+    @staticmethod
+    def _parse_task_id_from_workspace_id(workspace_id: str) -> Optional[int]:
+        try:
+            return int(str(workspace_id).split("_")[-1])
+        except (TypeError, ValueError, IndexError):
+            return None
+
+    def _file_record_allowed_for_workspace(self, record: Any, path: Path) -> bool:
+        workspace_abs = self.workspace_dir.resolve()
+        resolved_path = path.resolve()
+        if resolved_path == workspace_abs or resolved_path.is_relative_to(
+            workspace_abs
+        ):
+            return True
+
+        owner_user_id = self.owner_user_id
+        if owner_user_id is None:
+            return True
+
+        record_user_id = getattr(record, "user_id", None)
+        if record_user_id != owner_user_id:
+            return False
+
+        record_task_id = getattr(record, "task_id", None)
+        if record_task_id is None:
+            return True
+        return (
+            self.current_task_id is not None and record_task_id == self.current_task_id
+        )
+
     def resolve_file_id(self, file_id: str) -> Optional[Path]:
         file_id = str(file_id).strip()
         if not file_id:
@@ -274,6 +306,14 @@ class TaskWorkspace:
                 if record and record.storage_path:
                     resolved_path = Path(record.storage_path)
                     if resolved_path.exists() and resolved_path.is_file():
+                        if not self._file_record_allowed_for_workspace(
+                            record, resolved_path
+                        ):
+                            logger.warning(
+                                "Rejected file_id outside workspace scope: %s",
+                                file_id,
+                            )
+                            return None
                         return resolved_path
                 return None
             finally:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -228,6 +228,7 @@ async def create_default_tools(
         workspace_config={
             "base_dir": str(get_uploads_dir() / f"user_{owner_id}"),
             "task_id": task_id,
+            "user_id": owner_id,
             "allowed_external_dirs": allowed_external_dirs,
         },
         include_mcp_tools=bool(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -641,6 +641,44 @@ def _add_file_link_aliases(
         path_to_file_id[f"/{task_local_path}"] = file_id
 
 
+def _uploaded_file_record_in_task_scope(
+    file_record: Any, task_id: int, task_user_id: int
+) -> bool:
+    try:
+        record_user_id = int(getattr(file_record, "user_id"))
+    except (TypeError, ValueError):
+        return False
+
+    if record_user_id != int(task_user_id):
+        return False
+
+    record_task_id = getattr(file_record, "task_id", None)
+    if record_task_id is None:
+        return True
+
+    try:
+        return int(record_task_id) == int(task_id)
+    except (TypeError, ValueError):
+        return False
+
+
+def _output_path_in_current_task_scope(
+    relative_path: str, task_id: int, task_user_id: int
+) -> bool:
+    parts = Path(relative_path.lstrip("/")).parts
+    task_dirs = {f"web_task_{task_id}", f"task_{task_id}"}
+
+    if (
+        len(parts) >= 4
+        and parts[0] == f"user_{task_user_id}"
+        and parts[1] in task_dirs
+        and parts[2] == "output"
+    ):
+        return True
+
+    return len(parts) >= 3 and parts[0] in task_dirs and parts[1] == "output"
+
+
 def _normalize_file_outputs(
     db: Session,
     task_id: int,
@@ -715,6 +753,15 @@ def _normalize_file_outputs(
 
         resolved_path, relative_path = resolved_info
         normalized_relative_path = relative_path.lstrip("/")
+        if not _output_path_in_current_task_scope(
+            normalized_relative_path, task_id, task_user_id
+        ):
+            logger.warning(
+                "Skipping file output outside current task output scope: %s",
+                relative_path,
+            )
+            continue
+
         expected_file_id = item_file_id or _build_output_file_id(
             normalized_relative_path
         )
@@ -724,6 +771,15 @@ def _normalize_file_outputs(
             .filter(UploadedFile.storage_path == str(resolved_path))
             .first()
         )
+        if file_record is not None and not _uploaded_file_record_in_task_scope(
+            file_record, task_id, task_user_id
+        ):
+            logger.warning(
+                "Skipping file output record outside task/user scope: %s",
+                getattr(file_record, "file_id", str(resolved_path)),
+            )
+            continue
+
         if file_record is None and item_file_id:
             file_record = (
                 db.query(UploadedFile)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -685,10 +685,30 @@ def _normalize_file_outputs(
 
         if resolved_info is None:
             if item_file_id:
+                file_record = (
+                    db.query(UploadedFile)
+                    .filter(
+                        UploadedFile.file_id == item_file_id,
+                        UploadedFile.user_id == task_user_id,
+                        or_(
+                            UploadedFile.task_id == task_id,
+                            UploadedFile.task_id.is_(None),
+                        ),
+                    )
+                    .first()
+                )
+                if file_record is None:
+                    logger.warning(
+                        "Skipping file output outside task/user scope: %s",
+                        item_file_id,
+                    )
+                    continue
                 normalized_outputs.append(
                     build_file_ref(
-                        file_id=item_file_id,
-                        filename=item_filename or "output",
+                        file_id=str(file_record.file_id),
+                        filename=item_filename or str(file_record.filename),
+                        mime_type=getattr(file_record, "mime_type", None),
+                        size=getattr(file_record, "file_size", None),
                     )
                 )
             continue
@@ -707,7 +727,13 @@ def _normalize_file_outputs(
         if file_record is None and item_file_id:
             file_record = (
                 db.query(UploadedFile)
-                .filter(UploadedFile.file_id == item_file_id)
+                .filter(
+                    UploadedFile.file_id == item_file_id,
+                    UploadedFile.user_id == task_user_id,
+                    or_(
+                        UploadedFile.task_id == task_id, UploadedFile.task_id.is_(None)
+                    ),
+                )
                 .first()
             )
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -32,6 +32,7 @@ from ...config import (
     get_uploads_dir,
 )
 from ...core.agent.trace import TraceEvent, TraceHandler
+from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
 from ..models.database import get_db
 from ..models.task import Task, TaskStatus
@@ -170,6 +171,8 @@ def _build_uploaded_files_context(
         "## UPLOADED FILES",
         "The user has uploaded file(s) for this turn. Use these exact file_id values:",
         *file_summaries,
+        "",
+        FILE_REF_MODEL_INSTRUCTIONS,
     ]
     if is_agent_builder:
         joined_file_ids = ", ".join(f'"{file_id}"' for file_id in file_ids)
@@ -643,7 +646,7 @@ def _normalize_file_outputs(
     task_id: int,
     task_user_id: int,
     file_outputs: Any,
-) -> tuple[list[Dict[str, str]], Dict[str, str]]:
+) -> tuple[list[Dict[str, Any]], Dict[str, str]]:
     from ..models.uploaded_file import UploadedFile
 
     if isinstance(file_outputs, str):
@@ -651,7 +654,7 @@ def _normalize_file_outputs(
     if not isinstance(file_outputs, list):
         return [], {}
 
-    normalized_outputs: list[Dict[str, str]] = []
+    normalized_outputs: list[Dict[str, Any]] = []
     path_to_file_id: Dict[str, str] = {}
     changed = False
 
@@ -683,10 +686,10 @@ def _normalize_file_outputs(
         if resolved_info is None:
             if item_file_id:
                 normalized_outputs.append(
-                    {
-                        "file_id": item_file_id,
-                        "filename": item_filename or "output",
-                    }
+                    build_file_ref(
+                        file_id=item_file_id,
+                        filename=item_filename or "output",
+                    )
                 )
             continue
 
@@ -729,10 +732,12 @@ def _normalize_file_outputs(
             path_to_file_id[item_file_id] = final_file_id
 
         normalized_outputs.append(
-            {
-                "file_id": final_file_id,
-                "filename": final_filename,
-            }
+            build_file_ref(
+                file_id=final_file_id,
+                filename=final_filename,
+                mime_type=getattr(file_record, "mime_type", None),
+                size=getattr(file_record, "file_size", None),
+            )
         )
 
         for raw_path in raw_paths:
@@ -2042,6 +2047,7 @@ async def handle_chat_message(
                         file_prompt = (
                             "## UPLOADED FILES\n"
                             f"The user has uploaded {len(file_info_list)} file(s): {file_names}\n\n"
+                            f"{FILE_REF_MODEL_INSTRUCTIONS}\n\n"
                         )
 
                         if is_agent_builder:
@@ -3446,6 +3452,7 @@ async def handle_builder_chat(
             if file_ids:
                 user_message += (
                     f"\n\n[Uploaded file_ids: {file_ids}. "
+                    "Use file_id as the canonical file handle and do not guess storage paths. "
                     "Please call `create_knowledge_base_from_file` with these file_ids immediately, "
                     "then create or update the agent with the resulting collection_name.]"
                 )

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -156,6 +156,8 @@ class WebToolConfig(BaseToolConfig):
         # Ensure base_dir is in workspace_config (required by ToolFactory._create_workspace)
         if "base_dir" not in workspace_config:
             workspace_config["base_dir"] = workspace_base_dir
+        if self._user_id is not None and "user_id" not in workspace_config:
+            workspace_config["user_id"] = self._user_id
         self._workspace_config = workspace_config
         self._explicit_vision_model = vision_model
         self._explicit_llm = llm

--- a/tests/core/agent/test_browser_tools.py
+++ b/tests/core/agent/test_browser_tools.py
@@ -42,3 +42,31 @@ async def test_browser_tools_share_runtime_task_session_after_setup() -> None:
 
     assert session_tools
     assert {tool._task_id for tool in session_tools} == {"runtime-task"}
+
+
+def test_browser_task_session_mixin_defaults_to_step_scoped_session() -> None:
+    tool = BrowserTaskSessionMixin()
+    tool._task_id = "task-412"
+
+    args = tool._with_default_session(
+        {"url": "poster.html", "_xagent_step_id": "render english"}
+    )
+
+    assert args["session_id"] == "task-412:render_english"
+    assert "_xagent_step_id" not in args
+
+
+def test_browser_task_session_mixin_keeps_explicit_session() -> None:
+    tool = BrowserTaskSessionMixin()
+    tool._task_id = "task-412"
+
+    args = tool._with_default_session(
+        {
+            "url": "poster.html",
+            "session_id": "custom-session",
+            "_xagent_step_id": "render_english",
+        }
+    )
+
+    assert args["session_id"] == "custom-session"
+    assert "_xagent_step_id" not in args

--- a/tests/core/agent/test_browser_tools.py
+++ b/tests/core/agent/test_browser_tools.py
@@ -5,9 +5,11 @@ import inspect
 import pytest
 
 from xagent.core.tools.adapters.vibe.browser_use import (
+    BrowserScreenshotTool,
     BrowserTaskSessionMixin,
     create_browser_tools,
 )
+from xagent.core.workspace import TaskWorkspace
 
 
 @pytest.mark.asyncio
@@ -70,3 +72,56 @@ def test_browser_task_session_mixin_keeps_explicit_session() -> None:
 
     assert args["session_id"] == "custom-session"
     assert "_xagent_step_id" not in args
+
+
+@pytest.mark.asyncio
+async def test_browser_screenshot_returns_registered_file_ref(
+    tmp_path, monkeypatch
+) -> None:
+    def mock_create_record(self, file_id, file_path, db_session=None):
+        path_str = str(file_path)
+        resolved_str = str(file_path.resolve())
+        self._recently_registered_files[path_str] = file_id
+        self._recently_registered_files[resolved_str] = file_id
+        self._file_id_to_path[file_id] = file_path
+
+    monkeypatch.setattr(TaskWorkspace, "_create_file_record", mock_create_record)
+
+    async def fake_browser_screenshot(**kwargs):
+        return {
+            "success": True,
+            "session_id": kwargs["session_id"],
+            "screenshot": (
+                "data:image/png;base64,"
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
+                "DElEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+            ),
+            "format": "png",
+            "full_page": True,
+            "wait_for_lazy_load": False,
+            "message": "ok",
+            "error": "",
+        }
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.browser_use.browser_screenshot",
+        fake_browser_screenshot,
+    )
+
+    workspace = TaskWorkspace("test_task", str(tmp_path))
+    tool = BrowserScreenshotTool(task_id="task-412", workspace=workspace)
+
+    result = await tool.run_json_async(
+        {
+            "full_page": True,
+            "output_filename": "poster_en.png",
+            "_xagent_step_id": "render_english",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["screenshot"] == "output/poster_en.png"
+    assert result["file_id"]
+    assert result["file_ref"]["file_id"] == result["file_id"]
+    assert result["file_ref"]["relative_path"] == "output/poster_en.png"
+    assert result["markdown_link"] == (f"[poster_en.png](file:{result['file_id']})")

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -72,6 +72,27 @@ class FakeWriteFileTool:
         }
 
 
+class FakeBrowserNavigateTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "browser_navigate"
+            description = "Navigate a browser page."
+
+        self.metadata = Metadata()
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {
+            "success": True,
+            "session_id": args.get("session_id", ""),
+            "url": args["url"],
+            "title": "",
+            "message": "ok",
+        }
+
+
 class BrokenTool:
     def __init__(self) -> None:
         class Metadata:
@@ -295,6 +316,32 @@ async def test_react_pattern_runs_tool_call_then_final_answer() -> None:
     assert "use this date when forming search queries" in system_prompt
     assert "not supported by the conversation" in system_prompt
     assert "available context is insufficient" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_react_passes_runtime_step_to_browser_tool_call() -> None:
+    pattern = ReActPattern()
+    runtime = PatternRuntime()
+    runtime.active_react_step_id = "render_english_poster"
+    tool = FakeBrowserNavigateTool()
+
+    result = await pattern._execute_tool_safely(
+        {
+            "id": "call-browser",
+            "name": "browser_navigate",
+            "args": {"url": "poster_en.html"},
+        },
+        [tool],
+        runtime,
+    )
+
+    assert result["success"] is True
+    assert tool.calls == [
+        {
+            "url": "poster_en.html",
+            "_xagent_step_id": "render_english_poster",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_instance_bound_tools.py
+++ b/tests/core/tools/test_instance_bound_tools.py
@@ -147,12 +147,13 @@ async def test_tool_creation_function():
 
         # Test that tools are created and bound correctly
         assert (
-            len(file_tools) == 16
-        )  # Should have 16 file tools (13 original + 2 new editing tools + 1 translate_json tool)
+            len(file_tools) == 17
+        )  # Should have 17 file tools, including prepare_html_asset.
 
         # Test tool functionality
         write_tool = next(tool for tool in file_tools if tool.name == "write_file")
         read_tool = next(tool for tool in file_tools if tool.name == "read_file")
+        assert any(tool.name == "prepare_html_asset" for tool in file_tools)
 
         # Use the tools
         write_tool.func("function_test.txt", "Test content")
@@ -171,9 +172,9 @@ async def test_tool_creation_function():
         assert "fetch_skill_file" in skill_tool_names
         print("✅ Skill tools creation test passed!")
 
-        # Total tools: 16 file + 3 skill = 19
+        # Total tools: 17 file + 3 skill = 20
         all_tools = file_tools + skill_tools
-        assert len(all_tools) == 19
+        assert len(all_tools) == 20
 
         print("✅ Tool creation function test passed!")
 

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -256,7 +256,10 @@ class TestWorkspaceFileToolConsistency:
         assert not (workspace.output_dir.parent / "safe.png").exists()
 
     @pytest.mark.usefixtures("mock_workspace_db")
-    @pytest.mark.parametrize("assets_dir", ["/assets", "../assets", "assets/../../x"])
+    @pytest.mark.parametrize(
+        "assets_dir",
+        ["/assets", "../assets", "assets/../../x", "input/assets", "temp/assets"],
+    )
     def test_prepare_html_asset_rejects_unsafe_assets_dir(self, tmp_path, assets_dir):
         """Test that the assets directory must stay inside output."""
         workspace = TaskWorkspace("test_task", str(tmp_path))
@@ -264,7 +267,7 @@ class TestWorkspaceFileToolConsistency:
 
         source = tools.write_file("input/logo.png", "fake image")
 
-        with pytest.raises(ValueError, match="assets_dir must be a relative path"):
+        with pytest.raises(ValueError, match="assets_dir must"):
             tools.prepare_html_asset(source["file_id"], assets_dir=assets_dir)
 
 

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -270,6 +270,15 @@ class TestWorkspaceFileToolConsistency:
         with pytest.raises(ValueError, match="assets_dir must"):
             tools.prepare_html_asset(source["file_id"], assets_dir=assets_dir)
 
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_prepare_html_asset_rejects_missing_file_ref(self, tmp_path):
+        """Test that None file refs are not coerced into a filename."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            tools.prepare_html_asset(None)  # type: ignore[arg-type]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -55,6 +55,8 @@ class TestWorkspaceFileToolConsistency:
         assert write_result["markdown_link"] == (
             f"[{test_filename}](file:{write_result['file_id']})"
         )
+        assert write_result["file_ref"]["file_id"] == write_result["file_id"]
+        assert write_result["file_ref"]["relative_path"] == "output/test_file.txt"
 
         # Verify file exists in output directory
         output_file = workspace.output_dir / test_filename

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -45,6 +45,15 @@ class TestWorkspaceFileToolConsistency:
         write_result = tools.write_file(test_filename, test_content)
         assert write_result["success"] is True
         assert isinstance(write_result.get("file_id"), str)
+        assert write_result["filename"] == test_filename
+        assert write_result["mime_type"] == "text/plain"
+        assert write_result["size"] == len(test_content)
+        assert write_result["preview_url"].endswith(write_result["file_id"])
+        assert write_result["download_url"].endswith(write_result["file_id"])
+        assert write_result["public_preview_url"].endswith(write_result["file_id"])
+        assert write_result["markdown_link"] == (
+            f"[{test_filename}](file:{write_result['file_id']})"
+        )
 
         # Verify file exists in output directory
         output_file = workspace.output_dir / test_filename
@@ -197,6 +206,66 @@ class TestWorkspaceFileToolConsistency:
 
         read_content = tools.read_file(f"file:{file_id}")
         assert read_content == test_content
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_prepare_html_asset_copies_file_id_to_output_assets(self, tmp_path):
+        """Test that file_id assets get copied into the output HTML bundle."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/logo.png", "fake image")
+        result = tools.prepare_html_asset(source["file_id"])
+
+        assert result["success"] is True
+        assert result["source_file_id"] == source["file_id"]
+        assert isinstance(result["asset_file_id"], str)
+        assert result["html_src"] == "assets/logo.png"
+        assert result["filename"] == "logo.png"
+        assert result["mime_type"] == "image/png"
+        assert result["relative_path"] == "output/assets/logo.png"
+        assert (workspace.output_dir / "assets" / "logo.png").read_text() == (
+            "fake image"
+        )
+        assert tools.read_file(f"file:{result['asset_file_id']}") == "fake image"
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_prepare_html_asset_accepts_file_link_prefix(self, tmp_path):
+        """Test that file:file_id references are accepted for HTML assets."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/photo.jpg", "fake jpg")
+        result = tools.prepare_html_asset(f"file:{source['file_id']}")
+
+        assert result["success"] is True
+        assert result["html_src"] == "assets/photo.jpg"
+        assert (workspace.output_dir / "assets" / "photo.jpg").exists()
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_prepare_html_asset_sanitizes_alias(self, tmp_path):
+        """Test that aliases cannot escape the assets directory."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/logo.png", "fake image")
+        result = tools.prepare_html_asset(source["file_id"], alias="../../safe.png")
+
+        assert result["html_src"] == "assets/safe.png"
+        assert result["relative_path"] == "output/assets/safe.png"
+        assert (workspace.output_dir / "assets" / "safe.png").exists()
+        assert not (workspace.output_dir.parent / "safe.png").exists()
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    @pytest.mark.parametrize("assets_dir", ["/assets", "../assets", "assets/../../x"])
+    def test_prepare_html_asset_rejects_unsafe_assets_dir(self, tmp_path, assets_dir):
+        """Test that the assets directory must stay inside output."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/logo.png", "fake image")
+
+        with pytest.raises(ValueError, match="assets_dir must be a relative path"):
+            tools.prepare_html_asset(source["file_id"], assets_dir=assets_dir)
 
 
 if __name__ == "__main__":

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -2,6 +2,8 @@
 Tests for workspace file tool consistency between write and read operations.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from xagent.core.tools.adapters.vibe.workspace_file_tool import WorkspaceFileTools
@@ -50,7 +52,6 @@ class TestWorkspaceFileToolConsistency:
         assert write_result["size"] == len(test_content)
         assert write_result["preview_url"].endswith(write_result["file_id"])
         assert write_result["download_url"].endswith(write_result["file_id"])
-        assert write_result["public_preview_url"].endswith(write_result["file_id"])
         assert write_result["markdown_link"] == (
             f"[{test_filename}](file:{write_result['file_id']})"
         )
@@ -214,7 +215,7 @@ class TestWorkspaceFileToolConsistency:
         tools = WorkspaceFileTools(workspace)
 
         source = tools.write_file("input/logo.png", "fake image")
-        result = tools.prepare_html_asset(source["file_id"])
+        result = tools.prepare_html_asset(source["file_id"], "index.html")
 
         assert result["success"] is True
         assert result["source_file_id"] == source["file_id"]
@@ -235,7 +236,7 @@ class TestWorkspaceFileToolConsistency:
         tools = WorkspaceFileTools(workspace)
 
         source = tools.write_file("input/photo.jpg", "fake jpg")
-        result = tools.prepare_html_asset(f"file:{source['file_id']}")
+        result = tools.prepare_html_asset(f"file:{source['file_id']}", "index.html")
 
         assert result["success"] is True
         assert result["html_src"] == "assets/photo.jpg"
@@ -248,7 +249,9 @@ class TestWorkspaceFileToolConsistency:
         tools = WorkspaceFileTools(workspace)
 
         source = tools.write_file("input/logo.png", "fake image")
-        result = tools.prepare_html_asset(source["file_id"], alias="../../safe.png")
+        result = tools.prepare_html_asset(
+            source["file_id"], "index.html", alias="../../safe.png"
+        )
 
         assert result["html_src"] == "assets/safe.png"
         assert result["relative_path"] == "output/assets/safe.png"
@@ -257,18 +260,51 @@ class TestWorkspaceFileToolConsistency:
 
     @pytest.mark.usefixtures("mock_workspace_db")
     @pytest.mark.parametrize(
-        "assets_dir",
-        ["/assets", "../assets", "assets/../../x", "input/assets", "temp/assets"],
+        "assets_subdir",
+        ["/assets", "../assets", "assets/../../x"],
     )
-    def test_prepare_html_asset_rejects_unsafe_assets_dir(self, tmp_path, assets_dir):
+    def test_prepare_html_asset_rejects_unsafe_assets_subdir(
+        self, tmp_path, assets_subdir
+    ):
         """Test that the assets directory must stay inside output."""
         workspace = TaskWorkspace("test_task", str(tmp_path))
         tools = WorkspaceFileTools(workspace)
 
         source = tools.write_file("input/logo.png", "fake image")
 
-        with pytest.raises(ValueError, match="assets_dir must"):
-            tools.prepare_html_asset(source["file_id"], assets_dir=assets_dir)
+        with pytest.raises(ValueError, match="assets_subdir must"):
+            tools.prepare_html_asset(
+                source["file_id"], "index.html", assets_subdir=assets_subdir
+            )
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_prepare_html_asset_uses_html_path_for_relative_src(self, tmp_path):
+        """Test that nested HTML outputs get local relative asset paths."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/logo.png", "fake image")
+        result = tools.prepare_html_asset(
+            source["file_id"], "reports/index.html", alias="logo.png"
+        )
+
+        assert result["html_src"] == "assets/logo.png"
+        assert result["relative_path"] == "output/reports/assets/logo.png"
+        assert (workspace.output_dir / "reports" / "assets" / "logo.png").exists()
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    @pytest.mark.parametrize(
+        "html_path", ["/index.html", "../index.html", "input/x.html"]
+    )
+    def test_prepare_html_asset_rejects_unsafe_html_path(self, tmp_path, html_path):
+        """Test that HTML target paths must stay inside output."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        source = tools.write_file("input/logo.png", "fake image")
+
+        with pytest.raises(ValueError, match="html_path must"):
+            tools.prepare_html_asset(source["file_id"], html_path)
 
     @pytest.mark.usefixtures("mock_workspace_db")
     def test_prepare_html_asset_rejects_missing_file_ref(self, tmp_path):
@@ -277,7 +313,40 @@ class TestWorkspaceFileToolConsistency:
         tools = WorkspaceFileTools(workspace)
 
         with pytest.raises(FileNotFoundError, match="File not found"):
-            tools.prepare_html_asset(None)  # type: ignore[arg-type]
+            tools.prepare_html_asset(None, "index.html")  # type: ignore[arg-type]
+
+    def test_resolve_file_id_rejects_other_user_records(self, tmp_path, mocker):
+        """Test that DB file_id lookup is scoped to the workspace owner."""
+        external_file = tmp_path / "other-user.txt"
+        external_file.write_text("private")
+        workspace = TaskWorkspace("web_task_10", str(tmp_path))
+        workspace.owner_user_id = 1
+
+        class FakeQuery:
+            def filter(self, *_args):
+                return self
+
+            def first(self):
+                return SimpleNamespace(
+                    file_id="foreign-file",
+                    user_id=2,
+                    task_id=None,
+                    storage_path=str(external_file),
+                )
+
+        class FakeSession:
+            def query(self, *_args):
+                return FakeQuery()
+
+            def close(self):
+                pass
+
+        mocker.patch(
+            "xagent.core.storage.manager.create_db_session",
+            return_value=FakeSession(),
+        )
+
+        assert workspace.resolve_file_id("foreign-file") is None
 
 
 if __name__ == "__main__":

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -107,7 +107,7 @@ def test_build_uploaded_files_context_includes_agent_builder_kb_instruction():
     assert "FAQ.docx: file_id=file-123" in context
     assert "## FILE REFERENCES" in context
     assert "Treat file_id as the canonical file handle" in context
-    assert "call prepare_html_asset(file_id, alias) first" in context
+    assert "call prepare_html_asset(file_id, html_path, alias) first" in context
     assert "create_knowledge_base_from_file" in context
     assert 'file_ids = ["file-123"]' in context
     assert "Do NOT ask the user to upload again" in context

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -105,6 +105,9 @@ def test_build_uploaded_files_context_includes_agent_builder_kb_instruction():
     )
 
     assert "FAQ.docx: file_id=file-123" in context
+    assert "## FILE REFERENCES" in context
+    assert "Treat file_id as the canonical file handle" in context
+    assert "call prepare_html_asset(file_id, alias) first" in context
     assert "create_knowledge_base_from_file" in context
     assert 'file_ids = ["file-123"]' in context
     assert "Do NOT ask the user to upload again" in context
@@ -118,6 +121,8 @@ def test_append_uploaded_files_context_to_message_is_idempotent():
 
     message = _append_uploaded_files_context_to_message("Upload File", context)
     assert message.startswith("Upload File\n\n## UPLOADED FILES")
+    assert "Do not guess storage paths" in message
+    assert "Use the returned html_src inside HTML" in message
     assert _append_uploaded_files_context_to_message(message, context) == message
 
 

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -10,6 +10,7 @@ from xagent.web.api.websocket import (
     _append_uploaded_files_context_to_message,
     _build_uploaded_files_context,
     _display_message_for_user,
+    _normalize_file_outputs,
     _selected_file_refs_from_task,
     handle_file_upload_for_task,
 )
@@ -242,6 +243,98 @@ def test_selected_file_refs_from_task_ignores_missing_config(db_session):
     task = _create_task(db_session, task_id=10, user_id=1)
 
     assert _selected_file_refs_from_task(task, db_session) == []
+
+
+def test_normalize_file_outputs_rejects_foreign_storage_path_record(
+    db_session,
+    tmp_path,
+    monkeypatch,
+):
+    uploads_dir = tmp_path / "uploads"
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
+    _create_user(db_session, 1, "owner")
+    _create_user(db_session, 2, "other")
+    _create_task(db_session, task_id=20, user_id=1)
+    _create_task(db_session, task_id=10, user_id=2)
+    foreign_path = uploads_dir / "user_2" / "web_task_10" / "output" / "secret.txt"
+    foreign_path.parent.mkdir(parents=True)
+    foreign_path.write_text("secret")
+    db_session.add(
+        UploadedFile(
+            file_id="foreign-output",
+            user_id=2,
+            task_id=10,
+            filename="secret.txt",
+            storage_path=str(foreign_path),
+            mime_type="text/plain",
+            file_size=len("secret"),
+        )
+    )
+    db_session.flush()
+
+    normalized_outputs, path_to_file_id = _normalize_file_outputs(
+        db_session,
+        task_id=20,
+        task_user_id=1,
+        file_outputs=[{"path": str(foreign_path)}],
+    )
+
+    assert normalized_outputs == []
+    assert path_to_file_id == {}
+
+
+def test_normalize_file_outputs_rejects_foreign_untracked_storage_path(
+    db_session,
+    tmp_path,
+    monkeypatch,
+):
+    uploads_dir = tmp_path / "uploads"
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
+    _create_user(db_session, 1, "owner")
+    _create_task(db_session, task_id=20, user_id=1)
+    foreign_path = uploads_dir / "user_2" / "web_task_10" / "output" / "secret.txt"
+    foreign_path.parent.mkdir(parents=True)
+    foreign_path.write_text("secret")
+
+    normalized_outputs, path_to_file_id = _normalize_file_outputs(
+        db_session,
+        task_id=20,
+        task_user_id=1,
+        file_outputs=[{"path": str(foreign_path)}],
+    )
+
+    assert normalized_outputs == []
+    assert path_to_file_id == {}
+    assert db_session.query(UploadedFile).count() == 0
+
+
+def test_normalize_file_outputs_registers_current_task_output_path(
+    db_session,
+    tmp_path,
+    monkeypatch,
+):
+    uploads_dir = tmp_path / "uploads"
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
+    _create_user(db_session, 1, "owner")
+    _create_task(db_session, task_id=20, user_id=1)
+    output_path = uploads_dir / "user_1" / "web_task_20" / "output" / "report.txt"
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text("report")
+
+    normalized_outputs, path_to_file_id = _normalize_file_outputs(
+        db_session,
+        task_id=20,
+        task_user_id=1,
+        file_outputs=[{"path": str(output_path), "filename": "report.txt"}],
+    )
+
+    assert len(normalized_outputs) == 1
+    assert normalized_outputs[0]["filename"] == "report.txt"
+    assert path_to_file_id[str(output_path)] == normalized_outputs[0]["file_id"]
+    file_record = db_session.query(UploadedFile).one()
+    assert file_record.user_id == 1
+    assert file_record.task_id == 20
+    assert file_record.storage_path == str(output_path)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared FileRef contract for model/API-facing file references
- return FileRef metadata from workspace file writes and websocket file outputs
- add prepare_html_asset so models can copy file_id assets into HTML output bundles and use returned html_src
- inject FileRef usage rules into uploaded-file model context

## Tests
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent-file-id-contract/src pytest tests/web/test_websocket_uploaded_files_context.py -q
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent-file-id-contract/src pytest tests/core/tools/test_workspace_file_tool_consistency.py tests/core/tools/test_workspace_file_operations.py -q
- pre-commit hooks during git commit