### PR TITLE
fix(js_executor): convert pptxgenjs warn-only failures into hard throws

### DIFF
--- a/src/xagent/core/tools/core/javascript_executor.py
+++ b/src/xagent/core/tools/core/javascript_executor.py
@@ -15,15 +15,28 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
-# JS source: regex of pptxgenjs API method names whose "methodName: <desc>"
-# console.log output indicates a validation failure that did NOT throw.
-# Keeping the list narrow (only known pptxgenjs methods) avoids
-# misclassifying unrelated user `console.log("Sum: 42")` style strings.
-_PPTXGENJS_WARN_JS_REGEX = (
-    r"/^(?:addText|addTable|addImage|addShape|addChart|"
-    r"addMedia|addNotes|addSlide|addSection|addBackgroundImage|"
-    r"writeFile|stream|write): /"
+# Known pptxgenjs API method names whose "methodName: <desc>" console.log
+# output indicates a validation failure that did NOT throw. Defined as a
+# tuple so additions are obvious in code review; the JS regex is built
+# from it so the two stay in sync. The list is intentionally narrow —
+# only real pptxgenjs methods — so unrelated user logs like
+# `console.log("Sum: 42")` aren't misclassified.
+_PPTXGENJS_WARN_METHODS = (
+    "addText",
+    "addTable",
+    "addImage",
+    "addShape",
+    "addChart",
+    "addMedia",
+    "addNotes",
+    "addSlide",
+    "addSection",
+    "addBackgroundImage",
+    "writeFile",
+    "stream",
+    "write",
 )
+_PPTXGENJS_WARN_JS_REGEX = f"/^(?:{'|'.join(_PPTXGENJS_WARN_METHODS)}): /"
 
 
 def _wrap_user_code(code: str) -> str:

--- a/src/xagent/core/tools/core/javascript_executor.py
+++ b/src/xagent/core/tools/core/javascript_executor.py
@@ -15,6 +15,64 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
+# JS source: regex of pptxgenjs API method names whose "methodName: <desc>"
+# console.log output indicates a validation failure that did NOT throw.
+# Keeping the list narrow (only known pptxgenjs methods) avoids
+# misclassifying unrelated user `console.log("Sum: 42")` style strings.
+_PPTXGENJS_WARN_JS_REGEX = (
+    r"/^(?:addText|addTable|addImage|addShape|addChart|"
+    r"addMedia|addNotes|addSlide|addSection|addBackgroundImage|"
+    r"writeFile|stream|write): /"
+)
+
+
+def _wrap_user_code(code: str) -> str:
+    """Build the JS source actually fed to ``node`` for *code*.
+
+    Two responsibilities:
+
+    1. Buffer ``console.log`` so it doesn't interleave with our own
+       diagnostic output. Logs are flushed back to stdout when the
+       script finishes normally.
+    2. Intercept the pptxgenjs "warn only, keep going" failure path —
+       pptxgenjs calls ``console.log("addTable: tableRows has a bad
+       row...")`` and then continues, leaving a malformed ``.pptx`` on
+       disk while node still exits 0. We rewrite the intercepted call
+       to ``throw`` when it matches the pptxgenjs API method pattern,
+       which the outer ``try/catch`` converts to ``process.exit(1)``.
+       That puts the failure on the framework's normal hard-error path
+       (non-zero exit, populated stderr) so the agent gets a clear
+       error signal and can retry with corrected code.
+    """
+    return f"""
+const __PPTXGENJS_WARN_RE = {_PPTXGENJS_WARN_JS_REGEX};
+const __logs = [];
+const __originalLog = console.log;
+console.log = (...args) => {{
+    const __msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ');
+    if (__PPTXGENJS_WARN_RE.test(__msg)) {{
+        throw new Error(
+            'pptxgenjs reported a validation problem and the generated '
+            + 'output is likely malformed even though the call did not '
+            + 'throw. Fix the offending arguments and retry. Warning: '
+            + __msg
+        );
+    }}
+    __logs.push(__msg);
+}};
+
+try {{
+{code}
+}} catch (error) {{
+    console.error(error.message);
+    process.exit(1);
+}}
+
+console.log = __originalLog;
+__logs.forEach(__line => console.log(__line));
+"""
+
+
 class JavaScriptExecutorCore:
     """JavaScript executor using Node.js"""
 
@@ -92,9 +150,10 @@ class JavaScriptExecutorCore:
                 json.dumps({"dependencies": deps}), encoding="utf-8"
             )
 
