### PR TITLE
feat: add Redis hot path cache

### DIFF
--- a/docker-compose-sandbox.yml
+++ b/docker-compose-sandbox.yml
@@ -45,12 +45,16 @@ services:
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - BOXLITE_HOME_DIR=/root/.xagent/boxlite
+      - XAGENT_REDIS_URL=redis://redis:6379/0
+      - XAGENT_HOT_PATH_CACHE_ENABLED=${XAGENT_HOT_PATH_CACHE_ENABLED:-true}
     env_file:
       - .env
     volumes:
       - xagent_data:/root/.xagent
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -78,6 +82,20 @@ services:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U xagent -d xagent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - xagent_network
+
+  # Redis cache for hot-path API reads
+  redis:
+    image: redis:7-alpine
+    container_name: xagent_redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,12 +40,16 @@ services:
       - BACKEND_PORT=8000
       - XAGENT_UPLOADS_DIR=/root/.xagent/uploads
       - XAGENT_MAX_UPLOAD_SIZE=${XAGENT_MAX_UPLOAD_SIZE:-100M}
+      - XAGENT_REDIS_URL=redis://redis:6379/0
+      - XAGENT_HOT_PATH_CACHE_ENABLED=${XAGENT_HOT_PATH_CACHE_ENABLED:-true}
     env_file:
       - .env
     volumes:
       - xagent_data:/root/.xagent
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -70,6 +74,20 @@ services:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U xagent -d xagent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - xagent_network
+
+  # Redis cache for hot-path API reads
+  redis:
+    image: redis:7-alpine
+    container_name: xagent_redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/example.env
+++ b/example.env
@@ -27,6 +27,22 @@ PORT="80"
 # DATABASE_URL="sqlite:///home/xagent/.xagent/xagent.db"
 
 # ===========================================
+# Hot Path Cache Configuration
+# ===========================================
+# Enables short-TTL cache for high-frequency task/agent/model read paths.
+# Docker Compose deployments start a Redis service and set
+# XAGENT_REDIS_URL=redis://redis:6379/0 automatically.
+#
+# For local backend runs outside Docker Compose, uncomment these if Redis is
+# running on your machine, for example via `brew services start redis`.
+# XAGENT_REDIS_URL="redis://localhost:6379/0"
+# XAGENT_HOT_PATH_CACHE_ENABLED="true"
+# Default TTL for agent/model response cache entries.
+# XAGENT_HOT_PATH_CACHE_TTL_SECONDS="30"
+# Default TTL for task polling cache entries.
+# XAGENT_HOT_PATH_TASK_CACHE_TTL_SECONDS="30"
+
+# ===========================================
 # LLM API Keys
 # ===========================================
 # OPENAI_API_KEY="your-openai-api-key"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "python-dotenv >= 1.0.1",
   "mcp>=1.12.4",
   "requests >= 2.32.0",
+  "redis>=5.0.0",
   "pillow >= 10.0.0",
   "lancedb>=0.13.0",
   "pyarrow>=16.1.0",

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -52,6 +52,10 @@ SANDBOX_VOLUMES = "SANDBOX_VOLUMES"
 BOXLITE_HOME_DIR = "BOXLITE_HOME_DIR"
 WEB_SEARCH_PROVIDER = "XAGENT_WEB_SEARCH_PROVIDER"
 WEB_CRAWL_TLS_IMPERSONATE = "XAGENT_WEB_CRAWL_TLS_IMPERSONATE"
+REDIS_URL = "XAGENT_REDIS_URL"
+HOT_PATH_CACHE_ENABLED = "XAGENT_HOT_PATH_CACHE_ENABLED"
+HOT_PATH_CACHE_TTL_SECONDS = "XAGENT_HOT_PATH_CACHE_TTL_SECONDS"
+HOT_PATH_TASK_CACHE_TTL_SECONDS = "XAGENT_HOT_PATH_TASK_CACHE_TTL_SECONDS"
 
 TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
 TOOL_MAX_RECURSION_DEPTH = "XAGENT_TOOL_MAX_RECURSION_DEPTH"
@@ -182,6 +186,51 @@ def get_task_lease_heartbeat_seconds() -> int:
         )
         return default
     return min(seconds, max(1, get_task_lease_ttl_seconds() - 1))
+
+
+def _get_positive_int_env(env_var: str, default: int, *, minimum: int = 1) -> int:
+    value = os.getenv(env_var)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", env_var, value, default)
+        return default
+    if parsed < minimum:
+        logger.warning("Invalid %s=%r; falling back to %s", env_var, value, default)
+        return default
+    return parsed
+
+
+def get_redis_url() -> str | None:
+    """Return the optional Redis URL used by hot-path cache backends."""
+    value = os.getenv(REDIS_URL)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def get_hot_path_cache_enabled() -> bool:
+    """Return whether optional hot-path caching is enabled.
+
+    Caching is inert unless ``XAGENT_REDIS_URL`` is configured or tests install
+    an explicit cache backend. This flag gives operators a kill switch without
+    changing the Redis URL.
+    """
+    value = os.getenv(HOT_PATH_CACHE_ENABLED, "true").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def get_hot_path_cache_ttl_seconds() -> int:
+    """Default TTL for agent/model hot-path response caches."""
+    return _get_positive_int_env(HOT_PATH_CACHE_TTL_SECONDS, 30)
+
+
+def get_hot_path_task_cache_ttl_seconds() -> int:
+    """Default TTL for task polling response caches."""
+    return _get_positive_int_env(HOT_PATH_TASK_CACHE_TTL_SECONDS, 30)
 
 
 def get_web_dir() -> Path:

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, field_validator
 
 from .....config import get_uploads_dir
