### PR TITLE
fix: tighten kb collection mutation boundaries

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -742,7 +742,7 @@ async def list_collections(
 
         # Step 2: Get stats. Try metadata cache first; fallback to realtime scan.
         stats: Dict[str, Dict[str, int]] = {}
-        if not force_realtime:
+        if not force_realtime and is_admin:
             try:
                 for info in metadata_collections:
                     if info.name in collection_keys or is_admin:
@@ -841,7 +841,7 @@ async def list_collections(
                 if key not in stats:
                     if key in realtime_stats:
                         stats[key] = realtime_stats[key]
-                    elif key in metadata_stats_by_name:
+                    elif is_admin and key in metadata_stats_by_name:
                         stats[key] = metadata_stats_by_name[key]
                     else:
                         stats[key] = {
@@ -915,7 +915,11 @@ async def list_collections(
                     processed_documents=(
                         stats[collection]["parses"]
                         if stats[collection]["parses"] > 0
-                        else metadata_processed_documents_by_name.get(collection, 0)
+                        else (
+                            metadata_processed_documents_by_name.get(collection, 0)
+                            if is_admin
+                            else 0
+                        )
                     ),
                     timestamp_now=realtime_timestamp if used_realtime else None,
                 )

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -224,11 +224,13 @@ class DocumentRecord:
         doc_id: Document identifier.
         file_id: Optional file identifier for uploaded file tracking.
         source_path: Original source path if available.
+        user_id: Optional tenant owner for owner-aware control-plane cleanup.
     """
 
     doc_id: str
     file_id: Optional[str] = None
     source_path: Optional[str] = None
+    user_id: Optional[int] = None
 
 
 class FilterOperator(str, Enum):
@@ -334,16 +336,26 @@ class MetadataStore(ABC):
         """Delete persisted metadata/config rows for a collection."""
 
     @abstractmethod
-    async def rename_collection(self, old_name: str, new_name: str) -> None:
+    async def rename_collection(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> None:
         """Rename persisted control-plane keys after a data-plane collection rename.
 
         Updates rows that gate :meth:`list_collections` visibility (for example
         per-tenant config rows and aggregate metadata) so they stay aligned with
-        vector tables when the ``collection`` / ``name`` fields change.
+        vector tables when the ``collection`` / ``name`` fields change. Non-admin
+        callers only rename their tenant config; admin callers rename global
+        metadata/cache rows as well.
 
         Args:
             old_name: Previous collection name (sanitized by the caller).
             new_name: Target collection name (sanitized by the caller).
+            user_id: User ID for tenant-scoped rename.
+            is_admin: Whether the caller can rename across tenants.
         """
 
     @abstractmethod
@@ -383,6 +395,10 @@ class MetadataStore(ABC):
         Returns:
             Config JSON string if found, None otherwise.
         """
+
+    @abstractmethod
+    def list_collection_config_owner_ids(self, collection_name: str) -> set[int]:
+        """List user IDs that have collection_config rows for a collection."""
 
     @abstractmethod
     def get_raw_connection(self) -> Any:
@@ -445,8 +461,14 @@ class VectorIndexStore(ABC):
         self,
         collection_name: str,
         new_name: str,
+        user_id: Optional[int],
+        is_admin: bool,
     ) -> List[str]:
         """Rename collection key across vector-side tables.
+
+        Applies the same multi-tenancy filter semantics as other vector store
+        writes: non-admin callers rename only rows for ``user_id``; admin callers
+        rename all matching rows.
 
         Returns:
             Warning messages generated during best-effort updates.
@@ -1271,6 +1293,20 @@ class IngestionStatusStore(ABC):
             DatabaseOperationError: If delete operation fails.
         """
 
+    @abstractmethod
+    def rename_collection_status(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> List[str]:
+        """Rename ingestion status rows for a collection.
+
+        Applies tenant filtering for non-admin callers and global filtering for
+        admin callers. Returns warnings for best-effort update failures.
+        """
+
     # --- Async methods ---
 
     @abstractmethod
@@ -1340,6 +1376,16 @@ class IngestionStatusStore(ABC):
         Raises:
             DatabaseOperationError: If delete operation fails.
         """
+
+    @abstractmethod
+    async def rename_collection_status_async(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> List[str]:
+        """Async version of :meth:`rename_collection_status`."""
 
 
 class PromptTemplateStore(ABC):

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -80,7 +80,13 @@ class LanceDBMetadataStore(MetadataStore):
         except Exception as exc:
             logger.debug("Failed to delete collection metadata: %s", exc)
 
-    async def rename_collection(self, old_name: str, new_name: str) -> None:
+    async def rename_collection(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> None:
         """Rename ``collection_config`` and ``collection_metadata`` keys.
 
         See :meth:`MetadataStore.rename_collection`.
@@ -96,12 +102,18 @@ class LanceDBMetadataStore(MetadataStore):
 
         safe_old = escape_lancedb_string(old_name)
         now = datetime.now(timezone.utc).replace(tzinfo=None)
+        if is_admin:
+            config_where = f"collection = '{safe_old}'"
+        elif user_id is None:
+            config_where = f"collection = '{safe_old}' AND user_id = 0"
+        else:
+            config_where = f"collection = '{safe_old}' AND user_id = {user_id}"
 
         config_table = None
         try:
             config_table = conn.open_table("collection_config")
             config_table.update(
-                f"collection = '{safe_old}'",
+                config_where,
                 {"collection": new_name, "updated_at": now},
             )
         finally:
@@ -110,10 +122,15 @@ class LanceDBMetadataStore(MetadataStore):
         meta_table = None
         try:
             meta_table = conn.open_table("collection_metadata")
-            meta_table.update(
-                f"name = '{safe_old}'",
-                {"name": new_name, "updated_at": now},
-            )
+            if is_admin:
+                meta_table.update(
+                    f"name = '{safe_old}'",
+                    {"name": new_name, "updated_at": now},
+                )
+            else:
+                # Tenant-scoped rename invalidates the global cache for the old
+                # name; admin/global list can rebuild accurate aggregate stats.
+                meta_table.delete(f"name = '{safe_old}'")
         finally:
             _safe_close_table(meta_table)
 
@@ -415,6 +432,47 @@ class LanceDBMetadataStore(MetadataStore):
         finally:
             _safe_close_table(table)
 
+    def list_collection_config_owner_ids(self, collection_name: str) -> set[int]:
+        """List owners with collection_config rows for a collection."""
+        from ..LanceDB.schema_manager import (
+            _safe_close_table,
+            ensure_collection_config_table,
+        )
+
+        owner_ids: set[int] = set()
+        table = None
+        try:
+            conn = self.get_raw_connection()
+            ensure_collection_config_table(conn)
+            table = conn.open_table("collection_config")
+            safe_collection = escape_lancedb_string(collection_name)
+            rows = query_to_list(
+                table.search()
+                .where(f"collection = '{safe_collection}'")
+                .select(["user_id"])
+                .limit(-1)
+            )
+            for row in rows:
+                raw_user_id = row.get("user_id")
+                if raw_user_id is None:
+                    continue
+                try:
+                    owner_ids.add(int(raw_user_id))
+                except (TypeError, ValueError):
+                    logger.debug(
+                        "Skipping invalid collection_config user_id: %r",
+                        raw_user_id,
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to list collection_config owners for %s: %s",
+                collection_name,
+                exc,
+            )
+        finally:
+            _safe_close_table(table)
+        return owner_ids
+
     def get_raw_connection(self) -> DBConnection:
         """Get the underlying LanceDB connection.
 
@@ -552,6 +610,17 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 raw_doc_id = item.get("doc_id")
                 if not raw_doc_id:
                     continue
+                raw_user_id = item.get("user_id")
+                user_id_value = None
+                if raw_user_id is not None:
+                    try:
+                        user_id_value = int(raw_user_id)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Skipping invalid user_id on document record %s: %r",
+                            raw_doc_id,
+                            raw_user_id,
+                        )
                 records.append(
                     DocumentRecord(
                         doc_id=str(raw_doc_id),
@@ -561,6 +630,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                             if item.get("source_path")
                             else None
                         ),
+                        user_id=user_id_value,
                     )
                 )
             return records
@@ -612,11 +682,21 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         self,
         collection_name: str,
         new_name: str,
+        user_id: Optional[int],
+        is_admin: bool,
     ) -> List[str]:
         from ..LanceDB.schema_manager import _safe_close_table
 
         warnings: List[str] = []
         safe_old_name = escape_lancedb_string(collection_name)
+        filters = FilterCondition("collection", FilterOperator.EQ, collection_name)
+        where_expr = self.build_filter_expression(
+            filters=filters,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        if not where_expr:
+            where_expr = f"collection = '{safe_old_name}'"
         conn = self._get_connection()
         for table_name in self.list_table_names():
             if table_name not in {
@@ -629,7 +709,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             try:
                 table = conn.open_table(table_name)
                 table.update(
-                    f"collection = '{safe_old_name}'",
+                    where_expr,
                     {"collection": new_name},
                 )
             except Exception as exc:  # noqa: BLE001
@@ -2166,6 +2246,39 @@ class LanceDBIngestionStatusStore(IngestionStatusStore):
         finally:
             _safe_close_table(table)
 
+    def rename_collection_status(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> List[str]:
+        """Rename ingestion status rows for a collection."""
+        from ..LanceDB.schema_manager import _safe_close_table
+
+        warnings: List[str] = []
+        table = None
+        try:
+            conn = self._get_sync_connection()
+            self._ensure_ingestion_runs_table(conn)
+            table = conn.open_table("ingestion_runs")
+            where_expr = self._build_load_filter(old_name, None, user_id, is_admin)
+            if where_expr:
+                table.update(
+                    where_expr,
+                    {
+                        "collection": new_name,
+                        "updated_at": datetime.now(timezone.utc),
+                    },
+                )
+        except Exception as exc:  # noqa: BLE001
+            message = f"Failed to rename ingestion status: {exc}"
+            logger.warning(message)
+            warnings.append(message)
+        finally:
+            _safe_close_table(table)
+        return warnings
+
     # --- Async methods ---
 
     async def write_ingestion_status_async(
@@ -2229,6 +2342,21 @@ class LanceDBIngestionStatusStore(IngestionStatusStore):
         return self.clear_ingestion_status(
             collection=collection,
             doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    async def rename_collection_status_async(
+        self,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> List[str]:
+        """Async version of rename_collection_status."""
+        return self.rename_collection_status(
+            old_name=old_name,
+            new_name=new_name,
             user_id=user_id,
             is_admin=is_admin,
         )

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -13,8 +13,19 @@ import threading
 import time
 import unicodedata
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TypedDict, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    TypeVar,
+    cast,
+)
 
 from fastapi import (
     APIRouter,
@@ -78,7 +89,11 @@ from ...core.tools.core.RAG_tools.pipelines.web_ingestion import (
 )
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
-from ...core.tools.core.RAG_tools.storage.factory import get_vector_index_store
+from ...core.tools.core.RAG_tools.storage.factory import (
+    get_ingestion_status_store,
+    get_metadata_store,
+    get_vector_index_store,
+)
 from ...core.tools.core.RAG_tools.utils.string_utils import (
     generate_deterministic_doc_id,
 )
@@ -98,6 +113,7 @@ from ..models.user import User
 from ..services.kb_collection_service import (
     delete_collection_physical_dir,
     delete_collection_uploaded_files,
+    list_collection_uploaded_file_owner_ids,
     rename_collection_storage,
 )
 from ..services.kb_file_service import (
@@ -2840,11 +2856,22 @@ class ResolvedDocumentMatch(TypedDict):
     source_path: Optional[str]
 
 
-_DELETE_SHARED_COLLECTION_DETAIL = (
-    "Only admin users can delete collections containing documents from other users."
-)
-
 _CONFIG_ONLY_SENTINEL_KEY = "__config_only__"
+_DeleteMode = Literal["full", "config_only"]
+_CollectionMutationMode = Literal["tenant", "global"]
+
+
+@dataclass
+class CollectionMutationScope:
+    """Resolved collection mutation boundary for tenant/global operations."""
+
+    mode: _CollectionMutationMode
+    collection_name: str
+    requester_user_id: int
+    is_admin: bool
+    owner_user_ids: set[int]
+    document_records: List[DocumentRecord]
+    file_ids_by_owner: Dict[int, set[str]]
 
 
 def _http_detail_to_str(detail: Any) -> str:
@@ -2886,36 +2913,16 @@ def _get_collection_document_counts(
     return total_count, own_count
 
 
-def _check_can_delete_collection(
-    collection_name: str,
-    user_id: int,
-    is_admin: bool,
-) -> None:
-    """Validate collection name and non-admin full-delete permission."""
-    if not collection_name or not collection_name.strip():
-        raise HTTPException(status_code=422, detail="Collection name cannot be empty")
-    if is_admin:
-        return
-
-    total_count, own_count = _get_collection_document_counts(
-        collection_name, user_id, is_admin=False
-    )
-    if total_count > 0 and own_count < total_count:
-        raise HTTPException(status_code=403, detail=_DELETE_SHARED_COLLECTION_DETAIL)
-
-
 def _resolve_delete_mode_from_counts(
     total_count: int,
     own_count: int,
     is_admin: bool,
-) -> str:
-    """Decide full|config_only|forbidden from precomputed total/own counts."""
+) -> _DeleteMode:
+    """Decide full|config_only from precomputed total/own counts."""
     if is_admin:
         return "full"
     if total_count > 0 and own_count == 0:
         return "config_only"
-    if total_count > 0 and own_count < total_count:
-        return "forbidden"
     return "full"
 
 
@@ -2923,8 +2930,8 @@ def _get_collection_delete_mode(
     collection_name: str,
     user_id: int,
     is_admin: bool,
-) -> str:
-    """Return full|config_only|forbidden for collection delete."""
+) -> _DeleteMode:
+    """Return full|config_only for collection delete."""
     if not collection_name or not collection_name.strip():
         raise HTTPException(status_code=422, detail="Collection name cannot be empty")
     if is_admin:
@@ -2934,6 +2941,123 @@ def _get_collection_delete_mode(
         collection_name, user_id, is_admin=False
     )
     return _resolve_delete_mode_from_counts(total_count, own_count, is_admin=False)
+
+
+def _get_document_record_owner_id(
+    record: DocumentRecord,
+    *,
+    fallback_user_id: int,
+) -> int:
+    """Return the owner for storage cleanup, falling back for legacy projections."""
+    raw_user_id = getattr(record, "user_id", None)
+    if raw_user_id is None:
+        return fallback_user_id
+    try:
+        return int(raw_user_id)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid user_id on document record %s: %r; falling back to user_%s",
+            getattr(record, "doc_id", "<unknown>"),
+            raw_user_id,
+            fallback_user_id,
+        )
+        return fallback_user_id
+
+
+def _group_document_file_ids_by_owner(
+    records: List[DocumentRecord],
+    *,
+    fallback_user_id: int,
+) -> Dict[int, set[str]]:
+    """Group uploaded file ids by document owner for tenant storage cleanup."""
+    grouped: Dict[int, set[str]] = {}
+    for record in records:
+        owner_id = _get_document_record_owner_id(
+            record, fallback_user_id=fallback_user_id
+        )
+        grouped.setdefault(owner_id, set())
+        file_id = _get_document_record_file_id(record)
+        if file_id:
+            grouped[owner_id].add(file_id)
+    return grouped
+
+
+def _get_collection_storage_owner_ids(
+    records: List[DocumentRecord],
+    *,
+    fallback_user_id: int,
+) -> set[int]:
+    """Return owners whose physical KB storage may need collection-level cleanup."""
+    if not records:
+        return {fallback_user_id}
+    return {
+        _get_document_record_owner_id(record, fallback_user_id=fallback_user_id)
+        for record in records
+    }
+
+
+def _resolve_collection_mutation_scope(
+    *,
+    collection_name: str,
+    requester_user_id: int,
+    is_admin: bool,
+    db: Session,
+    vector_store: Any = None,
+) -> CollectionMutationScope:
+    """Resolve tenant/global mutation ownership once for delete and rename."""
+    if vector_store is None:
+        vector_store = get_vector_index_store()
+    document_records = vector_store.list_document_records(
+        collection_name=collection_name,
+        user_id=requester_user_id,
+        is_admin=is_admin,
+    )
+    file_ids_by_owner = _group_document_file_ids_by_owner(
+        document_records,
+        fallback_user_id=requester_user_id,
+    )
+
+    if not is_admin:
+        owner_user_ids = {requester_user_id}
+        file_ids_by_owner.setdefault(requester_user_id, set())
+        return CollectionMutationScope(
+            mode="tenant",
+            collection_name=collection_name,
+            requester_user_id=requester_user_id,
+            is_admin=False,
+            owner_user_ids=owner_user_ids,
+            document_records=document_records,
+            file_ids_by_owner=file_ids_by_owner,
+        )
+
+    owner_user_ids = (
+        {
+            _get_document_record_owner_id(record, fallback_user_id=requester_user_id)
+            for record in document_records
+        }
+        if document_records
+        else set()
+    )
+    owner_user_ids.update(
+        get_metadata_store().list_collection_config_owner_ids(collection_name)
+    )
+    owner_user_ids.update(
+        list_collection_uploaded_file_owner_ids(db, collection_name=collection_name)
+    )
+    if not owner_user_ids:
+        owner_user_ids = {requester_user_id}
+    for owner_id in owner_user_ids:
+        file_ids_by_owner.setdefault(owner_id, set())
+
+    return CollectionMutationScope(
+        mode="global",
+        collection_name=collection_name,
+        requester_user_id=requester_user_id,
+        is_admin=True,
+        owner_user_ids=owner_user_ids,
+        document_records=document_records,
+        file_ids_by_owner=file_ids_by_owner,
+    )
 
 
 def _remove_user_collection_config(
@@ -3032,7 +3156,7 @@ def _strip_config_only_sentinel(
     )
 
 
-def _preflight_batch_delete_permissions(
+def _validate_and_prefetch_batch_delete_counts(
     unique_names: List[str],
     user_id: int,
     is_admin: bool,
@@ -3041,9 +3165,9 @@ def _preflight_batch_delete_permissions(
     List[BatchDeleteFailureItem],
     Dict[str, tuple[int, int]],
 ]:
-    """Preflight validation for batch delete permissions and empty names.
+    """Validate batch delete names and prefetch count hints.
 
-    Returns ``(allowed_names, failed_items, counts_by_name)``. For non-admin
+    Returns ``(valid_names, failed_items, counts_by_name)``. For non-admin
     callers ``counts_by_name`` maps the trimmed collection name to its
     ``(total, own)`` document counts so callers can reuse them when invoking
     ``_perform_kb_collection_delete`` (avoids redundant LanceDB scans).
@@ -3091,28 +3215,21 @@ def _preflight_batch_delete_permissions(
         )
     except Exception as exc:
         logger.error(
-            "Batch permission scan failed (vector store grouped counts): %s",
+            "Batch delete count prefetch failed (vector store grouped counts): %s",
             exc,
             exc_info=True,
         )
         raise HTTPException(
             status_code=500,
-            detail="Failed to scan documents table for batch delete permission.",
+            detail="Failed to scan documents table for batch delete.",
         ) from exc
 
     for name in non_empty:
         key = str(name).strip()
         total = int(totals.get(key, 0))
         own = int(owns.get(key, 0))
-        if total > 0 and 0 < own < total:
-            failed.append(
-                BatchDeleteFailureItem(
-                    name=name, error=_DELETE_SHARED_COLLECTION_DETAIL
-                )
-            )
-        else:
-            allowed.append(name)
-            counts_by_name[key] = (total, own)
+        allowed.append(name)
+        counts_by_name[key] = (total, own)
 
     return allowed, failed, counts_by_name
 
@@ -3173,7 +3290,7 @@ def _perform_kb_collection_delete(
                 status_code=422, detail=f"Invalid collection name: {str(e)}"
             ) from e
 
-        preflight_delete_mode: Optional[str] = None
+        preflight_delete_mode: Optional[_DeleteMode] = None
         if preflight_counts is not None:
             total_count, own_count = preflight_counts
             preflight_delete_mode = _resolve_delete_mode_from_counts(
@@ -3203,53 +3320,48 @@ def _perform_kb_collection_delete(
                     delete_mode,
                 )
 
-        if delete_mode == "forbidden":
-            raise HTTPException(
-                status_code=403, detail=_DELETE_SHARED_COLLECTION_DETAIL
-            )
         if delete_mode == "config_only":
             return _perform_config_only_collection_delete(safe_collection, user_id)
 
-        vector_store = get_vector_index_store()
-        collection_records = vector_store.list_document_records(
+        mutation_scope = _resolve_collection_mutation_scope(
             collection_name=safe_collection,
-            user_id=user_id,
+            requester_user_id=user_id,
             is_admin=is_admin,
-        )
-        collection_file_ids = {
-            file_id
-            for file_id in (
-                _get_document_record_file_id(record) for record in collection_records
-            )
-            if file_id
-        }
-
-        collection_dir = get_upload_path(
-            "", user_id=user_id, collection=safe_collection
+            db=db,
         )
 
         result = delete_collection(safe_collection, user_id, is_admin)
 
-        physical_cleanup = delete_collection_physical_dir(
-            user_id=user_id,
-            collection_name=safe_collection,
-        )
-        physical_cleanup_status = physical_cleanup.status
-        physical_cleanup_error = physical_cleanup.error
-        if physical_cleanup.collection_dir is not None:
-            collection_dir = physical_cleanup.collection_dir
+        physical_cleanup_by_owner = {}
+        for owner_id in sorted(mutation_scope.owner_user_ids):
+            physical_cleanup_by_owner[owner_id] = delete_collection_physical_dir(
+                user_id=owner_id,
+                collection_name=safe_collection,
+            )
 
         if result.status == "error":
             cleanup_warnings = list(result.warnings) if result.warnings else []
-            if physical_cleanup_status == "success":
-                cleanup_warnings.append(
-                    f"Physical directory moved to trash: {collection_dir} "
-                    "(trash cleanup requires external scheduler/cron)"
+            for owner_id, physical_cleanup in physical_cleanup_by_owner.items():
+                collection_dir = physical_cleanup.collection_dir or get_upload_path(
+                    "", user_id=owner_id, collection=safe_collection
                 )
-            elif physical_cleanup_status == "not_found":
-                cleanup_warnings.append(
-                    "Physical directory cleanup: No physical directory found (collection had no files)"
-                )
+                physical_cleanup_status = physical_cleanup.status
+                if physical_cleanup_status == "success":
+                    cleanup_warnings.append(
+                        f"Physical directory moved to trash for user_{owner_id}: "
+                        f"{collection_dir} "
+                        "(trash cleanup requires external scheduler/cron)"
+                    )
+                elif physical_cleanup_status == "not_found":
+                    cleanup_warnings.append(
+                        f"Physical directory cleanup for user_{owner_id}: "
+                        "No physical directory found (collection had no files)"
+                    )
+                elif physical_cleanup.error:
+                    cleanup_warnings.append(
+                        f"Physical directory cleanup for user_{owner_id}: "
+                        f"{physical_cleanup.status} - {physical_cleanup.error}"
+                    )
 
             return CollectionOperationResult(
                 status="error",
@@ -3260,33 +3372,40 @@ def _perform_kb_collection_delete(
                 deleted_counts=result.deleted_counts,
             )
 
-        remaining_records = vector_store.list_document_records(
+        remaining_records = get_vector_index_store().list_document_records(
             collection_name=None,
             user_id=user_id,
             is_admin=is_admin,
         )
-        remaining_file_ids = {
-            file_id
-            for file_id in (
-                _get_document_record_file_id(record) for record in remaining_records
-            )
-            if file_id
-        }
+        remaining_file_ids_by_owner = _group_document_file_ids_by_owner(
+            remaining_records,
+            fallback_user_id=user_id,
+        )
         deleted_uploaded_files = 0
-        if physical_cleanup_status in {"success", "not_found"}:
-            deleted_uploaded_files = delete_collection_uploaded_files(
-                db,
-                user_id=user_id,
-                collection_file_ids=collection_file_ids,
-                remaining_file_ids=remaining_file_ids,
-                collection_dir=collection_dir,
+        for owner_id in sorted(mutation_scope.owner_user_ids):
+            physical_cleanup = physical_cleanup_by_owner[owner_id]
+            physical_cleanup_status = physical_cleanup.status
+            collection_dir = physical_cleanup.collection_dir or get_upload_path(
+                "", user_id=owner_id, collection=safe_collection
             )
-        else:
-            logger.warning(
-                "Preserving UploadedFile records for collection %s because physical cleanup status is %s",
-                safe_collection,
-                physical_cleanup_status,
-            )
+            if physical_cleanup_status in {"success", "not_found"}:
+                deleted_uploaded_files += delete_collection_uploaded_files(
+                    db,
+                    user_id=owner_id,
+                    collection_file_ids=mutation_scope.file_ids_by_owner.get(
+                        owner_id, set()
+                    ),
+                    remaining_file_ids=remaining_file_ids_by_owner.get(owner_id, set()),
+                    collection_dir=collection_dir,
+                )
+            else:
+                logger.warning(
+                    "Preserving UploadedFile records for collection %s/user_%s "
+                    "because physical cleanup status is %s",
+                    safe_collection,
+                    owner_id,
+                    physical_cleanup_status,
+                )
         if deleted_uploaded_files:
             logger.info(
                 "Deleted %s UploadedFile record(s) for collection %s",
@@ -3295,35 +3414,55 @@ def _perform_kb_collection_delete(
             )
 
         cleanup_warnings = list(result.warnings) if result.warnings else []
-        cleanup_info_message = ""
+        cleanup_info_messages: List[str] = []
+        has_physical_cleanup_issue = False
 
-        if physical_cleanup_status == "success":
-            cleanup_info = (
-                f"Physical directory moved to trash: {collection_dir} "
-                "(trash cleanup requires external scheduler/cron)"
+        for owner_id, physical_cleanup in physical_cleanup_by_owner.items():
+            physical_cleanup_status = physical_cleanup.status
+            physical_cleanup_error = physical_cleanup.error
+            collection_dir = physical_cleanup.collection_dir or get_upload_path(
+                "", user_id=owner_id, collection=safe_collection
             )
-            cleanup_warnings.append(cleanup_info)
-            cleanup_info_message = f" {cleanup_info}."
-        elif physical_cleanup_status == "not_found":
-            cleanup_info = "Physical directory cleanup: No physical directory found (collection had no files)"
-            cleanup_warnings.append(cleanup_info)
-            cleanup_info_message = f" {cleanup_info}."
-        elif physical_cleanup_status == "error" and physical_cleanup_error:
-            cleanup_info = f"Physical directory cleanup: Warning - {physical_cleanup_error}. Database deletion proceeded, but physical file cleanup status is uncertain."
-            cleanup_warnings.append(cleanup_info)
-            cleanup_info_message = f" {cleanup_info}"
-        elif physical_cleanup_status == "failed" and physical_cleanup_error:
-            cleanup_info = (
-                f"Physical directory cleanup: Failed - {physical_cleanup_error}"
-            )
-            cleanup_warnings.append(cleanup_info)
-            cleanup_info_message = f" {cleanup_info}"
+
+            if physical_cleanup_status == "success":
+                cleanup_info = (
+                    f"Physical directory moved to trash for user_{owner_id}: "
+                    f"{collection_dir} "
+                    "(trash cleanup requires external scheduler/cron)"
+                )
+                cleanup_warnings.append(cleanup_info)
+                cleanup_info_messages.append(cleanup_info)
+            elif physical_cleanup_status == "not_found":
+                cleanup_info = (
+                    f"Physical directory cleanup for user_{owner_id}: "
+                    "No physical directory found (collection had no files)"
+                )
+                cleanup_warnings.append(cleanup_info)
+                cleanup_info_messages.append(cleanup_info)
+            elif physical_cleanup_status == "error" and physical_cleanup_error:
+                has_physical_cleanup_issue = True
+                cleanup_info = (
+                    f"Physical directory cleanup for user_{owner_id}: Warning - "
+                    f"{physical_cleanup_error}. Database deletion proceeded, but "
+                    "physical file cleanup status is uncertain."
+                )
+                cleanup_warnings.append(cleanup_info)
+                cleanup_info_messages.append(cleanup_info)
+            elif physical_cleanup_status == "failed" and physical_cleanup_error:
+                has_physical_cleanup_issue = True
+                cleanup_info = (
+                    f"Physical directory cleanup for user_{owner_id}: Failed - "
+                    f"{physical_cleanup_error}"
+                )
+                cleanup_warnings.append(cleanup_info)
+                cleanup_info_messages.append(cleanup_info)
+
+        cleanup_info_message = ""
+        if cleanup_info_messages:
+            cleanup_info_message = f" {'; '.join(cleanup_info_messages)}."
 
         final_status = result.status
-        if result.status == "success" and physical_cleanup_status in (
-            "error",
-            "failed",
-        ):
+        if result.status == "success" and has_physical_cleanup_issue:
             final_status = "partial_success"
             if not cleanup_info_message:
                 cleanup_info_message = " Database deletion succeeded, but physical file cleanup encountered issues."
@@ -3420,7 +3559,7 @@ async def batch_delete_collections_api(
         seen.add(key)
         unique_names.append(raw_name)
 
-    allowed, failed, counts_by_name = _preflight_batch_delete_permissions(
+    allowed, failed, counts_by_name = _validate_and_prefetch_batch_delete_counts(
         unique_names, user_id, is_admin
     )
 
@@ -4246,16 +4385,6 @@ async def rename_collection_api(
     Returns:
         Success message
     """
-    from ...core.tools.core.RAG_tools.management.status import (
-        clear_ingestion_status,
-        load_ingestion_status,
-        write_ingestion_status,
-    )
-    from ...core.tools.core.RAG_tools.storage.factory import (
-        get_metadata_store,
-        get_vector_index_store,
-    )
-
     vector_store = get_vector_index_store()
 
     if not new_name or not new_name.strip():
@@ -4305,35 +4434,76 @@ async def rename_collection_api(
                 detail=f"Access denied for collection: {safe_new_collection}",
             )
 
-    physical_rename_status = "not_found"
-    physical_rename_error: Optional[str] = None
-    old_collection_dir: Optional[Path] = None
-    new_collection_dir: Optional[Path] = None
-    collection_records = vector_store.list_document_records(
+    mutation_scope = _resolve_collection_mutation_scope(
         collection_name=safe_old_collection,
-        user_id=int(_user.id),
+        requester_user_id=int(_user.id),
         is_admin=bool(_user.is_admin),
+        db=db,
+        vector_store=vector_store,
     )
-    collection_file_ids = {
-        file_id
-        for file_id in (
-            _get_document_record_file_id(record) for record in collection_records
-        )
-        if file_id
-    }
 
-    physical_rename = rename_collection_storage(
-        db,
-        user_id=int(_user.id),
-        old_collection_name=safe_old_collection,
-        new_collection_name=safe_new_collection,
-        collection_file_ids=collection_file_ids,
-    )
-    physical_rename_status = physical_rename.status
-    physical_rename_error = physical_rename.error
-    old_collection_dir = physical_rename.old_collection_dir
-    new_collection_dir = physical_rename.new_collection_dir
-    if physical_rename_status == "failed":
+    for owner_id in sorted(mutation_scope.owner_user_ids):
+        old_dir = get_upload_path(
+            "",
+            user_id=owner_id,
+            collection=safe_old_collection,
+            create_if_not_exists=False,
+            collection_is_sanitized=True,
+        )
+        new_dir = get_upload_path(
+            "",
+            user_id=owner_id,
+            collection=safe_new_collection,
+            create_if_not_exists=False,
+            collection_is_sanitized=True,
+        )
+        if old_dir.exists() and old_dir.is_dir() and new_dir.exists():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Failed to rename collection: target physical directory already "
+                    f"exists for user_{owner_id}. A collection named "
+                    f"'{safe_new_collection}' already has physical files."
+                ),
+            )
+
+    physical_rename_results = {}
+    renamed_owner_ids: list[int] = []
+    for owner_id in sorted(mutation_scope.owner_user_ids):
+        physical_rename = rename_collection_storage(
+            db,
+            user_id=owner_id,
+            old_collection_name=safe_old_collection,
+            new_collection_name=safe_new_collection,
+            collection_file_ids=mutation_scope.file_ids_by_owner.get(owner_id, set()),
+        )
+        physical_rename_results[owner_id] = physical_rename
+        if physical_rename.status == "success":
+            renamed_owner_ids.append(owner_id)
+        if physical_rename.status != "failed":
+            continue
+
+        for rollback_owner_id in reversed(renamed_owner_ids):
+            rollback = rename_collection_storage(
+                db,
+                user_id=rollback_owner_id,
+                old_collection_name=safe_new_collection,
+                new_collection_name=safe_old_collection,
+                collection_file_ids=mutation_scope.file_ids_by_owner.get(
+                    rollback_owner_id, set()
+                ),
+            )
+            if rollback.status != "success":
+                logger.error(
+                    "Failed to roll back physical collection rename for user_%s "
+                    "%s -> %s: %s",
+                    rollback_owner_id,
+                    safe_new_collection,
+                    safe_old_collection,
+                    rollback.error,
+                )
+
+        physical_rename_error = physical_rename.error
         if (
             physical_rename_error
             == "Another operation is in progress; please try again later."
@@ -4350,11 +4520,12 @@ async def rename_collection_api(
 
     # Step 2: Update collection name in all tables (documents, parses, chunks, embeddings)
     # Use storage abstraction layer which handles all tables including embeddings
-    vector_store = get_vector_index_store()
     warnings.extend(
         vector_store.rename_collection_data(
             collection_name=safe_old_collection,
             new_name=safe_new_collection,
+            user_id=int(_user.id),
+            is_admin=bool(_user.is_admin),
         )
     )
 
@@ -4363,58 +4534,78 @@ async def rename_collection_api(
         await metadata_store.rename_collection(
             old_name=safe_old_collection,
             new_name=safe_new_collection,
+            user_id=int(_user.id),
+            is_admin=bool(_user.is_admin),
         )
     except Exception as e:
         logger.warning("Failed to rename metadata store keys: %s", e)
         warnings.append(f"Failed to rename collection metadata: {e}")
 
-    # Migrate ingestion status from old collection name to new
+    # Best-effort scoped ingestion status rename. The status store owns how
+    # collection/user filters map to its backend tables.
     try:
-        status_entries = load_ingestion_status(collection=safe_old_collection)
-        for entry in status_entries:
-            doc_id = entry.get("doc_id")
-            if doc_id:
-                write_ingestion_status(
-                    safe_new_collection,
-                    doc_id,
-                    status=entry.get("status", "pending"),
-                    message=entry.get("message", ""),
-                    parse_hash=entry.get("parse_hash", ""),
-                )
-                clear_ingestion_status(safe_old_collection, doc_id)
+        warnings.extend(
+            get_ingestion_status_store().rename_collection_status(
+                old_name=safe_old_collection,
+                new_name=safe_new_collection,
+                user_id=int(_user.id),
+                is_admin=bool(_user.is_admin),
+            )
+        )
     except Exception as e:
         logger.warning("Failed to update ingestion status: %s", e)
         warnings.append(f"Failed to update ingestion status: {e}")
 
     # Step 3: Add physical rename status to warnings and message for visibility
+    rename_info_messages: list[str] = []
+    has_physical_rename_issue = False
+    for owner_id, physical_rename in physical_rename_results.items():
+        physical_rename_status = physical_rename.status
+        physical_rename_error = physical_rename.error
+        if (
+            physical_rename_status == "success"
+            and physical_rename.old_collection_dir is not None
+            and physical_rename.new_collection_dir is not None
+        ):
+            rename_info = (
+                f"Physical directory renamed for user_{owner_id}: "
+                f"{physical_rename.old_collection_dir.name} -> "
+                f"{physical_rename.new_collection_dir.name}"
+            )
+            warnings.append(rename_info)
+            rename_info_messages.append(rename_info)
+        elif physical_rename_status == "not_found":
+            rename_info = (
+                f"Physical directory rename for user_{owner_id}: "
+                "No physical directory found (collection had no files)"
+            )
+            warnings.append(rename_info)
+            rename_info_messages.append(rename_info)
+        elif physical_rename_status == "error" and physical_rename_error:
+            has_physical_rename_issue = True
+            rename_info = (
+                f"Physical directory rename for user_{owner_id}: Warning - "
+                f"{physical_rename_error}. Database rename proceeded, but physical "
+                "directory rename status is uncertain."
+            )
+            warnings.append(rename_info)
+            rename_info_messages.append(rename_info)
+        elif physical_rename_status == "failed" and physical_rename_error:
+            has_physical_rename_issue = True
+            rename_info = (
+                f"Physical directory rename for user_{owner_id}: Failed - "
+                f"{physical_rename_error}"
+            )
+            warnings.append(rename_info)
+            rename_info_messages.append(rename_info)
+
     rename_info_message = ""
-    if (
-        physical_rename_status == "success"
-        and old_collection_dir is not None
-        and new_collection_dir is not None
-    ):
-        rename_info = f"Physical directory renamed: {old_collection_dir.name} -> {new_collection_dir.name}"
-        warnings.append(rename_info)
-        rename_info_message = f" {rename_info}."
-    elif physical_rename_status == "not_found":
-        rename_info = "Physical directory rename: No physical directory found (collection had no files)"
-        warnings.append(rename_info)
-        rename_info_message = f" {rename_info}."
-    elif physical_rename_status == "error" and physical_rename_error:
-        rename_info = (
-            f"Physical directory rename: Warning - {physical_rename_error}. "
-            "Database rename proceeded, but physical directory rename status is uncertain."
-        )
-        warnings.append(rename_info)
-        rename_info_message = f" {rename_info}"
-    elif physical_rename_status == "failed" and physical_rename_error:
-        rename_info = f"Physical directory rename: Failed - {physical_rename_error}"
-        warnings.append(rename_info)
-        rename_info_message = f" {rename_info}"
+    if rename_info_messages:
+        rename_info_message = f" {'; '.join(rename_info_messages)}."
 
     # Step 4: Determine final status
     final_status = "success" if not warnings else "partial_success"
-    if physical_rename_status in ("error", "failed"):
+    if has_physical_rename_issue:
         final_status = "partial_success"
         if not rename_info_message:
             rename_info_message = " Database rename succeeded, but physical directory rename encountered issues."
@@ -4423,7 +4614,7 @@ async def rename_collection_api(
     base_message = (
         f"Collection renamed from '{safe_old_collection}' to '{safe_new_collection}'"
     )
-    if warnings and len(warnings) > (1 if physical_rename_status != "not_found" else 0):
+    if warnings:
         final_message = f"{base_message} with some warnings"
     else:
         final_message = base_message

--- a/src/xagent/web/services/kb_collection_service.py
+++ b/src/xagent/web/services/kb_collection_service.py
@@ -13,7 +13,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ...config import get_uploads_dir
-from ..config import get_upload_path
+from ..config import get_upload_path, sanitize_path_component
 from ..kb_physical_sync import collection_physical_lock, move_collection_dir_to_trash
 from ..models.uploaded_file import UploadedFile
 from .kb_file_service import delete_uploaded_file_if_orphaned
@@ -39,6 +39,81 @@ class CollectionPhysicalRenameResult:
     error: Optional[str] = None
     old_collection_dir: Optional[Path] = None
     new_collection_dir: Optional[Path] = None
+
+
+def _path_belongs_to_collection_dir(
+    storage_path: str,
+    *,
+    owner_id: int,
+    collection_name: str,
+) -> bool:
+    """Return True when a stored path is under the owner's collection dir."""
+    try:
+        collection_dir = get_upload_path(
+            "",
+            user_id=owner_id,
+            collection=collection_name,
+            create_if_not_exists=False,
+            collection_is_sanitized=True,
+        ).resolve()
+        file_path = Path(storage_path).resolve()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "Skipping collection owner discovery for invalid path %s: %s",
+            storage_path,
+            exc,
+        )
+        return False
+    return file_path == collection_dir or collection_dir in file_path.parents
+
+
+def list_collection_uploaded_file_owner_ids(
+    db: Session,
+    *,
+    collection_name: str,
+) -> Set[int]:
+    """List UploadedFile owners with files under a collection directory."""
+    owner_ids: Set[int] = set()
+    try:
+        safe_collection = sanitize_path_component(collection_name, "collection")
+    except ValueError:
+        logger.debug("Invalid collection name for UploadedFile owner discovery")
+        return owner_ids
+
+    try:
+        candidates = (
+            db.query(UploadedFile.user_id, UploadedFile.storage_path)
+            .filter(
+                UploadedFile.user_id.isnot(None),
+                UploadedFile.storage_path.contains(safe_collection),
+            )
+            .all()
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to list UploadedFile owner candidates for %s: %s",
+            collection_name,
+            exc,
+        )
+        return owner_ids
+
+    for row in candidates:
+        raw_user_id = getattr(row, "user_id", None)
+        storage_path = getattr(row, "storage_path", None)
+        if raw_user_id is None or not storage_path:
+            continue
+        try:
+            owner_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            logger.debug("Skipping invalid UploadedFile user_id: %r", raw_user_id)
+            continue
+        if _path_belongs_to_collection_dir(
+            str(storage_path),
+            owner_id=owner_id,
+            collection_name=safe_collection,
+        ):
+            owner_ids.add(owner_id)
+    return owner_ids
 
 
 def delete_collection_physical_dir(

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -852,6 +852,87 @@ async def test_list_collections_non_admin_realtime_does_not_overwrite_global_met
     save_collection_mock.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_list_collections_non_admin_uses_tenant_stats_despite_metadata_cache(
+    temp_lancedb_dir: str,
+) -> None:
+    """A visible shared-name collection should show only the caller's document count."""
+    collection = "shared_name_cache_test"
+    now = datetime.now(timezone.utc)
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-user-1",
+                "source_path": "/path/user1.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-1",
+                "uploaded_at": now,
+                "title": "User 1",
+                "language": "en",
+                "user_id": 1,
+            },
+            {
+                "collection": collection,
+                "doc_id": "doc-user-2",
+                "source_path": "/path/user2.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-2",
+                "uploaded_at": now,
+                "title": "User 2",
+                "language": "en",
+                "user_id": 2,
+            },
+        ]
+    )
+    await get_metadata_store().save_collection_config(collection, "{}", user_id=1)
+
+    result = await list_collections(user_id=1, is_admin=False)
+
+    info = next(c for c in result.collections if c.name == collection)
+    assert info.documents == 1
+    assert info.owners == [1]
+    assert info.document_names == ["user1.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_list_collections_non_admin_stale_config_does_not_use_global_stats(
+    temp_lancedb_dir: str,
+) -> None:
+    """A stale user config should not inherit another user's cached stats."""
+    collection = "stale_config_shared_name_test"
+    now = datetime.now(timezone.utc)
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": "doc-user-2",
+                "source_path": "/path/user2.pdf",
+                "file_type": "pdf",
+                "content_hash": "hash-2",
+                "uploaded_at": now,
+                "title": "User 2",
+                "language": "en",
+                "user_id": 2,
+            }
+        ]
+    )
+    await get_metadata_store().save_collection_config(collection, "{}", user_id=1)
+
+    result = await list_collections(user_id=1, is_admin=False)
+
+    info = next(c for c in result.collections if c.name == collection)
+    assert info.documents == 0
+    assert info.parses == 0
+    assert info.chunks == 0
+    assert info.embeddings == 0
+    assert info.processed_documents == 0
+    assert info.owners == []
+    assert info.document_names == []
+
+
 # --- delete_collection metadata cleanup Tests ---
 
 

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+    LanceDBIngestionStatusStore,
     LanceDBMainPointerStore,
     LanceDBMetadataStore,
     LanceDBPromptTemplateStore,
