### PR TITLE
fix: restore user message file attachments

### DIFF
--- a/frontend/src/components/chat/user-message-content.tsx
+++ b/frontend/src/components/chat/user-message-content.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import React from "react"
+
+import { FileAttachment } from "@/components/file/file-attachment"
+import type { ChatFileInfo } from "@/lib/chat-files"
+
+interface BuildUserMessageContentOptions {
+  scrollableText?: boolean
+  onPreview?: (file: ChatFileInfo) => void
+}
+
+export function buildUserMessageContent(
+  message: string,
+  files: ChatFileInfo[],
+  options: BuildUserMessageContentOptions = {},
+): React.ReactNode {
+  if (files.length === 0) {
+    return message
+  }
+
+  const textClassName = options.scrollableText
+    ? "whitespace-pre-wrap max-h-60 overflow-y-auto"
+    : undefined
+
+  return (
+    <div className="space-y-2">
+      <div className={textClassName}>{message}</div>
+      <FileAttachment
+        files={files}
+        variant="user-message"
+        onPreview={options.onPreview}
+      />
+    </div>
+  )
+}
+
+export function userMessagePreviewFiles(files: ChatFileInfo[]) {
+  return files
+    .map((file) => ({
+      fileId: file.file_id || "",
+      fileName: file.name,
+    }))
+    .filter((file) => !!file.fileId)
+}

--- a/frontend/src/components/preview-sheet.tsx
+++ b/frontend/src/components/preview-sheet.tsx
@@ -17,11 +17,11 @@ export function PreviewSheet({ open, onOpenChange, title, actions, children }: P
   return (
     <div className="w-full border rounded-xl overflow-hidden bg-background flex flex-col h-[100%] shadow-lg">
       <div data-slot="sheet-header" className="flex flex-col gap-1.5 p-4 flex-shrink-0 bg-background/80 backdrop-blur-sm border-b">
-        <div className="flex items-center justify-between">
-          <h3 data-slot="sheet-title" className="text-foreground font-semibold flex items-center gap-2">
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <h3 data-slot="sheet-title" className="min-w-0 flex-1 truncate text-foreground font-semibold">
             {title}
           </h3>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             {actions}
             <Button
               variant="outline"

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation"
 import { FileText, Target, Zap, CheckCircle, XCircle, Wrench, Activity, Search, Lightbulb, AlertTriangle, Info, Brain, Bot } from "lucide-react"
 import { JsonRenderer, MarkdownRenderer } from "../components/ui/markdown-renderer"
 import { FileAttachment } from "@/components/file/file-attachment"
+import { buildUserMessageContent, userMessagePreviewFiles } from "@/components/chat/user-message-content"
 import { ReplayScheduler } from '@/lib/replay-scheduler'
 import { CollapsibleSection } from "@/components/collapsible-section"
 import { Badge } from "@/components/ui/badge"
 import { ClarificationForm } from "@/components/chat/clarification-form"
+import { extractUserMessageFiles } from "@/lib/chat-files"
 
 interface WebSocketMessage {
   type: string
@@ -40,6 +42,7 @@ import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLO
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { unwrapFinalAnswerContent } from "@/lib/final-answer"
+import { upsertUserMessageAttachment } from "@/lib/chat-message-upsert"
 
 // Unique ID generator for messages
 let messageIdCounter = 0
@@ -258,6 +261,7 @@ interface Message {
   isFileOutput?: boolean
   traceEvents?: TraceEvent[]
   interactions?: Interaction[]
+  hasFileAttachments?: boolean
 }
 
 interface Task {
@@ -405,6 +409,7 @@ interface AppState {
 type AppAction =
   | { type: "SET_TASK_ID"; payload: number | null }
   | { type: "ADD_MESSAGE"; payload: Message }
+  | { type: "UPSERT_USER_MESSAGE_ATTACHMENT"; payload: { matchText: string; message: Message } }
   | { type: "SET_CURRENT_TASK"; payload: Task }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[] } }
   | { type: "TRIGGER_TASK_UPDATE" }
@@ -470,6 +475,14 @@ const initialState: AppState = {
   isHistoryLoading: false,
 }
 
+const normalizeMessagePayload = (message: Message): Message => ({
+  ...message,
+  rawContent:
+    message.rawContent ??
+    (typeof message.content === "string" ? message.content : undefined),
+  hasFileAttachments: message.hasFileAttachments ?? false,
+})
+
 function appReducer(state: AppState, action: AppAction): AppState {
   console.log('🔍 Reducer called with action:', action.type, action)
 
@@ -499,7 +512,7 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return newState
 
     case "ADD_MESSAGE": {
-      const newMessage = action.payload
+      const newMessage = normalizeMessagePayload(action.payload)
       let messageToAdd = newMessage
       let newTraceEvents = state.traceEvents
 
@@ -516,6 +529,22 @@ function appReducer(state: AppState, action: AppAction): AppState {
         return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
       })
       return { ...state, messages: updatedMessages, traceEvents: newTraceEvents }
+    }
+
+    case "UPSERT_USER_MESSAGE_ATTACHMENT": {
+      const messageToAdd = normalizeMessagePayload(action.payload.message)
+      const messages = upsertUserMessageAttachment(
+        state.messages,
+        action.payload.matchText,
+        messageToAdd,
+      )
+      if (messages === state.messages) {
+        return state
+      }
+      messages.sort((a, b) => {
+        return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
+      })
+      return { ...state, messages }
     }
 
     case "SET_CURRENT_TASK":
@@ -1023,6 +1052,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               id: generateMessageId("msg-user"),
               role: "user",
               content: messageContent,
+              rawContent: messageContent,
               timestamp: message.timestamp?.toString() || Date.now().toString(),
             }
           })
