### PR TITLE
feat: add authorized file delivery redirects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "${PORT:-80}:80"
     volumes:
       - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - xagent_data:/root/.xagent:ro
     depends_on:
       - frontend
       - backend

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,6 +14,13 @@ server {
     # defense in depth against unbounded request bodies before the backend can reject them.
     client_max_body_size 500M;
 
+    # Private file serving target for backend-authorized X-Accel-Redirect.
+    # Browsers cannot access this location directly because it is marked internal.
+    location /_xagent_internal_files/ {
+        internal;
+        alias /root/.xagent/uploads/;
+    }
+
     # Proxy to backend API
     location /api/ {
         proxy_pass http://backend;

--- a/example.env
+++ b/example.env
@@ -210,6 +210,18 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # logged and skipped; unexpected S3 errors fail startup.
 # XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED="true"
 
+# Redirect authenticated preview/download requests to short-lived durable-object
+# URLs when the storage backend can sign them. Keep disabled unless the signed
+# URL endpoint is reachable by browsers (for example public S3/MinIO or CDN).
+# XAGENT_FILE_DELIVERY_REDIRECT_ENABLED="false"
+# XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS="300"
+
+# Let nginx serve local upload bytes after the backend authorizes a file_id.
+# This requires docker/nginx.conf's internal location and a shared read-only
+# uploads volume mounted into nginx. Keep disabled for direct local backend runs.
+# XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED="false"
+# XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX="/_xagent_internal_files/"
+
 # External upload directories for knowledge base file access
 # Comma-separated list of directory paths (existing dirs only)
 # XAGENT_EXTERNAL_UPLOAD_DIRS="/path/to/uploads1,/path/to/uploads2"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -43,6 +43,10 @@ FILE_STORAGE_OPTIONS = "XAGENT_FILE_STORAGE_OPTIONS"
 FILE_MATERIALIZE_DIR = "XAGENT_FILE_MATERIALIZE_DIR"
 PREVIEW_TMP_DIR = "XAGENT_PREVIEW_TMP_DIR"
 FILE_STORAGE_STARTUP_SYNC_ENABLED = "XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED"
+FILE_DELIVERY_REDIRECT_ENABLED = "XAGENT_FILE_DELIVERY_REDIRECT_ENABLED"
+FILE_DELIVERY_SIGNED_URL_TTL_SECONDS = "XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS"
+FILE_DELIVERY_ACCEL_REDIRECT_ENABLED = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED"
+FILE_DELIVERY_ACCEL_REDIRECT_PREFIX = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX"
 SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 DATABASE_URL = "DATABASE_URL"
@@ -418,6 +422,82 @@ def get_file_storage_startup_sync_enabled() -> bool:
         f"Invalid {FILE_STORAGE_STARTUP_SYNC_ENABLED} value: {env_value!r}. "
         "Expected a boolean value."
     )
+
+
+def get_file_delivery_redirect_enabled() -> bool:
+    """Return whether private file endpoints may redirect to durable object URLs."""
+    env_value = os.getenv(FILE_DELIVERY_REDIRECT_ENABLED)
+    if env_value is None or not env_value.strip():
+        return False
+
+    normalized = env_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    raise ValueError(
+        f"Invalid {FILE_DELIVERY_REDIRECT_ENABLED} value: {env_value!r}. "
+        "Expected a boolean value."
+    )
+
+
+def get_file_delivery_signed_url_ttl_seconds() -> int:
+    """Get signed durable-object URL lifetime for private file delivery redirects."""
+    env_value = os.getenv(FILE_DELIVERY_SIGNED_URL_TTL_SECONDS)
+    if env_value is None or not env_value.strip():
+        return 300
+
+    try:
+        ttl = int(env_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {FILE_DELIVERY_SIGNED_URL_TTL_SECONDS} value: {env_value!r}."
+        ) from exc
+
+    if ttl <= 0:
+        raise ValueError(
+            f"Invalid {FILE_DELIVERY_SIGNED_URL_TTL_SECONDS} value: {env_value!r}. "
+            "Value must be positive."
+        )
+
+    return ttl
+
+
+def get_file_delivery_accel_redirect_enabled() -> bool:
+    """Return whether private file endpoints may use nginx X-Accel-Redirect."""
+    env_value = os.getenv(FILE_DELIVERY_ACCEL_REDIRECT_ENABLED)
+    if env_value is None or not env_value.strip():
+        return False
+
+    normalized = env_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    raise ValueError(
+        f"Invalid {FILE_DELIVERY_ACCEL_REDIRECT_ENABLED} value: {env_value!r}. "
+        "Expected a boolean value."
+    )
+
+
+def get_file_delivery_accel_redirect_prefix() -> str:
+    """Get the internal nginx URI prefix used for X-Accel-Redirect."""
+    env_value = os.getenv(FILE_DELIVERY_ACCEL_REDIRECT_PREFIX)
+    prefix = (
+        env_value.strip()
+        if env_value is not None and env_value.strip()
+        else "/_xagent_internal_files/"
+    )
+    if not prefix.startswith("/"):
+        raise ValueError(
+            f"Invalid {FILE_DELIVERY_ACCEL_REDIRECT_PREFIX} value: {env_value!r}. "
+            "Value must start with '/'."
+        )
+    if not prefix.endswith("/"):
+        prefix += "/"
+    return prefix
 
 
 def format_file_size(size_bytes: int) -> str:

--- a/src/xagent/core/file_storage/storage.py
+++ b/src/xagent/core/file_storage/storage.py
@@ -76,6 +76,30 @@ class FsspecFileStorage:
     def stat(self, key: str) -> StoredObject:
         return self._stored_object(self._normalize_key(key))
 
+    def signed_url(
+        self,
+        key: str,
+        *,
+        expires: int,
+        content_type: str | None = None,
+        content_disposition: str | None = None,
+    ) -> str | None:
+        """Return a temporary direct-access URL when the backend supports it."""
+        if self._backend != "s3" or not hasattr(self._fs, "url"):
+            return None
+
+        url_kwargs: dict[str, str] = {}
+        if content_type:
+            url_kwargs["ResponseContentType"] = content_type
+        if content_disposition:
+            url_kwargs["ResponseContentDisposition"] = content_disposition
+
+        full_path = self._full_path(self._normalize_key(key))
+        try:
+            return str(self._fs.url(full_path, expires=expires, **url_kwargs))
+        except TypeError:
+            return str(self._fs.url(full_path, expires=expires))
+
     def content_hash(self, key: str) -> str:
         normalized_key = self._normalize_key(key)
         if self._backend == "file":

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -3,14 +3,25 @@ import logging
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional, Tuple, cast
+from urllib.parse import quote
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import (
+    FileResponse,
+    RedirectResponse,
+    Response,
+)
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ...config import get_uploads_dir
+from ...config import (
+    get_file_delivery_accel_redirect_enabled,
+    get_file_delivery_accel_redirect_prefix,
+    get_file_delivery_redirect_enabled,
+    get_file_delivery_signed_url_ttl_seconds,
+    get_uploads_dir,
+)
 from ...core.file_storage.factory import get_file_storage
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
@@ -73,6 +84,84 @@ def _file_integrity_failed() -> HTTPException:
     return HTTPException(
         status_code=409,
         detail=FILE_INTEGRITY_REUPLOAD_MESSAGE,
+    )
+
+
+def _content_disposition_header(disposition: str, filename: str) -> str:
+    safe_name = Path(filename).name or "file"
+    return f'{disposition}; filename="{safe_name}"'
+
+
+def _inline_download_disposition(media_type: str) -> str:
+    return (
+        "inline"
+        if media_type.startswith(("image/", "video/", "audio/", "text/"))
+        else "attachment"
+    )
+
+
+def _preview_can_redirect(path: Path, media_type: str) -> bool:
+    if path.suffix.lower() in {".pptx", ".ppt"}:
+        return False
+    return media_type not in {"text/html", "application/xhtml+xml", "image/svg+xml"}
+
+
+def _durable_redirect_response(
+    file_ref: ManagedFileRef,
+    *,
+    filename: str,
+    media_type: str,
+    disposition: str,
+) -> RedirectResponse | None:
+    if not get_file_delivery_redirect_enabled():
+        return None
+
+    try:
+        signed_url = file_ref.signed_access_url(
+            expires=get_file_delivery_signed_url_ttl_seconds(),
+            content_type=media_type,
+            content_disposition=_content_disposition_header(disposition, filename),
+        )
+    except DurableStorageOperationError as exc:
+        raise _durable_storage_unavailable() from exc
+
+    if not signed_url:
+        return None
+
+    return RedirectResponse(url=signed_url, status_code=307)
+
+
+def _accel_redirect_response(
+    path: Path,
+    *,
+    owner_user_id: int,
+    filename: str,
+    media_type: str,
+    disposition: str,
+) -> Response | None:
+    if not get_file_delivery_accel_redirect_enabled():
+        return None
+    if not path.exists() or not path.is_file():
+        return None
+
+    _ensure_under_uploads(path, owner_user_id)
+    uploads_root = get_uploads_dir().resolve()
+    try:
+        relative_path = path.resolve().relative_to(uploads_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Access denied") from exc
+
+    internal_prefix = get_file_delivery_accel_redirect_prefix()
+    internal_uri = (
+        internal_prefix.rstrip("/") + "/" + quote(relative_path.as_posix(), safe="/")
+    )
+    return Response(
+        status_code=200,
+        media_type=media_type,
+        headers={
+            "X-Accel-Redirect": internal_uri,
+            "Content-Disposition": _content_disposition_header(disposition, filename),
+        },
     )
 
 
@@ -723,34 +812,55 @@ async def download_file(
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         _ensure_under_uploads(full_path, owner_user_id)
+        content_disposition = _inline_download_disposition(media_type)
+        redirect_response = _durable_redirect_response(
+            file_ref,
+            filename=file_name,
+            media_type=media_type,
+            disposition=content_disposition,
+        )
+        if redirect_response is not None:
+            return redirect_response
         if full_path.exists() and full_path.is_file():
-            content_disposition = (
-                "inline"
-                if media_type.startswith(("image/", "video/", "audio/", "text/"))
-                else "attachment"
+            accel_response = _accel_redirect_response(
+                full_path,
+                owner_user_id=owner_user_id,
+                filename=file_name,
+                media_type=media_type,
+                disposition=content_disposition,
             )
+            if accel_response is not None:
+                return accel_response
             return FileResponse(
                 path=str(full_path),
                 filename=file_name,
                 media_type=media_type,
                 headers={
-                    "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
+                    "Content-Disposition": _content_disposition_header(
+                        content_disposition, file_name
+                    )
                 },
             )
         if file_ref.has_durable_object:
-            content_disposition = (
-                "inline"
-                if media_type.startswith(("image/", "video/", "audio/", "text/"))
-                else "attachment"
-            )
             try:
                 restored_path = file_ref.ensure_local()
+                accel_response = _accel_redirect_response(
+                    restored_path,
+                    owner_user_id=owner_user_id,
+                    filename=file_name,
+                    media_type=media_type,
+                    disposition=content_disposition,
+                )
+                if accel_response is not None:
+                    return accel_response
                 return FileResponse(
                     path=str(restored_path),
                     filename=file_name,
                     media_type=media_type,
                     headers={
-                        "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
+                        "Content-Disposition": _content_disposition_header(
+                            content_disposition, file_name
+                        )
                     },
                 )
             except DurableObjectIntegrityError as exc:
@@ -771,18 +881,26 @@ async def download_file(
 
     # For images and other viewable content, set Content-Disposition to inline
     # to allow browser to display the file instead of downloading it
-    content_disposition = (
-        "inline"
-        if media_type.startswith(("image/", "video/", "audio/", "text/"))
-        else "attachment"
+    content_disposition = _inline_download_disposition(media_type)
+
+    accel_response = _accel_redirect_response(
+        full_path,
+        owner_user_id=owner_user_id,
+        filename=file_name,
+        media_type=media_type,
+        disposition=content_disposition,
     )
+    if accel_response is not None:
+        return accel_response
 
     return FileResponse(
         path=str(full_path),
         filename=file_name,
         media_type=media_type,
         headers={
-            "Content-Disposition": f'{content_disposition}; filename="{file_name}"'
+            "Content-Disposition": _content_disposition_header(
+                content_disposition, file_name
+            )
         },
     )
 
@@ -804,6 +922,24 @@ async def preview_file(
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         _ensure_under_uploads(full_path, owner_user_id)
+        if _preview_can_redirect(full_path, media_type):
+            redirect_response = _durable_redirect_response(
+                file_ref,
+                filename=file_name,
+                media_type=media_type,
+                disposition="inline",
+            )
+            if redirect_response is not None:
+                return redirect_response
+            accel_response = _accel_redirect_response(
+                full_path,
+                owner_user_id=owner_user_id,
+                filename=file_name,
+                media_type=media_type,
+                disposition="inline",
+            )
+            if accel_response is not None:
+                return accel_response
         if file_ref.has_durable_object:
             try:
                 materialized_path = file_ref.materialize()
@@ -830,6 +966,17 @@ async def preview_file(
 
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
+
+    if _preview_can_redirect(full_path, media_type):
+        accel_response = _accel_redirect_response(
+            full_path,
+            owner_user_id=owner_user_id,
+            filename=file_name,
+            media_type=media_type,
+            disposition="inline",
+        )
+        if accel_response is not None:
+            return accel_response
 
     return FileResponse(
         path=str(full_path),

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -129,6 +129,8 @@ def _durable_redirect_response(
             content_type=media_type,
             content_disposition=_content_disposition_header(disposition, filename),
         )
+    except DurableObjectIntegrityError as exc:
+        raise _file_integrity_failed() from exc
     except DurableStorageOperationError as exc:
         raise _durable_storage_unavailable() from exc
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -89,7 +89,14 @@ def _file_integrity_failed() -> HTTPException:
 
 def _content_disposition_header(disposition: str, filename: str) -> str:
     safe_name = Path(filename).name or "file"
-    return f'{disposition}; filename="{safe_name}"'
+    fallback_name = "".join(
+        character if 0x20 <= ord(character) <= 0x7E else "_" for character in safe_name
+    )
+    escaped_name = fallback_name.replace("\\", "\\\\").replace('"', '\\"')
+    encoded_name = quote(safe_name, safe="")
+    return (
+        f"{disposition}; filename=\"{escaped_name}\"; filename*=UTF-8''{encoded_name}"
+    )
 
 
 def _inline_download_disposition(media_type: str) -> str:

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -179,6 +179,27 @@ class ManagedFileRef:
     def open_read(self) -> BinaryIO:
         return self.ensure_local().open("rb")
 
+    def signed_access_url(
+        self,
+        *,
+        expires: int,
+        content_type: str | None = None,
+        content_disposition: str | None = None,
+    ) -> str | None:
+        if not self.has_durable_object:
+            return None
+        try:
+            return self.storage.signed_url(
+                self.storage_key,
+                expires=expires,
+                content_type=content_type,
+                content_disposition=content_disposition,
+            )
+        except Exception as exc:
+            raise DurableStorageOperationError(
+                f"Failed to sign durable object URL: {self.storage_key}"
+            ) from exc
+
     def sync_to_durable(
         self,
         *,

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -8,7 +8,7 @@ import mimetypes
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, BinaryIO, Literal
+from typing import Any, BinaryIO, Literal, NoReturn
 
 from ...core.file_storage import FsspecFileStorage, StoredObject, get_file_storage
 from ..models.uploaded_file import UploadedFile
@@ -73,21 +73,34 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _checksum_matches(expected_checksum: str, actual_sha256_hex: str) -> bool:
-    normalized_expected = expected_checksum.strip()
-    if normalized_expected.lower() == actual_sha256_hex:
-        return True
-
-    if normalized_expected.lower().startswith("sha256:"):
-        prefixed_value = normalized_expected.split(":", 1)[1]
-        if prefixed_value.lower() == actual_sha256_hex:
-            return True
+def _checksum_to_sha256_hex(checksum: str) -> str | None:
+    normalized = checksum.strip()
+    if normalized.lower().startswith("sha256:"):
+        normalized = normalized.split(":", 1)[1]
 
     try:
-        decoded = base64.b64decode(normalized_expected, validate=True)
+        bytes.fromhex(normalized)
+    except ValueError:
+        pass
+    else:
+        if len(normalized) == 64:
+            return normalized.lower()
+
+    try:
+        decoded = base64.b64decode(normalized, validate=True)
     except (binascii.Error, ValueError):
-        return False
-    return len(decoded) == 32 and decoded.hex() == actual_sha256_hex
+        return None
+    return decoded.hex() if len(decoded) == 32 else None
+
+
+def _checksum_matches(expected_checksum: str, actual_checksum: str) -> bool:
+    expected_sha256 = _checksum_to_sha256_hex(expected_checksum)
+    actual_sha256 = _checksum_to_sha256_hex(actual_checksum)
+    return (
+        expected_sha256 is not None
+        and actual_sha256 is not None
+        and expected_sha256 == actual_sha256
+    )
 
 
 @dataclass
@@ -187,6 +200,8 @@ class ManagedFileRef:
         content_disposition: str | None = None,
     ) -> str | None:
         if not self.has_durable_object:
+            return None
+        if not self._verify_durable_checksum_for_direct_access():
             return None
         try:
             return self.storage.signed_url(
@@ -320,6 +335,39 @@ class ManagedFileRef:
         if _checksum_matches(str(expected_checksum), actual_checksum):
             return
 
+        self._raise_integrity_error(str(expected_checksum), actual_checksum)
+
+    def _verify_durable_checksum_for_direct_access(self) -> bool:
+        expected_checksum = getattr(self.record, "checksum", None)
+        if not expected_checksum:
+            logger.warning(
+                "Skipping direct durable access without DB checksum: "
+                "file_id=%s storage_key=%s",
+                getattr(self.record, "file_id", None),
+                self.storage_key,
+            )
+            return False
+
+        try:
+            actual_checksum = self.storage.content_hash(self.storage_key)
+        except Exception as exc:
+            logger.warning(
+                "Falling back to backend-mediated durable access because content "
+                "hash is unavailable: file_id=%s storage_key=%s error=%s",
+                getattr(self.record, "file_id", None),
+                self.storage_key,
+                exc,
+            )
+            return False
+
+        if _checksum_matches(str(expected_checksum), str(actual_checksum)):
+            return True
+
+        self._raise_integrity_error(str(expected_checksum), str(actual_checksum))
+
+    def _raise_integrity_error(
+        self, expected_checksum: str, actual_checksum: str
+    ) -> NoReturn:
         logger.error(
             "Durable object integrity check failed: file_id=%s storage_key=%s "
             "expected_checksum=%s actual_checksum=%s",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -12,6 +12,10 @@ from xagent.config import (
     DATABASE_URL,
     EXTERNAL_SKILLS_LIBRARY_DIRS,
     EXTERNAL_UPLOAD_DIRS,
+    FILE_DELIVERY_ACCEL_REDIRECT_ENABLED,
+    FILE_DELIVERY_ACCEL_REDIRECT_PREFIX,
+    FILE_DELIVERY_REDIRECT_ENABLED,
+    FILE_DELIVERY_SIGNED_URL_TTL_SECONDS,
     FILE_MATERIALIZE_DIR,
     FILE_STORAGE_OPTIONS,
     FILE_STORAGE_STARTUP_SYNC_ENABLED,
@@ -45,6 +49,10 @@ from xagent.config import (
     get_default_task_execution_mode,
     get_external_skills_dirs,
     get_external_upload_dirs,
+    get_file_delivery_accel_redirect_enabled,
+    get_file_delivery_accel_redirect_prefix,
+    get_file_delivery_redirect_enabled,
+    get_file_delivery_signed_url_ttl_seconds,
     get_file_materialize_dir,
     get_file_storage_options,
     get_file_storage_startup_sync_enabled,
@@ -133,6 +141,16 @@ class TestEnvironmentVariableConstants:
         assert (
             FILE_STORAGE_STARTUP_SYNC_ENABLED
             == "XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED"
+        )
+
+    def test_file_delivery_accel_redirect_constants(self):
+        assert (
+            FILE_DELIVERY_ACCEL_REDIRECT_ENABLED
+            == "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED"
+        )
+        assert (
+            FILE_DELIVERY_ACCEL_REDIRECT_PREFIX
+            == "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX"
         )
 
     def test_redis_url_constant(self):
@@ -354,6 +372,113 @@ class TestFileStorageConfig:
             ValueError, match="XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED"
         ):
             get_file_storage_startup_sync_enabled()
+
+    def test_file_delivery_redirect_enabled_defaults_false(self, monkeypatch):
+        monkeypatch.delenv(FILE_DELIVERY_REDIRECT_ENABLED, raising=False)
+
+        assert get_file_delivery_redirect_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+            ("on", True),
+            ("false", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+        ],
+    )
+    def test_file_delivery_redirect_enabled_parses_bool(
+        self, monkeypatch, value, expected
+    ):
+        monkeypatch.setenv(FILE_DELIVERY_REDIRECT_ENABLED, value)
+
+        assert get_file_delivery_redirect_enabled() is expected
+
+    def test_file_delivery_redirect_enabled_rejects_invalid(self, monkeypatch):
+        monkeypatch.setenv(FILE_DELIVERY_REDIRECT_ENABLED, "maybe")
+
+        with pytest.raises(ValueError, match="XAGENT_FILE_DELIVERY_REDIRECT_ENABLED"):
+            get_file_delivery_redirect_enabled()
+
+    def test_file_delivery_signed_url_ttl_defaults_to_300(self, monkeypatch):
+        monkeypatch.delenv(FILE_DELIVERY_SIGNED_URL_TTL_SECONDS, raising=False)
+
+        assert get_file_delivery_signed_url_ttl_seconds() == 300
+
+    def test_file_delivery_signed_url_ttl_with_env_var(self, monkeypatch):
+        monkeypatch.setenv(FILE_DELIVERY_SIGNED_URL_TTL_SECONDS, "60")
+
+        assert get_file_delivery_signed_url_ttl_seconds() == 60
+
+    @pytest.mark.parametrize("value", ["0", "-1", "abc"])
+    def test_file_delivery_signed_url_ttl_rejects_invalid(self, monkeypatch, value):
+        monkeypatch.setenv(FILE_DELIVERY_SIGNED_URL_TTL_SECONDS, value)
+
+        with pytest.raises(
+            ValueError, match="XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS"
+        ):
+            get_file_delivery_signed_url_ttl_seconds()
+
+    def test_file_delivery_accel_redirect_enabled_defaults_false(self, monkeypatch):
+        monkeypatch.delenv(FILE_DELIVERY_ACCEL_REDIRECT_ENABLED, raising=False)
+
+        assert get_file_delivery_accel_redirect_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+            ("on", True),
+            ("false", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+        ],
+    )
+    def test_file_delivery_accel_redirect_enabled_parses_bool(
+        self, monkeypatch, value, expected
+    ):
+        monkeypatch.setenv(FILE_DELIVERY_ACCEL_REDIRECT_ENABLED, value)
+
+        assert get_file_delivery_accel_redirect_enabled() is expected
+
+    def test_file_delivery_accel_redirect_enabled_rejects_invalid(self, monkeypatch):
+        monkeypatch.setenv(FILE_DELIVERY_ACCEL_REDIRECT_ENABLED, "maybe")
+
+        with pytest.raises(
+            ValueError, match="XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED"
+        ):
+            get_file_delivery_accel_redirect_enabled()
+
+    def test_file_delivery_accel_redirect_prefix_defaults_to_internal_uri(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv(FILE_DELIVERY_ACCEL_REDIRECT_PREFIX, raising=False)
+
+        assert get_file_delivery_accel_redirect_prefix() == "/_xagent_internal_files/"
+
+    def test_file_delivery_accel_redirect_prefix_normalizes_trailing_slash(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(FILE_DELIVERY_ACCEL_REDIRECT_PREFIX, "/private-files")
+
+        assert get_file_delivery_accel_redirect_prefix() == "/private-files/"
+
+    def test_file_delivery_accel_redirect_prefix_requires_absolute_uri(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(FILE_DELIVERY_ACCEL_REDIRECT_PREFIX, "private-files")
+
+        with pytest.raises(
+            ValueError, match="XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX"
+        ):
+            get_file_delivery_accel_redirect_prefix()
 
 
 class TestGetUploadsDir:

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -155,6 +155,81 @@ def test_object_uri_quotes_key_without_backend_branch(monkeypatch, tmp_path):
     assert stored.uri.endswith("/uploads/file%20with%20spaces.txt")
 
 
+def test_local_file_storage_does_not_return_signed_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    get_file_storage.cache_clear()
+
+    storage = get_file_storage()
+
+    assert storage.signed_url("uploads/data.txt", expires=300) is None
+
+
+def test_s3_signed_url_includes_response_headers(tmp_path):
+    class S3UrlStorage:
+        def __init__(self):
+            self.calls = []
+
+        def url(self, path, **kwargs):
+            self.calls.append((path, kwargs))
+            return "https://cdn.example.com/signed"
+
+    backend = S3UrlStorage()
+    storage = FsspecFileStorage(
+        fs=backend,
+        root="bucket/root",
+        backend="s3",
+        base_uri="s3://bucket/root",
+        materialize_dir=tmp_path,
+    )
+
+    signed_url = storage.signed_url(
+        "uploads/data.txt",
+        expires=120,
+        content_type="text/plain",
+        content_disposition="inline; filename*=UTF-8''data.txt",
+    )
+
+    assert signed_url == "https://cdn.example.com/signed"
+    assert backend.calls == [
+        (
+            "bucket/root/uploads/data.txt",
+            {
+                "expires": 120,
+                "ResponseContentType": "text/plain",
+                "ResponseContentDisposition": "inline; filename*=UTF-8''data.txt",
+            },
+        )
+    ]
+
+
+def test_s3_signed_url_falls_back_for_basic_fsspec_url_signature(tmp_path):
+    class BasicUrlStorage:
+        def __init__(self):
+            self.calls = []
+
+        def url(self, path, *, expires):
+            self.calls.append((path, expires))
+            return "https://cdn.example.com/basic"
+
+    backend = BasicUrlStorage()
+    storage = FsspecFileStorage(
+        fs=backend,
+        root="bucket/root",
+        backend="s3",
+        base_uri="s3://bucket/root",
+        materialize_dir=tmp_path,
+    )
+
+    signed_url = storage.signed_url(
+        "uploads/data.txt",
+        expires=120,
+        content_type="text/plain",
+    )
+
+    assert signed_url == "https://cdn.example.com/basic"
+    assert backend.calls == [("bucket/root/uploads/data.txt", 120)]
+
+
 def test_list_uses_detailed_find_metadata_without_per_object_info(tmp_path):
     class DetailedFindStorage:
         def exists(self, path):

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -211,9 +211,16 @@ def test_signed_access_url_returns_none_without_durable_object(tmp_path):
 
 
 def test_signed_access_url_delegates_to_storage(tmp_path):
+    checksum = sha256(b"remote content").hexdigest()
+
     class SigningStorage:
         def __init__(self):
             self.calls = []
+            self.content_hash_calls = []
+
+        def content_hash(self, key):
+            self.content_hash_calls.append(key)
+            return checksum
 
         def signed_url(
             self,
@@ -232,6 +239,7 @@ def test_signed_access_url_delegates_to_storage(tmp_path):
         storage_backend="s3",
         storage_key="users/7/uploads/file-123/object.txt",
         storage_status="available",
+        checksum=checksum,
     )
 
     signed_url = ManagedFileRef(record, storage=storage).signed_access_url(
@@ -241,9 +249,59 @@ def test_signed_access_url_delegates_to_storage(tmp_path):
     )
 
     assert signed_url == "https://cdn.example.com/signed"
+    assert storage.content_hash_calls == ["users/7/uploads/file-123/object.txt"]
     assert storage.calls == [
         ("users/7/uploads/file-123/object.txt", 60, "text/plain", "inline")
     ]
+
+
+def test_signed_access_url_rejects_checksum_mismatch(tmp_path):
+    class MismatchedStorage:
+        def content_hash(self, key):
+            del key
+            return sha256(b"wrong content").hexdigest()
+
+        def signed_url(self, **kwargs):
+            raise AssertionError("signed URL should not be generated")
+
+    record = _record(
+        tmp_path / "uploads" / "object.txt",
+        storage_backend="s3",
+        storage_key="users/7/uploads/file-123/object.txt",
+        storage_status="available",
+        checksum=sha256(b"expected content").hexdigest(),
+    )
+
+    with pytest.raises(DurableObjectIntegrityError):
+        ManagedFileRef(record, storage=MismatchedStorage()).signed_access_url(
+            expires=60
+        )
+
+
+def test_signed_access_url_falls_back_when_checksum_unavailable(tmp_path):
+    class UnhashableStorage:
+        def __init__(self):
+            self.signed_calls = []
+
+        def content_hash(self, key):
+            del key
+            raise RuntimeError("head metadata unavailable")
+
+        def signed_url(self, **kwargs):
+            self.signed_calls.append(kwargs)
+            return "https://cdn.example.com/signed"
+
+    storage = UnhashableStorage()
+    record = _record(
+        tmp_path / "uploads" / "object.txt",
+        storage_backend="s3",
+        storage_key="users/7/uploads/file-123/object.txt",
+        storage_status="available",
+        checksum=sha256(b"expected content").hexdigest(),
+    )
+
+    assert ManagedFileRef(record, storage=storage).signed_access_url(expires=60) is None
+    assert storage.signed_calls == []
 
 
 def test_sync_to_durable_uploads_local_file_and_updates_record(monkeypatch, tmp_path):

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -204,6 +204,48 @@ def test_open_read_prefers_existing_local_file_over_durable(monkeypatch, tmp_pat
         assert handle.read() == b"current local content"
 
 
+def test_signed_access_url_returns_none_without_durable_object(tmp_path):
+    record = _record(tmp_path / "uploads" / "local.txt")
+
+    assert ManagedFileRef(record).signed_access_url(expires=300) is None
+
+
+def test_signed_access_url_delegates_to_storage(tmp_path):
+    class SigningStorage:
+        def __init__(self):
+            self.calls = []
+
+        def signed_url(
+            self,
+            key,
+            *,
+            expires,
+            content_type=None,
+            content_disposition=None,
+        ):
+            self.calls.append((key, expires, content_type, content_disposition))
+            return "https://cdn.example.com/signed"
+
+    storage = SigningStorage()
+    record = _record(
+        tmp_path / "uploads" / "object.txt",
+        storage_backend="s3",
+        storage_key="users/7/uploads/file-123/object.txt",
+        storage_status="available",
+    )
+
+    signed_url = ManagedFileRef(record, storage=storage).signed_access_url(
+        expires=60,
+        content_type="text/plain",
+        content_disposition="inline",
+    )
+
+    assert signed_url == "https://cdn.example.com/signed"
+    assert storage.calls == [
+        ("users/7/uploads/file-123/object.txt", 60, "text/plain", "inline")
+    ]
+
+
 def test_sync_to_durable_uploads_local_file_and_updates_record(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
     source = tmp_path / "uploads" / "sync.txt"

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -223,6 +223,67 @@ class TestAdminFileAccess:
 
         assert response.status_code == 403
 
+    def test_regular_user_cannot_get_signed_redirect_for_other_user_file(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        another_user = User(
+            username="signed-other",
+            password_hash=hash_password("signed-other"),
+            is_admin=False,
+        )
+        session.add(another_user)
+        session.commit()
+
+        another_user_id = int(cast(Any, another_user.id))
+        task = Task(
+            id=801,
+            user_id=another_user_id,
+            title="Signed redirect denied",
+            description="other user's file",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            another_user_id,
+            int(cast(Any, task.id)),
+            "signed-secret.txt",
+            "secret content",
+        )
+        uploaded_file.storage_status = "available"
+        uploaded_file.storage_key = (
+            f"users/{another_user_id}/uploads/{uploaded_file.file_id}/signed-secret.txt"
+        )
+        uploaded_file.storage_backend = "s3"
+        session.commit()
+
+        def fail_signed_access_url(self, **kwargs):
+            del self, kwargs
+            raise AssertionError("access check must happen before signing")
+
+        monkeypatch.setattr(ManagedFileRef, "signed_access_url", fail_signed_access_url)
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+
+        for path in [
+            f"/api/files/download/{uploaded_file.file_id}",
+            f"/api/files/preview/{uploaded_file.file_id}",
+        ]:
+            response = client.get(
+                path,
+                headers=user_headers,
+                follow_redirects=False,
+            )
+            assert response.status_code == 403
+
     def test_missing_file_id_returns_404(self, test_db, temp_uploads_dir):
         admin_user, regular_user, test_app, session = test_db
         del regular_user, session, temp_uploads_dir

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 
 from xagent.core.file_storage.factory import get_file_storage
 from xagent.web.api.auth import hash_password
-from xagent.web.api.files import file_router
+from xagent.web.api.files import _content_disposition_header, file_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.database import Base, get_db
 from xagent.web.models.uploaded_file import UploadedFile
@@ -158,6 +158,12 @@ def _corrupt_durable_copy_and_remove_local(
 class TestFileUpload:
     """Test file upload functionality"""
 
+    def test_content_disposition_header_escapes_filename_and_adds_utf8_parameter(self):
+        assert _content_disposition_header("attachment", 'quo"te\\文\r\n.txt') == (
+            'attachment; filename="quo\\"te\\\\___.txt"; '
+            "filename*=UTF-8''quo%22te%5C%E6%96%87%0D%0A.txt"
+        )
+
     def test_upload_text_file_success(
         self, client, test_db, sample_files, temp_uploads_dir, auth_headers
     ):
@@ -262,7 +268,10 @@ class TestFileUpload:
         assert storage_key.endswith(f"/{file_id}/redirect.txt")
         assert expires == 42
         assert content_type == "text/plain"
-        assert content_disposition == 'inline; filename="redirect.txt"'
+        assert (
+            content_disposition
+            == "inline; filename=\"redirect.txt\"; filename*=UTF-8''redirect.txt"
+        )
 
     def test_preview_redirects_to_signed_durable_url_when_enabled(
         self, client, temp_uploads_dir, auth_headers, monkeypatch
@@ -341,7 +350,8 @@ class TestFileUpload:
         assert download.headers["content-type"].startswith("text/plain")
         assert (
             download.headers["content-disposition"]
-            == 'inline; filename="local accel.txt"'
+            == 'inline; filename="local accel.txt"; '
+            "filename*=UTF-8''local%20accel.txt"
         )
 
     def test_preview_uses_accel_redirect_for_local_text_when_enabled(
@@ -369,7 +379,8 @@ class TestFileUpload:
         assert preview.headers["x-accel-redirect"].endswith("/user_1/preview-accel.txt")
         assert (
             preview.headers["content-disposition"]
-            == 'inline; filename="preview-accel.txt"'
+            == 'inline; filename="preview-accel.txt"; '
+            "filename*=UTF-8''preview-accel.txt"
         )
 
     def test_preview_does_not_accel_redirect_html(

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -533,6 +533,50 @@ class TestFileUpload:
         assert "re-upload" in download.json()["detail"]
         assert not list(temp_uploads_dir.rglob("integrity-download.txt"))
 
+    def test_download_redirect_enabled_checksum_mismatch_asks_user_to_reupload(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch, tmp_path
+    ):
+        from xagent.core.file_storage.storage import FsspecFileStorage
+
+        object_root = tmp_path / "objects"
+        monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        get_file_storage.cache_clear()
+
+        upload = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "integrity-redirect-download.txt",
+                    b"expected redirect download content",
+                    "text/plain",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200
+        file_id = upload.json()["file_id"]
+        _corrupt_durable_copy_and_remove_local(
+            object_root, temp_uploads_dir, "integrity-redirect-download.txt"
+        )
+
+        def fail_signed_url(self, key, **kwargs):
+            del self, key, kwargs
+            raise AssertionError("signed URL should not be generated")
+
+        monkeypatch.setattr(FsspecFileStorage, "signed_url", fail_signed_url)
+
+        download = client.get(
+            f"/api/files/download/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert download.status_code == 409
+        assert "re-upload" in download.json()["detail"]
+        assert not list(temp_uploads_dir.rglob("integrity-redirect-download.txt"))
+
     def test_download_registered_file_rejects_local_path_outside_uploads(
         self, client, test_db, tmp_path, auth_headers
     ):
@@ -689,6 +733,50 @@ class TestFileUpload:
 
         assert preview.status_code == 409
         assert "re-upload" in preview.json()["detail"]
+
+    def test_preview_redirect_enabled_checksum_mismatch_asks_user_to_reupload(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch, tmp_path
+    ):
+        from xagent.core.file_storage.storage import FsspecFileStorage
+
+        object_root = tmp_path / "objects"
+        monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        get_file_storage.cache_clear()
+
+        upload = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "integrity-redirect-preview.txt",
+                    b"expected redirect preview content",
+                    "text/plain",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200
+        file_id = upload.json()["file_id"]
+        _corrupt_durable_copy_and_remove_local(
+            object_root, temp_uploads_dir, "integrity-redirect-preview.txt"
+        )
+
+        def fail_signed_url(self, key, **kwargs):
+            del self, key, kwargs
+            raise AssertionError("signed URL should not be generated")
+
+        monkeypatch.setattr(FsspecFileStorage, "signed_url", fail_signed_url)
+
+        preview = client.get(
+            f"/api/files/preview/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert preview.status_code == 409
+        assert "re-upload" in preview.json()["detail"]
+        assert not list(temp_uploads_dir.rglob("integrity-redirect-preview.txt"))
 
     def test_public_preview_checksum_mismatch_asks_user_to_reupload(
         self, client, temp_uploads_dir, monkeypatch, tmp_path, auth_headers

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -210,6 +210,192 @@ class TestFileUpload:
         assert download.status_code == 200
         assert download.content == b"durable content"
 
+    def test_download_redirects_to_signed_durable_url_when_enabled(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS", "42")
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("redirect.txt", b"redirect content", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+        calls = []
+
+        def signed_access_url(
+            self,
+            *,
+            expires,
+            content_type=None,
+            content_disposition=None,
+        ):
+            calls.append(
+                (
+                    self.storage_key,
+                    expires,
+                    content_type,
+                    content_disposition,
+                )
+            )
+            return "https://cdn.example.com/private/redirect.txt?sig=abc"
+
+        monkeypatch.setattr(ManagedFileRef, "signed_access_url", signed_access_url)
+
+        download = client.get(
+            f"/api/files/download/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert download.status_code == 307
+        assert (
+            download.headers["location"]
+            == "https://cdn.example.com/private/redirect.txt?sig=abc"
+        )
+        assert len(calls) == 1
+        storage_key, expires, content_type, content_disposition = calls[0]
+        assert storage_key.endswith(f"/{file_id}/redirect.txt")
+        assert expires == 42
+        assert content_type == "text/plain"
+        assert content_disposition == 'inline; filename="redirect.txt"'
+
+    def test_preview_redirects_to_signed_durable_url_when_enabled(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("preview.txt", b"preview content", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        def signed_access_url(
+            self,
+            *,
+            expires,
+            content_type=None,
+            content_disposition=None,
+        ):
+            del self, expires, content_type, content_disposition
+            return "https://cdn.example.com/private/preview.txt?sig=abc"
+
+        monkeypatch.setattr(ManagedFileRef, "signed_access_url", signed_access_url)
+
+        preview = client.get(
+            f"/api/files/preview/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert preview.status_code == 307
+        assert (
+            preview.headers["location"]
+            == "https://cdn.example.com/private/preview.txt?sig=abc"
+        )
+
+    def test_download_uses_accel_redirect_for_local_file_when_enabled(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        del temp_uploads_dir
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED", "true")
+        monkeypatch.setenv(
+            "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX", "/private-files"
+        )
+        response = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "local accel.txt",
+                    b"local accel content",
+                    "text/plain",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        download = client.get(
+            f"/api/files/download/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert download.status_code == 200
+        assert download.content == b""
+        assert "location" not in download.headers
+        assert download.headers["x-accel-redirect"].endswith(
+            f"/user_1/{quote('local accel.txt')}"
+        )
+        assert download.headers["content-type"].startswith("text/plain")
+        assert (
+            download.headers["content-disposition"]
+            == 'inline; filename="local accel.txt"'
+        )
+
+    def test_preview_uses_accel_redirect_for_local_text_when_enabled(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        del temp_uploads_dir
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED", "true")
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("preview-accel.txt", b"preview accel", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        preview = client.get(
+            f"/api/files/preview/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert preview.status_code == 200
+        assert preview.content == b""
+        assert preview.headers["x-accel-redirect"].endswith("/user_1/preview-accel.txt")
+        assert (
+            preview.headers["content-disposition"]
+            == 'inline; filename="preview-accel.txt"'
+        )
+
+    def test_preview_does_not_accel_redirect_html(
+        self, client, temp_uploads_dir, auth_headers, monkeypatch
+    ):
+        del temp_uploads_dir
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED", "true")
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("index.html", b"<h1>preview</h1>", "text/html")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        preview = client.get(
+            f"/api/files/preview/{file_id}",
+            headers=auth_headers,
+            follow_redirects=False,
+        )
+
+        assert preview.status_code == 200
+        assert "x-accel-redirect" not in preview.headers
+        assert preview.content == b"<h1>preview</h1>"
+
     def test_upload_remote_storage_outage_returns_503_and_rolls_back(
         self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- add optional authenticated file delivery redirects for durable S3-compatible storage
- add optional nginx X-Accel-Redirect delivery for local upload files after backend authorization
- keep both delivery accelerators disabled by default so direct local backend development continues to use FileResponse/StreamingResponse

## Configuration

### S3/CDN direct delivery
Use this when files are stored in S3-compatible durable storage and the signed URL endpoint is reachable by browsers. The backend still owns file_id lookup and authorization, then redirects to a short-lived signed URL.

```env
XAGENT_FILE_STORAGE_URI="s3://xagent-bucket/prod/files"
XAGENT_FILE_STORAGE_OPTIONS='{"endpoint_url":"https://s3.example.com","region_name":"us-east-1"}'
XAGENT_FILE_DELIVERY_REDIRECT_ENABLED="true"
XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS="300"
```

### nginx local-file delivery
Use this when uploads live on a local/shared volume visible to nginx. The backend authorizes the file_id request, then responds with X-Accel-Redirect so nginx serves the bytes from its internal-only location.

```env
XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED="true"
XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX="/_xagent_internal_files/"
```

The default docker compose now mounts `xagent_data` read-only into nginx, and `docker/nginx.conf` defines the internal `/_xagent_internal_files/` location.

### Defaults and fallback
All new redirect options default to disabled. Delivery order is:
1. S3 signed URL redirect when enabled and available
2. nginx X-Accel-Redirect when enabled and the local file exists under uploads
3. existing FastAPI FileResponse/StreamingResponse fallback

## Testing
- `ruff check src/xagent/config.py src/xagent/core/file_storage/storage.py src/xagent/web/services/managed_file_ref.py src/xagent/web/api/files.py tests/core/test_config.py tests/core/test_file_storage.py tests/web/services/test_managed_file_ref.py tests/web/test_file_upload.py tests/web/test_admin_file_access.py`
- `git diff --check`
- `PYTHONPATH=src python -m pytest tests/core/test_config.py::TestFileStorageConfig tests/core/test_file_storage.py tests/web/services/test_managed_file_ref.py tests/web/test_file_upload.py tests/web/test_admin_file_access.py -q`

Note: `docker compose config` could not run in this worktree because `.env` is absent and `docker-compose.yml` references `env_file: .env`.