@@ -71,7 +72,14 @@ def test_metadata_store_rename_collection_updates_tables(
     mock_conn.open_table.side_effect = _open
 
     store = LanceDBMetadataStore()
-    asyncio.run(store.rename_collection("old_col", "new_col"))
+    asyncio.run(
+        store.rename_collection(
+            "old_col",
+            "new_col",
+            user_id=1,
+            is_admin=True,
+        )
+    )
 
     mock_config.update.assert_called_once()
     cfg_where, cfg_updates = mock_config.update.call_args[0]
@@ -82,6 +90,57 @@ def test_metadata_store_rename_collection_updates_tables(
     meta_where, meta_updates = mock_meta.update.call_args[0]
     assert "old_col" in meta_where
     assert meta_updates["name"] == "new_col"
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.LanceDBMetadataStore.ensure_collection_metadata_table",
+    new_callable=AsyncMock,
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.LanceDB.schema_manager.ensure_collection_config_table"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_metadata_store_rename_collection_tenant_scoped_config_only(
+    mock_get_connection: Mock,
+    _mock_ensure_config: Mock,
+    _mock_ensure_meta: AsyncMock,
+) -> None:
+    """Tenant rename should update only the caller's config row."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    mock_config = Mock()
+    mock_meta = Mock()
+
+    def _open(name: str) -> Mock:
+        if name == "collection_config":
+            return mock_config
+        if name == "collection_metadata":
+            return mock_meta
+        raise AssertionError(name)
+
+    mock_conn.open_table.side_effect = _open
+
+    store = LanceDBMetadataStore()
+    asyncio.run(
+        store.rename_collection(
+            "old_col",
+            "new_col",
+            user_id=42,
+            is_admin=False,
+        )
+    )
+
+    mock_config.update.assert_called_once()
+    cfg_where, cfg_updates = mock_config.update.call_args[0]
+    assert "old_col" in cfg_where
+    assert "user_id = 42" in cfg_where
+    assert cfg_updates["collection"] == "new_col"
+    mock_meta.delete.assert_called_once()
+    assert "old_col" in mock_meta.delete.call_args.args[0]
+    mock_meta.update.assert_not_called()
 
 
 @patch(
@@ -273,6 +332,38 @@ def test_metadata_store_get_collection_success(mock_get_connection: Mock) -> Non
     assert collection.document_names == ["a.pdf", "b.pdf"]
 
 
+@patch("xagent.core.tools.core.RAG_tools.storage.lancedb_stores.query_to_list")
+@patch(
+    "xagent.core.tools.core.RAG_tools.LanceDB.schema_manager.ensure_collection_config_table"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_metadata_store_list_collection_config_owner_ids(
+    mock_get_connection: Mock,
+    _mock_ensure_config: Mock,
+    mock_query_to_list: Mock,
+) -> None:
+    """Metadata store should own stale collection_config owner discovery."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+    mock_query_to_list.return_value = [
+        {"user_id": 101},
+        {"user_id": "202"},
+        {"user_id": None},
+        {"user_id": "bad"},
+    ]
+
+    store = LanceDBMetadataStore()
+
+    assert store.list_collection_config_owner_ids("FAQ") == {101, 202}
+    mock_conn.open_table.assert_called_once_with("collection_config")
+    mock_query_to_list.assert_called_once()
+    mock_table.search.return_value.where.assert_called_once()
+
+
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.UserPermissions.get_user_filter"
 )