@@ -1144,6 +1174,34 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               timestamp: message.timestamp
             })
 
+            const files = extractUserMessageFiles(eventData)
+            const onPreview = (file: typeof files[number]) => {
+              const currentFileId = file.file_id || ""
+              if (!currentFileId) {
+                return
+              }
+              const normalizedFiles = userMessagePreviewFiles(files)
+              dispatch({
+                type: "OPEN_FILE_PREVIEW",
+                payload: {
+                  fileId: currentFileId,
+                  fileName: file.name,
+                  files: normalizedFiles,
+                  index: normalizedFiles.findIndex(
+                    (previewFile) => previewFile.fileId === currentFileId,
+                  )
+                }
+              })
+            }
+            const content = buildUserMessageContent(messageContent, files, {
+              scrollableText: true,
+              onPreview,
+            })
+
+            console.log('📁 Files extracted:', files)
+            console.log('🔍 Context structure:', eventData.context)
+            console.log('🔍 State structure:', eventData.context?.state)
+
             // Check if this is a duplicate message
             // Note: We don't cache messages from WebSocket to prevent blocking subsequent identical messages
             // This is especially important for historical data loading where we might receive multiple identical messages
@@ -1156,52 +1214,23 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
             if (isDuplicate) {
               console.log('⚠️ User message filtered as duplicate:', messageContent)
+              if (files.length > 0) {
+                dispatch({
+                  type: "UPSERT_USER_MESSAGE_ATTACHMENT",
+                  payload: {
+                    matchText: messageContent,
+                    message: {
+                      id: generateMessageId("msg-user"),
+                      role: "user",
+                      content,
+                      rawContent: messageContent,
+                      timestamp: message.timestamp,
+                      hasFileAttachments: true,
+                    },
+                  },
+                })
+              }
               return
-            }
-
-            // Extract files from context.state.file_info (based on the actual WS event structure)
-            let files = eventData.files || []
-            if (eventData.context && eventData.context.state && eventData.context.state.file_info) {
-              files = eventData.context.state.file_info
-            }
-
-            console.log('📁 Files extracted:', files)
-            console.log('🔍 Context structure:', eventData.context)
-            console.log('🔍 State structure:', eventData.context?.state)
-
-            // Create message content with file attachments
-            let content: React.ReactNode = messageContent
-
-            if (files.length > 0) {
-              content = (
-                <div className="space-y-2">
-                  <div className="whitespace-pre-wrap max-h-60 overflow-y-auto">{messageContent}</div>
-                  <FileAttachment
-                    files={files}
-                    variant="user-message"
-                    onPreview={(file) => {
-                      const currentFileId = file.file_id || ""
-                      const normalizedFiles = files.map((f: any) => ({
-                        fileId: f.file_id || "",
-                        fileName: f.name,
-                      })).filter((item: { fileId: string }) => !!item.fileId)
-
-                      if (!currentFileId) {
-                        return
-                      }
-                      dispatch({
-                        type: "OPEN_FILE_PREVIEW",
-                        payload: {
-                          fileId: currentFileId,
-                          fileName: file.name,
-                          files: normalizedFiles,
-                          index: normalizedFiles.findIndex((f: any) => f.fileId === currentFileId)
-                        }
-                      })
-                    }}
-                  />
-                </div>
-              )
             }
 
             console.log('📤 Dispatching user message:', {
@@ -1215,7 +1244,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               id: generateMessageId("msg-user"),
               role: "user" as const,
               content: content,
+              rawContent: messageContent,
               timestamp: message.timestamp,
+              hasFileAttachments: files.length > 0,
             }
 
             console.log('📤 Message payload:', messagePayload)
@@ -3796,7 +3827,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 id: optimisticId,
                 role: "user",
                 content: content,
+                rawContent: message,
                 timestamp: Date.now().toString(),
+                hasFileAttachments: !!(files && files.length > 0),
               }
             })
           }
