### PR TITLE
fix: make user message display idempotent

### DIFF
--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -338,6 +338,7 @@ class AgentRunner:
         metadata: dict[str, Any] = {"display_message": resolved_display_message}
         if files is not None:
             metadata["files"] = files
+        self._ensure_user_message_turn_id(metadata)
 
         added = context.add_user_message(resolved_execution_message, metadata=metadata)
         # Set a "this turn is waiting to be traced" pending marker before
@@ -360,6 +361,7 @@ class AgentRunner:
         # Snapshot the watermark BEFORE the callback so we can detect a
         # change (see comment below) and persist it.
         watermark_before = self._read_trace_watermark(context)
+        traced_turn_ids_before = self._read_traced_turn_ids(context)
         await self._dispatch_callback(
             "on_user_message_posted",
             runner=self,
@@ -375,7 +377,10 @@ class AgentRunner:
         # has now been emitted; doing both in one persist keeps the
         # invariant {pending => never traced yet} on every durable state.
         watermark_after = self._read_trace_watermark(context)
-        if watermark_after and watermark_after != watermark_before:
+        traced_turn_ids_after = self._read_traced_turn_ids(context)
+        if (
+            watermark_after and watermark_after != watermark_before
+        ) or traced_turn_ids_after != traced_turn_ids_before:
             self._clear_pending_user_message_marker(context)
             await self._persist_injected_context(
                 execution_id=execution_id,
@@ -401,6 +406,16 @@ class AgentRunner:
         return value if isinstance(value, str) and value else None
 
     @staticmethod
+    def _read_traced_turn_ids(context: ExecutionContext) -> tuple[str, ...]:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return ()
+        value = metadata.get("_user_message_trace_turn_ids")
+        if not isinstance(value, list):
+            return ()
+        return tuple(item for item in value if isinstance(item, str) and item)
+
+    @staticmethod
     def _set_pending_user_message_marker(
         context: ExecutionContext, message: Any
     ) -> None:
@@ -417,12 +432,24 @@ class AgentRunner:
         metadata = getattr(context, "metadata", None)
         if isinstance(metadata, dict):
             metadata["_pending_user_message_trace_timestamp"] = ts
+            turn_id = AgentRunner._message_turn_id(message)
+            if turn_id:
+                metadata["_pending_user_message_trace_turn_id"] = turn_id
 
     @staticmethod
     def _clear_pending_user_message_marker(context: ExecutionContext) -> None:
         metadata = getattr(context, "metadata", None)
         if isinstance(metadata, dict):
             metadata.pop("_pending_user_message_trace_timestamp", None)
+            metadata.pop("_pending_user_message_trace_turn_id", None)
+
+    @staticmethod
+    def _message_turn_id(message: Any) -> str | None:
+        metadata = getattr(message, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get("turn_id")
+        return value if isinstance(value, str) and value else None
 
     @staticmethod
     def _message_iso_timestamp(message: Any) -> str | None:
@@ -530,6 +557,13 @@ class AgentRunner:
         candidates.append(context_metadata)
 
         for candidate in candidates:
+            turn_id = candidate.get("turn_id")
+            if isinstance(turn_id, str) and turn_id:
+                metadata["turn_id"] = turn_id
+                break
+        self._ensure_user_message_turn_id(metadata)
+
+        for candidate in candidates:
             if "display_message" in candidate:
                 display_message = candidate.get("display_message")
                 metadata["display_message"] = (
@@ -554,6 +588,15 @@ class AgentRunner:
                 break
 
         return metadata
+
+    @staticmethod
+    def _ensure_user_message_turn_id(metadata: dict[str, Any]) -> str:
+        value = metadata.get("turn_id")
+        if isinstance(value, str) and value:
+            return value
+        turn_id = str(uuid4())
+        metadata["turn_id"] = turn_id
+        return turn_id
 
     def _apply_request_context(
         self,

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -21,6 +21,7 @@ from .trace import (
 # checkpoint round-trips because ``context.metadata`` is persisted in
 # ``ExecutionContext.to_dict``.
 TRACE_WATERMARK_KEY = "_user_message_trace_watermark"
+TRACE_TURN_IDS_KEY = "_user_message_trace_turn_ids"
 
 # Stamped on ``context.metadata`` by ``runner.inject_user_message`` just
 # before persisting a freshly-injected user message, and cleared when the
@@ -32,6 +33,12 @@ TRACE_WATERMARK_KEY = "_user_message_trace_watermark"
 # - pending only -> crashed between persist and trace emit, replay that turn
 # - watermark    -> normal "trace already emitted" path, fast-skip
 PENDING_MARKER_KEY = "_pending_user_message_trace_timestamp"
+PENDING_TURN_ID_KEY = "_pending_user_message_trace_turn_id"
+
+# Public per-turn identifier stored on ``Message.metadata`` and copied to the
+# user-message trace payload. Unlike timestamp/content watermarks this survives
+# identical user text, file-only turns, and replay ordering changes.
+TURN_ID_KEY = "turn_id"
 
 
 @dataclass
@@ -67,6 +74,7 @@ class TraceEventCallback:
                 context=context,
                 message=get_display_user_message(context, task or ""),
                 files=files,
+                turn_id=self._message_turn_id(self._latest_user_message(context)),
             )
             # Mark the latest user message (if the runner added one) as
             # traced so a subsequent resume does not re-emit it.
@@ -118,11 +126,14 @@ class TraceEventCallback:
         # the frontend's ``has_files`` fallback render the bubble.
         if not bubble_text and not resolved_files:
             return
+        if self._message_turn_id(message) in self._traced_turn_ids(context):
+            return
         await self._emit_user_message_trace(
             tracer=tracer,
             context=context,
             message=bubble_text,
             files=resolved_files,
+            turn_id=self._message_turn_id(message),
         )
         self._mark_traced(context, message)
 
@@ -181,6 +192,7 @@ class TraceEventCallback:
         context: Any,
         message: str,
         files: list[dict[str, Any]],
+        turn_id: str | None = None,
     ) -> None:
         """Emit a user-message trace event with a browser-safe payload.
 
@@ -205,6 +217,8 @@ class TraceEventCallback:
         """
         safe_files = project_file_info_to_chip(files)
         trace_data: dict[str, Any] = {}
+        if turn_id:
+            trace_data[TURN_ID_KEY] = turn_id
         if safe_files:
             # Surface uploaded files at the top level of trace_data so the
             # frontend user-message renderer (which reads ``eventData.files``)
@@ -217,6 +231,8 @@ class TraceEventCallback:
     async def _emit_untraced_user_messages(self, *, tracer: Any, context: Any) -> None:
         watermark = self._watermark(context)
         pending = self._pending_marker(context)
+        pending_turn_id = self._pending_turn_id(context)
+        traced_turn_ids = self._traced_turn_ids(context)
         # Disambiguate old/pre-PR checkpoints from genuinely-pending turns:
         # a checkpoint that has neither marker is from before this PR (or
         # from a code path that doesn't go through the runner's
@@ -225,7 +241,12 @@ class TraceEventCallback:
         # crash-window for newly-injected messages is covered by the
         # pending marker below; long-term per-turn idempotency is tracked
         # in #454.
-        if watermark is None and pending is None:
+        if (
+            watermark is None
+            and pending is None
+            and pending_turn_id is None
+            and not traced_turn_ids
+        ):
             return
 
         messages = list(getattr(context, "messages", []) or [])
@@ -240,15 +261,20 @@ class TraceEventCallback:
             # Same display vs execution split as on_user_message_posted —
             # see the comment there.
             bubble_text = self._display_message_from(message) or content
+            turn_id = self._message_turn_id(message)
+            if turn_id and turn_id in traced_turn_ids:
+                continue
+            if pending_turn_id is not None and turn_id != pending_turn_id:
+                continue
             ts = self._message_timestamp_iso(message)
-            if watermark and ts and ts <= watermark:
+            if not turn_id and watermark and ts and ts <= watermark:
                 continue
             # Pending marker present without watermark advance: only replay
             # the matching turn. Any other historical turn at this point
             # was already visible to the client on the prior run; skip it
             # so we don't spam re-emissions for everything older than the
             # crash point.
-            if pending is not None and ts != pending:
+            if pending_turn_id is None and pending is not None and ts != pending:
                 continue
             files = self._files_from_message(message)
             # For the chronologically first user message we additionally fall
@@ -268,6 +294,7 @@ class TraceEventCallback:
                 context=context,
                 message=bubble_text,
                 files=files,
+                turn_id=turn_id,
             )
             self._mark_traced(context, message)
 
@@ -285,16 +312,51 @@ class TraceEventCallback:
         value = metadata.get(PENDING_MARKER_KEY)
         return value if isinstance(value, str) and value else None
 
+    def _pending_turn_id(self, context: Any) -> str | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get(PENDING_TURN_ID_KEY)
+        return value if isinstance(value, str) and value else None
+
     def _mark_traced(self, context: Any, message: Any) -> None:
         ts = self._message_timestamp_iso(message)
-        if ts is None:
-            return
         metadata = getattr(context, "metadata", None)
         if not isinstance(metadata, dict):
             return
-        existing = metadata.get(TRACE_WATERMARK_KEY)
-        if not isinstance(existing, str) or ts > existing:
-            metadata[TRACE_WATERMARK_KEY] = ts
+        turn_id = self._message_turn_id(message)
+        if turn_id:
+            traced = metadata.get(TRACE_TURN_IDS_KEY)
+            traced_ids = (
+                [value for value in traced if isinstance(value, str) and value]
+                if isinstance(traced, list)
+                else []
+            )
+            if turn_id not in traced_ids:
+                traced_ids.append(turn_id)
+                metadata[TRACE_TURN_IDS_KEY] = traced_ids
+        if ts is not None:
+            existing = metadata.get(TRACE_WATERMARK_KEY)
+            if not isinstance(existing, str) or ts > existing:
+                metadata[TRACE_WATERMARK_KEY] = ts
+
+    def _traced_turn_ids(self, context: Any) -> set[str]:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return set()
+        value = metadata.get(TRACE_TURN_IDS_KEY)
+        if not isinstance(value, list):
+            return set()
+        return {item for item in value if isinstance(item, str) and item}
+
+    def _message_turn_id(self, message: Any | None) -> str | None:
+        if message is None:
+            return None
+        metadata = getattr(message, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        value = metadata.get(TURN_ID_KEY)
+        return value if isinstance(value, str) and value else None
 
     def _message_timestamp_iso(self, message: Any) -> str | None:
         ts = getattr(message, "timestamp", None)

--- a/src/xagent/migrations/versions/20260522_add_turn_id_to_task_chat_messages.py
+++ b/src/xagent/migrations/versions/20260522_add_turn_id_to_task_chat_messages.py
@@ -1,0 +1,72 @@
+"""add turn_id to task_chat_messages
+
+Revision ID: 20260522_add_task_chat_message_turn_id
+Revises: 20260521_merge_alembic_heads
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "20260522_add_task_chat_message_turn_id"
+down_revision: Union[str, None] = "20260521_merge_alembic_heads"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        return
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "turn_id" not in existing_columns:
+        op.add_column(
+            "task_chat_messages",
+            sa.Column("turn_id", sa.String(length=64), nullable=True),
+        )
+
+    inspector = Inspector.from_engine(bind)
+    existing_indexes = {
+        idx["name"] for idx in inspector.get_indexes("task_chat_messages")
+    }
+    if "ix_task_chat_messages_turn_id" not in existing_indexes:
+        op.create_index(
+            op.f("ix_task_chat_messages_turn_id"),
+            "task_chat_messages",
+            ["turn_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    if "task_chat_messages" not in inspector.get_table_names():
+        return
+
+    existing_indexes = {
+        idx["name"] for idx in inspector.get_indexes("task_chat_messages")
+    }
+    if "ix_task_chat_messages_turn_id" in existing_indexes:
+        op.drop_index(op.f("ix_task_chat_messages_turn_id"), "task_chat_messages")
+
+    existing_columns = {
+        col["name"] for col in inspector.get_columns("task_chat_messages")
+    }
+    if "turn_id" in existing_columns:
+        op.drop_column("task_chat_messages", "turn_id")

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -151,6 +151,13 @@ class DatabaseTraceHandler(BaseTraceHandler):
 
             # Serialize data to ensure JSON compatibility
             data = self._serialize_data_for_json(event.data or {})
+            if self._is_duplicate_user_message_turn(db, event_type_str, data):
+                logger.debug(
+                    "Skipping duplicate user_message turn_id=%s for task %s",
+                    data.get("turn_id") if isinstance(data, dict) else None,
+                    self.task_id,
+                )
+                return
 
             # Create trace event record
             trace_event = DatabaseTraceEvent(
@@ -237,6 +244,28 @@ class DatabaseTraceHandler(BaseTraceHandler):
             logger.error(f"Failed to save trace event to database: {e}")
             db.rollback()
             raise
+
+    def _is_duplicate_user_message_turn(
+        self,
+        db: Session,
+        event_type: str,
+        data: Any,
+    ) -> bool:
+        if event_type != "user_message" or not isinstance(data, dict):
+            return False
+        turn_id = data.get("turn_id")
+        if not isinstance(turn_id, str) or not turn_id:
+            return False
+        return (
+            db.query(DatabaseTraceEvent.id)
+            .filter(
+                DatabaseTraceEvent.task_id == self.task_id,
+                DatabaseTraceEvent.event_type == "user_message",
+                DatabaseTraceEvent.data["turn_id"].as_string() == turn_id,
+            )
+            .first()
+            is not None
+        )
 
     def _serialize_data_for_json(self, data: Any) -> Any:
         """Recursively serialize data to ensure JSON compatibility and clean problematic characters."""

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -351,6 +351,27 @@ def _attachment_fingerprint(attachments: Any) -> str:
     return "|".join(sorted(file_ids))
 
 
+def _trace_user_message_turn_id(event_type: str, data: Any) -> str | None:
+    if event_type != "user_message" or not isinstance(data, dict):
+        return None
+    turn_id = data.get("turn_id")
+    return turn_id if isinstance(turn_id, str) and turn_id else None
+
+
+def _is_duplicate_user_message_turn(
+    event_type: str,
+    data: Any,
+    seen_turn_ids: set[str],
+) -> bool:
+    turn_id = _trace_user_message_turn_id(event_type, data)
+    if turn_id is None:
+        return False
+    if turn_id in seen_turn_ids:
+        return True
+    seen_turn_ids.add(turn_id)
+    return False
+
+
 def create_stream_event(
     event_type: str,
     task_id: Union[int, str],
@@ -2968,6 +2989,8 @@ async def send_historical_data_as_stream(
             # files no longer collapse into one — the second row used to
             # be dropped and its file chips disappeared on reload.
             trace_message_keys: set[tuple[str, str, str]] = set()
+            trace_user_turn_ids: set[str] = set()
+            seen_trace_user_turn_ids: set[str] = set()
 
             for trace_event in trace_events:
                 normalized_event_data = trace_event.data
@@ -2990,24 +3013,39 @@ async def send_historical_data_as_stream(
                     content = normalized_event_data.get(
                         "message"
                     ) or normalized_event_data.get("content")
-                    if isinstance(content, str) and content.strip():
-                        event_attachments = normalized_event_data.get(
-                            "files"
-                        ) or normalized_event_data.get("attachments")
-                        attachment_key = _attachment_fingerprint(event_attachments)
-                        if trace_event.event_type == "user_message":
+                    event_attachments = normalized_event_data.get(
+                        "files"
+                    ) or normalized_event_data.get("attachments")
+                    attachment_key = _attachment_fingerprint(event_attachments)
+                    if trace_event.event_type == "user_message":
+                        trace_turn_id = _trace_user_message_turn_id(
+                            "user_message", normalized_event_data
+                        )
+                        if trace_turn_id:
+                            trace_user_turn_ids.add(trace_turn_id)
+                        elif isinstance(content, str) and content.strip():
                             trace_message_keys.add(
                                 ("user", content.strip(), attachment_key)
                             )
-                        elif trace_event.event_type in {"agent_message", "ai_message"}:
-                            trace_message_keys.add(
-                                ("assistant", content.strip(), attachment_key)
-                            )
+                    elif (
+                        trace_event.event_type in {"agent_message", "ai_message"}
+                        and isinstance(content, str)
+                        and content.strip()
+                    ):
+                        trace_message_keys.add(
+                            ("assistant", content.strip(), attachment_key)
+                        )
 
             for trace_event in trace_events:
                 normalized_event_data = normalized_trace_data_by_event_id.get(
                     str(trace_event.event_id), trace_event.data
                 )
+                if _is_duplicate_user_message_turn(
+                    str(trace_event.event_type),
+                    normalized_event_data,
+                    seen_trace_user_turn_ids,
+                ):
+                    continue
                 if _is_agent_checkpoint_data(normalized_event_data):
                     continue
                 if historical_path_to_file_id and isinstance(
@@ -3056,16 +3094,28 @@ async def send_historical_data_as_stream(
                 # turn (user uploaded files without typing) and must be kept.
                 if not content and not row_attachments:
                     continue
-                if (
-                    content
-                    and (role, content, _attachment_fingerprint(row_attachments))
-                    in trace_message_keys
-                ):
-                    continue
 
                 if role == "user":
+                    row_turn_id = getattr(chat_message, "turn_id", None)
+                    if isinstance(row_turn_id, str):
+                        row_turn_id = row_turn_id.strip() or None
+                    else:
+                        row_turn_id = None
+
+                    if row_turn_id:
+                        if row_turn_id in trace_user_turn_ids:
+                            continue
+                    elif (
+                        content
+                        and (role, content, _attachment_fingerprint(row_attachments))
+                        in trace_message_keys
+                    ):
+                        continue
+
                     event_type = "user_message"
                     data: dict[str, Any] = {"message": content, "content": content}
+                    if row_turn_id:
+                        data["turn_id"] = row_turn_id
                     if row_attachments:
                         # Surface the persisted chip payload at the top level
                         # so the frontend user-message renderer can show
@@ -3074,6 +3124,12 @@ async def send_historical_data_as_stream(
                         data["files"] = row_attachments
                         data["attachments"] = row_attachments
                 elif role == "assistant":
+                    if (
+                        content
+                        and (role, content, _attachment_fingerprint(row_attachments))
+                        in trace_message_keys
+                    ):
+                        continue
                     interactions = chat_message.interactions
                     data = {
                         "message": content,

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -258,6 +258,15 @@ class WebSocketTraceHandler(TraceHandler):
 
             # Convert trace event to unified stream format
             stream_event = self._convert_trace_event_to_stream_event(event)
+            if stream_event:
+                stream_data = stream_event.get("data")
+                if isinstance(stream_data, dict) and await asyncio.to_thread(
+                    self._has_prior_user_message_turn,
+                    str(stream_event.get("event_type") or ""),
+                    stream_data,
+                    str(event.id),
+                ):
+                    stream_event = None
 
             # Send to all connected WebSocket clients for this task
             if stream_event:
@@ -368,6 +377,46 @@ class WebSocketTraceHandler(TraceHandler):
             stream_event["data"]["task_description"] = self._task_description
 
         return stream_event
+
+    def _has_prior_user_message_turn(
+        self,
+        event_type: str,
+        data: Dict[str, Any],
+        event_id: str,
+    ) -> bool:
+        if event_type != "user_message" or not isinstance(data, dict):
+            return False
+        turn_id = data.get("turn_id")
+        if not isinstance(turn_id, str) or not turn_id:
+            return False
+
+        try:
+            from contextlib import closing
+
+            from ..models.database import get_db
+            from ..models.task import TraceEvent as DatabaseTraceEvent
+
+            with closing(get_db()) as db_gen:
+                db = next(db_gen)
+                return (
+                    db.query(DatabaseTraceEvent.id)
+                    .filter(
+                        DatabaseTraceEvent.task_id == self.task_id,
+                        DatabaseTraceEvent.event_type == "user_message",
+                        DatabaseTraceEvent.event_id != event_id,
+                        DatabaseTraceEvent.data["turn_id"].as_string() == turn_id,
+                    )
+                    .first()
+                    is not None
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Could not check prior user_message turn_id=%s for task %s: %s",
+                turn_id,
+                self.task_id,
+                exc,
+            )
+            return False
 
     def _serialize_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Recursively serialize data to ensure JSON compatibility."""

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
+from uuid import uuid4
 
 if TYPE_CHECKING:
     from ....core.agent.service import AgentService
@@ -377,7 +378,8 @@ class TelegramBotInstance:
 
                 await restore_telegram_task_context(agent_service, db, int(task.id))
 
-                context: dict = {}
+                message_turn_id = str(uuid4())
+                context: dict = {"turn_id": message_turn_id}
 
                 if files:
                     uploaded_info = await self._download_and_register_files(
@@ -413,6 +415,7 @@ class TelegramBotInstance:
                     task_id=int(task.id),  # type: ignore
                     user_id=int(user.id),  # type: ignore
                     content=text,
+                    turn_id=message_turn_id,
                 )
 
                 loading_msg = await last_message.answer(

--- a/src/xagent/web/models/chat_message.py
+++ b/src/xagent/web/models/chat_message.py
@@ -21,6 +21,10 @@ class TaskChatMessage(Base):  # type: ignore
     content = Column(Text, nullable=False)
     message_type = Column(String(64), nullable=False)
     interactions = Column(JSON, nullable=True)
+    # Stable per-user-turn identity shared with user_message trace events. Used
+    # by historical replay to reconcile trace rows with transcript rows without
+    # collapsing distinct turns that happen to share text/attachments.
+    turn_id = Column(String(64), nullable=True, index=True)
     # Per-message attachments (uploaded files). For user messages this is the
     # list of files the user attached when sending this turn. Stored as JSON so
     # the original file metadata (file_id, name, size, type) is available for

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -23,6 +23,7 @@ def persist_user_message(
     content: str,
     *,
     attachments: Optional[List[Dict[str, Any]]] = None,
+    turn_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     return _persist_message(
         db=db,
@@ -32,6 +33,7 @@ def persist_user_message(
         content=content,
         message_type="user_message",
         attachments=attachments,
+        turn_id=turn_id,
     )
 
 
@@ -42,6 +44,7 @@ def persist_user_message_no_commit(
     content: str,
     *,
     attachments: Optional[List[Dict[str, Any]]] = None,
+    turn_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     """``persist_user_message`` variant that stages the row but does NOT commit.
 
@@ -65,6 +68,7 @@ def persist_user_message_no_commit(
         content=normalized_content,
         message_type="user_message",
         interactions=None,
+        turn_id=turn_id,
         # Pass through ``attachments`` directly so an explicit empty list
         # round-trips as ``[]`` rather than being coerced to ``NULL`` —
         # callers may want to distinguish "no attachments specified" from
@@ -163,6 +167,7 @@ def _persist_message(
     message_type: str,
     interactions: Optional[List[Dict[str, Any]]] = None,
     attachments: Optional[List[Dict[str, Any]]] = None,
+    turn_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     normalized_content = content.strip()
     if not normalized_content and not attachments:
@@ -175,6 +180,7 @@ def _persist_message(
         content=normalized_content,
         message_type=message_type,
         interactions=interactions,
+        turn_id=turn_id,
         # Pass through ``attachments`` directly so an explicit empty list
         # round-trips as ``[]`` rather than being coerced to ``NULL``.
         attachments=attachments,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -47,9 +47,10 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 from ..models.task import Task, TaskStatus
 from ..models.user import User
@@ -100,6 +101,10 @@ class TaskTurnPayload:
     # name, size, type) — already path-stripped by the websocket layer
     # before reaching here.
     attachments: Optional[List[Dict[str, Any]]] = None
+    # Stable identity shared by the transcript row and the user_message trace
+    # event for this user turn. Historical replay uses it to merge persisted
+    # transcript rows with trace rows without collapsing repeated text.
+    turn_id: str = field(default_factory=lambda: str(uuid4()))
 
     @property
     def for_agent(self) -> str:
@@ -300,6 +305,7 @@ class TaskTurnOrchestrator:
                 user_id=int(user.id),
                 content=payload.transcript_message,
                 attachments=payload.attachments,
+                turn_id=payload.turn_id,
             )
             if persisted_message is not None:
                 db.flush()
@@ -574,7 +580,7 @@ async def _schedule_bg(
                 await execute_task_background(
                     task_id=task_id,
                     user_message=payload.transcript_message,
-                    context=context or {},
+                    context=_execution_context_with_turn_id(context, payload.turn_id),
                     agent_manager=_get_agent_manager(),
                     user_id=int(bg_user_row.id),
                     before_message_id=before_message_id,
@@ -640,3 +646,12 @@ async def _schedule_bg(
         force_fresh,
     )
     return bg_task
+
+
+def _execution_context_with_turn_id(
+    context: Optional[Dict[str, Any]], turn_id: str
+) -> Dict[str, Any]:
+    execution_context = dict(context or {})
+    if turn_id:
+        execution_context["turn_id"] = turn_id
+    return execution_context

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -649,6 +649,8 @@ async def test_runner_inject_user_message_with_files_dispatches_trace_callback(
         msg for msg in reversed(context.messages) if msg.role == "user"
     )
     assert new_user_message.metadata.get("files") == files
+    turn_id = new_user_message.metadata.get("turn_id")
+    assert isinstance(turn_id, str) and turn_id
 
     user_message_events = [
         event
@@ -657,6 +659,7 @@ async def test_runner_inject_user_message_with_files_dispatches_trace_callback(
         and event["data"].get("message") == "Use the attached PDF."
     ]
     assert len(user_message_events) == 1
+    assert user_message_events[0]["data"]["turn_id"] == turn_id
     assert user_message_events[0]["data"]["files"] == files
     assert user_message_events[0]["data"]["attachments"] == files
 
@@ -739,6 +742,8 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
     assert latest_user.content == execution_message
     assert latest_user.metadata["display_message"] == "Read file"
     assert latest_user.metadata["files"] == files
+    turn_id = latest_user.metadata.get("turn_id")
+    assert isinstance(turn_id, str) and turn_id
 
     checkpoint_messages = tracer.by_execution_id["exec-display-contract"]["context"][
         "messages"
@@ -749,6 +754,7 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
     assert latest_checkpoint_user["content"] == execution_message
     assert latest_checkpoint_user["metadata"]["display_message"] == "Read file"
     assert latest_checkpoint_user["metadata"]["files"] == files
+    assert latest_checkpoint_user["metadata"]["turn_id"] == turn_id
 
 
 @pytest.mark.asyncio
@@ -781,10 +787,13 @@ async def test_runner_initial_user_message_preserves_display_metadata(
     assert first_user.content == execution_message
     assert first_user.metadata["display_message"] == "Read file"
     assert first_user.metadata["files"] == files
+    turn_id = first_user.metadata.get("turn_id")
+    assert isinstance(turn_id, str) and turn_id
     user_event = next(
         event for event in tracer.events if event["event_type"] == "task_start_message"
     )
     assert user_event["data"]["message"] == "Read file"
+    assert user_event["data"]["turn_id"] == turn_id
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_tracing.py
+++ b/tests/core/agent/test_tracing.py
@@ -6,7 +6,11 @@ from typing import Any
 import pytest
 
 from xagent.core.agent import ExecutionContext, TraceEventCallback
-from xagent.core.agent.tracing import PENDING_MARKER_KEY
+from xagent.core.agent.tracing import (
+    PENDING_MARKER_KEY,
+    PENDING_TURN_ID_KEY,
+    TRACE_TURN_IDS_KEY,
+)
 
 
 def _stamp_pending(context: ExecutionContext) -> None:
@@ -25,6 +29,9 @@ def _stamp_pending(context: ExecutionContext) -> None:
     ts = callback._message_timestamp_iso(latest)
     if ts:
         context.metadata[PENDING_MARKER_KEY] = ts
+    turn_id = callback._message_turn_id(latest)
+    if turn_id:
+        context.metadata[PENDING_TURN_ID_KEY] = turn_id
 
 
 class TraceRecorder:
@@ -221,7 +228,7 @@ async def test_on_user_message_posted_emits_trace_event_with_files() -> None:
     ]
     new_message = context.add_user_message(
         "Follow-up question with a file.",
-        metadata={"files": files},
+        metadata={"files": files, "turn_id": "turn-files"},
     )
 
     await callback.on_user_message_posted(
@@ -235,6 +242,7 @@ async def test_on_user_message_posted_emits_trace_event_with_files() -> None:
     event = tracer.events[0]
     assert event["event_type"] == "task_start_message"
     assert event["data"]["message"] == "Follow-up question with a file."
+    assert event["data"]["turn_id"] == "turn-files"
     assert event["data"]["files"] == files
     assert event["data"]["attachments"] == files
 
@@ -249,12 +257,15 @@ async def test_on_user_message_posted_prevents_resume_from_duplicating() -> None
     runner = SimpleNamespace(tracer=tracer)
     context = ExecutionContext(execution_id="exec-cont")
     context.metadata["task"] = "Original task"
-    msg = context.add_user_message("Follow-up.", metadata={"files": []})
+    msg = context.add_user_message(
+        "Follow-up.", metadata={"files": [], "turn_id": "turn-follow-up"}
+    )
 
     await callback.on_user_message_posted(runner=runner, context=context, message=msg)
     await callback.on_run_start(runner=runner, context=context, resume=True)
 
     assert len(tracer.events) == 1  # not two
+    assert context.metadata[TRACE_TURN_IDS_KEY] == ["turn-follow-up"]
 
 
 @pytest.mark.asyncio
@@ -275,7 +286,10 @@ async def test_on_run_start_resume_emits_untraced_user_message() -> None:
             "type": "text/csv",
         }
     ]
-    context.add_user_message("Continue from here.", metadata={"files": files})
+    context.add_user_message(
+        "Continue from here.",
+        metadata={"files": files, "turn_id": "turn-recover"},
+    )
     # Simulate the runner: pending marker stamped just before the
     # crashed checkpoint. Catch-up will only replay turns whose ts
     # matches this marker, not all history.
@@ -291,6 +305,7 @@ async def test_on_run_start_resume_emits_untraced_user_message() -> None:
     assert len(tracer.events) == 1
     data = tracer.events[0]["data"]
     assert data["message"] == "Continue from here."
+    assert data["turn_id"] == "turn-recover"
     assert data["files"] == files
 
 
@@ -338,7 +353,10 @@ async def test_on_run_start_resume_with_pending_marker_replays_only_pending_turn
     context.add_user_message("Earlier historical turn.")
     pending_msg = context.add_user_message(
         "The turn that crashed mid-emit.",
-        metadata={"files": [{"file_id": "fid-crash", "name": "c.txt"}]},
+        metadata={
+            "files": [{"file_id": "fid-crash", "name": "c.txt"}],
+            "turn_id": "turn-crash",
+        },
     )
     # Pending marker points at the second message — only it should replay.
     pending_ts = callback._message_timestamp_iso(pending_msg)
@@ -350,6 +368,7 @@ async def test_on_run_start_resume_with_pending_marker_replays_only_pending_turn
     assert len(tracer.events) == 1
     data = tracer.events[0]["data"]
     assert data["message"] == "The turn that crashed mid-emit."
+    assert data["turn_id"] == "turn-crash"
     assert data["files"][0]["file_id"] == "fid-crash"
 
 
@@ -363,7 +382,7 @@ async def test_on_run_start_resume_skips_already_traced_user_messages() -> None:
     runner = SimpleNamespace(tracer=tracer)
     context = ExecutionContext(execution_id="exec-pure-resume")
     context.metadata["task"] = "Original task"
-    msg = context.add_user_message("Original turn.")
+    msg = context.add_user_message("Original turn.", metadata={"turn_id": "turn-orig"})
     callback._mark_traced(context, msg)
 
     await callback.on_run_start(runner=runner, context=context, resume=True)
@@ -372,6 +391,38 @@ async def test_on_run_start_resume_skips_already_traced_user_messages() -> None:
     )
 
     assert tracer.events == []
+
+
+@pytest.mark.asyncio
+async def test_on_user_message_posted_is_idempotent_by_turn_id() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-dup-turn")
+    msg = context.add_user_message("Same turn.", metadata={"turn_id": "turn-dup"})
+
+    await callback.on_user_message_posted(runner=runner, context=context, message=msg)
+    await callback.on_user_message_posted(runner=runner, context=context, message=msg)
+
+    assert len(tracer.events) == 1
+    assert tracer.events[0]["data"]["turn_id"] == "turn-dup"
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resume_turn_ids_allow_identical_text() -> None:
+    tracer = TraceRecorder()
+    callback = TraceEventCallback()
+    runner = SimpleNamespace(tracer=tracer)
+    context = ExecutionContext(execution_id="exec-identical")
+    context.add_user_message("Repeat", metadata={"turn_id": "turn-a"})
+    context.add_user_message("Repeat", metadata={"turn_id": "turn-b"})
+    context.metadata[PENDING_TURN_ID_KEY] = "turn-b"
+
+    await callback.on_run_start(runner=runner, context=context, resume=True)
+
+    assert len(tracer.events) == 1
+    assert tracer.events[0]["data"]["message"] == "Repeat"
+    assert tracer.events[0]["data"]["turn_id"] == "turn-b"
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
@@ -257,6 +258,13 @@ async def test_begin_turn_passes_force_fresh_through_to_schedule_bg(
     kwargs = mock_schedule_bg.await_args.kwargs
     assert kwargs["payload"] is payload
     assert kwargs["force_fresh"] is True
+
+    persisted = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.task_id == int(task.id), TaskChatMessage.role == "user")
+        .one()
+    )
+    assert persisted.turn_id == payload.turn_id
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +680,7 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
             user=user,
             payload=payload,
             force_fresh=False,
-            context=None,
+            context={"turn_id": "caller-turn", "existing": "value"},
         )
         await bg_task
 
@@ -687,3 +695,5 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
     assert (
         kwargs["llm_user_message"] == "summarize this\n\n[uploaded file: secret.txt]"
     ), "execution_message must reach execute_task_background.llm_user_message"
+    assert kwargs["context"]["turn_id"] == payload.turn_id
+    assert kwargs["context"]["existing"] == "value"

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -13,15 +16,19 @@ from xagent.core.agent.trace import (
     TraceEventType,
     TraceScope,
 )
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
 from xagent.web.api.websocket import (
     _is_agent_checkpoint_data,
+    _is_duplicate_user_message_turn,
     _persist_agent_outbound_event,
     create_stream_event,
+    send_historical_data_as_stream,
 )
 from xagent.web.api.ws_trace_handlers import (
     WebSocketTraceHandler,
     get_event_type_mapping,
 )
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
@@ -139,3 +146,325 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
         assert trace_event.step_id == "react-step-1"
     finally:
         db.close()
+
+
+def test_database_trace_handler_dedupes_user_message_turn_id() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="tester", password_hash="hashed_password", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Task chat",
+            status=TaskStatus.PENDING,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        handler = DatabaseTraceHandler(int(task.id))
+        event_type = TraceEventType(
+            TraceScope.TASK,
+            TraceAction.START,
+            TraceCategory.MESSAGE,
+        )
+        first = TraceEvent(
+            event_type,
+            task_id=str(task.id),
+            data={"message": "Repeat", "turn_id": "turn-1"},
+        )
+        duplicate = TraceEvent(
+            event_type,
+            task_id=str(task.id),
+            data={"message": "Repeat", "turn_id": "turn-1"},
+        )
+        different_turn = TraceEvent(
+            event_type,
+            task_id=str(task.id),
+            data={"message": "Repeat", "turn_id": "turn-2"},
+        )
+
+        handler._save_trace_event(db, first)
+        handler._save_trace_event(db, duplicate)
+        handler._save_trace_event(db, different_turn)
+
+        rows = (
+            db.query(DatabaseTraceEvent)
+            .filter_by(task_id=int(task.id), event_type="user_message")
+            .order_by(DatabaseTraceEvent.id)
+            .all()
+        )
+        assert [row.data["turn_id"] for row in rows] == ["turn-1", "turn-2"]
+    finally:
+        db.close()
+
+
+def test_websocket_trace_handler_dedupes_prior_user_message_turn_id(
+    monkeypatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="tester", password_hash="hashed_password", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Task chat",
+            status=TaskStatus.PENDING,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="first-event",
+                event_type="user_message",
+                timestamp=task.created_at,
+                data={"message": "Repeat", "turn_id": "turn-1"},
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+
+    handler = WebSocketTraceHandler(task_id)
+    assert not handler._has_prior_user_message_turn(
+        "user_message", {"turn_id": "turn-1"}, "first-event"
+    )
+    assert handler._has_prior_user_message_turn(
+        "user_message", {"turn_id": "turn-1"}, "second-event"
+    )
+    assert not handler._has_prior_user_message_turn(
+        "user_message", {"turn_id": "turn-2"}, "second-event"
+    )
+
+
+def test_historical_replay_duplicate_turn_helper_allows_distinct_turns() -> None:
+    seen: set[str] = set()
+
+    assert not _is_duplicate_user_message_turn(
+        "user_message", {"message": "Repeat", "turn_id": "turn-1"}, seen
+    )
+    assert _is_duplicate_user_message_turn(
+        "user_message", {"message": "Repeat", "turn_id": "turn-1"}, seen
+    )
+    assert not _is_duplicate_user_message_turn(
+        "user_message", {"message": "Repeat", "turn_id": "turn-2"}, seen
+    )
+
+
+@pytest.mark.asyncio
+async def test_historical_replay_uses_turn_id_before_legacy_content_dedupe(
+    monkeypatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="tester", password_hash="hashed_password", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Chat task",
+            status=TaskStatus.COMPLETED,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        task_id = int(task.id)
+        user_id = int(user.id)
+        base_time = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="trace-turn-a",
+                event_type="user_message",
+                timestamp=base_time + timedelta(seconds=1),
+                data={"message": "Repeat", "turn_id": "turn-A"},
+            )
+        )
+        db.add_all(
+            [
+                TaskChatMessage(
+                    task_id=task_id,
+                    user_id=user_id,
+                    role="user",
+                    content="Repeat",
+                    message_type="user_message",
+                    turn_id="turn-A",
+                    created_at=base_time + timedelta(seconds=2),
+                ),
+                TaskChatMessage(
+                    task_id=task_id,
+                    user_id=user_id,
+                    role="user",
+                    content="Repeat",
+                    message_type="user_message",
+                    turn_id="turn-B",
+                    created_at=base_time + timedelta(seconds=3),
+                ),
+            ]
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    user_message_events = [
+        event
+        for event in sent_events
+        if event.get("type") == "trace_event"
+        and event.get("event_type") == "user_message"
+    ]
+
+    assert [
+        (event["data"].get("message"), event["data"].get("turn_id"))
+        for event in user_message_events
+    ] == [("Repeat", "turn-A"), ("Repeat", "turn-B")]
+
+
+@pytest.mark.asyncio
+async def test_historical_replay_dedupes_file_only_turns_by_turn_id(
+    monkeypatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="tester", password_hash="hashed_password", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Chat task",
+            status=TaskStatus.COMPLETED,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        task_id = int(task.id)
+        user_id = int(user.id)
+        base_time = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        attachments = [{"file_id": "fid-only", "name": "only.pdf"}]
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="trace-file-only",
+                event_type="user_message",
+                timestamp=base_time + timedelta(seconds=1),
+                data={"message": "", "turn_id": "turn-file", "files": attachments},
+            )
+        )
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=user_id,
+                role="user",
+                content="",
+                message_type="user_message",
+                turn_id="turn-file",
+                attachments=attachments,
+                created_at=base_time + timedelta(seconds=2),
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    user_message_events = [
+        event
+        for event in sent_events
+        if event.get("type") == "trace_event"
+        and event.get("event_type") == "user_message"
+    ]
+
+    assert [
+        (event["data"].get("turn_id"), event["data"].get("files"))
+        for event in user_message_events
+    ] == [("turn-file", attachments)]

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -187,9 +187,11 @@ def test_persist_user_message_stores_attachments_for_chip_replay():
             int(task.user_id),
             "Read this for me.",
             attachments=attachments,
+            turn_id="turn-attachments",
         )
         row = db_session.query(TaskChatMessage).first()
         assert row is not None
+        assert row.turn_id == "turn-attachments"
         assert row.attachments == attachments
     finally:
         db_session.close()


### PR DESCRIPTION
## Summary
- add stable per-turn IDs to user message metadata, transcript rows, channel transcript rows, and user_message trace payloads
- make resume catch-up and historical replay prefer turn IDs while keeping legacy timestamp/content+attachment fallbacks
- dedupe persisted and replayed user_message trace events by turn_id, including file-only turns

Closes #454

## Tests
- PYTHONPATH=src ruff check src/xagent/web/services/task_orchestrator.py src/xagent/web/api/websocket.py src/xagent/web/channels/telegram/bot.py tests/web/services/test_task_orchestrator.py tests/web/test_agent_checkpoint_stream.py
- PYTHONPATH=src python -m pytest tests/web/services/test_task_orchestrator.py tests/web/test_agent_checkpoint_stream.py tests/web/test_chat_history_service.py tests/core/agent/test_tracing.py tests/core/agent/test_runner.py
- PYTHONPATH=src alembic heads
- commit hook: ruff check, ruff format, mypy, isort, codespell