-        # Create the JS script
+        # Create the JS script — wrap user code so pptxgenjs warn-only
+        # failures get converted to throws (see _wrap_user_code).
         script_file = temp_path / "script.js"
-        script_file.write_text(code, encoding="utf-8")
+        script_file.write_text(_wrap_user_code(code), encoding="utf-8")
 
         # Install dependencies if needed
         if deps:
@@ -151,30 +210,13 @@ class JavaScriptExecutorCore:
                 json.dumps({"dependencies": deps}), encoding="utf-8"
             )
 
-        # Create the JS script in execution directory (so files are created there)
+        # Create the JS script in execution directory (so files are created
+        # there). The wrapper buffers console.log AND converts pptxgenjs
+        # warn-only validation failures into thrown errors — see
+        # _wrap_user_code. When capture_output is False the caller has
+        # opted out of buffering and gets the raw code.
         script_file = exec_dir / "script.js"
-
-        # Wrap code to capture output
-        wrapped_code = code
-        if capture_output:
-            wrapped_code = f"""
-const logs = [];
-const originalLog = console.log;
-console.log = (...args) => {{
-    logs.push(args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' '));
-}};
-
-try {{
-{code}
-}} catch (error) {{
-    console.error(error.message);
-    process.exit(1);
-}}
-
-console.log = originalLog;
-logs.forEach(log => console.log(log));
-"""
-
+        wrapped_code = _wrap_user_code(code) if capture_output else code
         script_file.write_text(wrapped_code, encoding="utf-8")
 
         # Install dependencies in temp directory

--- a/src/xagent/core/tools/core/javascript_executor.py
+++ b/src/xagent/core/tools/core/javascript_executor.py
@@ -19,8 +19,10 @@ logger = logging.getLogger(__name__)
 # output indicates a validation failure that did NOT throw. Defined as a
 # tuple so additions are obvious in code review; the JS regex is built
 # from it so the two stay in sync. The list is intentionally narrow —
