### PR TITLE
fix: preserve response language across agent planning

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -337,10 +337,19 @@ class ExecutionContext:
             "latest, yesterday, and tomorrow."
         )
 
+    def _current_user_request_text(self) -> str:
+        for message in reversed(self.messages):
+            if message.hidden or message.role != "user":
+                continue
+            content = str(message.content or "").strip()
+            if content:
+                return content
+        return str(self.metadata.get("task") or "").strip()
+
     def _system_context(self) -> str:
         parts = [self._current_time_context()]
         dag_step_id = self.metadata.get("dag_step_id")
-        current_task = str(self.metadata.get("task") or "").strip()
+        current_task = self._current_user_request_text()
         if current_task and not dag_step_id:
             parts.append(
                 "Current user request:\n"

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import uuid4
 
 from ...artifact_refs.observation import format_tool_result_for_observation
+from ..language import dag_step_language_rules, response_language_rules
 from .components import (
     COMPONENT_LOADERS,
     ExecutionComponent,
@@ -349,7 +350,8 @@ class ExecutionContext:
                 "resolve references and preserve continuity, but do not re-answer "
                 "previous requests or repeat previous final answers unless the "
                 "current user request explicitly asks to revise, continue, compare, "
-                "or summarize them."
+                "or summarize them.\n\n"
+                f"{response_language_rules()}"
             )
         process_description = str(
             self.metadata.get("process_description") or ""
@@ -403,7 +405,8 @@ class ExecutionContext:
                 f"- Current step dependencies: {dag_dependencies}\n"
                 f"- Suggested tools for this step: {suggested_tools}\n\n"
                 "Only execute the current DAG step. Detailed step boundary rules are "
-                "provided in the latest DAG step instruction message."
+                "provided in the latest DAG step instruction message.\n\n"
+                f"{dag_step_language_rules()}"
             )
         memory_context = self.metadata.get(MEMORY_CONTEXT_METADATA_KEY)
         if memory_context:

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -341,6 +341,8 @@ class ExecutionContext:
         for message in reversed(self.messages):
             if message.hidden or message.role != "user":
                 continue
+            if message.metadata.get("response_to_waiting_for_user"):
+                continue
             content = str(message.content or "").strip()
             if content:
                 return content

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -1,0 +1,45 @@
+"""Prompt snippets for preserving user-facing response language."""
+
+
+def response_language_rules(*, subject: str = "current user request") -> str:
+    """Return language rules for user-facing prose.
+
+    The model can infer the language from the referenced subject; the important
+    constraint is that auxiliary context must not override the user's language.
+    """
+    return (
+        "Response language rules: Use the same natural language as the "
+        f"{subject} for all user-facing prose. If the {subject} explicitly asks "
+        "to translate, rewrite, or answer in another language, use that requested "
+        "target language. Do not let retrieved memories, tool results, source "
+        "documents, examples, or earlier turns change the response language unless "
+        "the current user request explicitly asks for that language change."
+    )
+
+
+def plan_language_rules() -> str:
+    """Return language rules for DAG plan generation."""
+    return (
+        "Plan language rules: Write every plan step task, description, "
+        "termination_condition, and completion_evidence in the same natural "
+        "language as the current user request. If the current user request "
+        "explicitly asks to translate, rewrite, or answer in another language, "
+        "use that requested target language for those fields. Any final synthesis "
+        "or final result produced from the plan must use that same language. "
+        "Do not let retrieved memories, tool results, source documents, examples, "
+        "or earlier turns change the plan language unless the current user request "
+        "explicitly asks for that language change."
+    )
+
+
+def dag_step_language_rules() -> str:
+    """Return language rules for executing an individual DAG step."""
+    return (
+        "Step language rules: Use the same natural language as the current DAG "
+        "step title and description for all user-facing prose and for this step's "
+        "final_answer. If the current step explicitly asks to translate, rewrite, "
+        "or answer in another language, use that requested target language. Do "
+        "not switch languages because dependency results, tool outputs, source "
+        "documents, memories, examples, or earlier turns use another language "
+        "unless this current step explicitly requires that language change."
+    )

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -39,7 +39,7 @@ def dag_step_language_rules() -> str:
         "step title and description for all user-facing prose and for this step's "
         "final_answer. If the current step explicitly asks to translate, rewrite, "
         "or answer in another language, use that requested target language. Do "
-        "not switch languages because dependency results, tool outputs, source "
-        "documents, memories, examples, or earlier turns use another language "
-        "unless this current step explicitly requires that language change."
+        "not let dependency results, tool results, source documents, retrieved "
+        "memories, examples, or earlier turns change the step language unless "
+        "this current step explicitly asks for that language change."
     )

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -13,7 +13,7 @@ def response_language_rules(*, subject: str = "current user request") -> str:
         "to translate, rewrite, or answer in another language, use that requested "
         "target language. Do not let retrieved memories, tool results, source "
         "documents, examples, or earlier turns change the response language unless "
