### PR TITLE
fix(test): bypass caplog with a direct handler to stop a CI flake

### DIFF
--- a/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
@@ -246,20 +246,54 @@ class TestBuildExecutionEnv:
         env = wrapper._build_execution_env()
         assert env["MY_API_KEY"] == "secret"
 
-    def test_missing_env_var_warns(self, monkeypatch, caplog):
+    def test_missing_env_var_warns(self, monkeypatch):
         monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
         wrapper = _create_test_wrapper(_FakeToolNoParams())
         wrapper._env_vars = ["NONEXISTENT_VAR"]
         import logging
 
-        # Bind caplog to the specific logger so a prior test (or an
-        # import-time ``logging.basicConfig(...)`` in one of the MCP
-        # tool modules) cannot leave the handler chain in a state where
-        # WARNING records are silently dropped. pytest 8+ stopped
-        # aggressively overriding handler levels from ``caplog.at_level``,
-        # so the context-manager form alone is fragile under the
-        # CI's pytest-xdist worker test ordering.
-        with caplog.at_level(logging.WARNING, logger=SandboxedToolWrapper.__module__):
+        # Bypass ``caplog`` entirely. Under pytest 8/9 + xdist on
+        # Python 3.12, the caplog handler can be left in a state where
+        # WARNING records are silently dropped between tests on the
+        # same worker (pytest-dev/pytest#11886). Both the plain
+        # ``caplog.at_level()`` and the logger-bound form proved
+        # unreliable for this test in CI. Attach our own list-collecting
+        # handler directly to the target logger so we don't depend on
+        # the caplog chain at all, and reset every piece of process-wide
+        # logging state that a prior test could have flipped.
+        target_logger = logging.getLogger(SandboxedToolWrapper.__module__)
+        records: list[logging.LogRecord] = []
+
+        class _ListHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        list_handler = _ListHandler(level=logging.WARNING)
+
+        original_level = target_logger.level
+        original_disabled = target_logger.disabled
+        original_propagate = target_logger.propagate
+        # ``logging.disable(level)`` is a process-wide threshold that
+        # short-circuits Logger.isEnabledFor; reset to NOTSET for the
+        # duration of this test so a prior test's ``logging.disable``
+        # call cannot suppress our WARNING.
+        previous_disable_level = logging.root.manager.disable
+        target_logger.addHandler(list_handler)
+        target_logger.setLevel(logging.WARNING)
+        target_logger.disabled = False
+        target_logger.propagate = True
+        logging.disable(logging.NOTSET)
+        try:
             env = wrapper._build_execution_env()
+        finally:
+            target_logger.removeHandler(list_handler)
+            target_logger.setLevel(original_level)
+            target_logger.disabled = original_disabled
+            target_logger.propagate = original_propagate
+            logging.disable(previous_disable_level)
+
         assert "NONEXISTENT_VAR" not in env
-        assert "NONEXISTENT_VAR" in caplog.text
+        messages = [record.getMessage() for record in records]
+        assert any("NONEXISTENT_VAR" in m for m in messages), (
+            f"expected a warning mentioning NONEXISTENT_VAR; got {messages!r}"
+        )

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
@@ -252,7 +252,17 @@ class TestBuildExecutionEnv:
         wrapper._env_vars = ["NONEXISTENT_VAR"]
         import logging
 
-        with caplog.at_level(logging.WARNING):
+        # Bind caplog to the specific logger so a prior test (or an
+        # import-time ``logging.basicConfig(...)`` in one of the MCP
+        # tool modules) cannot leave the handler chain in a state where
+        # WARNING records are silently dropped. pytest 8+ stopped
+        # aggressively overriding handler levels from ``caplog.at_level``,
+        # so the context-manager form alone is fragile under the
+        # CI's pytest-xdist worker test ordering.
+        with caplog.at_level(
+            logging.WARNING,
+            logger="xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper",
+        ):
             env = wrapper._build_execution_env()
         assert "NONEXISTENT_VAR" not in env
         assert "NONEXISTENT_VAR" in caplog.text

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
@@ -259,10 +259,7 @@ class TestBuildExecutionEnv:
         # aggressively overriding handler levels from ``caplog.at_level``,
         # so the context-manager form alone is fragile under the
         # CI's pytest-xdist worker test ordering.