-# only real pptxgenjs methods — so unrelated user logs like
-# `console.log("Sum: 42")` aren't misclassified.
+# only real pptxgenjs methods that the library is known to emit
+# `<method>: <description>` warnings from. Generic-sounding names like
+# bare `write` or `stream` are deliberately excluded so unrelated user
+# logs (`console.log("write: complete")`) can't trip the detector.
 _PPTXGENJS_WARN_METHODS = (
     "addText",
     "addTable",
@@ -33,37 +35,71 @@ _PPTXGENJS_WARN_METHODS = (
     "addSection",
     "addBackgroundImage",
     "writeFile",
-    "stream",
-    "write",
 )
 _PPTXGENJS_WARN_JS_REGEX = f"/^(?:{'|'.join(_PPTXGENJS_WARN_METHODS)}): /"
 
 
-def _wrap_user_code(code: str) -> str:
+def _requests_pptxgenjs(packages: Optional[list[str]]) -> bool:
+    """True iff the caller asked for the pptxgenjs npm package.
+
+    The validation-error interception only runs when this is true —
+    otherwise a user script that happens to log a pptxgenjs-shaped
+    string (``console.log("addTable: oh no")``) would be misclassified
+    as a library warning, returning success=False against the agent's
+    expectation.
+    """
+    if not packages:
+        return False
+    return any((pkg or "").strip().lower() == "pptxgenjs" for pkg in packages)
+
+
+def _wrap_user_code(code: str, *, intercept_pptxgenjs: bool) -> str:
     """Build the JS source actually fed to ``node`` for *code*.
 
-    Two responsibilities:
+    Responsibilities:
 
     1. Buffer ``console.log`` so it doesn't interleave with our own
        diagnostic output. Logs are flushed back to stdout when the
        script finishes normally.
-    2. Intercept the pptxgenjs "warn only, keep going" failure path —
-       pptxgenjs calls ``console.log("addTable: tableRows has a bad
-       row...")`` and then continues, leaving a malformed ``.pptx`` on
-       disk while node still exits 0. We rewrite the intercepted call
-       to ``throw`` when it matches the pptxgenjs API method pattern,
-       which the outer ``try/catch`` converts to ``process.exit(1)``.
-       That puts the failure on the framework's normal hard-error path
-       (non-zero exit, populated stderr) so the agent gets a clear
-       error signal and can retry with corrected code.
+    2. (Only when ``intercept_pptxgenjs`` is true.) Intercept the
+       pptxgenjs "warn only, keep going" failure path — pptxgenjs
+       calls ``console.log("addTable: tableRows has a bad row...")``
+       and then continues, leaving a malformed ``.pptx`` on disk
+       while node still exits 0.
+
+       We record a wrapper-scoped flag the moment a matching message
+       is seen, AND throw inside the override so an unguarded pptxgenjs
+       call bails before ``writeFile`` runs. After the user-code
+       ``try`` block we re-check the flag — that way a user
+       ``try/catch`` around the pptxgenjs call can swallow the injected
+       throw and still not suppress the failure, because the flag check
+       runs outside user code's reach. Either path lands the failure
+       on the framework's normal hard-error path (non-zero exit,
+       populated stderr) so the agent gets a clear error signal and
+       can retry with corrected code.
+
+    The flag-after-try design comes directly from rogercloud's review
+    on PR #442: relying on the in-throw mechanism alone is unsafe —
+    user code can catch and continue past it.
     """
+    intercept_flag = "true" if intercept_pptxgenjs else "false"
     return f"""
+const __INTERCEPT_PPTXGENJS = {intercept_flag};
 const __PPTXGENJS_WARN_RE = {_PPTXGENJS_WARN_JS_REGEX};
 const __logs = [];
+let __pptxgenjsValidationFailure = null;
 const __originalLog = console.log;
 console.log = (...args) => {{
     const __msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ');
-    if (__PPTXGENJS_WARN_RE.test(__msg)) {{
+    if (__INTERCEPT_PPTXGENJS && __PPTXGENJS_WARN_RE.test(__msg)) {{
+        if (__pptxgenjsValidationFailure === null) {{
+            __pptxgenjsValidationFailure = __msg;
+        }}
+        // Throw so an unguarded pptxgenjs call site bails before
+        // writeFile creates a malformed .pptx. If user code happens
+        // to wrap the call in try/catch, this throw gets swallowed —
+        // but the flag set just above still survives, and the
+        // wrapper-level check after the try block exits the process.
         throw new Error(
             'pptxgenjs reported a validation problem and the generated '
             + 'output is likely malformed even though the call did not '
@@ -74,14 +110,36 @@ console.log = (...args) => {{
     __logs.push(__msg);
 }};
 
+let __userCodeError = null;
 try {{
 {code}
 }} catch (error) {{
-    console.error(error.message);
-    process.exit(1);
+    // Don't exit yet: even if user code's own try/catch consumed our
+    // injected throw, the wrapper-scoped flag is the source of truth
+    // for pptxgenjs failures. Record any unrelated user-code error
+    // here and fall through to the post-try checks below.
+    __userCodeError = error;
 }}
 
 console.log = __originalLog;
+
+if (__pptxgenjsValidationFailure !== null) {{
+    // Wrapper-owned failure: runs outside user code's reach so a
+    // user-level try/catch cannot suppress it.
+    console.error(
+        'pptxgenjs reported a validation problem and the generated '
+        + 'output is likely malformed even though the call did not '
+        + 'throw. Fix the offending arguments and retry. Warning: '
+        + __pptxgenjsValidationFailure
+    );
+    process.exit(1);
+}}
+
+if (__userCodeError !== null) {{
+    console.error(__userCodeError.message);
+    process.exit(1);
+}}
+
 __logs.forEach(__line => console.log(__line));
 """
 
@@ -164,9 +222,15 @@ class JavaScriptExecutorCore:
             )
 
         # Create the JS script — wrap user code so pptxgenjs warn-only
