### PR TITLE
fix(sandbox): register sandbox-generated files on the host

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -201,6 +201,27 @@ class SandboxedToolWrapper(AbstractBaseTool):
     def state_type(self) -> Optional[Type[BaseModel]]:
         return self._target.state_type()
 
+    def _get_target_workspace(self) -> Optional[TaskWorkspace]:
+        """Return the target tool's bound workspace, if any.
+
+        Sandboxed executor tools (JS/Python/command) hold a TaskWorkspace on
+        ``_workspace``; for FunctionTool wrappers we check the bound method's
+        owner instance instead. Returns None when there is no usable workspace.
+        """
+        candidates: list[Any] = [self._target]
+        if isinstance(self._target, FunctionTool):
+            method_target = extract_bound_method_target(self._target)
+            if method_target is not None:
+                candidates.append(method_target[0])
+
+        for candidate in candidates:
+            workspace = getattr(candidate, "_workspace", None) or getattr(
+                candidate, "workspace", None
+            )
+            if isinstance(workspace, TaskWorkspace):
+                return workspace
+        return None
+
     def _build_execution_env(self) -> dict[str, str]:
         """Build per-exec environment variables (scoped to this process, not the sandbox)."""
         env = {"PYTHONPATH": _SANDBOX_SRC_ROOT}
@@ -359,9 +380,22 @@ class SandboxedToolWrapper(AbstractBaseTool):
             # Execute script in sandbox
             logger.debug(f"Executing tool {self._target.name} in sandbox")
             command = self._build_execution_command(args, result_file)