@@ -297,8 +388,8 @@ def test_vector_store_list_document_records_filters_and_maps(
     mock_table.schema = [SimpleNamespace(name="doc_id")]
     mock_conn.open_table.return_value = mock_table
     mock_query_to_list.return_value = [
-        {"doc_id": "doc-1", "source_path": "/tmp/a.pdf"},
-        {"doc_id": "doc-2", "source_path": None},
+        {"doc_id": "doc-1", "source_path": "/tmp/a.pdf", "user_id": 1},
+        {"doc_id": "doc-2", "source_path": None, "user_id": 1},
     ]
 
     store = LanceDBVectorIndexStore()
@@ -311,6 +402,7 @@ def test_vector_store_list_document_records_filters_and_maps(
 
     assert [r.doc_id for r in records] == ["doc-1", "doc-2"]
     assert records[0].source_path == "/tmp/a.pdf"
+    assert records[0].user_id == 1
     mock_table.search.return_value.where.assert_called_once()
 
 
@@ -337,11 +429,112 @@ def test_vector_store_rename_collection_data_updates_expected_tables(
     mock_conn.open_table.return_value = mock_table
 
     store = LanceDBVectorIndexStore()
-    warnings = store.rename_collection_data("old_name", "new_name")
+    warnings = store.rename_collection_data(
+        "old_name",
+        "new_name",
+        user_id=None,
+        is_admin=True,
+    )
 
     assert warnings == []
     # 4 target tables should be updated; control-plane table excluded.
     assert mock_table.update.call_count == 4
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.UserPermissions.get_user_filter"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_ingestion_status_store_rename_collection_status_is_tenant_scoped(
+    mock_get_connection: Mock,
+    mock_user_filter: Mock,
+) -> None:
+    """Non-admin status rename should include both collection and user filters."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+    mock_user_filter.return_value = "user_id == 101"
+
+    store = LanceDBIngestionStatusStore()
+    warnings = store.rename_collection_status(
+        old_name="old",
+        new_name="new",
+        user_id=101,
+        is_admin=False,
+    )
+
+    assert warnings == []
+    where_expr = mock_table.update.call_args.args[0]
+    assert "collection == 'old'" in where_expr
+    assert "user_id == 101" in where_expr
+    assert mock_table.update.call_args.args[1]["collection"] == "new"
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.UserPermissions.get_user_filter"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_ingestion_status_store_rename_collection_status_admin_is_global(
+    mock_get_connection: Mock,
+    mock_user_filter: Mock,
+) -> None:
+    """Admin status rename should update every owner for the collection."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_table = Mock()
+    mock_conn.open_table.return_value = mock_table
+    mock_user_filter.return_value = None
+
+    store = LanceDBIngestionStatusStore()
+    warnings = store.rename_collection_status(
+        old_name="old",
+        new_name="new",
+        user_id=999,
+        is_admin=True,
+    )
+
+    assert warnings == []
+    where_expr = mock_table.update.call_args.args[0]
+    assert where_expr == "collection == 'old'"
+    assert mock_table.update.call_args.args[1]["collection"] == "new"
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_vector_store_rename_collection_data_tenant_scoped(
+    mock_get_connection: Mock,
+) -> None:
+    """Tenant rename should include the user filter in each table update."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    table_names = ["documents", "parses", "chunks", "embeddings_text_embedding_v4"]
+    mock_conn.table_names.return_value = table_names
+    mock_conn.list_tables.return_value = table_names
+    mock_table = Mock()
+    mock_table.schema = Mock(names=[])
+    mock_conn.open_table.return_value = mock_table
+
+    store = LanceDBVectorIndexStore()
+    warnings = store.rename_collection_data(
+        "old_name",
+        "new_name",
+        user_id=42,
+        is_admin=False,
+    )
+
+    assert warnings == []
+    assert mock_table.update.call_count == 4
+    for call_args in mock_table.update.call_args_list:
+        where_expr = call_args.args[0]
+        assert "old_name" in where_expr
+        assert "user_id" in where_expr
+        assert "42" in where_expr
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/test_multitenancy.py
+++ b/tests/core/tools/core/RAG_tools/test_multitenancy.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -35,6 +35,7 @@ from xagent.core.tools.core.RAG_tools.management.collections import (
 )
 from xagent.core.tools.core.RAG_tools.parse.parse_document import parse_document
 from xagent.core.tools.core.RAG_tools.retrieval.search_engine import search_dense_engine
+from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.core.tools.core.RAG_tools.storage.factory import (
     get_vector_store_raw_connection,
 )
@@ -44,7 +45,11 @@ from xagent.core.tools.core.RAG_tools.vector_storage.vector_manager import (
     read_chunks_for_embedding,
     write_vectors_to_db,
 )
-from xagent.web.api.kb import delete_collection_api, list_collections_api
+from xagent.web.api.kb import (
+    delete_collection_api,
+    list_collections_api,
+    rename_collection_api,
+)
 
 
 class _FakeEmbeddingAdapter(BaseEmbedding):
@@ -938,6 +943,416 @@ class TestAPIMultiTenancy:
 
         mock_delete_collection.assert_called_once_with("test_collection", 999, True)
         assert isinstance(result, CollectionOperationResult)
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
+    @patch(
+        "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
+        return_value=set(),
+    )
+    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.web.api.kb.delete_collection_uploaded_files")
+    @patch("xagent.web.api.kb.delete_collection_physical_dir")
+    @patch("xagent.web.api.kb.delete_collection")
+    async def test_delete_collection_api_admin_cleans_all_owner_storage(
+        self,
+        mock_delete_collection,
+        mock_delete_collection_physical_dir,
+        mock_delete_collection_uploaded_files,
+        mock_get_metadata_store,
+        _mock_uploaded_owner_ids,
+        _mock_ensure_collection_access,
+        mock_get_vector_store,
+    ):
+        """Admin global delete should clean storage for every owner in the collection."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+        from xagent.web.models.user import User
+        from xagent.web.services.kb_collection_service import (
+            CollectionPhysicalDeleteResult,
+        )
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 999
+        mock_user.is_admin = True
+        mock_get_metadata_store.return_value.list_collection_config_owner_ids.return_value = set()
+
+        owner_one_dir = Path("/tmp/uploads/user_101/team")
+        owner_two_dir = Path("/tmp/uploads/user_202/team")
+        mock_get_vector_store.return_value.list_document_records.side_effect = [
+            [
+                DocumentRecord(doc_id="doc-a", file_id="file-a", user_id=101),
+                DocumentRecord(doc_id="doc-b", file_id="file-b", user_id=202),
+            ],
+            [],
+        ]
+        mock_delete_collection_physical_dir.side_effect = [
+            CollectionPhysicalDeleteResult(
+                status="success", collection_dir=owner_one_dir
+            ),
+            CollectionPhysicalDeleteResult(
+                status="success", collection_dir=owner_two_dir
+            ),
+        ]
+        mock_delete_collection_uploaded_files.return_value = 1
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="team",
+            message="Collection deleted",
+            warnings=[],
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+
+        mock_delete_collection.assert_called_once_with("team", 999, True)
+        assert mock_delete_collection_physical_dir.call_args_list == [
+            call(user_id=101, collection_name="team"),
+            call(user_id=202, collection_name="team"),
+        ]
+        assert mock_delete_collection_uploaded_files.call_args_list == [
+            call(
+                ANY,
+                user_id=101,
+                collection_file_ids={"file-a"},
+                remaining_file_ids=set(),
+                collection_dir=owner_one_dir,
+            ),
+            call(
+                ANY,
+                user_id=202,
+                collection_file_ids={"file-b"},
+                remaining_file_ids=set(),
+                collection_dir=owner_two_dir,
+            ),
+        ]
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    @patch("xagent.web.api.kb.get_ingestion_status_store")
+    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch("xagent.web.api.kb._list_collections_with_retry", new_callable=AsyncMock)
+    @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
+    @patch(
+        "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
+        return_value=set(),
+    )
+    @patch("xagent.web.api.kb.rename_collection_storage")
+    async def test_rename_collection_api_admin_renames_all_owner_storage(
+        self,
+        mock_rename_collection_storage,
+        _mock_uploaded_owner_ids,
+        _mock_ensure_collection_access,
+        mock_list_collections,
+        mock_get_vector_store,
+        mock_get_metadata_store,
+        mock_get_ingestion_status_store,
+        tmp_path,
+    ):
+        """Admin global rename should reuse tenant storage rename for every owner."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import ListCollectionsResult
+        from xagent.web.models.user import User
+        from xagent.web.services.kb_collection_service import (
+            CollectionPhysicalRenameResult,
+        )
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 999
+        mock_user.is_admin = True
+
+        mock_list_collections.return_value = ListCollectionsResult(
+            status="success",
+            total_count=0,
+            collections=[],
+            message="",
+            warnings=[],
+        )
+        vector_store = MagicMock()
+        vector_store.list_document_records.return_value = [
+            DocumentRecord(doc_id="doc-a", file_id="file-a", user_id=101),
+            DocumentRecord(doc_id="doc-b", file_id="file-b", user_id=202),
+        ]
+        vector_store.rename_collection_data.return_value = []
+        mock_get_vector_store.return_value = vector_store
+        metadata_store = MagicMock()
+        metadata_store.rename_collection = AsyncMock()
+        metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_get_metadata_store.return_value = metadata_store
+        status_store = MagicMock()
+        status_store.rename_collection_status.return_value = []
+        mock_get_ingestion_status_store.return_value = status_store
+        mock_rename_collection_storage.side_effect = [
+            CollectionPhysicalRenameResult(
+                status="not_found",
+                old_collection_dir=tmp_path / "user_101" / "old",
+                new_collection_dir=tmp_path / "user_101" / "new",
+            ),
+            CollectionPhysicalRenameResult(
+                status="not_found",
+                old_collection_dir=tmp_path / "user_202" / "old",
+                new_collection_dir=tmp_path / "user_202" / "new",
+            ),
+        ]
+
+        result = await rename_collection_api(
+            "old", new_name="new", _user=mock_user, db=MagicMock()
+        )
+
+        assert mock_rename_collection_storage.call_args_list == [
+            call(
+                ANY,
+                user_id=101,
+                old_collection_name="old",
+                new_collection_name="new",
+                collection_file_ids={"file-a"},
+            ),
+            call(
+                ANY,
+                user_id=202,
+                old_collection_name="old",
+                new_collection_name="new",
+                collection_file_ids={"file-b"},
+            ),
+        ]
+        vector_store.rename_collection_data.assert_called_once_with(
+            collection_name="old",
+            new_name="new",
+            user_id=999,
+            is_admin=True,
+        )
+        metadata_store.rename_collection.assert_awaited_once_with(
+            old_name="old",
+            new_name="new",
+            user_id=999,
+            is_admin=True,
+        )
+        status_store.rename_collection_status.assert_called_once_with(
+            old_name="old",
+            new_name="new",
+            user_id=999,
+            is_admin=True,
+        )
+        assert result["status"] == "partial_success"
+
+    @pytest.mark.asyncio
+    @patch("xagent.web.api.kb.get_ingestion_status_store")
+    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch("xagent.web.api.kb._list_collections_with_retry", new_callable=AsyncMock)
+    @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
+    @patch("xagent.web.api.kb.rename_collection_storage")
+    async def test_rename_collection_api_non_admin_is_tenant_scoped(
+        self,
+        mock_rename_collection_storage,
+        _mock_ensure_collection_access,
+        mock_list_collections,
+        mock_get_vector_store,
+        mock_get_metadata_store,
+        mock_get_ingestion_status_store,
+        tmp_path,
+    ):
+        """Regular rename should not mutate another user's same-name collection."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import ListCollectionsResult
+        from xagent.web.models.user import User
+        from xagent.web.services.kb_collection_service import (
+            CollectionPhysicalRenameResult,
+        )
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 101
+        mock_user.is_admin = False
+
+        mock_list_collections.return_value = ListCollectionsResult(
+            status="success",
+            total_count=0,
+            collections=[],
+            message="",
+            warnings=[],
+        )
+        vector_store = MagicMock()
+        vector_store.list_document_records.return_value = [
+            DocumentRecord(doc_id="doc-a", file_id="file-a", user_id=101),
+        ]
+        vector_store.rename_collection_data.return_value = []
+        mock_get_vector_store.return_value = vector_store
+        metadata_store = MagicMock()
+        metadata_store.rename_collection = AsyncMock()
+        mock_get_metadata_store.return_value = metadata_store
+        status_store = MagicMock()
+        status_store.rename_collection_status.return_value = []
+        mock_get_ingestion_status_store.return_value = status_store
+        mock_rename_collection_storage.return_value = CollectionPhysicalRenameResult(
+            status="not_found",
+            old_collection_dir=tmp_path / "user_101" / "old",
+            new_collection_dir=tmp_path / "user_101" / "new",
+        )
+
+        result = await rename_collection_api(
+            "old", new_name="new", _user=mock_user, db=MagicMock()
+        )
+
+        mock_rename_collection_storage.assert_called_once_with(
+            ANY,
+            user_id=101,
+            old_collection_name="old",
+            new_collection_name="new",
+            collection_file_ids={"file-a"},
+        )
+        vector_store.rename_collection_data.assert_called_once_with(
+            collection_name="old",
+            new_name="new",
+            user_id=101,
+            is_admin=False,
+        )
+        metadata_store.rename_collection.assert_awaited_once_with(
+            old_name="old",
+            new_name="new",
+            user_id=101,
+            is_admin=False,
+        )
+        status_store.rename_collection_status.assert_called_once_with(
+            old_name="old",
+            new_name="new",
+            user_id=101,
+            is_admin=False,
+        )
+        assert result["status"] == "partial_success"
+
+    @pytest.mark.asyncio
+    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
+    @patch(
+        "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
+        return_value=set(),
+    )
+    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.web.api.kb.delete_collection_uploaded_files")
+    @patch("xagent.web.api.kb.delete_collection_physical_dir")
+    @patch("xagent.web.api.kb.delete_collection")
+    async def test_delete_collection_api_admin_cleans_stale_config_owner_storage(
+        self,
+        mock_delete_collection,
+        mock_delete_collection_physical_dir,
+        mock_delete_collection_uploaded_files,
+        mock_get_metadata_store,
+        _mock_uploaded_owner_ids,
+        _mock_ensure_collection_access,
+        mock_get_vector_store,
+    ):
+        """Admin delete should clean owners discovered only from stale config."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+        from xagent.web.models.user import User
+        from xagent.web.services.kb_collection_service import (
+            CollectionPhysicalDeleteResult,
+        )
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 999
+        mock_user.is_admin = True
+        mock_get_metadata_store.return_value.list_collection_config_owner_ids.return_value = {
+            101
+        }
+
+        owner_dir = Path("/tmp/uploads/user_101/team")
+        mock_get_vector_store.return_value.list_document_records.side_effect = [[], []]
+        mock_delete_collection_physical_dir.return_value = (
+            CollectionPhysicalDeleteResult(status="success", collection_dir=owner_dir)
+        )
+        mock_delete_collection_uploaded_files.return_value = 1
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="team",
+            message="Collection deleted",
+            warnings=[],
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+
+        mock_delete_collection_physical_dir.assert_called_once_with(
+            user_id=101,
+            collection_name="team",
+        )
+        mock_delete_collection_uploaded_files.assert_called_once_with(
+            ANY,
+            user_id=101,
+            collection_file_ids=set(),
+            remaining_file_ids=set(),
+            collection_dir=owner_dir,
+        )
+        assert result.status == "success"
+
+    @pytest.mark.asyncio
+    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
+    @patch(
+        "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
+        return_value={101},
+    )
+    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.web.api.kb.delete_collection_uploaded_files")
+    @patch("xagent.web.api.kb.delete_collection_physical_dir")
+    @patch("xagent.web.api.kb.delete_collection")
+    async def test_delete_collection_api_admin_cleans_legacy_uploaded_file_owner(
+        self,
+        mock_delete_collection,
+        mock_delete_collection_physical_dir,
+        mock_delete_collection_uploaded_files,
+        mock_get_metadata_store,
+        _mock_uploaded_owner_ids,
+        _mock_ensure_collection_access,
+        mock_get_vector_store,
+    ):
+        """Admin delete should clean owners discovered only from UploadedFile paths."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import (
+            CollectionOperationResult,
+        )
+        from xagent.web.models.user import User
+        from xagent.web.services.kb_collection_service import (
+            CollectionPhysicalDeleteResult,
+        )
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 999
+        mock_user.is_admin = True
+        mock_get_metadata_store.return_value.list_collection_config_owner_ids.return_value = set()
+
+        owner_dir = Path("/tmp/uploads/user_101/team")
+        mock_get_vector_store.return_value.list_document_records.side_effect = [[], []]
+        mock_delete_collection_physical_dir.return_value = (
+            CollectionPhysicalDeleteResult(status="success", collection_dir=owner_dir)
+        )
+        mock_delete_collection_uploaded_files.return_value = 1
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="team",
+            message="Collection deleted",
+            warnings=[],
+            affected_documents=[],
+            deleted_counts={},
+        )
+
+        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+
+        mock_delete_collection_physical_dir.assert_called_once_with(
+            user_id=101,
+            collection_name="team",
+        )
+        mock_delete_collection_uploaded_files.assert_called_once_with(
+            ANY,
+            user_id=101,
+            collection_file_ids=set(),
+            remaining_file_ids=set(),
+            collection_dir=owner_dir,
+        )
         assert result.status == "success"
 
 

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -172,6 +172,63 @@ def _make_delete_tracker():
     return deleted_doc_ids, _fake_delete_document
 
 
