### PR TITLE
fix: coerce vision tool numeric parameters

### DIFF
--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -463,8 +463,6 @@ class OpenAILLM(BaseLLM):
 
         if max_tokens is not None:
             completion_params["max_tokens"] = max_tokens
-        elif self.default_max_tokens is not None:
-            completion_params["max_tokens"] = self.default_max_tokens
 
         if temperature is not None:
             completion_params["temperature"] = temperature

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -458,10 +458,18 @@ class OpenAILLM(BaseLLM):
         completion_params = {
             "model": self._model_name,
             "messages": self._sanitize_unicode_content(messages),
-            "temperature": temperature or self.default_temperature,
-            "max_tokens": max_tokens or self.default_max_tokens,
             **kwargs,
         }
+
+        if max_tokens is not None:
+            completion_params["max_tokens"] = max_tokens
+        elif self.default_max_tokens is not None:
+            completion_params["max_tokens"] = self.default_max_tokens
+
+        if temperature is not None:
+            completion_params["temperature"] = temperature
+        elif self.default_temperature is not None:
+            completion_params["temperature"] = self.default_temperature
 
         # Add optional parameters
         if tools:

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -102,11 +102,14 @@ class VisionCore:
                 return None
 
         try:
-            parsed = int(value)
+            parsed_float = float(value)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"{field_name} must be an integer") from exc
 
-        return parsed
+        if not parsed_float.is_integer():
+            raise ValueError(f"{field_name} must be an integer")
+
+        return int(parsed_float)
 
     def _convert_image_to_base64(self, image_path: str) -> str:
         """

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -74,6 +74,40 @@ class VisionCore:
         )
         self.output_directory.mkdir(parents=True, exist_ok=True)
 
+    def _coerce_optional_float(self, value: Any, field_name: str) -> Optional[float]:
+        """Normalize optional numeric tool arguments before model calls."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} must be a number")
+        if isinstance(value, str):
+            value = value.strip()
+            if value.lower() in {"", "none", "null"}:
+                return None
+
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field_name} must be a number") from exc
+
+    def _coerce_optional_int(self, value: Any, field_name: str) -> Optional[int]:
+        """Normalize optional integer tool arguments before model calls."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} must be an integer")
+        if isinstance(value, str):
+            value = value.strip()
+            if value.lower() in {"", "none", "null"}:
+                return None
+
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field_name} must be an integer") from exc
+
+        return parsed
+
     def _convert_image_to_base64(self, image_path: str) -> str:
         """
         Convert image to base64 format for LLM vision chat.
@@ -169,6 +203,9 @@ class VisionCore:
             Dictionary with analysis result and metadata
         """
         try:
+            temperature = self._coerce_optional_float(temperature, "temperature")
+            max_tokens = self._coerce_optional_int(max_tokens, "max_tokens")
+
             # Validate vision model capability
             if not self.vision_model.has_ability("vision"):
                 model_info = f"Model: {self.vision_model.__class__.__name__}"
@@ -313,6 +350,9 @@ class VisionCore:
             Result with detected objects and optionally marked image path
         """
         try:
+            temperature = self._coerce_optional_float(temperature, "temperature")
+            max_tokens = self._coerce_optional_int(max_tokens, "max_tokens")
+
             # Validate vision model capability
             if not self.vision_model.has_ability("vision"):
                 model_info = f"Model: {self.vision_model.__class__.__name__}"
@@ -408,8 +448,8 @@ class VisionCore:
             # Call the vision model
             raw_result = await self.vision_model.vision_chat(
                 messages=messages,
-                temperature=temperature or 0.1,
-                max_tokens=max_tokens or 2000,
+                temperature=temperature if temperature is not None else 0.1,
+                max_tokens=max_tokens if max_tokens is not None else 2000,
                 response_format={"type": "json_object"},
             )
 

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -254,6 +254,43 @@ class TestOpenAILLM:
         assert call_args.kwargs["max_tokens"] == 50
 
     @pytest.mark.asyncio
