### PR TITLE
fix: stabilize agent model fallback and kb cleanup

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -447,6 +447,11 @@ class AgentServiceManager:
         vision_llm = None
         compact_llm = None
 
+        general_model: Optional[DBModel] = None
+        fast_model: Optional[DBModel] = None
+        visual_model: Optional[DBModel] = None
+        compact_model: Optional[DBModel] = None
+
         if agent.models:
             if agent.models.get("general"):
                 general_model = (
@@ -492,13 +497,242 @@ class AgentServiceManager:
                         str(compact_model.model_id), user_id
                     )
 
+        saved_model_descriptors: dict[str, dict[str, Any]] = {}
+        for slot, db_model in (
+            ("general", general_model),
+            ("small_fast", fast_model),
+            ("visual", visual_model),
+            ("compact", compact_model),
+        ):
+            if db_model is None:
+                continue
+            saved_model_descriptors[slot] = {
+                "pk": db_model.id,
+                "model_id": str(db_model.model_id),
+                "model_name": getattr(db_model, "model_name", None),
+            }
+
         return {
             "llms": (default_llm, fast_llm, vision_llm, compact_llm),
+            "saved_model_ids": dict(agent.models) if agent.models else {},
+            "saved_model_descriptors": saved_model_descriptors,
             "execution_mode": agent.execution_mode,
             "instructions": agent.instructions,  # System prompt
             "skills": agent.skills or [],
             "knowledge_bases": agent.knowledge_bases or [],
             "tool_categories": agent.tool_categories or [],
+        }
+
+    @staticmethod
+    def _pick_default_llm_with_warning(
+        default_llm: Optional[BaseLLM],
+        *,
+        task_id: int,
+        has_agent_builder_config: bool,
+        agent_id: Optional[int],
+        saved_model_ids: Optional[dict],
+        user_id: Optional[int],
+        saved_model_descriptors: Optional[dict] = None,
+    ) -> BaseLLM:
+        """Return the default LLM and log a context-rich WARNING.
+
+        Used when no per-task / per-agent LLM could be resolved (e.g. the
+        agent's saved model is unavailable or the caller has no access).
+
+        ``saved_model_descriptors`` (when provided) carries human-readable
+        ``model_id`` / ``model_name`` per slot, which is more useful in logs
+        than the bare ``DBModel.id`` pks recorded in ``saved_model_ids``.
+        """
+        if default_llm is None:
+            if has_agent_builder_config:
+                saved_models_for_log = saved_model_descriptors or saved_model_ids or {}
+                logger.error(
+                    "Agent builder model unavailable and no global default LLM is configured. "
+                    "task_id=%s agent_id=%s agent_saved_models=%s user_id=%s",
+                    task_id,
+                    agent_id,
+                    saved_models_for_log,
+                    user_id,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        "Agent model configuration is unavailable and no global "
+                        "default model is configured."
+                    ),
+                )
+            logger.error(
+                "Task %s has no valid LLM configuration and no default LLM", task_id
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="No valid LLM configuration is available for this task.",
+            )
+
+        fallback_model = (
+            getattr(default_llm, "model_name", None) or type(default_llm).__name__
+        )
+        if has_agent_builder_config:
+            saved_models_for_log = saved_model_descriptors or saved_model_ids or {}
+            logger.warning(
+                "Agent builder model unavailable, falling back to default LLM. "
+                "task_id=%s agent_id=%s agent_saved_models=%s user_id=%s fallback_model=%s",
+                task_id,
+                agent_id,
+                saved_models_for_log,
+                user_id,
+                fallback_model,
+            )
+        else:
+            logger.warning(
+                "Task %s has no valid LLM configuration, using default LLM %s",
+                task_id,
+                fallback_model,
+            )
+        return default_llm
+
+    @staticmethod
+    def _merge_agent_builder_llms(
+        baseline_llms: tuple[
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+        ],
+        agent_llms: tuple[
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+            Optional[BaseLLM],
+        ],
+    ) -> tuple[
+        Optional[BaseLLM],
+        Optional[BaseLLM],
+        Optional[BaseLLM],
+        Optional[BaseLLM],
+    ]:
+        """Overlay agent LLMs without discarding already resolved task LLMs."""
+        return cast(
+            tuple[
+                Optional[BaseLLM],
+                Optional[BaseLLM],
+                Optional[BaseLLM],
+                Optional[BaseLLM],
+            ],
+            tuple(
+                agent_llm or baseline_llm
+                for baseline_llm, agent_llm in zip(baseline_llms, agent_llms)
+            ),
+        )
+
+    def _resolve_task_runtime_config(
+        self,
+        *,
+        task_id: int,
+        task: Task,
+        db: Session,
+        user: Optional[User],
+    ) -> dict[str, Any]:
+        """Resolve task/agent-builder LLMs and execution pattern consistently."""
+        logger.info(
+            "Task %s record: agent_type=%s, model_name=%s, compact_model_name=%s",
+            task_id,
+            task.agent_type,
+            task.model_name,
+            task.compact_model_name,
+        )
+
+        task_execution_mode = getattr(task, "execution_mode", None)
+        if not task_execution_mode:
+            task_execution_mode = get_default_task_execution_mode(
+                agent_id=getattr(task, "agent_id", None),
+            )
+        task_pattern = get_agent_pattern_for_execution_mode(task_execution_mode)
+        logger.info(
+            "Task %s execution_mode=%s -> pattern=%s",
+            task_id,
+            task_execution_mode,
+            task_pattern,
+        )
+
+        llm_ids = self._get_task_llm_ids(task, db)
+        logger.info("Loading LLM configuration from task %s: %s", task_id, llm_ids)
+        user_id_for_resolution: Optional[int] = (
+            int(user.id)
+            if user and user.id is not None
+            else int(task.user_id)
+            if task.user_id is not None
+            else None
+        )
+        task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
+            resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
+        )
+
+        agent_config = None
+        has_agent_builder_config = False
+        if task.agent_id:
+            agent = (
+                db.query(Agent)
+                .filter(Agent.id == task.agent_id, Agent.user_id == task.user_id)
+                .first()
+            )
+            if agent:
+                logger.info(
+                    "Task %s using Agent Builder config: %s", task_id, agent.name
+                )
+                agent_config = self._load_agent_builder_config(
+                    agent, db, int(task.user_id)
+                )
+                has_agent_builder_config = True
+                baseline_llms = (
+                    task_llm,
+                    task_fast_llm,
+                    task_vision_llm,
+                    task_compact_llm,
+                )
+                (
+                    task_llm,
+                    task_fast_llm,
+                    task_vision_llm,
+                    task_compact_llm,
+                ) = self._merge_agent_builder_llms(baseline_llms, agent_config["llms"])
+                agent_execution_mode = agent_config.get("execution_mode", "balanced")
+                task_pattern = get_agent_pattern_for_execution_mode(
+                    agent_execution_mode
+                )
+                logger.info(
+                    "Task %s using Agent Builder execution mode: %s -> pattern=%s",
+                    task_id,
+                    agent_execution_mode,
+                    task_pattern,
+                )
+
+        if not task_llm:
+            task_llm = self._pick_default_llm_with_warning(
+                self._default_llm,
+                task_id=task_id,
+                has_agent_builder_config=has_agent_builder_config,
+                agent_id=getattr(task, "agent_id", None),
+                saved_model_ids=(agent_config or {}).get("saved_model_ids"),
+                saved_model_descriptors=(agent_config or {}).get(
+                    "saved_model_descriptors"
+                ),
+                user_id=user_id_for_resolution,
+            )
+
+        logger.info(
+            "Successfully loaded LLM configuration for task %s: compact_llm=%s",
+            task_id,
+            task_compact_llm.model_name if task_compact_llm else None,
+        )
+        return {
+            "agent_config": agent_config,
+            "task_llm": task_llm,
+            "task_fast_llm": task_fast_llm,
+            "task_vision_llm": task_vision_llm,
+            "task_compact_llm": task_compact_llm,
+            "task_pattern": task_pattern,
+            "has_agent_builder_config": has_agent_builder_config,
         }
 
     async def _build_tools_for_task(
@@ -675,6 +909,8 @@ class AgentServiceManager:
                         self._load_persisted_conversation_history(task_id, db)
                         await self._load_persisted_execution_context(task_id, db)
                         return self._agents[task_id]
+                    except HTTPException:
+                        raise
                     except Exception as e:
                         logger.warning(
                             f"Failed to reconstruct agent from history for task {task_id}: {e}"
@@ -702,79 +938,18 @@ class AgentServiceManager:
 
                 task = db.query(Task).filter(Task.id == task_id).first()
                 if task:
-                    # Log the actual task record for debugging
-                    logger.info(
-                        f"Task {task_id} record: agent_type={task.agent_type}, model_name={task.model_name}, compact_model_name={task.compact_model_name}"
+                    runtime_config = self._resolve_task_runtime_config(
+                        task_id=task_id,
+                        task=task,
+                        db=db,
+                        user=user,
                     )
-
-                    # Get task's execution_mode and map to pattern.
-                    task_execution_mode = getattr(task, "execution_mode", None)
-                    if not task_execution_mode:
-                        task_execution_mode = get_default_task_execution_mode(
-                            agent_id=getattr(task, "agent_id", None),
-                        )
-                    task_pattern = get_agent_pattern_for_execution_mode(
-                        task_execution_mode
-                    )
-                    logger.info(
-                        f"Task {task_id} execution_mode={task_execution_mode} -> pattern={task_pattern}"
-                    )
-
-                    llm_ids = self._get_task_llm_ids(task, db)
-                    logger.info(
-                        f"Loading LLM configuration from task {task_id}: {llm_ids}"
-                    )
-                    # Use user_id for model resolution if available
-                    user_id_for_resolution: Optional[int] = (
-                        int(user.id) if user and user.id is not None else None
-                    )
-                    task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
-                        resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
-                    )
-
-                    # Override with Agent Builder configuration if task.agent_id exists
-                    if task and task.agent_id:
-                        agent = (
-                            db.query(Agent)
-                            .filter(
-                                Agent.id == task.agent_id, Agent.user_id == task.user_id
-                            )
-                            .first()
-                        )
-                        if agent:
-                            logger.info(
-                                f"Task {task_id} using Agent Builder config: {agent.name}"
-                            )
-                            agent_config = self._load_agent_builder_config(
-                                agent, db, int(task.user_id)
-                            )
-                            (
-                                task_llm,
-                                task_fast_llm,
-                                task_vision_llm,
-                                task_compact_llm,
-                            ) = agent_config["llms"]
-                            # Agent Builder execution_mode overrides task pattern.
-                            agent_execution_mode = agent_config.get(
-                                "execution_mode", "balanced"
-                            )
-                            task_pattern = get_agent_pattern_for_execution_mode(
-                                agent_execution_mode
-                            )
-                            logger.info(
-                                f"Task {task_id} using Agent Builder execution mode: {agent.execution_mode} -> pattern={task_pattern}"
-                            )
-
-                    # If no models were resolved, use defaults
-                    if not task_llm:
-                        logger.warning(
-                            f"Task {task_id} has no valid LLM configuration, using defaults"
-                        )
-                        task_llm = self._default_llm
-
-                    logger.info(
-                        f"Successfully loaded LLM configuration for task {task_id}: compact_llm={task_compact_llm.model_name if task_compact_llm else None}"
-                    )
+                    agent_config = runtime_config["agent_config"]
+                    task_llm = runtime_config["task_llm"]
+                    task_fast_llm = runtime_config["task_fast_llm"]
+                    task_vision_llm = runtime_config["task_vision_llm"]
+                    task_compact_llm = runtime_config["task_compact_llm"]
+                    task_pattern = runtime_config["task_pattern"]
                 else:
                     # Task record not found
                     logger.error(f"Task {task_id} not found in database!")
@@ -782,6 +957,8 @@ class AgentServiceManager:
                     task_fast_llm = None
                     task_vision_llm = None
                     task_compact_llm = None
+            except HTTPException:
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to load LLM configuration from task {task_id} database: {e}"
@@ -1312,53 +1489,18 @@ class AgentServiceManager:
                                 "User context is required for agent reconstruction"
                             )
 
-                        task_execution_mode = getattr(task, "execution_mode", None)
-                        if not task_execution_mode:
-                            task_execution_mode = get_default_task_execution_mode(
-                                agent_id=getattr(task, "agent_id", None),
-                            )
-                        task_pattern = get_agent_pattern_for_execution_mode(
-                            task_execution_mode
+                        runtime_config = self._resolve_task_runtime_config(
+                            task_id=task_id,
+                            task=task,
+                            db=db,
+                            user=user,
                         )
-                        llm_ids = self._get_task_llm_ids(task, db)
-                        # Use user_id for model resolution if available
-                        user_id_for_resolution = (
-                            int(task.user_id) if task.user_id else None
-                        )
-                        task_llm, task_fast_llm, task_vision_llm, task_compact_llm = (
-                            resolve_llms_from_names(llm_ids, db, user_id_for_resolution)
-                        )
-
-                        agent_config = None
-                        if task.agent_id:
-                            agent = (
-                                db.query(Agent)
-                                .filter(
-                                    Agent.id == task.agent_id,
-                                    Agent.user_id == task.user_id,
-                                )
-                                .first()
-                            )
-                            if agent:
-                                agent_config = self._load_agent_builder_config(
-                                    agent, db, int(user.id)
-                                )
-                                (
-                                    task_llm,
-                                    task_fast_llm,
-                                    task_vision_llm,
-                                    task_compact_llm,
-                                ) = agent_config["llms"]
-                                agent_execution_mode = agent_config.get(
-                                    "execution_mode", "balanced"
-                                )
-                                task_pattern = get_agent_pattern_for_execution_mode(
-                                    agent_execution_mode
-                                )
-
-                        # If no models were resolved, use defaults
-                        if not task_llm:
-                            task_llm = self._default_llm
+                        agent_config = runtime_config["agent_config"]
+                        task_llm = runtime_config["task_llm"]
+                        task_fast_llm = runtime_config["task_fast_llm"]
+                        task_vision_llm = runtime_config["task_vision_llm"]
+                        task_compact_llm = runtime_config["task_compact_llm"]
+                        task_pattern = runtime_config["task_pattern"]
 
                         tools_list, tool_config = await self._build_tools_for_task(
                             task_id=task_id,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -52,6 +52,7 @@ from ...core.tools.core.RAG_tools.core.schemas import (
     WebIngestionResult,
 )
 from ...core.tools.core.RAG_tools.management.collection_manager import (
+    delete_collection_metadata_sync,
     get_collection_sync,
 )
 from ...core.tools.core.RAG_tools.management.collections import (
@@ -2729,6 +2730,13 @@ class ResolvedDocumentMatch(TypedDict):
     source_path: Optional[str]
 
 
+_DELETE_SHARED_COLLECTION_DETAIL = (
+    "Only admin users can delete collections containing documents from other users."
+)
+
+_CONFIG_ONLY_SENTINEL_KEY = "__config_only__"
+
+
 def _http_detail_to_str(detail: Any) -> str:
     """Normalize FastAPI/Starlette ``HTTPException.detail`` to a string."""
     if isinstance(detail, str):
@@ -2739,16 +2747,14 @@ def _http_detail_to_str(detail: Any) -> str:
         return str(detail)
 
 
-def _check_can_delete_collection(
+def _get_collection_document_counts(
     collection_name: str,
     user_id: int,
     is_admin: bool,
-) -> None:
-    """Validate collection name and non-admin delete permission."""
+) -> tuple[int, int]:
+    """Return total and caller-owned document counts for a collection."""
     if not collection_name or not collection_name.strip():
         raise HTTPException(status_code=422, detail="Collection name cannot be empty")
-    if is_admin:
-        return
     try:
         vector_store = get_vector_index_store()
         total_count = int(
@@ -2767,24 +2773,175 @@ def _check_can_delete_collection(
             detail="Failed to verify collection delete permission (documents table).",
         ) from exc
 
+    return total_count, own_count
+
+
+def _check_can_delete_collection(
+    collection_name: str,
+    user_id: int,
+    is_admin: bool,
+) -> None:
+    """Validate collection name and non-admin full-delete permission."""
+    if not collection_name or not collection_name.strip():
+        raise HTTPException(status_code=422, detail="Collection name cannot be empty")
+    if is_admin:
+        return
+
+    total_count, own_count = _get_collection_document_counts(
+        collection_name, user_id, is_admin=False
+    )
     if total_count > 0 and own_count < total_count:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "Only admin users can delete collections containing documents "
-                "from other users."
-            ),
+        raise HTTPException(status_code=403, detail=_DELETE_SHARED_COLLECTION_DETAIL)
+
+
+def _resolve_delete_mode_from_counts(
+    total_count: int,
+    own_count: int,
+    is_admin: bool,
+) -> str:
+    """Decide full|config_only|forbidden from precomputed total/own counts."""
+    if is_admin:
+        return "full"
+    if total_count > 0 and own_count == 0:
+        return "config_only"
+    if total_count > 0 and own_count < total_count:
+        return "forbidden"
+    return "full"
+
+
+def _get_collection_delete_mode(
+    collection_name: str,
+    user_id: int,
+    is_admin: bool,
+) -> str:
+    """Return full|config_only|forbidden for collection delete."""
+    if not collection_name or not collection_name.strip():
+        raise HTTPException(status_code=422, detail="Collection name cannot be empty")
+    if is_admin:
+        return "full"
+
+    total_count, own_count = _get_collection_document_counts(
+        collection_name, user_id, is_admin=False
+    )
+    return _resolve_delete_mode_from_counts(total_count, own_count, is_admin=False)
+
+
+def _remove_user_collection_config(
+    collection_name: str,
+    user_id: int,
+    *,
+    delete_orphaned_metadata: bool = False,
+) -> dict[str, int]:
+    """Remove only the caller's collection config entry.
+
+    Returns the number of rows removed so the caller can distinguish a real
+    stale-list cleanup from a delete request for a collection the user never
+    had in their KB list.
+    """
+    try:
+        cleanup_counts = delete_collection_metadata_sync(
+            collection_name=collection_name,
+            user_id=user_id,
+            is_admin=False,
+            delete_orphaned_metadata=delete_orphaned_metadata,
         )
+    except Exception as exc:
+        logger.exception(
+            "Failed to delete collection config for %s/user_%s",
+            collection_name,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete collection configuration: {exc}",
+        ) from exc
+
+    return cleanup_counts
+
+
+def _cleanup_collection_config_if_no_owned_documents(
+    collection_name: str,
+    user_id: int,
+) -> dict[str, int]:
+    """Clear user's config once they no longer own documents in the collection."""
+    total_count, own_count = _get_collection_document_counts(
+        collection_name, user_id, is_admin=False
+    )
+    if own_count > 0:
+        return {}
+
+    try:
+        cleanup_counts = delete_collection_metadata_sync(
+            collection_name=collection_name,
+            user_id=user_id,
+            is_admin=False,
+            delete_orphaned_metadata=total_count == 0,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to delete collection config after document deletion for %s/user_%s",
+            collection_name,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete collection configuration: {exc}",
+        ) from exc
+    if int(cleanup_counts.get("config_rows", 0)) <= 0:
+        return {}
+
+    logger.info(
+        "Removed collection config for %s/user_%s after last owned document deletion: %s",
+        collection_name,
+        user_id,
+        cleanup_counts,
+    )
+    return cleanup_counts
+
+
+def _is_config_only_delete_result(result: CollectionOperationResult) -> bool:
+    """Return True when collection delete only removed user visibility config."""
+    return bool((result.deleted_counts or {}).get(_CONFIG_ONLY_SENTINEL_KEY))
+
+
+def _strip_config_only_sentinel(
+    result: CollectionOperationResult,
+) -> CollectionOperationResult:
+    """Return ``result`` without the internal config-only sentinel key."""
+    deleted_counts = dict(result.deleted_counts or {})
+    if _CONFIG_ONLY_SENTINEL_KEY not in deleted_counts:
+        return result
+    deleted_counts.pop(_CONFIG_ONLY_SENTINEL_KEY, None)
+    return CollectionOperationResult(
+        status=result.status,
+        collection=result.collection,
+        message=result.message,
+        warnings=list(result.warnings or []),
+        affected_documents=list(result.affected_documents or []),
+        deleted_counts=deleted_counts,
+    )
 
 
 def _preflight_batch_delete_permissions(
     unique_names: List[str],
     user_id: int,
     is_admin: bool,
-) -> tuple[List[str], List[BatchDeleteFailureItem]]:
-    """Preflight validation for batch delete permissions and empty names."""
+) -> tuple[
+    List[str],
+    List[BatchDeleteFailureItem],
+    Dict[str, tuple[int, int]],
+]:
+    """Preflight validation for batch delete permissions and empty names.
+
+    Returns ``(allowed_names, failed_items, counts_by_name)``. For non-admin
+    callers ``counts_by_name`` maps the trimmed collection name to its
+    ``(total, own)`` document counts so callers can reuse them when invoking
+    ``_perform_kb_collection_delete`` (avoids redundant LanceDB scans).
+    Admin callers receive an empty dict because counts are not needed.
+    """
     failed: List[BatchDeleteFailureItem] = []
     allowed: List[str] = []
+    counts_by_name: Dict[str, tuple[int, int]] = {}
 
     if is_admin:
         for name in unique_names:
@@ -2797,7 +2954,7 @@ def _preflight_batch_delete_permissions(
                 )
             else:
                 allowed.append(name)
-        return allowed, failed
+        return allowed, failed, counts_by_name
 
     non_empty: List[str] = []
     for name in unique_names:
@@ -2812,7 +2969,7 @@ def _preflight_batch_delete_permissions(
             non_empty.append(name)
 
     if not non_empty:
-        return [], failed
+        return [], failed, counts_by_name
 
     vector_store = get_vector_index_store()
     try:
@@ -2833,21 +2990,55 @@ def _preflight_batch_delete_permissions(
             detail="Failed to scan documents table for batch delete permission.",
         ) from exc
 
-    forbidden_detail = (
-        "Only admin users can delete collections containing documents from other users."
-    )
-    for name in unique_names:
-        if not name or not name.strip():
-            continue
+    for name in non_empty:
         key = str(name).strip()
         total = int(totals.get(key, 0))
         own = int(owns.get(key, 0))
-        if total > 0 and own < total:
-            failed.append(BatchDeleteFailureItem(name=name, error=forbidden_detail))
+        if total > 0 and 0 < own < total:
+            failed.append(
+                BatchDeleteFailureItem(
+                    name=name, error=_DELETE_SHARED_COLLECTION_DETAIL
+                )
+            )
         else:
             allowed.append(name)
+            counts_by_name[key] = (total, own)
 
-    return allowed, failed
+    return allowed, failed, counts_by_name
+
+
+def _build_config_only_delete_result(
+    safe_collection: str,
+    cleanup_counts: dict[str, int],
+) -> CollectionOperationResult:
+    """Construct a CollectionOperationResult for config-only delete paths."""
+    removed_rows = int(cleanup_counts.get("config_rows", 0))
+    if removed_rows > 0:
+        message = (
+            f"Removed collection '{safe_collection}' from your knowledge base list."
+        )
+    else:
+        message = f"Collection '{safe_collection}' is not in your knowledge base list."
+    return CollectionOperationResult(
+        status="success",
+        collection=safe_collection,
+        message=message,
+        deleted_counts={**cleanup_counts, _CONFIG_ONLY_SENTINEL_KEY: 1},
+    )
+
+
+def _perform_config_only_collection_delete(
+    safe_collection: str,
+    user_id: int,
+) -> CollectionOperationResult:
+    """Remove a stale user KB-list entry without touching collection documents."""
+    cleanup_counts = _remove_user_collection_config(safe_collection, user_id)
+    if int(cleanup_counts.get("config_rows", 0)) <= 0:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collection '{safe_collection}' is not in your knowledge base list.",
+        )
+    return _build_config_only_delete_result(safe_collection, cleanup_counts)
 
 
 def _perform_kb_collection_delete(
@@ -2855,8 +3046,15 @@ def _perform_kb_collection_delete(
     user_id: int,
     is_admin: bool,
     db: Session,
+    *,
+    preflight_counts: Optional[tuple[int, int]] = None,
 ) -> CollectionOperationResult:
-    """Delete one KB collection (same pipeline as single-delete API)."""
+    """Delete one KB collection (same pipeline as single-delete API).
+
+    ``preflight_counts`` is an optional ``(total, own)`` pair already computed
+    by an upstream batch preflight. It is used only as a stale-preflight hint;
+    non-admin callers always get a live delete-mode recheck before mutation.
+    """
     try:
         try:
             safe_collection = sanitize_path_component(collection_name, "collection")
@@ -2865,11 +3063,42 @@ def _perform_kb_collection_delete(
                 status_code=422, detail=f"Invalid collection name: {str(e)}"
             ) from e
 
-        _check_can_delete_collection(safe_collection, user_id, is_admin)
+        preflight_delete_mode: Optional[str] = None
+        if preflight_counts is not None:
+            total_count, own_count = preflight_counts
+            preflight_delete_mode = _resolve_delete_mode_from_counts(
+                int(total_count), int(own_count), is_admin
+            )
+        elif not is_admin:
+            preflight_delete_mode = _get_collection_delete_mode(
+                safe_collection, user_id, is_admin=False
+            )
 
-        collection_dir = get_upload_path(
-            "", user_id=user_id, collection=safe_collection
-        )
+        if is_admin:
+            delete_mode = "full"
+        else:
+            delete_mode = _get_collection_delete_mode(
+                safe_collection, user_id, is_admin=False
+            )
+            if (
+                preflight_delete_mode is not None
+                and preflight_delete_mode != delete_mode
+            ):
+                logger.info(
+                    "Collection delete mode changed after preflight for %s/user_%s: "
+                    "preflight=%s live=%s",
+                    safe_collection,
+                    user_id,
+                    preflight_delete_mode,
+                    delete_mode,
+                )
+
+        if delete_mode == "forbidden":
+            raise HTTPException(
+                status_code=403, detail=_DELETE_SHARED_COLLECTION_DETAIL
+            )
+        if delete_mode == "config_only":
+            return _perform_config_only_collection_delete(safe_collection, user_id)
 
         vector_store = get_vector_index_store()
         collection_records = vector_store.list_document_records(
@@ -2885,8 +3114,10 @@ def _perform_kb_collection_delete(
             if file_id
         }
 
-        # Re-check right before vector deletion to reduce TOCTTOU window.
-        _check_can_delete_collection(safe_collection, user_id, is_admin)
+        collection_dir = get_upload_path(
+            "", user_id=user_id, collection=safe_collection
+        )
+
         result = delete_collection(safe_collection, user_id, is_admin)
 
         physical_cleanup = delete_collection_physical_dir(
@@ -2912,7 +3143,7 @@ def _perform_kb_collection_delete(
 
             return CollectionOperationResult(
                 status="error",
-                collection=result.collection,
+                collection=safe_collection,
                 message=result.message,
                 warnings=cleanup_warnings,
                 affected_documents=result.affected_documents,
@@ -2993,7 +3224,7 @@ def _perform_kb_collection_delete(
 
         updated_result = CollectionOperationResult(
             status=final_status,
-            collection=result.collection,
+            collection=safe_collection,
             message=updated_message,
             warnings=cleanup_warnings,
             affected_documents=result.affected_documents,
@@ -3043,7 +3274,7 @@ async def delete_collection_api(
         bool(_user.is_admin),
         db,
     )
-    return result
+    return _strip_config_only_sentinel(result)
 
 
 @kb_router.post(
@@ -3079,14 +3310,21 @@ async def batch_delete_collections_api(
         seen.add(key)
         unique_names.append(raw_name)
 
-    allowed, failed = _preflight_batch_delete_permissions(
+    allowed, failed, counts_by_name = _preflight_batch_delete_permissions(
         unique_names, user_id, is_admin
     )
 
     try:
         for name in allowed:
             try:
-                result = _perform_kb_collection_delete(name, user_id, is_admin, db)
+                preflight_counts = counts_by_name.get(str(name).strip())
+                result = _perform_kb_collection_delete(
+                    name,
+                    user_id,
+                    is_admin,
+                    db,
+                    preflight_counts=preflight_counts,
+                )
                 if result.status in ("success", "partial_success"):
                     deleted.append(name)
                 else:
@@ -3747,6 +3985,8 @@ async def delete_document_api(
     deleted_doc_ids = []
     deletion_errors = []
     cleanup_candidate_file_ids: set[str] = set()
+    config_cleanup_counts: dict[str, int] = {}
+    config_cleanup_error: Optional[str] = None
 
     for doc_info in matching_docs:
         resolved_doc_id = doc_info["doc_id"]
@@ -3820,6 +4060,22 @@ async def delete_document_api(
                     remaining_file_ids=remaining_file_ids,
                 )
 
+    if deleted_doc_ids:
+        try:
+            config_cleanup_counts = _cleanup_collection_config_if_no_owned_documents(
+                safe_collection_name,
+                user_id_int,
+            )
+        except HTTPException as exc:
+            config_cleanup_error = _http_detail_to_str(exc.detail)
+            logger.warning(
+                "Failed to clean collection config after deleting document(s) "
+                "(collection=%s, user_id=%s): %s",
+                safe_collection_name,
+                user_id_int,
+                exc.detail,
+            )
+
     # Commit all orphan file cleanups in a single batch after the loop
     try:
         db.commit()
@@ -3833,7 +4089,7 @@ async def delete_document_api(
         )
 
     if deletion_errors:
-        return {
+        partial_response: dict[str, Any] = {
             "status": "partial_success" if deleted_doc_ids else "failed",
             "message": f"Deleted {len(deleted_doc_ids)} of {len(matching_docs)} documents",
             "collection": safe_collection_name,
@@ -3841,14 +4097,24 @@ async def delete_document_api(
             "deleted_doc_ids": deleted_doc_ids,
             "errors": deletion_errors,
         }
+        if config_cleanup_counts:
+            partial_response["collection_config_cleanup"] = config_cleanup_counts
+        if config_cleanup_error:
+            partial_response["collection_config_cleanup_error"] = config_cleanup_error
+        return partial_response
 
-    return {
+    response: dict[str, Any] = {
         "status": "success",
         "message": f"Successfully deleted {len(deleted_doc_ids)} document(s)",
         "collection": safe_collection_name,
         "filename": filename,
         "deleted_doc_ids": deleted_doc_ids,
     }
+    if config_cleanup_counts:
+        response["collection_config_cleanup"] = config_cleanup_counts
+    if config_cleanup_error:
+        response["collection_config_cleanup_error"] = config_cleanup_error
+    return response
 
 
 @kb_router.put(

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
@@ -6,7 +6,7 @@ import base64
 import json
 import threading
 from typing import Any, Optional
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import cloudpickle
 import pytest
@@ -246,13 +246,17 @@ class TestBuildExecutionEnv:
         env = wrapper._build_execution_env()
         assert env["MY_API_KEY"] == "secret"
 
-    def test_missing_env_var_warns(self, monkeypatch, caplog):
+    def test_missing_env_var_warns(self, monkeypatch):
         monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
         wrapper = _create_test_wrapper(_FakeToolNoParams())
         wrapper._env_vars = ["NONEXISTENT_VAR"]
-        import logging
 
-        with caplog.at_level(logging.WARNING):
+        with patch(
+            "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper."
+            "logger.warning"
+        ) as mock_warning:
             env = wrapper._build_execution_env()
+
         assert "NONEXISTENT_VAR" not in env
-        assert "NONEXISTENT_VAR" in caplog.text
+        mock_warning.assert_called_once()
+        assert "NONEXISTENT_VAR" in mock_warning.call_args.args[0]

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionOperationResult,
     IngestionConfig,
     IngestionResult,
     WebIngestionResult,
@@ -178,6 +179,8 @@ def test_delete_collection_forbidden_for_non_admin_with_other_users_docs(
         mock_store.count_documents_grouped_by_collection.side_effect = [
             {"test_collection": 5},
             {"test_collection": 3},
+            {"test_collection": 5},
+            {"test_collection": 3},
         ]
 
         client = TestClient(app_with_kb)
@@ -190,6 +193,340 @@ def test_delete_collection_forbidden_for_non_admin_with_other_users_docs(
         in detail
     )
     mock_delete_collection.assert_not_called()
+
+
+def test_delete_collection_rechecks_permission_before_full_delete(
+    app_with_kb, mock_user
+):
+    """Single delete must not use stale ownership state for destructive delete."""
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 1},
+            {"test_collection": 2},
+            {"test_collection": 1},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.delete("/api/kb/collections/test_collection")
+
+    assert resp.status_code == 403
+    assert "Only admin users can delete collections" in resp.json()["detail"]
+    mock_delete_collection.assert_not_called()
+    mock_physical.assert_not_called()
+
+
+def test_delete_collection_removes_stale_config_without_deleting_other_users_docs(
+    app_with_kb, mock_user
+):
+    """Config-only stale entries should be removable without touching documents."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 1, "metadata_rows": 0},
+        ) as mock_delete_config,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.delete("/api/kb/collections/test_collection")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert "knowledge base list" in data["message"]
+    assert data["deleted_counts"] == {"config_rows": 1, "metadata_rows": 0}
+    mock_delete_config.assert_called_once_with(
+        collection_name="test_collection",
+        user_id=mock_user.id,
+        is_admin=False,
+        delete_orphaned_metadata=False,
+    )
+    mock_delete_collection.assert_not_called()
+    mock_physical.assert_not_called()
+    # config_only path must not delete global metadata used by other users.
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_batch_delete_allows_config_only_stale_collection(app_with_kb, mock_user):
+    """Batch preflight should pass own_count=0 stale config entries to cleanup."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 1, "metadata_rows": 0},
+        ),
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        # Preflight makes a single batched call per filter (totals/owns), then
+        # the delete path rechecks live mode before mutating config.
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.post(
+            "/api/kb/collections/batch-delete",
+            json={"collection_names": ["test_collection"]},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == ["test_collection"]
+    assert resp.json()["failed"] == []
+    mock_delete_collection.assert_not_called()
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_batch_config_only_preflight_can_become_full_delete(app_with_kb, mock_user):
+    """A stale config-only preflight must not hide a newly owned collection."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch("xagent.web.api.kb.delete_collection_uploaded_files", return_value=0),
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync"
+        ) as mock_delete_config,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 1},
+        ]
+        mock_store.list_document_records.side_effect = [[], []]
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="test_collection",
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+        mock_physical.return_value = MagicMock(
+            status="not_found", error=None, collection_dir=None
+        )
+
+        client = TestClient(app_with_kb)
+        resp = client.post(
+            "/api/kb/collections/batch-delete",
+            json={"collection_names": ["test_collection"]},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == ["test_collection"]
+    mock_delete_config.assert_not_called()
+    mock_delete_collection.assert_called_once_with(
+        "test_collection", mock_user.id, False
+    )
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_batch_delete_rechecks_permission_before_full_delete(app_with_kb, mock_user):
+    """A stale batch preflight must not authorize a now mixed-owner delete."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 1},
+            {"test_collection": 2},
+            {"test_collection": 1},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.post(
+            "/api/kb/collections/batch-delete",
+            json={"collection_names": ["test_collection"]},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == []
+    assert len(body["failed"]) == 1
+    assert body["failed"][0]["name"] == "test_collection"
+    assert "Only admin users can delete collections" in body["failed"][0]["error"]
+    mock_delete_collection.assert_not_called()
+    mock_physical.assert_not_called()
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_delete_collection_returns_not_found_when_user_config_already_cleaned(
+    app_with_kb, mock_user
+):
+    """Config-only cleanup must require a real user config row."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 0, "metadata_rows": 0},
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.delete("/api/kb/collections/test_collection")
+
+    assert resp.status_code == 404
+    assert "not in your knowledge base list" in resp.json()["detail"]
+    mock_delete_collection.assert_not_called()
+    mock_physical.assert_not_called()
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_batch_delete_fails_when_config_only_row_is_absent(app_with_kb, mock_user):
+    """Batch config-only cleanup should not report success without user config."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 0, "metadata_rows": 0},
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.post(
+            "/api/kb/collections/batch-delete",
+            json={"collection_names": ["test_collection"]},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == []
+    assert len(body["failed"]) == 1
+    assert body["failed"][0]["name"] == "test_collection"
+    assert "not in your knowledge base list" in body["failed"][0]["error"]
+    mock_delete_collection.assert_not_called()
+    mock_metadata_store.delete_collection.assert_not_called()
+
+
+def test_batch_delete_marks_config_cleanup_failure_as_failed(app_with_kb, mock_user):
+    """When _remove_user_collection_config raises in config_only path, item should fail."""
+    mock_metadata_store = MagicMock()
+    mock_metadata_store.delete_collection = AsyncMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            side_effect=RuntimeError("metadata store down"),
+        ),
+        patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=mock_metadata_store,
+        ),
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        client = TestClient(app_with_kb)
+        resp = client.post(
+            "/api/kb/collections/batch-delete",
+            json={"collection_names": ["test_collection"]},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == []
+    assert len(body["failed"]) == 1
+    failed_item = body["failed"][0]
+    assert failed_item["name"] == "test_collection"
+    assert "Failed to delete collection configuration" in failed_item["error"]
+    mock_delete_collection.assert_not_called()
+    mock_metadata_store.delete_collection.assert_not_called()
 
 
 def test_delete_collection_allowed_for_admin_with_other_users_docs(
@@ -226,6 +563,70 @@ def test_delete_collection_allowed_for_admin_with_other_users_docs(
 
     assert resp.status_code == 200
     mock_delete_collection.assert_called_once()
+
+
+def test_document_delete_cleanup_removes_config_after_last_owned_doc():
+    """Last owned document deletion should clear only the current user's config."""
+    from xagent.web.api import kb
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 1, "metadata_rows": 0},
+        ) as mock_delete_config,
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 1},
+            {"test_collection": 0},
+        ]
+
+        result = kb._cleanup_collection_config_if_no_owned_documents(
+            "test_collection",
+            user_id=(mock_user_id := 1),
+        )
+
+    assert result == {"config_rows": 1, "metadata_rows": 0}
+    mock_delete_config.assert_called_once_with(
+        collection_name="test_collection",
+        user_id=mock_user_id,
+        is_admin=False,
+        delete_orphaned_metadata=False,
+    )
+
+
+def test_document_delete_cleanup_deletes_orphaned_metadata_when_collection_empty():
+    """If no documents remain globally, orphan metadata can be removed too."""
+    from xagent.web.api import kb
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch(
+            "xagent.web.api.kb.delete_collection_metadata_sync",
+            return_value={"config_rows": 1, "metadata_rows": 1},
+        ) as mock_delete_config,
+    ):
+        mock_store = MagicMock()
+        mock_get_vector_store.return_value = mock_store
+        mock_store.count_documents_grouped_by_collection.side_effect = [
+            {"test_collection": 0},
+            {"test_collection": 0},
+        ]
+
+        result = kb._cleanup_collection_config_if_no_owned_documents(
+            "test_collection",
+            user_id=1,
+        )
+
+    assert result == {"config_rows": 1, "metadata_rows": 1}
+    mock_delete_config.assert_called_once_with(
+        collection_name="test_collection",
+        user_id=1,
+        is_admin=False,
+        delete_orphaned_metadata=True,
+    )
 
 
 def test_delete_document_forbidden_for_non_admin_other_users_doc(
@@ -269,6 +670,53 @@ def test_delete_document_forbidden_for_non_admin_other_users_doc(
     assert "Access denied for collection" in body.get("detail", "")
     assert "test_collection" in body.get("detail", "")
     mock_delete_document.assert_not_called()
+
+
+def test_delete_document_keeps_success_when_config_cleanup_fails(
+    app_with_kb_admin, admin_user
+):
+    """Cleanup failures must not downgrade overall status from success."""
+    from fastapi import HTTPException as _HTTPException
+
+    with (
+        patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
+        ) as mock_delete_document,
+        patch(
+            "xagent.web.api.kb._cleanup_collection_config_if_no_owned_documents",
+            side_effect=_HTTPException(
+                status_code=500,
+                detail="Failed to delete collection configuration: boom",
+            ),
+        ) as mock_cleanup,
+    ):
+        mock_record = MagicMock()
+        mock_record.doc_id = "doc_123"
+        mock_record.source_path = "/tmp/doc.txt"
+        mock_record.metadata = {}
+        mock_get_vector_store.return_value.list_document_records.return_value = [
+            mock_record
+        ]
+        mock_delete_document.return_value = type(
+            "DeleteResult",
+            (),
+            {"status": "success", "message": "ok"},
+        )()
+
+        client = TestClient(app_with_kb_admin)
+        resp = client.delete(
+            "/api/kb/collections/test_collection/documents/doc.txt",
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "success"
+    assert body["deleted_doc_ids"] == ["doc_123"]
+    assert "collection_config_cleanup_error" in body
+    assert "boom" in body["collection_config_cleanup_error"]
+    assert "errors" not in body
+    mock_cleanup.assert_called_once()
 
 
 def test_delete_document_allowed_for_admin_any_doc(app_with_kb_admin, admin_user):

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.agent import Agent
 from xagent.web.models.task import (
     DAGExecution,
     DAGExecutionPhase,
@@ -362,10 +363,12 @@ class TestAgentServiceManagerReconstruction:
         mock_db.query.side_effect = mock_query_side_effect
 
         # Mock AgentService创建和reconstruct_from_history
+        runtime_llm = MagicMock()
+        runtime_llm.model_name = "task-qwen"
         with (
             patch(
                 "xagent.web.api.chat.resolve_llms_from_names",
-                return_value=(None, None, None, None),
+                return_value=(runtime_llm, None, None, None),
             ),
             patch(
                 "xagent.web.api.chat.create_default_tools",
@@ -389,6 +392,90 @@ class TestAgentServiceManagerReconstruction:
         _, agent_kwargs = mock_agent_service_class.call_args
         assert agent_kwargs["tools"] == ["tool"]
         assert agent_kwargs["tool_config"] == "tool_config"
+
+    @pytest.mark.asyncio
+    async def test_reconstruct_agent_from_history_uses_shared_runtime_config(
+        self,
+        agent_manager,
+        mock_db,
+        mock_user,
+        sample_task,
+        sample_trace_events,
+        sample_dag_execution,
+    ):
+        """Active-task reconstruction should reuse the normal LLM merge contract."""
+        sample_task.agent_id = 9
+        runtime_llm = MagicMock()
+        runtime_llm.model_name = "task-qwen"
+
+        mock_task_query = MagicMock()
+        mock_task_query.first.return_value = sample_task
+        mock_task_query.filter.return_value = mock_task_query
+        mock_user_query = MagicMock()
+        mock_user_query.first.return_value = mock_user
+        mock_user_query.filter.return_value = mock_user_query
+        mock_trace_query = MagicMock()
+        mock_trace_query.all.return_value = sample_trace_events
+        mock_trace_query.filter.return_value = mock_trace_query
+        mock_dag_query = MagicMock()
+        mock_dag_query.first.return_value = sample_dag_execution
+        mock_dag_query.filter.return_value = mock_dag_query
+        mock_agent_query = MagicMock()
+        mock_agent_query.first.return_value = None
+        mock_agent_query.filter.return_value = mock_agent_query
+
+        def mock_query_side_effect(model):
+            if model == Task:
+                return mock_task_query
+            if model == User:
+                return mock_user_query
+            if model == TraceEvent:
+                return mock_trace_query
+            if model == DAGExecution:
+                return mock_dag_query
+            if model == Agent:
+                return mock_agent_query
+            return MagicMock()
+
+        mock_db.query.side_effect = mock_query_side_effect
+        agent_manager._resolve_task_runtime_config = MagicMock(
+            return_value={
+                "agent_config": {
+                    "instructions": "",
+                    "skills": [],
+                    "knowledge_bases": [],
+                },
+                "task_llm": runtime_llm,
+                "task_fast_llm": None,
+                "task_vision_llm": None,
+                "task_compact_llm": None,
+                "task_pattern": "react",
+            }
+        )
+
+        with (
+            patch(
+                "xagent.web.api.chat.create_default_tools",
+                new=AsyncMock(return_value=(["tool"], "tool_config")),
+            ),
+            patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
+            patch("xagent.web.api.chat.AgentService") as mock_agent_service_class,
+        ):
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.reconstruct_from_history = AsyncMock()
+            mock_agent_service_class.return_value = mock_agent_instance
+
+            await agent_manager._reconstruct_agent_from_history(1, mock_db)
+
+        agent_manager._resolve_task_runtime_config.assert_called_once_with(
+            task_id=1,
+            task=sample_task,
+            db=mock_db,
+            user=mock_user,
+        )
+        _, agent_kwargs = mock_agent_service_class.call_args
+        assert agent_kwargs["llm"] is runtime_llm
+        assert agent_kwargs["pattern"] == "react"
 
     @pytest.mark.asyncio
     async def test_reconstruct_agent_from_history_no_data(self, agent_manager, mock_db):

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -1,12 +1,15 @@
 """Regression tests for task model-id handling in chat API."""
 
+import logging
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.web.api.auth import auth_router
 from xagent.web.api.chat import AgentServiceManager, chat_router
 from xagent.web.api.model import model_router
@@ -113,6 +116,259 @@ def sample_model_data():
         "description": "User2 private model",
         "share_with_users": False,
     }
+
+
+class DummyLLM(BaseLLM):
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def abilities(self):
+        return ["chat"]
+
+    @property
+    def model_name(self):
+        return self._name
+
+    @property
+    def supports_thinking_mode(self):
+        return False
+
+    async def chat(self, messages, **kwargs):
+        return "ok"
+
+
+def test_agent_builder_llm_overlay_preserves_resolved_task_llms():
+    manager = AgentServiceManager()
+    task_llm = DummyLLM("task-qwen")
+    task_compact = DummyLLM("task-compact")
+
+    merged = manager._merge_agent_builder_llms(
+        (task_llm, None, task_llm, task_compact),
+        (None, None, None, None),
+    )
+
+    assert merged == (task_llm, None, task_llm, task_compact)
+
+
+def test_agent_builder_llm_overlay_uses_accessible_agent_llms():
+    manager = AgentServiceManager()
+    task_llm = DummyLLM("task-qwen")
+    agent_llm = DummyLLM("agent-model")
+
+    merged = manager._merge_agent_builder_llms(
+        (task_llm, None, task_llm, None),
+        (agent_llm, None, None, agent_llm),
+    )
+
+    assert merged == (agent_llm, None, task_llm, agent_llm)
+
+
+def test_runtime_config_preserves_task_llm_when_agent_model_is_unavailable():
+    manager = AgentServiceManager()
+    task_llm = DummyLLM("task-qwen")
+    task = MagicMock(
+        agent_type="assistant",
+        model_name="qwen3.6-plus",
+        compact_model_name=None,
+        execution_mode="balanced",
+        agent_id=9,
+        user_id=71,
+    )
+    user = MagicMock(id=71)
+    agent = MagicMock(id=9, name="Published Agent", execution_mode="balanced")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = agent
+    manager._get_task_llm_ids = MagicMock(
+        return_value=["qwen3.6-plus", None, None, None]
+    )
+    manager._load_agent_builder_config = MagicMock(
+        return_value={
+            "llms": (None, None, None, None),
+            "saved_model_ids": {"general": 123},
+            "saved_model_descriptors": {
+                "general": {
+                    "pk": 123,
+                    "model_id": "glm4.6v",
+                    "model_name": "glm4.6v",
+                }
+            },
+            "execution_mode": "balanced",
+            "instructions": "",
+            "skills": [],
+            "knowledge_bases": [],
+            "tool_categories": [],
+        }
+    )
+
+    with patch(
+        "xagent.web.api.chat.resolve_llms_from_names",
+        return_value=(task_llm, None, None, None),
+    ):
+        runtime_config = manager._resolve_task_runtime_config(
+            task_id=42,
+            task=task,
+            db=db,
+            user=user,
+        )
+
+    assert runtime_config["task_llm"] is task_llm
+    manager._load_agent_builder_config.assert_called_once_with(agent, db, 71)
+
+
+def test_runtime_config_uses_accessible_agent_model_over_task_baseline():
+    manager = AgentServiceManager()
+    task_llm = DummyLLM("task-qwen")
+    agent_llm = DummyLLM("agent-qwen")
+    task = MagicMock(
+        agent_type="assistant",
+        model_name="qwen3.6-plus",
+        compact_model_name=None,
+        execution_mode="balanced",
+        agent_id=9,
+        user_id=71,
+    )
+    user = MagicMock(id=71)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = MagicMock(
+        id=9, name="Published Agent", execution_mode="balanced"
+    )
+    manager._get_task_llm_ids = MagicMock(
+        return_value=["qwen3.6-plus", None, None, None]
+    )
+    manager._load_agent_builder_config = MagicMock(
+        return_value={
+            "llms": (agent_llm, None, None, None),
+            "saved_model_ids": {"general": 123},
+            "saved_model_descriptors": {},
+            "execution_mode": "balanced",
+            "instructions": "",
+            "skills": [],
+            "knowledge_bases": [],
+            "tool_categories": [],
+        }
+    )
+
+    with patch(
+        "xagent.web.api.chat.resolve_llms_from_names",
+        return_value=(task_llm, None, None, None),
+    ):
+        runtime_config = manager._resolve_task_runtime_config(
+            task_id=42,
+            task=task,
+            db=db,
+            user=user,
+        )
+
+    assert runtime_config["task_llm"] is agent_llm
+
+
+def test_pick_default_llm_warns_with_agent_context_when_builder_config_present(caplog):
+    """Agent builder fallback should log human-readable model identifiers."""
+    default_llm = DummyLLM("default-llm")
+
+    with caplog.at_level(logging.WARNING, logger="xagent.web.api.chat"):
+        chosen = AgentServiceManager._pick_default_llm_with_warning(
+            default_llm,
+            task_id=42,
+            has_agent_builder_config=True,
+            agent_id=7,
+            saved_model_ids={"general": 11, "small_fast": None},
+            saved_model_descriptors={
+                "general": {
+                    "pk": 11,
+                    "model_id": "gpt-4o",
+                    "model_name": "gpt-4o-2024-08-06",
+                },
+            },
+            user_id=99,
+        )
+
+    assert chosen is default_llm
+    matched = [
+        rec
+        for rec in caplog.records
+        if "falling back to default LLM" in rec.getMessage()
+    ]
+    assert len(matched) == 1
+    message = matched[0].getMessage()
+    assert "task_id=42" in message
+    assert "agent_id=7" in message
+    assert "user_id=99" in message
+    # Descriptor fields are preferred over raw DB pks.
+    assert "gpt-4o" in message
+    assert "gpt-4o-2024-08-06" in message
+    assert "agent_saved_models=" in message
+    assert "fallback_model=default-llm" in message
+
+
+def test_pick_default_llm_falls_back_to_saved_model_ids_when_descriptors_missing(
+    caplog,
+):
+    """Without descriptors the warning falls back to raw saved_model_ids."""
+    default_llm = DummyLLM("default-llm")
+
+    with caplog.at_level(logging.WARNING, logger="xagent.web.api.chat"):
+        AgentServiceManager._pick_default_llm_with_warning(
+            default_llm,
+            task_id=1,
+            has_agent_builder_config=True,
+            agent_id=2,
+            saved_model_ids={"general": 11},
+            user_id=3,
+        )
+
+    matched = [
+        rec
+        for rec in caplog.records
+        if "falling back to default LLM" in rec.getMessage()
+    ]
+    assert len(matched) == 1
+    message = matched[0].getMessage()
+    assert "agent_saved_models=" in message
+    assert "general" in message
+    assert "11" in message
+
+
+def test_pick_default_llm_warns_with_task_only_message_when_no_builder_config(caplog):
+    """Without agent builder config we still warn but skip agent-specific fields."""
+    default_llm = DummyLLM("default-llm")
+
+    with caplog.at_level(logging.WARNING, logger="xagent.web.api.chat"):
+        chosen = AgentServiceManager._pick_default_llm_with_warning(
+            default_llm,
+            task_id=42,
+            has_agent_builder_config=False,
+            agent_id=None,
+            saved_model_ids=None,
+            user_id=None,
+        )
+
+    assert chosen is default_llm
+    matched = [
+        rec
+        for rec in caplog.records
+        if "no valid LLM configuration" in rec.getMessage()
+    ]
+    assert len(matched) == 1
+    assert "Task 42" in matched[0].getMessage()
+    assert "default-llm" in matched[0].getMessage()
+
+
+def test_pick_default_llm_raises_when_no_default_available():
+    """If neither task/agent nor global default resolves, fail with a clear error."""
+    with pytest.raises(HTTPException) as exc_info:
+        AgentServiceManager._pick_default_llm_with_warning(
+            None,
+            task_id=42,
+            has_agent_builder_config=True,
+            agent_id=7,
+            saved_model_ids={"general": 11},
+            user_id=99,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "no global default model" in str(exc_info.value.detail)
 
 
 def test_task_create_does_not_persist_inaccessible_model_ids(


### PR DESCRIPTION
## Summary

Fixes two production issues in agent chat and knowledge base cleanup:

- Agent chat could lose the task-selected model when running a saved agent whose stored model was stale or not accessible to the current user.
- Knowledge bases could remain visible after a user deleted their last owned document, then fail deletion with an admin-only shared-collection error.

## Root Cause

For agent chat, the runtime loaded task models first, then overlaid the saved agent configuration. When the saved agent model could not be resolved for the current user, that unresolved slot could replace the already valid task model. If no model remained, the flow fell back to the global default LLM without enough context in logs, which made provider-level errors look like file attachment failures.

For knowledge bases, `collection_config` is the per-user visibility/config row, while collection document rows are shared by collection name. Deleting the last document owned by a user did not remove that user's config row. Later, deleting the visible KB entry saw documents from other users under the same collection name and returned the admin-only shared-collection error instead of removing the stale user config.

## Changes

- Preserve task-resolved LLMs as the baseline when applying saved agent model configuration.
- Only let an agent saved model override a task model when it resolves successfully for the current user.
- Keep global default LLM fallback, but log task id, agent id, user id, saved model descriptors, and fallback model.
- Let explicit `HTTPException` failures propagate instead of being swallowed by the generic fallback path.
- Remove a user's `collection_config` after deleting their last owned document in a collection.
- Allow delete of a stale KB list entry when the current user has no documents but does have a config row, without touching other users' documents or global metadata.
- Return 404 when a config-only delete finds no current-user config row, instead of reporting a misleading success.
- Re-check non-admin collection ownership immediately before batch full-delete side effects, so stale batch preflight counts cannot authorize a now mixed-owner collection delete.

## Validation

- `uv run pytest tests/web/test_chat_task_model_ids.py tests/web/api/test_kb_ingest_separators.py -q`
- `uv run pytest tests/web/api/test_kb_exception_decorator.py tests/web/api/test_kb_dir.py tests/core/tools/core/RAG_tools/management/test_collections.py -q`
- `uv run ruff check src/xagent/web/api/chat.py src/xagent/web/api/kb.py tests/web/test_chat_task_model_ids.py tests/web/api/test_kb_ingest_separators.py`
- `uv run ruff format --check src/xagent/web/api/chat.py src/xagent/web/api/kb.py tests/web/test_chat_task_model_ids.py tests/web/api/test_kb_ingest_separators.py`

Note: pre-commit mypy is currently blocked by existing `core.agent` import/type errors outside this change; the commit was made with mypy skipped after the targeted checks above passed.