+def test_list_collection_uploaded_file_owner_ids_uses_strict_path_containment(
+    test_env,
+    temp_uploads,
+):
+    """UploadedFile owner discovery should not confuse similar collection paths."""
+    _, _, user, TestingSessionLocal = test_env
+    from xagent.web.services.kb_collection_service import (
+        list_collection_uploaded_file_owner_ids,
+    )
+
+    session = TestingSessionLocal()
+    try:
+        matching_path = temp_uploads / f"user_{user.id}" / "FAQ" / "a.pdf"
+        similar_path = temp_uploads / f"user_{user.id}" / "FAQ-old" / "b.pdf"
+        unrelated_path = temp_uploads / f"user_{user.id}" / "Other" / "c.pdf"
+        for path in (matching_path, similar_path, unrelated_path):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("data")
+
+        session.add_all(
+            [
+                UploadedFile(
+                    file_id="match",
+                    user_id=user.id,
+                    filename="a.pdf",
+                    storage_path=str(matching_path),
+                    file_size=1,
+                ),
+                UploadedFile(
+                    file_id="similar",
+                    user_id=user.id,
+                    filename="b.pdf",
+                    storage_path=str(similar_path),
+                    file_size=1,
+                ),
+                UploadedFile(
+                    file_id="unrelated",
+                    user_id=user.id,
+                    filename="c.pdf",
+                    storage_path=str(unrelated_path),
+                    file_size=1,
+                ),
+            ]
+        )
+        session.commit()
+
+        assert list_collection_uploaded_file_owner_ids(
+            session, collection_name="FAQ"
+        ) == {user.id}
+        assert (
+            list_collection_uploaded_file_owner_ids(session, collection_name="Missing")
+            == set()
+        )
+    finally:
+        session.close()
+
+
 def test_kb_ingest_creates_collection_dir(test_env, temp_uploads):
     """Test that ingesting a document creates a collection-specific directory"""
     app, headers, user, _ = test_env