-            result = await self._sandbox.exec(
-                command[0], *command[1:], env=self._build_execution_env()
-            )
+
+            # Files written by the sandbox process appear on the host via the
+            # mounted workspace volume, but the sandbox cannot reach the host
+            # database, so file registration done inside the sandbox is silently
+            # dropped. Wrap the exec on the host side so new workspace files get
+            # registered with valid file_ids.
+            workspace = self._get_target_workspace()
+            if workspace is not None:
+                with workspace.auto_register_files():
+                    result = await self._sandbox.exec(
+                        command[0], *command[1:], env=self._build_execution_env()
+                    )
+            else:
+                result = await self._sandbox.exec(
+                    command[0], *command[1:], env=self._build_execution_env()
+                )
 
             # Check execution result
             if result.exit_code != 0:

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -692,10 +692,13 @@ def generic_oauth_login(
         params["access_type"] = "offline"
         params["include_granted_scopes"] = "true"
         params["prompt"] = "consent"
+    if provider.lower() == "zoom":
+            params["prompt"] = "login"
     if scope_str:
         params["scope"] = scope_str
 
-    full_auth_url = f"{auth_url}?{urlencode(params)}"
+    separator = "&" if "?" in auth_url else "?"
+    full_auth_url = f"{auth_url}{separator}{urlencode(params)}"
     return RedirectResponse(full_auth_url)
 
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -693,7 +693,7 @@ def generic_oauth_login(
         params["include_granted_scopes"] = "true"
         params["prompt"] = "consent"
     if provider.lower() == "zoom":
-            params["prompt"] = "login"
+        params["prompt"] = "login"
     if scope_str:
         params["scope"] = scope_str
 

--- a/tests/core/tools/adapters/sandboxed_tool/test_file_registration.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_file_registration.py
@@ -1,0 +1,143 @@
+"""Test that SandboxedToolWrapper registers files produced by the sandbox.
+
+Files written inside the sandbox appear on the host via the mounted workspace
+volume, but the sandbox process cannot reach the host database, so any
+``workspace.auto_register_files()`` call made inside the sandbox is silently
+dropped. The wrapper must register newly-created workspace files on the host
+side around each ``sandbox.exec`` call so they receive valid ``file_id``s.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Type
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from tests.core.tools.adapters.sandboxed_tool.conftest import FakeBaseTool
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandbox_config import (
+    sandbox_config,
+)
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
+    SandboxedToolWrapper,
+)
+from xagent.core.workspace import TaskWorkspace
+
+
+@dataclass
+class FakeExecResult:
+    exit_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    error_message: str = ""
+
+
+class _Args(BaseModel):
+    payload: str = Field(default="")
+
+
+@sandbox_config()
+class _ToolWithWorkspace(FakeBaseTool):
+    """Fake tool that holds a TaskWorkspace, mirroring real executor tools."""
+
+    def __init__(self, workspace: TaskWorkspace) -> None:
+        self._workspace = workspace
+
+    @property
+    def name(self) -> str:
+        return "tool_with_workspace"
+
+    def args_type(self) -> Type[BaseModel]:
+        return _Args
+
+
+@sandbox_config()
+class _ToolNoWorkspace(FakeBaseTool):
+    """Fake tool without any workspace attribute."""
+
+    @property
+    def name(self) -> str:
+        return "tool_no_workspace"
+
+
+def _make_sandbox_writing(file_to_create) -> MagicMock:
+    """Mock sandbox whose exec writes a file (simulating the mounted volume)."""
+
+    async def fake_exec(*_args: Any, **_kwargs: Any) -> FakeExecResult:
+        file_to_create.parent.mkdir(parents=True, exist_ok=True)
+        file_to_create.write_bytes(b"fake pptx bytes")
+        return FakeExecResult(exit_code=0, stdout='{"success": true}')
+
+    sb = MagicMock()
+    sb.name = "sb-test"
+    sb.write_file = AsyncMock()
+    sb.exec = AsyncMock(side_effect=fake_exec)
+    return sb
+
+
+@pytest.fixture(autouse=True)
+def _clear_class_state():
+    """Reset shared class-level state between tests."""
+    SandboxedToolWrapper._sandbox_deps_installed = {}
+    SandboxedToolWrapper._sandbox_deps_locks = {}
+    SandboxedToolWrapper._locks_lock = asyncio.Lock()
+    yield
+    SandboxedToolWrapper._sandbox_deps_installed = {}
+    SandboxedToolWrapper._sandbox_deps_locks = {}
+
+
+class TestSandboxedToolFileRegistration:
+    """Verify workspace file registration happens on the host side."""
+
+    @pytest.mark.asyncio
+    async def test_registers_files_created_by_sandbox(self, tmp_path):
+        """Files produced inside the sandbox must be registered on the host."""
+        # Non-numeric workspace id keeps DB writes a no-op while still letting
+        # the in-memory file_id cache populate.
+        workspace = TaskWorkspace(id="test_pptx_ws", base_dir=str(tmp_path))
+        generated = workspace.output_dir / "deck.pptx"
+
+        sandbox = _make_sandbox_writing(generated)
+        SandboxedToolWrapper._sandbox_deps_installed["sb-test"] = True
+
+        wrapper = SandboxedToolWrapper(_ToolWithWorkspace(workspace), sandbox)
+
+        await wrapper.run_json_async({"payload": "go"})
+
+        assert generated.exists(), "sandbox.exec should have created the file"
+
+        file_id = workspace.get_file_id_from_path(str(generated))
+        assert file_id, (
+            "auto_register_files should have assigned a file_id on the host "
+            "after the sandbox exec returned"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_runs_unchanged(self, tmp_path):
+        """Tools without a workspace must still execute, with no extra wrapping."""
+        sandbox = MagicMock()
+        sandbox.name = "sb-no-ws"
+        sandbox.write_file = AsyncMock()
+        sandbox.exec = AsyncMock(
+            return_value=FakeExecResult(exit_code=0, stdout='{"ok": true}')
+        )
+        SandboxedToolWrapper._sandbox_deps_installed["sb-no-ws"] = True
+
+        wrapper = SandboxedToolWrapper(_ToolNoWorkspace(), sandbox)
+
+        assert wrapper._get_target_workspace() is None
+        result = await wrapper.run_json_async({})
+        assert result == {"ok": True}
+
+    def test_get_target_workspace_finds_tool_attribute(self, tmp_path):
+        """_get_target_workspace finds a TaskWorkspace on the target tool."""
+        workspace = TaskWorkspace(id="lookup_ws", base_dir=str(tmp_path))
+        sandbox = MagicMock()
+        sandbox.name = "sb-lookup"
+        sandbox.write_file = AsyncMock()
+        sandbox.exec = AsyncMock()
+
+        wrapper = SandboxedToolWrapper(_ToolWithWorkspace(workspace), sandbox)
+
+        assert wrapper._get_target_workspace() is workspace

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -1,0 +1,177 @@
+"""Regression tests for generic_oauth_login URL construction.
+
+Covers two bugs the PR fixed:
+  1. When auth_url already contains a query string, params must be appended
+     with '&' (no second '?').
+  2. Zoom provider must include `prompt=login` in the redirect URL.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api.auth import create_access_token, generic_oauth_login
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+
+# ---------- helpers ---------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    """Fresh SQLite DB + a single user for each test."""
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _token_for(user: User) -> str:
+    return create_access_token(
+        data={"sub": user.username, "type": "access"},
+        expires_delta=timedelta(minutes=5),
+    )
+
+
+def _provider(auth_url: str, default_scopes=None, redirect_uri=None):
+    """A duck-typed stand-in for the OAuthProvider ORM row."""
+    return SimpleNamespace(
+        client_id=encrypt_value("test-client-id"),
+        auth_url=auth_url,
+        redirect_uri=redirect_uri,
+        default_scopes=default_scopes or [],
+    )
+
+
+def _location(response) -> str:
+    # RedirectResponse stores the target in the Location header.
+    return response.headers["location"]
+
+
+# ---------- the actual regression checks ------------------------------------
+
+
+def test_auth_url_with_query_uses_ampersand_separator(db_session):
+    """If db_provider.auth_url already has '?', params must be appended with '&'."""
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = _provider(
+        auth_url="https://example.com/oauth/authorize?tenant=acme",
+        default_scopes=["openid", "profile"],
+        redirect_uri="https://app.example.com/cb",
+    )
+
+    resp = generic_oauth_login(
+        provider="custom",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    url = _location(resp)
+
+    # Only one '?' allowed in the whole URL — this is the regression.
+    assert url.count("?") == 1, f"second '?' leaked into URL: {url}"
+
+    parsed = urlparse(url)
+    base = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    qs = parse_qs(parsed.query)
+
+    assert base == "https://example.com/oauth/authorize"
+    assert qs["tenant"] == ["acme"], "pre-existing query param dropped"
+    assert qs["client_id"] == ["test-client-id"]
+    assert qs["redirect_uri"] == ["https://app.example.com/cb"]
+    assert qs["response_type"] == ["code"]
+    assert "state" in qs
+
+
+def test_auth_url_without_query_uses_question_mark(db_session):
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = _provider(
+        auth_url="https://example.com/oauth/authorize",
+        default_scopes=["openid"],
+        redirect_uri="https://app.example.com/cb",
+    )
+
+    resp = generic_oauth_login(
+        provider="custom",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    url = _location(resp)
+
+    assert url.count("?") == 1
+    assert url.startswith("https://example.com/oauth/authorize?")
+
+
+def test_zoom_provider_sets_prompt_login(db_session):
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = _provider(
+        auth_url="https://zoom.us/oauth/authorize",
+        default_scopes=["user:read"],
+        redirect_uri="https://app.example.com/cb",
+    )
+
+    resp = generic_oauth_login(
+        provider="zoom",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    url = _location(resp)
+    qs = parse_qs(urlparse(url).query)
+
+    assert qs.get("prompt") == ["login"], f"zoom prompt missing: {url}"
+
+
+def test_non_zoom_provider_does_not_set_prompt_login(db_session):
+    """Sanity: only Zoom gets prompt=login (Google gets prompt=consent, others none)."""
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = _provider(
+        auth_url="https://example.com/oauth/authorize",
+        default_scopes=["openid"],
+        redirect_uri="https://app.example.com/cb",
+    )
+
+    resp = generic_oauth_login(
+        provider="custom",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+    assert "prompt" not in qs


### PR DESCRIPTION
## Summary

- Sandboxed executor tools (`execute_javascript_code`, `python_executor`, `command_executor`) write files into the workspace via the mounted volume, but the sandbox process cannot reach the host database. As a result, the in-tool `workspace.auto_register_files()` call silently dropped every registration — files landed on disk without a `file_id`.
- Symptom: a generated `.pptx` rendered in chat as a bare `<a>filename.pptx</a>` (no `href`, no `data-file-path`, no `file-link` class), so it could not be clicked. The 文件管理 panel also showed the file as unregistered.
- Fix: in `SandboxedToolWrapper.run_json_async`, wrap the `sandbox.exec` call with `workspace.auto_register_files()` on the **host** side when the target tool exposes a `TaskWorkspace`. The host process has full DB access, so new files get a real `file_id`. New `_get_target_workspace()` helper handles both direct `AbstractBaseTool` targets and bound-method `FunctionTool` wrappers.

## Repro

1. In the demo (e.g. `demo.xagent.run/task/1100`), run the `presentation-generator` skill → it calls `execute_javascript_code` with `pptxgenjs`.
2. Before this fix: the resulting `.pptx` appears on disk but the chat link is a no-`href` `<a>` tag and the file is missing from 文件管理.
3. After this fix: the file is registered with a UUID, appears in 文件管理, and is reachable.

## Test plan

- [x] New `tests/core/tools/adapters/sandboxed_tool/test_file_registration.py` (3 tests) — registration happens on host, no-workspace fal