### PR TITLE
fix(tools): enforce tool policy in tasks

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -63,6 +63,7 @@ class AgentService:
         self.tool_config = tool_config
         self.tracer = tracer or Tracer()
         self._tools_initialized = False
+        self._tool_policy_signature: Any | None = None
         self._is_paused = False
         self._pause_event = None
         self._current_runner = None
@@ -542,7 +543,7 @@ class AgentService:
             return None
 
     async def _ensure_tools_initialized(self) -> None:
-        if self.tool_config and not self._tools_initialized:
+        if self.tool_config:
             try:
                 from ..tools.adapters.vibe.factory import ToolFactory
 
@@ -552,16 +553,16 @@ class AgentService:
                 ):
                     self.tool_config._workspace_config["task_id"] = self.id
 
+                policy_signature = self._current_tool_policy_signature()
+                if (
+                    self._tools_initialized
+                    and policy_signature == self._tool_policy_signature
+                ):
+                    return
+
+                # Rebuild the tool list so disabled tools disappear from reused agents.
                 new_tools = await ToolFactory.create_all_tools(self.tool_config)
-                existing_tool_names = {
-                    tool.name for tool in self.tools if hasattr(tool, "name")
-                }
-                for tool in new_tools:
-                    if (
-                        not hasattr(tool, "name")
-                        or tool.name not in existing_tool_names
-                    ):
-                        self.tools.append(tool)
+                self.tools = list(new_tools)
 
                 if hasattr(self.tool_config, "get_allowed_tools"):
                     allowed_tools = self.tool_config.get_allowed_tools()
@@ -577,11 +578,44 @@ class AgentService:
                 if self._execution_adapter is not None:
                     self._execution_adapter.config.tools = self.tools
                 self._tools_initialized = True
+                self._tool_policy_signature = policy_signature
             except Exception as exc:
                 logger.error("Failed to initialize tools from configuration: %s", exc)
                 raise RuntimeError(
                     f"Tool initialization failed for AgentService '{self.name}': {exc}"
                 ) from exc
+
+    def _current_tool_policy_signature(self) -> tuple[Any, ...]:
+        if not self.tool_config:
+            return ()
+
+        refresh_overrides = getattr(
+            self.tool_config, "refresh_user_tool_overrides", None
+        )
+        if callable(refresh_overrides):
+            # Re-read the hook-backed policy before comparing signatures.
+            refresh_overrides()
+
+        get_overrides = getattr(self.tool_config, "get_user_tool_overrides", None)
+        overrides: Any = get_overrides() if callable(get_overrides) else {}
+        if isinstance(overrides, dict):
+            override_items = tuple(
+                sorted(
+                    (
+                        str(name),
+                        override.get("enabled") if isinstance(override, dict) else None,
+                    )
+                    for name, override in overrides.items()
+                )
+            )
+        else:
+            override_items = ()
+
+        get_allowed_tools = getattr(self.tool_config, "get_allowed_tools", None)
+        allowed_tools = get_allowed_tools() if callable(get_allowed_tools) else None
+        allowed_items = tuple(str(name) for name in allowed_tools or ())
+
+        return (override_items, allowed_items)
 
     def _execution_type(self) -> str:
         if self.pattern == "dag_plan_execute":

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -613,7 +613,11 @@ class AgentService:
 
         get_allowed_tools = getattr(self.tool_config, "get_allowed_tools", None)
         allowed_tools = get_allowed_tools() if callable(get_allowed_tools) else None
-        allowed_items = tuple(str(name) for name in allowed_tools or ())
+        allowed_items = (
+            None
+            if allowed_tools is None
+            else tuple(str(name) for name in allowed_tools)
+        )
 
         return (override_items, allowed_items)
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -550,7 +550,9 @@ class AgentServiceManager:
                 allowed_collections=agent_config.get("knowledge_bases"),
                 allowed_skills=agent_config.get("skills"),
             )
-            all_tools = await ToolFactory.create_all_tools(temp_config)
+            all_tools = await ToolFactory.create_all_tools(
+                temp_config, apply_user_override_filter=False
+            )
             allowed_tools = []
 
             for tool in all_tools:
@@ -870,7 +872,9 @@ class AgentServiceManager:
                     )
 
                     # Get all tools and filter by category
-                    all_tools = await ToolFactory.create_all_tools(temp_config)
+                    all_tools = await ToolFactory.create_all_tools(
+                        temp_config, apply_user_override_filter=False
+                    )
                     allowed_tools = []
 
                     for tool in all_tools:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -346,6 +346,12 @@ class WebToolConfig(BaseToolConfig):
             self._cached_tool_overrides = {}
         return self._cached_tool_overrides
 
+    def refresh_user_tool_overrides(self) -> dict:
+        """Reload per-user tool overrides from the registered hook."""
+        # The policy can change while an AgentService instance is reused.
+        self._cached_tool_overrides = None
+        return self.get_user_tool_overrides()
+
     def get_excluded_agent_id(self) -> Optional[int]:
         """Get agent ID to exclude from agent tools (to prevent self-calls)."""
         return getattr(self, "_excluded_agent_id", None)

