### PR TITLE
feat(workforce): add workforce foundation infrastructure

### DIFF
--- a/src/xagent/migrations/versions/20260523_add_workforce_core_tables.py
+++ b/src/xagent/migrations/versions/20260523_add_workforce_core_tables.py
@@ -50,6 +50,18 @@ def _drop_index_if_exists(index_name: str, table_name: str) -> None:
         op.drop_index(op.f(index_name), table_name=table_name)
 
 
+def _foreign_key_if_table_exists(
+    table_name: str,
+    columns: list[str],
+    referent: list[str],
+    *,
+    ondelete: str,
+) -> list[sa.ForeignKeyConstraint]:
+    if not _table_exists(table_name):
+        return []
+    return [sa.ForeignKeyConstraint(columns, referent, ondelete=ondelete)]
+
+
 def upgrade() -> None:
     if not _table_exists("workforces"):
         op.create_table(
@@ -76,11 +88,17 @@ def upgrade() -> None:
                 server_default=sa.func.now(),
                 nullable=True,
             ),
-            sa.ForeignKeyConstraint(
-                ["manager_agent_id"], ["agents.id"], ondelete="RESTRICT"
+            *_foreign_key_if_table_exists(
+                "agents",
+                ["manager_agent_id"],
+                ["agents.id"],
+                ondelete="RESTRICT",
             ),
-            sa.ForeignKeyConstraint(
-                ["owner_user_id"], ["users.id"], ondelete="CASCADE"
+            *_foreign_key_if_table_exists(
+                "users",
+                ["owner_user_id"],
+                ["users.id"],
+                ondelete="CASCADE",
             ),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint(
@@ -124,9 +142,17 @@ def upgrade() -> None:
                 server_default=sa.func.now(),
                 nullable=True,
             ),
-            sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="RESTRICT"),
-            sa.ForeignKeyConstraint(
-                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            *_foreign_key_if_table_exists(
+                "agents",
+                ["agent_id"],
+                ["agents.id"],
+                ondelete="RESTRICT",
+            ),
+            *_foreign_key_if_table_exists(
+                "workforces",
+                ["workforce_id"],
+                ["workforces.id"],
+                ondelete="CASCADE",
             ),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
@@ -156,10 +182,23 @@ def upgrade() -> None:
                 nullable=True,
             ),
             sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
-            sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="SET NULL"),
-            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-            sa.ForeignKeyConstraint(
-                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            *_foreign_key_if_table_exists(
+                "tasks",
+                ["task_id"],
+                ["tasks.id"],
+                ondelete="SET NULL",
+            ),
+            *_foreign_key_if_table_exists(
+                "users",
+                ["user_id"],
+                ["users.id"],
+                ondelete="CASCADE",
+            ),
+            *_foreign_key_if_table_exists(
+                "workforces",
+                ["workforce_id"],
+                ["workforces.id"],
+                ondelete="CASCADE",
             ),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("task_id"),
@@ -188,9 +227,17 @@ def upgrade() -> None:
                 server_default=sa.func.now(),
                 nullable=True,
             ),
-            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
-            sa.ForeignKeyConstraint(
-                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            *_foreign_key_if_table_exists(
+                "users",
+                ["user_id"],
+                ["users.id"],
+                ondelete="CASCADE",
+            ),
+            *_foreign_key_if_table_exists(
+                "workforces",
+                ["workforce_id"],
+                ["workforces.id"],
+                ondelete="CASCADE",
             ),
             sa.PrimaryKeyConstraint("id"),
         )