@@ -3849,7 +3882,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             id: generateMessageId("msg-user-optimistic"),
             role: "user",
             content: content,
+            rawContent: message,
             timestamp: Date.now().toString(),
+            hasFileAttachments: !!(files && files.length > 0),
           }
         })
 

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -3,10 +3,12 @@
 import React, { createContext, useContext, useReducer, useCallback, useEffect, useState, useRef } from "react"
 import { FileText, Target, Zap, CheckCircle, XCircle, Clock, Wrench, Activity, Search, Lightbulb, AlertTriangle, Info, Brain, Bot, Sparkles } from "lucide-react"
 import { JsonRenderer } from "../components/ui/markdown-renderer"
-import { FileAttachment } from "@/components/file/file-attachment"
+import { buildUserMessageContent } from "@/components/chat/user-message-content"
 import { ReplayScheduler } from '@/lib/replay-scheduler'
 import { CollapsibleSection } from "../components/collapsible-section"
 import { Badge } from "@/components/ui/badge"
+import { extractUserMessageFiles } from "@/lib/chat-files"
+import { upsertUserMessageAttachment } from "@/lib/chat-message-upsert"
 
 interface WebSocketMessage {
   type: string
@@ -23,6 +25,7 @@ import { getApiUrl, getUploadApiUrl } from "@/lib/utils"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { unwrapFinalAnswerContent } from "@/lib/final-answer"
+import { normalizeTimestampMs } from "@/lib/time-utils"
 
 // Unique ID generator for messages
 let messageIdCounter = 0
@@ -136,10 +139,12 @@ interface Message {
   id: string
   role: "user" | "assistant"
   content: string | React.ReactNode
+  rawContent?: string
   timestamp: string
   status?: "pending" | "running" | "completed" | "failed"
   isResult?: boolean
   isFileOutput?: boolean
+  hasFileAttachments?: boolean
   interactions?: unknown[]
 }
 
@@ -282,6 +287,7 @@ interface AppState {
 type AppAction =
   | { type: "SET_TASK_ID"; payload: number | null }
   | { type: "ADD_MESSAGE"; payload: Message }
+  | { type: "UPSERT_USER_MESSAGE_ATTACHMENT"; payload: { matchText: string; message: Message } }
   | { type: "SET_CURRENT_TASK"; payload: Task }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: unknown[] } }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
@@ -340,6 +346,14 @@ const initialState: AppState = {
   planMemoryInfo: null,
 }
 
