### PR TITLE
fix: merge alembic migration heads

### DIFF
--- a/src/xagent/migrations/versions/20260521_merge_alembic_heads.py
+++ b/src/xagent/migrations/versions/20260521_merge_alembic_heads.py
@@ -1,0 +1,26 @@
+"""merge public mcp visibility and chat message attachments heads
+
+Revision ID: 20260521_merge_alembic_heads
+Revises: 20260518_add_chat_message_attachments, 20260519_add_public_mcp_visibility
+Create Date: 2026-05-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20260521_merge_alembic_heads"
+down_revision: Union[str, tuple[str, str], None] = (
+    "20260518_add_chat_message_attachments",
+    "20260519_add_public_mcp_visibility",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/migrations/test_migration_integration.py
+++ b/tests/migrations/test_migration_integration.py
@@ -27,6 +27,34 @@ from sqlalchemy.exc import SQLAlchemyError
 project_root = Path(__file__).parent.parent.parent
 
 
+def _revision_reached(
+    script_dir: ScriptDirectory, target_revision: str, current_revisions: set[str]
+) -> bool:
+    """Return whether target_revision is present in or behind current heads."""
+    pending = list(current_revisions)
+    visited: set[str] = set()
+
+    while pending:
+        revision_id = pending.pop()
+        if revision_id == target_revision:
+            return True
+        if revision_id in visited:
+            continue
+
+        visited.add(revision_id)
+        revision = script_dir.get_revision(revision_id)
+
+        down_revisions = revision.down_revision
+        if down_revisions is None:
+            continue
+        if isinstance(down_revisions, str):
+            pending.append(down_revisions)
+        else:
+            pending.extend(down_revisions)
+
+    return False
+
+
 class MigrationTester:
     """Helper class to test database migrations."""
 
@@ -121,6 +149,12 @@ class MigrationTester:
                 # We want index 1 (name)
                 result = conn.execute(text(f"PRAGMA table_info({table_name})"))
                 return [row[1] for row in result]
+
+    def get_alembic_versions(self) -> set[str]:
+        """Get current Alembic version rows."""
+        with self.engine.begin() as conn:
+            result = conn.execute(text("SELECT version_num FROM alembic_version"))
+            return {row[0] for row in result}
 
 
 class TestMigrations:
@@ -332,6 +366,7 @@ class TestMigrations:
         # Get all migrations from START_REVISION to head
         script_dir = ScriptDirectory.from_config(sqlite_tester.alembic_cfg)
         revisions = list(script_dir.walk_revisions(START_REVISION, "heads"))
+        assert revisions, "Expected migrations from START_REVISION to heads"
         revisions.reverse()  # START_REVISION to head
 
         # Upgrade one revision at a time
@@ -339,10 +374,13 @@ class TestMigrations:
             command.upgrade(sqlite_tester.alembic_cfg, revision.revision)
 
             # Verify version
-            with sqlite_tester.engine.begin() as conn:
-                result = conn.execute(text("SELECT version_num FROM alembic_version"))
-                version = result.scalar()
-                assert version == revision.revision
+            current_revisions = sqlite_tester.get_alembic_versions()
+            assert _revision_reached(
+                script_dir, revision.revision, current_revisions
+            ), (
+                f"{revision.revision} should be present in or behind current "
+                f"Alembic heads {sorted(current_revisions)}"
+            )
 
         # After all upgrades, verify that migrations actually added their columns
         # This tests that migrations work, not just that they're idempotent
@@ -388,6 +426,7 @@ class TestMigrations:
         # Get all migrations from START_REVISION to head
         script_dir = ScriptDirectory.from_config(postgresql_tester.alembic_cfg)
         revisions = list(script_dir.walk_revisions(START_REVISION, "heads"))
+        assert revisions, "Expected migrations from START_REVISION to heads"
         revisions.reverse()  # START_REVISION to head
 
         # Upgrade one revision at a time
@@ -395,10 +434,13 @@ class TestMigrations:
             command.upgrade(postgresql_tester.alembic_cfg, revision.revision)
 
             # Verify version
-            with postgresql_tester.engine.begin() as conn:
-                result = conn.execute(text("SELECT version_num FROM alembic_version"))
-                version = result.scalar()
-                assert version == revision.revision
+            current_revisions = postgresql_tester.get_alembic_versions()
+            assert _revision_reached(
+                script_dir, revision.revision, current_revisions
+            ), (
+                f"{revision.revision} should be present in or behind current "
+                f"Alembic heads {sorted(current_revisions)}"
+            )
 
         # After all upgrades, verify that migrations actually added their columns
         agents_columns = postgresql_tester.get_column_names("agents")


### PR DESCRIPTION
## Summary
- add an Alembic merge revision for the chat message attachments and public MCP visibility migration heads
- update incremental migration tests to handle Alembic's valid multi-head intermediate state while walking a branched graph

## Verification
- PYTHONPATH=src alembic heads
- PYTHONPATH=src python -m pytest tests/migrations/test_migration_integration.py::TestMigrations::test_sqlite_stamp_head_creates_wide_alembic_version_table tests/migrations/test_migration_integration.py::TestMigrations::test_sqlite_upgrade tests/migrations/test_migration_integration.py::TestMigrations::test_sqlite_idempotence_with_sqlalchemy tests/migrations/test_migration_integration.py::TestMigrations::test_sqlite_incremental_upgrade
- ruff check tests/migrations/test_migration_integration.py src/xagent/migrations/versions/20260521_merge_alembic_heads.py
- git diff --check