-        "the current user request explicitly asks for that language change."
+        f"the {subject} explicitly asks for that language change."
     )
 
 
@@ -27,8 +27,8 @@ def plan_language_rules() -> str:
         "use that requested target language for those fields. Any final synthesis "
         "or final result produced from the plan must use that same language. "
         "Do not let retrieved memories, tool results, source documents, examples, "
-        "or earlier turns change the plan language unless the current user request "
-        "explicitly asks for that language change."
+        "completed step results, or earlier turns change the plan language unless "
+        "the current user request explicitly asks for that language change."
     )
 
 

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -12,7 +12,6 @@ from ...context.enrichment import (
     latest_user_text,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
-from ...language import dag_step_language_rules
 from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult
@@ -1129,7 +1128,6 @@ class DAGPattern(AgentPattern):
             "step. Do not inspect, verify, revise, optimize, regenerate, or perform "
             "downstream work unless the termination condition explicitly requires "
             "that work.\n\n"
-            f"{dag_step_language_rules()}\n\n"
             f"{dependency_note}\n\n"
             "Execute only the current DAG step. The current step title and "
             "description plus the termination condition define the entire "

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -12,6 +12,7 @@ from ...context.enrichment import (
     latest_user_text,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
+from ...language import dag_step_language_rules
 from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult
@@ -1128,6 +1129,7 @@ class DAGPattern(AgentPattern):
             "step. Do not inspect, verify, revise, optimize, regenerate, or perform "
             "downstream work unless the termination condition explicitly requires "
             "that work.\n\n"
+            f"{dag_step_language_rules()}\n\n"
             f"{dependency_note}\n\n"
             "Execute only the current DAG step. The current step title and "
             "description plus the termination condition define the entire "

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from ...language import plan_language_rules
+
 logger = logging.getLogger(__name__)
 
 
@@ -256,6 +258,7 @@ class LLMPlanGenerator(PlanGenerator):
                         "limits, but they define the expected tool scope for the "
                         "step executor; choose them carefully so the executor does "
                         "not need to perform sibling or downstream step work. "
+                        f"{plan_language_rules()} "
                         "Keep ids stable "
                         "across replans when a completed step can be reused."
                     ),

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -109,6 +109,24 @@ def test_format_tool_result_uses_shared_image_artifact_observation() -> None:
     assert "/api/files/public/preview/" not in content
 
 
+def test_system_context_preserves_current_request_language_over_memory() -> None:
+    ctx = ExecutionContext(execution_id="exec-language")
+    ctx.metadata["task"] = "Can you analyze this GitHub project?"
+    ctx.metadata[MEMORY_CONTEXT_METADATA_KEY] = (
+        "Relevant memory:\n- Task: 怎么样进入 github trending？\n"
+        "Result: 使用中文总结增长策略。"
+    )
+    ctx.add_user_message("Can you analyze this GitHub project?")
+
+    system_message = ctx.get_messages_for_llm()[0]["content"]
+
+    assert "Current user request:" in system_message
+    assert "Can you analyze this GitHub project?" in system_message
+    assert "Response language rules" in system_message
+    assert "Use the same natural language as the current user request" in system_message
+    assert "Do not let retrieved memories" in system_message
+
+
 def test_memory_enrichment_uses_web_user_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -136,6 +136,21 @@ def test_response_language_rules_uses_custom_subject_throughout() -> None:
     assert "unless the current user request explicitly asks" not in rules
 
 
+def test_system_context_uses_latest_user_message_as_current_request() -> None:
+    ctx = ExecutionContext(execution_id="exec-follow-up-language")
+    ctx.metadata["task"] = "Can you analyze this GitHub project?"
+    ctx.add_user_message("Can you analyze this GitHub project?")
+    ctx.add_assistant_message("Sure, here is the analysis.")
+    ctx.add_user_message("请继续用中文总结")
+
+    system_message = ctx.get_messages_for_llm()[0]["content"]
+
+    assert "Current user request:\n请继续用中文总结" in system_message
+    assert "Current user request:\nCan you analyze this GitHub project?" not in (
+        system_message
+    )
+
+
 def test_dag_step_system_context_preserves_step_language_for_final_answer() -> None:
     ctx = ExecutionContext(
         execution_id="exec-dag-language",

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -151,6 +151,30 @@ def test_system_context_uses_latest_user_message_as_current_request() -> None:
     )
 
 
+def test_system_context_ignores_waiting_for_user_answer_as_current_request() -> None:
+    ctx = ExecutionContext(execution_id="exec-waiting-for-user-language")
+    ctx.metadata["task"] = "Book a trip"
+    ctx.add_user_message("Book a trip")
+    ctx.add_assistant_message("What city?")
+    ctx.add_user_message(
+        "北京",
+        metadata={
+            "response_to_waiting_for_user": {
+                "question": "What city?",
+            },
+        },
+    )
+
+    messages = ctx.get_messages_for_llm()
+    system_message = messages[0]["content"]
+    waiting_answer_message = messages[-1]["content"]
+
+    assert "Current user request:\nBook a trip" in system_message
+    assert "Current user request:\n北京" not in system_message
+    assert "answer to a pending agent question" in waiting_answer_message
+    assert "User answer: 北京" in waiting_answer_message
+
+
 def test_dag_step_system_context_preserves_step_language_for_final_answer() -> None:
     ctx = ExecutionContext(
         execution_id="exec-dag-language",

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -23,6 +23,7 @@ from xagent.core.agent.context.enrichment import (
     enrich_context_with_skill,
     generate_and_store_react_memory,
 )
+from xagent.core.agent.language import response_language_rules
 from xagent.core.agent.runtime import LLMCallInterrupted
 from xagent.web.user_isolated_memory import current_user_id
 
@@ -125,6 +126,14 @@ def test_system_context_preserves_current_request_language_over_memory() -> None
     assert "Response language rules" in system_message
     assert "Use the same natural language as the current user request" in system_message
     assert "Do not let retrieved memories" in system_message
+
+
+def test_response_language_rules_uses_custom_subject_throughout() -> None:
+    rules = response_language_rules(subject="current DAG step")
+
+    assert "If the current DAG step explicitly asks" in rules
+    assert "unless the current DAG step explicitly asks" in rules
+    assert "unless the current user request explicitly asks" not in rules
 
 
 def test_dag_step_system_context_preserves_step_language_for_final_answer() -> None:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -127,6 +127,27 @@ def test_system_context_preserves_current_request_language_over_memory() -> None
     assert "Do not let retrieved memories" in system_message
 
 
+def test_dag_step_system_context_preserves_step_language_for_final_answer() -> None:
+    ctx = ExecutionContext(
+        execution_id="exec-dag-language",
+        metadata={
+            "dag_step_id": "research",
+            "dag_step_name": "Research best practices",
+            "dag_step_description": "Find lessons from the repository",
+        },
+    )
+    ctx.add_user_message("Dependency results: {'prior': '中文内容'}")
+
+    system_message = ctx.get_messages_for_llm()[0]["content"]
+
+    assert "Step language rules" in system_message
+    assert (
+        "Use the same natural language as the current DAG step title and "
+        "description for all user-facing prose and for this step's final_answer"
+    ) in system_message
+    assert "Do not let dependency results, tool results" in system_message
+
+
 def test_memory_enrichment_uses_web_user_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1178,6 +1178,7 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
         "user request"
     ) in system_prompt
     assert "Any final synthesis or final result produced from the plan" in system_prompt
+    assert "completed step results" in system_prompt
     assert llm.calls[0]["tool_choice"] == "required"
     assert llm.calls[0]["thinking"] == {"type": "disabled", "enable": False}
     assert "response_format" not in llm.calls[0]

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1171,6 +1171,13 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     assert "Few-shot examples" in system_prompt
     assert "must be concrete and action-specific" in system_prompt
     assert "suggested execution tool scope" in system_prompt
+    assert "Plan language rules" in system_prompt
+    assert (
+        "Write every plan step task, description, termination_condition, "
+        "and completion_evidence in the same natural language as the current "
+        "user request"
+    ) in system_prompt
+    assert "Any final synthesis or final result produced from the plan" in system_prompt
     assert llm.calls[0]["tool_choice"] == "required"
     assert llm.calls[0]["thinking"] == {"type": "disabled", "enable": False}
     assert "response_format" not in llm.calls[0]
@@ -1282,6 +1289,27 @@ async def test_dag_dependency_summary_does_not_add_extra_system_message() -> Non
         message["role"] == "user" and "Dependency results" in message["content"]
         for message in child_messages
     )
