### PR TITLE
feat: preserve uploaded-file chips on user-message bubbles

### DIFF
--- a/src/xagent/core/agent/attachments.py
+++ b/src/xagent/core/agent/attachments.py
@@ -1,0 +1,48 @@
+"""Shared projection from raw upload metadata to the UI chip shape.
+
+Both the websocket persistence path
+(``_normalize_attachments_for_persistence``) and the trace callback's
+context fallback (``_files_from_context``) need to project the full
+``file_info_list`` (which contains absolute filesystem paths) down to the
+minimal shape the frontend FileAttachment chip needs:
+
+    {"file_id": str, "name": str, "size": Any, "type": Any}
+
+Keeping that projection in one place prevents the two callers from drifting
+on what fields are exposed to clients (paths must never leak — the
+attachments column and trace event payloads both reach the browser).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def project_file_info_to_chip(file_info_list: Any) -> List[Dict[str, Any]]:
+    """Project ``file_info_list`` to the chip shape; tolerant to None/garbage.
+
+    Entries without a ``file_id`` are dropped (the chip can't be rendered or
+    clicked without one). Absolute filesystem paths are *not* copied across.
+    ``original_name`` is preferred over ``name`` for the chip label so a
+    server-side normalized basename doesn't override the user's filename.
+    """
+    if not isinstance(file_info_list, list):
+        return []
+    projected: List[Dict[str, Any]] = []
+    for info in file_info_list:
+        if not isinstance(info, dict):
+            continue
+        file_id = info.get("file_id")
+        if not file_id:
+            continue
+        projected.append(
+            {
+                "file_id": str(file_id),
+                "name": str(
+                    info.get("original_name") or info.get("name") or "uploaded file"
+                ),
+                "size": info.get("size"),
+                "type": info.get("type"),
+            }
+        )
+    return projected

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -311,6 +311,10 @@ class AgentRunner:
             context = ExecutionContext.from_dict(checkpoint["context"])
             self.context_manager.set_context(context)
 
+        # Display-vs-execution split: ``execution_message`` is the prompt
+        # the agent runtime sees (may be enriched with file refs / system
+        # context); ``display_message`` is what the chat bubble should
+        # show. Both fall back to ``message`` for legacy callers.
         resolved_execution_message = (
             execution_message if execution_message is not None else message
         )
@@ -326,19 +330,62 @@ class AgentRunner:
         resolved_display_message = (
             display_message if display_message is not None else message
         )
+        # Attach files + display text to the new Message so they survive
+        # checkpoint round-trips: Message.metadata is serialized by
+        # ExecutionContext. The on_user_message_posted callback reads
+        # display_message back from metadata so the chat bubble shows the
+        # user-typed text rather than the LLM-augmented prompt.
         metadata: dict[str, Any] = {"display_message": resolved_display_message}
         if files is not None:
             metadata["files"] = files
 
-        context.add_user_message(resolved_execution_message, metadata=metadata)
+        added = context.add_user_message(resolved_execution_message, metadata=metadata)
+        # Persist BEFORE emitting the trace so the message is durable even
+        # if the trace dispatch fails — the resume path's catch-up logic
+        # in TraceEventCallback.on_run_start will replay any missed events.
         await self._persist_injected_context(
             execution_id=execution_id,
             context=context,
             label="user_message_injected",
         )
+        # Snapshot the watermark BEFORE the callback so we can detect a
+        # change (see comment below) and persist it.
+        watermark_before = self._read_trace_watermark(context)
+        await self._dispatch_callback(
+            "on_user_message_posted",
+            runner=self,
+            context=context,
+            message=added,
+            files=files,
+        )
+        # Re-persist when the trace callback advanced the watermark —
+        # without this a worker crash between trace emission and the next
+        # checkpoint would let the resume path replay the same user_message
+        # event because the watermark was still living only in memory.
+        watermark_after = self._read_trace_watermark(context)
+        if watermark_after and watermark_after != watermark_before:
+            await self._persist_injected_context(
+                execution_id=execution_id,
+                context=context,
+                label="user_message_trace_watermark",
+            )
         if request_interrupt:
             self.pause(execution_id, reason=reason or "new user message")
         return context
+
+    @staticmethod
+    def _read_trace_watermark(context: ExecutionContext) -> str | None:
+        """Read the user-message trace watermark off context metadata, if any.
+
+        Kept in-runner so we don't import the tracing module (which would
+        create a cycle) — the key is a stable contract spelled out in
+        ``core.agent.tracing.TRACE_WATERMARK_KEY``.
+        """
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get("_user_message_trace_watermark")
+        return value if isinstance(value, str) and value else None
 
     async def post_user_message(
         self,

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -340,9 +340,18 @@ class AgentRunner:
             metadata["files"] = files
 
         added = context.add_user_message(resolved_execution_message, metadata=metadata)
+        # Set a "this turn is waiting to be traced" pending marker before
+        # we persist. The resume catch-up logic uses this to disambiguate
+        # an old checkpoint that pre-dates this PR (no watermark, no
+        # pending marker — should NOT replay history) from a checkpoint
+        # that crashed mid-emit (pending marker present — replay this
+        # specific turn). Without this, ``_emit_untraced_user_messages``
+        # would treat any missing-watermark checkpoint as "everything
+        # untraced" and re-render historical user messages on resume.
+        self._set_pending_user_message_marker(context, added)
         # Persist BEFORE emitting the trace so the message is durable even
         # if the trace dispatch fails — the resume path's catch-up logic
-        # in TraceEventCallback.on_run_start will replay any missed events.
+        # in TraceEventCallback.on_run_start will replay the marked turn.
         await self._persist_injected_context(
             execution_id=execution_id,
             context=context,
@@ -362,8 +371,12 @@ class AgentRunner:
         # without this a worker crash between trace emission and the next
         # checkpoint would let the resume path replay the same user_message
         # event because the watermark was still living only in memory.
+        # The same persist also clears the pending marker since the trace
+        # has now been emitted; doing both in one persist keeps the
+        # invariant {pending => never traced yet} on every durable state.
         watermark_after = self._read_trace_watermark(context)
         if watermark_after and watermark_after != watermark_before:
+            self._clear_pending_user_message_marker(context)
             await self._persist_injected_context(
                 execution_id=execution_id,
                 context=context,
@@ -386,6 +399,45 @@ class AgentRunner:
             return None
         value = metadata.get("_user_message_trace_watermark")
         return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _set_pending_user_message_marker(
+        context: ExecutionContext, message: Any
+    ) -> None:
+        """Stamp ``_pending_user_message_trace_timestamp`` on context.metadata.
+
+        Mirrored in ``core.agent.tracing.PENDING_MARKER_KEY``; kept in-runner
+        to avoid an import cycle. The timestamp is the just-added message's
+        normalized ISO-UTC timestamp so the catch-up loop can replay this
+        specific turn rather than scanning history.
+        """
+        ts = AgentRunner._message_iso_timestamp(message)
+        if ts is None:
+            return
+        metadata = getattr(context, "metadata", None)
+        if isinstance(metadata, dict):
+            metadata["_pending_user_message_trace_timestamp"] = ts
+
+    @staticmethod
+    def _clear_pending_user_message_marker(context: ExecutionContext) -> None:
+        metadata = getattr(context, "metadata", None)
+        if isinstance(metadata, dict):
+            metadata.pop("_pending_user_message_trace_timestamp", None)
+
+    @staticmethod
+    def _message_iso_timestamp(message: Any) -> str | None:
+        """ISO-UTC string of ``message.timestamp`` — same normalization the
+        tracing module uses for its watermark, kept here to avoid a cycle.
+        """
+        from datetime import datetime, timezone
+
+        ts = getattr(message, "timestamp", None)
+        if isinstance(ts, datetime):
+            aware = ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
+            return aware.astimezone(timezone.utc).isoformat()
+        if isinstance(ts, str) and ts:
+            return ts
+        return None
 
     async def post_user_message(
         self,

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
+from .attachments import project_file_info_to_chip
 from .result import extract_assistant_message
 from .trace import (
     get_display_user_message,
@@ -11,6 +13,14 @@ from .trace import (
     trace_task_completion,
     trace_user_message,
 )
+
+# Stored on ``context.metadata`` to remember which user messages have already
+# been emitted as ``trace_user_message`` events. Uses the latest traced
+# message's ISO-8601 UTC timestamp as a high-water mark — ISO strings compare
+# lexicographically when timezone-normalized, and the mark survives
+# checkpoint round-trips because ``context.metadata`` is persisted in
+# ``ExecutionContext.to_dict``.
+TRACE_WATERMARK_KEY = "_user_message_trace_watermark"
 
 
 @dataclass
@@ -29,16 +39,81 @@ class TraceEventCallback:
         if tracer is None or not callable(getattr(tracer, "trace_event", None)):
             return
 
-        execution_id = str(getattr(context, "execution_id", "") or "")
-
-        task = self._task_from_context(context)
-        if task and not (resume or checkpoint):
-            await trace_user_message(
-                tracer,
-                execution_id,
-                get_display_user_message(context, task),
-                {"context": self._context_payload(context)},
+        if not (resume or checkpoint):
+            task = self._task_from_context(context)
+            files = self._files_from_context(context)
+            # File-only turn: the user uploaded files without typing. The
+            # transcript row is still persisted (see
+            # ``persist_user_message_no_commit``), so the live trace bubble
+            # should also fire — otherwise the chip would only show up on
+            # next reload via historical replay, mismatching the persist
+            # behavior. ``get_display_user_message`` is what handles the
+            # "" → "Uploaded file(s)" frontend fallback in the bubble.
+            if not task and not files:
+                return
+            await self._emit_user_message_trace(
+                tracer=tracer,
+                context=context,
+                message=get_display_user_message(context, task or ""),
+                files=files,
             )
+            # Mark the latest user message (if the runner added one) as
+            # traced so a subsequent resume does not re-emit it.
+            latest = self._latest_user_message(context)
+            if latest is not None:
+                self._mark_traced(context, latest)
+            return
+
+        # Resume / checkpoint replay: emit any user messages the prior turn
+        # did not get to trace. This handles two real scenarios:
+        #   1. ``inject_user_message`` was called, the checkpoint was
+        #      persisted, but the in-process trace emission was lost
+        #      (worker crash between persist and emit).
+        #   2. Defensive double-coverage for the continuation flow even
+        #      though ``on_user_message_posted`` already covers the happy
+        #      path — keeps the chip from disappearing if the callback
+        #      somehow didn't fire on the prior worker.
+        await self._emit_untraced_user_messages(tracer=tracer, context=context)
+
+    async def on_user_message_posted(
+        self,
+        *,
+        runner: Any,
+        context: Any,
+        message: Any,
+        files: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Fire when ``runner.inject_user_message`` lands a fresh user turn.
+
+        ``message`` is the freshly added ``Message`` instance. ``files`` is
+        the normalized attachment list the websocket layer received; when
+        absent we fall back to ``message.metadata['files']`` (which
+        ``inject_user_message`` populates when the caller passes ``files``).
+        """
+        tracer = getattr(runner, "tracer", None)
+        if tracer is None or not callable(getattr(tracer, "trace_event", None)):
+            return
+
+        # ``Message.content`` holds the LLM-facing execution text (with
+        # any uploaded-files context appended). The chat bubble must
+        # render the user-typed string instead, so prefer
+        # ``metadata['display_message']`` when the runner stashed one.
+        content = getattr(message, "content", None) or ""
+        bubble_text = self._display_message_from(message) or content
+        resolved_files = files or self._files_from_message(message)
+        # File-only continuation: user uploaded files without typing.
+        # ``inject_user_message`` still added the (empty-content) Message
+        # so the chip survives checkpoints — we mirror that here and let
+        # the frontend's ``has_files`` fallback render the bubble.
+        if not bubble_text and not resolved_files:
+            return
+        await self._emit_user_message_trace(
+            tracer=tracer,
+            context=context,
+            message=bubble_text,
+            files=resolved_files,
+        )
+        self._mark_traced(context, message)
 
     async def on_run_end(
         self, *, runner: Any, context: Any, result: dict[str, Any]
@@ -88,6 +163,131 @@ class TraceEventCallback:
             data={**data, "context": self._context_payload(context)},
         )
 