+    async def test_vision_chat_preserves_zero_temperature(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """Vision calls should preserve explicit 0.0 instead of using defaults."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_chat_completion
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh"
+                        },
+                    },
+                ],
+            }
+        ]
+
+        response = await llm.vision_chat(messages, temperature=0.0)
+
+        assert isinstance(response, dict)
+        assert response.get("type") == "text"
+
+        call_args = mock_client.chat.completions.create.call_args
+        assert call_args.kwargs["temperature"] == 0.0
+        assert call_args.kwargs["max_tokens"] == 1024
+
+    @pytest.mark.asyncio
     async def test_cleanup(self, openai_llm_config, mock_chat_completion, mocker):
         """Test that client cleanup works properly."""
         # Setup mock

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -288,7 +288,7 @@ class TestOpenAILLM:
 
         call_args = mock_client.chat.completions.create.call_args
         assert call_args.kwargs["temperature"] == 0.0
-        assert call_args.kwargs["max_tokens"] == 1024
+        assert "max_tokens" not in call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_cleanup(self, openai_llm_config, mock_chat_completion, mocker):

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -325,6 +325,42 @@ class TestVisionToolUnderstandImages:
         assert call_args.kwargs.get("max_tokens") == 200
 
     @pytest.mark.asyncio
+    async def test_understand_coerces_string_numeric_parameters(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        """Tool calls may pass optional numeric arguments as strings."""
+        result = await vision_tool_without_workspace.understand_images(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            "What is in this image?",
+            temperature="0.7",
+            max_tokens="200",
+        )
+
+        assert result.success is True
+
+        call_args = mock_vision_model.vision_chat.call_args
+        assert call_args.kwargs.get("temperature") == 0.7
+        assert call_args.kwargs.get("max_tokens") == 200
+
+    @pytest.mark.asyncio
+    async def test_understand_ignores_blank_optional_numeric_parameters(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        """Blank optional values should not be sent to OpenAI as strings."""
+        result = await vision_tool_without_workspace.understand_images(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            "What is in this image?",
+            temperature="",
+            max_tokens="",
+        )
+
+        assert result.success is True
+
+        call_args = mock_vision_model.vision_chat.call_args
+        assert call_args.kwargs.get("temperature") is None
+        assert call_args.kwargs.get("max_tokens") is None
+
+    @pytest.mark.asyncio
     async def test_understand_file_not_found_with_workspace(
         self, vision_tool_with_workspace, mock_workspace
     ):
@@ -475,6 +511,23 @@ class TestVisionToolDetectObjects:
         messages = call_kwargs["messages"]
         prompt = messages[0]["content"][0]["text"]  # User message text
         assert "0.9" in prompt
+
+    @pytest.mark.asyncio
+    async def test_detect_objects_preserves_zero_temperature(
+        self, mock_vision_model_with_detection
+    ):
+        """A valid zero temperature should not be replaced by the detection default."""
+        vision_tool = VisionTool(mock_vision_model_with_detection)
+        result = await vision_tool.detect_objects(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            task="Detect objects",
+            temperature=0.0,
+        )
+
+        assert result.success is True
+
+        call_kwargs = mock_vision_model_with_detection.vision_chat.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.0
 
     @pytest.mark.asyncio
     async def test_detect_objects_unstructured_response(

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -343,6 +343,36 @@ class TestVisionToolUnderstandImages:
         assert call_args.kwargs.get("max_tokens") == 200
 
     @pytest.mark.asyncio
+    async def test_understand_coerces_decimal_string_integer_parameters(
+        self, vision_tool_without_workspace, mock_vision_model
+    ):
+        """Integer parameters may arrive as decimal strings from tool payloads."""
+        result = await vision_tool_without_workspace.understand_images(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            "What is in this image?",
+            max_tokens="200.0",
+        )
+
+        assert result.success is True
+
+        call_args = mock_vision_model.vision_chat.call_args
+        assert call_args.kwargs.get("max_tokens") == 200
+
+    @pytest.mark.asyncio
+    async def test_understand_rejects_fractional_integer_parameters(
+        self, vision_tool_without_workspace
+    ):
+        """Fractional max_tokens values should not be silently truncated."""
+        result = await vision_tool_without_workspace.understand_images(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            "What is in this image?",
+            max_tokens="200.5",
+        )
+
+        assert result.success is False
+        assert "max_tokens must be an integer" in result.error
+
+    @pytest.mark.asyncio
     async def test_understand_ignores_blank_optional_numeric_parameters(
         self, vision_tool_without_workspace, mock_vision_model
     ):


### PR DESCRIPTION
## Summary

- Normalize optional numeric parameters in vision tools before model calls.
- Avoid sending empty optional temperature and max_tokens values to OpenAI vision chat requests.
- Preserve explicit zero values such as temperature 0.0.

## Root cause

Vision tool calls could pass optional numeric arguments as strings. When temperature reached OpenAI as a string value, the API rejected the request with invalid_value because OpenAI requires temperature to be a float.

## Production check

The backend service journal contains a matching OpenAI 400 at 2026-05-19 14:25:08 +0800. The error was OpenAI bad request with temperature must be Float and code invalid_value.

## Validation

- uv run pytest tests/core/tools/test_vision_tool.py tests/core/model/chat/basic/test_openai.py
- uv run ruff check src/xagent/core/tools/core/vision_tool.py src/xagent/core/model/chat/basic/openai.py tests/core/tools/test_vision_tool.py tests/core/model/chat/basic/test_openai.py
- pre-commit hooks passed during commit

Supersedes #445, which was closed after the branch was rebased to drop unrelated commits from another fix branch.
