### PR TITLE
ref: centralize agent model cache stores

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, field_validator
 
 from .....config import get_uploads_dir
-from .....web.services.hot_path_cache import invalidate_agent_cache
+from .....web.services.agent_store import AgentStore
 from .....web.services.model_service import (
     _get_visible_user_ids,
     _is_model_visible_to_user,
@@ -460,7 +460,7 @@ class CreateAgentTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Create a new agent with the given configuration."""
-        from .....web.models.agent import Agent, AgentStatus
+        from .....web.models.agent import AgentStatus
         from .....web.models.user import UserDefaultModel, UserModel
 
         try:
@@ -580,8 +580,7 @@ class CreateAgentTool(AbstractBaseTool):
                     ),
                 ).model_dump()
 
-            # Create the agent in DRAFT status
-            agent = Agent(
+            agent = AgentStore(self._db).create_agent(
                 user_id=self._user_id,
                 name=agent_name,
                 description=agent_description,
@@ -591,14 +590,9 @@ class CreateAgentTool(AbstractBaseTool):
                 knowledge_bases=knowledge_bases,
                 skills=ensure_list(args.get("skills")),
                 tool_categories=ensure_list(args.get("tool_categories")),
-                suggested_prompts=[],
                 status=AgentStatus.DRAFT,  # Create as DRAFT, not PUBLISHED
+                suggested_prompts=[],
             )
-
-            self._db.add(agent)
-            self._db.commit()
-            self._db.refresh(agent)
-            invalidate_agent_cache(self._user_id, int(agent.id))
 
             # Generate the tool name and markdown link
             tool_name = gen_agent_tool_name(agent_name)
@@ -807,6 +801,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
             # Track changes
             changes = []
+            updates: dict[str, Any] = {}
 
             # Update name if provided
             new_name = args.get("name", "").strip() if args.get("name") else None
@@ -830,7 +825,7 @@ class UpdateAgentTool(AbstractBaseTool):
                         status="error",
                         message=f"Error: Agent with name '{new_name}' already exists",
                     ).model_dump()
-                agent.name = new_name
+                updates["name"] = new_name
                 changes.append(f"name → '{new_name}'")
 
             # Update description if provided
@@ -838,7 +833,7 @@ class UpdateAgentTool(AbstractBaseTool):
                 args.get("description", "").strip() if args.get("description") else None
             )
             if new_description:
-                agent.description = new_description
+                updates["description"] = new_description
                 changes.append("description updated")
 
             # Update instructions if provided
@@ -848,13 +843,13 @@ class UpdateAgentTool(AbstractBaseTool):
                 else None
             )
             if new_instructions:
-                agent.instructions = new_instructions
+                updates["instructions"] = new_instructions
                 changes.append("instructions updated")
 
             # Update tool_categories if provided
             new_tool_categories = ensure_list(args.get("tool_categories"))
             if new_tool_categories is not None:
-                agent.tool_categories = new_tool_categories
+                updates["tool_categories"] = new_tool_categories
                 changes.append(f"tool_categories → {new_tool_categories}")
 
             # Update knowledge_bases if provided
@@ -875,19 +870,19 @@ class UpdateAgentTool(AbstractBaseTool):
                             + ", ".join(missing_kbs)
                         ),
                     ).model_dump()
-                agent.knowledge_bases = new_knowledge_bases
+                updates["knowledge_bases"] = new_knowledge_bases
                 changes.append(f"knowledge_bases → {new_knowledge_bases}")
 
             # Update skills if provided
             new_skills = ensure_list(args.get("skills"))
             if new_skills is not None:
-                agent.skills = new_skills
+                updates["skills"] = new_skills
                 changes.append(f"skills → {new_skills}")
 
             # Update execution_mode if provided
             new_execution_mode = args.get("execution_mode")
             if new_execution_mode in ["flash", "balanced", "think", "auto"]:
-                agent.execution_mode = new_execution_mode
+                updates["execution_mode"] = new_execution_mode
                 changes.append(f"execution_mode → {new_execution_mode}")
 
             # Check if there were any changes
@@ -903,22 +898,25 @@ class UpdateAgentTool(AbstractBaseTool):
                     f"All fields were the same or no values were provided.",
                 ).model_dump()
 
-            # Commit changes to database
-            self._db.commit()
-            self._db.refresh(agent)
-            invalidate_agent_cache(self._user_id, int(agent.id))
+            agent = (
+                AgentStore(self._db).update_agent_fields(
+                    self._user_id, agent_id, updates
+                )
+                or agent
+            )
 
             # Generate the tool name and markdown link
-            tool_name = gen_agent_tool_name(agent.name)
-            markdown_link = f"[{agent.name}](agent://{agent.id})"
+            agent_name = str(agent.name)
+            tool_name = gen_agent_tool_name(agent_name)
+            markdown_link = f"[{agent_name}](agent://{agent.id})"
 
             logger.info(
-                f"Updated {agent.status.value.upper()} agent '{agent.name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
+                f"Updated {agent.status.value.upper()} agent '{agent_name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
             )
 
             return UpdateAgentToolResult(
                 agent_id=agent.id,
-                agent_name=agent.name,
+                agent_name=agent_name,
                 tool_name=tool_name,
                 markdown_link=markdown_link,
                 status="success",

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -7,7 +7,7 @@ from ..models.database import get_db
 from ..models.task import Task
 from ..models.user import User
 from ..schemas.user import UserListResponse, UserResponse
-from ..services.hot_path_cache import invalidate_model_cache
+from ..services.model_store import ModelStore
 
 router = APIRouter(prefix="/api/admin/users", tags=["admin-users"])
 
@@ -92,6 +92,6 @@ async def delete_user(
     # Delete the user (UserModel and UserDefaultModel have cascade delete)
     db.delete(user)
     db.commit()
-    invalidate_model_cache(None)
+    ModelStore(db).invalidate_after_user_delete()
 
     return {"message": "User deleted successfully"}

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -17,26 +17,18 @@ from ...core.memory.in_memory import InMemoryMemoryStore
 from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...core.tracing import create_agent_tracer
 from ...core.utils.api_key import generate_api_key
-from ...core.utils.type_check import ensure_list
 from ..auth_dependencies import get_current_user
-from ..models.agent import Agent, AgentStatus
+from ..models.agent import Agent
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_db
 from ..models.model import Model as DBModel
-from ..models.task import Task
 from ..models.user import User
 from ..schemas.agent_api_key import (
     APIKeyGenerateResponse,
     APIKeyMetadataResponse,
     APIKeyRevokeResponse,
 )
-from ..services.hot_path_cache import (
-    agent_detail_key,
-    agent_list_key,
-    cache_get,
-    cache_set,
-    invalidate_agent_cache,
-)
+from ..services.agent_store import AgentStore
 from ..services.llm_utils import UserAwareModelStorage
 from ..tools.config import WebToolConfig
 from ..user_isolated_memory import UserContext
@@ -278,30 +270,6 @@ def _delete_logo(logo_url: str) -> None:
         logger.error(f"Failed to delete logo {logo_url}: {e}")
 
 
-def _agent_to_response(agent: Agent, db: Session) -> AgentResponse:
-    """Convert Agent model to response."""
-    return AgentResponse(
-        id=agent.id,
-        user_id=agent.user_id,
-        name=agent.name,
-        description=agent.description,
-        instructions=agent.instructions,
-        execution_mode=agent.execution_mode or "graph",
-        models=agent.models,
-        knowledge_bases=ensure_list(agent.knowledge_bases) or [],
-        skills=ensure_list(agent.skills) or [],
-        tool_categories=ensure_list(agent.tool_categories) or [],
-        suggested_prompts=ensure_list(agent.suggested_prompts) or [],
-        logo_url=agent.logo_url,
-        status=agent.status.value,
-        published_at=agent.published_at.isoformat() if agent.published_at else None,
-        created_at=agent.created_at.isoformat(),
-        updated_at=agent.updated_at.isoformat(),
-        widget_enabled=agent.widget_enabled,
-        allowed_domains=ensure_list(agent.allowed_domains) or [],
-    )
-
-
 def _get_owned_agent_or_404(agent_id: int, current_user: User, db: Session) -> Agent:
     """Resolve an agent_id against the caller's ownership, raising 404 otherwise.
 
@@ -424,13 +392,10 @@ async def create_agent(
 ) -> AgentResponse:
     """Create a new custom agent."""
     try:
+        store = AgentStore(db)
+        user_id = int(current_user.id)
         # Check for duplicate name
-        existing = (
-            db.query(Agent)
-            .filter(Agent.user_id == current_user.id, Agent.name == agent_data.name)
-            .first()
-        )
-        if existing:
+        if store.agent_name_exists(user_id, agent_data.name):
             raise HTTPException(
                 status_code=400, detail="Agent with this name already exists"
             )
@@ -440,9 +405,8 @@ async def create_agent(
         )
         await _validate_knowledge_bases_exist(agent_data.knowledge_bases, current_user)
 
-        # Create agent
-        agent = Agent(
-            user_id=current_user.id,
+        agent = store.create_agent(
+            user_id=user_id,
             name=agent_data.name,
             description=agent_data.description,
             instructions=agent_data.instructions,
@@ -452,26 +416,21 @@ async def create_agent(
             skills=agent_data.skills,
             tool_categories=agent_data.tool_categories,
             suggested_prompts=agent_data.suggested_prompts,
-            status=AgentStatus.DRAFT,
-            widget_enabled=True,
-            allowed_domains=[],
         )
-
-        db.add(agent)
-        db.commit()
-        db.refresh(agent)
 
         # Save logo if provided
         if agent_data.logo_base64:
             logo_url = _save_logo(agent_data.logo_base64, agent.id)  # type: ignore[arg-type]
             if logo_url:
-                agent.logo_url = logo_url  # type: ignore[assignment]
-                db.commit()
-                db.refresh(agent)
+                agent = (
+                    store.update_agent_fields(
+                        user_id, int(agent.id), {"logo_url": logo_url}
+                    )
+                    or agent
+                )
 
-        invalidate_agent_cache(int(current_user.id), int(agent.id))
         logger.info(f"Created agent {agent.id} for user {current_user.id}")
-        return _agent_to_response(agent, db)
+        return AgentResponse.model_validate(store.agent_to_response_dict(agent))
 
     except HTTPException:
         raise
@@ -488,36 +447,8 @@ async def list_agents(
 ) -> List[AgentListItem]:
     """List all agents for the current user."""
     try:
-        cache_key = agent_list_key(int(current_user.id))
-        cached = cache_get(cache_key)
-        if isinstance(cached, list):
-            return [AgentListItem.model_validate(item) for item in cached]
-
-        agents = (
-            db.query(Agent)
-            .filter(Agent.user_id == current_user.id)
-            .order_by(Agent.created_at.desc())
-            .all()
-        )
-
-        response = [
-            AgentListItem(
-                id=agent.id,
-                name=agent.name,
-                description=agent.description,
-                logo_url=agent.logo_url,
-                status=agent.status.value,
-                created_at=agent.created_at.isoformat(),
-                updated_at=agent.updated_at.isoformat()
-                if agent.updated_at
-                else agent.created_at.isoformat(),
-                widget_enabled=agent.widget_enabled,
-                allowed_domains=agent.allowed_domains or [],
-            )
-            for agent in agents
-        ]
-        cache_set(cache_key, [item.model_dump(mode="json") for item in response])
-        return response
+        items = AgentStore(db).list_agent_items(int(current_user.id))
+        return [AgentListItem.model_validate(item) for item in items]
 
     except Exception as e:
         logger.error(f"Failed to list agents: {e}")
@@ -532,23 +463,10 @@ async def get_agent(
 ) -> AgentResponse:
     """Get agent details."""
     try:
-        cache_key = agent_detail_key(int(current_user.id), agent_id)
-        cached = cache_get(cache_key)
-        if isinstance(cached, dict):
-            return AgentResponse.model_validate(cached)
-
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
-
-        if not agent:
+        response = AgentStore(db).get_agent_response(int(current_user.id), agent_id)
+        if response is None:
             raise HTTPException(status_code=404, detail="Agent not found")
-
-        response = _agent_to_response(agent, db)
-        cache_set(cache_key, response.model_dump(mode="json"))
-        return response
+        return AgentResponse.model_validate(response)
 
     except HTTPException:
         raise
@@ -566,11 +484,9 @@ async def update_agent(
 ) -> AgentResponse:
     """Update an existing agent."""
     try:
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
+        store = AgentStore(db)
+        user_id = int(current_user.id)
+        agent = store.get_owned_agent(user_id, agent_id)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
@@ -590,43 +506,37 @@ async def update_agent(
         await _validate_knowledge_bases_exist(effective_kb, current_user)  # type: ignore[arg-type]
 
         # Update fields
+        updates: dict[str, object] = {}
         if agent_data.name is not None:
             # Check for duplicate name (excluding current agent)
-            existing = (
-                db.query(Agent)
-                .filter(
-                    Agent.user_id == current_user.id,
-                    Agent.name == agent_data.name,
-                    Agent.id != agent_id,
-                )
-                .first()
-            )
-            if existing:
+            if store.agent_name_exists(
+                user_id, agent_data.name, exclude_agent_id=agent_id
+            ):
                 raise HTTPException(
                     status_code=400, detail="Agent with this name already exists"
                 )
-            agent.name = agent_data.name  # type: ignore[assignment]
+            updates["name"] = agent_data.name
 
         if agent_data.description is not None:
-            agent.description = agent_data.description  # type: ignore[assignment]
+            updates["description"] = agent_data.description
         if agent_data.instructions is not None:
-            agent.instructions = agent_data.instructions  # type: ignore[assignment]
+            updates["instructions"] = agent_data.instructions
         if agent_data.models is not None:
-            agent.models = agent_data.models  # type: ignore[assignment]
+            updates["models"] = agent_data.models
         if agent_data.knowledge_bases is not None:
-            agent.knowledge_bases = agent_data.knowledge_bases  # type: ignore[assignment]
+            updates["knowledge_bases"] = agent_data.knowledge_bases
         if agent_data.skills is not None:
-            agent.skills = agent_data.skills  # type: ignore[assignment]
+            updates["skills"] = agent_data.skills
         if agent_data.tool_categories is not None:
-            agent.tool_categories = agent_data.tool_categories  # type: ignore[assignment]
+            updates["tool_categories"] = agent_data.tool_categories
         if agent_data.execution_mode is not None:
-            agent.execution_mode = agent_data.execution_mode  # type: ignore[assignment]
+            updates["execution_mode"] = agent_data.execution_mode
         if agent_data.suggested_prompts is not None:
-            agent.suggested_prompts = agent_data.suggested_prompts  # type: ignore[assignment]
+            updates["suggested_prompts"] = agent_data.suggested_prompts
         if agent_data.widget_enabled is not None:
-            agent.widget_enabled = agent_data.widget_enabled  # type: ignore[assignment]
+            updates["widget_enabled"] = agent_data.widget_enabled
         if agent_data.allowed_domains is not None:
-            agent.allowed_domains = agent_data.allowed_domains  # type: ignore[assignment]
+            updates["allowed_domains"] = agent_data.allowed_domains
 
         # Handle logo
         if agent_data.logo_base64 is not None:
@@ -636,14 +546,13 @@ async def update_agent(
 
             # Save new logo
             logo_url = _save_logo(agent_data.logo_base64, agent.id)  # type: ignore[arg-type]
-            agent.logo_url = logo_url  # type: ignore[assignment]
+            updates["logo_url"] = logo_url
 
-        db.commit()
-        db.refresh(agent)
+        if updates:
+            agent = store.update_agent_fields(user_id, agent_id, updates) or agent
 
-        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Updated agent {agent_id} for user {current_user.id}")
-        return _agent_to_response(agent, db)
+        return AgentResponse.model_validate(store.agent_to_response_dict(agent))
 
     except HTTPException:
         raise
@@ -661,11 +570,9 @@ async def delete_agent(
 ) -> dict:
     """Delete an agent."""
     try:
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
+        store = AgentStore(db)
+        user_id = int(current_user.id)
+        agent = store.get_owned_agent(user_id, agent_id)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
@@ -674,12 +581,7 @@ async def delete_agent(
         if agent.logo_url:
             _delete_logo(agent.logo_url)  # type: ignore[arg-type]
 
-        db.query(AgentApiKey).filter(AgentApiKey.agent_id == agent_id).delete()
-        db.query(Task).filter(Task.agent_id == agent_id).update({Task.agent_id: None})
-        db.delete(agent)
-        db.commit()
-
-        invalidate_agent_cache(int(current_user.id), agent_id)
+        store.delete_agent(user_id, agent_id)
         logger.info(f"Deleted agent {agent_id} for user {current_user.id}")
         return {"message": "Agent deleted successfully"}
 
@@ -699,30 +601,24 @@ async def publish_agent(
 ) -> PublishResponse:
     """Publish an agent (make it publicly accessible)."""
     try:
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
+        store = AgentStore(db)
+        agent = store.get_owned_agent(int(current_user.id), agent_id)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        if agent.status == AgentStatus.PUBLISHED:
+        if agent.status.value == "published":
             return PublishResponse(
                 message="Agent is already published",
-                agent=_agent_to_response(agent, db),
+                agent=AgentResponse.model_validate(store.agent_to_response_dict(agent)),
             )
 
-        agent.status = AgentStatus.PUBLISHED
-        agent.published_at = datetime.now()  # type: ignore[assignment]
-        db.commit()
-        db.refresh(agent)
+        agent = store.publish_agent(int(current_user.id), agent_id) or agent
 
-        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Published agent {agent_id} for user {current_user.id}")
         return PublishResponse(
-            message="Agent published successfully", agent=_agent_to_response(agent, db)
+            message="Agent published successfully",
+            agent=AgentResponse.model_validate(store.agent_to_response_dict(agent)),
         )
 
     except HTTPException:
@@ -741,30 +637,24 @@ async def unpublish_agent(
 ) -> PublishResponse:
     """Unpublish an agent (revert to draft status)."""
     try:
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
+        store = AgentStore(db)
+        agent = store.get_owned_agent(int(current_user.id), agent_id)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        if agent.status != AgentStatus.PUBLISHED:
+        if agent.status.value != "published":
             return PublishResponse(
-                message="Agent is not published", agent=_agent_to_response(agent, db)
+                message="Agent is not published",
+                agent=AgentResponse.model_validate(store.agent_to_response_dict(agent)),
             )
 
-        agent.status = AgentStatus.DRAFT
-        agent.published_at = None  # type: ignore[assignment]
-        db.commit()
-        db.refresh(agent)
+        agent = store.unpublish_agent(int(current_user.id), agent_id) or agent
 
-        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Unpublished agent {agent_id} for user {current_user.id}")
         return PublishResponse(
             message="Agent unpublished successfully",
-            agent=_agent_to_response(agent, db),
+            agent=AgentResponse.model_validate(store.agent_to_response_dict(agent)),
         )
 
     except HTTPException:
@@ -784,11 +674,9 @@ async def upload_agent_logo(
 ) -> dict:
     """Upload or update agent logo."""
     try:
-        agent = (
-            db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
-            .first()
-        )
+        store = AgentStore(db)
+        user_id = int(current_user.id)
+        agent = store.get_owned_agent(user_id, agent_id)
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
@@ -802,11 +690,8 @@ async def upload_agent_logo(
         if not logo_url:
             raise HTTPException(status_code=400, detail="Failed to save logo")
 
-        agent.logo_url = logo_url  # type: ignore[assignment]
-        db.commit()
-        db.refresh(agent)
+        store.update_agent_fields(user_id, agent_id, {"logo_url": logo_url})
 
-        invalidate_agent_cache(int(current_user.id), agent_id)
         logger.info(f"Updated logo for agent {agent_id}")
         return {"logo_url": logo_url}
 

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -36,15 +36,8 @@ from ..schemas.model import (
     UserDefaultModelCreate,
     UserDefaultModelResponse,
 )
-from ..services.hot_path_cache import (
-    cache_get,
-    cache_set,
-    invalidate_model_cache,
-    model_list_key,
-    user_default_model_key,
-    user_default_models_key,
-)
 from ..services.llm_utils import CoreStorage
+from ..services.model_store import ModelSharingConflictError, ModelStore
 from ..user_isolated_memory import UserContext
 
 logger = logging.getLogger(__name__)
@@ -72,17 +65,7 @@ def _can_user_share(user: User) -> bool:
     return bool(user.is_admin)
 
 
-# Create router
 model_router = APIRouter(prefix="/api/models", tags=["models"])
-
-
-def _model_has_shared_visibility(db: Session, model_id: int) -> bool:
-    return (
-        db.query(UserModel.id)
-        .filter(UserModel.model_id == model_id, UserModel.is_shared.is_(True))
-        .first()
-        is not None
-    )
 
 
 def _decode_model_identifier(model_id: str) -> str:
@@ -137,38 +120,6 @@ def _resolve_accessible_model(
         return model_storage, db_model, shared
 
     raise HTTPException(status_code=404, detail="Model not found or access denied")
-
-
-def _serialize_model_with_access(
-    db_model: DBModel, user_model: UserModel, requesting_user_id: Optional[int] = None
-) -> dict[str, Any]:
-    """Build a model response payload with user access info."""
-
-    is_owner = (
-        user_model.is_owner and user_model.user_id == requesting_user_id
-        if requesting_user_id is not None
-        else user_model.is_owner
-    )
-
-    return {
-        "id": db_model.id,
-        "model_id": db_model.model_id,
-        "category": db_model.category,
-        "model_provider": db_model.model_provider,
-        "model_name": db_model.model_name,
-        "base_url": db_model.base_url,
-        "temperature": db_model.temperature,
-        "dimension": db_model.dimension,
-        "abilities": db_model.abilities,
-        "description": db_model.description,
-        "created_at": db_model.created_at.isoformat() if db_model.created_at else None,
-        "updated_at": db_model.updated_at.isoformat() if db_model.updated_at else None,
-        "is_active": db_model.is_active,
-        "is_owner": is_owner,
-        "can_edit": is_owner and user_model.can_edit,
-        "can_delete": is_owner and user_model.can_delete,
-        "is_shared": user_model.is_shared,
-    }
 
 
 def _normalize_provider_model_id(model_id: str) -> str:
@@ -399,17 +350,11 @@ async def create_model(
 
     # Create user model relationship
     is_share: bool = model.share_with_users and _can_user_share(user)
-    user_model = UserModel(
-        user_id=user.id,
-        model_id=db_model.id,
-        is_owner=True,
-        can_edit=True,
-        can_delete=True,
+    ModelStore(db).create_user_model_link(
+        user_id=int(user.id),
+        model_id=int(db_model.id),
         is_shared=is_share,
     )
-    db.add(user_model)
-    db.commit()
-    invalidate_model_cache(None if is_share else int(user.id))
 
     # No pre-creation for other users — dynamic discovery handles visibility.
 
@@ -451,90 +396,14 @@ async def list_models(
     user: User = Depends(get_current_user),
 ) -> List[ModelWithAccessInfo]:
     """List all model configurations accessible to the current user"""
-    current_user_id = int(user.id)
-    cache_key = model_list_key(
-        current_user_id,
+    return ModelStore(db).list_models(
+        user_id=int(user.id),
         skip=skip,
         limit=limit,
         model_provider=model_provider,
         category=category,
         is_active=is_active,
     )
-    cached = cache_get(cache_key)
-    if isinstance(cached, list):
-        return [ModelWithAccessInfo.model_validate(item) for item in cached]
-
-    from ..services.model_service import (
-        _get_visible_user_ids,
-        build_user_model_visibility_filter,
-    )
-
-    # Get models that user has access to (owned or shared from visible users)
-    visible_ids = _get_visible_user_ids(db, current_user_id)
-
-    # Correlated subquery: for each DBModel, pick exactly one UserModel row,
-    # preferring the user's own row (deduplicates legacy shared data).
-    best_user_model_id = (
-        db.query(UserModel.id)
-        .filter(
-            UserModel.model_id == DBModel.id,
-            build_user_model_visibility_filter(current_user_id, visible_ids),
-        )
-        .order_by(
-            (UserModel.user_id == user.id).desc(),
-            UserModel.is_owner.desc(),
-        )
-        .limit(1)
-        .correlate(DBModel)
-        .scalar_subquery()
-    )
-
-    query = (
-        db.query(DBModel, UserModel)
-        .join(UserModel, DBModel.id == UserModel.model_id)
-        .filter(UserModel.id == best_user_model_id)
-    )
-    if model_provider:
-        query = query.filter(DBModel.model_provider == model_provider)
-
-    if category:
-        query = query.filter(DBModel.category == category)
-
-    if is_active is not None:
-        query = query.filter(DBModel.is_active == is_active)
-
-    models = query.offset(skip).limit(limit).all()
-
-    result = []
-    for db_model, user_model in models:
-        is_owner = user_model.is_owner and user_model.user_id == user.id
-        model_data = {
-            "id": db_model.id,
-            "model_id": db_model.model_id,
-            "category": db_model.category,
-            "model_provider": db_model.model_provider,
-            "model_name": db_model.model_name,
-            "base_url": db_model.base_url,
-            "temperature": db_model.temperature,
-            "dimension": db_model.dimension,
-            "abilities": db_model.abilities,
-            "description": db_model.description,
-            "created_at": db_model.created_at.isoformat()
-            if db_model.created_at
-            else None,
-            "updated_at": db_model.updated_at.isoformat()
-            if db_model.updated_at
-            else None,
-            "is_active": db_model.is_active,
-            "is_owner": is_owner,
-            "can_edit": is_owner and user_model.can_edit,
-            "can_delete": is_owner and user_model.can_delete,
-            "is_shared": user_model.is_shared,
-        }
-        result.append(ModelWithAccessInfo.model_validate(model_data))
-
-    cache_set(cache_key, [item.model_dump(mode="json") for item in result])
-    return result
 
 
 @model_router.get("/user-default")
@@ -542,165 +411,8 @@ async def get_user_default_models(
     db: Session = Depends(get_db), user: User = Depends(get_current_user)
 ) -> list:
     """Get all user's default model configurations with per-type admin fallback"""
-    current_user_id = int(user.id)
-    cache_key = user_default_models_key(current_user_id)
-    cached = cache_get(cache_key)
-    if isinstance(cached, list):
-        return cached
-
     try:
-        from ..services.model_service import (
-            _get_visible_user_ids,
-            build_user_model_visibility_filter,
-        )
-
-        # Get all possible config types
-        all_config_types = [
-            "general",
-            "small_fast",
-            "visual",
-            "compact",
-            "embedding",
-            "image",
-            "image_edit",
-            "asr",
-            "tts",
-        ]
-
-        # Get user's own defaults
-        user_defaults_by_type: dict[str, UserDefaultModel] = {}
-        user_defaults = (
-            db.query(UserDefaultModel)
-            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-            .filter(UserDefaultModel.user_id == user.id, DBModel.is_active)
-            .all()
-        )
-
-        # Organize user defaults by config type
-        for ud in user_defaults:
-            user_defaults_by_type[str(ud.config_type)] = ud
-
-        result = []
-        visible_ids = _get_visible_user_ids(db, current_user_id)
-
-        # Process each config type
-        for config_type in all_config_types:
-            user_model = None
-            if config_type in user_defaults_by_type:
-                # User has their own default for this type
-                ud = user_defaults_by_type[config_type]
-
-                # Get user model relationship for access info (two-step: own or shared)
-                user_model = (
-                    db.query(UserModel)
-                    .filter(
-                        UserModel.model_id == ud.model_id,
-                        build_user_model_visibility_filter(
-                            current_user_id, visible_ids
-                        ),
-                    )
-                    .first()
-                )
-
-                if user_model:
-                    is_owner = user_model.is_owner and user_model.user_id == user.id
-                    model_data = {
-                        "id": ud.id,
-                        "user_id": ud.user_id,
-                        "model_id": ud.model_id,
-                        "config_type": ud.config_type,
-                        "created_at": ud.created_at.isoformat()
-                        if ud.created_at
-                        else None,
-                        "updated_at": ud.updated_at.isoformat()
-                        if ud.updated_at
-                        else None,
-                        "model": {
-                            "id": user_model.model.id,
-                            "model_id": user_model.model.model_id,
-                            "category": user_model.model.category,
-                            "model_provider": user_model.model.model_provider,
-                            "model_name": user_model.model.model_name,
-                            "base_url": user_model.model.base_url,
-                            "temperature": user_model.model.temperature,
-                            "dimension": user_model.model.dimension,
-                            "abilities": user_model.model.abilities,
-                            "description": user_model.model.description,
-                            "created_at": user_model.model.created_at.isoformat()
-                            if user_model.model.created_at
-                            else None,
-                            "updated_at": user_model.model.updated_at.isoformat()
-                            if user_model.model.updated_at
-                            else None,
-                            "is_active": user_model.model.is_active,
-                            "is_owner": is_owner,
-                            "can_edit": is_owner and user_model.can_edit,
-                            "can_delete": is_owner and user_model.can_delete,
-                            "is_shared": user_model.is_shared,
-                        },
-                    }
-                    result.append(model_data)
-                    continue
-
-            if not user_model:
-                # User has no default for this type (or it's stale), try visible users' shared defaults
-                admin_default = (
-                    db.query(UserDefaultModel)
-                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
-                    .filter(
-                        UserDefaultModel.user_id.in_(visible_ids),
-                        UserDefaultModel.config_type == config_type,
-                        DBModel.is_active,
-                        UserModel.is_shared.is_(True),
-                    )
-                    .first()
-                )
-
-                if admin_default:
-                    logger.info(
-                        f"User {user.username} has no {config_type} default, using visible user default for display"
-                    )
-
-                    model_data = {
-                        "id": admin_default.id,
-                        "user_id": admin_default.user_id,
-                        "model_id": admin_default.model_id,
-                        "config_type": admin_default.config_type,
-                        "created_at": admin_default.created_at.isoformat()
-                        if admin_default.created_at
-                        else None,
-                        "updated_at": admin_default.updated_at.isoformat()
-                        if admin_default.updated_at
-                        else None,
-                        "model": {
-                            "id": admin_default.model.id,
-                            "model_id": admin_default.model.model_id,
-                            "category": admin_default.model.category,
-                            "model_provider": admin_default.model.model_provider,
-                            "model_name": admin_default.model.model_name,
-                            "base_url": admin_default.model.base_url,
-                            "temperature": admin_default.model.temperature,
-                            "dimension": admin_default.model.dimension,
-                            "abilities": admin_default.model.abilities,
-                            "description": admin_default.model.description,
-                            "created_at": admin_default.model.created_at.isoformat()
-                            if admin_default.model.created_at
-                            else None,
-                            "updated_at": admin_default.model.updated_at.isoformat()
-                            if admin_default.model.updated_at
-                            else None,
-                            "is_active": admin_default.model.is_active,
-                            "is_owner": False,
-                            "can_edit": False,
-                            "can_delete": False,
-                            "is_shared": True,
-                        },
-                    }
-                    result.append(model_data)
-
-        cache_set(cache_key, result)
-        return result
+        return ModelStore(db).get_user_default_models(user)
     except Exception as e:
         logger.error(f"Error getting user default models: {e}")
         # Return an empty list even if an error occurs, instead of 404
@@ -715,7 +427,7 @@ async def get_model_by_path(
 
     _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(
+        ModelStore(db).serialize_model_with_access(
             db_model, user_model, requesting_user_id=int(user.id)
         )
     )
@@ -1635,34 +1347,11 @@ async def set_user_default_model(
             ),
         )
 
-    existing_default = (
-        db.query(UserDefaultModel)
-        .filter(
-            UserDefaultModel.user_id == user.id,
-            UserDefaultModel.config_type == config_type,
-        )
-        .first()
-    )
-    old_default_was_shared = bool(
-        existing_default
-        and _model_has_shared_visibility(db, int(existing_default.model_id))
-    )
-    new_default_is_shared = bool(user_model.is_shared)
-
-    # Remove existing configuration for this config_type
-    if existing_default:
-        db.delete(existing_default)
-
-    # Create new default configuration
-    user_default = UserDefaultModel(
-        user_id=user.id, model_id=config.model_id, config_type=config_type
-    )
-
-    db.add(user_default)
-    db.commit()
-    db.refresh(user_default)
-    invalidate_model_cache(
-        None if old_default_was_shared or new_default_is_shared else int(user.id)
+    user_default = ModelStore(db).set_user_default_model(
+        user_id=int(user.id),
+        model_id=int(config.model_id),
+        config_type=config_type,
+        user_model=user_model,
     )
 
     # If this is an embedding model configuration, trigger memory store check
@@ -1693,28 +1382,7 @@ async def get_user_default_model(
     user: User = Depends(get_current_user),
 ) -> Optional[UserDefaultModelResponse]:
     """Get a user's default model configuration for a specific type"""
-    cache_key = user_default_model_key(int(user.id), config_type)
-    cached = cache_get(cache_key)
-    if isinstance(cached, dict):
-        return UserDefaultModelResponse.model_validate(cached)
-
-    user_default = (
-        db.query(UserDefaultModel)
-        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-        .filter(
-            UserDefaultModel.user_id == user.id,
-            UserDefaultModel.config_type == config_type,
-            DBModel.is_active,
-        )
-        .first()
-    )
-
-    if not user_default:
-        return None
-
-    response = UserDefaultModelResponse.model_validate(user_default)
-    cache_set(cache_key, response.model_dump(mode="json"))
-    return response
+    return ModelStore(db).get_user_default_model(int(user.id), config_type)
 
 
 @model_router.delete("/user-default/{config_type}")
@@ -1725,23 +1393,12 @@ async def delete_user_default_model(
 ) -> dict:
     """Delete a user's default model configuration"""
 
-    user_default = (
-        db.query(UserDefaultModel)
-        .filter(
-            UserDefaultModel.user_id == user.id,
-            UserDefaultModel.config_type == config_type,
-        )
-        .first()
+    user_default = ModelStore(db).delete_user_default_model(
+        user_id=int(user.id), config_type=config_type
     )
 
     if not user_default:
         raise HTTPException(status_code=404, detail="Default configuration not found")
-
-    default_was_shared = _model_has_shared_visibility(db, int(user_default.model_id))
-
-    db.delete(user_default)
-    db.commit()
-    invalidate_model_cache(None if default_was_shared else int(user.id))
 
     return {"message": "Default configuration deleted successfully"}
 
@@ -1759,7 +1416,7 @@ async def get_model(
     """Get a specific model configuration"""
     _, db_model, user_model = _resolve_accessible_model(db, user, model_id)
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(
+        ModelStore(db).serialize_model_with_access(
             db_model, user_model, requesting_user_id=int(user.id)
         )
     )
@@ -1782,15 +1439,10 @@ async def update_model(
     # Get the database model
     db_model = user_model.model
 
+    model_store = ModelStore(db)
+
     # Constraint 2: shared models cannot change category or abilities
-    is_shared = (
-        db.query(UserModel)
-        .filter(
-            UserModel.model_id == db_model.id,
-            UserModel.is_shared.is_(True) == True,  # noqa: E712
-        )
-        .first()
-    )
+    is_shared = model_store.model_has_shared_visibility(int(db_model.id))
     if is_shared:
         locked = []
         if (
@@ -1808,53 +1460,11 @@ async def update_model(
                 detail=f"Cannot change {' and '.join(locked)} of a shared model. Un-share first.",
             )
 
-    # Handle sharing updates
-    if model_update.share_with_users is not None:
-        # Only check sharing permission when enabling sharing
-        if model_update.share_with_users and not _can_user_share(user):
-            raise HTTPException(
-                status_code=403, detail="Only administrators can enable global sharing"
-            )
-
-        # Update sharing status
-        if model_update.share_with_users:
-            # Enable sharing: just update owner's record to shared=True
-            db.query(UserModel).filter(
-                UserModel.model_id == db_model.id,
-                UserModel.user_id == user.id,
-            ).update({"is_shared": True})
-        else:
-            # `share_with_users=false` on an already-unshared model is a no-op
-            if is_shared:
-                # Constraint 1: owner cannot un-share own default model
-                owner_defaults = (
-                    db.query(UserDefaultModel)
-                    .filter(
-                        UserDefaultModel.model_id == db_model.id,
-                        UserDefaultModel.user_id == user.id,
-                    )
-                    .count()
-                )
-                if owner_defaults > 0:
-                    raise HTTPException(
-                        409,
-                        detail="Cannot un-share: you have this model as your default. Change default first.",
-                    )
-
-                # Disable sharing:
-                # 1. Update owner's record to shared=False
-                user_model.is_shared = False  # type: ignore[assignment]
-
-                # 2. Delete all non-owner UserModel records
-                db.query(UserModel).filter(
-                    UserModel.model_id == db_model.id, UserModel.is_owner.is_(False)
-                ).delete()
-
-                # 3. Clean up non-owner UserDefaultModel records
-                db.query(UserDefaultModel).filter(
-                    UserDefaultModel.model_id == db_model.id,
-                    UserDefaultModel.user_id != user.id,
-                ).delete()
+    share_with_users = model_update.share_with_users
+    if share_with_users and not _can_user_share(user):
+        raise HTTPException(
+            status_code=403, detail="Only administrators can enable global sharing"
+        )
 
     # Update model configuration in-place
     update_data = model_update.model_dump(exclude_unset=True)
@@ -1877,16 +1487,26 @@ async def update_model(
         if hasattr(db_model, field):
             setattr(db_model, field, value)
 
-    # Commit database changes
-    db.commit()
-    db.refresh(db_model)
-    invalidate_model_cache(
-        None if is_shared or model_update.share_with_users is not None else int(user.id)
-    )
+    if share_with_users is not None:
+        try:
+            model_store.set_model_sharing(
+                user_id=int(user.id),
+                db_model=db_model,
+                user_model=user_model,
+                share_with_users=share_with_users,
+            )
+        except ModelSharingConflictError as exc:
+            raise HTTPException(409, detail=str(exc)) from exc
+    else:
+        model_store.commit_model_update(
+            user_id=int(user.id),
+            db_model=db_model,
+            invalidate_globally=is_shared,
+        )
 
     # Return updated model with access info
     return ModelWithAccessInfo.model_validate(
-        _serialize_model_with_access(
+        model_store.serialize_model_with_access(
             db_model, user_model, requesting_user_id=int(user.id)
         )
     )
@@ -1920,17 +1540,7 @@ async def delete_model(
             detail="Cannot delete: you have this model as your default. Change default first.",
         )
 
-    # Delete all user model relationships
-    db.query(UserModel).filter(UserModel.model_id == user_model.model.id).delete()
-
-    # Delete all user default model configurations
-    db.query(UserDefaultModel).filter(
-        UserDefaultModel.model_id == user_model.model.id
-    ).delete()
-
-    # Delete the model using CoreStorage
-    model_storage.delete(user_model.model.model_id)
-    invalidate_model_cache(None)
+    ModelStore(db).delete_model(model_storage=model_storage, user_model=user_model)
 
     return {"message": "Model deleted successfully"}
 

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -1,0 +1,230 @@
+"""Agent DB/cache boundary for web and builder write paths."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ...core.utils.type_check import ensure_list
+from ..models.agent import Agent, AgentStatus
+from ..models.agent_api_key import AgentApiKey
+from ..models.task import Task
+from .hot_path_cache import (
+    agent_detail_key,
+    agent_list_key,
+    cache_get,
+    cache_set,
+    invalidate_agent_cache,
+)
+
+_AGENT_UPDATE_FIELDS = {
+    "name",
+    "description",
+    "instructions",
+    "execution_mode",
+    "models",
+    "knowledge_bases",
+    "skills",
+    "tool_categories",
+    "suggested_prompts",
+    "logo_url",
+    "status",
+    "widget_enabled",
+    "allowed_domains",
+}
+
+
+class AgentStore:
+    """Owns Agent reads/writes that participate in hot-path cache policy."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def agent_to_response_dict(self, agent: Agent) -> dict[str, Any]:
+        return {
+            "id": agent.id,
+            "user_id": agent.user_id,
+            "name": agent.name,
+            "description": agent.description,
+            "instructions": agent.instructions,
+            "execution_mode": agent.execution_mode or "graph",
+            "models": agent.models,
+            "knowledge_bases": ensure_list(agent.knowledge_bases) or [],
+            "skills": ensure_list(agent.skills) or [],
+            "tool_categories": ensure_list(agent.tool_categories) or [],
+            "suggested_prompts": ensure_list(agent.suggested_prompts) or [],
+            "logo_url": agent.logo_url,
+            "status": agent.status.value,
+            "published_at": agent.published_at.isoformat()
+            if agent.published_at
+            else None,
+            "created_at": agent.created_at.isoformat(),
+            "updated_at": agent.updated_at.isoformat(),
+            "widget_enabled": agent.widget_enabled,
+            "allowed_domains": ensure_list(agent.allowed_domains) or [],
+        }
+
+    def agent_to_list_item_dict(self, agent: Agent) -> dict[str, Any]:
+        return {
+            "id": agent.id,
+            "name": agent.name,
+            "description": agent.description,
+            "logo_url": agent.logo_url,
+            "status": agent.status.value,
+            "created_at": agent.created_at.isoformat(),
+            "updated_at": agent.updated_at.isoformat()
+            if agent.updated_at
+            else agent.created_at.isoformat(),
+            "widget_enabled": agent.widget_enabled,
+            "allowed_domains": ensure_list(agent.allowed_domains) or [],
+        }
+
+    def list_agent_items(self, user_id: int) -> list[dict[str, Any]]:
+        cache_key = agent_list_key(user_id)
+        cached = cache_get(cache_key)
+        if isinstance(cached, list):
+            return cached
+
+        agents = (
+            self.db.query(Agent)
+            .filter(Agent.user_id == user_id)
+            .order_by(Agent.created_at.desc())
+            .all()
+        )
+        response = [self.agent_to_list_item_dict(agent) for agent in agents]
+        cache_set(cache_key, response)
+        return response
+
+    def get_agent_response(self, user_id: int, agent_id: int) -> dict[str, Any] | None:
+        cache_key = agent_detail_key(user_id, agent_id)
+        cached = cache_get(cache_key)
+        if isinstance(cached, dict):
+            return cached
+
+        agent = self.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+
+        response = self.agent_to_response_dict(agent)
+        cache_set(cache_key, response)
+        return response
+
+    def get_owned_agent(self, user_id: int, agent_id: int) -> Agent | None:
+        return (
+            self.db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.user_id == user_id)
+            .first()
+        )
+
+    def agent_name_exists(
+        self, user_id: int, name: str, *, exclude_agent_id: int | None = None
+    ) -> bool:
+        query = self.db.query(Agent.id).filter(
+            Agent.user_id == user_id, Agent.name == name
+        )
+        if exclude_agent_id is not None:
+            query = query.filter(Agent.id != exclude_agent_id)
+        return query.first() is not None
+
+    def create_agent(
+        self,
+        *,
+        user_id: int,
+        name: str,
+        description: str | None,
+        instructions: str | None,
+        execution_mode: str | None = None,
+        models: dict[str, Any] | None = None,
+        knowledge_bases: list[str] | None = None,
+        skills: list[str] | None = None,
+        tool_categories: list[str] | None = None,
+        suggested_prompts: list[str] | None = None,
+        status: AgentStatus = AgentStatus.DRAFT,
+        widget_enabled: bool = True,
+        allowed_domains: list[str] | None = None,
+    ) -> Agent:
+        agent = Agent(
+            user_id=user_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode or "graph",
+            models=models,
+            knowledge_bases=knowledge_bases or [],
+            skills=skills or [],
+            tool_categories=tool_categories or [],
+            suggested_prompts=suggested_prompts or [],
+            status=status,
+            widget_enabled=widget_enabled,
+            allowed_domains=allowed_domains or [],
+        )
+        self.db.add(agent)
+        self.db.commit()
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, int(agent.id))
+        return agent
+
+    def update_agent_fields(
+        self, user_id: int, agent_id: int, updates: dict[str, Any]
+    ) -> Agent | None:
+        agent = self.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+
+        unknown_fields = set(updates) - _AGENT_UPDATE_FIELDS
+        if unknown_fields:
+            raise ValueError(
+                f"Unsupported agent update fields: {', '.join(sorted(unknown_fields))}"
+            )
+
+        for field, value in updates.items():
+            setattr(agent, field, value)
+
+        self.db.commit()
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, agent_id)
+        return agent
+
+    def delete_agent(self, user_id: int, agent_id: int) -> Agent | None:
+        agent = self.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+
+        self.db.query(AgentApiKey).filter(AgentApiKey.agent_id == agent_id).delete()
+        self.db.query(Task).filter(Task.agent_id == agent_id).update(
+            {Task.agent_id: None}
+        )
+        self.db.delete(agent)
+        self.db.commit()
+        invalidate_agent_cache(user_id, agent_id)
+        return agent
+
+    def publish_agent(self, user_id: int, agent_id: int) -> Agent | None:
+        agent = self.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+        if agent.status == AgentStatus.PUBLISHED:
+            return agent
+
+        agent.status = AgentStatus.PUBLISHED
+        agent.published_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+        self.db.commit()
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, agent_id)
+        return agent
+
+    def unpublish_agent(self, user_id: int, agent_id: int) -> Agent | None:
+        agent = self.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+        if agent.status != AgentStatus.PUBLISHED:
+            return agent
+
+        agent.status = AgentStatus.DRAFT
+        agent.published_at = None  # type: ignore[assignment]
+        self.db.commit()
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, agent_id)
+        return agent

--- a/src/xagent/web/services/model_store.py
+++ b/src/xagent/web/services/model_store.py
@@ -1,0 +1,477 @@
+"""Model DB/cache boundary for web model management paths."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.orm import Session, joinedload
+
+from ..models.model import Model as DBModel
+from ..models.user import User, UserDefaultModel, UserModel
+from ..schemas.model import ModelWithAccessInfo, UserDefaultModelResponse
+from .hot_path_cache import (
+    cache_get,
+    cache_set,
+    invalidate_model_cache,
+    model_list_key,
+    user_default_model_key,
+    user_default_models_key,
+)
+from .llm_utils import CoreStorage
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_CONFIG_TYPES = [
+    "general",
+    "small_fast",
+    "visual",
+    "compact",
+    "embedding",
+    "image",
+    "image_edit",
+    "asr",
+    "tts",
+]
+
+
+class ModelSharingConflictError(ValueError):
+    """Raised when a model sharing state transition violates model constraints."""
+
+
+class ModelStore:
+    """Owns model reads/writes that participate in hot-path cache policy."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def serialize_model_with_access(
+        self,
+        db_model: DBModel,
+        user_model: UserModel,
+        *,
+        requesting_user_id: int | None = None,
+    ) -> dict[str, Any]:
+        is_owner = (
+            user_model.is_owner and user_model.user_id == requesting_user_id
+            if requesting_user_id is not None
+            else user_model.is_owner
+        )
+
+        return {
+            "id": db_model.id,
+            "model_id": db_model.model_id,
+            "category": db_model.category,
+            "model_provider": db_model.model_provider,
+            "model_name": db_model.model_name,
+            "base_url": db_model.base_url,
+            "temperature": db_model.temperature,
+            "dimension": db_model.dimension,
+            "abilities": db_model.abilities,
+            "description": db_model.description,
+            "created_at": db_model.created_at.isoformat()
+            if db_model.created_at
+            else None,
+            "updated_at": db_model.updated_at.isoformat()
+            if db_model.updated_at
+            else None,
+            "is_active": db_model.is_active,
+            "is_owner": is_owner,
+            "can_edit": is_owner and user_model.can_edit,
+            "can_delete": is_owner and user_model.can_delete,
+            "is_shared": user_model.is_shared,
+        }
+
+    def model_has_shared_visibility(self, model_id: int) -> bool:
+        return (
+            self.db.query(UserModel.id)
+            .filter(UserModel.model_id == model_id, UserModel.is_shared.is_(True))
+            .first()
+            is not None
+        )
+
+    def list_models(
+        self,
+        *,
+        user_id: int,
+        skip: int,
+        limit: int,
+        model_provider: str | None,
+        category: str | None,
+        is_active: bool | None,
+    ) -> list[ModelWithAccessInfo]:
+        cache_key = model_list_key(
+            user_id,
+            skip=skip,
+            limit=limit,
+            model_provider=model_provider,
+            category=category,
+            is_active=is_active,
+        )
+        cached = cache_get(cache_key)
+        if isinstance(cached, list):
+            return [ModelWithAccessInfo.model_validate(item) for item in cached]
+
+        from .model_service import (
+            _get_visible_user_ids,
+            build_user_model_visibility_filter,
+        )
+
+        visible_ids = _get_visible_user_ids(self.db, user_id)
+        best_user_model_id = (
+            self.db.query(UserModel.id)
+            .filter(
+                UserModel.model_id == DBModel.id,
+                build_user_model_visibility_filter(user_id, visible_ids),
+            )
+            .order_by(
+                (UserModel.user_id == user_id).desc(),
+                UserModel.is_owner.desc(),
+            )
+            .limit(1)
+            .correlate(DBModel)
+            .scalar_subquery()
+        )
+
+        query = (
+            self.db.query(DBModel, UserModel)
+            .join(UserModel, DBModel.id == UserModel.model_id)
+            .filter(UserModel.id == best_user_model_id)
+        )
+        if model_provider:
+            query = query.filter(DBModel.model_provider == model_provider)
+        if category:
+            query = query.filter(DBModel.category == category)
+        if is_active is not None:
+            query = query.filter(DBModel.is_active == is_active)
+
+        result = [
+            ModelWithAccessInfo.model_validate(
+                self.serialize_model_with_access(
+                    db_model,
+                    user_model,
+                    requesting_user_id=user_id,
+                )
+            )
+            for db_model, user_model in query.offset(skip).limit(limit).all()
+        ]
+        cache_set(cache_key, [item.model_dump(mode="json") for item in result])
+        return result
+
+    def get_user_default_models(self, user: User) -> list[dict[str, Any]]:
+        user_id = int(user.id)
+        cache_key = user_default_models_key(user_id)
+        cached = cache_get(cache_key)
+        if isinstance(cached, list):
+            return cached
+
+        user_defaults = (
+            self.db.query(UserDefaultModel)
+            .options(joinedload(UserDefaultModel.model))
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            .filter(UserDefaultModel.user_id == user.id, DBModel.is_active)
+            .all()
+        )
+        user_defaults_by_type: dict[str, UserDefaultModel] = {}
+        for user_default in user_defaults:
+            user_defaults_by_type[str(user_default.config_type)] = user_default
+
+        result: list[dict[str, Any]] = []
+
+        from .model_service import (
+            _get_visible_user_ids,
+            build_user_model_visibility_filter,
+        )
+
+        visible_ids = _get_visible_user_ids(self.db, user_id)
+
+        default_model_ids = [int(default.model_id) for default in user_defaults]
+        visible_user_models_by_model_id: dict[int, UserModel] = {}
+        if default_model_ids:
+            visible_user_models = (
+                self.db.query(UserModel)
+                .options(joinedload(UserModel.model))
+                .filter(
+                    UserModel.model_id.in_(default_model_ids),
+                    build_user_model_visibility_filter(user_id, visible_ids),
+                )
+                .order_by(
+                    UserModel.model_id,
+                    (UserModel.user_id == user_id).desc(),
+                    UserModel.is_owner.desc(),
+                )
+                .all()
+            )
+            for visible_user_model in visible_user_models:
+                visible_user_models_by_model_id.setdefault(
+                    int(visible_user_model.model_id), visible_user_model
+                )
+
+        fallback_defaults_by_type: dict[str, UserDefaultModel] = {}
+        fallback_defaults = (
+            self.db.query(UserDefaultModel)
+            .options(joinedload(UserDefaultModel.model))
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+            .filter(
+                UserDefaultModel.user_id.in_(visible_ids),
+                UserDefaultModel.config_type.in_(DEFAULT_MODEL_CONFIG_TYPES),
+                DBModel.is_active,
+                UserModel.is_shared.is_(True),
+            )
+            .order_by(
+                UserDefaultModel.config_type,
+                (UserDefaultModel.user_id == user_id).desc(),
+            )
+            .all()
+        )
+        for fallback_candidate in fallback_defaults:
+            fallback_defaults_by_type.setdefault(
+                str(fallback_candidate.config_type), fallback_candidate
+            )
+
+        for config_type in DEFAULT_MODEL_CONFIG_TYPES:
+            user_model: UserModel | None = None
+            if config_type in user_defaults_by_type:
+                user_default = user_defaults_by_type[config_type]
+                user_model = visible_user_models_by_model_id.get(
+                    int(user_default.model_id)
+                )
+                if user_model:
+                    result.append(
+                        self._default_model_payload(
+                            user_default,
+                            self.serialize_model_with_access(
+                                user_model.model,
+                                user_model,
+                                requesting_user_id=user_id,
+                            ),
+                        )
+                    )
+                    continue
+
+            if not user_model:
+                fallback_default_for_type = fallback_defaults_by_type.get(config_type)
+                if fallback_default_for_type:
+                    logger.info(
+                        "User %s has no %s default, using visible user default for display",
+                        user.username,
+                        config_type,
+                    )
+                    result.append(
+                        self._default_model_payload(
+                            fallback_default_for_type,
+                            self._shared_fallback_model_payload(
+                                fallback_default_for_type.model
+                            ),
+                        )
+                    )
+
+        cache_set(cache_key, result)
+        return result
+
+    def get_user_default_model(
+        self, user_id: int, config_type: str
+    ) -> UserDefaultModelResponse | None:
+        cache_key = user_default_model_key(user_id, config_type)
+        cached = cache_get(cache_key)
+        if isinstance(cached, dict):
+            return UserDefaultModelResponse.model_validate(cached)
+
+        user_default = (
+            self.db.query(UserDefaultModel)
+            .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+            .filter(
+                UserDefaultModel.user_id == user_id,
+                UserDefaultModel.config_type == config_type,
+                DBModel.is_active,
+            )
+            .first()
+        )
+        if not user_default:
+            return None
+
+        response = UserDefaultModelResponse.model_validate(user_default)
+        cache_set(cache_key, response.model_dump(mode="json"))
+        return response
+
+    def create_user_model_link(
+        self, *, user_id: int, model_id: int, is_shared: bool
+    ) -> UserModel:
+        user_model = UserModel(
+            user_id=user_id,
+            model_id=model_id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_shared=is_shared,
+        )
+        self.db.add(user_model)
+        self.db.commit()
+        invalidate_model_cache(None if is_shared else user_id)
+        return user_model
+
+    def set_user_default_model(
+        self,
+        *,
+        user_id: int,
+        model_id: int,
+        config_type: str,
+        user_model: UserModel,
+    ) -> UserDefaultModel:
+        existing_default = (
+            self.db.query(UserDefaultModel)
+            .filter(
+                UserDefaultModel.user_id == user_id,
+                UserDefaultModel.config_type == config_type,
+            )
+            .first()
+        )
+        old_default_was_shared = bool(
+            existing_default
+            and self.model_has_shared_visibility(int(existing_default.model_id))
+        )
+        new_default_is_shared = bool(user_model.is_shared)
+
+        if existing_default:
+            self.db.delete(existing_default)
+
+        user_default = UserDefaultModel(
+            user_id=user_id,
+            model_id=model_id,
+            config_type=config_type,
+        )
+        self.db.add(user_default)
+        self.db.commit()
+        self.db.refresh(user_default)
+        invalidate_model_cache(
+            None if old_default_was_shared or new_default_is_shared else user_id
+        )
+        return user_default
+
+    def delete_user_default_model(
+        self, *, user_id: int, config_type: str
+    ) -> UserDefaultModel | None:
+        user_default = (
+            self.db.query(UserDefaultModel)
+            .filter(
+                UserDefaultModel.user_id == user_id,
+                UserDefaultModel.config_type == config_type,
+            )
+            .first()
+        )
+        if user_default is None:
+            return None
+
+        default_was_shared = self.model_has_shared_visibility(
+            int(user_default.model_id)
+        )
+        self.db.delete(user_default)
+        self.db.commit()
+        invalidate_model_cache(None if default_was_shared else user_id)
+        return user_default
+
+    def commit_model_update(
+        self, *, user_id: int, db_model: DBModel, invalidate_globally: bool
+    ) -> None:
+        self.db.commit()
+        self.db.refresh(db_model)
+        invalidate_model_cache(None if invalidate_globally else user_id)
+
+    def set_model_sharing(
+        self,
+        *,
+        user_id: int,
+        db_model: DBModel,
+        user_model: UserModel,
+        share_with_users: bool,
+    ) -> None:
+        model_id = int(db_model.id)
+        currently_shared = self.model_has_shared_visibility(model_id)
+
+        if share_with_users:
+            user_model.is_shared = True  # type: ignore[assignment]
+        elif currently_shared:
+            owner_defaults = (
+                self.db.query(UserDefaultModel)
+                .filter(
+                    UserDefaultModel.model_id == model_id,
+                    UserDefaultModel.user_id == user_id,
+                )
+                .count()
+            )
+            if owner_defaults > 0:
+                raise ModelSharingConflictError(
+                    "Cannot un-share: you have this model as your default. "
+                    "Change default first."
+                )
+
+            user_model.is_shared = False  # type: ignore[assignment]
+            self.db.query(UserModel).filter(
+                UserModel.model_id == model_id, UserModel.is_owner.is_(False)
+            ).delete()
+            self.db.query(UserDefaultModel).filter(
+                UserDefaultModel.model_id == model_id,
+                UserDefaultModel.user_id != user_id,
+            ).delete()
+
+        self.db.commit()
+        self.db.refresh(db_model)
+        self.db.refresh(user_model)
+        invalidate_model_cache(None)
+
+    def delete_model(
+        self, *, model_storage: CoreStorage, user_model: UserModel
+    ) -> None:
+        model_id = int(user_model.model.id)
+        self.db.query(UserModel).filter(UserModel.model_id == model_id).delete()
+        self.db.query(UserDefaultModel).filter(
+            UserDefaultModel.model_id == model_id
+        ).delete()
+        model_storage.delete(user_model.model.model_id)
+        invalidate_model_cache(None)
+
+    def invalidate_after_user_delete(self) -> None:
+        invalidate_model_cache(None)
+
+    def _default_model_payload(
+        self, user_default: UserDefaultModel, model_payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "id": user_default.id,
+            "user_id": user_default.user_id,
+            "model_id": user_default.model_id,
+            "config_type": user_default.config_type,
+            "created_at": user_default.created_at.isoformat()
+            if user_default.created_at
+            else None,
+            "updated_at": user_default.updated_at.isoformat()
+            if user_default.updated_at
+            else None,
+            "model": model_payload,
+        }
+
+    def _shared_fallback_model_payload(self, db_model: DBModel) -> dict[str, Any]:
+        return {
+            "id": db_model.id,
+            "model_id": db_model.model_id,
+            "category": db_model.category,
+            "model_provider": db_model.model_provider,
+            "model_name": db_model.model_name,
+            "base_url": db_model.base_url,
+            "temperature": db_model.temperature,
+            "dimension": db_model.dimension,
+            "abilities": db_model.abilities,
+            "description": db_model.description,
+            "created_at": db_model.created_at.isoformat()
+            if db_model.created_at
+            else None,
+            "updated_at": db_model.updated_at.isoformat()
+            if db_model.updated_at
+            else None,
+            "is_active": db_model.is_active,
+            "is_owner": False,
+            "can_edit": False,
+            "can_delete": False,
+            "is_shared": True,
+        }

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -57,7 +57,7 @@ class TestCreateAgentTool:
                     "xagent.web.services.llm_utils.UserAwareModelStorage"
                 ) as mock_storage_class,
                 patch(
-                    "xagent.core.tools.adapters.vibe.agent_tool.invalidate_agent_cache"
+                    "xagent.web.services.agent_store.invalidate_agent_cache"
                 ) as mock_invalidate_agent_cache,
             ):
                 mock_storage = Mock()
@@ -426,7 +426,7 @@ class TestUpdateAgentTool:
             db.refresh(existing_agent)
 
             with patch(
-                "xagent.core.tools.adapters.vibe.agent_tool.invalidate_agent_cache"
+                "xagent.web.services.agent_store.invalidate_agent_cache"
             ) as mock_invalidate_agent_cache:
                 tool = UpdateAgentTool(db=db, user_id=user.id, task_id="test_task")
 


### PR DESCRIPTION
## Summary
- add shared AgentStore and ModelStore boundaries for cached user-facing resources
- move agent/model mutation cache invalidation out of REST handlers and shared writers
- route Builder/Vibe agent writes and model default/share mutations through the shared store boundary

Fixes #469

## Validation
- ruff check src/xagent/web/services/agent_store.py src/xagent/web/services/model_store.py src/xagent/web/api/agents.py src/xagent/web/api/model.py src/xagent/web/api/admin_users.py src/xagent/core/tools/adapters/vibe/agent_tool.py tests/core/tools/test_create_agent_tool.py tests/web/test_dynamic_model_sharing.py
- PYTHONPATH=src pytest tests/core/tools/test_create_agent_tool.py -q --disable-warnings
- PYTHONPATH=src pytest tests/web/test_dynamic_model_sharing.py tests/web/api/test_agents_management.py tests/web/services/test_hot_path_cache.py -q --disable-warnings