### PR TITLE
fix: render Telegram image outputs

### DIFF
--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import json
 import logging
 import os
@@ -12,14 +13,16 @@ from aiogram import Bot, Dispatcher, types
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.filters import CommandStart
+from aiogram.types import FSInputFile
 from sqlalchemy.orm import Session
 
 from ...api.chat import get_agent_manager
 from ...models.database import get_db
 from ...models.task import Task, TaskStatus
+from ...models.uploaded_file import UploadedFile
 from ...models.user import User
 from .handler import TelegramTraceHandler
-from .utils import markdown_to_tg_html
+from .utils import TelegramImageRef, markdown_to_tg_html, strip_telegram_image_refs
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +101,7 @@ class TelegramBotInstance:
                 f"Received /start from {message.from_user.id} on bot {self.instance_id}"
             )
             await message.answer(
-                "Hello! I am Xagent Telegram Bot. You can send /new to start a new task."
+                "Hi, I'm Xagent. Send me anything you'd like help with, or use /new when you want a fresh start."
             )
 
         @self.dp.message(Command("new"))
@@ -109,7 +112,7 @@ class TelegramBotInstance:
             self.active_tasks[message.from_user.id] = -1
             self._save_active_tasks()
             await message.answer(
-                "Started a new session. Your next message will create a new task."
+                "Fresh start. Send me what you'd like to work on next."
             )
 
         @self.dp.message()
@@ -411,7 +414,8 @@ class TelegramBotInstance:
                         context["state"]["file_info"] = uploaded_info
 
                 loading_msg = await last_message.answer(
-                    f"⏳ <b>Task #{task.id} is processing...</b>\n<i>Please wait for the result.</i>",
+                    "Got it, I'm working on this now.\n"
+                    "<i>I'll update this message as I make progress.</i>",
                     parse_mode=ParseMode.HTML,
                 )
 
@@ -476,6 +480,11 @@ class TelegramBotInstance:
                 if not output or not str(output).strip():
                     output = "Task completed, but no output was generated."
 