+const normalizeMessagePayload = (message: Message): Message => ({
+  ...message,
+  rawContent:
+    message.rawContent ??
+    (typeof message.content === "string" ? message.content : undefined),
+  hasFileAttachments: message.hasFileAttachments ?? false,
+})
+
 function appReducer(state: AppState, action: AppAction): AppState {
   console.log('🔍 Reducer called with action:', action.type, action)
 
@@ -355,15 +369,29 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return newState
 
     case "ADD_MESSAGE":
-      const newMessage = action.payload
+      const newMessage = normalizeMessagePayload(action.payload)
       const updatedMessages = [...state.messages, newMessage]
       // Sort messages by timestamp
       updatedMessages.sort((a, b) => {
-        const timeA = typeof a.timestamp === 'number' ? a.timestamp : new Date(a.timestamp).getTime()
-        const timeB = typeof b.timestamp === 'number' ? b.timestamp : new Date(b.timestamp).getTime()
-        return timeA - timeB
+        return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
       })
       return { ...state, messages: updatedMessages }
+
+    case "UPSERT_USER_MESSAGE_ATTACHMENT": {
+      const messageToAdd = normalizeMessagePayload(action.payload.message)
+      const messages = upsertUserMessageAttachment(
+        state.messages,
+        action.payload.matchText,
+        messageToAdd,
+      )
+      if (messages === state.messages) {
+        return state
+      }
+      messages.sort((a, b) => {
+        return normalizeTimestampMs(a.timestamp) - normalizeTimestampMs(b.timestamp)
+      })
+      return { ...state, messages }
+    }
 
     case "SET_CURRENT_TASK":
       return { ...state, currentTask: action.payload }
@@ -848,30 +876,34 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
             if (isDuplicate) {
               console.log('⚠️ User message filtered as duplicate:', messageContent)
+              const files = extractUserMessageFiles(eventData)
+              if (files.length > 0) {
+                dispatch({
+                  type: "UPSERT_USER_MESSAGE_ATTACHMENT",
+                  payload: {
+                    matchText: messageContent,
+                    message: {
+                      id: generateMessageId("msg-user"),
+                      role: "user",
+                      content: buildUserMessageContent(messageContent, files),
+                      rawContent: messageContent,
+                      timestamp: message.timestamp,
+                      hasFileAttachments: true,
+                    },
+                  },
+                })
+              }
               return
             }
 
-            // Extract files from context.state.file_info (based on the actual WS event structure)
-            let files = eventData.files || []
-            if (eventData.context && eventData.context.state && eventData.context.state.file_info) {
-              files = eventData.context.state.file_info
-            }
+            const files = extractUserMessageFiles(eventData)
 
             console.log('📁 Files extracted:', files)
             console.log('🔍 Context structure:', eventData.context)
             console.log('🔍 State structure:', eventData.context?.state)
 
             // Create message content with file attachments
-            let content: React.ReactNode = messageContent
-
-            if (files.length > 0) {
-              content = (
-                <div className="space-y-2">
-                  <div>{messageContent}</div>
-                  <FileAttachment files={files} variant="user-message" />
-                </div>
-              )
-            }
+            const content = buildUserMessageContent(messageContent, files)
 
             console.log('📤 Dispatching user message:', {
               content,
@@ -884,7 +916,9 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               id: generateMessageId("msg-user"),
               role: "user" as const,
               content: content,
+              rawContent: messageContent,
               timestamp: message.timestamp,
+              hasFileAttachments: files.length > 0,
             }
 
             console.log('📤 Message payload:', messagePayload)

--- a/frontend/src/lib/chat-files.test.ts
+++ b/frontend/src/lib/chat-files.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest"
+
+import { extractUserMessageFiles } from "./chat-files"
+
+describe("extractUserMessageFiles", () => {
+  it("reads the stable top-level files shape first", () => {
+    expect(
+      extractUserMessageFiles({
+        files: [
+          {
+            file_id: "file-1",
+            name: "brief.md",
+            size: 42,
+            type: "text/markdown",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        file_id: "file-1",
+        name: "brief.md",
+        size: 42,
+        type: "text/markdown",
+      },
+    ])
+  })
+
+  it("falls back to historical context locations", () => {
+    expect(
+      extractUserMessageFiles({
+        context: {
+          messages: [
+            {
+              role: "user",
+              metadata: {
+                files: [
+                  {
+                    file_id: "file-2",
+                    filename: "meta-image-upload.md",
+                    file_size: "3552",
+                    mime_type: "text/markdown",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        file_id: "file-2",
+        name: "meta-image-upload.md",
+        size: 3552,
+        type: "text/markdown",
+      },
+    ])
+  })
+
+  it("does not reuse files from historical user messages", () => {
+    expect(
+      extractUserMessageFiles({
+        context: {
+          messages: [
+            {
+              role: "user",
+              metadata: {
+                files: [
+                  {
+                    file_id: "old-file",
+                    filename: "old.md",
+                    file_size: 42,
+                    mime_type: "text/markdown",
+                  },
+                ],
+              },
+            },
+            {
+              role: "assistant",
+              content: "Done",
+            },
+            {
+              role: "user",
+              content: "Summarize this",
+            },
+          ],
+        },
+      }),
+    ).toEqual([])
+  })
+
+  it("only falls back to files on the latest user message", () => {
+    expect(
+      extractUserMessageFiles({
+        context: {
+          messages: [
+            {
+              role: "user",
+              metadata: {
+                files: [
+                  {
+                    file_id: "old-file",
+                    filename: "old.md",
+                    file_size: 42,
+                    mime_type: "text/markdown",
+                  },
+                ],
+              },
+            },
+            {
+              role: "user",
+              metadata: {
+                files: [
+                  {
+                    file_id: "new-file",
+                    filename: "new.md",
+                    file_size: 84,
+                    mime_type: "text/markdown",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        file_id: "new-file",
+        name: "new.md",
+        size: 84,
+        type: "text/markdown",
+      },
+    ])
+  })
+
+  it("normalizes dirty data and deduplicates by file id", () => {
+    expect(
+      extractUserMessageFiles({
+        files: [
+          { file_id: "file-1", name: "brief.md", size: "bad" },
+          { file_id: "file-1", name: "brief.md", size: 42 },
+          { name: "loose.txt", size: 3, type: "text/plain" },
+          { name: "loose.txt", size: 3, type: "text/plain" },
+          { size: 99, type: "text/plain" },
+        ],
+      }),
+    ).toEqual([
+      {
+        file_id: "file-1",
+        name: "brief.md",
+        size: 0,
+        type: "",
+      },
+      {
+        name: "loose.txt",
+        size: 3,
+        type: "text/plain",
+      },
+    ])
+  })
+})

--- a/frontend/src/lib/chat-files.ts
+++ b/frontend/src/lib/chat-files.ts
@@ -1,0 +1,126 @@
+export interface ChatFileInfo {
+  file_id?: string
+  name: string
+  size: number
+  type: string
+  path?: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asFileArray = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : []
+
+const normalizeFile = (value: unknown): ChatFileInfo | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const rawFileId = value.file_id ?? value.id
+  const fileId = typeof rawFileId === "string" ? rawFileId.trim() : ""
+  const rawName = value.name ?? value.original_name ?? value.filename
+  const name = typeof rawName === "string" ? rawName.trim() : ""
+  if (!fileId && !name) {
+    return null
+  }
+
+  const rawSize = value.size ?? value.file_size
+  const size = typeof rawSize === "number"
+    ? rawSize
+    : Number.isFinite(Number(rawSize))
+      ? Number(rawSize)
+      : 0
+  const rawType = value.type ?? value.mime_type
+  const type = typeof rawType === "string" ? rawType : ""
+  const rawPath = value.path
+
+  return {
+    ...(fileId ? { file_id: fileId } : {}),
+    name,
+    size,
+    type,
+    ...(typeof rawPath === "string" ? { path: rawPath } : {}),
+  }
+}
+
+const addFiles = (
+  target: ChatFileInfo[],
+  seen: Set<string>,
+  values: unknown,
+) => {
+  for (const value of asFileArray(values)) {
+    const file = normalizeFile(value)
+    if (!file) {
+      continue
+    }
+    const key = file.file_id || `${file.name}:${file.size}:${file.type}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    target.push(file)
+  }
+}
+
+const latestUserMessage = (messages: unknown): Record<string, unknown> | null => {
+  const messageList = asFileArray(messages)
+  for (let index = messageList.length - 1; index >= 0; index -= 1) {
+    const message = messageList[index]
+    if (isRecord(message) && message.role === "user") {
+      return message
+    }
+  }
+  return null
+}
+
+export function extractUserMessageFiles(eventData: unknown): ChatFileInfo[] {
+  if (!isRecord(eventData)) {
+    return []
+  }
+
+  const files: ChatFileInfo[] = []
+  const seen = new Set<string>()
+
+  addFiles(files, seen, eventData.files)
+
+  const context = isRecord(eventData.context) ? eventData.context : null
+  if (context) {
+    addFiles(files, seen, context.files)
+    addFiles(files, seen, context.file_info)
+
+    const state = isRecord(context.state) ? context.state : null
+    if (state) {
+      addFiles(files, seen, state.file_info)
+    }
+
+    const metadata = isRecord(context.metadata) ? context.metadata : null
+    if (metadata) {
+      addFiles(files, seen, metadata.files)
+      addFiles(files, seen, metadata.file_info)
+
+      const requestContext = isRecord(metadata.request_context)
+        ? metadata.request_context
+        : null
+      if (requestContext) {
+        addFiles(files, seen, requestContext.files)
+        addFiles(files, seen, requestContext.file_info)
+      }
+    }
+
+    if (files.length > 0) {
+      return files
+    }
+
+    const message = latestUserMessage(context.messages)
+    const messageMetadata = message && isRecord(message.metadata)
+      ? message.metadata
+      : null
+    if (messageMetadata) {
+      addFiles(files, seen, messageMetadata.files)
+      addFiles(files, seen, messageMetadata.file_info)
+    }
+  }
+
+  return files
+}

--- a/frontend/src/lib/chat-message-upsert.test.ts
+++ b/frontend/src/lib/chat-message-upsert.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type UserMessageAttachmentState,
+  upsertUserMessageAttachment,
+} from "./chat-message-upsert"
+
+describe("upsertUserMessageAttachment", () => {
+  it("replaces a matching plain user message with the attachment version", () => {
+    const result = upsertUserMessageAttachment(
+      [
+        { role: "assistant", content: "hello" },
+        { role: "user", content: "Read file" },
+      ],
+      "Read file",
+      {
+        role: "user",
+        content: "Read file with files",
+        rawContent: "Read file",
+        hasFileAttachments: true,
+      },
+    )
+
+    expect(result).toEqual([
+      { role: "assistant", content: "hello" },
+      {
+        role: "user",
+        content: "Read file with files",
+        rawContent: "Read file",
+        hasFileAttachments: true,
+      },
+    ])
+  })
+
+  it("does not rewrite assistant messages or different user messages", () => {
+    const plain: UserMessageAttachmentState[] = [
+      { role: "assistant", content: "Read file" },
+      { role: "user", content: "Other request" },
+    ]
+    const result = upsertUserMessageAttachment(plain, "Read file", {
+      role: "user",
+      content: "Read file with files",
+      rawContent: "Read file",
+      hasFileAttachments: true,
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toBe(plain[0])
+    expect(result[1]).toBe(plain[1])
+    expect(result[2]).toEqual({
+      role: "user",
+      content: "Read file with files",
+      rawContent: "Read file",
+      hasFileAttachments: true,
+    })
+  })
+
+  it("does not add another message when one already has attachments", () => {
+    const messages = [
+      {
+        role: "user",
+        content: "Read file with files",
+        rawContent: "Read file",
+        hasFileAttachments: true,
+      },
+    ]
+
+    expect(
+      upsertUserMessageAttachment(messages, "Read file", {
+        role: "user",
+        content: "replacement",
+        rawContent: "Read file",
+        hasFileAttachments: true,
+      }),
+    ).toBe(messages)
+  })
+})

--- a/frontend/src/lib/chat-message-upsert.ts
+++ b/frontend/src/lib/chat-message-upsert.ts
@@ -1,0 +1,44 @@
+export interface UserMessageAttachmentState {
+  role: string
+  content: unknown
+  rawContent?: string
+  hasFileAttachments?: boolean
+}
+
+export const userMessageText = (message: UserMessageAttachmentState): string => {
+  if (message.rawContent) {
+    return message.rawContent.trim()
+  }
+  return typeof message.content === "string" ? message.content.trim() : ""
+}
+
+export function upsertUserMessageAttachment<
+  T extends UserMessageAttachmentState,
+>(messages: T[], matchText: string, messageWithAttachments: T): T[] {
+  const normalizedMatchText = matchText.trim()
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (
+      message.role === "user" &&
+      !message.hasFileAttachments &&
+      userMessageText(message) === normalizedMatchText
+    ) {
+      const nextMessages = [...messages]
+      nextMessages[index] = messageWithAttachments
+      return nextMessages
+    }
+  }
+
+  const alreadyHasAttachments = messages.some(
+    (message) =>
+      message.role === "user" &&
+      message.hasFileAttachments === true &&
+      userMessageText(message) === normalizedMatchText,
+  )
+  if (alreadyHasAttachments) {
+    return messages
+  }
+
+  return [...messages, messageWithAttachments]
+}

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -75,6 +75,25 @@ def _file_integrity_failed() -> HTTPException:
     )
 
 
+def _download_content_disposition(media_type: str) -> str:
+    return (
+        "inline"
+        if media_type.startswith(("image/", "video/", "audio/", "text/"))
+        else "attachment"
+    )
+
+
+def _download_file_response(
+    path: Path, file_name: str, media_type: str
+) -> FileResponse:
+    return FileResponse(
+        path=str(path),
+        filename=file_name,
+        media_type=media_type,
+        content_disposition_type=_download_content_disposition(media_type),
+    )
+
+
 async def _write_upload_with_size_limit(uploaded: UploadFile, target_path: Path) -> int:
     """Persist an uploaded file while enforcing the configured size limit."""
     total_size = 0
@@ -820,35 +839,11 @@ async def download_file(
         media_type = guess_media_type(file_name)
         _ensure_under_uploads(full_path, owner_user_id)
         if full_path.exists() and full_path.is_file():
-            content_disposition = (
-                "inline"
-                if media_type.startswith(("image/", "video/", "audio/", "text/"))
-                else "attachment"
-            )
-            return FileResponse(
-                path=str(full_path),
-                filename=file_name,
-                media_type=media_type,
-                headers={
-                    "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
-                },
-            )
+            return _download_file_response(full_path, file_name, media_type)
         if file_ref.has_durable_object:
-            content_disposition = (
-                "inline"
-                if media_type.startswith(("image/", "video/", "audio/", "text/"))
-                else "attachment"
-            )
             try:
                 restored_path = file_ref.ensure_local()
-                return FileResponse(
-                    path=str(restored_path),
-                    filename=file_name,
-                    media_type=media_type,
-                    headers={
-                        "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
-                    },
-                )
+                return _download_file_response(restored_path, file_name, media_type)
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
@@ -865,22 +860,7 @@ async def download_file(
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
 
-    # For images and other viewable content, set Content-Disposition to inline
-    # to allow browser to display the file instead of downloading it
-    content_disposition = (
-        "inline"
-        if media_type.startswith(("image/", "video/", "audio/", "text/"))
-        else "attachment"
-    )
-
-    return FileResponse(
-        path=str(full_path),
-        filename=file_name,
-        media_type=media_type,
-        headers={
-            "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
-        },
-    )
+    return _download_file_response(full_path, file_name, media_type)
 
 
 @file_router.get("/preview/{file_id:path}", response_model=None)

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -107,6 +107,168 @@ async def test_trace_callback_prefers_latest_message_display_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_trace_callback_emits_display_files_from_context_metadata() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Read file"
+    context.metadata["request_context"] = {
+        "file_info": [
+            {
+                "file_id": "file-123",
+                "name": "normalized.md",
+                "original_name": "brief.md",
+                "size": 42,
+                "type": "text/markdown",
+                "storage_path": "/tmp/secret/brief.md",
+            }
+        ]
+    }
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert tracer.events[0]["data"]["files"] == [
+        {
+            "file_id": "file-123",
+            "name": "brief.md",
+            "size": 42,
+            "type": "text/markdown",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_emits_display_files_from_message_metadata() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Read file"
+    message = context.add_user_message(
+        "Read file\n\n## UPLOADED FILES\nfile_id=file-123",
+        metadata={
+            "display_message": "Read file",
+            "files": [
+                {
+                    "file_id": "file-123",
+                    "name": "brief.md",
+                    "size": 42,
+                    "type": "text/markdown",
+                    "storage_path": "/tmp/secret/brief.md",
+                }
+            ],
+        },
+    )
+
+    await callback.on_user_message_posted(
+        runner=runner,
+        context=context,
+        message=message,
+    )
+
+    assert tracer.events[0]["data"]["message"] == "Read file"
+    assert tracer.events[0]["data"]["files"] == [
+        {
+            "file_id": "file-123",
+            "name": "brief.md",
+            "size": 42,
+            "type": "text/markdown",
+        }
+    ]
+    assert "storage_path" not in tracer.events[0]["data"]["files"][0]
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_does_not_reuse_historical_message_files() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Summarize this"
+    context.add_user_message(
+        "Read file",
+        metadata={
+            "files": [
+                {
+                    "file_id": "old-file",
+                    "filename": "old.md",
+                    "file_size": 42,
+                    "mime_type": "text/markdown",
+                }
+            ]
+        },
+    )
+    context.add_user_message("Summarize this")
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert "files" not in tracer.events[0]["data"]
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_uses_only_latest_message_files() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "Read latest file"
+    old_message = context.add_user_message(
+        "Read old file",
+        metadata={
+            "files": [
+                {
+                    "file_id": "old-file",
+                    "name": "old.md",
+                    "size": 42,
+                    "type": "text/markdown",
+                }
+            ]
+        },
+    )
+    callback._mark_traced(context, old_message)
+    context.add_user_message(
+        "Read latest file",
+        metadata={
+            "files": [
+                {
+                    "file_id": "new-file",
+                    "name": "new.md",
+                    "size": 84,
+                    "type": "text/markdown",
+                    "storage_path": "/tmp/secret/new.md",
+                }
+            ]
+        },
+    )
+    _stamp_pending(context)
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert tracer.events[0]["data"]["files"] == [
+        {
+            "file_id": "new-file",
+            "name": "new.md",
+            "size": 84,
+            "type": "text/markdown",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trace_callback_omits_files_when_context_has_no_files() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-trace")
+    context.metadata["task"] = "No files"
+
+    await callback.on_run_start(runner=runner, context=context)
+
+    assert "files" not in tracer.events[0]["data"]
+
+
+@pytest.mark.asyncio
 async def test_trace_callback_failed_run_emits_error() -> None:
     tracer = TraceRecorder()
     callback = TraceEventCallback()

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -816,6 +816,34 @@ class TestFileManagement:
             # If upload failed, skip download test
             pytest.skip("Upload failed, skipping download test")
 
+    def test_download_file_with_unicode_filename(
+        self, client, temp_uploads_dir, auth_headers
+    ):
+        """Unicode filenames should produce an RFC 5987 content disposition."""
+        upload_response = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "中文 文件.docx",
+                    b"unicode filename content",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload_response.status_code == 200
+        file_id = upload_response.json()["file_id"]
+
+        response = client.get(f"/api/files/download/{file_id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.content == b"unicode filename content"
+        content_disposition = response.headers["content-disposition"]
+        assert content_disposition.startswith("attachment;")
+        assert "filename*=utf-8''" in content_disposition.lower()
+        assert "%E4%B8%AD%E6%96%87%20%E6%96%87%E4%BB%B6.docx" in content_disposition
+
     def test_download_file_not_found(self, client, test_db, auth_headers):
         """Test downloading non-existent file"""
         response = client.get(


### PR DESCRIPTION
## Summary

Fixes user-message file attachment rendering across normal Task and Agent Chat flows by standardizing the `user_message.data.files` display protocol and shared frontend extraction/rendering path.

Also fixes two file UX regressions found during local validation:
- Unicode filenames no longer crash download responses.
- Long preview titles no longer hide the preview close button.

## Root Cause

The upload/read path worked, but file display metadata was not emitted or consumed through one stable boundary. Some flows only kept file metadata in runtime context or message metadata, while frontend duplicate filtering could keep a plain-text user message and drop the later trace event containing files.

A follow-up review also found that the compatibility fallback was too broad: it aggregated files from all historical user messages. This is now scoped to the current/latest user message only.

The download crash came from manually writing non-ASCII filenames into `Content-Disposition`, which Starlette encodes as latin-1.

## Changes

- Emit display-safe top-level `files` on initial trace `user_message` events.
- Normalize display files to `file_id`, `name`, `size`, and `type` only.
- Add shared frontend helpers for extracting user message files and rendering attachment content.
- Add reducer-level attachment upsert so duplicate user-message echoes can be upgraded from plain text to file-backed content.
- Scope historical fallback to the latest user message to avoid showing stale attachments on later turns.
- Use `FileResponse(content_disposition_type=...)` for downloads instead of hand-written `Content-Disposition` headers.
- Keep preview sheet actions visible when filenames are long.

## Validation

- `uv run pytest tests/core/agent/test_tracing.py tests/web/test_file_upload.py -k "trace_callback or download_file_success or unicode_filename or durable_storage_after_local_file_deleted or remote_storage_outage_returns_503_when_local_missing or existing_local_file_during_remote_outage"`
- `npm run test:run -- src/lib/chat-files.test.ts src/lib/chat-message-upsert.test.ts`
- `npm run type-check`
- `npm run lint -- src/lib/chat-files.ts src/lib/chat-files.test.ts src/lib/chat-message-upsert.ts src/lib/chat-message-upsert.test.ts src/components/chat/user-message-content.tsx src/components/preview-sheet.tsx`
- pre-commit hooks: ruff, ruff format, mypy, npm lint, npm type-check

## Notes

No database migration is included. Existing historical tasks can recover attachments only when the current/latest user message still contains compatible file metadata.