+    async def _emit_user_message_trace(
+        self,
+        *,
+        tracer: Any,
+        context: Any,
+        message: str,
+        files: list[dict[str, Any]],
+    ) -> None:
+        trace_data: dict[str, Any] = {"context": self._context_payload(context)}
+        if files:
+            # Surface uploaded files at the top level of trace_data so the
+            # frontend user-message renderer (which reads ``eventData.files``)
+            # can show clickable file chips alongside the user's message.
+            trace_data["files"] = files
+            trace_data["attachments"] = files
+        execution_id = str(getattr(context, "execution_id", "") or "")
+        await trace_user_message(tracer, execution_id, message, trace_data)
+
+    async def _emit_untraced_user_messages(self, *, tracer: Any, context: Any) -> None:
+        watermark = self._watermark(context)
+        messages = list(getattr(context, "messages", []) or [])
+        # Resolve once outside the loop — every miss inside would otherwise
+        # rescan the full message list (O(N^2) in the worst case where many
+        # turns lack ``Message.metadata['files']``).
+        first_user_idx = self._first_user_message_index(messages)
+        for index, message in enumerate(messages):
+            if getattr(message, "role", None) != "user":
+                continue
+            content = getattr(message, "content", None) or ""
+            # Same display vs execution split as on_user_message_posted —
+            # see the comment there.
+            bubble_text = self._display_message_from(message) or content
+            ts = self._message_timestamp_iso(message)
+            if watermark and ts and ts <= watermark:
+                continue
+            files = self._files_from_message(message)
+            # For the chronologically first user message we additionally fall
+            # back to request_context.file_info — the runner's fresh-start
+            # path attaches files to the request_context dict but not to the
+            # ``Message`` itself, so a crash-recovery resume needs this
+            # fallback to surface chips for the *original* turn.
+            if not files and index == first_user_idx:
+                files = self._files_from_context(context)
+            # File-only message (empty content + non-empty files) is a real
+            # turn — the persist layer keeps the row when attachments are
+            # present, and the live bubble should match.
+            if not bubble_text and not files:
+                continue
+            await self._emit_user_message_trace(
+                tracer=tracer,
+                context=context,
+                message=bubble_text,
+                files=files,
+            )
+            self._mark_traced(context, message)
+
+    def _watermark(self, context: Any) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get(TRACE_WATERMARK_KEY)
+        return value if isinstance(value, str) and value else None
+
+    def _mark_traced(self, context: Any, message: Any) -> None:
+        ts = self._message_timestamp_iso(message)
+        if ts is None:
+            return
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return
+        existing = metadata.get(TRACE_WATERMARK_KEY)
+        if not isinstance(existing, str) or ts > existing:
+            metadata[TRACE_WATERMARK_KEY] = ts
+
+    def _message_timestamp_iso(self, message: Any) -> str | None:
+        ts = getattr(message, "timestamp", None)
+        if isinstance(ts, datetime):
+            # Normalize to UTC so the watermark's lexicographical comparison
+            # is stable even when callers stamp messages with naive datetimes
+            # or non-UTC offsets. Without this, an aware ``T12:00:00+00:00``
+            # would sort *after* an equivalent naive ``T12:00:00`` and the
+            # watermark could let already-traced messages re-emit.
+            aware = ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
+            return aware.astimezone(timezone.utc).isoformat()
+        if isinstance(ts, str) and ts:
+            return ts
+        return None
+
+    def _latest_user_message(self, context: Any) -> Any | None:
+        messages = list(getattr(context, "messages", []) or [])
+        for message in reversed(messages):
+            if getattr(message, "role", None) == "user":
+                return message
+        return None
+
+    def _first_user_message_index(self, messages: list[Any]) -> int:
+        for index, message in enumerate(messages):
+            if getattr(message, "role", None) == "user":
+                return index
+        return -1
+
+    def _files_from_message(self, message: Any) -> list[dict[str, Any]]:
+        # Run through the shared projector even though ``inject_user_message``
+        # is supposed to hand us already-chip-shaped files. Defense in depth
+        # against a caller that drops raw ``file_info`` (with absolute
+        # paths) into ``Message.metadata['files']`` directly — the trace
+        # event payload reaches the browser, so paths must not leak.
+        metadata = getattr(message, "metadata", None)
+        if not isinstance(metadata, dict):
+            return []
+        return project_file_info_to_chip(metadata.get("files"))
+
+    @staticmethod
+    def _display_message_from(message: Any) -> str | None:
+        """Return ``Message.metadata['display_message']`` if it's a non-empty
+        string, else None. The runner sets it when the LLM-facing execution
+        text differs from the user-typed bubble text (see
+        ``runner.inject_user_message``).
+        """
+        metadata = getattr(message, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get("display_message")
+        return value if isinstance(value, str) and value else None
+
     def _context_payload(self, context: Any) -> dict[str, Any] | None:
         to_dict = getattr(context, "to_dict", None)
         if callable(to_dict):
@@ -108,3 +308,20 @@ class TraceEventCallback:
                 if isinstance(content, str) and content:
                     return content
         return None
+
+    def _files_from_context(self, context: Any) -> list[dict[str, Any]]:
+        """Extract uploaded-file chips from the execution context.
+
+        The websocket adapter wraps the raw context dict — including
+        ``file_info`` — inside ``metadata["request_context"]`` when starting
+        a run. Delegates the projection (and path stripping) to the shared
+        ``project_file_info_to_chip`` helper so the chip shape stays
+        consistent with the persistence-layer normalization.
+        """
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return []
+        request_context = metadata.get("request_context")
+        if not isinstance(request_context, dict):
+            return []
+        return project_file_info_to_chip(request_context.get("file_info"))

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -22,6 +22,17 @@ from .trace import (
 # ``ExecutionContext.to_dict``.
 TRACE_WATERMARK_KEY = "_user_message_trace_watermark"
 
+# Stamped on ``context.metadata`` by ``runner.inject_user_message`` just
+# before persisting a freshly-injected user message, and cleared when the
+# follow-up persist records the advanced watermark. Carries the injected
+# message's ISO-UTC timestamp.
+#
+# The catch-up loop on resume uses this to disambiguate three cases:
+# - both absent  -> old/pre-PR checkpoint, do nothing (don't replay history)
+# - pending only -> crashed between persist and trace emit, replay that turn
+# - watermark    -> normal "trace already emitted" path, fast-skip
+PENDING_MARKER_KEY = "_pending_user_message_trace_timestamp"
+
 
 @dataclass
 class TraceEventCallback:
@@ -205,6 +216,18 @@ class TraceEventCallback:
 
     async def _emit_untraced_user_messages(self, *, tracer: Any, context: Any) -> None:
         watermark = self._watermark(context)
+        pending = self._pending_marker(context)
+        # Disambiguate old/pre-PR checkpoints from genuinely-pending turns:
+        # a checkpoint that has neither marker is from before this PR (or
+        # from a code path that doesn't go through the runner's
+        # inject_user_message). Treating it as "everything is untraced"
+        # would re-emit every historical user message on resume. The
+        # crash-window for newly-injected messages is covered by the
+        # pending marker below; long-term per-turn idempotency is tracked
+        # in #454.
+        if watermark is None and pending is None:
+            return
+
         messages = list(getattr(context, "messages", []) or [])
         # Resolve once outside the loop — every miss inside would otherwise
         # rescan the full message list (O(N^2) in the worst case where many
@@ -219,6 +242,13 @@ class TraceEventCallback:
             bubble_text = self._display_message_from(message) or content
             ts = self._message_timestamp_iso(message)
             if watermark and ts and ts <= watermark:
+                continue
+            # Pending marker present without watermark advance: only replay
+            # the matching turn. Any other historical turn at this point
+            # was already visible to the client on the prior run; skip it
+            # so we don't spam re-emissions for everything older than the
+            # crash point.
+            if pending is not None and ts != pending:
                 continue
             files = self._files_from_message(message)
             # For the chronologically first user message we additionally fall
@@ -246,6 +276,13 @@ class TraceEventCallback:
         if not isinstance(metadata, dict):
             return None
         value = metadata.get(TRACE_WATERMARK_KEY)
+        return value if isinstance(value, str) and value else None
+
+    def _pending_marker(self, context: Any) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get(PENDING_MARKER_KEY)
         return value if isinstance(value, str) and value else None
 
     def _mark_traced(self, context: Any, message: Any) -> None:

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -171,13 +171,35 @@ class TraceEventCallback:
         message: str,
         files: list[dict[str, Any]],
     ) -> None:
-        trace_data: dict[str, Any] = {"context": self._context_payload(context)}
-        if files:
+        """Emit a user-message trace event with a browser-safe payload.
+
+        Browser-safety contract (rogercloud review): a user-message trace
+        event reaches the chat UI / historical-replay client and must not
+        carry raw filesystem paths.
+
+        1. We deliberately do NOT attach ``ExecutionContext.to_dict()`` to
+           the trace payload. The context dict can contain raw paths under
+           ``metadata.request_context.file_info`` and
+           ``messages[].metadata.files`` that were not stripped at ingest
+           (e.g. when a caller passes raw ``file_info`` straight into
+           ``Message.metadata['files']``). Anything internal that needs the
+           full context lives in the checkpoint, not the user-facing trace.
+
+        2. ``files`` is funnelled through ``project_file_info_to_chip``
+           regardless of how it arrived. This is defence in depth — even
+           if a future caller passes raw ``file_info`` with absolute paths
+           to ``on_user_message_posted(files=...)``, the projector strips
+           anything outside the chip schema (``file_id`` / ``name`` /
+           ``size`` / ``type``).
+        """
+        safe_files = project_file_info_to_chip(files)
+        trace_data: dict[str, Any] = {}
+        if safe_files:
             # Surface uploaded files at the top level of trace_data so the
             # frontend user-message renderer (which reads ``eventData.files``)
             # can show clickable file chips alongside the user's message.
-            trace_data["files"] = files
-            trace_data["attachments"] = files
+            trace_data["files"] = safe_files
+            trace_data["attachments"] = safe_files
         execution_id = str(getattr(context, "execution_id", "") or "")
         await trace_user_message(tracer, execution_id, message, trace_data)
 

--- a/src/xagent/migrations/versions/20260518_add_attachments_to_task_chat_messages.py
+++ b/src/xagent/migrations/versions/20260518_add_attachments_to_task_chat_messages.py
@@ -1,0 +1,55 @@
+"""add attachments column to task_chat_messages
+
+Revision ID: 20260518_add_chat_message_attachments
+Revises: 20260509_add_durable_file_storage_fields
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "20260518_add_chat_message_attachments"
+down_revision: Union[str, None] = "20260509_add_durable_file_storage_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        # Base table doesn't exist yet; nothing to do for this migration.
+        return
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "attachments" not in existing_columns:
+        op.add_column(
+            "task_chat_messages",
+            sa.Column("attachments", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        return
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "attachments" in existing_columns:
+        op.drop_column("task_chat_messages", "attachments")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -307,6 +307,43 @@ def _selected_file_refs_from_task(task: Any, db: Session) -> list[dict[str, Any]
     return refs
 
 
+def _normalize_attachments_for_persistence(
+    file_info_list: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Project file_info_list to the minimal shape we persist on chat rows.
+
+    Thin wrapper around the shared
+    ``core.agent.attachments.project_file_info_to_chip`` so the trace
+    callback and the persistence path can't drift on what fields the
+    browser sees (paths must never leak — the attachments column and the
+    user_message trace events both reach the UI).
+    """
+    from ...core.agent.attachments import project_file_info_to_chip
+
+    return project_file_info_to_chip(file_info_list)
+
+
+def _attachment_fingerprint(attachments: Any) -> str:
+    """Order-independent fingerprint of a chip-shaped attachment list.
+
+    Used by the replay dedup key so two user turns with the same typed
+    text but different uploaded files don't collapse into one. We
+    fingerprint on ``file_id`` only — the field is stable across the
+    trace event payload and the persisted ``TaskChatMessage.attachments``
+    column, and the order of items isn't meaningful for identity.
+    """
+    if not isinstance(attachments, list):
+        return ""
+    file_ids: list[str] = []
+    for item in attachments:
+        if not isinstance(item, dict):
+            continue
+        file_id = item.get("file_id")
+        if isinstance(file_id, str) and file_id.strip():
+            file_ids.append(file_id.strip())
+    return "|".join(sorted(file_ids))
+
+
 def create_stream_event(
     event_type: str,
     task_id: Union[int, str],
@@ -2213,12 +2250,21 @@ async def handle_chat_message(
                     if hasattr(dag_pattern, "tracer") and hasattr(
                         dag_pattern, "task_id"
                     ):
-                        trace_data = {
+                        trace_data: Dict[str, Any] = {
                             "context": context,
                             "pattern": "DAG Plan-Execute Continuation",
                             "continuation": "true",
                             "files": display_file_refs,
                         }
+                        # Surface uploaded files at the top level so the
+                        # frontend user-message renderer can show clickable
+                        # file chips alongside the continuation bubble
+                        # (matches what historical replay shows on reload).
+                        # ``files`` is already populated above via #455's
+                        # display_file_refs; mirror it under ``attachments``
+                        # for the historical-replay client contract.
+                        if display_file_refs:
+                            trace_data["attachments"] = display_file_refs
                         await trace_user_message(
                             dag_pattern.tracer,
                             str(dag_pattern.task_id),
@@ -2285,6 +2331,12 @@ async def handle_chat_message(
                 if task_is_running and supports_live_control:
                     logger.info(f"Using agent message control for task {task_id}")
                     assert agent_service is not None
+                    # Pass the user-typed bubble text + display-safe file refs
+                    # alongside the LLM-augmented execution text. The runner
+                    # persists them onto Message.metadata so its tracing
+                    # callback can emit the bubble with the typed content +
+                    # file chips rather than the inflated prompt; matches what
+                    # historical replay shows on reload.
                     posted = await agent_service.post_user_message(
                         str(task_id),
                         execution_message=user_message_for_llm,
@@ -2427,9 +2479,16 @@ async def handle_chat_message(
                         TurnKind,
                     )
 
+                    # Strip absolute filesystem paths before the row hits
+                    # disk — the attachments column is exposed to historical-
+                    # replay clients, so paths must not leak.
+                    persisted_attachments = _normalize_attachments_for_persistence(
+                        file_info_list
+                    )
                     payload = TaskTurnPayload(
                         transcript_message=display_user_message,
                         execution_message=user_message_for_llm,
+                        attachments=persisted_attachments or None,
                     )
                     # WS path only has two legal entries into begin_turn:
                     #   PENDING                  → CREATE
@@ -2867,7 +2926,12 @@ async def send_historical_data_as_stream(
             historical_path_to_file_id: Dict[str, str] = {}
             normalized_trace_data_by_event_id: Dict[str, Any] = {}
             task_user_id = int(cast(Any, task.user_id))
-            trace_message_keys: set[tuple[str, str]] = set()
+            # Dedup key for "is this chat_messages row already covered by a
+            # trace event?". Includes an attachment fingerprint so two
+            # user turns with the same typed text but different uploaded
+            # files no longer collapse into one — the second row used to
+            # be dropped and its file chips disappeared on reload.
+            trace_message_keys: set[tuple[str, str, str]] = set()
 
             for trace_event in trace_events:
                 normalized_event_data = trace_event.data
@@ -2891,10 +2955,18 @@ async def send_historical_data_as_stream(
                         "message"
                     ) or normalized_event_data.get("content")
                     if isinstance(content, str) and content.strip():
+                        event_attachments = normalized_event_data.get(
+                            "files"
+                        ) or normalized_event_data.get("attachments")
+                        attachment_key = _attachment_fingerprint(event_attachments)
                         if trace_event.event_type == "user_message":
-                            trace_message_keys.add(("user", content.strip()))
+                            trace_message_keys.add(
+                                ("user", content.strip(), attachment_key)
+                            )
                         elif trace_event.event_type in {"agent_message", "ai_message"}:
-                            trace_message_keys.add(("assistant", content.strip()))
+                            trace_message_keys.add(
+                                ("assistant", content.strip(), attachment_key)
+                            )
 
             for trace_event in trace_events:
                 normalized_event_data = normalized_trace_data_by_event_id.get(
@@ -2934,14 +3006,37 @@ async def send_historical_data_as_stream(
             for chat_message in chat_messages:
                 role = str(chat_message.role)
                 content = str(chat_message.content or "").strip()
-                if not content:
+                # Read attachments off the row so file-only turns (empty
+                # content + non-empty attachments) survive replay and so the
+                # chip metadata reaches the synthesized user_message event.
+                _attachments_raw = chat_message.attachments
+                row_attachments: Optional[list] = (
+                    _attachments_raw
+                    if isinstance(_attachments_raw, list) and _attachments_raw
+                    else None
+                )
+                # Drop only when there's nothing to render — empty text *and*
+                # no attachments. A row with attachments but no text is a real
+                # turn (user uploaded files without typing) and must be kept.
+                if not content and not row_attachments:
                     continue
-                if (role, content) in trace_message_keys:
+                if (
+                    content
+                    and (role, content, _attachment_fingerprint(row_attachments))
+                    in trace_message_keys
+                ):
                     continue
 
                 if role == "user":
                     event_type = "user_message"
                     data: dict[str, Any] = {"message": content, "content": content}
+                    if row_attachments:
+                        # Surface the persisted chip payload at the top level
+                        # so the frontend user-message renderer can show
+                        # clickable file chips on reload, matching the live
+                        # event shape emitted by the agent tracing callback.
+                        data["files"] = row_attachments
+                        data["attachments"] = row_attachments
                 elif role == "assistant":
                     interactions = chat_message.interactions
                     data = {

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2337,6 +2337,14 @@ async def handle_chat_message(
                     # callback can emit the bubble with the typed content +
                     # file chips rather than the inflated prompt; matches what
                     # historical replay shows on reload.
+                    # ``post_user_message`` routes into ``AgentRunner.inject_user_message``,
+                    # which dispatches ``on_user_message_posted`` — that callback
+                    # is the single emission point for the live-control
+                    # continuation user-message trace. Do not emit a second
+                    # ``trace_user_message`` here; doing so would render the
+                    # bubble twice in the live UI. The DAG Plan-Execute
+                    # continuation path above is a separate code path and
+                    # keeps its own immediate trace.
                     posted = await agent_service.post_user_message(
                         str(task_id),
                         execution_message=user_message_for_llm,
@@ -2348,18 +2356,6 @@ async def handle_chat_message(
                     if not posted:
                         logger.warning(
                             f"agent execution {task_id} was not live; attempting resume from checkpoint"
-                        )
-                    else:
-                        await trace_user_message(
-                            agent_service.tracer,
-                            str(task_id),
-                            display_user_message,
-                            {
-                                "context": context,
-                                "pattern": "Agent Live Control",
-                                "continuation": "true",
-                                "files": display_file_refs,
-                            },
                         )
 
                     previous_task = background_task_manager.running_tasks.get(task_id)

--- a/src/xagent/web/models/chat_message.py
+++ b/src/xagent/web/models/chat_message.py
@@ -21,6 +21,11 @@ class TaskChatMessage(Base):  # type: ignore
     content = Column(Text, nullable=False)
     message_type = Column(String(64), nullable=False)
     interactions = Column(JSON, nullable=True)
+    # Per-message attachments (uploaded files). For user messages this is the
+    # list of files the user attached when sending this turn. Stored as JSON so
+    # the original file metadata (file_id, name, size, type) is available for
+    # historical replay without having to re-derive it from the message body.
+    attachments = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     task = relationship("Task", back_populates="chat_messages")

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -21,6 +21,8 @@ def persist_user_message(
     task_id: int,
     user_id: int,
     content: str,
+    *,
+    attachments: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[TaskChatMessage]:
     return _persist_message(
         db=db,
@@ -29,6 +31,7 @@ def persist_user_message(
         role="user",
         content=content,
         message_type="user_message",
+        attachments=attachments,
     )
 
 
@@ -37,6 +40,8 @@ def persist_user_message_no_commit(
     task_id: int,
     user_id: int,
     content: str,
+    *,
+    attachments: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[TaskChatMessage]:
     """``persist_user_message`` variant that stages the row but does NOT commit.
 
@@ -46,11 +51,12 @@ def persist_user_message_no_commit(
     responsible for calling ``db.commit()`` (or ``db.rollback()`` on
     failure).
 
-    Returns ``None`` when content is whitespace-only, same as the
-    regular ``persist_user_message``.
+    Returns ``None`` when content is whitespace-only AND no attachments
+    are provided. A row with empty content but non-empty attachments is
+    still persisted (the user uploaded files but didn't type anything).
     """
     normalized_content = content.strip()
-    if not normalized_content:
+    if not normalized_content and not attachments:
         return None
     message = TaskChatMessage(
         task_id=task_id,
@@ -59,6 +65,11 @@ def persist_user_message_no_commit(
         content=normalized_content,
         message_type="user_message",
         interactions=None,
+        # Pass through ``attachments`` directly so an explicit empty list
+        # round-trips as ``[]`` rather than being coerced to ``NULL`` —
+        # callers may want to distinguish "no attachments specified" from
+        # "attachments key was set, just empty".
+        attachments=attachments,
     )
     db.add(message)
     return message
@@ -151,9 +162,10 @@ def _persist_message(
     content: str,
     message_type: str,
     interactions: Optional[List[Dict[str, Any]]] = None,
+    attachments: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[TaskChatMessage]:
     normalized_content = content.strip()
-    if not normalized_content:
+    if not normalized_content and not attachments:
         return None
 
     message = TaskChatMessage(
@@ -163,6 +175,9 @@ def _persist_message(
         content=normalized_content,
         message_type=message_type,
         interactions=interactions,
+        # Pass through ``attachments`` directly so an explicit empty list
+        # round-trips as ``[]`` rather than being coerced to ``NULL``.
+        attachments=attachments,
     )
     db.add(message)
     db.commit()

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -878,12 +878,20 @@ def _get_models_by_category(
             ):
                 continue
 
-            api_key = cast(Optional[str], getattr(db_model, "api_key", None))
-            if not api_key:
-                raise ValueError(f"{model_type} model API key cannot be empty")
+            # api_key may be empty for self-hosted Xinference (no auth);
+            # the adapter handles that gracefully so we don't pre-validate
+            # it here. Skip the model only when base_url is missing —
+            # without that there's no way to reach the service. Raising
+            # here would abort loading ALL models of this category in one
+            # go (the outer try/except returns {}), so any per-model issue
+            # is downgraded to a per-model warning + skip.
             base_url = cast(Optional[str], getattr(db_model, "base_url", None))
             if not base_url:
-                raise ValueError(f"{model_type} model base URL cannot be empty")
+                logger.warning(
+                    f"Skipping {model_type} model {db_model.model_name}: "
+                    "base_url is empty"
+                )
+                continue
 
             model_provider = str(db_model.model_provider).strip().lower()
             try:

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -49,7 +49,7 @@ import enum
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..models.task import Task, TaskStatus
 from ..models.user import User
@@ -93,6 +93,12 @@ class TaskTurnPayload:
 
     transcript_message: str
     execution_message: Optional[str] = None
+    # Per-turn uploaded-file metadata persisted alongside the transcript
+    # row so historical replay can render the same clickable chips the
+    # user saw live. Each entry is the minimal chip shape (file_id,
+    # name, size, type) — already path-stripped by the websocket layer
+    # before reaching here.
+    attachments: Optional[List[Dict[str, Any]]] = None
 
     @property
     def for_agent(self) -> str:
@@ -292,6 +298,7 @@ class TaskTurnOrchestrator:
                 task_id=task_id,
                 user_id=int(user.id),
                 content=payload.transcript_message,
+                attachments=payload.attachments,
             )
             if persisted_message is not None:
                 db.flush()

--- a/tests/core/agent/test_attachments.py
+++ b/tests/core/agent/test_attachments.py
@@ -1,0 +1,62 @@
+"""Tests for the shared file_info → chip-shape projector."""
+
+from xagent.core.agent.attachments import project_file_info_to_chip
+
+
+def test_project_keeps_chip_fields_and_strips_paths():
+    """Only chip-relevant fields persist; absolute paths must not leak
+    (the field reaches the browser via both the attachments column and
+    the user_message trace event payload)."""
+    raw = [
+        {
+            "file_id": "uuid-1",
+            "name": "normalized.xlsx",
+            "original_name": "Q1 Report.xlsx",
+            "size": 12345,
+            "type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            "path": "/abs/leak/should/be/stripped.xlsx",
+        }
+    ]
+    assert project_file_info_to_chip(raw) == [
+        {
+            "file_id": "uuid-1",
+            "name": "Q1 Report.xlsx",  # original_name preferred over name
+            "size": 12345,
+            "type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        }
+    ]
+
+
+def test_project_drops_entries_without_file_id():
+    out = project_file_info_to_chip(
+        [
+            {"name": "no-id.txt", "size": 1},
+            {"file_id": "keep", "name": "keep.txt"},
+        ]
+    )
+    assert out == [{"file_id": "keep", "name": "keep.txt", "size": None, "type": None}]
+
+
+def test_project_falls_back_to_name_when_original_name_missing():
+    assert project_file_info_to_chip([{"file_id": "fid", "name": "x.txt"}]) == [
+        {"file_id": "fid", "name": "x.txt", "size": None, "type": None}
+    ]
+
+
+def test_project_falls_back_to_placeholder_when_no_name_at_all():
+    assert project_file_info_to_chip([{"file_id": "fid"}]) == [
+        {"file_id": "fid", "name": "uploaded file", "size": None, "type": None}
+    ]
+
+
+def test_project_tolerates_garbage_input():
+    """Defensive — caller may pass None, a non-list, or list of non-dicts;
+    the projector should return [] rather than raise."""
+    assert project_file_info_to_chip(None) == []
+    assert project_file_info_to_chip("not a list") == []  # type: ignore[arg-type]
+    assert project_file_info_to_chip([None, "garbage", 42]) == []  # type: ignore[list-item]
+    assert project_file_info_to_chip([]) == []

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -611,6 +611,57 @@ async def test_runner_resume_restores_from_latest_checkpoint_after_restart(
 
 
 @pytest.mark.asyncio
+async def test_runner_inject_user_message_with_files_dispatches_trace_callback(
+    tmp_path: Path,
+) -> None:
+    """End-to-end coverage of the continuation chip path: a websocket-style
+    ``post_user_message`` call with attachments must (a) attach the files to
+    the new Message so they survive checkpoints and (b) fire the trace
+    callback so the chip is broadcast live (instead of only appearing after
+    a page reload via historical replay)."""
+    tracer = RecordingTraceEventTracer()
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        callbacks=[TraceEventCallback()],
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    await runner.run(task="Original task", execution_id="exec-cont-files")
+
+    files = [
+        {
+            "file_id": "fid-cont",
+            "name": "follow-up.pdf",
+            "size": 2048,
+            "type": "application/pdf",
+        }
+    ]
+    context = await runner.post_user_message(
+        "exec-cont-files",
+        "Use the attached PDF.",
+        request_interrupt=False,
+        files=files,
+    )
+
+    assert context is not None
+    new_user_message = next(
+        msg for msg in reversed(context.messages) if msg.role == "user"
+    )
+    assert new_user_message.metadata.get("files") == files
+
+    user_message_events = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "task_start_message"
+        and event["data"].get("message") == "Use the attached PDF."
+    ]
+    assert len(user_message_events) == 1
+    assert user_message_events[0]["data"]["files"] == files
+    assert user_message_events[0]["data"]["attachments"] == files
+
+
+@pytest.mark.asyncio
 async def test_runner_post_user_message_alias_matches_inject_behavior(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -341,7 +341,60 @@ async def test_on_user_message_posted_emits_for_file_only_continuation() -> None
     assert len(tracer.events) == 1
     data = tracer.events[0]["data"]
     assert data["message"] == ""
-    assert data["files"] == files
+    # The trace funnels files through ``project_file_info_to_chip`` for
+    # browser-safety (see _emit_user_message_trace); ``size``/``type`` are
+    # filled with ``None`` when missing so the chip schema stays uniform.
+    assert data["files"] == [
+        {"file_id": "fid-only", "name": "x.pdf", "size": None, "type": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emit_user_message_trace_strips_absolute_paths_from_files() -> None:
+    """Browser-safety contract: even if a caller hands the callback raw
+    ``file_info`` (with absolute ``path`` keys), the emitted trace payload
+    must not contain that path. The trace event reaches the chat UI /
+    historical-replay client, which is not allowed to see runtime paths.
+    """
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-path-leak")
+    raw_files = [
+        {
+            "file_id": "fid-1",
+            "name": "doc.pdf",
+            "size": 2048,
+            "type": "application/pdf",
+            "path": "/abs/secret/doc.pdf",
+            "workspace_path": "/workspace/input/doc.pdf",
+        }
+    ]
+    new_msg = context.add_user_message("hello", metadata={"files": raw_files})
+
+    await callback.on_user_message_posted(
+        runner=runner, context=context, message=new_msg, files=raw_files
+    )
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    # No raw context payload — the full ExecutionContext.to_dict() can
+    # also carry path-bearing metadata, so we don't include it.
+    assert "context" not in data
+    # Files at the top level are projected to the chip schema (no
+    # ``path``/``workspace_path``).
+    for chip in data["files"]:
+        assert "path" not in chip
+        assert "workspace_path" not in chip
+    assert data["files"] == [
+        {
+            "file_id": "fid-1",
+            "name": "doc.pdf",
+            "size": 2048,
+            "type": "application/pdf",
+        }
+    ]
+    assert data["attachments"] == data["files"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -136,3 +136,342 @@ async def test_trace_callback_no_tracer_is_noop() -> None:
         context=context,
         result={"success": True, "output": "Done"},
     )
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_surfaces_uploaded_files_for_chip_rendering() -> None:
+    """On run start, file_info from request_context must flow to trace_data.files
+    so the frontend can render attachment chips alongside the user bubble."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "can u generate this?"
+    context.metadata["request_context"] = {
+        "uploaded_files": ["/abs/path/Q1.xlsx"],
+        "file_info": [
+            {
+                "file_id": "6cdc124b-d758-47e3-9871-284e1c90a98a",
+                "name": "normalized.xlsx",
+                "original_name": "Q1 Report.xlsx",
+                "size": 291953,
+                "type": (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+                "path": "/abs/leak/should/be/stripped.xlsx",
+            }
+        ],
+    }
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["files"] == [
+        {
+            "file_id": "6cdc124b-d758-47e3-9871-284e1c90a98a",
+            "name": "Q1 Report.xlsx",
+            "size": 291953,
+            "type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        }
+    ]
+    assert data["attachments"] == data["files"]
+    for f in data["files"]:
+        assert "path" not in f
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_posted_emits_trace_event_with_files() -> None:
+    """When the websocket calls ``post_user_message`` with attachments, the
+    runner's ``on_user_message_posted`` callback must emit a user_message
+    trace event with the files surfaced at the top level."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-cont")
+    context.metadata["task"] = "Original task"
+    files = [
+        {
+            "file_id": "fid-cont-1",
+            "name": "follow-up.pdf",
+            "size": 4096,
+            "type": "application/pdf",
+        }
+    ]
+    new_message = context.add_user_message(
+        "Follow-up question with a file.",
+        metadata={"files": files},
+    )
+
+    await callback.on_user_message_posted(
+        runner=runner,
+        context=context,
+        message=new_message,
+        files=files,
+    )
+
+    assert len(tracer.events) == 1
+    event = tracer.events[0]
+    assert event["event_type"] == "task_start_message"
+    assert event["data"]["message"] == "Follow-up question with a file."
+    assert event["data"]["files"] == files
+    assert event["data"]["attachments"] == files
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_posted_prevents_resume_from_duplicating() -> None:
+    """After ``on_user_message_posted`` fires, a subsequent resume must NOT
+    re-emit the same user_message trace event — the watermark stored on
+    ``context.metadata`` is the claim ticket that prevents duplication."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-cont")
+    context.metadata["task"] = "Original task"
+    msg = context.add_user_message("Follow-up.", metadata={"files": []})
+
+    await callback.on_user_message_posted(runner=runner, context=context, message=msg)
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert len(tracer.events) == 1  # not two
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_emits_untraced_user_message() -> None:
+    """If a checkpoint contains a user message whose trace event was never
+    emitted (e.g., worker crashed between persist and emit), the resume's
+    ``on_run_start`` must replay it so the chip still shows up."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-recovery")
+    context.metadata["task"] = "Original task"
+    files = [
+        {
+            "file_id": "fid-recover",
+            "name": "recover.csv",
+            "size": 256,
+            "type": "text/csv",
+        }
+    ]
+    context.add_user_message("Continue from here.", metadata={"files": files})
+
+    await callback.on_run_start(
+        runner=runner,
+        context=context,
+        resume=True,
+        checkpoint={"context": context.to_dict()},
+    )
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["message"] == "Continue from here."
+    assert data["files"] == files
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_skips_already_traced_user_messages() -> None:
+    """A pure resume (no new user message since the watermark) must NOT
+    emit anything — protects scenario where user clicks "Resume" on a
+    paused task without sending a new message."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-pure-resume")
+    context.metadata["task"] = "Original task"
+    msg = context.add_user_message("Original turn.")
+    callback._mark_traced(context, msg)
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+    await callback.on_run_start(
+        runner=runner, context=context, checkpoint={"context": context.to_dict()}
+    )
+
+    assert tracer.events == []
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_fresh_emits_for_file_only_initial_turn() -> None:
+    """User uploaded files without typing on the first turn — the live
+    bubble must still fire (the transcript row is persisted by
+    ``persist_user_message_no_commit`` when attachments are present, so the
+    trace event should match)."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-file-only-fresh")
+    # No ``metadata["task"]`` and no user message in context — only files.
+    context.metadata["request_context"] = {
+        "file_info": [
+            {
+                "file_id": "fid-only-upload",
+                "name": "report.pdf",
+                "size": 1024,
+                "type": "application/pdf",
+            }
+        ]
+    }
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["files"][0]["file_id"] == "fid-only-upload"
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_posted_emits_for_file_only_continuation() -> None:
+    """Continuation where the user only attaches files (no new text) must
+    still emit a trace event so the live chip lands — mirrors the
+    persistence layer, which keeps file-only rows."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-file-only-cont")
+    context.metadata["task"] = "Original task"
+    files = [{"file_id": "fid-only", "name": "x.pdf"}]
+    new_msg = context.add_user_message("", metadata={"files": files})
+
+    await callback.on_user_message_posted(
+        runner=runner, context=context, message=new_msg, files=files
+    )
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["message"] == ""
+    assert data["files"] == files
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_posted_still_skips_truly_empty_turn() -> None:
+    """Regression guard: when there's neither text nor files, the callback
+    must stay silent — otherwise an accidental empty inject would emit a
+    blank bubble."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-empty")
+    empty_msg = context.add_user_message("")
+
+    await callback.on_user_message_posted(
+        runner=runner, context=context, message=empty_msg, files=None
+    )
+
+    assert tracer.events == []
+
+
+@pytest.mark.asyncio
+async def test_emit_untraced_picks_up_file_only_message_on_resume() -> None:
+    """Crash-recovery: a checkpoint with a file-only user message (empty
+    content + files in Message.metadata) must surface its chip on resume."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-file-only-recover")
+    context.metadata["task"] = "Original task"
+    context.add_user_message("Original turn.")
+    callback._mark_traced(context, context.messages[-1])
+    # Second turn: file-only, never traced before the crash.
+    files = [{"file_id": "fid-rec", "name": "rec.csv"}]
+    context.add_user_message("", metadata={"files": files})
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    # ``_files_from_message`` runs through ``project_file_info_to_chip``
+    # for defense-in-depth, which canonicalizes the chip shape (size/type
+    # default to ``None`` when absent in the source).
+    assert data["files"] == [
+        {"file_id": "fid-rec", "name": "rec.csv", "size": None, "type": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_files_from_message_strips_paths_from_unprojected_metadata() -> None:
+    """Defense in depth: if a caller drops raw ``file_info`` (with absolute
+    paths) into ``Message.metadata['files']``, the trace callback must still
+    project it through ``project_file_info_to_chip`` so paths don't reach
+    the browser. ``inject_user_message`` is *supposed* to hand us
+    chip-shaped files, but we don't want to rely on every caller doing
+    the right thing for a security-relevant field."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-path-leak")
+    context.metadata["task"] = "Original task"
+    # Simulate a caller bypassing the websocket-side normalization.
+    raw_file_info = [
+        {
+            "file_id": "fid",
+            "name": "x.txt",
+            "path": "/abs/secret/should/not/leak.txt",
+            "extra_internal_field": "should-not-leak",
+        }
+    ]
+    msg = context.add_user_message("hi", metadata={"files": raw_file_info})
+
+    await callback.on_user_message_posted(runner=runner, context=context, message=msg)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["files"] == [
+        {"file_id": "fid", "name": "x.txt", "size": None, "type": None}
+    ]
+    for entry in data["files"]:
+        assert "path" not in entry
+        assert "extra_internal_field" not in entry
+
+
+def test_message_timestamp_iso_normalizes_naive_to_utc() -> None:
+    """Watermark uses ISO-string lexicographical comparison — naive and
+    aware datetimes for the same wall-clock instant must produce the same
+    sort key, otherwise a checkpoint with naive timestamps could let an
+    already-traced message re-emit on resume."""
+    from datetime import datetime, timezone
+
+    callback = TraceEventCallback()
+    naive = SimpleNamespace(timestamp=datetime(2026, 5, 18, 12, 0, 0))
+    aware_utc = SimpleNamespace(
+        timestamp=datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+    )
+    assert callback._message_timestamp_iso(naive) == callback._message_timestamp_iso(
+        aware_utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_falls_back_to_request_context_for_initial_files() -> (
+    None
+):
+    """Crash-recovery for the very first turn: runner attaches the initial
+    user message but didn't propagate request_context.file_info into
+    Message.metadata. The resume catch-up surfaces chips by falling back
+    to context.metadata.request_context.file_info for that turn."""
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-first-recovery")
+    context.metadata["task"] = "Initial task"
+    context.metadata["request_context"] = {
+        "file_info": [
+            {
+                "file_id": "fid-initial",
+                "name": "initial.xlsx",
+                "original_name": "initial.xlsx",
+                "size": 1024,
+                "type": (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+            }
+        ]
+    }
+    context.add_user_message("Initial task")
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["files"][0]["file_id"] == "fid-initial"

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -6,6 +6,25 @@ from typing import Any
 import pytest
 
 from xagent.core.agent import ExecutionContext, TraceEventCallback
+from xagent.core.agent.tracing import PENDING_MARKER_KEY
+
+
+def _stamp_pending(context: ExecutionContext) -> None:
+    """Mark the most-recently added user message as 'pending trace emit'.
+
+    Mirrors what ``runner.inject_user_message`` does just before it
+    persists the injected-message checkpoint. The catch-up loop on
+    resume requires either a watermark or this marker before it will
+    replay anything — otherwise it would re-emit history on pre-PR
+    checkpoints. See ``tracing.PENDING_MARKER_KEY`` for the contract.
+    """
+    callback = TraceEventCallback()
+    latest = callback._latest_user_message(context)
+    if latest is None:
+        return
+    ts = callback._message_timestamp_iso(latest)
+    if ts:
+        context.metadata[PENDING_MARKER_KEY] = ts
 
 
 class TraceRecorder:
@@ -257,6 +276,10 @@ async def test_on_run_start_resume_emits_untraced_user_message() -> None:
         }
     ]
     context.add_user_message("Continue from here.", metadata={"files": files})
+    # Simulate the runner: pending marker stamped just before the
+    # crashed checkpoint. Catch-up will only replay turns whose ts
+    # matches this marker, not all history.
+    _stamp_pending(context)
 
     await callback.on_run_start(
         runner=runner,
@@ -269,6 +292,65 @@ async def test_on_run_start_resume_emits_untraced_user_message() -> None:
     data = tracer.events[0]["data"]
     assert data["message"] == "Continue from here."
     assert data["files"] == files
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_skips_pre_pr_checkpoint_history() -> None:
+    """Pre-PR checkpoints (created before the chip-attachments PR landed)
+    have neither the trace watermark nor the pending marker on
+    ``context.metadata``. Resume catch-up must NOT replay every historical
+    user message in that case — otherwise it would re-render bubbles the
+    client already saw on the prior worker.
+    """
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-pre-pr")
+    context.metadata["task"] = "Old task"
+    context.add_user_message("First historical turn.")
+    context.add_user_message("Second historical turn.")
+    # Crucially: no _user_message_trace_watermark, no
+    # _pending_user_message_trace_timestamp — this is what an
+    # already-running task looks like on first resume after upgrade.
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+    await callback.on_run_start(
+        runner=runner, context=context, checkpoint={"context": context.to_dict()}
+    )
+
+    assert tracer.events == []
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_with_pending_marker_replays_only_pending_turn() -> (
+    None
+):
+    """When a checkpoint carries a pending marker but no watermark advance
+    (the runner persisted the injected user message and then crashed
+    before the trace was emitted), catch-up should fire exactly once for
+    the matching turn — not for any older history that lacks the marker.
+    """
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-pending-replay")
+    context.metadata["task"] = "Original task"
+    context.add_user_message("Earlier historical turn.")
+    pending_msg = context.add_user_message(
+        "The turn that crashed mid-emit.",
+        metadata={"files": [{"file_id": "fid-crash", "name": "c.txt"}]},
+    )
+    # Pending marker points at the second message — only it should replay.
+    pending_ts = callback._message_timestamp_iso(pending_msg)
+    assert pending_ts is not None
+    context.metadata[PENDING_MARKER_KEY] = pending_ts
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert len(tracer.events) == 1
+    data = tracer.events[0]["data"]
+    assert data["message"] == "The turn that crashed mid-emit."
+    assert data["files"][0]["file_id"] == "fid-crash"
 
 
 @pytest.mark.asyncio
@@ -522,6 +604,9 @@ async def test_on_run_start_resume_falls_back_to_request_context_for_initial_fil
         ]
     }
     context.add_user_message("Initial task")
+    # Same crash-recovery framing: stamp the pending marker so catch-up
+    # knows this is the turn to replay.
+    _stamp_pending(context)
 
     await callback.on_run_start(runner=runner, context=context, resume=True)
 

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -11,6 +11,7 @@ from xagent.web.services.chat_history_service import (
     load_task_transcript,
     persist_assistant_message,
     persist_user_message,
+    persist_user_message_no_commit,
 )
 
 
@@ -162,3 +163,92 @@ def test_build_assistant_transcript_content_skips_empty_unknown_interactions_hea
     content = build_assistant_transcript_content("Test", [{"type": "unknown_type"}])
 
     assert content == "Test"
+
+
+def test_persist_user_message_stores_attachments_for_chip_replay():
+    """Uploaded-file metadata must round-trip through ``attachments`` so the
+    historical-replay path can render the same chips the user saw live."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        attachments = [
+            {
+                "file_id": "fid-1",
+                "name": "Q1 Report.xlsx",
+                "size": 12345,
+                "type": (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                ),
+            }
+        ]
+        persist_user_message(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Read this for me.",
+            attachments=attachments,
+        )
+        row = db_session.query(TaskChatMessage).first()
+        assert row is not None
+        assert row.attachments == attachments
+    finally:
+        db_session.close()
+
+
+def test_persist_user_message_no_commit_allows_empty_content_with_attachments():
+    """User uploaded files without typing — the row should still be staged
+    so the chips survive reload."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        attachments = [{"file_id": "fid-only", "name": "x.pdf"}]
+        msg = persist_user_message_no_commit(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "",
+            attachments=attachments,
+        )
+        assert msg is not None
+        db_session.commit()
+        row = db_session.query(TaskChatMessage).first()
+        assert row is not None
+        assert row.content == ""
+        assert row.attachments == attachments
+
+        # Sanity guard: still drops empty rows with no attachments.
+        assert (
+            persist_user_message_no_commit(
+                db_session,
+                int(task.id),
+                int(task.user_id),
+                "   ",
+                attachments=None,
+            )
+            is None
+        )
+    finally:
+        db_session.close()
+
+
+def test_persist_user_message_preserves_empty_attachments_list_as_empty_list():
+    """An explicit empty ``attachments=[]`` (e.g. a SDK caller that always
+    sends the key) must round-trip as ``[]`` rather than being coerced to
+    ``NULL`` — callers may want to distinguish "no attachments specified"
+    from "attachments key was set, just empty"."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        # Non-empty content + empty attachments → row persists with [].
+        persist_user_message(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Just a text message.",
+            attachments=[],
+        )
+        row = db_session.query(TaskChatMessage).first()
+        assert row is not None
+        assert row.attachments == []  # not None
+    finally:
+        db_session.close()

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -12,6 +12,7 @@ from xagent.web.api.websocket import (
     _build_uploaded_files_context,
     _display_file_refs_from_file_info,
     _display_message_for_user,
+    _normalize_attachments_for_persistence,
     _normalize_file_outputs,
     _register_uploaded_files_for_agent,
     _selected_file_refs_from_task,
@@ -646,3 +647,44 @@ def test_display_file_refs_from_file_info_omits_runtime_paths():
     ]
     assert "path" not in refs[0]
     assert "workspace_path" not in refs[0]
+
+
+def test_normalize_attachments_keeps_chip_fields_and_strips_paths():
+    """Only chip-relevant fields persist; absolute paths must not leak
+    into chat history (which is exposed to historical-replay clients)."""
+    raw = [
+        {
+            "file_id": "uuid-1",
+            "name": "normalized.xlsx",
+            "original_name": "Q1 Report.xlsx",
+            "size": 12345,
+            "type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            "path": "/abs/leak/should/be/stripped.xlsx",
+        }
+    ]
+    assert _normalize_attachments_for_persistence(raw) == [
+        {
+            "file_id": "uuid-1",
+            "name": "Q1 Report.xlsx",  # original_name preferred over name
+            "size": 12345,
+            "type": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        }
+    ]
+
+
+def test_normalize_attachments_drops_entries_without_file_id():
+    assert _normalize_attachments_for_persistence(
+        [
+            {"name": "no-id.txt", "size": 1},
+            {"file_id": "keep", "name": "keep.txt"},
+        ]
+    ) == [{"file_id": "keep", "name": "keep.txt", "size": None, "type": None}]
+
+
+def test_normalize_attachments_handles_empty():
+    assert _normalize_attachments_for_persistence([]) == []
+    assert _normalize_attachments_for_persistence(None) == []


### PR DESCRIPTION
## Summary

Uploaded files attached to a user message currently vanish from the chat in two situations: (1) **on page reload**, because they're only baked into the LLM prompt body, not stored alongside the transcript row, and (2) **on the live continuation bubble**, because the agent runner's `post_user_message` path persists + resumes the checkpoint but never emits a fresh `trace_user_message` event (`on_run_start` early-returns on `resume=True`).

This PR fixes both halves end-to-end:

- **Persistence layer** (`5a30093`) — new `attachments` JSON column on `task_chat_messages` plumbed through `TaskTurnPayload` → `TaskTurnOrchestrator.begin_turn` → `persist_user_message_no_commit`, so chip metadata lands in the same atomic commit as the status flip. Websocket strips absolute paths before persistence (the column is exposed to historical-replay clients). The DAG continuation `trace_user_message` event also carries `files`/`attachments` so the live render matches what historical replay shows on reload.

- **Runner trace layer** (`699c1c1`) — new `TraceEventCallback.on_user_message_posted` callback emits `trace_user_message` with the chip payload the moment `inject_user_message` lands a continuation turn. A per-context watermark (`_user_message_trace_watermark`, ISO timestamp in `context.metadata`) dedupes against the resume's `on_run_start`. The resume branch now defensively replays untraced user messages instead of bare early-returning — covers the crash-recovery window between persist and trace emission. `files` is plumbed through `ExecutionRegistry` → `AgentExecutionAdapter` → `AgentService.post_user_message` → the websocket continuation call site.

Drive-by: `model_service` falls back to a per-model warning + skip when `base_url` is missing, instead of aborting the entire category load at the first misconfigured row (was masking a real config bug as "no models found").

## Test plan

- [x] Full `tests/core/agent/` suite — 257 passed (includes 7 new tests for the chip pipeline: fresh-start `files` surfacing, `on_user_message_posted` emission, inject→resume dedup, resume catch-up of untraced messages, pure-resume regression guard, `request_context` fallback for the initial turn, end-to-end runner inject with `files`)
- [x] Full `tests/web/` suite — 652 passed (remaining failures/errors are pre-existing on `main`, in files this PR doesn't touch)
- [x] Migration applies cleanly on a fresh sqlite via `alembic upgrade head`; `attachments` column verified present
- [x] mypy clean on all changed files
- [ ] Manual: upload a file in the chat → confirm chip persists across reload, and continuation messages with new files also show chips live before reload

## Follow-ups (not in this PR)

- Frontend chip rendering wiring in `app-context-chat.tsx` — depends on chat-context infra that we haven't landed yet, will come in a separate PR
- Backfill helper for legacy `trace_events` rows that pre-date this PR (their `data.files` is empty, but the new `attachments` column can be used to retroactively populate chip data for old tasks)