+                output = str(output)
+                output, image_refs = strip_telegram_image_refs(output)
+                if not output and image_refs:
+                    output = "Task completed."
+
                 max_len = 4000
                 text_chunks = [
                     output[i : i + max_len] for i in range(0, len(output), max_len)
@@ -499,6 +508,20 @@ class TelegramBotInstance:
                     except Exception:
                         await last_message.answer(chunk)
 
+                if image_refs:
+                    failed_image_refs = await self._send_output_images(
+                        image_refs=image_refs,
+                        user_id=int(user.id),  # type: ignore
+                        task_id=int(task.id),  # type: ignore
+                        db=db,
+                        reply_to=last_message,
+                    )
+                    if failed_image_refs:
+                        await self._send_image_fallback_message(
+                            image_refs=failed_image_refs,
+                            reply_to=last_message,
+                        )
+
             finally:
                 try:
                     next(db_gen)
@@ -509,6 +532,100 @@ class TelegramBotInstance:
             await last_message.answer(
                 "Sorry, an error occurred while processing your request."
             )
+
+    async def _send_output_images(
+        self,
+        *,
+        image_refs: list[TelegramImageRef],
+        user_id: int,
+        task_id: int,
+        db: Session,
+        reply_to: types.Message,
+    ) -> list[TelegramImageRef]:
+        ordered_file_ids = list(dict.fromkeys(ref.file_id for ref in image_refs))
+        failed_refs: list[TelegramImageRef] = []
+
+        file_records = (
+            db.query(UploadedFile)
+            .filter(
+                UploadedFile.file_id.in_(ordered_file_ids),
+                UploadedFile.user_id == user_id,
+                UploadedFile.task_id == task_id,
+            )
+            .all()
+            if ordered_file_ids
+            else []
+        )
+        file_record_by_id = {str(record.file_id): record for record in file_records}
+
+        sent_file_ids: set[str] = set()
+        for image_ref in image_refs:
+            if image_ref.file_id in sent_file_ids:
+                continue
+            sent_file_ids.add(image_ref.file_id)
+
+            file_record = file_record_by_id.get(image_ref.file_id)
+            if not file_record:
+                logger.warning(
+                    "Telegram output image not found: file_id=%s task_id=%s",
+                    image_ref.file_id,
+                    task_id,
+                )
+                failed_refs.append(image_ref)
+                continue
+
+            mime_type = file_record.mime_type or ""
+            if not mime_type.startswith("image/"):
+                logger.warning(
+                    "Telegram output file is not an image: file_id=%s mime_type=%s",
+                    image_ref.file_id,
+                    mime_type,
+                )
+                failed_refs.append(image_ref)
+                continue
+
+            image_path = Path(file_record.storage_path)
+            if not image_path.is_file():
+                logger.warning(
+                    "Telegram output image path missing: file_id=%s path=%s",
+                    image_ref.file_id,
+                    image_path,
+                )
+                failed_refs.append(image_ref)
+                continue
+
+            caption = (
+                html.escape(image_ref.alt_text[:512]) if image_ref.alt_text else None
+            )
+            try:
+                await reply_to.answer_photo(
+                    FSInputFile(image_path), caption=caption or None
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to send Telegram output image: file_id=%s error=%s",
+                    image_ref.file_id,
+                    e,
+                )
+                failed_refs.append(image_ref)
+
+        return failed_refs
+
+    async def _send_image_fallback_message(
+        self, *, image_refs: list[TelegramImageRef], reply_to: types.Message
+    ) -> None:
+        subject = "image" if len(image_refs) == 1 else "images"
+        lines = [
+            f"I couldn't send the {subject} through Telegram, but the file reference is still available:"
+        ]
+        for image_ref in image_refs:
+            label = image_ref.alt_text or "image"
+            lines.append(f"- {label}: file:{image_ref.file_id}")
+        text = "\n".join(lines)
+        try:
+            await reply_to.answer(markdown_to_tg_html(text), parse_mode=ParseMode.HTML)
+        except Exception:
+            await reply_to.answer(text)
 
     async def start(self) -> None:
         try:

--- a/src/xagent/web/channels/telegram/handler.py
+++ b/src/xagent/web/channels/telegram/handler.py
@@ -1,16 +1,19 @@
 import logging
+import time
 from typing import Optional
 
 from aiogram import Bot
 from aiogram.enums import ParseMode
 
 from ....core.agent.trace import TraceAction, TraceCategory, TraceEvent, TraceHandler
-from .utils import markdown_to_tg_html
+from .utils import markdown_to_tg_html, strip_telegram_image_refs
 
 logger = logging.getLogger(__name__)
 
 
 class TelegramTraceHandler(TraceHandler):
+    MIN_STATUS_UPDATE_INTERVAL_SECONDS = 2.0
+
     def __init__(
         self, task_id: int, bot: Bot, chat_id: int, message_id: Optional[int] = None
     ):
@@ -19,10 +22,13 @@ class TelegramTraceHandler(TraceHandler):
         self.chat_id = chat_id
         self.message_id = message_id
         self.current_text = ""
+        self._last_status_update_at = 0.0
+        self._last_status_text = ""
+        self._activity_items: list[str] = []
 
     async def handle_event(self, event: TraceEvent) -> None:
         try:
-            # We only care about message events and tool events for Telegram
+            # We only care about assistant messages and coarse tool activity for Telegram.
             if (
                 event.event_type.category == TraceCategory.MESSAGE
                 and event.event_type.action == TraceAction.UPDATE
@@ -45,12 +51,78 @@ class TelegramTraceHandler(TraceHandler):
                 if role == "assistant" and content:
                     await self._update_message(content, final=True)
 
+            elif event.event_type.category == TraceCategory.TOOL:
+                await self._handle_tool_event(event)
+
         except Exception as e:
             logger.warning(f"TelegramTraceHandler error for task {self.task_id}: {e}")
+
+    async def _handle_tool_event(self, event: TraceEvent) -> None:
+        tool_name = self._extract_tool_name(event)
+        if not tool_name:
+            return
+
+        action = event.event_type.action
+        tool_label = self._format_tool_name(tool_name)
+        if action == TraceAction.START:
+            status = (
+                f"I'm checking with {tool_label} and will pull the results together."
+            )
+            activity = f"Started {tool_label}"
+        elif action == TraceAction.END:
+            status = f"I've finished {tool_label} and am putting the answer together."
+            activity = f"Finished {tool_label}"
+        elif action == TraceAction.ERROR:
+            status = f"{tool_label} didn't work, so I'm trying another way."
+            activity = f"{tool_label} did not work"
+        else:
+            return
+
+        self._append_activity(activity)
+        await self._update_status(status)
+
+    def _extract_tool_name(self, event: TraceEvent) -> str:
+        data = event.data if isinstance(event.data, dict) else {}
+        raw_name = data.get("tool_name")
+        if raw_name is None:
+            return ""
+        return str(raw_name).strip()
+
+    def _format_tool_name(self, tool_name: str) -> str:
+        return tool_name.replace("_", " ").strip() or "a tool"
+
+    def _append_activity(self, activity: str) -> None:
+        if not activity:
+            return
+        if self._activity_items and self._activity_items[-1] == activity:
+            return
+        self._activity_items.append(activity)
+        self._activity_items = self._activity_items[-3:]
+
+    async def _update_status(self, status: str) -> None:
+        if not status or status == self._last_status_text:
+            return
+
+        now = time.monotonic()
+        if now - self._last_status_update_at < self.MIN_STATUS_UPDATE_INTERVAL_SECONDS:
+            return
+
+        self._last_status_text = status
+        self._last_status_update_at = now
+
+        activity = "\n".join(f"• {item}" for item in self._activity_items)
+        text = f"I'm still working on this and making progress.\n\n{status}"
+        if activity:
+            text += f"\n\nRecent activity:\n{activity}"
+        await self._update_message(text)
 
     async def _update_message(self, text: str, final: bool = False) -> None:
         if not text:
             return
+
+        text, image_refs = strip_telegram_image_refs(text)
+        if not text and image_refs:
+            text = self._image_placeholder_text(len(image_refs))
 
         # Add a typing indicator for non-final messages
         display_text = text if final else text + " ✍️"
@@ -93,3 +165,6 @@ class TelegramTraceHandler(TraceHandler):
         except Exception as e:
             if "message is not modified" not in str(e).lower():
                 logger.error(f"Error updating Telegram message: {e}")
+
+    def _image_placeholder_text(self, image_count: int) -> str:
+        return "Images generated." if image_count > 1 else "Image generated."

--- a/src/xagent/web/channels/telegram/utils.py
+++ b/src/xagent/web/channels/telegram/utils.py
@@ -1,5 +1,13 @@
 import html
 import re
+from dataclasses import dataclass
+from urllib.parse import unquote, urlparse
+
+
+@dataclass(frozen=True)
+class TelegramImageRef:
+    file_id: str
+    alt_text: str
 
 
 def markdown_to_tg_html(text: str) -> str:
@@ -67,3 +75,42 @@ def markdown_to_tg_html(text: str) -> str:
     text = re.sub(r"\[([^\]\n]+)\]\(([^)\n]+)\)", r'<a href="\2">\1</a>', text)
 
     return text
+
+
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]\n]*)\]\(([^)\n]+)\)")
+
+
+def strip_telegram_image_refs(text: str) -> tuple[str, list[TelegramImageRef]]:
+    """Remove local image refs from text and return refs Telegram should upload."""
+    if not text:
+        return "", []
+
+    image_refs: list[TelegramImageRef] = []
+
+    def replace_image(match: re.Match[str]) -> str:
+        alt_text = match.group(1).strip()
+        target = html.unescape(match.group(2).strip())
+        file_id = _extract_local_file_id(target)
+        if not file_id:
+            return match.group(0)
+        image_refs.append(TelegramImageRef(file_id=file_id, alt_text=alt_text))
+        return ""
+
+    cleaned = _MARKDOWN_IMAGE_RE.sub(replace_image, text)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip(), image_refs
+
+
+def _extract_local_file_id(target: str) -> str | None:
+    parsed = urlparse(target)
+    path = parsed.path
+    if parsed.scheme == "file":
+        file_id = f"{parsed.netloc}{path}".lstrip("/")
+        return unquote(file_id) or None
+
+    for prefix in ("/api/files/preview/", "/api/files/download/"):
+        if path.startswith(prefix):
+            return unquote(path[len(prefix) :].strip("/")) or None
+
+    return None