@@ -1201,7 +1258,6 @@ def test_kb_delete_physical_cleanup_failure_preserves_uploaded_file_records(
     db.close()
 
     with (
-        patch("xagent.web.api.kb._check_can_delete_collection"),
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
         patch(
             "xagent.web.api.kb.delete_collection_physical_dir"
@@ -1418,9 +1474,7 @@ def test_kb_rename_physical_directory_rename(test_env, temp_uploads):
         ) as mock_list_tables,
         patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.status.load_ingestion_status"
-        ) as mock_load_status,
+        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1439,7 +1493,7 @@ def test_kb_rename_physical_directory_rename(test_env, temp_uploads):
         mock_rename_storage.return_value = mock_rename_result
 
         # Mock ingestion status operations
-        mock_load_status.return_value = []
+        mock_get_status_store.return_value.rename_collection_status.return_value = []
 
         # Attempt rename
         response = client.put(
@@ -1472,9 +1526,7 @@ def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
         ) as mock_list_tables,
         patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.status.load_ingestion_status"
-        ) as mock_load_status,
+        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1492,7 +1544,7 @@ def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
         mock_rename_result.new_collection_dir = None
         mock_rename_storage.return_value = mock_rename_result
 
-        mock_load_status.return_value = []
+        mock_get_status_store.return_value.rename_collection_status.return_value = []
 
         response = client.put(
             "/api/kb/collections/%20%20team%20notes%20%20",
@@ -1529,9 +1581,7 @@ def test_kb_rename_accepts_unicode_collection_name(test_env, temp_uploads):
         ) as mock_list_tables,
         patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.status.load_ingestion_status"