+
+
+def test_dag_step_instruction_preserves_step_language_for_final_answer() -> None:
+    pattern = DAGPattern(lambda **_: build_plan(PlanStep(id="unused", task="unused")))
+    instruction = pattern._step_instruction(
+        root_context=ExecutionContext(execution_id="dag-language"),
+        step=PlanStep(
+            id="research",
+            task="Research best practices",
+            description="Find lessons from the repository",
+            termination_condition="Stop after the lessons are summarized.",
+            completion_evidence="The summary has been returned.",
+        ),
+    )
+
+    assert "Step language rules" in instruction
+    assert (
+        "Use the same natural language as the current DAG step title and "
+        "description for all user-facing prose and for this step's final_answer"
+    ) in instruction
+    assert "Do not switch languages because dependency results" in instruction
 
 
 @pytest.mark.parametrize(

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1291,27 +1291,6 @@ async def test_dag_dependency_summary_does_not_add_extra_system_message() -> Non
     )
 
 
-def test_dag_step_instruction_preserves_step_language_for_final_answer() -> None:
-    pattern = DAGPattern(lambda **_: build_plan(PlanStep(id="unused", task="unused")))
-    instruction = pattern._step_instruction(
-        root_context=ExecutionContext(execution_id="dag-language"),
-        step=PlanStep(
-            id="research",
-            task="Research best practices",
-            description="Find lessons from the repository",
-            termination_condition="Stop after the lessons are summarized.",
-            completion_evidence="The summary has been returned.",
-        ),
-    )
-
-    assert "Step language rules" in instruction
-    assert (
-        "Use the same natural language as the current DAG step title and "
-        "description for all user-facing prose and for this step's final_answer"
-    ) in instruction
-    assert "Do not switch languages because dependency results" in instruction
-
-
 @pytest.mark.parametrize(
     ("plan", "error"),
     [


### PR DESCRIPTION
## Summary
- add shared prompt rules that keep user-facing responses in the current request language
- apply the same language rule to DAG plan step fields and final synthesis expectations
- apply step-level language rules so DAG step final_answer follows the generated step language instead of dependency/tool output language

## Tests
- PYTHONPATH=src pytest tests/core/agent/test_dag.py
- PYTHONPATH=src pytest tests/core/agent/test_context.py
- ruff check src/xagent/core/agent/language.py src/xagent/core/agent/context/execution.py src/xagent/core/agent/pattern/dag/plan_generator.py src/xagent/core/agent/pattern/dag/dag.py tests/core/agent/test_context.py tests/core/agent/test_dag.py