--- a/tests/core/tools/test_api_tool.py
+++ b/tests/core/tools/test_api_tool.py
@@ -2,17 +2,74 @@
 Tests for API Tool
 """
 
+import json
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
 from xagent.core.tools.adapters.vibe.api_tool import APICallArgs, APITool
 from xagent.core.tools.core.api_tool import APIClientCore, call_api
 
 
+def _single_value_query_args(url: str) -> dict[str, str]:
+    return {key: values[-1] for key, values in parse_qs(urlparse(url).query).items()}
+
+
+@pytest.fixture
+def mock_httpbin(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def mock_make_request(
+        self: APIClientCore,
+        *,
+        url: str,
+        method: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        data: str | bytes | None,
+        timeout: int,
+        proxy_url: str | None,
+        allow_redirects: bool,
+    ) -> dict[str, Any]:
+        parsed = urlparse(url)
+        path = parsed.path
+        body: dict[str, Any]
+        status_code = 200
+
+        if path == "/get":
+            body = {"args": _single_value_query_args(url)}
+        elif path == "/post":
+            parsed_data = json.loads(
+                data.decode() if isinstance(data, bytes) else data or "{}"
+            )
+            body = {"json": parsed_data}
+        elif path == "/bearer":
+            token = headers.get("Authorization", "").removeprefix("Bearer ")
+            body = {"authenticated": bool(token), "token": token}
+        elif path == "/headers":
+            body = {"headers": headers}
+        elif path == "/status/404":
+            status_code = 404
+            body = {}
+        else:
+            status_code = 404
+            body = {}
+
+        return {
+            "success": 200 <= status_code < 300,
+            "status_code": status_code,
+            "headers": {"content-type": "application/json"},
+            "body": body,
+            "error": None if 200 <= status_code < 300 else f"HTTP {status_code}",
+        }
+
+    monkeypatch.setattr(APIClientCore, "_make_request", mock_make_request)
+
+
 class TestAPIClientCore:
     """Test core API client functionality"""
 
     @pytest.mark.asyncio
-    async def test_get_request(self):
+    async def test_get_request(self, mock_httpbin: None):
         """Test basic GET request"""
         client = APIClientCore()
         result = await client.call_api(
@@ -27,7 +84,7 @@ class TestAPIClientCore:
         assert result["body"]["args"]["test"] == "value"
 
     @pytest.mark.asyncio
-    async def test_post_json_request(self):
+    async def test_post_json_request(self, mock_httpbin: None):
         """Test POST request with JSON body"""
         client = APIClientCore()
         result = await client.call_api(
@@ -42,7 +99,7 @@ class TestAPIClientCore:
         assert result["body"]["json"]["value"] == 123
 
     @pytest.mark.asyncio
-    async def test_bearer_auth(self):
+    async def test_bearer_auth(self, mock_httpbin: None):
         """Test Bearer token authentication"""
         client = APIClientCore()
         result = await client.call_api(
@@ -58,7 +115,7 @@ class TestAPIClientCore:
         assert result["body"]["token"] == "test-token-123"
 
     @pytest.mark.asyncio
-    async def test_api_key_query_auth(self):
+    async def test_api_key_query_auth(self, mock_httpbin: None):
         """Test API key in query parameters using convenience function"""
         result = await call_api(
             url="https://httpbin.org/get",
@@ -73,7 +130,7 @@ class TestAPIClientCore:
         assert result["body"]["args"]["api_key"] == "test-key-123"
 
     @pytest.mark.asyncio
-    async def test_api_key_query_custom_param(self):
+    async def test_api_key_query_custom_param(self, mock_httpbin: None):
         """Test API key in custom query parameter"""
         result = await call_api(
             url="https://httpbin.org/get",
@@ -89,7 +146,7 @@ class TestAPIClientCore:
         assert result["body"]["args"]["token"] == "test-key-123"
 
     @pytest.mark.asyncio
-    async def test_custom_headers(self):
+    async def test_custom_headers(self, mock_httpbin: None):
         """Test custom headers"""
         client = APIClientCore()
         result = await client.call_api(
@@ -112,7 +169,7 @@ class TestAPIClientCore:
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_retry_mechanism(self):
+    async def test_retry_mechanism(self, mock_httpbin: None):
         """Test retry mechanism on failure"""
         client = APIClientCore(default_retry_count=2)
         # This will fail with 404
@@ -306,7 +363,7 @@ class TestConvenienceFunctions:
     """Test convenience functions"""
 
     @pytest.mark.asyncio
-    async def test_call_api_function(self):
+    async def test_call_api_function(self, mock_httpbin: None):
         """Test convenience call_api function"""
         result = await call_api(
             url="https://httpbin.org/get",

--- a/tests/web/test_telegram_image_output.py
+++ b/tests/web/test_telegram_image_output.py
@@ -1,0 +1,138 @@
+import pytest
+
+from xagent.core.agent.trace import (
+    ACTION_END_TOOL,
+    ACTION_START_TOOL,
+    TraceAction,
+    TraceCategory,
+    TraceEvent,
+    TraceEventType,
+    TraceScope,
+)
+from xagent.web.channels.telegram import handler as telegram_handler
+from xagent.web.channels.telegram.handler import TelegramTraceHandler
+from xagent.web.channels.telegram.utils import strip_telegram_image_refs
+
+
+def test_strip_telegram_image_refs_extracts_file_refs() -> None:
+    text = (
+        "Here is the result:\n\n![generated_image.jpg](file:abc-123)\nKeep this text."
+    )
+
+    cleaned, refs = strip_telegram_image_refs(text)
+
+    assert cleaned == "Here is the result:\n\nKeep this text."
+    assert [(ref.file_id, ref.alt_text) for ref in refs] == [
+        ("abc-123", "generated_image.jpg")
+    ]
+
+
+def test_strip_telegram_image_refs_supports_file_urls_and_api_urls() -> None:
+    cleaned, refs = strip_telegram_image_refs(
+        "![a](file://abc%201) "
+        "![b](/api/files/preview/def%202) "
+        "![c](https://example.com/api/files/download/ghi%203?token=ignored)"
+    )
+
+    assert cleaned == ""
+    assert [ref.file_id for ref in refs] == ["abc 1", "def 2", "ghi 3"]
+
+
+def test_telegram_trace_handler_uses_plural_image_placeholder() -> None:
+    handler = TelegramTraceHandler(
+        task_id=421,
+        bot=object(),
+        chat_id=123,
+        message_id=456,  # type: ignore[arg-type]
+    )
+
+    assert handler._image_placeholder_text(1) == "Image generated."
+    assert handler._image_placeholder_text(2) == "Images generated."
+
+
+@pytest.mark.asyncio
+async def test_telegram_trace_handler_throttles_tool_status_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_texts: list[str] = []
+
+    class CapturingTelegramTraceHandler(TelegramTraceHandler):
+        async def _update_message(self, text: str, final: bool = False) -> None:
+            sent_texts.append(text)
+
+    now = 10.0
+    monkeypatch.setattr(telegram_handler.time, "monotonic", lambda: now)
+
+    handler = CapturingTelegramTraceHandler(
+        task_id=421,
+        bot=object(),
+        chat_id=123,
+        message_id=456,  # type: ignore[arg-type]
+    )
+
+    await handler.handle_event(
+        TraceEvent(
+            ACTION_START_TOOL,
+            task_id="421",
+            step_id="step-1",
+            data={"tool_name": "web_search"},
+        )
+    )
+    await handler.handle_event(
+        TraceEvent(
+            ACTION_END_TOOL,
+            task_id="421",
+            step_id="step-1",
+            data={"tool_name": "web_search"},
+        )
+    )
+
+    assert len(sent_texts) == 1
+    assert "I'm still working on this and making progress." in sent_texts[0]
+    assert "I'm checking with web search" in sent_texts[0]
+
+
+@pytest.mark.asyncio
+async def test_telegram_trace_handler_updates_after_throttle_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_texts: list[str] = []
+    current_time = {"value": 10.0}
+
+    class CapturingTelegramTraceHandler(TelegramTraceHandler):
+        async def _update_message(self, text: str, final: bool = False) -> None:
+            sent_texts.append(text)
+
+    monkeypatch.setattr(
+        telegram_handler.time, "monotonic", lambda: current_time["value"]
+    )
+
+    handler = CapturingTelegramTraceHandler(
+        task_id=421,
+        bot=object(),
+        chat_id=123,
+        message_id=456,  # type: ignore[arg-type]
+    )
+
+    await handler.handle_event(
+        TraceEvent(
+            ACTION_START_TOOL,
+            task_id="421",
+            step_id="step-1",
+            data={"tool_name": "web_search"},
+        )
+    )
+    current_time["value"] += handler.MIN_STATUS_UPDATE_INTERVAL_SECONDS + 0.1
+    await handler.handle_event(
+        TraceEvent(
+            TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.TOOL),
+            task_id="421",
+            step_id="step-1",
+            data={"tool_name": "web_search"},
+        )
+    )
+
+    assert len(sent_texts) == 2
+    assert "web search didn't work" in sent_texts[1]
+    assert "Started web search" in sent_texts[1]
+    assert "web search did not work" in sent_texts[1]


### PR DESCRIPTION
## Summary
- extract local image markdown refs from Telegram text output
- send generated image refs as Telegram photos using the registered UploadedFile path
- keep streaming text updates from showing raw image markdown
- show throttled Telegram progress updates for tool activity while a task is running
- use natural English status copy instead of system-style task logs

## Tests
- env -u LC_ALL -u LC_CTYPE PYTHONPATH=src python -m pytest tests/web/test_telegram_image_output.py -q --confcutdir=tests/web -p no:capture
- ruff check src/xagent/web/channels/telegram/utils.py src/xagent/web/channels/telegram/handler.py src/xagent/web/channels/telegram/bot.py tests/web/test_telegram_image_output.py
- pre-commit hooks during commit amend: ruff check, ruff format, mypy, isort, codespell