--- a/tests/core/agent/test_agent_service_tool_refresh.py
+++ b/tests/core/agent/test_agent_service_tool_refresh.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent.service import AgentService
+
+
+class NamedTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class RefreshingToolConfig:
+    _workspace_config = None
+
+    def __init__(self) -> None:
+        self.refresh_count = 0
+
+    def refresh_user_tool_overrides(self) -> None:
+        self.refresh_count += 1
+
+    def get_user_tool_overrides(self) -> dict[str, dict[str, bool]]:
+        return {"disabled": {"enabled": self.refresh_count < 2}}
+
+    def get_allowed_tools(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_agent_service_refreshes_initialized_tools_when_policy_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_config = RefreshingToolConfig()
+    tool_sets: list[list[Any]] = [
+        [NamedTool("allowed"), NamedTool("disabled")],
+        [NamedTool("allowed")],
+    ]
+
+    async def create_all_tools(config: Any) -> list[Any]:
+        assert config is tool_config
+        return tool_sets.pop(0)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+
+    service = AgentService(
+        name="tool-refresh-test",
+        id="tool-refresh-test",
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+
+    await service._ensure_tools_initialized()
+    assert {tool.name for tool in service.tools} == {"allowed", "disabled"}
+
+    await service._ensure_tools_initialized()
+    assert {tool.name for tool in service.tools} == {"allowed"}
+    assert tool_config.refresh_count == 2

--- a/tests/core/agent/test_agent_service_tool_refresh.py
+++ b/tests/core/agent/test_agent_service_tool_refresh.py
@@ -15,8 +15,9 @@ class NamedTool:
 class RefreshingToolConfig:
     _workspace_config = None
 
-    def __init__(self) -> None:
+    def __init__(self, allowed_tools: list[str] | None = None) -> None:
         self.refresh_count = 0
+        self.allowed_tools = allowed_tools
 
     def refresh_user_tool_overrides(self) -> None:
         self.refresh_count += 1
@@ -24,8 +25,21 @@ class RefreshingToolConfig:
     def get_user_tool_overrides(self) -> dict[str, dict[str, bool]]:
         return {"disabled": {"enabled": self.refresh_count < 2}}
 
-    def get_allowed_tools(self) -> None:
-        return None
+    def get_allowed_tools(self) -> list[str] | None:
+        return self.allowed_tools
+
+
+class AllowedToolsConfig:
+    _workspace_config = None
+
+    def __init__(self, allowed_tools: list[str] | None = None) -> None:
+        self.allowed_tools = allowed_tools
+
+    def get_user_tool_overrides(self) -> dict[str, dict[str, bool]]:
+        return {}
+
+    def get_allowed_tools(self) -> list[str] | None:
+        return self.allowed_tools
 
 
 @pytest.mark.asyncio
@@ -60,3 +74,33 @@ async def test_agent_service_refreshes_initialized_tools_when_policy_changes(
     await service._ensure_tools_initialized()
     assert {tool.name for tool in service.tools} == {"allowed"}
     assert tool_config.refresh_count == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_service_refreshes_when_allowed_tools_changes_from_all_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_config = AllowedToolsConfig(allowed_tools=None)
+
+    async def create_all_tools(config: Any) -> list[Any]:
+        assert config is tool_config
+        return [NamedTool("allowed"), NamedTool("disabled")]
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+
+    service = AgentService(
+        name="allowed-tools-refresh-test",
+        id="allowed-tools-refresh-test",
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+
+    await service._ensure_tools_initialized()
+    assert {tool.name for tool in service.tools} == {"allowed", "disabled"}
+
+    tool_config.allowed_tools = []
+    await service._ensure_tools_initialized()
+    assert service.tools == []

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -1,6 +1,7 @@
 """Unit tests for AgentServiceManager task existence checking and reconstruction"""
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -251,6 +252,57 @@ class TestAgentServiceManagerReconstruction:
         workspace_config = tool_config.get_workspace_config()
         assert workspace_config["base_dir"] == str(uploads_dir / "user_7")
         assert str(uploads_dir / "user_7") in workspace_config["allowed_external_dirs"]
+
+    @pytest.mark.asyncio
+    async def test_build_tools_maps_categories_from_full_catalog(
+        self, agent_manager, mock_db, sample_task, mock_user, monkeypatch
+    ):
+        """Disabled runtime tools should still be eligible for category allow-lists."""
+
+        class _Tool:
+            description = ""
+
+            def __init__(self, name: str, category: str) -> None:
+                self.name = name
+                self.metadata = SimpleNamespace(
+                    category=SimpleNamespace(value=category)
+                )
+
+        basic_tool = _Tool("calculator", "basic")
+        browser_tool = _Tool("browser_navigate", "browser")
+        override_filter_values: list[bool] = []
+
+        async def create_all_tools(
+            config,
+            apply_user_override_filter: bool = True,
+        ):
+            override_filter_values.append(apply_user_override_filter)
+            if apply_user_override_filter:
+                return [basic_tool]
+            return [basic_tool, browser_tool]
+
+        monkeypatch.setattr(
+            "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+            create_all_tools,
+        )
+
+        with patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None):
+            _tools, tool_config = await agent_manager._build_tools_for_task(
+                task_id=sample_task.id,
+                task=sample_task,
+                db=mock_db,
+                user=mock_user,
+                agent_config={
+                    "tool_categories": ["browser"],
+                    "knowledge_bases": [],
+                    "skills": [],
+                },
+                task_llm=None,
+                task_vision_llm=None,
+            )
+
+        assert override_filter_values[0] is False
+        assert tool_config.get_allowed_tools() == ["browser_navigate"]
 
     @pytest.mark.asyncio
     async def test_get_agent_for_task_existing_task_with_reconstruction(


### PR DESCRIPTION
## Summary
- Refreshes reusable AgentService tool configuration when per-user or team tool policy changes.
- Rebuilds the service tool list instead of appending, so disabled tools are removed from future executions.
- Adds a ToolConfig refresh hook to invalidate cached user tool overrides before comparing policy state.

## Behavior
- Tool policy signatures track user override enabled flags and allowed tool names.
- Existing registered runners keep their execution-scoped tool list; refreshed tools update service state and future runner construction.

## Tests
- Added `tests/core/agent/test_agent_service_tool_refresh.py` to cover refreshing an already-initialized service after policy changes.