### PR TITLE
fix: keep task thread id across follow-up turns

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -860,26 +860,43 @@ async def execute_task_background(
     user_message: str,
     context: Dict[str, Any],
     agent_manager: Any,
-    user: Any,
-    task: Any,
-    db: Session,
-    force_fresh_execution: bool = False,
+    user_id: int | None,
+    before_message_id: int | None = None,
     llm_user_message: Optional[str] = None,
 ) -> None:
     """Execute task in background without blocking WebSocket message loop"""
+    from ..models.database import get_db
     from ..models.task import Task, TaskStatus
-    from ..services.chat_history_service import persist_assistant_message
+    from ..models.user import User
+    from ..services.chat_history_service import (
+        load_task_transcript,
+        persist_assistant_message,
+    )
+    from ..services.task_execution_context_service import (
+        load_task_execution_recovery_state,
+    )
 
     # Wait for previous background task to complete
     await background_task_manager.wait_for_previous(task_id)
 
+    db_gen = get_db()
     try:
+        db = next(db_gen)
         logger.info(f"Background task execution started for task {task_id}")
 
-        # Set up user context
-        user_id = int(user.id) if user else None
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is None:
+            raise ValueError(f"Task {task_id} not found")
 
-        with UserContext(user_id):
+        task_user_id = _task_user_id(task)
+        effective_user_id = user_id if user_id is not None else task_user_id
+        user = (
+            db.query(User).filter(User.id == effective_user_id).first()
+            if effective_user_id is not None
+            else None
+        )
+
+        with UserContext(effective_user_id):
             # Get agent service
             agent_service = await agent_manager.get_agent_for_task(
                 task_id, db, user=user
@@ -888,9 +905,22 @@ async def execute_task_background(
                 agent_service.set_outbound_message_handler(
                     make_agent_outbound_handler(task_id)
                 )
+            if before_message_id is not None:
+                conversation_history = load_task_transcript(
+                    db,
+                    task_id,
+                    before_message_id=before_message_id,
+                )
+                agent_service.set_conversation_history(conversation_history)
+            recovery_state = await load_task_execution_recovery_state(db, task_id)
+            execution_context_messages = recovery_state.get("messages", [])
+            agent_service.set_execution_context_messages(execution_context_messages)
+            agent_service.set_recovered_skill_context(
+                recovery_state.get("skill_context")
+            )
 
-            # Execute task with automatic token tracking
-            actual_task_id = None if force_fresh_execution else str(task_id)
+            # Execute the next turn under the same task/thread id.
+            actual_task_id = str(task_id)
             task_for_agent = llm_user_message or user_message
             result = await agent_manager.execute_task(
                 agent_service=agent_service,
@@ -901,7 +931,6 @@ async def execute_task_background(
                 db_session=db,
             )
 
-        task_user_id = _task_user_id(task)
         if task_user_id is not None:
             normalized_outputs, path_to_file_id = _normalize_file_outputs(
                 db,
@@ -931,14 +960,11 @@ async def execute_task_background(
 
         # Task execution result is logged by ConsoleTraceHandler, no need for duplicate logs
 
-        # Update task status (get new session to avoid expiration)
-        from ..models.database import get_db
-
-        db_gen = get_db()
-        db_new = next(db_gen)
-        waiting_for_control = False
-        final_task_status = task.status.value
+        db_new_gen = get_db()
         try:
+            db_new = next(db_new_gen)
+            waiting_for_control = False
+            final_task_status = task.status.value
             task_updated = db_new.query(Task).filter(Task.id == task_id).first()
             if task_updated:
                 # Caller is responsible for the lease lifecycle (acquire +
@@ -1004,7 +1030,10 @@ async def execute_task_background(
                         else None,
                     )
         finally:
-            db_new.close()
+            try:
+                next(db_new_gen)
+            except StopIteration:
+                pass
 
         # Note: trace_task_completion is handled by the agent execution logic (e.g., dag_plan_execute.py)
 
@@ -1071,6 +1100,10 @@ async def execute_task_background(
     finally:
         # Clean up background task record
         background_task_manager.cleanup_task(task_id)
+        try:
+            next(db_gen)
+        except StopIteration:
+            pass
 
 
 async def execute_continuation_background(
@@ -1932,12 +1965,6 @@ async def handle_chat_message(
 
         # Call Agent to handle - use same agent manager as chat API
         try:
-            from ..services.chat_history_service import (
-                load_task_transcript,
-            )
-            from ..services.task_execution_context_service import (
-                load_task_execution_recovery_state,
-            )
             from .chat import get_agent_manager
 
             # Get database session
@@ -2170,47 +2197,41 @@ async def handle_chat_message(
 
                 # DAG plan-execute will automatically send user_message trace event
 
-                # Get agent service
-                agent_service = await get_agent_manager().get_agent_for_task(
-                    task_id, db, user=user
-                )
-                if hasattr(agent_service, "set_outbound_message_handler"):
-                    agent_service.set_outbound_message_handler(
-                        make_agent_outbound_handler(task_id)
-                    )
-
-                # NOTE: the user message is persisted inside
-                # ``TaskTurnOrchestrator.begin_turn`` below as part of
-                # the atomic transition (claim + persist + schedule
-                # commit together). We previously persisted it inline
-                # here and had to best-effort-delete on schedule
-                # rejection; that's now handled by begin_turn's
-                # transactional rollback. ``persisted_user_message`` is
-                # populated after begin_turn returns by reading back
-                # the latest user-role message — needed for the
-                # transcript-history slice below.
-                persisted_user_message = None
+                # The user message is persisted inside
+                # ``TaskTurnOrchestrator.begin_turn`` as part of the atomic
+                # transition (claim + persist + schedule commit together).
 
                 # Check if there's an old task running (PAUSED, WAITING_FOR_USER, or RUNNING status)
                 # If so, use continuation mechanism; otherwise execute normally
-                dag_pattern = (
-                    agent_service.get_dag_pattern()
-                    if hasattr(agent_service, "get_dag_pattern")
-                    else None
-                )
-
                 # Only use continuation when task is active and has old task
                 task_is_running = task.status in [
                     TaskStatus.PAUSED,
                     TaskStatus.WAITING_FOR_USER,
                     TaskStatus.RUNNING,
                 ]
-                supports_live_control = getattr(
-                    agent_service, "supports_live_control", lambda: False
-                )()
-                has_continuation = dag_pattern and hasattr(
-                    dag_pattern, "request_continuation"
-                )
+                agent_service = None
+                dag_pattern = None
+                supports_live_control = False
+                has_continuation = False
+                if task_is_running:
+                    agent_service = await get_agent_manager().get_agent_for_task(
+                        task_id, db, user=user
+                    )
+                    if hasattr(agent_service, "set_outbound_message_handler"):
+                        agent_service.set_outbound_message_handler(
+                            make_agent_outbound_handler(task_id)
+                        )
+                    dag_pattern = (
+                        agent_service.get_dag_pattern()
+                        if hasattr(agent_service, "get_dag_pattern")
+                        else None
+                    )
+                    supports_live_control = getattr(
+                        agent_service, "supports_live_control", lambda: False
+                    )()
+                    has_continuation = bool(
+                        dag_pattern and hasattr(dag_pattern, "request_continuation")
+                    )
 
                 if task_is_running and has_continuation and not supports_live_control:
                     # Use continuation: old task will handle at appropriate time
@@ -2293,6 +2314,7 @@ async def handle_chat_message(
                     return
                 if task_is_running and supports_live_control:
                     logger.info(f"Using agent message control for task {task_id}")
+                    assert agent_service is not None
                     posted = await agent_service.post_user_message(
                         str(task_id),
                         user_message_for_llm,
@@ -2335,35 +2357,6 @@ async def handle_chat_message(
                     logger.info(
                         f"Task {task_id} starting new execution turn (status: {task.status.value})"
                     )
-
-                    if persisted_user_message is not None:
-                        conversation_history = load_task_transcript(
-                            db,
-                            task_id,
-                            before_message_id=int(persisted_user_message.id),
-                        )
-                        agent_service.set_conversation_history(conversation_history)
-                    recovery_state = await load_task_execution_recovery_state(
-                        db, task_id
-                    )
-                    execution_context_messages = recovery_state.get("messages", [])
-                    agent_service.set_execution_context_messages(
-                        execution_context_messages
-                    )
-                    agent_service.set_recovered_skill_context(
-                        recovery_state.get("skill_context")
-                    )
-
-                    # IMPORTANT: Check if task was completed/failed BEFORE updating status
-                    # This is needed to force fresh execution instead of continuation
-                    was_completed_or_failed = task.status in [
-                        TaskStatus.COMPLETED,
-                        TaskStatus.FAILED,
-                    ]
-                    if was_completed_or_failed:
-                        logger.info(
-                            f"🔄 Task {task_id} was {task.status.value}, will force fresh execution"
-                        )
 
                     # The execution wrapper acquires the lease just before it
                     # starts running. Avoid acquiring it during setup so setup
@@ -2436,14 +2429,6 @@ async def handle_chat_message(
                     if hasattr(task, "examples") and task.examples:
                         context["examples"] = task.examples
 
-                    # For completed/failed tasks, we need to force a fresh execution
-                    # by not passing task_id to agent.execute_task
-                    force_fresh_execution = was_completed_or_failed
-                    if force_fresh_execution:
-                        logger.info(
-                            f"Confirmed: Task {task_id} was completed/failed, forcing fresh execution"
-                        )
-
                     # WS builds the display/execution payload here and
                     # delegates the full new-turn transition to the
                     # shared orchestrator. ``begin_turn`` owns the
@@ -2452,7 +2437,6 @@ async def handle_chat_message(
                     # single-commit transaction, and the lease-aware bg
                     # schedule -- so WS and /v1 SDK use one turn-
                     # lifecycle state machine.
-                    from ..models.chat_message import TaskChatMessage
                     from ..services.task_orchestrator import (
                         TaskTurnError,
                         TaskTurnOrchestrator,
@@ -2465,8 +2449,8 @@ async def handle_chat_message(
                         execution_message=user_message_for_llm,
                     )
                     # WS path only has two legal entries into begin_turn:
-                    #   PENDING                  → CREATE, no force_fresh
-                    #   COMPLETED / FAILED       → APPEND, force_fresh=True
+                    #   PENDING                  → CREATE
+                    #   COMPLETED / FAILED       → APPEND
                     # PAUSED / WAITING_FOR_USER / RUNNING should have been
                     # intercepted by the continuation path above. Reaching
                     # this branch with any of them is an upstream-dispatch
@@ -2480,7 +2464,7 @@ async def handle_chat_message(
                         TaskStatus.FAILED,
                     ):
                         turn_kind = TurnKind.APPEND
-                        turn_force_fresh = True  # WS always re-engages fresh
+                        turn_force_fresh = False
                     else:
                         logger.error(
                             f"WS schedule reached for task {task_id} with "
@@ -2509,17 +2493,6 @@ async def handle_chat_message(
                             context=context,
                         )
                         logger.info(f"Task {task_id} started in background")
-                        # Fetch the message begin_turn just persisted so the
-                        # transcript-history slice below can use its id.
-                        persisted_user_message = (
-                            db.query(TaskChatMessage)
-                            .filter(
-                                TaskChatMessage.task_id == task_id,
-                                TaskChatMessage.role == "user",
-                            )
-                            .order_by(TaskChatMessage.id.desc())
-                            .first()
-                        )
                     except TaskTurnError as busy_err:
                         # begin_turn's atomic transaction rolls back on
                         # bg_inflight / busy — neither the status flip

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -918,6 +918,11 @@ async def execute_task_background(
             agent_service.set_recovered_skill_context(
                 recovery_state.get("skill_context")
             )
+            _register_uploaded_files_for_agent(
+                agent_service,
+                context.get("file_info", []),
+                db,
+            )
 
             # Execute the next turn under the same task/thread id.
             actual_task_id = str(task_id)
@@ -1707,10 +1712,7 @@ async def handle_file_upload_for_task(
 ) -> dict:
     """Handle file upload for task"""
     try:
-        from pathlib import Path
-
         from ..models.uploaded_file import UploadedFile
-        from .chat import get_agent_manager
 
         uploaded_files = []
         file_info_list = []
@@ -1726,12 +1728,6 @@ async def handle_file_upload_for_task(
                 task_id,
             )
             return {"uploaded_files": [], "file_info_list": []}
-
-        # Get agent
-        agent_service = await get_agent_manager().get_agent_for_task(
-            task_id, db, user=user
-        )
-        logger.info(f"🤖 Got agent service for task {task_id}")
 
         for file_info in files:
             file_id = file_info.get("file_id")
@@ -1769,9 +1765,6 @@ async def handle_file_upload_for_task(
                 continue
 
             try:
-                # Add file to workspace, use original filename
-                from pathlib import Path
-
                 # Use normalized filename instead of original
                 original_file_name = Path(file_name).name
                 normalized_file_name = normalize_filename(original_file_name)
@@ -1785,60 +1778,10 @@ async def handle_file_upload_for_task(
                 target_path = source_path
                 uploaded_files.append(str(target_path))
 
-                workspace_link_path: Path | None = None
-                if agent_service.workspace:
-                    try:
-                        input_dir = Path(agent_service.workspace.input_dir)
-                        input_dir.mkdir(parents=True, exist_ok=True)
-                        candidate = input_dir / normalized_file_name
-                        # If something with the same name already exists in
-                        # input/, give the link a unique numeric suffix.
-                        suffix_idx = 1
-                        stem, ext = candidate.stem, candidate.suffix
-                        while candidate.exists() or candidate.is_symlink():
-                            try:
-                                if candidate.resolve() == source_path.resolve():
-                                    break  # already pointing at the right file
-                            except OSError:
-                                pass
-                            candidate = input_dir / f"{stem}_{suffix_idx}{ext}"
-                            suffix_idx += 1
-                        if not (candidate.exists() or candidate.is_symlink()):
-                            try:
-                                candidate.symlink_to(source_path.resolve())
-                                workspace_link_path = candidate
-                            except OSError as link_err:
-                                # Fall back to copy when symlinks aren't
-                                # supported (e.g. some Windows configs).
-                                logger.warning(
-                                    f"symlink failed ({link_err}); copying "
-                                    f"{source_path.name} into workspace"
-                                )
-
-                                shutil.copy2(source_path, candidate)
-                                workspace_link_path = candidate
-                        else:
-                            workspace_link_path = candidate
-                    except Exception as link_err:  # noqa: BLE001
-                        logger.warning(
-                            f"Could not expose {source_path.name} in task "
-                            f"workspace input/: {link_err}"
-                        )
-
                 if file_record.task_id is None:
                     file_record.task_id = task_id
 
                 db.flush()
-
-                if agent_service.workspace:
-                    # Pass absolute path so resolve_path() in register_file
-                    # doesn't mistake a CWD-relative storage_path for a
-                    # workspace-relative one (looking under output/...).
-                    agent_service.workspace.register_file(
-                        str(target_path.resolve()),
-                        file_id=str(file_record.file_id),
-                        db_session=db,
-                    )
 
                 # Build file info using normalized filename
                 file_info_list.append(
@@ -1849,15 +1792,12 @@ async def handle_file_upload_for_task(
                         "size": file_size,
                         "type": file_type,
                         "path": str(target_path),
-                        "workspace_path": (
-                            str(workspace_link_path) if workspace_link_path else None
-                        ),
+                        "workspace_path": None,
                     }
                 )
 
                 logger.info(
-                    f"File registered: storage={target_path} "
-                    f"input_link={workspace_link_path} "
+                    f"File staged: storage={target_path} "
                     f"(original={original_file_name} normalized={normalized_file_name})"
                 )
 
@@ -1872,6 +1812,73 @@ async def handle_file_upload_for_task(
     except Exception as e:
         logger.error(f"Error handling file upload for task {task_id}: {e}")
         raise
+
+
+def _register_uploaded_files_for_agent(
+    agent_service: Any,
+    file_info_list: List[Dict[str, Any]],
+    db: Session,
+) -> None:
+    """Expose staged upload records to the agent workspace under its DB session."""
+    workspace = getattr(agent_service, "workspace", None)
+    if not workspace:
+        return
+
+    input_dir = Path(workspace.input_dir)
+    input_dir.mkdir(parents=True, exist_ok=True)
+
+    for file_info in file_info_list:
+        file_id = str(file_info.get("file_id") or "")
+        source_path = Path(str(file_info.get("path") or ""))
+        if not file_id or not source_path.exists():
+            logger.warning(
+                "Skipping unavailable uploaded file for workspace: %s", file_info
+            )
+            continue
+
+        normalized_file_name = normalize_filename(
+            Path(str(file_info.get("name") or source_path.name)).name
+        )
+        candidate = input_dir / normalized_file_name
+        suffix_idx = 1
+        stem, ext = candidate.stem, candidate.suffix
+        while candidate.exists() or candidate.is_symlink():
+            try:
+                if candidate.resolve() == source_path.resolve():
+                    break
+            except OSError:
+                pass
+            candidate = input_dir / f"{stem}_{suffix_idx}{ext}"
+            suffix_idx += 1
+
+        workspace_link_path: Path | None
+        if candidate.exists() or candidate.is_symlink():
+            workspace_link_path = candidate
+        else:
+            try:
+                candidate.symlink_to(source_path.resolve())
+                workspace_link_path = candidate
+            except OSError as link_err:
+                logger.warning(
+                    f"symlink failed ({link_err}); copying "
+                    f"{source_path.name} into workspace"
+                )
+                shutil.copy2(source_path, candidate)
+                workspace_link_path = candidate
+
+        # Pass absolute path so resolve_path() in register_file doesn't mistake
+        # a CWD-relative storage_path for a workspace-relative one.
+        workspace.register_file(
+            str(source_path.resolve()),
+            file_id=file_id,
+            db_session=db,
+        )
+        file_info["workspace_path"] = str(workspace_link_path)
+        logger.info(
+            "File registered for agent workspace: storage=%s input_link=%s",
+            source_path,
+            workspace_link_path,
+        )
 
 
 async def get_authenticated_user(

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -220,7 +220,6 @@ class FeishuBotInstance:
                     .first()
                 )
 
-            was_completed_or_failed = False
             if not task:
                 is_new_task = True
 
@@ -243,10 +242,6 @@ class FeishuBotInstance:
                 self._save_active_tasks()
             else:
                 is_new_task = False
-                was_completed_or_failed = task.status in [
-                    TaskStatus.COMPLETED,
-                    TaskStatus.FAILED,
-                ]
                 task.status = TaskStatus.PENDING
                 db.commit()
 
@@ -308,8 +303,7 @@ class FeishuBotInstance:
 
             from ...user_isolated_memory import UserContext
 
-            force_fresh_execution = not is_new_task and was_completed_or_failed
-            actual_task_id = None if force_fresh_execution else str(task.id)
+            actual_task_id = str(task.id)
 
             with UserContext(int(user.id)):
                 result = await agent_manager.execute_task(

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -335,7 +335,6 @@ class TelegramBotInstance:
                     )
 
                 is_new_task = False
-                was_completed_or_failed = False
                 if not task:
                     task_title = text if text else "Untitled Task"
                     if len(task_title) > 50:
@@ -356,10 +355,6 @@ class TelegramBotInstance:
                     self._save_active_tasks()
                     is_new_task = True
                 else:
-                    was_completed_or_failed = task.status in [
-                        TaskStatus.COMPLETED,
-                        TaskStatus.FAILED,
-                    ]
                     task.status = TaskStatus.PENDING
                     db.commit()
 
@@ -430,8 +425,7 @@ class TelegramBotInstance:
 
                 from ...user_isolated_memory import UserContext
 
-                force_fresh_execution = not is_new_task and was_completed_or_failed
-                actual_task_id = None if force_fresh_execution else str(task.id)
+                actual_task_id = str(task.id)
 
                 with UserContext(int(user.id)):  # type: ignore
                     result = await agent_manager.execute_task(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -287,12 +287,17 @@ class TaskTurnOrchestrator:
 
             from .chat_history_service import persist_user_message_no_commit
 
-            persist_user_message_no_commit(
+            persisted_message = persist_user_message_no_commit(
                 db=db,
                 task_id=task_id,
                 user_id=int(user.id),
                 content=payload.transcript_message,
             )
+            if persisted_message is not None:
+                db.flush()
+                before_message_id = int(persisted_message.id)
+            else:
+                before_message_id = None
             db.commit()
         except TaskTurnError:
             raise
@@ -309,6 +314,7 @@ class TaskTurnOrchestrator:
             payload=payload,
             force_fresh=force_fresh,
             context=context,
+            before_message_id=before_message_id,
         )
 
 
@@ -494,6 +500,7 @@ async def _schedule_bg(
     payload: TaskTurnPayload,
     force_fresh: bool,
     context: Optional[Dict[str, Any]],
+    before_message_id: Optional[int] = None,
 ) -> "asyncio.Task[None]":
     """Lease-aware bg scheduler.
 
@@ -557,10 +564,8 @@ async def _schedule_bg(
                     user_message=payload.transcript_message,
                     context=context or {},
                     agent_manager=_get_agent_manager(),
-                    user=bg_user_row,
-                    task=bg_task_row,
-                    db=bg_db,
-                    force_fresh_execution=force_fresh,
+                    user_id=int(bg_user_row.id),
+                    before_message_id=before_message_id,
                     llm_user_message=payload.execution_message,
                 )
                 try:

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.trace import get_display_user_message
+from xagent.web.api import websocket as websocket_api
 from xagent.web.api.chat import _build_task_agent_config
 from xagent.web.api.websocket import (
     _append_uploaded_files_context_to_message,
@@ -12,9 +13,11 @@ from xagent.web.api.websocket import (
     _display_message_for_user,
     _normalize_file_outputs,
     _selected_file_refs_from_task,
+    execute_task_background,
     handle_file_upload_for_task,
 )
 from xagent.web.models import Base
+from xagent.web.models import database as database_models
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -50,13 +53,14 @@ def _create_task(
     task_id: int,
     user_id: int,
     selected_file_ids: list[str] | None = None,
+    status: TaskStatus = TaskStatus.PENDING,
 ) -> Task:
     task = Task(
         id=task_id,
         user_id=user_id,
         title=f"task-{task_id}",
         description="task",
-        status=TaskStatus.PENDING,
+        status=status,
         agent_config=(
             {"selected_file_ids": selected_file_ids}
             if selected_file_ids is not None
@@ -91,6 +95,103 @@ def _create_uploaded_file(
     db.add(file_record)
     db.flush()
     return file_record
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_status",
+    [TaskStatus.COMPLETED, TaskStatus.FAILED],
+)
+async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
+    db_session,
+    monkeypatch,
+    terminal_status,
+):
+    user = _create_user(db_session, 1, "owner")
+    _create_task(
+        db_session,
+        task_id=10,
+        user_id=1,
+        status=terminal_status,
+    )
+    captured: dict[str, object] = {}
+
+    class BackgroundTaskManager:
+        async def wait_for_previous(self, task_id):
+            captured["waited_for"] = task_id
+
+        def cleanup_task(self, task_id):
+            captured["cleaned_up"] = task_id
+
+    class BroadcastManager:
+        async def broadcast_to_task(self, event, task_id):
+            captured["broadcast_task_id"] = task_id
+
+    class AgentService:
+        def set_conversation_history(self, history):
+            captured["conversation_history"] = history
+
+        def set_execution_context_messages(self, messages):
+            captured["execution_context_messages"] = messages
+
+        def set_recovered_skill_context(self, skill_context):
+            captured["skill_context"] = skill_context
+
+    class AgentManager:
+        async def get_agent_for_task(self, task_id, db, user=None):
+            captured["agent_db"] = db
+            return AgentService()
+
+        async def execute_task(
+            self,
+            *,
+            agent_service,
+            task,
+            context,
+            task_id,
+            tracking_task_id,
+            db_session,
+        ):
+            captured["agent_task"] = task
+            captured["agent_task_id"] = task_id
+            captured["tracking_task_id"] = tracking_task_id
+            return {"success": True, "output": "ok", "file_outputs": []}
+
+    def fake_get_db():
+        yield db_session
+
+    def fake_release_current_runner_task_lease(db, task_id, *, status):
+        return True
+
+    monkeypatch.setattr(
+        websocket_api,
+        "background_task_manager",
+        BackgroundTaskManager(),
+    )
+    monkeypatch.setattr(websocket_api, "manager", BroadcastManager())
+    monkeypatch.setattr(
+        websocket_api,
+        "release_current_runner_task_lease",
+        fake_release_current_runner_task_lease,
+    )
+    monkeypatch.setattr(database_models, "get_db", fake_get_db)
+    monkeypatch.setattr(
+        "xagent.web.services.chat_history_service.persist_assistant_message",
+        lambda *args, **kwargs: None,
+    )
+
+    await execute_task_background(
+        task_id=10,
+        user_message="重试",
+        context={},
+        agent_manager=AgentManager(),
+        user_id=int(user.id),
+        llm_user_message="重试",
+    )
+
+    assert captured["agent_task_id"] == "10"
+    assert captured["tracking_task_id"] == "10"
+    assert captured["agent_task"] == "重试"
 
 
 def test_build_uploaded_files_context_includes_agent_builder_kb_instruction():

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -12,6 +12,7 @@ from xagent.web.api.websocket import (
     _build_uploaded_files_context,
     _display_message_for_user,
     _normalize_file_outputs,
+    _register_uploaded_files_for_agent,
     _selected_file_refs_from_task,
     execute_task_background,
     handle_file_upload_for_task,
@@ -473,23 +474,13 @@ async def test_handle_file_upload_for_task_rejects_unowned_and_wrong_task_files(
         filename="other-task.txt",
     )
 
-    class Workspace:
-        def __init__(self):
-            self.input_dir = str(tmp_path / "workspace" / "input")
-            self.registered_files = []
-
-        def register_file(self, path, file_id, db_session=None):
-            self.registered_files.append((path, file_id, db_session))
-
-    workspace = Workspace()
-
-    class Manager:
-        async def get_agent_for_task(self, task_id, db, user=None):
-            return SimpleNamespace(workspace=workspace)
-
     import xagent.web.api.chat as chat_api
 
-    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: Manager())
+    monkeypatch.setattr(
+        chat_api,
+        "get_agent_manager",
+        lambda: pytest.fail("file staging must not create an AgentService"),
+    )
 
     result = await handle_file_upload_for_task(
         10,
@@ -504,9 +495,48 @@ async def test_handle_file_upload_for_task_rejects_unowned_and_wrong_task_files(
     )
 
     assert [item["file_id"] for item in result["file_info_list"]] == ["valid-file"]
-    assert [item[1] for item in workspace.registered_files] == ["valid-file"]
     db_session.refresh(valid_file)
     assert valid_file.task_id == 10
+
+
+def test_register_uploaded_files_for_agent_uses_execution_db_session(
+    db_session,
+    tmp_path,
+):
+    upload = _create_uploaded_file(
+        db_session,
+        tmp_path,
+        file_id="valid-file",
+        user_id=1,
+        task_id=10,
+        filename="valid file.txt",
+    )
+
+    class Workspace:
+        def __init__(self):
+            self.input_dir = str(tmp_path / "workspace" / "input")
+            self.registered_files = []
+
+        def register_file(self, path, file_id, db_session=None):
+            self.registered_files.append((path, file_id, db_session))
+
+    workspace = Workspace()
+    file_info = {
+        "file_id": "valid-file",
+        "name": "valid_file.txt",
+        "path": str(upload.storage_path),
+        "workspace_path": None,
+    }
+
+    _register_uploaded_files_for_agent(
+        SimpleNamespace(workspace=workspace),
+        [file_info],
+        db_session,
+    )
+
+    assert [item[1] for item in workspace.registered_files] == ["valid-file"]
+    assert workspace.registered_files[0][2] is db_session
+    assert file_info["workspace_path"]
 
 
 def test_get_display_user_message_reads_agent_context_state():


### PR DESCRIPTION
## Summary
- stop forcing completed/failed task follow-up messages into fresh executions
- keep WebSocket, Telegram, and Feishu follow-up turns on the original task/thread id
- add regression coverage for completed and failed tasks reusing their task id

## Tests
- `ruff check src/xagent/web/api/websocket.py src/xagent/web/channels/telegram/bot.py src/xagent/web/channels/feishu/bot.py tests/web/test_websocket_uploaded_files_context.py`
- `PYTHONPATH=src pytest tests/web/test_websocket_uploaded_files_context.py -q`