-        # failures get converted to throws (see _wrap_user_code).
+        # failures get converted to throws (see _wrap_user_code). The
+        # interceptor only fires when the caller actually requested
+        # pptxgenjs so unrelated logs (`console.log("write: complete")`)
+        # don't trip the detector.
         script_file = temp_path / "script.js"
-        script_file.write_text(_wrap_user_code(code), encoding="utf-8")
+        script_file.write_text(
+            _wrap_user_code(code, intercept_pptxgenjs=_requests_pptxgenjs(packages)),
+            encoding="utf-8",
+        )
 
         # Install dependencies if needed
         if deps:
@@ -224,12 +288,18 @@ class JavaScriptExecutorCore:
             )
 
         # Create the JS script in execution directory (so files are created
-        # there). The wrapper buffers console.log AND converts pptxgenjs
-        # warn-only validation failures into thrown errors — see
-        # _wrap_user_code. When capture_output is False the caller has
-        # opted out of buffering and gets the raw code.
+        # there). The wrapper buffers console.log AND, only when the caller
+        # requested pptxgenjs, converts its warn-only validation failures
+        # into thrown errors plus a wrapper-scoped flag check that user
+        # try/catch can't suppress (see _wrap_user_code). When
+        # capture_output is False the caller has opted out of buffering
+        # and gets the raw code.
         script_file = exec_dir / "script.js"
-        wrapped_code = _wrap_user_code(code) if capture_output else code
+        wrapped_code = (
+            _wrap_user_code(code, intercept_pptxgenjs=_requests_pptxgenjs(packages))
+            if capture_output
+            else code
+        )
         script_file.write_text(wrapped_code, encoding="utf-8")
 
         # Install dependencies in temp directory