+from .....web.services.hot_path_cache import invalidate_agent_cache
 from .....web.services.model_service import (
     _get_visible_user_ids,
     _is_model_visible_to_user,
@@ -597,6 +598,7 @@ class CreateAgentTool(AbstractBaseTool):
             self._db.add(agent)
             self._db.commit()
             self._db.refresh(agent)
+            invalidate_agent_cache(self._user_id, int(agent.id))
 
             # Generate the tool name and markdown link
             tool_name = gen_agent_tool_name(agent_name)
@@ -904,6 +906,7 @@ class UpdateAgentTool(AbstractBaseTool):
             # Commit changes to database
             self._db.commit()
             self._db.refresh(agent)
+            invalidate_agent_cache(self._user_id, int(agent.id))
 
             # Generate the tool name and markdown link
             tool_name = gen_agent_tool_name(agent.name)

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -7,6 +7,7 @@ from ..models.database import get_db
 from ..models.task import Task
 from ..models.user import User
 from ..schemas.user import UserListResponse, UserResponse
+from ..services.hot_path_cache import invalidate_model_cache
 
 router = APIRouter(prefix="/api/admin/users", tags=["admin-users"])
 
@@ -91,5 +92,6 @@ async def delete_user(
     # Delete the user (UserModel and UserDefaultModel have cascade delete)
     db.delete(user)
     db.commit()
+    invalidate_model_cache(None)
 
     return {"message": "User deleted successfully"}

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -29,6 +29,13 @@ from ..schemas.agent_api_key import (
     APIKeyMetadataResponse,
     APIKeyRevokeResponse,
 )
+from ..services.hot_path_cache import (
+    agent_detail_key,
+    agent_list_key,
+    cache_get,
+    cache_set,
+    invalidate_agent_cache,
+)
 from ..services.llm_utils import UserAwareModelStorage
 from ..tools.config import WebToolConfig
 from ..user_isolated_memory import UserContext
@@ -461,6 +468,7 @@ async def create_agent(
                 db.commit()
                 db.refresh(agent)
 
+        invalidate_agent_cache(int(current_user.id), int(agent.id))
         logger.info(f"Created agent {agent.id} for user {current_user.id}")
         return _agent_to_response(agent, db)
 
@@ -479,6 +487,11 @@ async def list_agents(
 ) -> List[AgentListItem]:
     """List all agents for the current user."""
     try:
+        cache_key = agent_list_key(int(current_user.id))
+        cached = cache_get(cache_key)
+        if isinstance(cached, list):
+            return [AgentListItem.model_validate(item) for item in cached]
+
         agents = (
             db.query(Agent)
             .filter(Agent.user_id == current_user.id)
@@ -486,7 +499,7 @@ async def list_agents(
             .all()
         )
 
-        return [
+        response = [
             AgentListItem(
                 id=agent.id,
                 name=agent.name,
@@ -502,6 +515,8 @@ async def list_agents(
             )
             for agent in agents
         ]
+        cache_set(cache_key, [item.model_dump(mode="json") for item in response])
+        return response
 
     except Exception as e:
         logger.error(f"Failed to list agents: {e}")
@@ -516,6 +531,11 @@ async def get_agent(
 ) -> AgentResponse:
     """Get agent details."""
     try:
+        cache_key = agent_detail_key(int(current_user.id), agent_id)
+        cached = cache_get(cache_key)
+        if isinstance(cached, dict):
+            return AgentResponse.model_validate(cached)
+
         agent = (
             db.query(Agent)
             .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
@@ -525,7 +545,9 @@ async def get_agent(
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        return _agent_to_response(agent, db)
+        response = _agent_to_response(agent, db)
+        cache_set(cache_key, response.model_dump(mode="json"))
+        return response
 
     except HTTPException:
         raise
@@ -618,6 +640,7 @@ async def update_agent(
         db.commit()
         db.refresh(agent)
 
+        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Updated agent {agent_id} for user {current_user.id}")
         return _agent_to_response(agent, db)
 
@@ -653,6 +676,7 @@ async def delete_agent(
         db.delete(agent)
         db.commit()
 
+        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Deleted agent {agent_id} for user {current_user.id}")
         return {"message": "Agent deleted successfully"}
 
@@ -692,6 +716,7 @@ async def publish_agent(
         db.commit()
         db.refresh(agent)
 
+        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Published agent {agent_id} for user {current_user.id}")
         return PublishResponse(
             message="Agent published successfully", agent=_agent_to_response(agent, db)
@@ -732,6 +757,7 @@ async def unpublish_agent(
         db.commit()
         db.refresh(agent)
 
+        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Unpublished agent {agent_id} for user {current_user.id}")
         return PublishResponse(
             message="Agent unpublished successfully",
@@ -777,6 +803,7 @@ async def upload_agent_logo(
         db.commit()
         db.refresh(agent)
 
+        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Updated logo for agent {agent_id}")
         return {"logo_url": logo_url}
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -25,14 +25,24 @@ from ...core.model.providers import is_placeholder_api_key
 from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store
 from ..models.agent import Agent
+from ..models.chat_message import TaskChatMessage
 from ..models.database import get_db
 from ..models.model import Model as DBModel
-from ..models.task import AgentType, Task, TaskStatus
+from ..models.task import AgentType, Task, TaskStatus, TraceEvent
 from ..models.user import User
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.chat_history_service import (
     get_latest_waiting_question,
     load_task_transcript,
+)
+from ..services.hot_path_cache import (
+    cache_get,
+    cache_set,
+    cache_version_token,
+    invalidate_task_cache,
+    task_cache_ttl_seconds,
+    web_task_detail_key,
+    web_task_status_key,
 )
 from ..services.llm_utils import resolve_llms_from_names
 from ..services.managed_file_ref import ensure_uploaded_file_local_path
@@ -57,6 +67,8 @@ logger = logging.getLogger(__name__)
 # Create router
 chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
 
+_TERMINAL_CACHE_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
+
 
 def _build_task_agent_config(
     request_agent_config: Optional[Dict[str, Any]],
@@ -70,6 +82,25 @@ def _build_task_agent_config(
     if selected_file_ids:
         task_agent_config["selected_file_ids"] = selected_file_ids
     return task_agent_config or None
+
+
+def _get_task_activity_ids(db: Session, task_id: int) -> tuple[int, int]:
+    max_trace_event_id = (
+        db.query(func.max(TraceEvent.id))
+        .filter(
+            TraceEvent.task_id == task_id,
+            TraceEvent.build_id.is_(None),
+        )
+        .scalar()
+        or 0
+    )
+    max_chat_message_id = (
+        db.query(func.max(TaskChatMessage.id))
+        .filter(TaskChatMessage.task_id == task_id)
+        .scalar()
+        or 0
+    )
+    return int(max_trace_event_id), int(max_chat_message_id)
 
 
 def create_default_llm() -> Optional[BaseLLM]:
@@ -2194,6 +2225,9 @@ async def get_task(
             mark_task_paused_if_stale(db, task)
             db.refresh(task)
 
+            cache_key = web_task_detail_key(task_id)
+            task_updated_at = cache_version_token(task.updated_at)
+
             # Get the raw status value safely
             if hasattr(task, "status") and task.status is not None:
                 if hasattr(task.status, "value"):
@@ -2210,6 +2244,27 @@ async def get_task(
             dag_execution = (
                 db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
             )
+            dag_updated_at = (
+                cache_version_token(dag_execution.updated_at) if dag_execution else None
+            )
+            activity_ids: tuple[int, int] | None = None
+            cached = cache_get(cache_key)
+            if (
+                isinstance(cached, dict)
+                and cached.get("updated_at") == task_updated_at
+                and cached.get("dag_updated_at") == dag_updated_at
+            ):
+                if task.status in _TERMINAL_CACHE_STATUSES:
+                    return cast(Dict[str, Any], cached["response"])
+                activity_ids = _get_task_activity_ids(db, task_id)
+                if cached.get("max_trace_event_id") == int(
+                    activity_ids[0]
+                ) and cached.get("max_chat_message_id") == int(activity_ids[1]):
+                    return cast(Dict[str, Any], cached["response"])
+
+            if task.status not in _TERMINAL_CACHE_STATUSES and activity_ids is None:
+                activity_ids = _get_task_activity_ids(db, task_id)
+
             if dag_execution:
                 dag_data = {
                     "phase": dag_execution.phase.value if dag_execution.phase else None,
@@ -2233,7 +2288,7 @@ async def get_task(
                     db, task_id
                 )
 
-            return {
+            response = {
                 "task_id": task.id,
                 "title": task.title,
                 "description": task.description,
@@ -2258,6 +2313,22 @@ async def get_task(
                 "waiting_question": waiting_question,
                 "waiting_interactions": waiting_interactions,
             }
+            cache_set(
+                cache_key,
+                {
+                    "updated_at": task_updated_at,
+                    "dag_updated_at": dag_updated_at,
+                    "max_trace_event_id": (
+                        activity_ids[0] if activity_ids is not None else None
+                    ),
+                    "max_chat_message_id": (
+                        activity_ids[1] if activity_ids is not None else None
+                    ),
+                    "response": response,
+                },
+                ttl_seconds=task_cache_ttl_seconds(),
+            )
+            return response
 
         # Execute in thread pool to avoid blocking
         return await asyncio.to_thread(_get_task_sync)
@@ -2289,6 +2360,22 @@ async def get_task_status(
             if not task:
                 raise HTTPException(status_code=404, detail="Task not found")
 
+            cache_key = web_task_status_key(task_id)
+            task_updated_at = cache_version_token(task.updated_at)
+            activity_ids: tuple[int, int] | None = None
+            cached = cache_get(cache_key)
+            if isinstance(cached, dict) and cached.get("updated_at") == task_updated_at:
+                if task.status in _TERMINAL_CACHE_STATUSES:
+                    return cast(Dict[str, Any], cached["response"])
+                activity_ids = _get_task_activity_ids(db, task_id)
+                if cached.get("max_trace_event_id") == int(
+                    activity_ids[0]
+                ) and cached.get("max_chat_message_id") == int(activity_ids[1]):
+                    return cast(Dict[str, Any], cached["response"])
+
+            if task.status not in _TERMINAL_CACHE_STATUSES and activity_ids is None:
+                activity_ids = _get_task_activity_ids(db, task_id)
+
             # Get the raw status value safely
             if hasattr(task, "status") and task.status is not None:
                 if hasattr(task.status, "value"):
@@ -2307,7 +2394,7 @@ async def get_task_status(
                     db, task_id
                 )
 
-            return {
+            response = {
                 "task_id": task.id,
                 "title": task.title,
                 "status": status_value,
@@ -2330,6 +2417,21 @@ async def get_task_status(
                 "waiting_question": waiting_question,
                 "waiting_interactions": waiting_interactions,
             }
+            cache_set(
+                cache_key,
+                {
+                    "updated_at": task_updated_at,
+                    "max_trace_event_id": (
+                        activity_ids[0] if activity_ids is not None else None
+                    ),
+                    "max_chat_message_id": (
+                        activity_ids[1] if activity_ids is not None else None
+                    ),
+                    "response": response,
+                },
+                ttl_seconds=task_cache_ttl_seconds(),
+            )
+            return response
 
         # Execute in thread pool to avoid blocking
         return await asyncio.to_thread(_get_task_status_sync)
@@ -2371,6 +2473,7 @@ async def update_task(
 
         task.title = title
         db.commit()
+        invalidate_task_cache(task_id)
 
         return {"status": "success", "message": "Task updated successfully"}
     except HTTPException:
@@ -2435,6 +2538,7 @@ async def delete_task(
 
         # Execute database operations in thread pool to avoid blocking
         task = await asyncio.to_thread(_delete_task_sync)
+        invalidate_task_cache(task_id)
 
         # Remove agent from manager if it exists
         get_agent_manager(request).remove_agent(task_id, int(user.id))

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -36,6 +36,14 @@ from ..schemas.model import (
     UserDefaultModelCreate,
     UserDefaultModelResponse,
 )
+from ..services.hot_path_cache import (
+    cache_get,
+    cache_set,
+    invalidate_model_cache,
+    model_list_key,
+    user_default_model_key,
+    user_default_models_key,
+)
 from ..services.llm_utils import CoreStorage
 from ..user_isolated_memory import UserContext
 
@@ -66,6 +74,15 @@ def _can_user_share(user: User) -> bool:
 
 # Create router
 model_router = APIRouter(prefix="/api/models", tags=["models"])
+
+
+def _model_has_shared_visibility(db: Session, model_id: int) -> bool:
+    return (
+        db.query(UserModel.id)
+        .filter(UserModel.model_id == model_id, UserModel.is_shared.is_(True))
+        .first()
+        is not None
+    )
 
 
 def _decode_model_identifier(model_id: str) -> str:
@@ -392,6 +409,7 @@ async def create_model(
     )
     db.add(user_model)
     db.commit()
+    invalidate_model_cache(None if is_share else int(user.id))
 
     # No pre-creation for other users — dynamic discovery handles visibility.
 
@@ -433,6 +451,18 @@ async def list_models(
     user: User = Depends(get_current_user),
 ) -> List[ModelWithAccessInfo]:
     """List all model configurations accessible to the current user"""
+    current_user_id = int(user.id)
+    cache_key = model_list_key(
+        current_user_id,
+        skip=skip,
+        limit=limit,
+        model_provider=model_provider,
+        category=category,
+        is_active=is_active,
+    )
+    cached = cache_get(cache_key)
+    if isinstance(cached, list):
+        return [ModelWithAccessInfo.model_validate(item) for item in cached]
 
     from ..services.model_service import (
         _get_visible_user_ids,
@@ -440,7 +470,7 @@ async def list_models(
     )
 
     # Get models that user has access to (owned or shared from visible users)
-    visible_ids = _get_visible_user_ids(db, int(user.id))
+    visible_ids = _get_visible_user_ids(db, current_user_id)
 
     # Correlated subquery: for each DBModel, pick exactly one UserModel row,
     # preferring the user's own row (deduplicates legacy shared data).
@@ -448,7 +478,7 @@ async def list_models(
         db.query(UserModel.id)
         .filter(
             UserModel.model_id == DBModel.id,
-            build_user_model_visibility_filter(int(user.id), visible_ids),
+            build_user_model_visibility_filter(current_user_id, visible_ids),
         )
         .order_by(
             (UserModel.user_id == user.id).desc(),
@@ -503,6 +533,7 @@ async def list_models(
         }
         result.append(ModelWithAccessInfo.model_validate(model_data))
 
+    cache_set(cache_key, [item.model_dump(mode="json") for item in result])
     return result
 
 
@@ -511,6 +542,11 @@ async def get_user_default_models(
     db: Session = Depends(get_db), user: User = Depends(get_current_user)
 ) -> list:
     """Get all user's default model configurations with per-type admin fallback"""
+    current_user_id = int(user.id)
+    cache_key = user_default_models_key(current_user_id)
+    cached = cache_get(cache_key)
+    if isinstance(cached, list):
+        return cached
 
     try:
         from ..services.model_service import (
@@ -545,7 +581,7 @@ async def get_user_default_models(
             user_defaults_by_type[str(ud.config_type)] = ud
 
         result = []
-        visible_ids = _get_visible_user_ids(db, int(user.id))
+        visible_ids = _get_visible_user_ids(db, current_user_id)
 
         # Process each config type
         for config_type in all_config_types:
@@ -559,7 +595,9 @@ async def get_user_default_models(
                     db.query(UserModel)
                     .filter(
                         UserModel.model_id == ud.model_id,
-                        build_user_model_visibility_filter(int(user.id), visible_ids),
+                        build_user_model_visibility_filter(
+                            current_user_id, visible_ids
+                        ),
                     )
                     .first()
                 )
@@ -661,6 +699,7 @@ async def get_user_default_models(
                     }
                     result.append(model_data)
 
+        cache_set(cache_key, result)
         return result
     except Exception as e:
         logger.error(f"Error getting user default models: {e}")
@@ -1596,11 +1635,23 @@ async def set_user_default_model(
             ),
         )
 
+    existing_default = (
+        db.query(UserDefaultModel)
+        .filter(
+            UserDefaultModel.user_id == user.id,
+            UserDefaultModel.config_type == config_type,
+        )
+        .first()
+    )
+    old_default_was_shared = bool(
+        existing_default
+        and _model_has_shared_visibility(db, int(existing_default.model_id))
+    )
+    new_default_is_shared = bool(user_model.is_shared)
+
     # Remove existing configuration for this config_type
-    db.query(UserDefaultModel).filter(
-        UserDefaultModel.user_id == user.id,
-        UserDefaultModel.config_type == config_type,
-    ).delete()
+    if existing_default:
+        db.delete(existing_default)
 
     # Create new default configuration
     user_default = UserDefaultModel(
@@ -1610,6 +1661,9 @@ async def set_user_default_model(
     db.add(user_default)
     db.commit()
     db.refresh(user_default)
+    invalidate_model_cache(
+        None if old_default_was_shared or new_default_is_shared else int(user.id)
+    )
 
     # If this is an embedding model configuration, trigger memory store check
     if config.config_type == "embedding":
@@ -1639,6 +1693,10 @@ async def get_user_default_model(
     user: User = Depends(get_current_user),
 ) -> Optional[UserDefaultModelResponse]:
     """Get a user's default model configuration for a specific type"""
+    cache_key = user_default_model_key(int(user.id), config_type)
+    cached = cache_get(cache_key)
+    if isinstance(cached, dict):
+        return UserDefaultModelResponse.model_validate(cached)
 
     user_default = (
         db.query(UserDefaultModel)
@@ -1654,7 +1712,9 @@ async def get_user_default_model(
     if not user_default:
         return None
 
-    return UserDefaultModelResponse.model_validate(user_default)
+    response = UserDefaultModelResponse.model_validate(user_default)
+    cache_set(cache_key, response.model_dump(mode="json"))
+    return response
 
 
 @model_router.delete("/user-default/{config_type}")
@@ -1677,8 +1737,11 @@ async def delete_user_default_model(
     if not user_default:
         raise HTTPException(status_code=404, detail="Default configuration not found")
 
+    default_was_shared = _model_has_shared_visibility(db, int(user_default.model_id))
+
     db.delete(user_default)
     db.commit()
+    invalidate_model_cache(None if default_was_shared else int(user.id))
 
     return {"message": "Default configuration deleted successfully"}
 
@@ -1817,6 +1880,9 @@ async def update_model(
     # Commit database changes
     db.commit()
     db.refresh(db_model)
+    invalidate_model_cache(
+        None if is_shared or model_update.share_with_users is not None else int(user.id)
+    )
 
     # Return updated model with access info
     return ModelWithAccessInfo.model_validate(
@@ -1864,6 +1930,7 @@ async def delete_model(
 
     # Delete the model using CoreStorage
     model_storage.delete(user_model.model.model_id)
+    invalidate_model_cache(None)
 
     return {"message": "Model deleted successfully"}
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -17,6 +17,7 @@ by the WebSocket UI path so both transports share one state machine.
 from typing import Tuple
 
 from fastapi import APIRouter, Depends
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ...models.agent import Agent
@@ -31,6 +32,14 @@ from ...schemas.v1 import (
     PublicStep,
     StepsResponse,
     TaskInfoResponse,
+)
+from ...services.hot_path_cache import (
+    cache_get,
+    cache_set,
+    cache_version_token,
+    task_cache_ttl_seconds,
+    task_snapshot_key,
+    task_steps_key,
 )
 from ...services.task_orchestrator import (
     TaskTurnError,
@@ -352,8 +361,13 @@ async def get_chat_task(
     # don't mis-interpret an in-flight task's last write timestamp as
     # a completion time.
     completed_at = task.updated_at if task.status in _TERMINAL_STATUSES else None
+    cache_key = task_snapshot_key(task_id)
+    task_updated_at = cache_version_token(task.updated_at)
+    cached = cache_get(cache_key)
+    if isinstance(cached, dict) and cached.get("updated_at") == task_updated_at:
+        return TaskInfoResponse.model_validate(cached["response"])
 
-    return TaskInfoResponse(
+    response = TaskInfoResponse(
         task_id=int(task.id),
         agent_id=int(task.agent_id),
         status=task.status.value,
@@ -363,6 +377,15 @@ async def get_chat_task(
         created_at=task.created_at,
         completed_at=completed_at,
     )
+    cache_set(
+        cache_key,
+        {
+            "updated_at": task_updated_at,
+            "response": response.model_dump(mode="json"),
+        },
+        ttl_seconds=task_cache_ttl_seconds(),
+    )
+    return response
 
 
 @router.get("/chat/tasks/{task_id}/steps", response_model=StepsResponse)
@@ -404,6 +427,15 @@ async def get_chat_task_steps(
     agent, _key = authed
     task = _resolve_task_or_404(task_id, agent, db)
 
+    max_event_id = (
+        db.query(func.max(TraceEvent.id)).filter(TraceEvent.task_id == task_id).scalar()
+        or 0
+    )
+    cache_key = task_steps_key(task_id)
+    cached = cache_get(cache_key)
+    if isinstance(cached, dict) and cached.get("max_event_id") == int(max_event_id):
+        return StepsResponse.model_validate(cached["response"])
+
     # Ordered ASC by ``id`` -- the trace_events PK is monotonically
     # increasing per write, so ordering by it gives us the same
     # temporal ordering as ``timestamp`` but without depending on
@@ -420,8 +452,17 @@ async def get_chat_task_steps(
     # FastAPI app or DB session.
     public_steps_data = map_trace_events_to_public_steps(events)
 
-    return StepsResponse(
+    response = StepsResponse(
         task_id=int(task.id),
         agent_id=int(task.agent_id),
         steps=[PublicStep(**step) for step in public_steps_data],
     )
+    cache_set(
+        cache_key,
+        {
+            "max_event_id": int(max_event_id),
+            "response": response.model_dump(mode="json"),
+        },
+        ttl_seconds=task_cache_ttl_seconds(),
+    )
+    return response

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -22,7 +22,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import RedirectResponse
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from ...config import (
@@ -39,6 +39,13 @@ from ..models.task import Task, TaskStatus
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..services.chat_history_service import get_latest_waiting_question
+from ..services.hot_path_cache import (
+    cache_get,
+    cache_set,
+    cache_version_token,
+    task_cache_ttl_seconds,
+    web_task_history_key,
+)
 from ..services.managed_file_ref import (
     DurableStorageOperationError,
     build_task_output_storage_key,
@@ -2789,6 +2796,38 @@ async def send_historical_data_as_stream(
             if mark_task_paused_if_stale(db, task):
                 db.refresh(task)
 
+            max_trace_event_id = (
+                db.query(func.max(TraceEvent.id))
+                .filter(
+                    TraceEvent.task_id == task_id,
+                    TraceEvent.build_id.is_(None),
+                )
+                .scalar()
+                or 0
+            )
+            max_chat_message_id = (
+                db.query(func.max(TaskChatMessage.id))
+                .filter(TaskChatMessage.task_id == task_id)
+                .scalar()
+                or 0
+            )
+            cache_key = web_task_history_key(task_id)
+            task_updated_at = cache_version_token(task.updated_at)
+            cached = cache_get(cache_key)
+            if (
+                isinstance(cached, dict)
+                and cached.get("updated_at") == task_updated_at
+                and cached.get("max_trace_event_id") == int(max_trace_event_id)
+                and cached.get("max_chat_message_id") == int(max_chat_message_id)
+                and isinstance(cached.get("events"), list)
+            ):
+                for cached_event in cached["events"]:
+                    if isinstance(cached_event, dict):
+                        await manager.send_personal_message(cached_event, websocket)
+                return
+
+            cached_stream_events: list[dict[str, Any]] = []
+
             # Determine is_dag from agent config if agent_id exists
             is_dag = None
             if task.agent_id:
@@ -2841,6 +2880,7 @@ async def send_historical_data_as_stream(
                 task.created_at if task.created_at else None,
             )
             await manager.send_personal_message(task_event, websocket)
+            cached_stream_events.append(task_event)
 
             # Get unified trace events (only VIBE phase, exclude BUILD phase)
             trace_events = (
@@ -3036,6 +3076,7 @@ async def send_historical_data_as_stream(
                     if event_data.get("step_id"):
                         stream_event["step_id"] = str(event_data["step_id"])
                     await manager.send_personal_message(stream_event, websocket)
+                    cached_stream_events.append(stream_event)
                 else:
                     # For other events, use original format
                     event_data = event["data"]
@@ -3047,6 +3088,7 @@ async def send_historical_data_as_stream(
                             event["timestamp"],
                         )
                         await manager.send_personal_message(event_obj, websocket)
+                        cached_stream_events.append(event_obj)
 
             # Send historical data completion marker
             completion_event = create_stream_event(
@@ -3058,6 +3100,7 @@ async def send_historical_data_as_stream(
                 },
             )
             await manager.send_personal_message(completion_event, websocket)
+            cached_stream_events.append(completion_event)
 
             # Historical trace replay can end with an in-flight event from before a
             # crash/restart, such as llm_call_start. Re-assert the current DB task
@@ -3092,6 +3135,18 @@ async def send_historical_data_as_stream(
                 if isinstance(question_interactions, list):
                     status_event["interactions"] = question_interactions
                 await manager.send_personal_message(status_event, websocket)
+                cached_stream_events.append(status_event)
+
+            cache_set(
+                cache_key,
+                {
+                    "updated_at": task_updated_at,
+                    "max_trace_event_id": int(max_trace_event_id),
+                    "max_chat_message_id": int(max_chat_message_id),
+                    "events": cached_stream_events,
+                },
+                ttl_seconds=task_cache_ttl_seconds(),
+            )
 
         except (ValueError, KeyError, TypeError) as e:
             # Data format error

--- a/src/xagent/web/services/hot_path_cache.py
+++ b/src/xagent/web/services/hot_path_cache.py
@@ -1,0 +1,295 @@
+"""Optional short-TTL cache for high-frequency web/API read paths."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections import OrderedDict
+from importlib import import_module
+from typing import Any, Protocol
+
+from ...config import (
+    get_hot_path_cache_enabled,
+    get_hot_path_cache_ttl_seconds,
+    get_hot_path_task_cache_ttl_seconds,
+    get_redis_url,
+)
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "xagent:hot:"
+
+
+class CacheBackend(Protocol):
+    def get_json(self, key: str) -> Any | None: ...
+
+    def set_json(self, key: str, value: Any, ttl_seconds: int) -> None: ...
+
+    def delete(self, *keys: str) -> None: ...
+
+    def delete_prefix(self, prefix: str) -> None: ...
+
+
+class NoOpCache:
+    def get_json(self, key: str) -> Any | None:
+        return None
+
+    def set_json(self, key: str, value: Any, ttl_seconds: int) -> None:
+        return None
+
+    def delete(self, *keys: str) -> None:
+        return None
+
+    def delete_prefix(self, prefix: str) -> None:
+        return None
+
+
+class InMemoryTTLCache:
+    """Small process-local cache used for tests and explicit local fallback."""
+
+    def __init__(self, maxsize: int = 4096) -> None:
+        self._maxsize = maxsize
+        self._items: OrderedDict[str, tuple[Any, float]] = OrderedDict()
+        self._lock = threading.RLock()
+
+    def get_json(self, key: str) -> Any | None:
+        now = time.time()
+        with self._lock:
+            item = self._items.get(key)
+            if item is None:
+                return None
+            value, expires_at = item
+            if expires_at <= now:
+                self._items.pop(key, None)
+                return None
+            self._items.move_to_end(key)
+            return value
+
+    def set_json(self, key: str, value: Any, ttl_seconds: int) -> None:
+        if ttl_seconds <= 0:
+            return
+        with self._lock:
+            self._items[key] = (value, time.time() + ttl_seconds)
+            self._items.move_to_end(key)
+            while len(self._items) > self._maxsize:
+                self._items.popitem(last=False)
+
+    def delete(self, *keys: str) -> None:
+        with self._lock:
+            for key in keys:
+                self._items.pop(key, None)
+
+    def delete_prefix(self, prefix: str) -> None:
+        with self._lock:
+            for key in list(self._items):
+                if key.startswith(prefix):
+                    self._items.pop(key, None)
+
+
+class RedisJsonCache:
+    def __init__(self, redis_url: str) -> None:
+        redis = import_module("redis")
+
+        self._client = redis.Redis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=0.2,
+            socket_timeout=0.2,
+            health_check_interval=30,
+        )
+
+    def get_json(self, key: str) -> Any | None:
+        try:
+            raw = self._client.get(_redis_key(key))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Hot-path cache read failed for %s: %s", key, exc)
+            return None
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            self.delete(key)
+            return None
+
+    def set_json(self, key: str, value: Any, ttl_seconds: int) -> None:
+        if ttl_seconds <= 0:
+            return
+        try:
+            self._client.setex(_redis_key(key), ttl_seconds, json.dumps(value))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Hot-path cache write failed for %s: %s", key, exc)
+
+    def delete(self, *keys: str) -> None:
+        if not keys:
+            return
+        try:
+            self._client.delete(*[_redis_key(key) for key in keys])
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Hot-path cache delete failed for %s: %s", keys, exc)
+
+    def delete_prefix(self, prefix: str) -> None:
+        try:
+            namespaced = _redis_key(prefix)
+            batch = []
+            for key in self._client.scan_iter(f"{namespaced}*"):
+                batch.append(key)
+                if len(batch) >= 500:
+                    self._client.delete(*batch)
+                    batch = []
+            if batch:
+                self._client.delete(*batch)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Hot-path cache prefix delete failed for %s: %s", prefix, exc)
+
+
+_backend: CacheBackend | None = None
+_backend_lock = threading.Lock()
+
+
+def _redis_key(key: str) -> str:
+    return f"{_KEY_PREFIX}{key}"
+
+
+def cache_version_token(value: Any) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
+
+
+def get_cache_backend() -> CacheBackend:
+    global _backend
+    if _backend is not None:
+        return _backend
+    with _backend_lock:
+        if _backend is not None:
+            return _backend
+        if not get_hot_path_cache_enabled():
+            _backend = NoOpCache()
+            return _backend
+        redis_url = get_redis_url()
+        if not redis_url:
+            _backend = NoOpCache()
+            return _backend
+        try:
+            _backend = RedisJsonCache(redis_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Hot-path Redis cache disabled: %s", exc)
+            _backend = NoOpCache()
+        return _backend
+
+
+def set_cache_backend_for_testing(backend: CacheBackend | None) -> None:
+    global _backend
+    with _backend_lock:
+        _backend = backend
+
+
+def cache_get(key: str) -> Any | None:
+    return get_cache_backend().get_json(key)
+
+
+def cache_set(key: str, value: Any, *, ttl_seconds: int | None = None) -> None:
+    get_cache_backend().set_json(
+        key,
+        value,
+        ttl_seconds if ttl_seconds is not None else get_hot_path_cache_ttl_seconds(),
+    )
+
+
+def cache_delete(*keys: str) -> None:
+    get_cache_backend().delete(*keys)
+
+
+def cache_delete_prefix(prefix: str) -> None:
+    get_cache_backend().delete_prefix(prefix)
+
+
+def task_snapshot_key(task_id: int) -> str:
+    return f"task:snapshot:{task_id}"
+
+
+def task_steps_key(task_id: int) -> str:
+    return f"task:steps:{task_id}"
+
+
+def web_task_detail_key(task_id: int) -> str:
+    return f"task:web:detail:{task_id}"
+
+
+def web_task_status_key(task_id: int) -> str:
+    return f"task:web:status:{task_id}"
+
+
+def web_task_history_key(task_id: int) -> str:
+    return f"task:web:history:{task_id}"
+
+
+def agent_list_key(user_id: int) -> str:
+    return f"agent:list:{user_id}"
+
+
+def agent_detail_key(user_id: int, agent_id: int) -> str:
+    return f"agent:detail:{user_id}:{agent_id}"
+
+
+def model_list_key(
+    user_id: int,
+    *,
+    skip: int,
+    limit: int,
+    model_provider: str | None,
+    category: str | None,
+    is_active: bool | None,
+) -> str:
+    provider = model_provider or "-"
+    cat = category or "-"
+    active = "none" if is_active is None else str(is_active).lower()
+    return f"model:list:{user_id}:{skip}:{limit}:{provider}:{cat}:{active}"
+
+
+def user_default_models_key(user_id: int) -> str:
+    return f"model:defaults:{user_id}"
+
+
+def user_default_model_key(user_id: int, config_type: str) -> str:
+    return f"model:default:{user_id}:{config_type}"
+
+
+def default_model_key(user_id: int, config_type: str) -> str:
+    return f"model:default-view:{user_id}:{config_type}"
+
+
+def invalidate_task_cache(task_id: int) -> None:
+    cache_delete(
+        task_snapshot_key(task_id),
+        task_steps_key(task_id),
+        web_task_detail_key(task_id),
+        web_task_status_key(task_id),
+        web_task_history_key(task_id),
+    )
+
+
+def invalidate_agent_cache(user_id: int, agent_id: int | None = None) -> None:
+    cache_delete(agent_list_key(user_id))
+    if agent_id is not None:
+        cache_delete(agent_detail_key(user_id, agent_id))
+
+
+def invalidate_model_cache(user_id: int | None = None) -> None:
+    if user_id is None:
+        cache_delete_prefix("model:")
+        return
+    cache_delete_prefix(f"model:list:{user_id}:")
+    cache_delete(user_default_models_key(user_id))
+    cache_delete_prefix(f"model:default:{user_id}:")
+    cache_delete_prefix(f"model:default-view:{user_id}:")
+
+
+def task_cache_ttl_seconds() -> int:
+    return get_hot_path_task_cache_ttl_seconds()

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -53,6 +53,7 @@ from typing import Any, Dict, Optional
 
 from ..models.task import Task, TaskStatus
 from ..models.user import User
+from .hot_path_cache import invalidate_task_cache
 from .task_lease_service import (
     acquire_task_lease,
     get_runner_id,
@@ -299,6 +300,7 @@ class TaskTurnOrchestrator:
             else:
                 before_message_id = None
             db.commit()
+            invalidate_task_cache(task_id)
         except TaskTurnError:
             raise
         except Exception:
@@ -421,6 +423,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             fresh.output = latest_assistant.content
             fresh.error_message = None
             bg_db.commit()
+            invalidate_task_cache(task_id)
             logger.info(
                 "finish_turn: task %s output written (%d chars)",
                 task_id,
@@ -447,6 +450,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             changed = True
         if changed:
             bg_db.commit()
+            invalidate_task_cache(task_id)
             logger.info(
                 "finish_turn: task %s marked failed (cleared stale output)",
                 task_id,
@@ -483,6 +487,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         fresh.error_message = "Task execution failed without status update; see /steps."
         fresh.output = None  # latest-turn snapshot invariant
         bg_db.commit()
+        invalidate_task_cache(task_id)
         logger.warning(
             "finish_turn: task %s bg coroutine returned with status=RUNNING; "
             "flipping to FAILED",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -16,9 +16,13 @@ from xagent.config import (
     FILE_STORAGE_OPTIONS,
     FILE_STORAGE_STARTUP_SYNC_ENABLED,
     FILE_STORAGE_URI,
+    HOT_PATH_CACHE_ENABLED,
+    HOT_PATH_CACHE_TTL_SECONDS,
+    HOT_PATH_TASK_CACHE_TTL_SECONDS,
     LANCEDB_PATH,
     MAX_TRACE_PAYLOAD_BYTES,
     MAX_UPLOAD_SIZE,
+    REDIS_URL,
     SANDBOX_CPUS,
     SANDBOX_ENV,
     SANDBOX_IMAGE,
@@ -42,9 +46,13 @@ from xagent.config import (
     get_file_storage_options,
     get_file_storage_startup_sync_enabled,
     get_file_storage_uri,
+    get_hot_path_cache_enabled,
+    get_hot_path_cache_ttl_seconds,
+    get_hot_path_task_cache_ttl_seconds,
     get_lancedb_path,
     get_max_trace_payload_bytes,
     get_max_upload_size_bytes,
+    get_redis_url,
     get_sandbox_cpus,
     get_sandbox_env,
     get_sandbox_image,
@@ -111,6 +119,47 @@ class TestEnvironmentVariableConstants:
             FILE_STORAGE_STARTUP_SYNC_ENABLED
             == "XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED"
         )
+
+    def test_redis_url_constant(self):
+        assert REDIS_URL == "XAGENT_REDIS_URL"
+
+    def test_hot_path_cache_constants(self):
+        assert HOT_PATH_CACHE_ENABLED == "XAGENT_HOT_PATH_CACHE_ENABLED"
+        assert HOT_PATH_CACHE_TTL_SECONDS == "XAGENT_HOT_PATH_CACHE_TTL_SECONDS"
+        assert (
+            HOT_PATH_TASK_CACHE_TTL_SECONDS == "XAGENT_HOT_PATH_TASK_CACHE_TTL_SECONDS"
+        )
+
+
+class TestHotPathCacheConfig:
+    def test_redis_url_empty_is_none(self, monkeypatch):
+        monkeypatch.delenv(REDIS_URL, raising=False)
+        assert get_redis_url() is None
+        monkeypatch.setenv(REDIS_URL, "  ")
+        assert get_redis_url() is None
+
+    def test_redis_url_strips_value(self, monkeypatch):
+        monkeypatch.setenv(REDIS_URL, " redis://localhost:6379/0 ")
+        assert get_redis_url() == "redis://localhost:6379/0"
+
+    def test_hot_path_cache_enabled_defaults_true(self, monkeypatch):
+        monkeypatch.delenv(HOT_PATH_CACHE_ENABLED, raising=False)
+        assert get_hot_path_cache_enabled() is True
+
+    def test_hot_path_cache_enabled_false(self, monkeypatch):
+        monkeypatch.setenv(HOT_PATH_CACHE_ENABLED, "false")
+        assert get_hot_path_cache_enabled() is False
+
+    def test_hot_path_ttls(self, monkeypatch):
+        monkeypatch.delenv(HOT_PATH_CACHE_TTL_SECONDS, raising=False)
+        monkeypatch.delenv(HOT_PATH_TASK_CACHE_TTL_SECONDS, raising=False)
+        assert get_hot_path_cache_ttl_seconds() == 30
+        assert get_hot_path_task_cache_ttl_seconds() == 30
+
+        monkeypatch.setenv(HOT_PATH_CACHE_TTL_SECONDS, "45")
+        monkeypatch.setenv(HOT_PATH_TASK_CACHE_TTL_SECONDS, "3")
+        assert get_hot_path_cache_ttl_seconds() == 45
+        assert get_hot_path_task_cache_ttl_seconds() == 3
 
 
 class TestGetWebSearchProvider:

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -52,9 +52,14 @@ class TestCreateAgentTool:
             mock_llm = Mock()
             mock_llm.model_id = "gpt-4"
 
-            with patch(
-                "xagent.web.services.llm_utils.UserAwareModelStorage"
-            ) as mock_storage_class:
+            with (
+                patch(
+                    "xagent.web.services.llm_utils.UserAwareModelStorage"
+                ) as mock_storage_class,
+                patch(
+                    "xagent.core.tools.adapters.vibe.agent_tool.invalidate_agent_cache"
+                ) as mock_invalidate_agent_cache,
+            ):
                 mock_storage = Mock()
                 mock_storage.get_configured_defaults.return_value = (
                     mock_llm,
@@ -83,6 +88,9 @@ class TestCreateAgentTool:
                 assert result["tool_name"] == "call_agent_test_agent"
                 assert "test_agent" in result["markdown_link"]
                 assert "agent://" in result["markdown_link"]
+                mock_invalidate_agent_cache.assert_called_once_with(
+                    user.id, result["agent_id"]
+                )
 
                 # Verify agent was created in database
                 agent = (
@@ -417,16 +425,22 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(existing_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id, task_id="test_task")
+            with patch(
+                "xagent.core.tools.adapters.vibe.agent_tool.invalidate_agent_cache"
+            ) as mock_invalidate_agent_cache:
+                tool = UpdateAgentTool(db=db, user_id=user.id, task_id="test_task")
 
-            result = await tool.run_json_async(
-                {
-                    "agent_id": existing_agent.id,
-                    "name": "updated_name",
-                    "description": "Updated description",
-                    "instructions": "Updated instructions",
-                }
-            )
+                result = await tool.run_json_async(
+                    {
+                        "agent_id": existing_agent.id,
+                        "name": "updated_name",
+                        "description": "Updated description",
+                        "instructions": "Updated instructions",
+                    }
+                )
+                mock_invalidate_agent_cache.assert_called_once_with(
+                    user.id, existing_agent.id
+                )
 
             # Verify result
             assert result["status"] == "success"

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -21,6 +21,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.services.hot_path_cache import (
+    InMemoryTTLCache,
+    set_cache_backend_for_testing,
+)
 
 from ..conftest import _admin_headers, _direct_db_session, client
 
@@ -928,6 +932,56 @@ def test_get_steps_empty_task_returns_empty_array(mock_start_task):
     assert body["task_id"] == task_id
     assert body["agent_id"] == agent_id
     assert body["steps"] == []
+
+
+def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="ai_message",
+        event_id="evt-cache-1",
+        timestamp=base,
+        data={"content": "cached"},
+    )
+
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        from xagent.web.api.v1 import _step_mapping
+
+        with patch(
+            "xagent.web.api.v1.tasks.map_trace_events_to_public_steps",
+            wraps=_step_mapping.map_trace_events_to_public_steps,
+        ) as mapper:
+            first = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
+            second = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
+
+            assert first.status_code == 200, first.text
+            assert second.status_code == 200, second.text
+            assert first.json() == second.json()
+            assert mapper.call_count == 1
+
+            _insert_trace_event(
+                task_id=task_id,
+                event_type="ai_message",
+                event_id="evt-cache-2",
+                timestamp=base.replace(second=1),
+                data={"content": "new"},
+            )
+            third = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
+
+            assert third.status_code == 200, third.text
+            assert mapper.call_count == 2
+            assert len(third.json()["steps"]) == 2
+    finally:
+        set_cache_backend_for_testing(None)
 
 
 # ===== source filtering: SDK API surface only sees source="sdk" tasks =====

--- a/tests/web/services/test_hot_path_cache.py
+++ b/tests/web/services/test_hot_path_cache.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from xagent.web.services import hot_path_cache
+from xagent.web.services.hot_path_cache import (
+    InMemoryTTLCache,
+    RedisJsonCache,
+    cache_delete_prefix,
+    cache_get,
+    cache_set,
+    set_cache_backend_for_testing,
+)
+
+
+def teardown_function() -> None:
+    set_cache_backend_for_testing(None)
+
+
+def test_in_memory_cache_respects_ttl(monkeypatch) -> None:
+    now = 1000.0
+    monkeypatch.setattr(hot_path_cache.time, "time", lambda: now)
+    set_cache_backend_for_testing(InMemoryTTLCache())
+
+    cache_set("sample", {"value": 1}, ttl_seconds=5)
+    assert cache_get("sample") == {"value": 1}
+
+    now = 1006.0
+    assert cache_get("sample") is None
+
+
+def test_delete_prefix_only_removes_matching_keys() -> None:
+    set_cache_backend_for_testing(InMemoryTTLCache())
+
+    cache_set("model:list:1", {"hit": True}, ttl_seconds=30)
+    cache_set("model:defaults:1", {"hit": True}, ttl_seconds=30)
+    cache_set("agent:list:1", {"hit": True}, ttl_seconds=30)
+
+    cache_delete_prefix("model:")
+
+    assert cache_get("model:list:1") is None
+    assert cache_get("model:defaults:1") is None
+    assert cache_get("agent:list:1") == {"hit": True}
+
+
+def test_redis_delete_prefix_deletes_in_batches(monkeypatch) -> None:
+    class FakeRedisClient:
+        def __init__(self) -> None:
+            self.deleted_batches: list[list[str]] = []
+
+        def scan_iter(self, pattern: str):
+            assert pattern == "xagent:hot:model:*"
+            for index in range(1001):
+                yield f"xagent:hot:model:{index}"
+
+        def delete(self, *keys: str) -> None:
+            self.deleted_batches.append(list(keys))
+
+    fake_client = FakeRedisClient()
+
+    class FakeRedis:
+        @staticmethod
+        def from_url(*args, **kwargs):
+            return fake_client
+
+    class FakeRedisModule:
+        Redis = FakeRedis
+
+    monkeypatch.setattr(
+        hot_path_cache,
+        "import_module",
+        lambda name: FakeRedisModule,
+    )
+
+    cache = RedisJsonCache("redis://example")
+    cache.delete_prefix("model:")
+
+    assert [len(batch) for batch in fake_client.deleted_batches] == [500, 500, 1]

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -456,6 +456,55 @@ def test_standalone_task_create_defaults_to_auto(test_db, user1_headers):
     assert resp.json()["execution_mode"] == "auto"
 
 
+def test_web_task_detail_cache_reuses_response_until_task_changes(
+    test_db, user1_headers, monkeypatch
+):
+    from xagent.web.services.hot_path_cache import (
+        InMemoryTTLCache,
+        set_cache_backend_for_testing,
+    )
+
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        create_resp = client.post(
+            "/api/chat/task/create",
+            json={"title": "cache-test", "description": "desc"},
+            headers=user1_headers,
+        )
+        assert create_resp.status_code == 200
+        task_id = create_resp.json()["task_id"]
+
+        first = client.get(f"/api/chat/task/{task_id}", headers=user1_headers)
+        assert first.status_code == 200
+        assert first.json()["title"] == "cache-test"
+
+        def fail_if_uncached(*args, **kwargs):
+            raise AssertionError("cache miss reached model id resolution")
+
+        monkeypatch.setattr(
+            AgentServiceManager,
+            "_get_task_llm_ids",
+            fail_if_uncached,
+        )
+        cached = client.get(f"/api/chat/task/{task_id}", headers=user1_headers)
+        assert cached.status_code == 200
+        assert cached.json()["title"] == "cache-test"
+
+        monkeypatch.undo()
+        update = client.put(
+            f"/api/chat/task/{task_id}",
+            json={"title": "cache-test-updated"},
+            headers=user1_headers,
+        )
+        assert update.status_code == 200
+
+        refreshed = client.get(f"/api/chat/task/{task_id}", headers=user1_headers)
+        assert refreshed.status_code == 200
+        assert refreshed.json()["title"] == "cache-test-updated"
+    finally:
+        set_cache_backend_for_testing(None)
+
+
 def test_get_task_llm_ids_preserves_stored_id_when_model_missing(test_db):
     ensure_system_initialized()
     from xagent.web.models.task import Task, TaskStatus

--- a/tests/web/test_dynamic_model_sharing.py
+++ b/tests/web/test_dynamic_model_sharing.py
@@ -20,6 +20,10 @@ from fastapi.testclient import TestClient
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import _can_user_share, model_router, set_can_share_hook
 from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.services.hot_path_cache import (
+    InMemoryTTLCache,
+    set_cache_backend_for_testing,
+)
 from xagent.web.services.model_service import (
     _get_visible_user_ids,
     set_visible_user_ids_hook,
@@ -66,9 +70,11 @@ def _reset_hooks():
     """Ensure hooks are reset between tests."""
     set_visible_user_ids_hook(None)
     set_can_share_hook(None)
+    set_cache_backend_for_testing(None)
     yield
     set_visible_user_ids_hook(None)
     set_can_share_hook(None)
+    set_cache_backend_for_testing(None)
 
 
 @pytest.fixture(scope="function")
@@ -1200,6 +1206,46 @@ class TestLegacyDataCompatibility:
 
 class TestGetUserDefaultModelsStaleSkip:
     """Tests for stale UserDefaultModel visibility."""
+
+    def test_shared_fallback_default_delete_invalidates_other_user_cache(
+        self, test_db, admin_headers, regular_headers, sample_model_data
+    ):
+        sample_model_data["share_with_users"] = True
+        create_response = client.post(
+            "/api/models/", json=sample_model_data, headers=admin_headers
+        )
+        assert create_response.status_code == 200
+        model_db_id = create_response.json()["id"]
+
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": model_db_id, "config_type": "general"},
+            headers=admin_headers,
+        )
+        assert default_response.status_code == 200
+
+        set_cache_backend_for_testing(InMemoryTTLCache())
+        defaults_before = client.get(
+            "/api/models/user-default", headers=regular_headers
+        )
+        assert defaults_before.status_code == 200
+        general_before = [
+            d for d in defaults_before.json() if d.get("config_type") == "general"
+        ]
+        assert len(general_before) == 1
+        assert general_before[0]["model"]["model_id"] == sample_model_data["model_id"]
+
+        delete_response = client.delete(
+            "/api/models/user-default/general", headers=admin_headers
+        )
+        assert delete_response.status_code == 200
+
+        defaults_after = client.get("/api/models/user-default", headers=regular_headers)
+        assert defaults_after.status_code == 200
+        general_after = [
+            d for d in defaults_after.json() if d.get("config_type") == "general"
+        ]
+        assert general_after == []
 
     def test_skips_stale_user_default_and_falls_back(
         self, test_db, admin_headers, regular_headers, sample_model_data


### PR DESCRIPTION
## Summary
- add optional Redis-backed hot-path cache for task, agent, and model read APIs
- cache Web UI task detail/status/history replay paths with DB-version checks and invalidation
- add Redis service wiring to docker compose deployments and document env config

## Tests
- ruff check src/xagent/web/services/hot_path_cache.py src/xagent/web/api/chat.py src/xagent/web/api/websocket.py tests/web/test_chat_task_model_ids.py
- PYTHONPATH=src pytest tests/web/test_chat_task_model_ids.py tests/web/api/v1/test_tasks.py tests/web/services/test_hot_path_cache.py -q --disable-warnings
- docker compose -f docker-compose.yml config --quiet
- docker compose -f docker-compose-sandbox.yml config --quiet