-        ) as mock_load_status,
+        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1549,7 +1599,7 @@ def test_kb_rename_accepts_unicode_collection_name(test_env, temp_uploads):
         mock_rename_result.new_collection_dir = None
         mock_rename_storage.return_value = mock_rename_result
 
-        mock_load_status.return_value = []
+        mock_get_status_store.return_value.rename_collection_status.return_value = []
 
         response = client.put(
             f"/api/kb/collections/{quote(old_collection_name, safe='')}",
@@ -1748,9 +1798,7 @@ def test_delete_after_rename_not_denied_by_stale_list_collections(test_env):
         patch("xagent.web.api.kb._list_collections_with_retry") as mock_retry,
         patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.status.load_ingestion_status"
-        ) as mock_load_status,
+        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
     ):
         mock_retry.side_effect = [stale_old_only, stale_old_only]
         mock_store = MagicMock()
@@ -1763,7 +1811,7 @@ def test_delete_after_rename_not_denied_by_stale_list_collections(test_env):
         mock_rename_result.old_collection_dir = None
         mock_rename_result.new_collection_dir = None
         mock_rename_storage.return_value = mock_rename_result
-        mock_load_status.return_value = []
+        mock_get_status_store.return_value.rename_collection_status.return_value = []
 
         rename_resp = client.put(
             f"/api/kb/collections/{old_collection_name}",
@@ -1843,9 +1891,7 @@ def test_delete_after_rename_not_blocked_when_new_collection_is_visible(test_env
         patch("xagent.web.api.kb._list_collections_with_retry") as mock_retry,
         patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.status.load_ingestion_status"
-        ) as mock_load_status,
+        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
     ):
         mock_retry.side_effect = [visible_old, visible_old]
         mock_store = MagicMock()
