### PR TITLE
fix: restore final answer streaming

### DIFF
--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -462,7 +462,7 @@ function TaskDetailContent() {
         <div className="flex-1 overflow-y-auto">
           <main className={`container max-w-4xl mx-auto px-4 py-8 relative z-0 transition-all`}>
             <div className="space-y-6 pb-4">
-              {state.isHistoryLoading || combinedItems.length === 0 ? (
+              {state.isHistoryLoading && combinedItems.length === 0 ? (
                 <div className="flex flex-col items-center justify-center min-h-[60vh] py-16 text-center">
                   <div className="relative mb-6">
                     <div className="w-16 h-16 rounded-2xl bg-muted/30 flex items-center justify-center animate-pulse">

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -43,9 +43,11 @@ import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 import {
   getFinalAnswerStreamActionPayload,
   getFinalAnswerStreamMessageId,
+  getWebSocketEventType,
   isFinalAnswerStreamEventType,
   isStreamingFinalAnswerMessage,
   mergeTraceEventsById,
+  shouldBufferMessageForHistoricalReplay,
 } from "@/lib/streaming-final-answer"
 
 // Unique ID generator for messages
@@ -472,7 +474,14 @@ type AppAction =
   | { type: "SET_TRACE_EVENTS"; payload: TraceEvent[] }
   | { type: "SELECT_STEP"; payload: string | null }
   | { type: "SET_PROCESSING"; payload: boolean }
-  | { type: "CLEAR_MESSAGES"; payload?: { keepMessageId?: string | null } }
+  | {
+      type: "CLEAR_MESSAGES";
+      payload?: {
+        keepMessageId?: string | null;
+        preserveUserMessages?: boolean;
+        preserveStreamingFinalAnswers?: boolean;
+      };
+    }
   | { type: "RESET_STATE" }
   | { type: "OPEN_FILE_PREVIEW"; payload: { fileId: string; fileName: string; files?: Array<{ fileId: string; fileName: string }>; index?: number } }
   | { type: "CLOSE_FILE_PREVIEW" }
@@ -742,11 +751,25 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, isProcessing: action.payload }
 
     case "CLEAR_MESSAGES":
-      if (action.payload?.keepMessageId) {
-        return {
-          ...state,
-          messages: state.messages.filter(m => m.id === action.payload?.keepMessageId)
-        }
+      if (action.payload) {
+        const {
+          keepMessageId,
+          preserveUserMessages,
+          preserveStreamingFinalAnswers,
+        } = action.payload
+        const messagesToKeep = state.messages.filter(message => {
+          if (keepMessageId && message.id === keepMessageId) {
+            return true
+          }
+          if (preserveUserMessages && message.role === "user") {
+            return true
+          }
+          return (
+            preserveStreamingFinalAnswers &&
+            isStreamingFinalAnswerMessage(message)
+          )
+        })
+        return { ...state, messages: messagesToKeep }
       }
       return { ...state, messages: [] }
 
@@ -980,7 +1003,14 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
       const keepMessageId = pendingOptimisticMessageId.current
       pendingOptimisticMessageId.current = null
 
-      dispatch({ type: "CLEAR_MESSAGES", payload: { keepMessageId } })
+      dispatch({
+        type: "CLEAR_MESSAGES",
+        payload: {
+          keepMessageId,
+          preserveUserMessages: true,
+          preserveStreamingFinalAnswers: true,
+        },
+      })
       dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
       dispatch({ type: "SET_STEPS", payload: [] })
     } else {
@@ -989,6 +1019,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
     }
 
     // Set history loading state
+    isHistoricalDataLoading = true
     dispatch({ type: "SET_HISTORY_LOADING", payload: true })
 
     // Safety timeout: if no history arrives within 2 seconds, assume empty or done
@@ -1108,15 +1139,24 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
   const handleMessage = useCallback((message: WebSocketMessage, dispatch: React.Dispatch<AppAction>, currentState: AppState) => {
     // If we're in replay mode, don't process immediately - collect for delayed playback
-    if (currentState.isReplaying) {
+    if (
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: currentState.isReplaying,
+        isHistoryLoading: currentState.isHistoryLoading || isHistoricalDataLoading,
+        message,
+      })
+    ) {
       // Add to replay cache
       dispatch({ type: "ADD_TO_REPLAY_CACHE", payload: message })
 
       // If this is historical_data_complete, start the delayed playback
-      const isHistoricalComplete = message.type === "historical_data_complete" ||
-        (message.type === "trace_event" && (message as any).event_type === "historical_data_complete")
+      const isHistoricalComplete =
+        getWebSocketEventType(message) === "historical_data_complete"
 
       if (isHistoricalComplete) {
+        isHistoricalDataLoading = false
+        dispatch({ type: "SET_HISTORY_LOADING", payload: false })
+        dispatch({ type: "SYNC_PROCESSING_STATUS" })
         // Add a small delay to ensure all events are collected before starting playback
         setTimeout(() => {
           startDelayedPlayback()
@@ -4098,6 +4138,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
     dispatch({ type: "SET_TASK_ID", payload: taskId })
     // Set history loading state immediately when switching tasks to prevent empty state flash
     if (taskId) {
+      isHistoricalDataLoading = true
       dispatch({ type: "SET_HISTORY_LOADING", payload: true })
     }
   }, [router])

--- a/frontend/src/contexts/app-context.tsx
+++ b/frontend/src/contexts/app-context.tsx
@@ -26,8 +26,10 @@ import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 import {
   getFinalAnswerStreamActionPayload,
   getFinalAnswerStreamMessageId,
+  getWebSocketEventType,
   isFinalAnswerStreamEventType,
   isStreamingFinalAnswerMessage,
+  shouldBufferMessageForHistoricalReplay,
 } from "@/lib/streaming-final-answer"
 
 // Unique ID generator for messages
@@ -804,15 +806,22 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
   const handleMessage = useCallback((message: WebSocketMessage, dispatch: React.Dispatch<AppAction>, currentState: AppState) => {
     // If we're in replay mode, don't process immediately - collect for delayed playback
-    if (currentState.isReplaying) {
+    if (
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: currentState.isReplaying,
+        isHistoryLoading: isHistoricalDataLoading,
+        message,
+      })
+    ) {
       // Add to replay cache
       dispatch({ type: "ADD_TO_REPLAY_CACHE", payload: message })
 
       // If this is historical_data_complete, start the delayed playback
-      const isHistoricalComplete = message.type === "historical_data_complete" ||
-        (message.type === "trace_event" && (message as any).event_type === "historical_data_complete")
+      const isHistoricalComplete =
+        getWebSocketEventType(message) === "historical_data_complete"
 
       if (isHistoricalComplete) {
+        isHistoricalDataLoading = false
         // Add a small delay to ensure all events are collected before starting playback
         setTimeout(() => {
           startDelayedPlayback()

--- a/frontend/src/lib/streaming-final-answer.test.ts
+++ b/frontend/src/lib/streaming-final-answer.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest"
 import {
   getFinalAnswerStreamActionPayload,
   getFinalAnswerStreamMessageId,
+  getWebSocketEventType,
   mergeTraceEventsById,
+  shouldBufferMessageForHistoricalReplay,
 } from "@/lib/streaming-final-answer"
 
 describe("streaming final answer events", () => {
@@ -72,5 +74,51 @@ describe("streaming final answer events", () => {
         stream_message_id: "final_answer_2",
       }),
     ).toBe("final_answer_2")
+  })
+
+  it("does not replay-buffer live final answer stream events", () => {
+    expect(
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: true,
+        isHistoryLoading: true,
+        message: { type: "final_answer_delta" },
+      }),
+    ).toBe(false)
+  })
+
+  it("only buffers non-stream events while historical replay is loading", () => {
+    expect(
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: true,
+        isHistoryLoading: true,
+        message: {
+          type: "trace_event",
+          event_type: "tool_execution_start",
+        },
+      }),
+    ).toBe(true)
+    expect(
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: true,
+        isHistoryLoading: false,
+        message: {
+          type: "trace_event",
+          event_type: "tool_execution_start",
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it("keeps historical completion as the replay flush marker", () => {
+    expect(getWebSocketEventType({ type: "historical_data_complete" })).toBe(
+      "historical_data_complete",
+    )
+    expect(
+      shouldBufferMessageForHistoricalReplay({
+        isReplaying: true,
+        isHistoryLoading: false,
+        message: { type: "historical_data_complete" },
+      }),
+    ).toBe(true)
   })
 })

--- a/frontend/src/lib/streaming-final-answer.ts
+++ b/frontend/src/lib/streaming-final-answer.ts
@@ -10,6 +10,12 @@ type TraceEventLike = {
   event_id?: string
 }
 
+type WebSocketEventLike = {
+  type?: unknown
+  event_type?: unknown
+  data?: unknown
+}
+
 export type FinalAnswerStreamEventType =
   | "final_answer_start"
   | "final_answer_delta"
@@ -41,6 +47,48 @@ export const isFinalAnswerStreamEventType = (
     value === "final_answer_end" ||
     value === "final_answer_error"
   )
+}
+
+export const getWebSocketEventType = (
+  message: WebSocketEventLike,
+): string | undefined => {
+  if (typeof message.type !== "string") {
+    return undefined
+  }
+  if (message.type !== "trace_event") {
+    return message.type
+  }
+
+  if (typeof message.event_type === "string") {
+    return message.event_type
+  }
+
+  const data =
+    message.data && typeof message.data === "object"
+      ? (message.data as Record<string, unknown>)
+      : {}
+  return typeof data.event_type === "string" ? data.event_type : message.type
+}
+
+export const shouldBufferMessageForHistoricalReplay = ({
+  isReplaying,
+  isHistoryLoading,
+  message,
+}: {
+  isReplaying: boolean
+  isHistoryLoading: boolean
+  message: WebSocketEventLike
+}): boolean => {
+  if (!isReplaying) {
+    return false
+  }
+
+  const eventType = getWebSocketEventType(message)
+  if (isFinalAnswerStreamEventType(eventType)) {
+    return false
+  }
+
+  return isHistoryLoading || eventType === "historical_data_complete"
 }
 
 export const getFinalAnswerStreamMessageId = (

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -665,7 +665,6 @@ class AutoPattern(AgentPattern):
             answer_emitter = FinalAnswerStreamSession(
                 runtime,
                 enabled=True,
-                buffer_deltas=True,
             )
             answer_streamer = ToolCallStringFieldStreamer(
                 runtime=runtime,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1221,10 +1221,7 @@ class DAGPattern(AgentPattern):
             tools=tools,
             metadata={"phase": "dag_completion_assessment"},
         )
-        final_answer_stream = FinalAnswerStreamSession(
-            runtime,
-            buffer_deltas=True,
-        )
+        final_answer_stream = FinalAnswerStreamSession(runtime)
         streamer = ToolCallStringFieldStreamer(
             runtime=runtime,
             tool_name=DAG_COMPLETION_TOOL_NAME,

--- a/src/xagent/core/agent/pattern/final_answer_stream.py
+++ b/src/xagent/core/agent/pattern/final_answer_stream.py
@@ -22,11 +22,9 @@ class FinalAnswerStreamSession:
         runtime: PatternRuntime,
         *,
         enabled: bool = True,
-        buffer_deltas: bool = False,
     ) -> None:
         self.runtime = runtime
         self.enabled = enabled
-        self.buffer_deltas = buffer_deltas
         self.message_id: str | None = None
         self._content = ""
         self._closed = False
@@ -48,9 +46,6 @@ class FinalAnswerStreamSession:
     async def emit_delta(self, delta: str) -> None:
         if not self.enabled or not delta or self._closed:
             return
-        if self.buffer_deltas:
-            self._content += delta
-            return
         if await self.start() is None:
             return
         self._content += delta
@@ -60,31 +55,16 @@ class FinalAnswerStreamSession:
     async def emit_prefix(self, content: str) -> None:
         if len(content) <= len(self._content):
             return
-        if self.buffer_deltas:
-            self._content = content
-            return
         await self.emit_delta(content[len(self._content) :])
 
     async def finish(self, content: str) -> None:
         if not self.enabled or self._closed:
             return
         final_content = content or self._content
-        if self.buffer_deltas:
-            if not final_content:
-                return
-            self._content = final_content
-            message_id = await self.start()
-            if message_id is None:
-                return
-            await self.runtime.emit_final_answer_delta(
-                message_id,
-                final_content,
-            )
-        else:
-            await self.emit_prefix(final_content)
-            message_id = self.message_id
-            if message_id is None:
-                return
+        await self.emit_prefix(final_content)
+        message_id = self.message_id
+        if message_id is None:
+            return
         await self.runtime.end_final_answer_stream(message_id, final_content)
         self._closed = True
 
@@ -98,14 +78,7 @@ class FinalAnswerStreamEmitter(FinalAnswerStreamSession):
     """Lazy final-answer UI stream emitter."""
 
     def __init__(self, runtime: PatternRuntime, *, enabled: bool = True) -> None:
-        super().__init__(runtime, enabled=enabled, buffer_deltas=False)
-
-
-class BufferedFinalAnswerStreamEmitter(FinalAnswerStreamSession):
-    """Collect a candidate answer and flush it only after validation succeeds."""
-
-    def __init__(self, runtime: PatternRuntime, *, enabled: bool = True) -> None:
-        super().__init__(runtime, enabled=enabled, buffer_deltas=True)
+        super().__init__(runtime, enabled=enabled)
 
 
 class ToolCallStringFieldStreamer:
@@ -182,11 +155,7 @@ class ReActFinalAnswerStreamer:
     """Streams ReAct final answers from final_answer control-tool args."""
 
     def __init__(self, runtime: PatternRuntime, *, enabled: bool = True) -> None:
-        self.emitter = FinalAnswerStreamSession(
-            runtime,
-            enabled=enabled,
-            buffer_deltas=True,
-        )
+        self.emitter = FinalAnswerStreamSession(runtime, enabled=enabled)
         self._tool_answer_streamer = ToolCallStringFieldStreamer(
             runtime=runtime,
             tool_name="final_answer",
@@ -194,12 +163,19 @@ class ReActFinalAnswerStreamer:
             emitter=self.emitter,
             enabled=enabled,
         )
+        self._disabled = not enabled
 
     @property
     def started(self) -> bool:
         return self._tool_answer_streamer.has_candidate
 
     async def handle_chunk(self, chunk: Any) -> None:
+        if self._disabled:
+            return
+        tool_names = _tool_call_names(chunk)
+        if tool_names and any(name != "final_answer" for name in tool_names):
+            self._disabled = True
+            return
         await self._tool_answer_streamer.handle_chunk(chunk)
 
     async def finish(self, final_content: str) -> None:
@@ -233,6 +209,17 @@ def _tool_call_arguments(chunk: Any, tool_name: str) -> str | None:
         arguments = function_payload.get("arguments")
         return arguments if isinstance(arguments, str) else None
     return None
+
+
+def _tool_call_names(chunk: Any) -> list[str]:
+    if not _is_tool_call_chunk(chunk):
+        return []
+    names: list[str] = []
+    for tool_call in list(getattr(chunk, "tool_calls", None) or []):
+        name = _function_payload(tool_call).get("name")
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
 
 
 def _merge_json_arguments_fragment(existing: str, fragment: str) -> str:

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -25,6 +25,25 @@ from .base import BaseLLM
 logger = logging.getLogger(__name__)
 
 
+def _anthropic_stream_tool_calls(
+    accumulated_tool_calls: Dict[str, Dict],
+) -> List[Dict[str, Any]]:
+    tool_calls_list: List[Dict[str, Any]] = []
+    for tool_call in accumulated_tool_calls.values():
+        arguments = tool_call.get("arguments") or "{}"
+        tool_calls_list.append(
+            {
+                "id": tool_call.get("id", ""),
+                "type": "function",
+                "function": {
+                    "name": tool_call.get("name", ""),
+                    "arguments": arguments,
+                },
+            }
+        )
+    return tool_calls_list
+
+
 def _handle_union_type(schema: Dict[str, Any], union_key: str) -> Dict[str, Any]:
     """Simplify anyOf/oneOf for Claude API compatibility.
 
@@ -752,6 +771,7 @@ class ClaudeLLM(BaseLLM):
 
         # Tool call accumulation
         accumulated_tool_calls: Dict[str, Dict] = {}
+        tool_id_by_content_block_index: Dict[int, str] = {}
         current_content = ""
 
         try:
@@ -905,11 +925,14 @@ class ClaudeLLM(BaseLLM):
                             # Initialize tool call
                             tool_id = block.id if hasattr(block, "id") else ""
                             tool_name = block.name if hasattr(block, "name") else ""
+                            block_index = getattr(event, "index", None)
                             accumulated_tool_calls[tool_id] = {
                                 "id": tool_id,
                                 "name": tool_name,
                                 "arguments": "",
                             }
+                            if isinstance(block_index, int):
+                                tool_id_by_content_block_index[block_index] = tool_id
 
                 elif event.type == "content_block_delta":
                     # Incremental content update
@@ -930,11 +953,19 @@ class ClaudeLLM(BaseLLM):
                             # IMPORTANT: event.index is an INTEGER (content block position 0, 1, 2, ...)
                             # NOT the tool_id string (like "toolu_01GK595WLP7ewvoLiMRV6sG4")
                             # We must use event.index to look up the correct tool_id
-                            if hasattr(event, "index") and accumulated_tool_calls:
+                            event_index = getattr(event, "index", None)
+                            if (
+                                isinstance(event_index, int)
+                                and event_index in tool_id_by_content_block_index
+                            ):
+                                tool_id = tool_id_by_content_block_index[event_index]
+                            elif (
+                                isinstance(event_index, int) and accumulated_tool_calls
+                            ):
                                 # Get tool_id by index (event.index is the position in content blocks)
                                 tool_ids = list(accumulated_tool_calls.keys())
-                                if 0 <= event.index < len(tool_ids):
-                                    tool_id = tool_ids[event.index]
+                                if 0 <= event_index < len(tool_ids):
+                                    tool_id = tool_ids[event_index]
                                 else:
                                     # Fallback to first tool if index is out of range
                                     logger.warning(
@@ -959,6 +990,14 @@ class ClaudeLLM(BaseLLM):
                                     else ""
                                 )
                                 accumulated_tool_calls[tool_id]["arguments"] += args
+                                if args:
+                                    yield StreamChunk(
+                                        type=ChunkType.TOOL_CALL,
+                                        tool_calls=_anthropic_stream_tool_calls(
+                                            accumulated_tool_calls
+                                        ),
+                                        raw=event,
+                                    )
                             else:
                                 logger.warning(
                                     f"tool_id {tool_id} not found in accumulated_tool_calls"
@@ -1014,27 +1053,11 @@ class ClaudeLLM(BaseLLM):
                         if stop_reason:
                             # Yield tool calls if accumulated
                             if accumulated_tool_calls:
-                                tool_calls_list = []
-                                for tool_call in accumulated_tool_calls.values():
-                                    # Ensure arguments is valid JSON
-                                    arguments = tool_call["arguments"]
-                                    if not arguments or arguments == "":
-                                        arguments = "{}"
-
-                                    tool_calls_list.append(
-                                        {
-                                            "id": tool_call["id"],
-                                            "type": "function",
-                                            "function": {
-                                                "name": tool_call["name"],
-                                                "arguments": arguments,
-                                            },
-                                        }
-                                    )
-
                                 yield StreamChunk(
                                     type=ChunkType.TOOL_CALL,
-                                    tool_calls=tool_calls_list,
+                                    tool_calls=_anthropic_stream_tool_calls(
+                                        accumulated_tool_calls
+                                    ),
                                     finish_reason=stop_reason,
                                     raw=event,
                                 )

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -21,6 +21,27 @@ from .base import BaseLLM
 logger = logging.getLogger(__name__)
 
 
+def _zhipu_stream_tool_calls(
+    accumulated_tool_calls: Dict[str, Dict],
+) -> List[Dict[str, Any]]:
+    tool_calls_list: List[Dict[str, Any]] = []
+    for tool_call in accumulated_tool_calls.values():
+        function_payload: Dict[str, Any] = {
+            "name": tool_call.get("name", ""),
+            "arguments": tool_call.get("arguments", ""),
+        }
+        item: Dict[str, Any] = {
+            "id": tool_call.get("id", ""),
+            "type": "function",
+            "function": function_payload,
+        }
+        index = tool_call.get("index")
+        if isinstance(index, int):
+            item["index"] = index
+        tool_calls_list.append(item)
+    return tool_calls_list
+
+
 class ZhipuLLM(BaseLLM):
     """
     Zhipu AI LLM client using the official Zhipu SDK.
@@ -440,10 +461,10 @@ class ZhipuLLM(BaseLLM):
                 Consume the synchronous Zhipu stream and put chunks into the queue.
                 This runs in a separate thread to avoid blocking the event loop.
                 """
-                if self._client is None:
-                    raise RuntimeError("Zhipu client is not initialized")
-
                 try:
+                    if self._client is None:
+                        raise RuntimeError("Zhipu client is not initialized")
+
                     stream = self._client.chat.completions.create(**completion_params)
 
                     for chunk in stream:
@@ -467,6 +488,9 @@ class ZhipuLLM(BaseLLM):
                                         tool_call_dict: Dict[str, Any] = {
                                             "id": getattr(tool_call, "id", None),
                                         }
+                                        index = getattr(tool_call, "index", None)
+                                        if isinstance(index, int):
+                                            tool_call_dict["index"] = index
 
                                         if hasattr(tool_call, "function"):
                                             func = tool_call.function
@@ -527,7 +551,7 @@ class ZhipuLLM(BaseLLM):
                         loop.call_soon_threadsafe(put_exception)
 
             # Start the producer thread
-            await loop.run_in_executor(None, stream_producer)
+            producer_task = loop.run_in_executor(None, stream_producer)
 
             # Consume chunks from the queue as they arrive (true streaming)
             while True:
@@ -582,19 +606,35 @@ class ZhipuLLM(BaseLLM):
 
                         # Check for tool calls
                         if delta.get("tool_calls"):
+                            saw_tool_call_delta = False
                             for tool_call in delta["tool_calls"]:
                                 tool_id = tool_call.get("id")
+                                index = tool_call.get("index")
 
                                 # Initialize tool call if not exists
+                                if not tool_id and isinstance(index, int):
+                                    for (
+                                        existing_id,
+                                        existing_tool_call,
+                                    ) in accumulated_tool_calls.items():
+                                        if existing_tool_call.get("index") == index:
+                                            tool_id = existing_id
+                                            break
+                                if not tool_id and len(accumulated_tool_calls) == 1:
+                                    tool_id = next(iter(accumulated_tool_calls.keys()))
                                 if tool_id and tool_id not in accumulated_tool_calls:
                                     accumulated_tool_calls[tool_id] = {
                                         "id": tool_id,
+                                        "index": index
+                                        if isinstance(index, int)
+                                        else None,
                                         "name": "",
                                         "arguments": "",
                                     }
 
                                 # Update tool call info
                                 if tool_id:
+                                    saw_tool_call_delta = True
                                     func = tool_call.get("function")
                                     if func:
                                         if func.get("name"):
@@ -605,28 +645,28 @@ class ZhipuLLM(BaseLLM):
                                             accumulated_tool_calls[tool_id][
                                                 "arguments"
                                             ] += func["arguments"]
+                                    if isinstance(index, int):
+                                        accumulated_tool_calls[tool_id]["index"] = index
+
+                            if saw_tool_call_delta:
+                                yield StreamChunk(
+                                    type=ChunkType.TOOL_CALL,
+                                    tool_calls=_zhipu_stream_tool_calls(
+                                        accumulated_tool_calls
+                                    ),
+                                    raw=chunk_dict,
+                                )
 
                     # Check for finish reason
                     finish_reason = choice.get("finish_reason")
                     if finish_reason:
                         # Yield tool calls if accumulated
                         if accumulated_tool_calls:
-                            tool_calls_list = []
-                            for tool_call in accumulated_tool_calls.values():
-                                tool_calls_list.append(
-                                    {
-                                        "id": tool_call["id"],
-                                        "type": "function",
-                                        "function": {
-                                            "name": tool_call["name"],
-                                            "arguments": tool_call["arguments"],
-                                        },
-                                    }
-                                )
-
                             yield StreamChunk(
                                 type=ChunkType.TOOL_CALL,
-                                tool_calls=tool_calls_list,
+                                tool_calls=_zhipu_stream_tool_calls(
+                                    accumulated_tool_calls
+                                ),
                                 finish_reason=finish_reason,
                                 raw=chunk_dict,
                             )
@@ -662,6 +702,8 @@ class ZhipuLLM(BaseLLM):
                         usage=usage_dict,
                         raw=chunk_dict,
                     )
+
+            await producer_task
 
         except LLMTimeoutError:
             # Re-raise timeout errors for retry

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -562,9 +562,7 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
 
 
 @pytest.mark.asyncio
-async def test_auto_pattern_buffers_direct_final_answer_until_decision_is_validated() -> (
-    None
-):
+async def test_auto_pattern_streams_direct_final_answer_as_tool_args_arrive() -> None:
     prefix = (
         '{"action":"final_answer","reason":"simple",'
         '"requires_current_or_external_facts":false,'
@@ -597,9 +595,15 @@ async def test_auto_pattern_buffers_direct_final_answer_until_decision_is_valida
     assert [event["type"] for event in collector.events] == [
         "final_answer_start",
         "final_answer_delta",
+        "final_answer_delta",
+        "final_answer_delta",
         "final_answer_end",
     ]
-    assert collector.events[1]["delta"] == "Hi there."
+    assert [event["delta"] for event in collector.events[1:-1]] == [
+        "Hi",
+        " there",
+        ".",
+    ]
     assert collector.events[-1]["content"] == "Hi there."
     assert len({event["message_id"] for event in collector.events}) == 1
     assert len(llm.calls) == 1

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -548,9 +548,15 @@ async def test_react_pattern_streams_final_answer_control_tool() -> None:
     assert [event["type"] for event in outbound.events] == [
         "final_answer_start",
         "final_answer_delta",
+        "final_answer_delta",
+        "final_answer_delta",
         "final_answer_end",
     ]
-    assert outbound.events[1]["delta"] == "Hi there."
+    assert [event["delta"] for event in outbound.events[1:-1]] == [
+        "Hi",
+        " there",
+        ".",
+    ]
     assert outbound.events[-1]["content"] == "Hi there."
 
 

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -1,5 +1,7 @@
 """Test cases for Claude LLM implementation using Anthropic SDK."""
 
+from types import SimpleNamespace
+
 import pytest
 from jsonschema import Draft202012Validator
 
@@ -7,6 +9,21 @@ from xagent.core.model.chat.basic.claude import (
     ClaudeLLM,
     _fix_pydantic_schema_for_claude,
 )
+from xagent.core.model.chat.types import ChunkType
+
+
+class _AsyncEventStream:
+    def __init__(self, events):
+        self._events = iter(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
 
 
 class TestClaudeLLM:
@@ -39,6 +56,74 @@ class TestClaudeLLM:
             "additionalProperties": False,
         }
         assert fixed["properties"]["limit"] == {"type": "integer"}
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_yields_tool_call_argument_deltas(self, llm, mocker):
+        """Claude input_json_delta events should surface before message stop."""
+        mock_client = mocker.AsyncMock()
+        events = [
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(
+                    type="tool_use",
+                    id="toolu_1",
+                    name="final_answer",
+                ),
+            ),
+            SimpleNamespace(
+                type="content_block_delta",
+                index=0,
+                delta=SimpleNamespace(
+                    type="input_json_delta",
+                    partial_json='{"answer":"Hel',
+                ),
+            ),
+            SimpleNamespace(
+                type="content_block_delta",
+                index=0,
+                delta=SimpleNamespace(
+                    type="input_json_delta",
+                    partial_json='lo"}',
+                ),
+            ),
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(stop_reason="tool_use"),
+            ),
+        ]
+        mock_client.messages.create.return_value = _AsyncEventStream(events)
+        mocker.patch(
+            "xagent.core.model.chat.basic.claude.AsyncAnthropic",
+            return_value=mock_client,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "answer"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "final_answer",
+                            "description": "Return final answer",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"answer": {"type": "string"}},
+                                "required": ["answer"],
+                            },
+                        },
+                    }
+                ],
+            )
+        ]
+
+        tool_chunks = [chunk for chunk in chunks if chunk.type == ChunkType.TOOL_CALL]
+        assert [
+            chunk.tool_calls[0]["function"]["arguments"] for chunk in tool_chunks
+        ] == ['{"answer":"Hel', '{"answer":"Hello"}', '{"answer":"Hello"}']
+        assert tool_chunks[-1].finish_reason == "tool_use"
 
     @pytest.mark.asyncio
     async def test_basic_chat_completion(self, llm, mocker):

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -1,10 +1,12 @@
 """Test cases for Zhipu LLM implementation."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from xagent.core.model.chat.basic.zhipu import ZhipuLLM
+from xagent.core.model.chat.types import ChunkType
 
 
 class TestZhipuLLM:
@@ -134,6 +136,92 @@ class TestZhipuLLM:
         assert result["type"] == "tool_call"
         assert len(result["tool_calls"]) == 1
         assert result["tool_calls"][0]["function"]["name"] == "calculator"
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_yields_tool_call_argument_deltas(
+        self, zhipu_llm, mock_zhipu_client
+    ):
+        """Zhipu stream_chat should consume the producer queue while it streams."""
+        mock_zhipu_client.chat.completions.create.return_value = [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            content=None,
+                            tool_calls=[
+                                SimpleNamespace(
+                                    id="call_1",
+                                    index=0,
+                                    function=SimpleNamespace(
+                                        name="final_answer",
+                                        arguments='{"answer":"Hel',
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            content=None,
+                            tool_calls=[
+                                SimpleNamespace(
+                                    id=None,
+                                    index=0,
+                                    function=SimpleNamespace(
+                                        name=None,
+                                        arguments='lo"}',
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=None, tool_calls=None),
+                        finish_reason="tool_calls",
+                    )
+                ],
+                usage=None,
+            ),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in zhipu_llm.stream_chat(
+                [{"role": "user", "content": "answer"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "final_answer",
+                            "description": "Return final answer",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"answer": {"type": "string"}},
+                                "required": ["answer"],
+                            },
+                        },
+                    }
+                ],
+            )
+        ]
+
+        tool_chunks = [chunk for chunk in chunks if chunk.type == ChunkType.TOOL_CALL]
+        assert [
+            chunk.tool_calls[0]["function"]["arguments"] for chunk in tool_chunks
+        ] == ['{"answer":"Hel', '{"answer":"Hello"}', '{"answer":"Hello"}']
+        assert tool_chunks[-1].finish_reason == "tool_calls"
 
     @pytest.mark.asyncio
     async def test_none_api_response(self, zhipu_llm, mock_zhipu_client):


### PR DESCRIPTION
## Summary
- stream final-answer deltas immediately instead of buffering until completion
- surface Claude and Zhipu streamed tool-call argument chunks as they arrive
- keep live stream events out of historical replay buffering and preserve user messages during same-task reconnects

## Tests
- PYTHONPATH=src pytest tests/core/agent/test_runtime.py tests/core/agent/test_react.py tests/core/agent/test_auto.py tests/core/agent/test_dag.py tests/core/model/chat/basic/test_claude.py tests/core/model/chat/basic/test_zhipu.py -q
- npm run --prefix frontend test -- streaming-final-answer.test.ts TraceEventRenderer.test.tsx --run
- npm run --prefix frontend type-check
- npm run --prefix frontend lint
- ruff check src/xagent/core/model/chat/basic/claude.py src/xagent/core/model/chat/basic/zhipu.py src/xagent/core/agent/pattern/final_answer_stream.py tests/core/model/chat/basic/test_claude.py tests/core/model/chat/basic/test_zhipu.py tests/core/agent/test_auto.py tests/core/agent/test_react.py
- git diff --check