--- a/src/xagent/migrations/versions/20260523_add_workforce_core_tables.py
+++ b/src/xagent/migrations/versions/20260523_add_workforce_core_tables.py
@@ -1,0 +1,247 @@
+"""add workforce core tables
+
+Revision ID: 20260523_add_workforce_core_tables
+Revises: 20260522_add_task_chat_message_turn_id
+Create Date: 2026-05-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260523_add_workforce_core_tables"
+down_revision: Union[str, None] = "20260522_add_task_chat_message_turn_id"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _inspector() -> sa.Inspector:
+    from alembic import context
+
+    return sa.inspect(context.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {idx["name"] for idx in _inspector().get_indexes(table_name)}
+
+
+def _create_index_if_missing(
+    index_name: str,
+    table_name: str,
+    columns: list[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if not _index_exists(table_name, index_name):
+        op.create_index(op.f(index_name), table_name, columns, unique=unique)
+
+
+def _drop_index_if_exists(index_name: str, table_name: str) -> None:
+    if _index_exists(table_name, index_name):
+        op.drop_index(op.f(index_name), table_name=table_name)
+
+
+def upgrade() -> None:
+    if not _table_exists("workforces"):
+        op.create_table(
+            "workforces",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("owner_user_id", sa.Integer(), nullable=False),
+            sa.Column("scope_type", sa.String(length=50), nullable=False),
+            sa.Column("scope_id", sa.String(length=200), nullable=False),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("manager_agent_id", sa.Integer(), nullable=False),
+            sa.Column("manager_instructions", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("canvas_layout", sa.JSON(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.ForeignKeyConstraint(
+                ["manager_agent_id"], ["agents.id"], ondelete="RESTRICT"
+            ),
+            sa.ForeignKeyConstraint(
+                ["owner_user_id"], ["users.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "scope_type", "scope_id", "name", name="uq_workforce_scope_name"
+            ),
+        )
+
+    _create_index_if_missing("ix_workforces_id", "workforces", ["id"])
+    _create_index_if_missing(
+        "ix_workforces_manager_agent_id", "workforces", ["manager_agent_id"]
+    )
+    _create_index_if_missing(
+        "ix_workforces_owner_user_id", "workforces", ["owner_user_id"]
+    )
+    _create_index_if_missing("ix_workforces_scope_id", "workforces", ["scope_id"])
+    _create_index_if_missing("ix_workforces_scope_type", "workforces", ["scope_type"])
+    _create_index_if_missing("ix_workforces_status", "workforces", ["status"])
+
+    if not _table_exists("workforce_agents"):
+        op.create_table(
+            "workforce_agents",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("agent_id", sa.Integer(), nullable=False),
+            sa.Column("alias", sa.String(length=200), nullable=True),
+            sa.Column("assignment_instructions", sa.Text(), nullable=False),
+            sa.Column("source_type", sa.String(length=20), nullable=False),
+            sa.Column("template_id", sa.String(length=200), nullable=True),
+            sa.Column("enabled", sa.Boolean(), nullable=False),
+            sa.Column("sort_order", sa.Integer(), nullable=False),
+            sa.Column("canvas_position", sa.JSON(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="RESTRICT"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
+        )
+
+    _create_index_if_missing(
+        "ix_workforce_agents_agent_id", "workforce_agents", ["agent_id"]
+    )
+    _create_index_if_missing("ix_workforce_agents_id", "workforce_agents", ["id"])
+    _create_index_if_missing(
+        "ix_workforce_agents_workforce_id", "workforce_agents", ["workforce_id"]
+    )
+
+    if not _table_exists("workforce_runs"):
+        op.create_table(
+            "workforce_runs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("task_id", sa.Integer(), nullable=True),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column("snapshot", sa.JSON(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("task_id"),
+        )
+
+    _create_index_if_missing("ix_workforce_runs_id", "workforce_runs", ["id"])
+    _create_index_if_missing("ix_workforce_runs_status", "workforce_runs", ["status"])
+    _create_index_if_missing("ix_workforce_runs_user_id", "workforce_runs", ["user_id"])
+    _create_index_if_missing(
+        "ix_workforce_runs_workforce_id", "workforce_runs", ["workforce_id"]
+    )
+
+    if not _table_exists("workforce_builder_messages"):
+        op.create_table(
+            "workforce_builder_messages",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("workforce_id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("role", sa.String(length=20), nullable=False),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("proposed_patch", sa.JSON(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=True,
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["workforce_id"], ["workforces.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    _create_index_if_missing(
+        "ix_workforce_builder_messages_id", "workforce_builder_messages", ["id"]
+    )
+    _create_index_if_missing(
+        "ix_workforce_builder_messages_user_id",
+        "workforce_builder_messages",
+        ["user_id"],
+    )
+    _create_index_if_missing(
+        "ix_workforce_builder_messages_workforce_id",
+        "workforce_builder_messages",
+        ["workforce_id"],
+    )
+
+
+def downgrade() -> None:
+    _drop_index_if_exists(
+        "ix_workforce_builder_messages_workforce_id",
+        "workforce_builder_messages",
+    )
+    _drop_index_if_exists(
+        "ix_workforce_builder_messages_user_id", "workforce_builder_messages"
+    )
+    _drop_index_if_exists(
+        "ix_workforce_builder_messages_id", "workforce_builder_messages"
+    )
+    if _table_exists("workforce_builder_messages"):
+        op.drop_table("workforce_builder_messages")
+
+    _drop_index_if_exists("ix_workforce_runs_workforce_id", "workforce_runs")
+    _drop_index_if_exists("ix_workforce_runs_user_id", "workforce_runs")
+    _drop_index_if_exists("ix_workforce_runs_status", "workforce_runs")
+    _drop_index_if_exists("ix_workforce_runs_id", "workforce_runs")
+    if _table_exists("workforce_runs"):
+        op.drop_table("workforce_runs")
+
+    _drop_index_if_exists("ix_workforce_agents_workforce_id", "workforce_agents")
+    _drop_index_if_exists("ix_workforce_agents_id", "workforce_agents")
+    _drop_index_if_exists("ix_workforce_agents_agent_id", "workforce_agents")
+    if _table_exists("workforce_agents"):
+        op.drop_table("workforce_agents")
+
+    _drop_index_if_exists("ix_workforces_status", "workforces")
+    _drop_index_if_exists("ix_workforces_scope_type", "workforces")
+    _drop_index_if_exists("ix_workforces_scope_id", "workforces")
+    _drop_index_if_exists("ix_workforces_owner_user_id", "workforces")
+    _drop_index_if_exists("ix_workforces_manager_agent_id", "workforces")
+    _drop_index_if_exists("ix_workforces_id", "workforces")
+    if _table_exists("workforces"):
+        op.drop_table("workforces")

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -16,6 +16,7 @@ from .uploaded_file import UploadedFile
 from .user import User, UserDefaultModel, UserModel
 from .user_channel import UserChannel
 from .user_oauth import UserOAuth
+from .workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage, WorkforceRun
 
 __all__ = [
     "Base",
@@ -47,4 +48,8 @@ __all__ = [
     "SandboxSnapshot",
     "OAuthProvider",
     "PublicMCPApp",
+    "Workforce",
+    "WorkforceAgent",
+    "WorkforceRun",
+    "WorkforceBuilderMessage",
 ]

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -59,6 +59,10 @@ def init_db(db_url: str | None = None) -> None:
         UserDefaultModel,
         UserModel,
         UserTemplateRelation,
+        Workforce,
+        WorkforceAgent,
+        WorkforceBuilderMessage,
+        WorkforceRun,
     )
     from .agent import Agent  # noqa: F401
     from .sandbox import SandboxInfo, SandboxSnapshot  # noqa: F401

--- a/src/xagent/web/models/workforce.py
+++ b/src/xagent/web/models/workforce.py
@@ -52,7 +52,11 @@ class Workforce(Base):  # type: ignore[no-any-unimported]
         back_populates="workforce",
         cascade="all, delete-orphan",
     )
-    runs = relationship("WorkforceRun", back_populates="workforce")
+    runs = relationship(
+        "WorkforceRun",
+        back_populates="workforce",
+        cascade="all, delete-orphan",
+    )
     builder_messages = relationship(
         "WorkforceBuilderMessage",
         back_populates="workforce",

--- a/src/xagent/web/models/workforce.py
+++ b/src/xagent/web/models/workforce.py
@@ -1,0 +1,144 @@
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class Workforce(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforces"
+    __table_args__ = (
+        UniqueConstraint(
+            "scope_type", "scope_id", "name", name="uq_workforce_scope_name"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    owner_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scope_type = Column(String(50), nullable=False, default="user", index=True)
+    scope_id = Column(String(200), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    description = Column(Text, nullable=True)
+    manager_agent_id = Column(
+        Integer,
+        ForeignKey("agents.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    manager_instructions = Column(Text, nullable=True)
+    status = Column(String(20), nullable=False, default="draft", index=True)
+    canvas_layout = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    owner = relationship("User", foreign_keys=[owner_user_id])
+    manager_agent = relationship("Agent", foreign_keys=[manager_agent_id])
+    workers = relationship(
+        "WorkforceAgent",
+        back_populates="workforce",
+        cascade="all, delete-orphan",
+    )
+    runs = relationship("WorkforceRun", back_populates="workforce")
+    builder_messages = relationship(
+        "WorkforceBuilderMessage",
+        back_populates="workforce",
+        cascade="all, delete-orphan",
+    )
+
+
+class WorkforceAgent(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_agents"
+    __table_args__ = (
+        UniqueConstraint("workforce_id", "agent_id", name="uq_workforce_agent"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    agent_id = Column(
+        Integer,
+        ForeignKey("agents.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    alias = Column(String(200), nullable=True)
+    assignment_instructions = Column(Text, nullable=False)
+    source_type = Column(String(20), nullable=False, default="existing")
+    template_id = Column(String(200), nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+    sort_order = Column(Integer, nullable=False, default=0)
+    canvas_position = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    workforce = relationship("Workforce", back_populates="workers")
+    agent = relationship("Agent", foreign_keys=[agent_id])
+
+
+class WorkforceRun(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    task_id = Column(
+        Integer, ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True, unique=True
+    )
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status = Column(String(20), nullable=False, default="pending", index=True)
+    snapshot = Column(JSON, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    workforce = relationship("Workforce", back_populates="runs")
+    task = relationship("Task")
+    user = relationship("User", foreign_keys=[user_id])
+
+
+class WorkforceBuilderMessage(Base):  # type: ignore[no-any-unimported]
+    __tablename__ = "workforce_builder_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    workforce_id = Column(
+        Integer,
+        ForeignKey("workforces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    role = Column(String(20), nullable=False)
+    content = Column(Text, nullable=False)
+    proposed_patch = Column(JSON, nullable=True)
+    status = Column(String(20), nullable=False, default="message")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    workforce = relationship("Workforce", back_populates="builder_messages")
+    user = relationship("User", foreign_keys=[user_id])

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -1,0 +1,192 @@
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce
+
+
+class WorkforcePolicy:
+    def resolve_create_scope(self, db: Session, user: User) -> tuple[str, str]:
+        del db
+        return ("user", str(user.id))
+
+    def can_create_workforce(
+        self,
+        db: Session,
+        user: User,
+        scope_type: str,
+        scope_id: str,
+    ) -> bool:
+        del db, scope_type, scope_id
+        return bool(user.id)
+
+    def can_view_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        del db
+        return bool(user.is_admin or int(workforce.owner_user_id) == int(user.id))
+
+    def can_run_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        return self.can_view_workforce(db, user, workforce)
+
+    def can_edit_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
+        del db
+        return bool(user.is_admin or int(workforce.owner_user_id) == int(user.id))
+
+    def get_visible_agent_ids(
+        self,
+        db: Session,
+        user: User,
+        purpose: str,
+    ) -> set[int] | None:
+        del db, user, purpose
+        return None
+
+    def before_workforce_run(
+        self, db: Session, user: User, workforce: Workforce
+    ) -> None:
+        del db, user, workforce
+
+    def after_workforce_run_created(
+        self,
+        db: Session,
+        user: User,
+        workforce: Workforce,
+        run: Any,
+        task: Any,
+    ) -> None:
+        del db, user, workforce, run, task
+
+    def record_workforce_event(
+        self,
+        db: Session,
+        user: User,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        del db, user, event_type, payload
+
+
+_workforce_policy: WorkforcePolicy = WorkforcePolicy()
+
+
+def set_workforce_policy(policy: WorkforcePolicy) -> None:
+    global _workforce_policy
+    _workforce_policy = policy
+
+
+def get_workforce_policy() -> WorkforcePolicy:
+    return _workforce_policy
+
+
+def resolve_create_scope(db: Session, user: User) -> tuple[str, str]:
+    return get_workforce_policy().resolve_create_scope(db, user)
+
+
+def can_create_workforce(
+    db: Session,
+    user: User,
+    scope_type: str,
+    scope_id: str,
+) -> bool:
+    return get_workforce_policy().can_create_workforce(db, user, scope_type, scope_id)
+
+
+def _normalize_visible_agent_ids(values: Iterable[int] | None) -> set[int] | None:
+    if values is None:
+        return None
+    normalized: set[int] = set()
+    for value in values:
+        if isinstance(value, int):
+            normalized.add(value)
+    return normalized
+
+
+def get_visible_agent_ids(db: Session, user: User, purpose: str) -> set[int] | None:
+    visible_agent_ids = get_workforce_policy().get_visible_agent_ids(db, user, purpose)
+    return _normalize_visible_agent_ids(visible_agent_ids)
+
+
+def can_view_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_view_workforce(db, user, workforce)
+
+
+def can_run_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_run_workforce(db, user, workforce)
+
+
+def can_edit_workforce(db: Session, user: User, workforce: Workforce) -> bool:
+    return get_workforce_policy().can_edit_workforce(db, user, workforce)
+
+
+def ensure_workforce_access(
+    db: Session,
+    user: User,
+    workforce: Workforce | None,
+    action: str = "view",
+) -> Workforce:
+    if workforce is None:
+        raise HTTPException(status_code=404, detail="Workforce not found")
+
+    allowed = False
+    if action == "view":
+        allowed = can_view_workforce(db, user, workforce)
+    elif action == "run":
+        allowed = can_run_workforce(db, user, workforce)
+    elif action == "edit":
+        allowed = can_edit_workforce(db, user, workforce)
+    else:
+        raise ValueError(f"Unsupported workforce access action: {action}")
+
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Access denied")
+    return workforce
+
+
+def ensure_agent_access(
+    agent: Agent | None,
+    user: User,
+    db: Session,
+    purpose: str = "workforce_select",
+    require_published: bool = False,
+) -> Agent:
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if user.is_admin or int(agent.user_id) == int(user.id):
+        if require_published and agent.status != AgentStatus.PUBLISHED:
+            raise HTTPException(
+                status_code=400,
+                detail="Workforce agents must be published",
+            )
+        return agent
+    visible_agent_ids = get_visible_agent_ids(db, user, purpose)
+    if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
+        if require_published and agent.status != AgentStatus.PUBLISHED:
+            raise HTTPException(
+                status_code=400,
+                detail="Workforce agents must be published",
+            )
+        return agent
+    raise HTTPException(status_code=403, detail="Access denied to agent")
+
+
+def ensure_workforce_agent_run_access(
+    agent: Agent | None,
+    user: User,
+    db: Session,
+) -> Agent:
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.status != AgentStatus.PUBLISHED:
+        raise HTTPException(
+            status_code=400, detail="Workforce agents must be published"
+        )
+    if user.is_admin or int(agent.user_id) == int(user.id):
+        return agent
+    visible_agent_ids = get_visible_agent_ids(db, user, "workforce_run")
+    if visible_agent_ids is not None and int(agent.id) in visible_agent_ids:
+        return agent
+    raise HTTPException(status_code=403, detail="Access denied to agent")

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -1,0 +1,250 @@
+import hashlib
+import re
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce, WorkforceAgent
+from .workforce_access import ensure_workforce_access, ensure_workforce_agent_run_access
+
+WORKFORCE_STATUSES = {"draft", "active", "archived"}
+RUN_STATUSES = {"pending", "running", "completed", "failed", "cancelled"}
+
+
+def normalize_workforce_status(status: str | None) -> str:
+    normalized = (status or "draft").strip().lower()
+    if normalized not in WORKFORCE_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid workforce status")
+    return normalized
+
+
+def normalize_workforce_run_status(status: str | None) -> str:
+    normalized = (status or "pending").strip().lower()
+    if normalized not in RUN_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid workforce run status")
+    return normalized
+
+
+def normalize_text(
+    value: str | None, field_name: str, required: bool = False
+) -> str | None:
+    if value is None:
+        if required:
+            raise HTTPException(status_code=400, detail=f"{field_name} is required")
+        return None
+    normalized = value.strip()
+    if required and not normalized:
+        raise HTTPException(status_code=400, detail=f"{field_name} is required")
+    return normalized or None
+
+
+def slugify_name(value: str | None, fallback: str = "worker") -> str:
+    base = (value or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "_", base).strip("_")
+    return slug or fallback
+
+
+_MAX_TOOL_NAME_LENGTH = 64
+_TOOL_NAME_PREFIX = "call_workforce_worker_"
+
+
+def build_worker_tool_name(worker_id: int, alias: str) -> str:
+    slug = slugify_name(alias)
+    raw = f"{_TOOL_NAME_PREFIX}{worker_id}_{slug}"
+    if len(raw) <= _MAX_TOOL_NAME_LENGTH:
+        return raw
+
+    worker_id_str = str(worker_id)
+    hash_suffix = "_" + hashlib.md5(slug.encode()).hexdigest()[:6]
+    available = (
+        _MAX_TOOL_NAME_LENGTH
+        - len(_TOOL_NAME_PREFIX)
+        - len(worker_id_str)
+        - len(hash_suffix)
+        - 1
+    )
+    if available < 4:
+        available = 4
+    truncated_slug = slug[:available]
+    return f"{_TOOL_NAME_PREFIX}{worker_id_str}_{truncated_slug}{hash_suffix}"
+
+
+def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
+    return sorted(
+        workforce.workers, key=lambda item: (item.sort_order or 0, item.id or 0)
+    )
+
+
+def validate_workforce_for_run(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+) -> tuple[Agent, list[WorkforceAgent]]:
+    workforce = ensure_workforce_access(db, user, workforce, action="run")
+    if workforce.status == "archived":
+        raise HTTPException(status_code=400, detail="Archived workforce cannot run")
+    if workforce.status != "active":
+        raise HTTPException(status_code=400, detail="Workforce must be active to run")
+
+    manager_agent = ensure_workforce_agent_run_access(workforce.manager_agent, user, db)
+    workers = _sorted_workers(workforce)
+    enabled_workers = [worker for worker in workers if worker.enabled]
+    if not enabled_workers:
+        raise HTTPException(
+            status_code=400, detail="Workforce requires at least one enabled worker"
+        )
+
+    for worker in enabled_workers:
+        ensure_workforce_agent_run_access(worker.agent, user, db)
+        instructions = normalize_text(
+            cast(str | None, worker.assignment_instructions),
+            "assignment_instructions",
+            required=True,
+        )
+        if instructions is None:
+            raise HTTPException(
+                status_code=400, detail="assignment_instructions is required"
+            )
+        if int(worker.agent_id) == int(workforce.manager_agent_id):
+            raise HTTPException(
+                status_code=400, detail="Manager agent cannot also be a worker"
+            )
+
+    return manager_agent, enabled_workers
+
+
+def build_manager_system_prompt(snapshot: dict[str, Any]) -> str:
+    workforce = snapshot["workforce"]
+    workers = snapshot["workers"]
+    lines = [
+        f'You are the Workforce Manager for "{workforce["name"]}".',
+        "",
+        "You are the only agent that talks to the user. You may delegate work only to the Worker Agents exposed as tools in this Workforce.",
+        "",
+        "Rules:",
+        "1. Decide which Worker Agents are needed for the user's request.",
+        "2. Give each Worker Agent a focused task with enough context.",
+        "3. Do not delegate outside this Workforce.",
+        "4. Consolidate Worker results into one final answer.",
+        "5. If Worker outputs conflict, resolve the conflict or explain uncertainty.",
+        "6. Do not expose internal tool names unless necessary.",
+        "",
+        "Available Worker Agents:",
+    ]
+    for worker in workers:
+        alias = worker.get("alias") or worker["name"]
+        lines.append(f"- {alias}: {worker['assignment_instructions']}")
+
+    manager_instructions = snapshot.get("manager", {}).get("workforce_instructions")
+    if manager_instructions:
+        lines.extend(
+            ["", "Workforce-specific manager instructions:", manager_instructions]
+        )
+    return "\n".join(lines)
+
+
+def build_worker_system_prompt(
+    workforce_name: str, assignment_instructions: str
+) -> str:
+    return "\n".join(
+        [
+            f'You are being called as part of Workforce "{workforce_name}".',
+            "",
+            "Your assignment in this Workforce:",
+            assignment_instructions,
+            "",
+            "Stay within this assignment. Return your result to the Workforce Manager. Do not address the end user directly unless asked.",
+        ]
+    )
+
+
+def build_agent_tool_overrides(
+    snapshot: dict[str, Any],
+    workforce_run_id: int | None = None,
+) -> dict[int, dict[str, Any]]:
+    workforce_name = snapshot["workforce"]["name"]
+    workforce_id = snapshot["workforce"]["id"]
+    overrides: dict[int, dict[str, Any]] = {}
+    for worker in snapshot["workers"]:
+        alias = worker.get("alias") or worker["name"]
+        description_parts = []
+        if worker.get("description"):
+            description_parts.append(worker["description"])
+        description_parts.append(f"Workforce role: {alias}.")
+        description_parts.append(f"Assignment: {worker['assignment_instructions']}")
+        overrides[int(worker["agent_id"])] = {
+            "tool_name": worker["tool_name"],
+            "description": " ".join(description_parts),
+            "extra_system_prompt": build_worker_system_prompt(
+                workforce_name, worker["assignment_instructions"]
+            ),
+            "workforce_run_id": workforce_run_id,
+            "workforce_id": workforce_id,
+            "workforce_name": workforce_name,
+            "worker_member_id": worker.get("member_id"),
+            "worker_alias": alias,
+        }
+    return overrides
+
+
+def build_workforce_snapshot(
+    db: Session, user: User, workforce: Workforce
+) -> dict[str, Any]:
+    manager_agent, enabled_workers = validate_workforce_for_run(db, user, workforce)
+    snapshot_workers: list[dict[str, Any]] = []
+    for worker in enabled_workers:
+        alias = (
+            normalize_text(cast(str | None, worker.alias), "alias") or worker.agent.name
+        )
+        assignment_instructions = normalize_text(
+            cast(str | None, worker.assignment_instructions),
+            "assignment_instructions",
+            required=True,
+        )
+        if assignment_instructions is None:
+            raise HTTPException(
+                status_code=400, detail="assignment_instructions is required"
+            )
+
+        snapshot_workers.append(
+            {
+                "member_id": worker.id,
+                "agent_id": worker.agent_id,
+                "name": worker.agent.name,
+                "alias": alias,
+                "description": worker.agent.description,
+                "assignment_instructions": assignment_instructions,
+                "execution_mode": worker.agent.execution_mode,
+                "tool_name": build_worker_tool_name(cast(int, worker.id), alias),
+                "enabled": bool(worker.enabled),
+            }
+        )
+
+    snapshot: dict[str, Any] = {
+        "version": 1,
+        "workforce": {
+            "id": workforce.id,
+            "name": workforce.name,
+            "description": workforce.description,
+            "status": workforce.status,
+            "scope_type": workforce.scope_type,
+            "scope_id": workforce.scope_id,
+            "owner_user_id": workforce.owner_user_id,
+        },
+        "manager": {
+            "agent_id": manager_agent.id,
+            "name": manager_agent.name,
+            "description": manager_agent.description,
+            "instructions": manager_agent.instructions,
+            "workforce_instructions": workforce.manager_instructions,
+            "execution_mode": manager_agent.execution_mode,
+            "models": manager_agent.models or {},
+        },
+        "workers": snapshot_workers,
+    }
+    snapshot["manager"]["runtime_prompt"] = build_manager_system_prompt(snapshot)
+    return snapshot

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -59,7 +59,7 @@ def build_worker_tool_name(worker_id: int, alias: str) -> str:
         return raw
 
     worker_id_str = str(worker_id)
-    hash_suffix = "_" + hashlib.md5(slug.encode()).hexdigest()[:6]
+    hash_suffix = "_" + hashlib.sha256(slug.encode()).hexdigest()[:6]
     available = (
         _MAX_TOOL_NAME_LENGTH
         - len(_TOOL_NAME_PREFIX)

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -1,0 +1,103 @@
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.user import User
+
+from ..models.workforce import Workforce, WorkforceAgent
+from .workforce_access import ensure_agent_access
+from .workforce_snapshot import normalize_text
+
+
+def ensure_supported_source_type(source_type: str) -> None:
+    if source_type != "existing":
+        raise HTTPException(
+            status_code=400,
+            detail="source_type must be existing; publish an agent before adding it to a workforce",
+        )
+
+
+def next_worker_sort_order(db: Session, workforce_id: int) -> int:
+    max_sort_order = (
+        db.query(WorkforceAgent.sort_order)
+        .filter(WorkforceAgent.workforce_id == workforce_id)
+        .order_by(WorkforceAgent.sort_order.desc(), WorkforceAgent.id.desc())
+        .first()
+    )
+    return (
+        int(max_sort_order[0]) + 1
+        if max_sort_order and max_sort_order[0] is not None
+        else 1
+    )
+
+
+def create_workforce_worker(
+    db: Session,
+    workforce: Workforce,
+    user: User,
+    *,
+    source_type: str,
+    assignment_instructions: str,
+    alias: str | None = None,
+    agent_id: int | None = None,
+    enabled: bool = True,
+    sort_order: int | None = None,
+    canvas_position: dict[str, Any] | None = None,
+) -> WorkforceAgent:
+    ensure_supported_source_type(source_type)
+
+    normalized_assignment = normalize_text(
+        assignment_instructions,
+        "assignment_instructions",
+        required=True,
+    )
+    if normalized_assignment is None:
+        raise HTTPException(
+            status_code=400, detail="assignment_instructions is required"
+        )
+
+    if agent_id is None:
+        raise HTTPException(status_code=400, detail="agent_id is required")
+
+    agent = ensure_agent_access(
+        db.query(Agent).filter(Agent.id == agent_id).first(),
+        user,
+        db,
+        require_published=True,
+    )
+    existing = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.workforce_id == workforce.id,
+            WorkforceAgent.agent_id == agent.id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="Agent already added to workforce")
+
+    agent_id_value = cast(int, agent.id)
+    workforce_manager_id = cast(int, workforce.manager_agent_id)
+    if agent_id_value == workforce_manager_id:
+        raise HTTPException(
+            status_code=400, detail="Manager agent cannot also be a worker"
+        )
+
+    workforce_id = cast(int, workforce.id)
+    worker = WorkforceAgent(
+        workforce_id=workforce_id,
+        agent_id=agent_id_value,
+        alias=normalize_text(alias, "alias"),
+        assignment_instructions=normalized_assignment,
+        source_type=source_type,
+        enabled=bool(enabled),
+        sort_order=sort_order
+        if sort_order is not None
+        else next_worker_sort_order(db, workforce_id),
+        canvas_position=canvas_position,
+    )
+    db.add(worker)
+    db.flush()
+    return worker

--- a/src/xagent/web/services/workforce_workers.py
+++ b/src/xagent/web/services/workforce_workers.py
@@ -7,7 +7,7 @@ from xagent.web.models.agent import Agent
 from xagent.web.models.user import User
 
 from ..models.workforce import Workforce, WorkforceAgent
-from .workforce_access import ensure_agent_access
+from .workforce_access import ensure_agent_access, ensure_workforce_access
 from .workforce_snapshot import normalize_text
 
 
@@ -46,6 +46,7 @@ def create_workforce_worker(
     sort_order: int | None = None,
     canvas_position: dict[str, Any] | None = None,
 ) -> WorkforceAgent:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
     ensure_supported_source_type(source_type)
 
     normalized_assignment = normalize_text(

--- a/tests/web/test_workforce_foundation.py
+++ b/tests/web/test_workforce_foundation.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from xagent.web.models import Agent, Base, User, Workforce
+from xagent.web.models import Agent, Base, User, Workforce, WorkforceRun
 from xagent.web.models.agent import AgentStatus
 from xagent.web.services.workforce_access import ensure_workforce_access
 from xagent.web.services.workforce_snapshot import (
@@ -105,6 +105,30 @@ def test_workforce_models_are_registered(db_session: Session) -> None:
     assert "workforce_agents" in tables
     assert "workforce_runs" in tables
     assert "workforce_builder_messages" in tables
+
+
+def test_deleting_workforce_deletes_runs_with_orm_cascade(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager)
+    run = WorkforceRun(
+        workforce_id=workforce.id,
+        user_id=user.id,
+        status="pending",
+        snapshot={"version": 1},
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    workforce_id = int(workforce.id)
+    run_id = int(run.id)
+    db_session.delete(workforce)
+    db_session.commit()
+
+    assert db_session.get(Workforce, workforce_id) is None
+    assert db_session.get(WorkforceRun, run_id) is None
 
 
 def test_build_workforce_snapshot_for_active_workforce(db_session: Session) -> None:

--- a/tests/web/test_workforce_foundation.py
+++ b/tests/web/test_workforce_foundation.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine, inspect
@@ -282,6 +284,11 @@ def test_workforce_status_and_tool_name_normalization() -> None:
     assert normalize_workforce_run_status(" Completed ") == "completed"
     assert len(tool_name) <= 64
     assert tool_name.startswith("call_workforce_worker_99_")
+    assert tool_name.endswith(
+        hashlib.sha256(
+            "this_worker_alias_is_long_enough_to_require_stable_truncation".encode()
+        ).hexdigest()[:6]
+    )
 
     with pytest.raises(HTTPException) as status_error:
         normalize_workforce_status("unknown")

--- a/tests/web/test_workforce_foundation.py
+++ b/tests/web/test_workforce_foundation.py
@@ -1,0 +1,289 @@
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.web.models import Agent, Base, User, Workforce
+from xagent.web.models.agent import AgentStatus
+from xagent.web.services.workforce_access import ensure_workforce_access
+from xagent.web.services.workforce_snapshot import (
+    build_agent_tool_overrides,
+    build_worker_tool_name,
+    build_workforce_snapshot,
+    normalize_workforce_run_status,
+    normalize_workforce_status,
+)
+from xagent.web.services.workforce_workers import (
+    create_workforce_worker,
+    ensure_supported_source_type,
+)
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _create_user(db: Session, username: str, *, is_admin: bool = False) -> User:
+    user = User(
+        username=username,
+        password_hash="hash",
+        is_admin=is_admin,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_agent(
+    db: Session,
+    user: User,
+    name: str,
+    *,
+    status: AgentStatus = AgentStatus.PUBLISHED,
+) -> Agent:
+    agent = Agent(
+        user_id=user.id,
+        name=name,
+        description=f"{name} description",
+        instructions=f"{name} instructions",
+        execution_mode="balanced",
+        models={"general": "test-model"},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=[],
+        suggested_prompts=[],
+        status=status,
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _create_workforce(
+    db: Session,
+    user: User,
+    manager: Agent,
+    *,
+    status: str = "active",
+) -> Workforce:
+    workforce = Workforce(
+        owner_user_id=user.id,
+        scope_type="user",
+        scope_id=str(user.id),
+        name="Research Team",
+        description="Coordinates research tasks",
+        manager_agent_id=manager.id,
+        manager_instructions="Prefer concise synthesis.",
+        status=status,
+    )
+    db.add(workforce)
+    db.flush()
+    return workforce
+
+
+def test_workforce_models_are_registered(db_session: Session) -> None:
+    tables = set(inspect(db_session.bind).get_table_names())
+
+    assert "workforces" in tables
+    assert "workforce_agents" in tables
+    assert "workforce_runs" in tables
+    assert "workforce_builder_messages" in tables
+
+
+def test_build_workforce_snapshot_for_active_workforce(db_session: Session) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    worker_agent = _create_agent(db_session, user, "Analyst")
+    workforce = _create_workforce(db_session, user, manager)
+    worker = create_workforce_worker(
+        db_session,
+        workforce,
+        user,
+        source_type="existing",
+        agent_id=worker_agent.id,
+        alias="Research Analyst",
+        assignment_instructions="Collect evidence and cite sources.",
+    )
+
+    snapshot = build_workforce_snapshot(db_session, user, workforce)
+    overrides = build_agent_tool_overrides(snapshot, workforce_run_id=123)
+
+    assert snapshot["version"] == 1
+    assert snapshot["workforce"]["status"] == "active"
+    assert snapshot["manager"]["agent_id"] == manager.id
+    assert "Workforce Manager" in snapshot["manager"]["runtime_prompt"]
+    assert snapshot["workers"] == [
+        {
+            "member_id": worker.id,
+            "agent_id": worker_agent.id,
+            "name": "Analyst",
+            "alias": "Research Analyst",
+            "description": "Analyst description",
+            "assignment_instructions": "Collect evidence and cite sources.",
+            "execution_mode": "balanced",
+            "tool_name": build_worker_tool_name(worker.id, "Research Analyst"),
+            "enabled": True,
+        }
+    ]
+    assert overrides[worker_agent.id]["workforce_run_id"] == 123
+    assert overrides[worker_agent.id]["tool_name"].startswith("call_workforce_worker_")
+
+
+def test_validate_workforce_run_requires_active_enabled_workers(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager, status="draft")
+
+    with pytest.raises(HTTPException) as draft_error:
+        build_workforce_snapshot(db_session, user, workforce)
+    assert draft_error.value.status_code == 400
+    assert draft_error.value.detail == "Workforce must be active to run"
+
+    workforce.status = "active"
+    worker_agent = _create_agent(db_session, user, "Analyst")
+    create_workforce_worker(
+        db_session,
+        workforce,
+        user,
+        source_type="existing",
+        agent_id=worker_agent.id,
+        assignment_instructions="Collect evidence.",
+        enabled=False,
+    )
+
+    with pytest.raises(HTTPException) as worker_error:
+        build_workforce_snapshot(db_session, user, workforce)
+    assert worker_error.value.status_code == 400
+    assert worker_error.value.detail == "Workforce requires at least one enabled worker"
+
+
+def test_workforce_access_allows_owner_and_admin_only(db_session: Session) -> None:
+    owner = _create_user(db_session, "owner")
+    admin = _create_user(db_session, "admin", is_admin=True)
+    other = _create_user(db_session, "other")
+    manager = _create_agent(db_session, owner, "Manager")
+    workforce = _create_workforce(db_session, owner, manager)
+
+    assert ensure_workforce_access(db_session, owner, workforce) is workforce
+    assert ensure_workforce_access(db_session, admin, workforce) is workforce
+
+    with pytest.raises(HTTPException) as denied:
+        ensure_workforce_access(db_session, other, workforce)
+    assert denied.value.status_code == 403
+    assert denied.value.detail == "Access denied"
+
+
+def test_create_workforce_worker_requires_published_existing_agent(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    draft_agent = _create_agent(
+        db_session, user, "Draft Worker", status=AgentStatus.DRAFT
+    )
+    workforce = _create_workforce(db_session, user, manager)
+
+    with pytest.raises(HTTPException) as unsupported:
+        ensure_supported_source_type("template")
+    assert unsupported.value.status_code == 400
+    assert unsupported.value.detail == (
+        "source_type must be existing; publish an agent before adding it to a workforce"
+    )
+
+    with pytest.raises(HTTPException) as unpublished:
+        create_workforce_worker(
+            db_session,
+            workforce,
+            user,
+            source_type="existing",
+            agent_id=draft_agent.id,
+            assignment_instructions="Collect evidence.",
+        )
+    assert unpublished.value.status_code == 400
+    assert unpublished.value.detail == "Workforce agents must be published"
+
+
+def test_create_workforce_worker_rejects_duplicate_worker(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    worker_agent = _create_agent(db_session, user, "Analyst")
+    workforce = _create_workforce(db_session, user, manager)
+
+    create_workforce_worker(
+        db_session,
+        workforce,
+        user,
+        source_type="existing",
+        agent_id=worker_agent.id,
+        assignment_instructions="Collect evidence.",
+    )
+
+    with pytest.raises(HTTPException) as duplicate:
+        create_workforce_worker(
+            db_session,
+            workforce,
+            user,
+            source_type="existing",
+            agent_id=worker_agent.id,
+            assignment_instructions="Collect evidence again.",
+        )
+    assert duplicate.value.status_code == 409
+    assert duplicate.value.detail == "Agent already added to workforce"
+
+
+def test_create_workforce_worker_rejects_manager_as_worker(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager)
+
+    with pytest.raises(HTTPException) as manager_worker:
+        create_workforce_worker(
+            db_session,
+            workforce,
+            user,
+            source_type="existing",
+            agent_id=manager.id,
+            assignment_instructions="Manage the work.",
+        )
+    assert manager_worker.value.status_code == 400
+    assert manager_worker.value.detail == "Manager agent cannot also be a worker"
+
+
+def test_workforce_status_and_tool_name_normalization() -> None:
+    tool_name = build_worker_tool_name(
+        99,
+        "This Worker Alias Is Long Enough To Require Stable Truncation",
+    )
+
+    assert normalize_workforce_status(None) == "draft"
+    assert normalize_workforce_status(" ACTIVE ") == "active"
+    assert normalize_workforce_run_status(None) == "pending"
+    assert normalize_workforce_run_status(" Completed ") == "completed"
+    assert len(tool_name) <= 64
+    assert tool_name.startswith("call_workforce_worker_99_")
+
+    with pytest.raises(HTTPException) as status_error:
+        normalize_workforce_status("unknown")
+    assert status_error.value.status_code == 400
+    assert status_error.value.detail == "Invalid workforce status"

--- a/tests/web/test_workforce_foundation.py
+++ b/tests/web/test_workforce_foundation.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from xagent.web.models import Agent, Base, User, Workforce, WorkforceRun
+from xagent.web.models import Agent, Base, User, Workforce, WorkforceAgent, WorkforceRun
 from xagent.web.models.agent import AgentStatus
 from xagent.web.services.workforce_access import ensure_workforce_access
 from xagent.web.services.workforce_snapshot import (
@@ -244,6 +244,30 @@ def test_create_workforce_worker_requires_published_existing_agent(
         )
     assert unpublished.value.status_code == 400
     assert unpublished.value.detail == "Workforce agents must be published"
+
+
+def test_create_workforce_worker_requires_workforce_edit_access(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    manager = _create_agent(db_session, owner, "Manager")
+    other_agent = _create_agent(db_session, other, "Other Worker")
+    workforce = _create_workforce(db_session, owner, manager)
+
+    with pytest.raises(HTTPException) as denied:
+        create_workforce_worker(
+            db_session,
+            workforce,
+            other,
+            source_type="existing",
+            agent_id=other_agent.id,
+            assignment_instructions="Collect evidence.",
+        )
+
+    assert denied.value.status_code == 403
+    assert denied.value.detail == "Access denied"
+    assert db_session.query(WorkforceAgent).count() == 0
 
 
 def test_create_workforce_worker_rejects_duplicate_worker(


### PR DESCRIPTION
## Summary

- Add Workforce core database models and Alembic migration.
- Register Workforce models with SQLAlchemy metadata initialization.
- Add internal Workforce access, snapshot, and worker validation services.
- Add tests for model registration, snapshot building, access control, worker validation, duplicate workers, and manager/worker separation.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests/web/test_workforce_foundation.py`
- `uv run pytest tests/migrations/test_migration_integration.py -k sqlite`
- `uv run python -m alembic heads`