@@ -1858,7 +1904,7 @@ def test_delete_after_rename_not_blocked_when_new_collection_is_visible(test_env
         mock_rename_result.old_collection_dir = None
         mock_rename_result.new_collection_dir = None
         mock_rename_storage.return_value = mock_rename_result
-        mock_load_status.return_value = []
+        mock_get_status_store.return_value.rename_collection_status.return_value = []
 
         rename_resp = client.put(
             f"/api/kb/collections/{old_collection_name}",

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -165,17 +165,18 @@ def test_ingest_separators_valid_json_passed_to_config(app_with_kb, mock_user):
     assert captured_config[0].separators == ["\n\n", "\n", "。"]
 
 
-def test_delete_collection_forbidden_for_non_admin_with_other_users_docs(
+def test_delete_collection_removes_only_current_user_docs_when_name_is_shared(
     app_with_kb, mock_user
 ):
-    """Non-admin is rejected by _ensure_collection_access before delete_collection."""
+    """Non-admin deletes own documents even when other users share the collection name."""
     with (
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
         patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
+        patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch("xagent.web.api.kb.delete_collection_uploaded_files", return_value=0),
     ):
         mock_store = MagicMock()
         mock_get_vector_store.return_value = mock_store
-        mock_store.list_document_records.return_value = []
         # Simulate total_count=5 and own_count=3 for the same collection.
         mock_store.count_documents_grouped_by_collection.side_effect = [
             {"test_collection": 5},
@@ -183,44 +184,67 @@ def test_delete_collection_forbidden_for_non_admin_with_other_users_docs(
             {"test_collection": 5},
             {"test_collection": 3},
         ]
+        mock_store.list_document_records.side_effect = [[], []]
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="test_collection",
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+        mock_physical.return_value = MagicMock(
+            status="not_found", error=None, collection_dir=None
+        )
 
         client = TestClient(app_with_kb)
         resp = client.delete("/api/kb/collections/test_collection")
 
-    assert resp.status_code == 403
-    detail = resp.json()["detail"]
-    assert (
-        "Only admin users can delete collections containing documents from other users."
-        in detail
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    mock_delete_collection.assert_called_once_with(
+        "test_collection", mock_user.id, False
     )
-    mock_delete_collection.assert_not_called()
 
 
 def test_delete_collection_rechecks_permission_before_full_delete(
     app_with_kb, mock_user
 ):
-    """Single delete must not use stale ownership state for destructive delete."""
+    """Single delete rechecks live state but mixed ownership still deletes only own docs."""
     with (
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
         patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
         patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch("xagent.web.api.kb.delete_collection_uploaded_files", return_value=0),
     ):
         mock_store = MagicMock()
         mock_get_vector_store.return_value = mock_store
         mock_store.count_documents_grouped_by_collection.side_effect = [
-            {"test_collection": 1},
+            {"test_collection": 2},
             {"test_collection": 1},
             {"test_collection": 2},
             {"test_collection": 1},
         ]
+        mock_store.list_document_records.side_effect = [[], []]
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="test_collection",
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+        mock_physical.return_value = MagicMock(
+            status="not_found", error=None, collection_dir=None
+        )
 
         client = TestClient(app_with_kb)
         resp = client.delete("/api/kb/collections/test_collection")
 
-    assert resp.status_code == 403
-    assert "Only admin users can delete collections" in resp.json()["detail"]
-    mock_delete_collection.assert_not_called()
-    mock_physical.assert_not_called()
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    mock_delete_collection.assert_called_once_with(
+        "test_collection", mock_user.id, False
+    )
+    mock_physical.assert_called_once()
 
 
 def test_delete_collection_removes_stale_config_without_deleting_other_users_docs(
@@ -366,8 +390,10 @@ def test_batch_config_only_preflight_can_become_full_delete(app_with_kb, mock_us
     mock_metadata_store.delete_collection.assert_not_called()
 
 
-def test_batch_delete_rechecks_permission_before_full_delete(app_with_kb, mock_user):
-    """A stale batch preflight must not authorize a now mixed-owner delete."""
+def test_batch_delete_rechecks_and_deletes_only_current_user_docs_for_shared_name(
+    app_with_kb, mock_user
+):
+    """A stale batch preflight rechecks, then tenant-scoped delete handles mixed ownership."""
     mock_metadata_store = MagicMock()
     mock_metadata_store.delete_collection = AsyncMock(return_value=None)
 
@@ -375,6 +401,7 @@ def test_batch_delete_rechecks_permission_before_full_delete(app_with_kb, mock_u
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
         patch("xagent.web.api.kb.delete_collection") as mock_delete_collection,
         patch("xagent.web.api.kb.delete_collection_physical_dir") as mock_physical,
+        patch("xagent.web.api.kb.delete_collection_uploaded_files", return_value=0),
         patch(
             "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
             return_value=mock_metadata_store,
@@ -388,6 +415,17 @@ def test_batch_delete_rechecks_permission_before_full_delete(app_with_kb, mock_u
             {"test_collection": 2},
             {"test_collection": 1},
         ]
+        mock_store.list_document_records.side_effect = [[], []]
+        mock_delete_collection.return_value = CollectionOperationResult(
+            status="success",
+            collection="test_collection",
+            message="deleted",
+            affected_documents=[],
+            deleted_counts={},
+        )
+        mock_physical.return_value = MagicMock(
+            status="not_found", error=None, collection_dir=None
+        )
 
         client = TestClient(app_with_kb)
         resp = client.post(
@@ -397,12 +435,12 @@ def test_batch_delete_rechecks_permission_before_full_delete(app_with_kb, mock_u
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["deleted"] == []
-    assert len(body["failed"]) == 1
-    assert body["failed"][0]["name"] == "test_collection"
-    assert "Only admin users can delete collections" in body["failed"][0]["error"]
-    mock_delete_collection.assert_not_called()
-    mock_physical.assert_not_called()
+    assert body["deleted"] == ["test_collection"]
+    assert body["failed"] == []
+    mock_delete_collection.assert_called_once_with(
+        "test_collection", mock_user.id, False
+    )
+    mock_physical.assert_called_once()
     mock_metadata_store.delete_collection.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
Tightens KB collection delete and rename behavior around tenant-scoped and admin-scoped mutations.

## Changes
- Scope regular user collection mutations to `user_id + collection_name`.
- Keep admin collection mutations global across owners.
- Move collection config owner discovery into the metadata store abstraction.
- Move UploadedFile owner discovery into the KB collection service.
- Add scoped ingestion status rename support.
- Avoid using global collection metadata stats for regular user collection lists.
- Expand regression coverage for mixed-owner collections, stale config cleanup, UploadedFile cleanup, and scoped rename/delete behavior.

## Test Plan
- `uv run ruff check src/xagent/web/api/kb.py src/xagent/web/services/kb_collection_service.py src/xagent/core/tools/core/RAG_tools/storage/contracts.py src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py tests/core/tools/core/RAG_tools/test_multitenancy.py tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py tests/web/api/test_kb_dir.py`
- `git diff --check`
- `uv run pytest tests/core/tools/core/RAG_tools/test_multitenancy.py tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py tests/web/api/test_kb_ingest_separators.py tests/core/tools/core/RAG_tools/management/test_collections.py tests/web/api/test_kb_dir.py::test_kb_delete_physical_cleanup_failure_preserves_uploaded_file_records tests/web/api/test_kb_dir.py::test_list_collection_uploaded_file_owner_ids_uses_strict_path_containment`