-        with caplog.at_level(
-            logging.WARNING,
-            logger="xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper",
-        ):
+        with caplog.at_level(logging.WARNING, logger=SandboxedToolWrapper.__module__):
             env = wrapper._build_execution_env()
         assert "NONEXISTENT_VAR" not in env
         assert "NONEXISTENT_VAR" in caplog.text

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py
@@ -4,6 +4,7 @@ Test init params extraction, serialization, and script generation for sandbox to
 
 import base64
 import json
+import logging
 import threading
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock
@@ -250,7 +251,6 @@ class TestBuildExecutionEnv:
         monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
         wrapper = _create_test_wrapper(_FakeToolNoParams())
         wrapper._env_vars = ["NONEXISTENT_VAR"]
-        import logging
 
         # Bypass ``caplog`` entirely. Under pytest 8/9 + xdist on
         # Python 3.12, the caplog handler can be left in a state where
@@ -281,7 +281,11 @@ class TestBuildExecutionEnv:
         target_logger.addHandler(list_handler)
         target_logger.setLevel(logging.WARNING)
         target_logger.disabled = False
-        target_logger.propagate = True
+        # The list_handler is attached directly to ``target_logger``,
+        # so propagation to the root logger is unnecessary — and harmful:
+        # it would leak this test's warning to whatever stream/file
+        # handler the root logger has hooked up (CI console output).
+        target_logger.propagate = False
         logging.disable(logging.NOTSET)
         try:
             env = wrapper._build_execution_env()


### PR DESCRIPTION
## Problem

\`tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py::TestBuildExecutionEnv::test_missing_env_var_warns\` has been flaking on \`xorbitsai:main\` CI for at least the past week. Three of the five most recent main runs failed with the identical assertion:

\`\`\`
FAILED tests/core/tools/adapters/sandboxed_tool/test_sandbox_init_params.py::TestBuildExecutionEnv::test_missing_env_var_warns
       AssertionError: assert 'NONEXISTENT_VAR' in ''
       where '' = caplog.text
\`\`\`

The failure is deterministic enough on Python 3.12 + pytest 9 + pytest-xdist that reruns reproduce it, but it never fires locally on a single test invocation.

## Root cause

[pytest 8 changed](https://github.com/pytest-dev/pytest/issues/11886) \`caplog.at_level(level)\` so it no longer aggressively overrides handler levels on the logger chain. Under xdist, a prior test on the same worker — or an import-time \`logging.basicConfig(...)\` in one of the MCP tool modules (\`src/xagent/web/tools/mcp/gmail.py\` / \`calendar.py\` / \`google_drive.py\`) — can leave caplog's handler chain in a state where WARNING records for the \`xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper\` logger get silently dropped. The test then sees \`caplog.text == ''\` and fails.

I first tried binding caplog to the specific logger (\`caplog.at_level(logger=...)\`). That still failed on rerun with the same empty-text assertion, which means the caplog handler chain itself is being corrupted somewhere in the xdist worker's prior test ordering — no variant of \`caplog.at_level\` can recover it.

## Fix

Drop \`caplog\` from this test entirely and capture directly:

- Attach a tiny list-collecting \`Handler\` to the target logger (resolved via \`SandboxedToolWrapper.__module__\` so the import path stays the single source of truth — no brittle string literal).
- Force the logger into a known-good state for the duration of the test: \`level=WARNING\`, \`disabled=False\`, \`propagate=False\` (the handler is attached directly to this logger, so propagating to root is unnecessary and would leak the warning to CI console output).
- Reset the process-wide \`logging.disable\` threshold to \`NOTSET\` so a prior test's \`logging.disable(level)\` call cannot short-circuit \`Logger.isEnabledFor\` and silently drop the WARNING at the source.
- Restore everything in \`finally\` so the test leaves no global state behind.

The test still asserts the same behaviour (\"the warning message mentioning NONEXISTENT_VAR was emitted\") — just via a capture mechanism that we own end-to-end, with no caplog dependency.

## Why a standalone PR

This is a pre-existing flake on \`main\` — not introduced by any feature branch — so it's worth fast-tracking independent of in-flight PRs that are getting blocked by it. One-file change. No production code touched.

## Verification

- ✅ Local: full \`tests/core/tools/adapters/sandboxed_tool/\` suite passes (13/13)
- ✅ \`ruff check\` / \`ruff format --check\` clean