### PR TITLE
fix: persist Telegram chat transcript

### DIFF
--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -17,6 +17,7 @@ from ...models.database import get_db
 from ...models.task import Task, TaskStatus
 from ...models.user import User
 from ...models.user_channel import UserChannel
+from ...services.execution_result_projection import project_execution_result_for_channel
 from .trace_handler import FeishuTraceHandler
 
 logger = logging.getLogger(__name__)
@@ -315,44 +316,11 @@ class FeishuBotInstance:
                     db_session=db,
                 )
 
-            task.status = (
-                TaskStatus.COMPLETED
-                if result.get("success", False)
-                else TaskStatus.FAILED
-            )
+            projection = project_execution_result_for_channel(result)
+            task.status = projection.task_status
             db.commit()
 
-            output = result.get("output", "")
-
-            chat_response = result.get("chat_response")
-            if isinstance(chat_response, dict):
-                interactions = chat_response.get("interactions", [])
-                if interactions:
-                    interaction_texts = []
-                    for interaction in interactions:
-                        label = interaction.get("label") or interaction.get(
-                            "field", "Input"
-                        )
-                        options = interaction.get("options", [])
-                        if options:
-                            opts = []
-                            for opt in options:
-                                if isinstance(opt, dict):
-                                    opts.append(
-                                        str(opt.get("label", opt.get("value", "")))
-                                    )
-                                else:
-                                    opts.append(str(opt))
-                            interaction_texts.append(
-                                f"• {label}\n  Options: {', '.join(opts)}"
-                            )
-                        else:
-                            interaction_texts.append(f"• {label}")
-                    if interaction_texts:
-                        output += "\n\n" + "\n".join(interaction_texts)
-
-            if not output or not str(output).strip():
-                output = "Task completed, but no output was generated."
+            output = projection.visible_text
 
             max_len = 4000
             text_chunks = [

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -21,8 +21,16 @@ from ...models.database import get_db
 from ...models.task import Task, TaskStatus
 from ...models.uploaded_file import UploadedFile
 from ...models.user import User
+from ...services.chat_history_service import persist_user_message
+from ...services.execution_result_projection import project_execution_result_for_channel
 from .handler import TelegramTraceHandler
-from .utils import TelegramImageRef, markdown_to_tg_html, strip_telegram_image_refs
+from .utils import (
+    TelegramImageRef,
+    markdown_to_tg_html,
+    persist_telegram_assistant_turn,
+    restore_telegram_task_context,
+    strip_telegram_image_refs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -368,19 +376,7 @@ class TelegramBotInstance:
                     user=user,  # type: ignore
                 )
 
-                from ...services.task_execution_context_service import (
-                    load_task_execution_recovery_state,
-                )
-
-                recovery_state = await load_task_execution_recovery_state(
-                    db, int(task.id)
-                )  # type: ignore
-                agent_service.set_execution_context_messages(
-                    recovery_state.get("messages", [])
-                )
-                agent_service.set_recovered_skill_context(
-                    recovery_state.get("skill_context")
-                )
+                await restore_telegram_task_context(agent_service, db, int(task.id))
 
                 context: dict = {}
 
@@ -413,6 +409,13 @@ class TelegramBotInstance:
                         context["state"] = context.get("state", {})
                         context["state"]["file_info"] = uploaded_info
 
+                persist_user_message(
+                    db=db,
+                    task_id=int(task.id),  # type: ignore
+                    user_id=int(user.id),  # type: ignore
+                    content=text,
+                )
+
                 loading_msg = await last_message.answer(
                     "Got it, I'm working on this now.\n"
                     "<i>I'll update this message as I make progress.</i>",
@@ -431,56 +434,34 @@ class TelegramBotInstance:
 
                 actual_task_id = str(task.id)
 
-                with UserContext(int(user.id)):  # type: ignore
-                    result = await agent_manager.execute_task(
-                        agent_service=agent_service,
-                        task=text,
-                        context=context,
-                        task_id=actual_task_id,
-                        tracking_task_id=str(task.id),
-                        db_session=db,
-                    )
+                try:
+                    with UserContext(int(user.id)):  # type: ignore
+                        result = await agent_manager.execute_task(
+                            agent_service=agent_service,
+                            task=text,
+                            context=context,
+                            task_id=actual_task_id,
+                            tracking_task_id=str(task.id),
+                            db_session=db,
+                        )
+                finally:
+                    if tg_handler in agent_service.tracer.handlers:
+                        agent_service.tracer.handlers.remove(tg_handler)
 
-                task.status = (
-                    TaskStatus.COMPLETED
-                    if result.get("success", False)
-                    else TaskStatus.FAILED
-                )
+                projection = project_execution_result_for_channel(result)
+                task.status = projection.task_status
                 db.commit()
 
-                output = result.get("output", "")
+                persist_telegram_assistant_turn(
+                    db=db,
+                    task_id=int(task.id),  # type: ignore
+                    user_id=int(user.id),  # type: ignore
+                    content=projection.transcript_content,
+                    interactions=projection.interactions,
+                    message_type=projection.message_type,
+                )
 
-                chat_response = result.get("chat_response")
-                if isinstance(chat_response, dict):
-                    interactions = chat_response.get("interactions", [])
-                    if interactions:
-                        interaction_texts = []
-                        for interaction in interactions:
-                            label = interaction.get("label") or interaction.get(
-                                "field", "Input"
-                            )
-                            options = interaction.get("options", [])
-                            if options:
-                                opts = []
-                                for opt in options:
-                                    if isinstance(opt, dict):
-                                        opts.append(
-                                            str(opt.get("label", opt.get("value", "")))
-                                        )
-                                    else:
-                                        opts.append(str(opt))
-                                interaction_texts.append(
-                                    f"• {label}\n  Options: {', '.join(opts)}"
-                                )
-                            else:
-                                interaction_texts.append(f"• {label}")
-                        if interaction_texts:
-                            output += "\n\n" + "\n".join(interaction_texts)
-
-                if not output or not str(output).strip():
-                    output = "Task completed, but no output was generated."
-
-                output = str(output)
+                output = projection.visible_text
                 output, image_refs = strip_telegram_image_refs(output)
                 if not output and image_refs:
                     output = "Task completed."

--- a/src/xagent/web/channels/telegram/handler.py
+++ b/src/xagent/web/channels/telegram/handler.py
@@ -28,6 +28,9 @@ class TelegramTraceHandler(TraceHandler):
 
     async def handle_event(self, event: TraceEvent) -> None:
         try:
+            if not self._matches_task(event):
+                return
+
             # We only care about assistant messages and coarse tool activity for Telegram.
             if (
                 event.event_type.category == TraceCategory.MESSAGE
@@ -56,6 +59,11 @@ class TelegramTraceHandler(TraceHandler):
 
         except Exception as e:
             logger.warning(f"TelegramTraceHandler error for task {self.task_id}: {e}")
+
+    def _matches_task(self, event: TraceEvent) -> bool:
+        if event.task_id is None:
+            return True
+        return str(event.task_id) == str(self.task_id)
 
     async def _handle_tool_event(self, event: TraceEvent) -> None:
         tool_name = self._extract_tool_name(event)

--- a/src/xagent/web/channels/telegram/utils.py
+++ b/src/xagent/web/channels/telegram/utils.py
@@ -1,7 +1,13 @@
 import html
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from ....core.agent.service import AgentService
 
 
 @dataclass(frozen=True)
@@ -30,19 +36,7 @@ def markdown_to_tg_html(text: str) -> str:
     text = re.sub(r"```(.*?)\n(.*?)\n```", replace_code_block, text, flags=re.DOTALL)
     text = re.sub(r"```(.*?)```", r"<pre>\1</pre>", text, flags=re.DOTALL)
 
-    # Replace tables
-    table_pattern = re.compile(r"(?:^.*\|.*(?:\n|$))+", re.MULTILINE)
-
-    def replace_table(match: re.Match) -> str:
-        table_content = str(match.group(0)).strip()
-        # Verify it has a separator line (e.g., |---| or ---|---)
-        if re.search(
-            r"^[ \t]*\|?[\s\-:]*[-]+[\s\-:]*\|[\s\-:|]*$", table_content, re.MULTILINE
-        ):
-            return f"\n<pre>{table_content}</pre>\n\n"
-        return str(match.group(0))
-
-    text = table_pattern.sub(replace_table, text)
+    text = _format_markdown_tables_for_telegram(text)
 
     # Replace inline code: `code`
     text = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", text)
@@ -77,6 +71,80 @@ def markdown_to_tg_html(text: str) -> str:
     return text
 
 
+def _format_markdown_tables_for_telegram(text: str) -> str:
+    """Render Markdown tables as wrapped Telegram-friendly lists."""
+    lines = text.splitlines()
+    rendered_lines: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        if _is_markdown_table_start(lines, index):
+            table_lines = [lines[index], lines[index + 1]]
+            index += 2
+            while index < len(lines) and "|" in lines[index].strip():
+                table_lines.append(lines[index])
+                index += 1
+            rendered_lines.extend(_render_markdown_table_as_list(table_lines))
+            continue
+
+        rendered_lines.append(lines[index])
+        index += 1
+
+    return "\n".join(rendered_lines)
+
+
+def _is_markdown_table_start(lines: list[str], index: int) -> bool:
+    return (
+        index + 1 < len(lines)
+        and "|" in lines[index]
+        and _is_markdown_table_separator(lines[index + 1])
+    )
+
+
+def _is_markdown_table_separator(line: str) -> bool:
+    cells = _split_markdown_table_row(line)
+    return bool(cells) and all(re.fullmatch(r":?-+:?", cell) for cell in cells)
+
+
+def _split_markdown_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _render_markdown_table_as_list(table_lines: list[str]) -> list[str]:
+    headers = _split_markdown_table_row(table_lines[0])
+    rows = [
+        _split_markdown_table_row(line)
+        for line in table_lines[2:]
+        if line.strip() and "|" in line
+    ]
+    if not headers or not rows:
+        return table_lines
+
+    rendered: list[str] = []
+    for row in rows:
+        padded_row = row + [""] * max(0, len(headers) - len(row))
+        if len(headers) == 2:
+            title = padded_row[0] or headers[0]
+            detail = padded_row[1]
+            rendered.append(
+                f"• <b>{title}</b>: {detail}" if detail else f"• <b>{title}</b>"
+            )
+            continue
+
+        title = next((cell for cell in padded_row if cell), "Row")
+        rendered.append(f"• <b>{title}</b>")
+        for header, cell in zip(headers, padded_row):
+            if cell and cell != title:
+                rendered.append(f"  {header}: {cell}")
+
+    return rendered
+
+
 _MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]\n]*)\]\(([^)\n]+)\)")
 
 
