### PR TITLE
fix: harden user message display contract

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -155,8 +155,11 @@ class AgentExecutionAdapter:
     async def post_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> bool:
@@ -173,6 +176,9 @@ class AgentExecutionAdapter:
         context = await self.registry.post_user_message(
             execution_id,
             message,
+            execution_message=execution_message,
+            display_message=display_message,
+            files=files,
             request_interrupt=request_interrupt,
             reason=reason,
         )

--- a/src/xagent/core/agent/registry.py
+++ b/src/xagent/core/agent/registry.py
@@ -204,8 +204,11 @@ class ExecutionRegistry:
     async def inject_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -216,6 +219,9 @@ class ExecutionRegistry:
         return await handle.runner.inject_user_message(
             execution_id,
             message,
+            execution_message=execution_message,
+            display_message=display_message,
+            files=files,
             request_interrupt=request_interrupt,
             reason=reason,
         )
@@ -223,23 +229,43 @@ class ExecutionRegistry:
     async def post_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
         context = await self.inject_user_message(
             execution_id,
             message,
+            execution_message=execution_message,
+            display_message=display_message,
+            files=files,
             request_interrupt=request_interrupt,
             reason=reason,
         )
         handle = self.get(execution_id)
         if handle is not None and context is not None:
+            resolved_execution_message = (
+                execution_message if execution_message is not None else message
+            )
+            resolved_display_message = (
+                display_message
+                if display_message is not None
+                else resolved_execution_message
+            )
             self._emit_event(
                 "execution.message_posted",
                 handle,
-                {"message": message, "request_interrupt": request_interrupt},
+                {
+                    "message": resolved_display_message,
+                    "display_message": resolved_display_message,
+                    "execution_message": resolved_execution_message,
+                    "files": files,
+                    "request_interrupt": request_interrupt,
+                },
             )
         return context
 

