### PR TITLE
chore: bump docker images to v0.4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ LANGFUSE_SECRET_KEY="your-langfuse-secret-key"
 ### Local Development Conventions
 
 **Commit and PR titles:**
-- Use a short conventional prefix: `feat:`, `fix:`, `enh:`, or `ref:`.
+- Use a short conventional prefix: `feat:`, `fix:`, `enh:`, `ref:`, or `chore:`.
 - Prefer the same prefix in PR titles so split PRs are easy to scan.
 - Keep branch names meaningful and task-oriented, for example `fix/remove-agent-v1` or `feat/agent-builder-preview`. Avoid generic agent/tool prefixes that do not describe the work.
 
@@ -307,6 +307,20 @@ npm run start  # Production mode
 
 **Development Mode:**
 Run both backend and frontend in separate terminals for full-stack development.
+
+### Docker Release Image Bumps
+
+When bumping Docker release image tags, update all fixed Xagent images together:
+- All fixed Xagent service images present in `docker-compose.yml`
+- `docker/docker-compose.sandbox.boxlite.yml` `SANDBOX_IMAGE`
+- `docker/docker-compose.sandbox.docker.yml` `SANDBOX_IMAGE`
+
+Validate both the base compose file and sandbox overlays:
+```bash
+docker compose config --quiet
+docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.boxlite.yml config --quiet
+docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.docker.yml config --quiet
+```
 
 ## Skills Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # Xagent Frontend (Next.js)
   frontend:
-    image: xprobe/xagent-frontend:0.4.0
+    image: xprobe/xagent-frontend:0.4.1
     container_name: xagent_frontend
     restart: unless-stopped
     networks:
@@ -30,7 +30,7 @@ services:
 
   # Xagent Backend (FastAPI)
   backend:
-    image: xprobe/xagent-backend:0.4.0
+    image: xprobe/xagent-backend:0.4.1
     container_name: xagent_backend
     restart: unless-stopped
     # Don't expose ports, only accessible through nginx

--- a/docker/docker-compose.sandbox.boxlite.yml
+++ b/docker/docker-compose.sandbox.boxlite.yml
@@ -3,7 +3,7 @@ services:
     environment:
       - SANDBOX_ENABLED=true
       - SANDBOX_IMPLEMENTATION=boxlite
-      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.4.0
+      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.4.1
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - BOXLITE_HOME_DIR=/root/.xagent/boxlite

--- a/docker/docker-compose.sandbox.docker.yml
+++ b/docker/docker-compose.sandbox.docker.yml
@@ -4,7 +4,7 @@ services:
       - SANDBOX_ENABLED=true
       - SANDBOX_IMPLEMENTATION=docker
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.4.0
+      - SANDBOX_IMAGE=xprobe/xagent-sandbox:0.4.1
       - SANDBOX_CPUS=1
       - SANDBOX_MEMORY=512
       - XAGENT_SANDBOX_HOST_PROJECT_ROOT=${XAGENT_SANDBOX_HOST_PROJECT_ROOT:-${PWD}}


### PR DESCRIPTION
## Summary
- bump compose frontend/backend images to v0.4.1
- bump sandbox overlay images to v0.4.1
- document Docker release image bump checklist in AGENTS.md

## Validation
- docker compose config --quiet
- docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.boxlite.yml config --quiet
- docker compose -f docker-compose.yml -f docker/docker-compose.sandbox.docker.yml config --quiet