@@ -100,6 +168,51 @@ def strip_telegram_image_refs(text: str) -> tuple[str, list[TelegramImageRef]]:
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned.strip(), image_refs
+
+
+async def restore_telegram_task_context(
+    agent_service: "AgentService",
+    db: "Session",
+    task_id: int,
+) -> None:
+    """Restore prior chat transcript and execution context for a Telegram turn."""
+    from ...services.chat_history_service import load_task_transcript
+    from ...services.task_execution_context_service import (
+        load_task_execution_recovery_state,
+    )
+
+    agent_service.set_conversation_history(load_task_transcript(db, task_id))
+
+    recovery_state: dict[str, Any] = await load_task_execution_recovery_state(
+        db, task_id
+    )
+    agent_service.set_execution_context_messages(recovery_state.get("messages", []))
+    agent_service.set_recovered_skill_context(recovery_state.get("skill_context"))
+
+
+def persist_telegram_assistant_turn(
+    db: "Session",
+    task_id: int,
+    user_id: int,
+    content: str,
+    interactions: list[dict[str, Any]] | None = None,
+    message_type: str = "assistant_message",
+) -> None:
+    """Persist a Telegram assistant turn when it has text or structured prompts."""
+    from ...services.chat_history_service import persist_assistant_message
+
+    normalized_interactions = interactions or []
+    if not content.strip() and not normalized_interactions:
+        return
+
+    persist_assistant_message(
+        db=db,
+        task_id=task_id,
+        user_id=user_id,
+        content=content,
+        interactions=normalized_interactions,
+        message_type=message_type,
+    )
 
 
 def _extract_local_file_id(target: str) -> str | None:

--- a/src/xagent/web/services/execution_result_projection.py
+++ b/src/xagent/web/services/execution_result_projection.py
@@ -1,0 +1,82 @@
+"""Shared projection from agent execution results to chat-channel state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..models.task import TaskStatus
+
+EMPTY_CHANNEL_OUTPUT_FALLBACK = "Task completed, but no output was generated."
+
+
+@dataclass(frozen=True)
+class ChannelExecutionProjection:
+    task_status: TaskStatus
+    visible_text: str
+    transcript_content: str
+    message_type: str
+    interactions: list[dict[str, Any]]
+
+
+def project_execution_result_for_channel(
+    result: dict[str, Any],
+) -> ChannelExecutionProjection:
+    """Project an execution result into the state chat channels should consume."""
+    status = str(result.get("status") or "")
+    chat_response = result.get("chat_response")
+    chat_message = ""
+    interactions: list[dict[str, Any]] = []
+
+    if isinstance(chat_response, dict):
+        chat_message = str(chat_response.get("message") or "")
+        raw_interactions = chat_response.get("interactions")
+        if isinstance(raw_interactions, list):
+            interactions = [item for item in raw_interactions if isinstance(item, dict)]
+
+    output = str(result.get("output") or "")
+    base_text = chat_message or output
+    if not base_text.strip() and not interactions:
+        base_text = EMPTY_CHANNEL_OUTPUT_FALLBACK
+
+    visible_text = _append_interactions(base_text, interactions)
+
+    return ChannelExecutionProjection(
+        task_status=_project_task_status(result, status),
+        visible_text=visible_text,
+        transcript_content=base_text,
+        message_type="question"
+        if status == "waiting_for_user" or interactions
+        else "assistant_message",
+        interactions=interactions,
+    )
+
+
+def _project_task_status(result: dict[str, Any], status: str) -> TaskStatus:
+    if status == "waiting_for_user":
+        return TaskStatus.WAITING_FOR_USER
+    if status == "interrupted":
+        return TaskStatus.PAUSED
+    return TaskStatus.COMPLETED if result.get("success", False) else TaskStatus.FAILED
+
+
+def _append_interactions(base_text: str, interactions: list[dict[str, Any]]) -> str:
+    if not interactions:
+        return base_text
+
+    interaction_texts: list[str] = []
+    for interaction in interactions:
+        label = interaction.get("label") or interaction.get("field", "Input")
+        options = interaction.get("options", [])
+        if options:
+            opts = []
+            for opt in options:
+                if isinstance(opt, dict):
+                    opts.append(str(opt.get("label", opt.get("value", ""))))
+                else:
+                    opts.append(str(opt))
+            interaction_texts.append(f"• {label}\n  Options: {', '.join(opts)}")
+        else:
+            interaction_texts.append(f"• {label}")
+
+    return base_text + "\n\n" + "\n".join(interaction_texts)

--- a/tests/web/test_execution_result_projection.py
+++ b/tests/web/test_execution_result_projection.py
@@ -1,0 +1,71 @@
+from xagent.web.models.task import TaskStatus
+from xagent.web.services.execution_result_projection import (
+    EMPTY_CHANNEL_OUTPUT_FALLBACK,
+    project_execution_result_for_channel,
+)
+
+
+def test_project_execution_result_waiting_for_user_uses_chat_message_as_question():
+    projection = project_execution_result_for_channel(
+        {
+            "status": "waiting_for_user",
+            "success": False,
+            "output": "Need input.",
+            "chat_response": {"message": "Choose A or B", "interactions": []},
+        }
+    )
+
+    assert projection.task_status == TaskStatus.WAITING_FOR_USER
+    assert projection.visible_text == "Choose A or B"
+    assert projection.transcript_content == "Choose A or B"
+    assert projection.message_type == "question"
+    assert projection.interactions == []
+
+
+def test_project_execution_result_appends_interactions_to_visible_text():
+    projection = project_execution_result_for_channel(
+        {
+            "success": True,
+            "output": "Need details.",
+            "chat_response": {
+                "message": "Choose a destination",
+                "interactions": [
+                    {
+                        "label": "Destination",
+                        "options": [{"label": "Tokyo"}, {"value": "Osaka"}],
+                    }
+                ],
+            },
+        }
+    )
+
+    assert projection.task_status == TaskStatus.COMPLETED
+    assert projection.transcript_content == "Choose a destination"
+    assert projection.message_type == "question"
+    assert projection.interactions == [
+        {
+            "label": "Destination",
+            "options": [{"label": "Tokyo"}, {"value": "Osaka"}],
+        }
+    ]
+    assert projection.visible_text == (
+        "Choose a destination\n\n• Destination\n  Options: Tokyo, Osaka"
+    )
+
+
+def test_project_execution_result_falls_back_for_empty_output():
+    projection = project_execution_result_for_channel({"success": True, "output": None})
+
+    assert projection.task_status == TaskStatus.COMPLETED
+    assert projection.visible_text == EMPTY_CHANNEL_OUTPUT_FALLBACK
+    assert projection.transcript_content == EMPTY_CHANNEL_OUTPUT_FALLBACK
+    assert projection.message_type == "assistant_message"
+
+
+def test_project_execution_result_maps_interrupted_to_paused():
+    projection = project_execution_result_for_channel(
+        {"status": "interrupted", "success": False, "output": "Paused."}
+    )
+
+    assert projection.task_status == TaskStatus.PAUSED
+    assert projection.visible_text == "Paused."

--- a/tests/web/test_telegram_image_output.py
+++ b/tests/web/test_telegram_image_output.py
@@ -11,7 +11,12 @@ from xagent.core.agent.trace import (
 )
 from xagent.web.channels.telegram import handler as telegram_handler
 from xagent.web.channels.telegram.handler import TelegramTraceHandler
-from xagent.web.channels.telegram.utils import strip_telegram_image_refs
+from xagent.web.channels.telegram.utils import (
+    markdown_to_tg_html,
+    persist_telegram_assistant_turn,
+    restore_telegram_task_context,
+    strip_telegram_image_refs,
+)
 
 
 def test_strip_telegram_image_refs_extracts_file_refs() -> None:
@@ -48,6 +53,197 @@ def test_telegram_trace_handler_uses_plural_image_placeholder() -> None:
 
     assert handler._image_placeholder_text(1) == "Image generated."
     assert handler._image_placeholder_text(2) == "Images generated."
+
+
+@pytest.mark.asyncio
+async def test_telegram_trace_handler_ignores_events_for_other_tasks() -> None:
+    sent_texts: list[str] = []
+
+    class CapturingTelegramTraceHandler(TelegramTraceHandler):
+        async def _update_message(self, text: str, final: bool = False) -> None:
+            sent_texts.append(text)
+
+    handler = CapturingTelegramTraceHandler(
+        task_id=421,
+        bot=object(),
+        chat_id=123,
+        message_id=456,  # type: ignore[arg-type]
+    )
+
+    await handler.handle_event(
+        TraceEvent(
+            ACTION_START_TOOL,
+            task_id="422",
+            step_id="step-1",
+            data={"tool_name": "browser_navigate"},
+        )
+    )
+
+    assert sent_texts == []
+
+
+def test_markdown_to_tg_html_renders_tables_as_wrapped_lists() -> None:
+    html = markdown_to_tg_html(
+        "| 特性 | 说明 |\n"
+        "|---|---|\n"
+        "| 统一可观测引擎 | 指标、日志、链路、宽事件统一在一个数据库中。 |\n"
+        "| 对象存储优先 | 成本最高降低 50 倍。 |\n"
+    )
+
+    assert "<pre>" not in html
+    assert (
+        "• <b>统一可观测引擎</b>: 指标、日志、链路、宽事件统一在一个数据库中。" in html
+    )
+    assert "• <b>对象存储优先</b>: 成本最高降低 50 倍。" in html
+
+
+def test_markdown_to_tg_html_renders_multi_column_tables_as_field_lists() -> None:
+    html = markdown_to_tg_html(
+        "| Tool | Status | Notes |\n"
+        "|---|---|---|\n"
+        "| web_search | done | Found product page |\n"
+    )
+
+    assert "<pre>" not in html
+    assert "• <b>web_search</b>" in html
+    assert "  Status: done" in html
+    assert "  Notes: Found product page" in html
+
+
+def test_markdown_to_tg_html_accepts_single_hyphen_table_delimiters() -> None:
+    html = markdown_to_tg_html(
+        "| Feature | Detail |\n| - | - |\n| Storage | Object storage first |\n"
+    )
+
+    assert "<pre>" not in html
+    assert "• <b>Storage</b>: Object storage first" in html
+
+
+@pytest.mark.asyncio
+async def test_restore_telegram_task_context_loads_transcript_and_recovery_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import chat_history_service, task_execution_context_service
+
+    db = object()
+    transcript = [{"role": "user", "content": "Generate a Spirited Away image"}]
+    recovery_state = {
+        "messages": [{"role": "tool", "content": "image generated"}],
+        "skill_context": {"style": "ghibli"},
+    }
+
+    class FakeAgentService:
+        def __init__(self) -> None:
+            self.conversation_history = None
+            self.execution_context_messages = None
+            self.recovered_skill_context = None
+
+        def set_conversation_history(self, messages):
+            self.conversation_history = messages
+
+        def set_execution_context_messages(self, messages):
+            self.execution_context_messages = messages
+
+        def set_recovered_skill_context(self, context):
+            self.recovered_skill_context = context
+
+    async def fake_load_recovery_state(received_db, received_task_id: int):
+        assert received_db is db
+        assert received_task_id == 423
+        return recovery_state
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "load_task_transcript",
+        lambda received_db, received_task_id: transcript,
+    )
+    monkeypatch.setattr(
+        task_execution_context_service,
+        "load_task_execution_recovery_state",
+        fake_load_recovery_state,
+    )
+
+    agent_service = FakeAgentService()
+
+    await restore_telegram_task_context(agent_service, db, 423)  # type: ignore[arg-type]
+
+    assert agent_service.conversation_history == transcript
+    assert agent_service.execution_context_messages == recovery_state["messages"]
+    assert agent_service.recovered_skill_context == recovery_state["skill_context"]
+
+
+def test_persist_telegram_assistant_turn_stores_failed_text_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import chat_history_service
+
+    persisted = []
+
+    def fake_persist_assistant_message(**kwargs):
+        persisted.append(kwargs)
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "persist_assistant_message",
+        fake_persist_assistant_message,
+    )
+
+    persist_telegram_assistant_turn(
+        db=object(),  # type: ignore[arg-type]
+        task_id=423,
+        user_id=7,
+        content="I could not generate that image.",
+        interactions=[],
+    )
+
+    assert persisted == [
+        {
+            "db": persisted[0]["db"],
+            "task_id": 423,
+            "user_id": 7,
+            "content": "I could not generate that image.",
+            "interactions": [],
+            "message_type": "assistant_message",
+        }
+    ]
+
+
+def test_persist_telegram_assistant_turn_stores_interactions_as_question(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import chat_history_service
+
+    persisted = []
+    interactions = [{"type": "text_input", "label": "Destination"}]
+
+    def fake_persist_assistant_message(**kwargs):
+        persisted.append(kwargs)
+
+    monkeypatch.setattr(
+        chat_history_service,
+        "persist_assistant_message",
+        fake_persist_assistant_message,
+    )
+
+    persist_telegram_assistant_turn(
+        db=object(),  # type: ignore[arg-type]
+        task_id=423,
+        user_id=7,
+        content="",
+        interactions=interactions,
+        message_type="question",
+    )
+
+    assert persisted == [
+        {
+            "db": persisted[0]["db"],
+            "task_id": 423,
+            "user_id": 7,
+            "content": "",
+            "interactions": interactions,
+            "message_type": "question",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist Telegram user and assistant turns into the task chat transcript
- restore both prior chat transcript and execution recovery state before running Telegram follow-up turns
- project execution results through a shared channel contract for task status, visible text, transcript content, message type, and interactions
- use the shared projection in Telegram and Feishu so waiting-for-user/interrupted control states are preserved
- improve Telegram progress isolation and Markdown table rendering

## Tests
- ruff check src/xagent/web/services/execution_result_projection.py src/xagent/web/channels/telegram/bot.py src/xagent/web/channels/telegram/utils.py src/xagent/web/channels/feishu/bot.py tests/web/test_execution_result_projection.py tests/web/test_telegram_image_output.py
- env -u LC_ALL -u LC_CTYPE PYTHONPATH=src python -m pytest tests/web/test_execution_result_projection.py tests/web/test_telegram_image_output.py -q --confcutdir=tests/web -p no:capture