--- a/src/xagent/core/agent/registry.py
+++ b/src/xagent/core/agent/registry.py
@@ -252,9 +252,7 @@ class ExecutionRegistry:
                 execution_message if execution_message is not None else message
             )
             resolved_display_message = (
-                display_message
-                if display_message is not None
-                else resolved_execution_message
+                display_message if display_message is not None else message
             )
             self._emit_event(
                 "execution.message_posted",

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -315,10 +315,13 @@ class AgentRunner:
             raise ValueError(
                 "inject_user_message requires message or execution_message"
             )
+        if display_message is None and message is None:
+            raise ValueError(
+                "inject_user_message requires display_message when "
+                "execution_message is provided without legacy message"
+            )
         resolved_display_message = (
-            display_message
-            if display_message is not None
-            else resolved_execution_message
+            display_message if display_message is not None else message
         )
         metadata: dict[str, Any] = {"display_message": resolved_display_message}
         if files is not None:

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -289,8 +289,11 @@ class AgentRunner:
     async def inject_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -305,7 +308,23 @@ class AgentRunner:
             context = ExecutionContext.from_dict(checkpoint["context"])
             self.context_manager.set_context(context)
 
-        context.add_user_message(message)
+        resolved_execution_message = (
+            execution_message if execution_message is not None else message
+        )
+        if resolved_execution_message is None:
+            raise ValueError(
+                "inject_user_message requires message or execution_message"
+            )
+        resolved_display_message = (
+            display_message
+            if display_message is not None
+            else resolved_execution_message
+        )
+        metadata: dict[str, Any] = {"display_message": resolved_display_message}
+        if files is not None:
+            metadata["files"] = files
+
+        context.add_user_message(resolved_execution_message, metadata=metadata)
         await self._persist_injected_context(
             execution_id=execution_id,
             context=context,
@@ -318,8 +337,11 @@ class AgentRunner:
     async def post_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -331,6 +353,9 @@ class AgentRunner:
         return await self.inject_user_message(
             execution_id,
             message,
+            execution_message=execution_message,
+            display_message=display_message,
+            files=files,
             request_interrupt=request_interrupt,
             reason=reason,
         )

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -97,7 +97,10 @@ class AgentRunner:
                 if role and content:
                     context.add_message(role, content)
             if task:
-                context.add_user_message(task)
+                context.add_user_message(
+                    task,
+                    metadata=self._initial_user_message_metadata(context),
+                )
 
         runtime = runtime or PatternRuntime(
             tracer=self.tracer,
@@ -412,6 +415,46 @@ class AgentRunner:
             context.attach_memory_session(memory_id, snapshot)
 
         return context
+
+    def _initial_user_message_metadata(
+        self, context: ExecutionContext
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        context_metadata = (
+            context.metadata if isinstance(context.metadata, dict) else {}
+        )
+        request_context = context_metadata.get("request_context")
+
+        candidates = []
+        if isinstance(request_context, dict):
+            candidates.append(request_context)
+        candidates.append(context_metadata)
+
+        for candidate in candidates:
+            if "display_message" in candidate:
+                display_message = candidate.get("display_message")
+                metadata["display_message"] = (
+                    display_message if isinstance(display_message, str) else ""
+                )
+                break
+            if "display_user_message" in candidate:
+                display_message = candidate.get("display_user_message")
+                metadata["display_message"] = (
+                    display_message if isinstance(display_message, str) else ""
+                )
+                break
+
+        for candidate in candidates:
+            files = candidate.get("files")
+            if isinstance(files, list):
+                metadata["files"] = files
+                break
+            attachments = candidate.get("attachments")
+            if isinstance(attachments, list):
+                metadata["files"] = attachments
+                break
+
+        return metadata
 
     def _apply_request_context(
         self,

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -203,8 +203,11 @@ class AgentService:
     async def post_user_message(
         self,
         execution_id: str,
-        message: str,
+        message: str | None = None,
         *,
+        execution_message: str | None = None,
+        display_message: str | None = None,
+        files: list[dict[str, Any]] | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> bool:
@@ -214,6 +217,9 @@ class AgentService:
             await self._execution_adapter.post_user_message(
                 execution_id,
                 message,
+                execution_message=execution_message,
+                display_message=display_message,
+                files=files,
                 request_interrupt=request_interrupt,
                 reason=reason,
             )

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -11,11 +11,37 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+DISPLAY_MESSAGE_KEY = "display_message"
 DISPLAY_USER_MESSAGE_KEY = "display_user_message"
+
+
+def _display_message_from_metadata(metadata: Any) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+    for key in (DISPLAY_MESSAGE_KEY, DISPLAY_USER_MESSAGE_KEY):
+        display_message = metadata.get(key)
+        if isinstance(display_message, str) and display_message.strip():
+            return display_message
+    return None
 
 
 def get_display_user_message(context: Any, fallback: str) -> str:
     """Return the user-visible message for trace/UI events."""
+    messages = getattr(context, "messages", None)
+    if isinstance(messages, list):
+        for message in reversed(messages):
+            if getattr(message, "role", None) != "user":
+                continue
+            display_message = _display_message_from_metadata(
+                getattr(message, "metadata", None)
+            )
+            if display_message:
+                return display_message
+            content = getattr(message, "content", None)
+            if isinstance(content, str) and content.strip():
+                return content
+            break
+
     candidates: list[dict[str, Any]] = []
     if isinstance(context, dict):
         candidates.append(context)
@@ -32,8 +58,8 @@ def get_display_user_message(context: Any, fallback: str) -> str:
         candidates.append(metadata)
 
     for candidate in candidates:
-        display_message = candidate.get(DISPLAY_USER_MESSAGE_KEY)
-        if isinstance(display_message, str) and display_message.strip():
+        display_message = _display_message_from_metadata(candidate)
+        if display_message:
             return display_message
 
     return fallback
@@ -1349,7 +1375,11 @@ async def trace_visualization_update(
 async def trace_user_message(
     tracer: Tracer, task_id: str, message: str, data: Optional[Dict[str, Any]] = None
 ) -> str:
-    """Trace user message event."""
+    """Trace a user-visible message event.
+
+    ``message`` is display text for transcript/UI surfaces. Runtime prompts and
+    internal execution context belong in LLM/runtime trace events instead.
+    """
     event_data = {"message": message}
     if data:
         event_data.update(data)

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -19,9 +19,9 @@ def _display_message_from_metadata(metadata: Any) -> str | None:
     if not isinstance(metadata, dict):
         return None
     for key in (DISPLAY_MESSAGE_KEY, DISPLAY_USER_MESSAGE_KEY):
-        display_message = metadata.get(key)
-        if isinstance(display_message, str) and display_message.strip():
-            return display_message
+        if key in metadata:
+            display_message = metadata.get(key)
+            return display_message if isinstance(display_message, str) else ""
     return None
 
 
@@ -35,7 +35,7 @@ def get_display_user_message(context: Any, fallback: str) -> str:
             display_message = _display_message_from_metadata(
                 getattr(message, "metadata", None)
             )
-            if display_message:
+            if display_message is not None:
                 return display_message
             content = getattr(message, "content", None)
             if isinstance(content, str) and content.strip():
@@ -59,7 +59,7 @@ def get_display_user_message(context: Any, fallback: str) -> str:
 
     for candidate in candidates:
         display_message = _display_message_from_metadata(candidate)
-        if display_message:
+        if display_message is not None:
             return display_message
 
     return fallback

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -206,6 +206,29 @@ def _display_message_for_user(user_message: str, has_files: bool) -> str:
     return user_message
 
 
+def _display_file_refs_from_file_info(
+    file_info_list: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return display-safe file refs without runtime paths."""
+    refs: list[dict[str, Any]] = []
+    for file_info in file_info_list:
+        file_id = str(file_info.get("file_id") or "").strip()
+        if not file_id:
+            continue
+        ref: dict[str, Any] = {"file_id": file_id}
+        name = file_info.get("name") or file_info.get("original_name")
+        if name is not None:
+            ref["name"] = str(name)
+        size = file_info.get("size")
+        if size is not None:
+            ref["size"] = size
+        file_type = file_info.get("type")
+        if file_type is not None:
+            ref["type"] = str(file_type)
+        refs.append(ref)
+    return refs
+
+
 def _selected_file_ids_from_task_config(task: Any) -> list[str]:
     """Return unique selected file ids stored during task creation."""
     agent_config = getattr(task, "agent_config", None)
@@ -2056,7 +2079,9 @@ async def handle_chat_message(
                     user_message,
                     bool(file_info_list),
                 )
+                display_file_refs = _display_file_refs_from_file_info(file_info_list)
                 context["display_message"] = display_user_message
+                context["files"] = display_file_refs
 
                 # DAG plan-execute will automatically send user_message trace event
 
@@ -2109,6 +2134,7 @@ async def handle_chat_message(
                             "context": context,
                             "pattern": "DAG Plan-Execute Continuation",
                             "continuation": "true",
+                            "files": display_file_refs,
                         }
                         await trace_user_message(
                             dag_pattern.tracer,
@@ -2180,7 +2206,7 @@ async def handle_chat_message(
                         str(task_id),
                         execution_message=user_message_for_llm,
                         display_message=display_user_message,
-                        files=file_info_list,
+                        files=display_file_refs,
                         request_interrupt=task.status == TaskStatus.RUNNING,
                         reason="new websocket user message",
                     )
@@ -2197,7 +2223,7 @@ async def handle_chat_message(
                                 "context": context,
                                 "pattern": "Agent Live Control",
                                 "continuation": "true",
-                                "files": file_info_list,
+                                "files": display_file_refs,
                             },
                         )
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2056,6 +2056,8 @@ async def handle_chat_message(
                     user_message,
                     bool(file_info_list),
                 )
+                context["display_message"] = display_user_message
+                context["display_user_message"] = display_user_message
 
                 # DAG plan-execute will automatically send user_message trace event
 
@@ -2179,13 +2181,29 @@ async def handle_chat_message(
                     assert agent_service is not None
                     posted = await agent_service.post_user_message(
                         str(task_id),
-                        user_message_for_llm,
+                        execution_message=user_message_for_llm,
+                        display_message=display_user_message,
+                        files=file_info_list,
                         request_interrupt=task.status == TaskStatus.RUNNING,
                         reason="new websocket user message",
                     )
                     if not posted:
                         logger.warning(
                             f"agent execution {task_id} was not live; attempting resume from checkpoint"
+                        )
+                    else:
+                        from ...core.agent.trace import trace_user_message
+
+                        await trace_user_message(
+                            agent_service.tracer,
+                            str(task_id),
+                            display_user_message,
+                            {
+                                "context": context,
+                                "pattern": "Agent Live Control",
+                                "continuation": "true",
+                                "files": file_info_list,
+                            },
                         )
 
                     previous_task = background_task_manager.running_tasks.get(task_id)
@@ -2280,7 +2298,6 @@ async def handle_chat_message(
                         logger.info(f"task_info event sent for existing task {task_id}")
 
                     # Build context with vibe mode information if available
-                    context["display_user_message"] = display_user_message
                     if hasattr(task, "execution_mode") and task.execution_mode:
                         context["execution_mode"] = task.execution_mode
                     if (

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -31,7 +31,7 @@ from ...config import (
     get_external_upload_dirs,
     get_uploads_dir,
 )
-from ...core.agent.trace import TraceEvent, TraceHandler
+from ...core.agent.trace import TraceEvent, TraceHandler, trace_user_message
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
 from ..models.database import get_db
@@ -2057,7 +2057,6 @@ async def handle_chat_message(
                     bool(file_info_list),
                 )
                 context["display_message"] = display_user_message
-                context["display_user_message"] = display_user_message
 
                 # DAG plan-execute will automatically send user_message trace event
 
@@ -2106,8 +2105,6 @@ async def handle_chat_message(
                     if hasattr(dag_pattern, "tracer") and hasattr(
                         dag_pattern, "task_id"
                     ):
-                        from ...core.agent.trace import trace_user_message
-
                         trace_data = {
                             "context": context,
                             "pattern": "DAG Plan-Execute Continuation",
@@ -2192,8 +2189,6 @@ async def handle_chat_message(
                             f"agent execution {task_id} was not live; attempting resume from checkpoint"
                         )
                     else:
-                        from ...core.agent.trace import trace_user_message
-
                         await trace_user_message(
                             agent_service.tracer,
                             str(task_id),

--- a/tests/core/agent/test_registry.py
+++ b/tests/core/agent/test_registry.py
@@ -219,6 +219,8 @@ async def test_registry_emits_lifecycle_and_message_events(
     assert all(event["execution_id"] == execution_id for event in events)
     assert events[1]["handle"]["status"] == "interrupted"
     assert events[2]["message"] == "Reply with only the number."
+    assert events[2]["display_message"] == "Reply with only the number."
+    assert events[2]["execution_message"] == "Reply with only the number."
     assert registry.unsubscribe(subscription_id) is True
     assert registry.unsubscribe(subscription_id) is False
 

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -701,6 +701,42 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
 
 
 @pytest.mark.asyncio
+async def test_runner_initial_user_message_preserves_display_metadata(
+    tmp_path: Path,
+) -> None:
+    tracer = RecordingTraceEventTracer()
+    agent = Agent(
+        name="writer",
+        patterns=[FakePattern({"success": True, "response": "Done"})],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        callbacks=[TraceEventCallback()],
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    execution_message = "Read file\n\n## UPLOADED FILES\nfile_id=file-123"
+    files = [{"file_id": "file-123", "name": "notes.txt"}]
+    result = await runner.run(
+        task=execution_message,
+        execution_id="exec-initial-display",
+        metadata={"request_context": {"display_message": "Read file", "files": files}},
+    )
+
+    first_user = next(
+        message for message in result["context"].messages if message.role == "user"
+    )
+    assert first_user.content == execution_message
+    assert first_user.metadata["display_message"] == "Read file"
+    assert first_user.metadata["files"] == files
+    user_event = next(
+        event for event in tracer.events if event["event_type"] == "task_start_message"
+    )
+    assert user_event["data"]["message"] == "Read file"
+
+
+@pytest.mark.asyncio
 async def test_runner_post_user_message_rejects_execution_without_display(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -701,6 +701,38 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
 
 
 @pytest.mark.asyncio
+async def test_runner_post_user_message_rejects_execution_without_display(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    checkpoint_context = ExecutionContext(execution_id="exec-display-required")
+    checkpoint_context.add_user_message("Original task")
+    await tracer.checkpoint(
+        type="checkpoint",
+        execution_id="exec-display-required",
+        pattern="FakePattern",
+        label="before_llm",
+        status="interrupted",
+        context=checkpoint_context.to_dict(),
+        pattern_state={},
+        metadata={},
+    )
+
+    with pytest.raises(ValueError, match="requires display_message"):
+        await runner.post_user_message(
+            "exec-display-required",
+            execution_message="Read file\n\n## UPLOADED FILES\nfile_id=file-123",
+            request_interrupt=False,
+        )
+
+
+@pytest.mark.asyncio
 async def test_trace_callback_does_not_emit_completion_for_interrupted_run(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -648,6 +648,59 @@ async def test_runner_post_user_message_alias_matches_inject_behavior(
 
 
 @pytest.mark.asyncio
+async def test_runner_post_user_message_preserves_display_and_execution_contract(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    checkpoint_context = ExecutionContext(execution_id="exec-display-contract")
+    checkpoint_context.add_user_message("Original task")
+    await tracer.checkpoint(
+        type="checkpoint",
+        execution_id="exec-display-contract",
+        pattern="FakePattern",
+        label="before_llm",
+        status="interrupted",
+        context=checkpoint_context.to_dict(),
+        pattern_state={},
+        metadata={},
+    )
+
+    execution_message = "Read file\n\n## UPLOADED FILES\nfile_id=file-123"
+    files = [{"file_id": "file-123", "name": "notes.txt"}]
+    context = await runner.post_user_message(
+        "exec-display-contract",
+        execution_message=execution_message,
+        display_message="Read file",
+        files=files,
+        request_interrupt=False,
+    )
+
+    assert context is not None
+    latest_user = [message for message in context.messages if message.role == "user"][
+        -1
+    ]
+    assert latest_user.content == execution_message
+    assert latest_user.metadata["display_message"] == "Read file"
+    assert latest_user.metadata["files"] == files
+
+    checkpoint_messages = tracer.by_execution_id["exec-display-contract"]["context"][
+        "messages"
+    ]
+    latest_checkpoint_user = [
+        message for message in checkpoint_messages if message["role"] == "user"
+    ][-1]
+    assert latest_checkpoint_user["content"] == execution_message
+    assert latest_checkpoint_user["metadata"]["display_message"] == "Read file"
+    assert latest_checkpoint_user["metadata"]["files"] == files
+
+
+@pytest.mark.asyncio
 async def test_trace_callback_does_not_emit_completion_for_interrupted_run(
     tmp_path: Path,
 ) -> None:

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -70,6 +70,24 @@ async def test_trace_callback_uses_display_user_message_when_present() -> None:
 
 
 @pytest.mark.asyncio
+async def test_trace_callback_prefers_latest_message_display_metadata() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Original task"
+    context.metadata["display_user_message"] = "Original task"
+    context.add_user_message(
+        "Read file\n\n## UPLOADED FILES\nfile_id=file-123",
+        metadata={"display_message": "Read file"},
+    )
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert tracer.events[0]["data"]["message"] == "Read file"
+
+
+@pytest.mark.asyncio
 async def test_trace_callback_failed_run_emits_error() -> None:
     tracer = TraceRecorder()
     callback = TraceEventCallback()

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -10,6 +10,7 @@ from xagent.web.api.chat import _build_task_agent_config
 from xagent.web.api.websocket import (
     _append_uploaded_files_context_to_message,
     _build_uploaded_files_context,
+    _display_file_refs_from_file_info,
     _display_message_for_user,
     _normalize_file_outputs,
     _register_uploaded_files_for_agent,
@@ -619,3 +620,29 @@ def test_display_message_for_file_only_turn_uses_placeholder():
         _display_message_for_user("Summarize this document", has_files=True)
         == "Summarize this document"
     )
+
+
+def test_display_file_refs_from_file_info_omits_runtime_paths():
+    refs = _display_file_refs_from_file_info(
+        [
+            {
+                "file_id": 123,
+                "name": "notes.txt",
+                "size": 42,
+                "type": "text/plain",
+                "path": "/internal/uploads/notes.txt",
+                "workspace_path": "/workspace/input/notes.txt",
+            }
+        ]
+    )
+
+    assert refs == [
+        {
+            "file_id": "123",
+            "name": "notes.txt",
+            "size": 42,
+            "type": "text/plain",
+        }
+    ]
+    assert "path" not in refs[0]
+    assert "workspace_path" not in refs[0]

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -599,6 +599,20 @@ def test_get_display_user_message_does_not_reuse_stale_context_display():
     assert get_display_user_message(context, "fallback") == "Second turn"
 
 
+def test_get_display_user_message_respects_empty_display_metadata():
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(
+                role="user",
+                content="Internal prompt\n\n## UPLOADED FILES\nfile_id=file-123",
+                metadata={"display_message": ""},
+            ),
+        ],
+    )
+
+    assert get_display_user_message(context, "fallback") == ""
+
+
 def test_display_message_for_file_only_turn_uses_placeholder():
     assert _display_message_for_user("", has_files=True) == "Uploaded file(s)"
     assert (

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -555,6 +555,50 @@ def test_get_display_user_message_reads_agent_context_state():
     )
 
 
+def test_get_display_user_message_prefers_latest_message_metadata():
+    context = SimpleNamespace(
+        metadata={
+            "display_user_message": "First turn",
+        },
+        messages=[
+            SimpleNamespace(
+                role="user",
+                content="First turn",
+                metadata={"display_message": "First turn"},
+            ),
+            SimpleNamespace(
+                role="user",
+                content="Second turn\n\n## UPLOADED FILES\nfile_id=file-123",
+                metadata={"display_message": "Second turn"},
+            ),
+        ],
+    )
+
+    assert get_display_user_message(context, "fallback") == "Second turn"
+
+
+def test_get_display_user_message_does_not_reuse_stale_context_display():
+    context = SimpleNamespace(
+        metadata={
+            "display_user_message": "First turn",
+        },
+        messages=[
+            SimpleNamespace(
+                role="user",
+                content="First turn",
+                metadata={"display_message": "First turn"},
+            ),
+            SimpleNamespace(
+                role="user",
+                content="Second turn",
+                metadata={},
+            ),
+        ],
+    )
+
+    assert get_display_user_message(context, "fallback") == "Second turn"
+
+
 def test_display_message_for_file_only_turn_uses_placeholder():
     assert _display_message_for_user("", has_files=True) == "Uploaded file(s)"
     assert (


### PR DESCRIPTION
## Summary
- add explicit display/execution message inputs for live-control user-message injection
- persist execution prompts in runtime messages while storing UI-safe display text in message metadata
- ensure WebSocket live-control user_message events use display text and carry files structurally
- prefer latest per-message display metadata when resolving trace user messages

## Tests
- `PYTHONPATH=src pytest tests/core/agent/test_runner.py tests/core/agent/test_registry.py tests/core/agent/test_tracing.py tests/core/agent/test_execution_adapter.py tests/web/test_websocket_uploaded_files_context.py`
- pre-commit hooks from commit

Closes #453