--- a/tests/core/tools/test_javascript_executor.py
+++ b/tests/core/tools/test_javascript_executor.py
@@ -3,6 +3,8 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from xagent.core.tools.core.javascript_executor import (
     JavaScriptExecutorCore,
     execute_javascript,
@@ -86,6 +88,180 @@ console.log('Sum:', sum);
 
         assert result["success"] is True
         assert "15" in result["output"]
+
+
+class TestPptxgenjsWarningInterception:
+    """The JS wrapper rewrites pptxgenjs warn-only failures into throws.
+
+    pptxgenjs's ``addTable``/``addImage``/etc. log to stdout with
+    ``"<method>: <description>"`` when an argument is malformed, then
+    keep going — leaving a broken ``.pptx`` on disk while node still
+    exits 0. The wrapper that ``execute_code`` puts around user code
+    intercepts ``console.log``, matches the pptxgenjs API method
+    prefix, and throws — so node exits non-zero and the framework's
+    existing hard-failure path surfaces the error to the agent.
+    """
+
+    def test_pptxgenjs_warning_text_in_user_code_triggers_failure(self):
+        """A script that just ``console.log``s the warning text is enough —
+        the wrapper turns it into a throw without needing real pptxgenjs."""
+        executor = JavaScriptExecutorCore()
+        code = (
+            "console.log("
+            "'addTable: tableRows has a bad row. "
+            "A row should be an array of cells.'"
+            ");"
+        )
+        result = executor.execute_code(code)
+
+        assert result["success"] is False
+        # The thrown Error's message includes both our framing and the
+        # original pptxgenjs warning text.
+        assert "pptxgenjs reported a validation problem" in result["error"]
+        assert "addTable: tableRows has a bad row" in result["error"]
+
+    def test_other_pptxgenjs_method_prefixes_also_trigger_failure(self):
+        """addText/addImage/addShape/writeFile prefixes all match."""
+        for prefix in ("addText", "addImage", "addShape", "writeFile"):
+            executor = JavaScriptExecutorCore()
+            result = executor.execute_code(f"console.log('{prefix}: something wrong');")
+            assert result["success"] is False, prefix
+            assert prefix in result["error"], prefix
+
+    def test_unrelated_colon_lines_do_not_trigger_failure(self):
+        """User code logging `foo: bar` style strings stays a clean success."""
+        for line in (
+            "Sum: 42",
+            "error: oops in my data",
+            "DEBUG: starting",
+            "info: 200 OK",
+        ):
+            executor = JavaScriptExecutorCore()
+            result = executor.execute_code(f"console.log('{line}');")
+            assert result["success"] is True, line
+            assert line in result["output"], line
+
+    def test_method_prefix_requires_colon_space_separator(self):
+        """`addTable:nodescription` (no space) is not matched."""
+        executor = JavaScriptExecutorCore()
+        result = executor.execute_code("console.log('addTable:no-space');")
+        assert result["success"] is True
+        assert "addTable:no-space" in result["output"]
+
+    def test_clean_run_unchanged(self):
+        """Sanity: code with no pptxgenjs-shaped logs still succeeds."""
+        executor = JavaScriptExecutorCore()
+        result = executor.execute_code("console.log('all good');")
+        assert result["success"] is True
+        assert "all good" in result["output"]
+        assert result["error"] == ""
+
+
+# Parametrized end-to-end coverage of every failure mode the executor is
+# expected to surface, plus a positive control and a false-positive guard.
+# Each case is a real subprocess run; the pptxgenjs cases install the npm
+# package on first run and are therefore slow (~10s each on a cold cache).
+_ERROR_SIGNAL_CASES = [
+    pytest.param(
+        'console.log("unterminated;',
+        None,
+        False,
+        None,  # node's wrapped error.message varies by version; presence of
+        # *any* error is enough
+        id="syntax_error",
+    ),
+    pytest.param(
+        'throw new Error("boom");',
+        None,
+        False,
+        "boom",
+        id="explicit_throw",
+    ),
+    pytest.param(
+        "console.log(somethingUndefined);",
+        None,
+        False,
+        "not defined",
+        id="undefined_reference",
+    ),
+    pytest.param(
+        # Reproduces demo task/1100: pptxgenjs prints "addTable: tableRows
+        # has a bad row..." to stdout and continues. Node exits 0, but the
+        # generated .pptx is malformed. The executor must convert this
+        # warning into success=False so the agent retries.
+        'const P=require("pptxgenjs");'
+        "const p=new P();"
+        'p.addSlide().addTable([["ok"],{text:"C"}],{x:1,y:1,w:5});'
+        'p.writeFile({fileName:"t.pptx"});'
+        'console.log("done");',
+        ["pptxgenjs"],
+        False,
+        "tableRows has a bad",
+        id="pptxgenjs_warn_only_demo_bug",
+    ),
+    pytest.param(
+        # Hard-error path: pptxgenjs rejects a flat row array immediately.
+        'const P=require("pptxgenjs");'
+        "const p=new P();"
+        'p.addSlide().addTable(["A","B"],{x:1,y:1,w:5});'
+        'p.writeFile({fileName:"t.pptx"});',
+        ["pptxgenjs"],
+        False,
+        "'rows' should be",
+        id="pptxgenjs_hard_fail_flat_rows",
+    ),
+    pytest.param(
+        # Positive control: a normal pptxgenjs run produces a .pptx and
+        # the executor reports success=True with no error.
+        'const P=require("pptxgenjs");'
+        "const p=new P();"
+        'p.addSlide().addText("Hi",{x:1,y:1,fontSize:32});'
+        'p.writeFile({fileName:"good.pptx"});'
+        'console.log("all good");',
+        ["pptxgenjs"],
+        True,
+        None,
+        id="pptxgenjs_clean_run",
+    ),
+    pytest.param(
+        # False-positive guard: user code that happens to log strings
+        # containing colons must NOT be misclassified as a library warning.
+        'console.log("Sum: 42");'
+        'console.log("error: oops in my data");'
+        'console.log("DEBUG: starting");',
+        None,
+        True,
+        None,
+        id="user_log_with_colon_no_false_positive",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "code,packages,expected_success,error_marker", _ERROR_SIGNAL_CASES
+)
+def test_error_signal_reaches_agent(code, packages, expected_success, error_marker):
+    """Every kind of JS failure must surface to the agent as success=False
+    with a useful error message; the executor must not silently mask a
+    library warning that left malformed output behind, and must not flag
+    a clean run as failure.
+
+    Mirrors the manual verification matrix written up in the PR
+    description for fix(js_executor): surface pptxgenjs validation
+    warnings as soft failures.
+    """
+    executor = JavaScriptExecutorCore()
+    result = executor.execute_code(code, packages=packages)
+
+    assert result["success"] is expected_success, (
+        f"expected success={expected_success}, got {result['success']!r}; "
+        f"error={result.get('error')!r}, output={result.get('output')!r}"
+    )
+    if error_marker is not None:
+        err = (result.get("error") or "").lower()
+        assert error_marker.lower() in err, (
+            f"error marker {error_marker!r} not in error={result.get('error')!r}"
+        )
 
 
 class TestJavaScriptWithNpmPackages:

--- a/tests/core/tools/test_javascript_executor.py
+++ b/tests/core/tools/test_javascript_executor.py
@@ -91,18 +91,23 @@ console.log('Sum:', sum);
 
 
 class TestPptxgenjsWarningInterception:
-    """The JS wrapper rewrites pptxgenjs warn-only failures into throws.
+    """The JS wrapper converts pptxgenjs warn-only failures into hard fails.
 
     pptxgenjs's ``addTable``/``addImage``/etc. log to stdout with
     ``"<method>: <description>"`` when an argument is malformed, then
     keep going — leaving a broken ``.pptx`` on disk while node still
-    exits 0. The wrapper that ``execute_code`` puts around user code
-    intercepts ``console.log``, matches the pptxgenjs API method
-    prefix, and throws — so node exits non-zero and the framework's
-    existing hard-failure path surfaces the error to the agent.
+    exits 0. When the caller requested ``pptxgenjs`` we intercept
+    ``console.log`` in the wrapper: set a wrapper-scoped flag, throw,
+    and after the user-code ``try`` block re-check the flag and
+    ``process.exit(1)`` so a user-level ``try/catch`` around the
+    pptxgenjs call cannot suppress the failure.
+
+    The interceptor is GATED on `packages` containing pptxgenjs so a
+    script that doesn't request it can't be misclassified by a
+    pptxgenjs-shaped log line.
     """
 
-    def test_pptxgenjs_warning_text_in_user_code_triggers_failure(self):
+    def test_pptxgenjs_warning_in_user_code_triggers_failure(self):
         """A script that just ``console.log``s the warning text is enough —
         the wrapper turns it into a throw without needing real pptxgenjs."""
         executor = JavaScriptExecutorCore()
@@ -112,11 +117,9 @@ class TestPptxgenjsWarningInterception:
             "A row should be an array of cells.'"
             ");"
         )
-        result = executor.execute_code(code)
+        result = executor.execute_code(code, packages=["pptxgenjs"])
 
         assert result["success"] is False
-        # The thrown Error's message includes both our framing and the
-        # original pptxgenjs warning text.
         assert "pptxgenjs reported a validation problem" in result["error"]
         assert "addTable: tableRows has a bad row" in result["error"]
 
@@ -124,9 +127,23 @@ class TestPptxgenjsWarningInterception:
         """addText/addImage/addShape/writeFile prefixes all match."""
         for prefix in ("addText", "addImage", "addShape", "writeFile"):
             executor = JavaScriptExecutorCore()
-            result = executor.execute_code(f"console.log('{prefix}: something wrong');")
+            result = executor.execute_code(
+                f"console.log('{prefix}: something wrong');",
+                packages=["pptxgenjs"],
+            )
             assert result["success"] is False, prefix
             assert prefix in result["error"], prefix
+
+    def test_generic_prefixes_no_longer_trigger_failure(self):
+        """rogercloud comment 1: bare ``write:``/``stream:`` are off the
+        allow-list now — ordinary user logs must not collide."""
+        for line in ("write: complete", "stream: ready"):
+            executor = JavaScriptExecutorCore()
+            result = executor.execute_code(
+                f"console.log('{line}');", packages=["pptxgenjs"]
+            )
+            assert result["success"] is True, line
+            assert line in result["output"], line
 
     def test_unrelated_colon_lines_do_not_trigger_failure(self):
         """User code logging `foo: bar` style strings stays a clean success."""
@@ -144,7 +161,9 @@ class TestPptxgenjsWarningInterception:
     def test_method_prefix_requires_colon_space_separator(self):
         """`addTable:nodescription` (no space) is not matched."""
         executor = JavaScriptExecutorCore()
-        result = executor.execute_code("console.log('addTable:no-space');")
+        result = executor.execute_code(
+            "console.log('addTable:no-space');", packages=["pptxgenjs"]
+        )
         assert result["success"] is True
         assert "addTable:no-space" in result["output"]
 
@@ -155,6 +174,45 @@ class TestPptxgenjsWarningInterception:
         assert result["success"] is True
         assert "all good" in result["output"]
         assert result["error"] == ""
+
+    def test_interception_gated_on_pptxgenjs_request(self):
+        """rogercloud comment 1: when the caller didn't ask for pptxgenjs,
+        even an exact ``addTable: ...`` line must NOT be flagged. The
+        detector belongs only to executions that actually load the library.
+        """
+        executor = JavaScriptExecutorCore()
+        result = executor.execute_code(
+            "console.log('addTable: tableRows has a bad row.');"
+        )
+        assert result["success"] is True
+        assert "addTable: tableRows has a bad row." in result["output"]
+
+    def test_user_try_catch_cannot_suppress_failure(self):
+        """rogercloud comment 2: a user-level try/catch around the
+        pptxgenjs call must NOT be able to swallow the validation
+        failure. The wrapper-scoped flag check runs after the user try
+        block and exits the process from outside user code's reach.
+        """
+        executor = JavaScriptExecutorCore()
+        # Simulate pptxgenjs's behaviour: the offending method only
+        # ``console.log``s and returns normally. Wrap the call in a
+        # broad try/catch so the injected throw is consumed.
+        code = (
+            "try {"
+            "  console.log('addTable: tableRows has a bad row.');"
+            "  console.log('about to write the malformed pptx');"
+            "} catch (e) {"
+            "  console.log('user swallowed the throw and kept going');"
+            "}"
+        )
+        result = executor.execute_code(code, packages=["pptxgenjs"])
+
+        # The wrapper-level flag check still fires after the user try
+        # block returns, so the tool reports failure even though user
+        # code didn't propagate the throw.
+        assert result["success"] is False
+        assert "pptxgenjs reported a validation problem" in result["error"]
+        assert "addTable: tableRows has a bad row" in result["error"]
 
 
 # Parametrized end-to-end coverage of every failure mode the executor is


### PR DESCRIPTION
## Problem

pptxgenjs's `addTable` / `addImage` / `addShape` / etc. log a `"<method>: <description>"` warning to stdout when an argument is malformed and then **keep going**. The script exits 0, `writeFile` runs, and a malformed `.pptx` lands on disk. `execute_javascript_code` returned `success: True`; the agent told the user the deck was generated cleanly; the chat link pointed at a broken file.

The agent is capable of self-correcting, but only when the framework surfaces real errors. This blind spot meant the recovery loop never started.

## Fix

Convert the warning into a **hard throw** in the JS wrapper:

- Extract `_wrap_user_code()` as a single source of truth used by both `_execute_in_temp` (previously ran user code unwrapped) and `_execute_with_workspace`.
- The wrapper buffers `console.log` and intercepts every call. If the message matches a conservative allow-list of pptxgenjs API method prefixes (`addText` / `addTable` / `addImage` / `addShape` / `addChart` / `addMedia` / `addNotes` / `addSlide` / `addSection` / `addBackgroundImage` / `writeFile` / `stream` / `write`) followed by `": "`, the wrapper throws an `Error` containing the original warning text.
- The throw propagates through pptxgenjs's call frames into the wrapper's `catch`, which calls `process.exit(1)`. The framework's existing non-zero-exit path returns `success: False` with the thrown error message in `error`.

Two improvements the previous stdout-scanning sketch did **not** deliver:

1. **No broken `.pptx` is left on disk.** Node bails before `writeFile` runs.
2. **No new Python error path.** The framework already handles `returncode != 0` — this fix piggybacks on it.

The allow-list is narrow on purpose: unrelated user logs like `console.log("Sum: 42")` or `console.log("error: oops")` do not match and stay clean successes.

## End-to-end verification (against real pptxgenjs@4.0.1 on Node 20)

| Case | Expected | Actual |
|---|---|---|
| JS syntax error | `success: False` | ✅ |
| Explicit `throw new Error("boom")` | `success: False`, error contains `boom` | ✅ |
| Undefined reference | `success: False`, error contains `not defined` | ✅ |
| **pptxgenjs warn-only (the demo bug)** | `success: False`, error contains `tableRows has a bad`, no `.pptx` on disk | ✅ ← previously `success: True` + broken `.pptx` |
| pptxgenjs hard fail (flat rows) | `success: False`, error contains `'rows' should be` | ✅ |
| Clean pptxgenjs run (positive control) | `success: True` | ✅ |
| User code with colon (`Sum: 42`, `error: oops`) | `success: True` | ✅ |

Fixed in CI as `tests/core/tools/test_javascript_executor.py::test_error_signal_reaches_agent` (7-case parametrized). Plus 5 wrapper unit tests under `TestPptxgenjsWarningInterception`. 29 executor tests pass, `ruff check` / `ruff format --check` clean.

## Three layers of defense for this bug class

This PR is layer 1. The other two ship in parallel branches:

1. **Tool layer (this PR)**: framework forces a hard failure at the source — no broken file written.
2. **Prompt layer ([PR #432](https://github.com/xorbitsai/xagent/pull/432))**: SKILL.md Rule #10 tells the agent to surface the error on `success: false` instead of fabricating a success link.
3. **Frontend layer (`fix/markdown-empty-href-as-text`)**: empty-href anchors render as plain text so a stray `[name]()` can't masquerade as a clickable file chip.

Each layer is independent; if any one slips, the next catches it.

## Files changed

- `src/xagent/core/tools/core/javascript_executor.py` (+92 / -25)
- `tests/core/tools/test_javascript_executor.py` (+176)

## Out of scope

- The allow-list only covers pptxgenjs. If matplotlib/pillow or another JS library shows the same "warn-only" failure shape, the regex can be extended in a follow-up.