### PR TITLE
fix: handle paused task follow-up turns

### DIFF
--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -277,7 +277,7 @@ function TaskDetailContent() {
       let groupIndex = 0;
       while (
         groupIndex < sortedMessages.length &&
-        sortedMessages[groupIndex].timestamp <= eventTime
+        sortedMessages[groupIndex].timestamp < eventTime
       ) {
         groupIndex += 1;
       }

--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -15,6 +15,7 @@ import { TaskFileManager } from "@/components/file/task-file-manager";
 import { getApiUrl } from "@/lib/utils";
 import { apiRequest } from "@/lib/api-wrapper";
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer";
+import { getProcessGroupIndex } from "@/lib/task-timeline";
 import type React from "react";
 import dagre from "dagre"
 import { CenterPanel } from "@/components/layout/center-panel"
@@ -279,13 +280,7 @@ function TaskDetailContent() {
 
     processEvents.forEach((event) => {
       const eventTime = toTimelineTime(event?.timestamp);
-      let groupIndex = 0;
-      while (
-        groupIndex < sortedMessages.length &&
-        sortedMessages[groupIndex].timestamp < eventTime
-      ) {
-        groupIndex += 1;
-      }
+      const groupIndex = getProcessGroupIndex(sortedMessages, eventTime);
 
       const group = processGroups.get(groupIndex) || [];
       group.push(event);

--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -20,6 +20,31 @@ import dagre from "dagre"
 import { CenterPanel } from "@/components/layout/center-panel"
 import { FilePreviewActionButtons } from "@/components/file/file-preview-action-buttons"
 
+const toTimelineTime = (ts: unknown): number => {
+  let time: number;
+  if (typeof ts === 'number') {
+    time = ts;
+  } else {
+    const n = Number(ts);
+    if (!isNaN(n)) {
+      time = n;
+    } else if (typeof ts === 'string' || ts instanceof Date) {
+      time = new Date(ts).getTime();
+    } else {
+      time = Number.NaN;
+    }
+  }
+
+  if (!Number.isFinite(time)) {
+    return 0;
+  }
+
+  if (time < 100000000000) {
+    return time * 1000;
+  }
+  return time;
+};
+
 function TaskDetailContent() {
   const { state, sendMessage, setTaskId, openFilePreview, closeFilePreview, requestStatus, dispatch, pauseTask, resumeTask } = useApp();
   const { t } = useI18n();
@@ -165,37 +190,19 @@ function TaskDetailContent() {
     isStreamingFinalAnswer?: boolean;
     traceEvents?: any[];
     interactions?: any[];
+    showEmptyStatus?: boolean;
   };
-  const combinedItems: CombinedItem[] = useMemo(() => {
-    const toTime = (ts: any): number => {
-      let time: number;
-      if (typeof ts === 'number') {
-        time = ts;
-      } else {
-        const n = Number(ts);
-        if (!isNaN(n)) {
-          time = n;
-        } else {
-          time = new Date(ts).getTime();
-        }
-      }
-
-      if (time < 100000000000) {
-        return time * 1000;
-      }
-      return time;
-    };
-
-    const msgItems: CombinedItem[] = state.messages
+  const messageItems: CombinedItem[] = useMemo(() => {
+    const items: CombinedItem[] = state.messages
       .filter((m) => m.role === 'user' || m.isResult)
       .map((m) => {
-        const id = m.id || `${m.role}-${toTime(m.timestamp)}`;
+        const id = m.id || `${m.role}-${toTimelineTime(m.timestamp)}`;
         return {
           id,
           role: m.role,
           content: m.content,
           rawContent: m.rawContent,
-          timestamp: toTime(m.timestamp),
+          timestamp: toTimelineTime(m.timestamp),
           status: m.status,
           isStreamingFinalAnswer: isStreamingFinalAnswerMessage({
             id,
@@ -207,10 +214,117 @@ function TaskDetailContent() {
         };
       });
 
-    const merged = msgItems;
-    merged.sort((a, b) => a.timestamp - b.timestamp);
-    return merged;
+    items.sort((a, b) => a.timestamp - b.timestamp);
+    return items;
   }, [state.messages]);
+
+  const lastMessageItem = messageItems[messageItems.length - 1];
+  const hasFinalAssistantMessage =
+    !!lastMessageItem &&
+    lastMessageItem.role === "assistant" &&
+    !(
+      lastMessageItem.isStreamingFinalAnswer &&
+      lastMessageItem.status === "failed"
+    );
+
+  const timelineItems: CombinedItem[] = useMemo(() => {
+    const items: CombinedItem[] = messageItems.map((item) => ({
+      ...item,
+      traceEvents: undefined,
+    }));
+    type TimelineProcessEvent = {
+      event_id?: string;
+      event_type?: string;
+      timestamp?: unknown;
+      [key: string]: unknown;
+    };
+    const processEventsById = new Map<string, TimelineProcessEvent>();
+    const addProcessEvent = (event: unknown, fallbackKey: string) => {
+      if (!event || typeof event !== 'object') {
+        return;
+      }
+      const processEvent = event as TimelineProcessEvent;
+      const eventKey =
+        typeof processEvent.event_id === 'string' && processEvent.event_id
+          ? processEvent.event_id
+          : fallbackKey;
+      if (!processEventsById.has(eventKey)) {
+        processEventsById.set(eventKey, processEvent);
+      }
+    };
+
+    if (Array.isArray(state.traceEvents)) {
+      state.traceEvents.forEach((event, index) => {
+        addProcessEvent(event, `state-${index}`);
+      });
+    }
+    messageItems.forEach((item) => {
+      item.traceEvents?.forEach((event, index) => {
+        addProcessEvent(event, `${item.id}-${index}`);
+      });
+    });
+
+    const processEvents = Array.from(processEventsById.values());
+    if (processEvents.length === 0) {
+      return items;
+    }
+
+    const sortedMessages = [...messageItems].sort((a, b) => a.timestamp - b.timestamp);
+    const processGroups = new Map<number, TimelineProcessEvent[]>();
+
+    processEvents.forEach((event) => {
+      const eventTime = toTimelineTime(event?.timestamp);
+      let groupIndex = 0;
+      while (
+        groupIndex < sortedMessages.length &&
+        sortedMessages[groupIndex].timestamp <= eventTime
+      ) {
+        groupIndex += 1;
+      }
+
+      const group = processGroups.get(groupIndex) || [];
+      group.push(event);
+      processGroups.set(groupIndex, group);
+    });
+
+    const groupEntries = Array.from(processGroups.entries()).sort((a, b) => a[0] - b[0]);
+    const latestGroupIndex = groupEntries.length > 0
+      ? groupEntries[groupEntries.length - 1][0]
+      : -1;
+
+    groupEntries.forEach(([groupIndex, events]) => {
+      if (events.length === 0) {
+        return;
+      }
+
+      const groupTimestamp = Math.min(
+        ...events.map((event) => toTimelineTime(event?.timestamp))
+      );
+      const firstEvent = events[0];
+      const shouldShowEmptyStatus =
+        !hasFinalAssistantMessage &&
+        groupIndex === latestGroupIndex &&
+        groupIndex >= sortedMessages.length;
+
+      items.push({
+        id: `process-${groupIndex}-${firstEvent?.event_id || groupTimestamp}`,
+        role: "assistant",
+        content: null,
+        timestamp: groupTimestamp,
+        traceEvents: events,
+        showEmptyStatus: shouldShowEmptyStatus,
+      });
+    });
+
+    items.sort((a, b) => a.timestamp - b.timestamp);
+    return items;
+  }, [
+    hasFinalAssistantMessage,
+    messageItems,
+    state.currentTask?.status,
+    state.isProcessing,
+    state.traceEvents,
+  ]);
 
   const waitingPrompt = useMemo(() => {
     if (state.currentTask?.status !== 'waiting_for_user') {
@@ -281,8 +395,8 @@ function TaskDetailContent() {
 
     if (waitingPrompt) {
       const normalizedPrompt = waitingPrompt.trim();
-      for (let i = combinedItems.length - 1; i >= 0; i--) {
-        const item = combinedItems[i];
+      for (let i = messageItems.length - 1; i >= 0; i--) {
+        const item = messageItems[i];
         if (
           item.role === 'assistant' &&
           typeof item.content === 'string' &&
@@ -293,15 +407,15 @@ function TaskDetailContent() {
       }
     }
 
-    for (let i = combinedItems.length - 1; i >= 0; i--) {
-      const item = combinedItems[i];
+    for (let i = messageItems.length - 1; i >= 0; i--) {
+      const item = messageItems[i];
       if (item.role === 'assistant' && item.interactions && item.interactions.length > 0) {
         return item.id;
       }
     }
 
     return null;
-  }, [combinedItems, state.currentTask?.status, waitingPrompt]);
+  }, [messageItems, state.currentTask?.status, waitingPrompt]);
 
   // DAG node and edge calculation
   const dagreGraph = new dagre.graphlib.Graph();
@@ -414,15 +528,6 @@ function TaskDetailContent() {
     });
   }
 
-  const lastCombinedItem = combinedItems[combinedItems.length - 1];
-  const hasFinalAssistantMessage =
-    !!lastCombinedItem &&
-    lastCombinedItem.role === "assistant" &&
-    !(
-      lastCombinedItem.isStreamingFinalAnswer &&
-      lastCombinedItem.status === "failed"
-    );
-
   const isPlanning = dagNodes.length === 0 && state.dagExecution?.phase === "planning";
   const hasError = dagNodes.length === 0 && (state.dagExecution?.phase === "failed" || state.currentTask?.status === "failed");
 
@@ -462,7 +567,7 @@ function TaskDetailContent() {
         <div className="flex-1 overflow-y-auto">
           <main className={`container max-w-4xl mx-auto px-4 py-8 relative z-0 transition-all`}>
             <div className="space-y-6 pb-4">
-              {state.isHistoryLoading && combinedItems.length === 0 ? (
+              {state.isHistoryLoading && timelineItems.length === 0 ? (
                 <div className="flex flex-col items-center justify-center min-h-[60vh] py-16 text-center">
                   <div className="relative mb-6">
                     <div className="w-16 h-16 rounded-2xl bg-muted/30 flex items-center justify-center animate-pulse">
@@ -475,7 +580,7 @@ function TaskDetailContent() {
                 </div>
               ) : (
                 <>
-                  {combinedItems.map((item) => {
+                  {timelineItems.map((item) => {
                     const isFailedFinalAnswerStream =
                       item.isStreamingFinalAnswer && item.status === "failed";
                     return (
@@ -492,11 +597,12 @@ function TaskDetailContent() {
                         timestamp={item.timestamp}
                         interactions={item.interactions}
                         interactionsActive={item.id === activeWaitingMessageId}
+                        showEmptyStatus={item.showEmptyStatus}
                       />
                     );
                   })}
 
-                  {(state.isProcessing || (state.traceEvents?.length || 0) > 0 || state.currentTask?.status === 'paused' || state.currentTask?.status === 'waiting_for_user' || state.currentTask?.status === 'failed') && !hasFinalAssistantMessage && (
+                  {(state.isProcessing || state.currentTask?.status === 'paused' || state.currentTask?.status === 'waiting_for_user' || state.currentTask?.status === 'failed') && !hasFinalAssistantMessage && !timelineItems.some((item) => item.showEmptyStatus) && (
                     <ChatMessage
                       role="assistant"
                       content={

--- a/frontend/src/app/task/[id]/page.tsx
+++ b/frontend/src/app/task/[id]/page.tsx
@@ -186,11 +186,12 @@ function TaskDetailContent() {
     content: string | React.ReactNode;
     rawContent?: string;
     timestamp: number;
-    status?: "pending" | "running" | "completed" | "failed";
+    status?: string;
     isStreamingFinalAnswer?: boolean;
     traceEvents?: any[];
     interactions?: any[];
     showEmptyStatus?: boolean;
+    timelineOrder?: number;
   };
   const messageItems: CombinedItem[] = useMemo(() => {
     const items: CombinedItem[] = state.messages
@@ -228,10 +229,15 @@ function TaskDetailContent() {
     );
 
   const timelineItems: CombinedItem[] = useMemo(() => {
-    const items: CombinedItem[] = messageItems.map((item) => ({
-      ...item,
-      traceEvents: undefined,
-    }));
+    const sortedMessages = [...messageItems].sort((a, b) => a.timestamp - b.timestamp);
+    const items: CombinedItem[] = sortedMessages.map((item, index) => {
+      const timelineOrder = index * 2 + 1;
+      return {
+        ...item,
+        traceEvents: undefined,
+        timelineOrder,
+      };
+    });
     type TimelineProcessEvent = {
       event_id?: string;
       event_type?: string;
@@ -269,7 +275,6 @@ function TaskDetailContent() {
       return items;
     }
 
-    const sortedMessages = [...messageItems].sort((a, b) => a.timestamp - b.timestamp);
     const processGroups = new Map<number, TimelineProcessEvent[]>();
 
     processEvents.forEach((event) => {
@@ -311,12 +316,19 @@ function TaskDetailContent() {
         role: "assistant",
         content: null,
         timestamp: groupTimestamp,
+        status: shouldShowEmptyStatus ? state.currentTask?.status : undefined,
         traceEvents: events,
         showEmptyStatus: shouldShowEmptyStatus,
+        timelineOrder: groupIndex * 2,
       });
     });
 
-    items.sort((a, b) => a.timestamp - b.timestamp);
+    items.sort(
+      (a, b) =>
+        a.timestamp - b.timestamp ||
+        (a.timelineOrder ?? Number.MAX_SAFE_INTEGER) -
+          (b.timelineOrder ?? Number.MAX_SAFE_INTEGER)
+    );
     return items;
   }, [
     hasFinalAssistantMessage,
@@ -592,7 +604,11 @@ function TaskDetailContent() {
                         traceEvents={item.traceEvents as any || []}
                         showProcessView={true}
                         taskStatus={
-                          isFailedFinalAnswerStream ? "failed" : undefined
+                          isFailedFinalAnswerStream
+                            ? "failed"
+                            : item.showEmptyStatus
+                              ? item.status
+                              : undefined
                         }
                         timestamp={item.timestamp}
                         interactions={item.interactions}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -317,6 +317,8 @@ export function ChatMessage({
     !!showProcessView &&
     Array.isArray(traceEvents) &&
     traceEvents.length > 0;
+  const isProcessOnlyMessage =
+    shouldShowProcess && !isUser && !content && showEmptyStatus === false;
 
   // Map event/action to i18n key
   const getEventTitle = (e: TraceEvent | undefined) => {
@@ -362,63 +364,65 @@ export function ChatMessage({
         </div>
       )}
 
-      <div
-        className={cn(
-          "flex w-full",
-          isUser ? "justify-end" : "justify-start"
-        )}
-      >
+      {!isProcessOnlyMessage && (
         <div
           className={cn(
-            "flex gap-4 transition-all duration-300",
-            isUser
-              ? "max-w-[85%] bg-secondary text-secondary-foreground p-3 rounded-2xl flex-row-reverse items-center"
-              : "bg-transparent p-0 w-full max-w-full"
+            "flex w-full",
+            isUser ? "justify-end" : "justify-start"
           )}
         >
-          {/* Avatar */}
-          {!isUser && (
-            <div
-              className={cn(
-                "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center shadow-md bg-transparent"
-              )}
-            >
-              <Bot className="w-5 h-5 text-muted-foreground" />
-            </div>
-          )}
-
-          {/* Message content */}
-          <div className={cn("flex-1 min-w-0")}>
-            {!isUser && taskStatus === "failed" ? (
-              <div className="py-3 text-sm leading-relaxed text-red-500 break-words [overflow-wrap:anywhere]">
-                {failedMessageText}
+          <div
+            className={cn(
+              "flex gap-4 transition-all duration-300",
+              isUser
+                ? "max-w-[85%] bg-secondary text-secondary-foreground p-3 rounded-2xl flex-row-reverse items-center"
+                : "bg-transparent p-0 w-full max-w-full"
+            )}
+          >
+            {/* Avatar */}
+            {!isUser && (
+              <div
+                className={cn(
+                  "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center shadow-md bg-transparent"
+                )}
+              >
+                <Bot className="w-5 h-5 text-muted-foreground" />
               </div>
-            ) : content ? (
-              typeof content === "string" ? (
-                isUser ? (
-                  <ExpandableMessage content={content} />
+            )}
+
+            {/* Message content */}
+            <div className={cn("flex-1 min-w-0")}>
+              {!isUser && taskStatus === "failed" ? (
+                <div className="py-3 text-sm leading-relaxed text-red-500 break-words [overflow-wrap:anywhere]">
+                  {failedMessageText}
+                </div>
+              ) : content ? (
+                typeof content === "string" ? (
+                  isUser ? (
+                    <ExpandableMessage content={content} />
+                  ) : (
+                    <MarkdownRenderer
+                      content={content}
+                      className="prose-sm pt-2 leading-relaxed break-words [overflow-wrap:anywhere]"
+                      onAgentClick={handleAgentClick}
+                      onFileClick={handleFileClick}
+                    />
+                  )
                 ) : (
-                  <MarkdownRenderer
-                    content={content}
-                    className="prose-sm pt-2 leading-relaxed break-words [overflow-wrap:anywhere]"
-                    onAgentClick={handleAgentClick}
-                    onFileClick={handleFileClick}
-                  />
+                  <div className="text-sm leading-relaxed break-words [overflow-wrap:anywhere]">{content}</div>
                 )
               ) : (
-                <div className="text-sm leading-relaxed break-words [overflow-wrap:anywhere]">{content}</div>
-              )
-            ) : (
-              !isUser && showEmptyStatus && <GeneratingIndicator latestTitle={latestTitle} taskStatus={taskStatus} errorMessage={errorMessage} />
-            )}
-            {!isUser && interactions && interactions.length > 0 && (
-              <div className="mt-4 border-t pt-4">
-                <ClarificationForm interactions={interactions} active={interactionsActive} onSend={onSendInteraction} />
-              </div>
-            )}
+                !isUser && showEmptyStatus && <GeneratingIndicator latestTitle={latestTitle} taskStatus={taskStatus} errorMessage={errorMessage} />
+              )}
+              {!isUser && interactions && interactions.length > 0 && (
+                <div className="mt-4 border-t pt-4">
+                  <ClarificationForm interactions={interactions} active={interactionsActive} onSend={onSendInteraction} />
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Action Row */}
       {copyableContent && (

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -70,6 +70,7 @@ export interface ChatMessageProps {
   timestamp?: number | string;
   interactions?: any[];
   interactionsActive?: boolean;
+  showEmptyStatus?: boolean;
   onSendInteraction?: (message: string, files?: File[], metadata?: any) => Promise<void> | void;
 }
 
@@ -275,6 +276,7 @@ export function ChatMessage({
   timestamp,
   interactions,
   interactionsActive = true,
+  showEmptyStatus = true,
   onSendInteraction,
 }: ChatMessageProps) {
   const { t } = useI18n();
@@ -407,7 +409,7 @@ export function ChatMessage({
                 <div className="text-sm leading-relaxed break-words [overflow-wrap:anywhere]">{content}</div>
               )
             ) : (
-              !isUser && <GeneratingIndicator latestTitle={latestTitle} taskStatus={taskStatus} errorMessage={errorMessage} />
+              !isUser && showEmptyStatus && <GeneratingIndicator latestTitle={latestTitle} taskStatus={taskStatus} errorMessage={errorMessage} />
             )}
             {!isUser && interactions && interactions.length > 0 && (
               <div className="mt-4 border-t pt-4">

--- a/frontend/src/lib/task-timeline.test.ts
+++ b/frontend/src/lib/task-timeline.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { getProcessGroupIndex } from "./task-timeline";
+
+describe("getProcessGroupIndex", () => {
+  it("places same-time process events after the user message that triggered them", () => {
+    expect(
+      getProcessGroupIndex([{ role: "user", timestamp: 1000 }], 1000)
+    ).toBe(1);
+  });
+
+  it("keeps same-time process events before an assistant message", () => {
+    expect(
+      getProcessGroupIndex([{ role: "assistant", timestamp: 1000 }], 1000)
+    ).toBe(0);
+  });
+
+  it("places process events between a same-time user and assistant pair", () => {
+    expect(
+      getProcessGroupIndex(
+        [
+          { role: "user", timestamp: 1000 },
+          { role: "assistant", timestamp: 1000 },
+        ],
+        1000
+      )
+    ).toBe(1);
+  });
+
+  it("keeps ordinary before and after timestamp ordering", () => {
+    const messages = [
+      { role: "user", timestamp: 1000 },
+      { role: "assistant", timestamp: 2000 },
+    ];
+
+    expect(getProcessGroupIndex(messages, 500)).toBe(0);
+    expect(getProcessGroupIndex(messages, 1500)).toBe(1);
+    expect(getProcessGroupIndex(messages, 2500)).toBe(2);
+  });
+});

--- a/frontend/src/lib/task-timeline.ts
+++ b/frontend/src/lib/task-timeline.ts
@@ -1,0 +1,24 @@
+export type TimelineAnchor = {
+  timestamp: number;
+  role?: string;
+};
+
+export function getProcessGroupIndex(
+  sortedMessages: TimelineAnchor[],
+  eventTime: number
+): number {
+  let groupIndex = 0;
+  while (groupIndex < sortedMessages.length) {
+    const message = sortedMessages[groupIndex];
+    if (message.timestamp < eventTime) {
+      groupIndex += 1;
+      continue;
+    }
+    if (message.timestamp === eventTime && message.role === "user") {
+      groupIndex += 1;
+      continue;
+    }
+    break;
+  }
+  return groupIndex;
+}

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -81,6 +81,7 @@ class AgentExecutionAdapter:
                 "request_context": dict(context or {}),
                 "selected_skill_context": self.config.recovered_skill_context,
             },
+            workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
         )
@@ -118,6 +119,7 @@ class AgentExecutionAdapter:
                 "request_context": dict(context or {}),
                 "selected_skill_context": self.config.recovered_skill_context,
             },
+            workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
         )
@@ -127,6 +129,7 @@ class AgentExecutionAdapter:
         return self.registry.pause(execution_id, reason=reason)
 
     async def resume(self, execution_id: str, **kwargs: Any) -> dict[str, Any] | None:
+        kwargs.setdefault("workspace_id", self._workspace_id(execution_id))
         handle = self.registry.get(execution_id)
         if handle is None:
             runner, execution_type = self._build_runner()
@@ -192,6 +195,11 @@ class AgentExecutionAdapter:
 
     def list_statuses(self) -> list[dict[str, Any]]:
         return self.registry.list_statuses()
+
+    def _workspace_id(self, execution_id: str) -> str:
+        return str(
+            self.config.service_id or self.config.current_task_id or execution_id
+        )
 
     def _build_runner(self) -> tuple[AgentRunner, str]:
         pattern, execution_type = self._build_pattern()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -31,6 +31,7 @@ from ...config import (
     get_external_upload_dirs,
     get_uploads_dir,
 )
+from ...core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from ...core.agent.trace import TraceEvent, TraceHandler, trace_user_message
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
@@ -66,6 +67,14 @@ from ..user_isolated_memory import UserContext
 from ..utils.db_timezone import safe_timestamp_to_unix
 
 logger = logging.getLogger(__name__)
+
+CHECKPOINT_EVENT_TYPE_NAME = str(CHECKPOINT_EVENT_TYPE)
+
+
+def _task_status_uses_live_control(status: TaskStatus) -> bool:
+    """Return True when a user message should be delivered to an active run."""
+
+    return status in {TaskStatus.WAITING_FOR_USER, TaskStatus.RUNNING}
 
 
 def _resolve_task_llm_ids(
@@ -2310,19 +2319,16 @@ async def handle_chat_message(
                 # ``TaskTurnOrchestrator.begin_turn`` as part of the atomic
                 # transition (claim + persist + schedule commit together).
 
-                # Check if there's an old task running (PAUSED, WAITING_FOR_USER, or RUNNING status)
-                # If so, use continuation mechanism; otherwise execute normally
-                # Only use continuation when task is active and has old task
-                task_is_running = task.status in [
-                    TaskStatus.PAUSED,
-                    TaskStatus.WAITING_FOR_USER,
-                    TaskStatus.RUNNING,
-                ]
+                # Messages to an actively executing task are control-plane
+                # input. A PAUSED task plus a fresh user message is a new
+                # turn on the same task/thread; only an explicit resume event
+                # should continue the paused checkpoint.
+                task_uses_live_control = _task_status_uses_live_control(task.status)
                 agent_service = None
                 dag_pattern = None
                 supports_live_control = False
                 has_continuation = False
-                if task_is_running:
+                if task_uses_live_control:
                     agent_service = await get_agent_manager().get_agent_for_task(
                         task_id, db, user=user
                     )
@@ -2342,7 +2348,11 @@ async def handle_chat_message(
                         dag_pattern and hasattr(dag_pattern, "request_continuation")
                     )
 
-                if task_is_running and has_continuation and not supports_live_control:
+                if (
+                    task_uses_live_control
+                    and has_continuation
+                    and not supports_live_control
+                ):
                     # Use continuation: old task will handle at appropriate time
                     logger.info(f"Using continuation for running task {task_id}")
                     assert dag_pattern is not None  # for mypy type checking
@@ -2429,7 +2439,7 @@ async def handle_chat_message(
 
                     # Continuation will be handled by old task, return directly
                     return
-                if task_is_running and supports_live_control:
+                if task_uses_live_control and supports_live_control:
                     logger.info(f"Using agent message control for task {task_id}")
                     assert agent_service is not None
                     # Pass the user-typed bubble text + display-safe file refs
@@ -2472,7 +2482,7 @@ async def handle_chat_message(
                     background_task_manager.register_task(task_id, bg_task)
 
                     return
-                elif task_is_running and not has_continuation:
+                elif task_uses_live_control and not has_continuation:
                     # Task is running but doesn't support continuation (shouldn't happen)
                     logger.error(
                         f"Task {task_id} is running but does not support continuation"
@@ -2486,7 +2496,7 @@ async def handle_chat_message(
                     )
                     return
                 else:
-                    # New task (PENDING/COMPLETED/FAILED), execute normally
+                    # New task/turn (PENDING/COMPLETED/FAILED/PAUSED), execute normally
                     logger.info(
                         f"Task {task_id} starting new execution turn (status: {task.status.value})"
                     )
@@ -2587,14 +2597,15 @@ async def handle_chat_message(
                         execution_message=user_message_for_llm,
                         attachments=persisted_attachments or None,
                     )
-                    # WS path only has two legal entries into begin_turn:
+                    # WS path has these legal entries into begin_turn:
                     #   PENDING                  → CREATE
                     #   COMPLETED / FAILED       → APPEND
-                    # PAUSED / WAITING_FOR_USER / RUNNING should have been
-                    # intercepted by the continuation path above. Reaching
-                    # this branch with any of them is an upstream-dispatch
-                    # bug; surface it as an agent_error rather than
-                    # silently letting begin_turn 409 on the wrong status.
+                    #   PAUSED + user message    → APPEND (new turn)
+                    # WAITING_FOR_USER / RUNNING should have been intercepted
+                    # by the live-control path above. Reaching this branch
+                    # with either is an upstream-dispatch bug; surface it as
+                    # an agent_error rather than silently letting begin_turn
+                    # 409 on the wrong status.
                     if task.status == TaskStatus.PENDING:
                         turn_kind = TurnKind.CREATE
                         turn_force_fresh = False
@@ -2604,12 +2615,15 @@ async def handle_chat_message(
                     ):
                         turn_kind = TurnKind.APPEND
                         turn_force_fresh = False
+                    elif task.status == TaskStatus.PAUSED:
+                        turn_kind = TurnKind.APPEND
+                        turn_force_fresh = False
                     else:
                         logger.error(
                             f"WS schedule reached for task {task_id} with "
                             f"unexpected status={task.status}; expected "
-                            "PENDING or terminal. Continuation path should "
-                            "have intercepted."
+                            "PENDING, PAUSED, or terminal. Live-control path "
+                            "should have intercepted."
                         )
                         await manager.broadcast_to_task(
                             {
@@ -3037,6 +3051,11 @@ async def send_historical_data_as_stream(
                 .filter(
                     TraceEvent.task_id == task_id,
                     TraceEvent.build_id.is_(None),  # ← Only get VIBE events
+                    # Agent checkpoints are persisted as trace rows for
+                    # resume/recovery, but they are internal snapshots and can
+                    # be megabytes each. Filtering them in SQL avoids loading
+                    # hundreds of large JSON blobs just to discard them below.
+                    TraceEvent.event_type != CHECKPOINT_EVENT_TYPE_NAME,
                 )
                 .order_by(TraceEvent.timestamp)
                 .all()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3057,7 +3057,7 @@ async def send_historical_data_as_stream(
                     # hundreds of large JSON blobs just to discard them below.
                     TraceEvent.event_type != CHECKPOINT_EVENT_TYPE_NAME,
                 )
-                .order_by(TraceEvent.timestamp)
+                .order_by(TraceEvent.timestamp, TraceEvent.id)
                 .all()
             )
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -70,10 +70,28 @@ logger = logging.getLogger(__name__)
 
 CHECKPOINT_EVENT_TYPE_NAME = str(CHECKPOINT_EVENT_TYPE)
 
+_pause_accepted_task_ids: set[int] = set()
 
-def _task_status_uses_live_control(status: TaskStatus) -> bool:
+
+def _mark_task_pause_accepted(task_id: int) -> None:
+    _pause_accepted_task_ids.add(int(task_id))
+
+
+def _clear_task_pause_accepted(task_id: int) -> None:
+    _pause_accepted_task_ids.discard(int(task_id))
+
+
+def _is_task_pause_accepted(task_id: int) -> bool:
+    return int(task_id) in _pause_accepted_task_ids
+
+
+def _task_status_uses_live_control(
+    status: TaskStatus, *, pause_accepted: bool = False
+) -> bool:
     """Return True when a user message should be delivered to an active run."""
 
+    if pause_accepted:
+        return False
     return status in {TaskStatus.WAITING_FOR_USER, TaskStatus.RUNNING}
 
 
@@ -1352,6 +1370,7 @@ async def execute_task_background(
         raise
     finally:
         # Clean up background task record
+        _clear_task_pause_accepted(task_id)
         background_task_manager.cleanup_task(task_id)
         try:
             next(db_gen)
@@ -1522,6 +1541,7 @@ async def execute_resume_background(
                 release_task_lease(db_cleanup, lease, status=TaskStatus.FAILED)
             finally:
                 db_cleanup.close()
+        _clear_task_pause_accepted(task_id)
         background_task_manager.cleanup_task(task_id)
 
 
@@ -2323,7 +2343,11 @@ async def handle_chat_message(
                 # input. A PAUSED task plus a fresh user message is a new
                 # turn on the same task/thread; only an explicit resume event
                 # should continue the paused checkpoint.
-                task_uses_live_control = _task_status_uses_live_control(task.status)
+                pause_accepted = _is_task_pause_accepted(task_id)
+                task_uses_live_control = _task_status_uses_live_control(
+                    task.status,
+                    pause_accepted=pause_accepted,
+                )
                 agent_service = None
                 dag_pattern = None
                 supports_live_control = False
@@ -2497,6 +2521,36 @@ async def handle_chat_message(
                     return
                 else:
                     # New task/turn (PENDING/COMPLETED/FAILED/PAUSED), execute normally
+                    if pause_accepted and task.status in {
+                        TaskStatus.RUNNING,
+                        TaskStatus.WAITING_FOR_USER,
+                    }:
+                        logger.info(
+                            "Task %s has an accepted pause request; waiting for "
+                            "the active run to persist its control state before "
+                            "routing the follow-up message",
+                            task_id,
+                        )
+                        await background_task_manager.wait_for_previous(task_id)
+                        db.refresh(task)
+                        if task.status in {
+                            TaskStatus.RUNNING,
+                            TaskStatus.WAITING_FOR_USER,
+                        }:
+                            await manager.broadcast_to_task(
+                                {
+                                    "type": "agent_error",
+                                    "message": (
+                                        "Task pause is still being applied; "
+                                        "please retry shortly."
+                                    ),
+                                    "timestamp": datetime.now(timezone.utc).timestamp(),
+                                },
+                                task_id,
+                            )
+                            return
+                        _clear_task_pause_accepted(task_id)
+
                     logger.info(
                         f"Task {task_id} starting new execution turn (status: {task.status.value})"
                     )
@@ -3590,6 +3644,7 @@ async def handle_pause_task(
                 logger.warning(f"No live execution found to pause for task {task_id}")
                 return
             logger.info("Agent pause_execution completed")
+            _mark_task_pause_accepted(task_id)
 
             # Send pause confirmation
             await manager.broadcast_to_task(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -65,12 +65,15 @@ from .task_lease_service import (
 logger = logging.getLogger(__name__)
 
 
-# Terminal statuses for the "is the previous turn finished?" check. A
-# task in any of these is eligible for ``TurnKind.APPEND``. PENDING and
-# RUNNING both signal "previous turn not done yet" → 409 busy. PAUSED
-# is intentionally excluded for now (semantics unclear; revisit when
-# pause/resume becomes a first-class SDK feature).
-_TERMINAL_STATUSES = (TaskStatus.COMPLETED, TaskStatus.FAILED)
+# Statuses for the "can a user message start the next turn?" check. A
+# task in any of these is eligible for ``TurnKind.APPEND``. PENDING is
+# claimed by ``CREATE``; RUNNING is still busy; WAITING_FOR_USER is an
+# answer to an explicit pending agent question and resumes that execution.
+_APPENDABLE_STATUSES = (
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+    TaskStatus.PAUSED,
+)
 
 
 @dataclass(frozen=True)
@@ -130,7 +133,7 @@ class TurnKind(str, enum.Enum):
     """
 
     CREATE = "create"  # PENDING → RUNNING; new task's first turn
-    APPEND = "append"  # TERMINAL → RUNNING; new turn on an existing task
+    APPEND = "append"  # APPENDABLE → RUNNING; new turn on an existing task
 
 
 class TaskTurnError(Exception):
@@ -186,7 +189,7 @@ class TaskTurnOrchestrator:
              with filter:
 
              - ``kind == CREATE`` → ``status == PENDING``
-             - ``kind == APPEND`` → ``status IN TERMINAL_STATUSES``
+             - ``kind == APPEND`` → ``status IN APPENDABLE_STATUSES``
 
              rowcount 0 → ``TaskTurnError("busy")``.
           3. ``persist_user_message(payload.transcript_message)`` in the
@@ -278,7 +281,7 @@ class TaskTurnOrchestrator:
             if kind == TurnKind.CREATE:
                 status_filter = Task.status == TaskStatus.PENDING
             else:  # APPEND
-                status_filter = Task.status.in_(_TERMINAL_STATUSES)
+                status_filter = Task.status.in_(_APPENDABLE_STATUSES)
 
             claimed = (
                 db.query(Task)

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -89,6 +89,22 @@ class FakeTool:
         self.teardown_calls.append(task_id)
 
 
+class StartHandle:
+    task = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"status": "running"}
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.start_kwargs: dict[str, Any] | None = None
+
+    def start(self, *args: Any, **kwargs: Any) -> StartHandle:
+        self.start_kwargs = dict(kwargs)
+        return StartHandle()
+
+
 class NoSkillManager:
     async def select_skill(self, **_: Any) -> None:
         return None
@@ -152,6 +168,26 @@ def dag_completion(answer: str = "dag done") -> dict[str, Any]:
             }
         ]
     }
+
+
+def test_execution_adapter_uses_service_id_as_runner_workspace_id() -> None:
+    registry = RecordingRegistry()
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="web-task",
+            pattern="react",
+            llm=FakeLLM(["unused"]),
+            service_id="web_task_458",
+            registry=cast(Any, registry),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    adapter.start(task="Generate a file", task_id="458")
+
+    assert registry.start_kwargs is not None
+    assert registry.start_kwargs["execution_id"] == "458"
+    assert registry.start_kwargs["workspace_id"] == "web_task_458"
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -1,0 +1,17 @@
+from xagent.web.api.websocket import _task_status_uses_live_control
+from xagent.web.models.task import TaskStatus
+
+
+def test_paused_task_user_message_is_not_live_control() -> None:
+    assert not _task_status_uses_live_control(TaskStatus.PAUSED)
+
+
+def test_active_task_user_messages_stay_live_control() -> None:
+    assert _task_status_uses_live_control(TaskStatus.RUNNING)
+    assert _task_status_uses_live_control(TaskStatus.WAITING_FOR_USER)
+
+
+def test_terminal_and_pending_statuses_are_not_live_control() -> None:
+    assert not _task_status_uses_live_control(TaskStatus.PENDING)
+    assert not _task_status_uses_live_control(TaskStatus.COMPLETED)
+    assert not _task_status_uses_live_control(TaskStatus.FAILED)

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -1,4 +1,9 @@
-from xagent.web.api.websocket import _task_status_uses_live_control
+from xagent.web.api.websocket import (
+    _clear_task_pause_accepted,
+    _is_task_pause_accepted,
+    _mark_task_pause_accepted,
+    _task_status_uses_live_control,
+)
 from xagent.web.models.task import TaskStatus
 
 
@@ -11,7 +16,29 @@ def test_active_task_user_messages_stay_live_control() -> None:
     assert _task_status_uses_live_control(TaskStatus.WAITING_FOR_USER)
 
 
+def test_accepted_pause_routes_active_task_out_of_live_control() -> None:
+    assert not _task_status_uses_live_control(
+        TaskStatus.RUNNING,
+        pause_accepted=True,
+    )
+    assert not _task_status_uses_live_control(
+        TaskStatus.WAITING_FOR_USER,
+        pause_accepted=True,
+    )
+
+
 def test_terminal_and_pending_statuses_are_not_live_control() -> None:
     assert not _task_status_uses_live_control(TaskStatus.PENDING)
     assert not _task_status_uses_live_control(TaskStatus.COMPLETED)
     assert not _task_status_uses_live_control(TaskStatus.FAILED)
+
+
+def test_pause_accepted_marker_can_be_cleared() -> None:
+    task_id = 12345
+    _clear_task_pause_accepted(task_id)
+
+    _mark_task_pause_accepted(task_id)
+    assert _is_task_pause_accepted(task_id)
+
+    _clear_task_pause_accepted(task_id)
+    assert not _is_task_pause_accepted(task_id)

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -230,6 +230,49 @@ async def test_begin_turn_append_clears_stale_error_message(
 
 
 @pytest.mark.asyncio
+async def test_begin_turn_append_accepts_paused_task_as_new_turn(
+    db_session,
+    mock_schedule_bg,
+) -> None:
+    """A message sent after pause starts the next turn, not a checkpoint resume."""
+    user = _create_user(db_session)
+    task = _create_task(
+        db_session,
+        user.id,
+        status=TaskStatus.PAUSED,
+        input_="previous request",
+        output="stale partial output",
+        error_message="stale pause detail",
+    )
+
+    payload = TaskTurnPayload("new request after pause")
+    await TaskTurnOrchestrator.begin_turn(
+        task=task,
+        payload=payload,
+        user=user,
+        db=db_session,
+        kind=TurnKind.APPEND,
+        force_fresh=False,
+    )
+
+    db_session.refresh(task)
+    assert task.status == TaskStatus.RUNNING
+    assert task.input == "new request after pause"
+    assert task.output is None
+    assert task.error_message is None
+
+    persisted = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.task_id == int(task.id), TaskChatMessage.role == "user")
+        .one()
+    )
+    assert persisted.content == "new request after pause"
+    assert persisted.turn_id == payload.turn_id
+
+    mock_schedule_bg.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_begin_turn_passes_force_fresh_through_to_schedule_bg(
     db_session,
     mock_schedule_bg,

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -520,6 +520,78 @@ async def test_historical_replay_skips_audit_only_trace_events(monkeypatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_historical_replay_skips_checkpoint_rows_before_streaming(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _create_trace_handler_test_task("checkpoint-history")
+    try:
+        task_id = int(task.id)
+        user_id = int(task.user_id)
+        base_time = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        db.add_all(
+            [
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id="checkpoint-row",
+                    event_type=str(CHECKPOINT_EVENT_TYPE),
+                    timestamp=base_time + timedelta(seconds=1),
+                    data={
+                        "checkpoint_type": CHECKPOINT_TYPE,
+                        "execution_id": str(task_id),
+                        "snapshot": {"context": {"messages": ["large"]}},
+                    },
+                ),
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id="llm-row",
+                    event_type="llm_call_start",
+                    timestamp=base_time + timedelta(seconds=2),
+                    data={"model_name": "test-model"},
+                ),
+            ]
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    streamed_event_ids = {
+        event.get("event_id")
+        for event in sent_events
+        if event.get("type") == "trace_event"
+    }
+    assert "checkpoint-row" not in streamed_event_ids
+    assert "llm-row" in streamed_event_ids
+
+
+@pytest.mark.asyncio
 async def test_historical_replay_uses_turn_id_before_legacy_content_dedupe(
     monkeypatch,
 ) -> None:

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -592,6 +592,91 @@ async def test_historical_replay_skips_checkpoint_rows_before_streaming(
 
 
 @pytest.mark.asyncio
+async def test_historical_replay_orders_equal_timestamps_by_id(
+    monkeypatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="tester", password_hash="hashed_password", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Chat task",
+            status=TaskStatus.COMPLETED,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        task_id = int(task.id)
+        user_id = int(user.id)
+        timestamp = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        db.add_all(
+            [
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id="first-row",
+                    event_type="llm_call_start",
+                    timestamp=timestamp,
+                    data={"model_name": "first-model"},
+                ),
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id="second-row",
+                    event_type="llm_call_end",
+                    timestamp=timestamp,
+                    data={"response": "done"},
+                ),
+            ]
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    streamed_event_ids = [
+        event.get("event_id")
+        for event in sent_events
+        if event.get("type") == "trace_event"
+        and event.get("event_id") in {"first-row", "second-row"}
+    ]
+    assert streamed_event_ids == ["first-row", "second-row"]
+
+
+@pytest.mark.asyncio
 async def test_historical_replay_uses_turn_id_before_legacy_content_dedupe(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat user messages on paused tasks as a new turn instead of routing them to live-control resume
- Keep runner workspace ids aligned with web task workspaces so command cwd and file tools share the same output directory
- Replay historical process events in timestamp order and skip large internal checkpoint rows during websocket history loading

## Tests
- PYTHONPATH=src pytest tests/core/agent/test_execution_adapter.py tests/web/test_agent_checkpoint_stream.py tests/web/services/test_task_orchestrator.py tests/web/api/test_websocket_turn_routing.py
- pre-commit hooks on commit: ruff check, ruff format, mypy, npm lint, npm type-check