### PR TITLE
fix: improve Telegram stop and output delivery

### DIFF
--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -26,10 +26,12 @@ from ...services.chat_history_service import persist_user_message
 from ...services.execution_result_projection import project_execution_result_for_channel
 from .handler import TelegramTraceHandler
 from .utils import (
+    TelegramFileRef,
     TelegramImageRef,
     markdown_to_tg_html,
     persist_telegram_assistant_turn,
     restore_telegram_task_context,
+    strip_telegram_file_refs,
     strip_telegram_image_refs,
 )
 
@@ -37,6 +39,9 @@ logger = logging.getLogger(__name__)
 
 
 class TelegramBotInstance:
+    queue_flush_delay_seconds = 1.0
+    stop_text_aliases = {"/stop", "/pause", "stop", "pause", "停止", "暂停"}
+
     def __init__(
         self,
         token: str,
@@ -53,6 +58,7 @@ class TelegramBotInstance:
         self.polling_task: Optional[asyncio.Task] = None
         self.user_message_queues: Dict[int, list] = {}
         self.user_message_tasks: Dict[int, asyncio.Task] = {}
+        self.user_active_executions: Dict[int, tuple[int, object]] = {}
 
         # Load active tasks state
         self.active_tasks_file = Path(f"data/telegram_active_tasks_{instance_id}.json")
@@ -118,11 +124,23 @@ class TelegramBotInstance:
             logger.info(
                 f"Received /new from {message.from_user.id} on bot {self.instance_id}"
             )
-            self.active_tasks[message.from_user.id] = -1
-            self._save_active_tasks()
+            self._start_new_conversation(message.from_user.id)
             await message.answer(
                 "Fresh start. Send me what you'd like to work on next."
             )
+
+        @self.dp.message(Command("stop", "pause"))
+        async def cmd_stop(message: types.Message) -> None:
+            logger.info(
+                f"Received stop command from {message.from_user.id} on bot {self.instance_id}"
+            )
+            stopped = self._stop_current_conversation(message.from_user.id)
+            if stopped:
+                await message.answer(
+                    "Stopped the current run. Send another message to continue here, or use /new for a fresh task."
+                )
+            else:
+                await message.answer("No active run to stop.")
 
         @self.dp.message()
         async def handle_message(message: types.Message) -> None:
@@ -143,6 +161,19 @@ class TelegramBotInstance:
             )
 
             user_id = message.from_user.id
+            if self._is_stop_request_text(msg_content):
+                logger.info(
+                    f"Received stop text from {user_id} on bot {self.instance_id}: {msg_content}"
+                )
+                stopped = self._stop_current_conversation(user_id)
+                if stopped:
+                    await message.answer(
+                        "Stopped the current run. Send another message to continue here, or use /new for a fresh task."
+                    )
+                else:
+                    await message.answer("No active run to stop.")
+                return
+
             if user_id not in self.user_message_queues:
                 self.user_message_queues[user_id] = []
             self.user_message_queues[user_id].append(message)
@@ -151,16 +182,74 @@ class TelegramBotInstance:
                 user_id not in self.user_message_tasks
                 or self.user_message_tasks[user_id].done()
             ):
-                self.user_message_tasks[user_id] = asyncio.create_task(
-                    self._process_user_queue(user_id)
-                )
+                self._schedule_user_queue(user_id)
+
+    def _schedule_user_queue(self, user_id: int) -> None:
+        self.user_message_tasks[user_id] = asyncio.create_task(
+            self._process_user_queue(user_id)
+        )
+
+    def _start_new_conversation(self, user_id: int) -> bool:
+        self.user_message_queues.pop(user_id, None)
+        stopped = self._stop_user_active_execution(
+            user_id, reason="new Telegram conversation requested"
+        )
+        self.active_tasks[user_id] = -1
+        self._save_active_tasks()
+        return stopped
+
+    def _stop_current_conversation(self, user_id: int) -> bool:
+        queued_messages = self.user_message_queues.pop(user_id, None)
+        stopped = self._stop_user_active_execution(
+            user_id, reason="Telegram stop requested"
+        )
+        return bool(queued_messages) or stopped
+
+    def _stop_user_active_execution(self, user_id: int, *, reason: str) -> bool:
+        active_execution = self.user_active_executions.get(user_id)
+        if active_execution is None:
+            return False
+
+        task_id, agent_service = active_execution
+        pause_execution_by_id = getattr(agent_service, "pause_execution_by_id", None)
+        if not callable(pause_execution_by_id):
+            logger.warning(
+                "Telegram active task %s for user %s does not support pause",
+                task_id,
+                user_id,
+            )
+            return False
+
+        try:
+            return bool(pause_execution_by_id(str(task_id), reason=reason))
+        except Exception as e:
+            logger.warning(
+                "Failed to pause Telegram active task %s for user %s: %s",
+                task_id,
+                user_id,
+                e,
+            )
+            return False
+
+    def _is_stop_request_text(self, text: str) -> bool:
+        normalized = text.strip().lower()
+        if normalized.startswith("/"):
+            normalized = normalized.split()[0].split("@", 1)[0]
+        return normalized in self.stop_text_aliases
 
     async def _process_user_queue(self, user_id: int) -> None:
-        await asyncio.sleep(1.0)
-        messages = self.user_message_queues.pop(user_id, [])
-        if not messages:
-            return
-        await self._process_user_messages_batch(user_id, messages)
+        try:
+            while True:
+                await asyncio.sleep(self.queue_flush_delay_seconds)
+                messages = self.user_message_queues.pop(user_id, [])
+                if messages:
+                    await self._process_user_messages_batch(user_id, messages)
+
+                if not self.user_message_queues.get(user_id):
+                    return
+        finally:
+            if self.user_message_tasks.get(user_id) is asyncio.current_task():
+                self.user_message_tasks.pop(user_id, None)
 
     async def _extract_message_content(
         self, message: types.Message
@@ -435,6 +524,8 @@ class TelegramBotInstance:
                 from ...user_isolated_memory import UserContext
 
                 actual_task_id = str(task.id)
+                active_execution = (int(task.id), agent_service)  # type: ignore[arg-type]
+                self.user_active_executions[user_id] = active_execution
 
                 try:
                     with UserContext(int(user.id)):  # type: ignore
@@ -447,6 +538,8 @@ class TelegramBotInstance:
                             db_session=db,
                         )
                 finally:
+                    if self.user_active_executions.get(user_id) == active_execution:
+                        self.user_active_executions.pop(user_id, None)
                     if tg_handler in agent_service.tracer.handlers:
                         agent_service.tracer.handlers.remove(tg_handler)
 
@@ -465,7 +558,8 @@ class TelegramBotInstance:
 
                 output = projection.visible_text
                 output, image_refs = strip_telegram_image_refs(output)
-                if not output and image_refs:
+                output, file_refs = strip_telegram_file_refs(output)
+                if not output and (image_refs or file_refs):
                     output = "Task completed."
 
                 max_len = 4000
@@ -502,6 +596,19 @@ class TelegramBotInstance:
                     if failed_image_refs:
                         await self._send_image_fallback_message(
                             image_refs=failed_image_refs,
+                            reply_to=last_message,
+                        )
+                if file_refs:
+                    failed_file_refs = await self._send_output_files(
+                        file_refs=file_refs,
+                        user_id=int(user.id),  # type: ignore
+                        task_id=int(task.id),  # type: ignore
+                        db=db,
+                        reply_to=last_message,
+                    )
+                    if failed_file_refs:
+                        await self._send_file_fallback_message(
+                            file_refs=failed_file_refs,
                             reply_to=last_message,
                         )
 
@@ -604,6 +711,90 @@ class TelegramBotInstance:
         for image_ref in image_refs:
             label = image_ref.alt_text or "image"
             lines.append(f"- {label}: file:{image_ref.file_id}")
+        text = "\n".join(lines)
+        try:
+            await reply_to.answer(markdown_to_tg_html(text), parse_mode=ParseMode.HTML)
+        except Exception:
+            await reply_to.answer(text)
+
+    async def _send_output_files(
+        self,
+        *,
+        file_refs: list[TelegramFileRef],
+        user_id: int,
+        task_id: int,
+        db: Session,
+        reply_to: types.Message,
+    ) -> list[TelegramFileRef]:
+        ordered_file_ids = list(dict.fromkeys(ref.file_id for ref in file_refs))
+        failed_refs: list[TelegramFileRef] = []
+
+        file_records = (
+            db.query(UploadedFile)
+            .filter(
+                UploadedFile.file_id.in_(ordered_file_ids),
+                UploadedFile.user_id == user_id,
+                UploadedFile.task_id == task_id,
+            )
+            .all()
+            if ordered_file_ids
+            else []
+        )
+        file_record_by_id = {str(record.file_id): record for record in file_records}
+
+        sent_file_ids: set[str] = set()
+        for file_ref in file_refs:
+            if file_ref.file_id in sent_file_ids:
+                continue
+            sent_file_ids.add(file_ref.file_id)
+
+            file_record = file_record_by_id.get(file_ref.file_id)
+            if not file_record:
+                logger.warning(
+                    "Telegram output file not found: file_id=%s task_id=%s",
+                    file_ref.file_id,
+                    task_id,
+                )
+                failed_refs.append(file_ref)
+                continue
+
+            file_path = Path(file_record.storage_path)
+            if not file_path.is_file():
+                logger.warning(
+                    "Telegram output file path missing: file_id=%s path=%s",
+                    file_ref.file_id,
+                    file_path,
+                )
+                failed_refs.append(file_ref)
+                continue
+
+            record_filename = getattr(file_record, "filename", "")
+            caption_source = file_ref.label or str(record_filename or "file")
+            caption = html.escape(caption_source[:1024])
+            try:
+                await reply_to.answer_document(
+                    FSInputFile(file_path), caption=caption or None
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to send Telegram output file: file_id=%s error=%s",
+                    file_ref.file_id,
+                    e,
+                )
+                failed_refs.append(file_ref)
+
+        return failed_refs
+
+    async def _send_file_fallback_message(
+        self, *, file_refs: list[TelegramFileRef], reply_to: types.Message
+    ) -> None:
+        subject = "file" if len(file_refs) == 1 else "files"
+        lines = [
+            f"I couldn't send the {subject} through Telegram, but the file reference is still available:"
+        ]
+        for file_ref in file_refs:
+            label = file_ref.label or "file"
+            lines.append(f"- {label}: file:{file_ref.file_id}")
         text = "\n".join(lines)
         try:
             await reply_to.answer(markdown_to_tg_html(text), parse_mode=ParseMode.HTML)

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -238,18 +238,23 @@ class TelegramBotInstance:
         return normalized in self.stop_text_aliases
 
     async def _process_user_queue(self, user_id: int) -> None:
-        try:
-            while True:
-                await asyncio.sleep(self.queue_flush_delay_seconds)
-                messages = self.user_message_queues.pop(user_id, [])
-                if messages:
-                    await self._process_user_messages_batch(user_id, messages)
+        while True:
+            await asyncio.sleep(self.queue_flush_delay_seconds)
+            messages = self.user_message_queues.pop(user_id, [])
+            if messages:
+                await self._process_user_messages_batch(user_id, messages)
 
-                if not self.user_message_queues.get(user_id):
-                    return
-        finally:
-            if self.user_message_tasks.get(user_id) is asyncio.current_task():
+            if self.user_message_queues.get(user_id):
+                continue
+
+            current_task = cast(asyncio.Task, asyncio.current_task())
+            if self.user_message_tasks.get(user_id) is current_task:
                 self.user_message_tasks.pop(user_id, None)
+
+            if not self.user_message_queues.get(user_id):
+                return
+
+            self.user_message_tasks[user_id] = current_task
 
     async def _extract_message_content(
         self, message: types.Message

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -651,6 +651,13 @@ class TelegramBotInstance:
                 output = projection.visible_text
                 output, image_refs = strip_telegram_image_refs(output)
                 output, file_refs = strip_telegram_file_refs(output)
+                output_image_refs, output_file_refs = (
+                    self._telegram_refs_from_file_outputs(result.get("file_outputs"))
+                )
+                image_refs, file_refs = self._dedupe_telegram_output_refs(
+                    [*image_refs, *output_image_refs],
+                    [*file_refs, *output_file_refs],
+                )
                 if not output and (image_refs or file_refs):
                     output = "Task completed."
 
@@ -795,6 +802,86 @@ class TelegramBotInstance:
                 failed_refs.append(image_ref)
 
         return failed_refs
+
+    def _telegram_refs_from_file_outputs(
+        self, file_outputs: Any
+    ) -> tuple[list[TelegramImageRef], list[TelegramFileRef]]:
+        """Convert structured execution file outputs into Telegram attachments."""
+        if isinstance(file_outputs, dict):
+            file_outputs = [file_outputs]
+        if not isinstance(file_outputs, list):
+            return [], []
+
+        image_refs: list[TelegramImageRef] = []
+        file_refs: list[TelegramFileRef] = []
+        for item in file_outputs:
+            if not isinstance(item, dict):
+                continue
+            raw_file_id = item.get("file_id")
+            file_id = str(raw_file_id).strip() if raw_file_id is not None else ""
+            if not file_id:
+                continue
+
+            label = self._file_output_label(item)
+            if self._file_output_is_image(item, label):
+                image_refs.append(TelegramImageRef(file_id=file_id, alt_text=label))
+            else:
+                file_refs.append(TelegramFileRef(file_id=file_id, label=label))
+
+        return image_refs, file_refs
+
+    def _file_output_label(self, file_output: dict[str, Any]) -> str:
+        for key in ("filename", "name", "relative_path", "path", "file_path"):
+            raw_value = file_output.get(key)
+            if isinstance(raw_value, str) and raw_value.strip():
+                label = Path(raw_value).name.strip()
+                if label:
+                    return label
+        return "file"
+
+    def _file_output_is_image(self, file_output: dict[str, Any], label: str) -> bool:
+        raw_mime_type = file_output.get("mime_type") or file_output.get("type")
+        mime_type = str(raw_mime_type or "").lower()
+        if mime_type.startswith("image/"):
+            return True
+
+        extension = str(file_output.get("extension") or Path(label).suffix).lower()
+        return extension in {
+            ".apng",
+            ".bmp",
+            ".gif",
+            ".heic",
+            ".heif",
+            ".jpeg",
+            ".jpg",
+            ".png",
+            ".tif",
+            ".tiff",
+            ".webp",
+        }
+
+    def _dedupe_telegram_output_refs(
+        self,
+        image_refs: list[TelegramImageRef],
+        file_refs: list[TelegramFileRef],
+    ) -> tuple[list[TelegramImageRef], list[TelegramFileRef]]:
+        deduped_images: list[TelegramImageRef] = []
+        image_file_ids: set[str] = set()
+        for image_ref in image_refs:
+            if image_ref.file_id in image_file_ids:
+                continue
+            image_file_ids.add(image_ref.file_id)
+            deduped_images.append(image_ref)
+
+        deduped_files: list[TelegramFileRef] = []
+        file_ids: set[str] = set()
+        for file_ref in file_refs:
+            if file_ref.file_id in image_file_ids or file_ref.file_id in file_ids:
+                continue
+            file_ids.add(file_ref.file_id)
+            deduped_files.append(file_ref)
+
+        return deduped_images, deduped_files
 
     async def _send_image_fallback_message(
         self, *, image_refs: list[TelegramImageRef], reply_to: types.Message

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Coroutine, Dict, Optional, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -59,6 +59,8 @@ class TelegramBotInstance:
         self.user_message_queues: Dict[int, list] = {}
         self.user_message_tasks: Dict[int, asyncio.Task] = {}
         self.user_active_executions: Dict[int, tuple[int, object]] = {}
+        self.user_preparing_executions: set[int] = set()
+        self.user_stop_events: Dict[int, asyncio.Event] = {}
 
         # Load active tasks state
         self.active_tasks_file = Path(f"data/telegram_active_tasks_{instance_id}.json")
@@ -190,8 +192,7 @@ class TelegramBotInstance:
         )
 
     def _start_new_conversation(self, user_id: int) -> bool:
-        self.user_message_queues.pop(user_id, None)
-        stopped = self._stop_user_active_execution(
+        stopped = self._request_current_conversation_stop(
             user_id, reason="new Telegram conversation requested"
         )
         self.active_tasks[user_id] = -1
@@ -199,11 +200,17 @@ class TelegramBotInstance:
         return stopped
 
     def _stop_current_conversation(self, user_id: int) -> bool:
-        queued_messages = self.user_message_queues.pop(user_id, None)
-        stopped = self._stop_user_active_execution(
+        return self._request_current_conversation_stop(
             user_id, reason="Telegram stop requested"
         )
-        return bool(queued_messages) or stopped
+
+    def _request_current_conversation_stop(self, user_id: int, *, reason: str) -> bool:
+        queued_messages = self.user_message_queues.pop(user_id, None)
+        stopped = self._stop_user_active_execution(user_id, reason=reason)
+        preparing = user_id in self.user_preparing_executions
+        if preparing and not stopped:
+            self._request_user_stop(user_id)
+        return bool(queued_messages) or stopped or preparing
 
     def _stop_user_active_execution(self, user_id: int, *, reason: str) -> bool:
         active_execution = self.user_active_executions.get(user_id)
@@ -230,6 +237,62 @@ class TelegramBotInstance:
                 e,
             )
             return False
+
+    def _get_user_stop_event(self, user_id: int) -> asyncio.Event:
+        event = self.user_stop_events.get(user_id)
+        if event is None:
+            event = asyncio.Event()
+            self.user_stop_events[user_id] = event
+        return event
+
+    def _request_user_stop(self, user_id: int) -> None:
+        self._get_user_stop_event(user_id).set()
+
+    def _consume_user_stop_request(self, user_id: int) -> bool:
+        event = self.user_stop_events.get(user_id)
+        if event is None or not event.is_set():
+            return False
+        event.clear()
+        return True
+
+    def _clear_user_stop_request(self, user_id: int) -> None:
+        event = self.user_stop_events.get(user_id)
+        if event is not None:
+            event.clear()
+
+    async def _await_execution_with_stop_monitor(
+        self,
+        user_id: int,
+        execution: Coroutine[Any, Any, dict[str, Any]],
+        *,
+        reason: str,
+    ) -> dict[str, Any]:
+        execution_task: asyncio.Task[dict[str, Any]] = asyncio.create_task(execution)
+        stop_event = self._get_user_stop_event(user_id)
+
+        try:
+            while True:
+                if execution_task.done():
+                    return await execution_task
+
+                if stop_event.is_set():
+                    while not execution_task.done():
+                        if self._stop_user_active_execution(user_id, reason=reason):
+                            stop_event.clear()
+                            break
+                        await asyncio.sleep(0.05)
+                    continue
+
+                done, _ = await asyncio.wait(
+                    {execution_task},
+                    timeout=0.05,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if execution_task in done:
+                    return await execution_task
+        finally:
+            if not execution_task.done():
+                execution_task.cancel()
 
     def _is_stop_request_text(self, text: str) -> bool:
         normalized = text.strip().lower()
@@ -397,6 +460,8 @@ class TelegramBotInstance:
         if not text and not files:
             return
 
+        self.user_preparing_executions.add(user_id)
+        self._clear_user_stop_request(user_id)
         try:
             db_gen = get_db()
             db = next(db_gen)
@@ -425,6 +490,9 @@ class TelegramBotInstance:
                     await last_message.answer(
                         "Configuration error: Cannot find the owner of this bot."
                     )
+                    return
+
+                if self._consume_user_stop_request(user_id):
                     return
 
                 active_task_id = self.active_tasks.get(user_id)
@@ -475,6 +543,11 @@ class TelegramBotInstance:
                 message_turn_id = str(uuid4())
                 context: dict = {"turn_id": message_turn_id}
 
+                if self._consume_user_stop_request(user_id):
+                    task.status = TaskStatus.PAUSED
+                    db.commit()
+                    return
+
                 if files:
                     uploaded_info = await self._download_and_register_files(
                         files=files,
@@ -503,6 +576,11 @@ class TelegramBotInstance:
 
                         context["state"] = context.get("state", {})
                         context["state"]["file_info"] = uploaded_info
+
+                if self._consume_user_stop_request(user_id):
+                    task.status = TaskStatus.PAUSED
+                    db.commit()
+                    return
 
                 persist_user_message(
                     db=db,
@@ -533,14 +611,23 @@ class TelegramBotInstance:
                 self.user_active_executions[user_id] = active_execution
 
                 try:
+                    if self._consume_user_stop_request(user_id):
+                        task.status = TaskStatus.PAUSED
+                        db.commit()
+                        return
+
                     with UserContext(int(user.id)):  # type: ignore
-                        result = await agent_manager.execute_task(
-                            agent_service=agent_service,
-                            task=text,
-                            context=context,
-                            task_id=actual_task_id,
-                            tracking_task_id=str(task.id),
-                            db_session=db,
+                        result = await self._await_execution_with_stop_monitor(
+                            user_id,
+                            agent_manager.execute_task(
+                                agent_service=agent_service,
+                                task=text,
+                                context=context,
+                                task_id=actual_task_id,
+                                tracking_task_id=str(task.id),
+                                db_session=db,
+                            ),
+                            reason="Telegram stop requested",
                         )
                 finally:
                     if self.user_active_executions.get(user_id) == active_execution:
@@ -627,6 +714,9 @@ class TelegramBotInstance:
             await last_message.answer(
                 "Sorry, an error occurred while processing your request."
             )
+        finally:
+            self.user_preparing_executions.discard(user_id)
+            self._clear_user_stop_request(user_id)
 
     async def _send_output_images(
         self,

--- a/src/xagent/web/channels/telegram/utils.py
+++ b/src/xagent/web/channels/telegram/utils.py
@@ -16,6 +16,12 @@ class TelegramImageRef:
     alt_text: str
 
 
+@dataclass(frozen=True)
+class TelegramFileRef:
+    file_id: str
+    label: str
+
+
 def markdown_to_tg_html(text: str) -> str:
     """Convert basic Markdown to Telegram-supported HTML."""
     if not text:
@@ -146,6 +152,7 @@ def _render_markdown_table_as_list(table_lines: list[str]) -> list[str]:
 
 
 _MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]\n]*)\]\(([^)\n]+)\)")
+_MARKDOWN_FILE_LINK_RE = re.compile(r"(?<!!)\[([^\]\n]+)\]\(([^)\n]+)\)")
 
 
 def strip_telegram_image_refs(text: str) -> tuple[str, list[TelegramImageRef]]:
@@ -165,9 +172,34 @@ def strip_telegram_image_refs(text: str) -> tuple[str, list[TelegramImageRef]]:
         return ""
 
     cleaned = _MARKDOWN_IMAGE_RE.sub(replace_image, text)
-    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
-    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
-    return cleaned.strip(), image_refs
+    return _clean_stripped_markdown_refs(cleaned), image_refs
+
+
+def strip_telegram_file_refs(text: str) -> tuple[str, list[TelegramFileRef]]:
+    """Remove local file links from text and return refs Telegram should upload."""
+    if not text:
+        return "", []
+
+    file_refs: list[TelegramFileRef] = []
+
+    def replace_file_link(match: re.Match[str]) -> str:
+        label = match.group(1).strip()
+        target = html.unescape(match.group(2).strip())
+        file_id = _extract_local_file_id(target)
+        if not file_id:
+            return match.group(0)
+        file_refs.append(TelegramFileRef(file_id=file_id, label=label))
+        return ""
+
+    cleaned = _MARKDOWN_FILE_LINK_RE.sub(replace_file_link, text)
+    return _clean_stripped_markdown_refs(cleaned), file_refs
+
+
+def _clean_stripped_markdown_refs(text: str) -> str:
+    text = re.sub(r"(?m)^[ \t]*[-*•][ \t]*(?:\n|$)", "", text)
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 
 async def restore_telegram_task_context(

--- a/tests/web/test_telegram_image_output.py
+++ b/tests/web/test_telegram_image_output.py
@@ -10,11 +10,14 @@ from xagent.core.agent.trace import (
     TraceScope,
 )
 from xagent.web.channels.telegram import handler as telegram_handler
+from xagent.web.channels.telegram.bot import TelegramBotInstance
 from xagent.web.channels.telegram.handler import TelegramTraceHandler
 from xagent.web.channels.telegram.utils import (
+    TelegramFileRef,
     markdown_to_tg_html,
     persist_telegram_assistant_turn,
     restore_telegram_task_context,
+    strip_telegram_file_refs,
     strip_telegram_image_refs,
 )
 
@@ -43,6 +46,34 @@ def test_strip_telegram_image_refs_supports_file_urls_and_api_urls() -> None:
     assert [ref.file_id for ref in refs] == ["abc 1", "def 2", "ghi 3"]
 
 
+def test_strip_telegram_file_refs_extracts_local_file_links() -> None:
+    text = (
+        "Generated files:\n"
+        "- [report.csv](file://file-1)\n"
+        "- [poster](https://example.com/poster.html)\n"
+        "![preview](file://image-1)"
+    )
+
+    cleaned, refs = strip_telegram_file_refs(text)
+
+    assert cleaned == (
+        "Generated files:\n"
+        "- [poster](https://example.com/poster.html)\n"
+        "![preview](file://image-1)"
+    )
+    assert [(ref.file_id, ref.label) for ref in refs] == [("file-1", "report.csv")]
+
+
+def test_strip_telegram_file_refs_supports_api_download_urls() -> None:
+    cleaned, refs = strip_telegram_file_refs(
+        "[a](/api/files/download/abc%201) "
+        "[b](https://example.com/api/files/preview/def%202?token=ignored)"
+    )
+
+    assert cleaned == ""
+    assert [ref.file_id for ref in refs] == ["abc 1", "def 2"]
+
+
 def test_telegram_trace_handler_uses_plural_image_placeholder() -> None:
     handler = TelegramTraceHandler(
         task_id=421,
@@ -53,6 +84,50 @@ def test_telegram_trace_handler_uses_plural_image_placeholder() -> None:
 
     assert handler._image_placeholder_text(1) == "Image generated."
     assert handler._image_placeholder_text(2) == "Images generated."
+
+
+@pytest.mark.asyncio
+async def test_send_output_files_uploads_documents(tmp_path) -> None:
+    output_path = tmp_path / "report.csv"
+    output_path.write_text("a,b\n1,2\n")
+
+    class FakeRecord:
+        file_id = "file-1"
+        storage_path = str(output_path)
+        filename = "report.csv"
+
+    class FakeQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [FakeRecord()]
+
+    class FakeDB:
+        def query(self, *args):
+            return FakeQuery()
+
+    class FakeReply:
+        def __init__(self) -> None:
+            self.documents = []
+
+        async def answer_document(self, document, caption=None):
+            self.documents.append((document, caption))
+
+    bot = object.__new__(TelegramBotInstance)
+    reply = FakeReply()
+
+    failed_refs = await bot._send_output_files(
+        file_refs=[TelegramFileRef(file_id="file-1", label="report.csv")],
+        user_id=7,
+        task_id=423,
+        db=FakeDB(),  # type: ignore[arg-type]
+        reply_to=reply,  # type: ignore[arg-type]
+    )
+
+    assert failed_refs == []
+    assert len(reply.documents) == 1
+    assert reply.documents[0][1] == "report.csv"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_telegram_image_output.py
+++ b/tests/web/test_telegram_image_output.py
@@ -14,6 +14,7 @@ from xagent.web.channels.telegram.bot import TelegramBotInstance
 from xagent.web.channels.telegram.handler import TelegramTraceHandler
 from xagent.web.channels.telegram.utils import (
     TelegramFileRef,
+    TelegramImageRef,
     markdown_to_tg_html,
     persist_telegram_assistant_turn,
     restore_telegram_task_context,
@@ -128,6 +129,52 @@ async def test_send_output_files_uploads_documents(tmp_path) -> None:
     assert failed_refs == []
     assert len(reply.documents) == 1
     assert reply.documents[0][1] == "report.csv"
+
+
+def test_telegram_refs_from_file_outputs_classifies_structured_outputs() -> None:
+    bot = object.__new__(TelegramBotInstance)
+
+    image_refs, file_refs = bot._telegram_refs_from_file_outputs(
+        [
+            {
+                "file_id": "image-1",
+                "filename": "plot.png",
+                "mime_type": "image/png",
+            },
+            {
+                "file_id": "file-1",
+                "filename": "report.csv",
+                "mime_type": "text/csv",
+            },
+            {"file_id": "", "filename": "ignored.txt"},
+        ]
+    )
+
+    assert [(ref.file_id, ref.alt_text) for ref in image_refs] == [
+        ("image-1", "plot.png")
+    ]
+    assert [(ref.file_id, ref.label) for ref in file_refs] == [("file-1", "report.csv")]
+
+
+def test_dedupe_telegram_output_refs_prefers_images_over_documents() -> None:
+    bot = object.__new__(TelegramBotInstance)
+
+    image_refs, file_refs = bot._dedupe_telegram_output_refs(
+        [
+            TelegramImageRef(file_id="image-1", alt_text="inline image"),
+            TelegramImageRef(file_id="image-1", alt_text="structured image"),
+        ],
+        [
+            TelegramFileRef(file_id="image-1", label="plot.png"),
+            TelegramFileRef(file_id="file-1", label="report.csv"),
+            TelegramFileRef(file_id="file-1", label="report duplicate.csv"),
+        ],
+    )
+
+    assert [(ref.file_id, ref.alt_text) for ref in image_refs] == [
+        ("image-1", "inline image")
+    ]
+    assert [(ref.file_id, ref.label) for ref in file_refs] == [("file-1", "report.csv")]
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -5,12 +5,21 @@ import pytest
 from xagent.web.channels.telegram.bot import TelegramBotInstance
 
 
+def make_bot() -> TelegramBotInstance:
+    bot = object.__new__(TelegramBotInstance)
+    bot.user_message_queues = {}
+    bot.user_message_tasks = {}
+    bot.user_active_executions = {}
+    bot.user_preparing_executions = set()
+    bot.user_stop_events = {}
+    return bot
+
+
 @pytest.mark.asyncio
 async def test_process_user_queue_drains_messages_added_while_batch_runs() -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
     bot.queue_flush_delay_seconds = 0
     bot.user_message_queues = {123: ["first"]}
-    bot.user_message_tasks = {}
 
     processed_batches: list[list[str]] = []
 
@@ -33,7 +42,7 @@ async def test_process_user_queue_drains_messages_added_while_batch_runs() -> No
 
 @pytest.mark.asyncio
 async def test_process_user_queue_drains_message_added_while_unregistering() -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
     bot.queue_flush_delay_seconds = 0
     bot.user_message_queues = {123: ["first"]}
 
@@ -69,7 +78,7 @@ async def test_process_user_queue_drains_message_added_while_unregistering() -> 
 
 
 def test_start_new_conversation_clears_queue_and_pauses_active_execution() -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
     bot.user_message_queues = {123: ["old queued message"]}
     bot.active_tasks = {123: 456}
     bot.saved = False
@@ -100,7 +109,7 @@ def test_start_new_conversation_clears_queue_and_pauses_active_execution() -> No
 
 
 def test_stop_current_conversation_preserves_active_task() -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
     bot.user_message_queues = {123: ["old queued message"]}
     bot.active_tasks = {123: 456}
     bot.saved = False
@@ -131,14 +140,56 @@ def test_stop_current_conversation_preserves_active_task() -> None:
 
 
 def test_stop_current_conversation_clears_pending_queue_without_active_run() -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
     bot.user_message_queues = {123: ["queued before execution"]}
-    bot.user_active_executions = {}
     bot.active_tasks = {123: 456}
 
     assert bot._stop_current_conversation(123) is True
     assert bot.user_message_queues == {}
     assert bot.active_tasks[123] == 456
+
+
+def test_stop_current_conversation_records_stop_during_preparation() -> None:
+    bot = make_bot()
+    bot.active_tasks = {123: 456}
+    bot.user_preparing_executions.add(123)
+
+    assert bot._stop_current_conversation(123) is True
+    assert bot.user_stop_events[123].is_set()
+    assert bot.active_tasks[123] == 456
+
+
+@pytest.mark.asyncio
+async def test_await_execution_with_stop_monitor_pauses_pending_stop() -> None:
+    bot = make_bot()
+
+    class FakeAgentService:
+        def __init__(self) -> None:
+            self.pause_calls: list[tuple[str, str | None]] = []
+
+        def pause_execution_by_id(
+            self, execution_id: str, reason: str | None = None
+        ) -> bool:
+            self.pause_calls.append((execution_id, reason))
+            return True
+
+    agent_service = FakeAgentService()
+    bot.user_active_executions = {123: (456, agent_service)}
+    bot._request_user_stop(123)
+
+    async def fake_execution() -> dict:
+        await asyncio.sleep(0)
+        return {"status": "interrupted"}
+
+    result = await bot._await_execution_with_stop_monitor(
+        123,
+        fake_execution(),
+        reason="Telegram stop requested",
+    )
+
+    assert result == {"status": "interrupted"}
+    assert agent_service.pause_calls == [("456", "Telegram stop requested")]
+    assert not bot.user_stop_events[123].is_set()
 
 
 @pytest.mark.parametrize(
@@ -155,6 +206,6 @@ def test_stop_current_conversation_clears_pending_queue_without_active_run() -> 
     ],
 )
 def test_stop_request_text_aliases(text: str, expected: bool) -> None:
-    bot = object.__new__(TelegramBotInstance)
+    bot = make_bot()
 
     assert bot._is_stop_request_text(text) is expected

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -31,6 +31,43 @@ async def test_process_user_queue_drains_messages_added_while_batch_runs() -> No
     assert bot.user_message_queues == {}
 
 
+@pytest.mark.asyncio
+async def test_process_user_queue_drains_message_added_while_unregistering() -> None:
+    bot = object.__new__(TelegramBotInstance)
+    bot.queue_flush_delay_seconds = 0
+    bot.user_message_queues = {123: ["first"]}
+
+    class RaceTaskDict(dict):
+        def __init__(self, user_id: int) -> None:
+            super().__init__()
+            self.user_id = user_id
+            self.injected = False
+
+        def pop(self, key, default=None):  # type: ignore[no-untyped-def]
+            value = super().pop(key, default)
+            if key == self.user_id and not self.injected:
+                self.injected = True
+                bot.user_message_queues.setdefault(key, []).append("second")
+            return value
+
+    bot.user_message_tasks = RaceTaskDict(123)
+    processed_batches: list[list[str]] = []
+
+    async def fake_process_batch(user_id: int, messages: list[str]) -> None:
+        processed_batches.append(list(messages))
+
+    bot._process_user_messages_batch = fake_process_batch
+
+    queue_task = asyncio.create_task(bot._process_user_queue(123))
+    bot.user_message_tasks[123] = queue_task
+
+    await queue_task
+
+    assert processed_batches == [["first"], ["second"]]
+    assert bot.user_message_tasks == {}
+    assert bot.user_message_queues == {}
+
+
 def test_start_new_conversation_clears_queue_and_pauses_active_execution() -> None:
     bot = object.__new__(TelegramBotInstance)
     bot.user_message_queues = {123: ["old queued message"]}

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -1,0 +1,123 @@
+import asyncio
+
+import pytest
+
+from xagent.web.channels.telegram.bot import TelegramBotInstance
+
+
+@pytest.mark.asyncio
+async def test_process_user_queue_drains_messages_added_while_batch_runs() -> None:
+    bot = object.__new__(TelegramBotInstance)
+    bot.queue_flush_delay_seconds = 0
+    bot.user_message_queues = {123: ["first"]}
+    bot.user_message_tasks = {}
+
+    processed_batches: list[list[str]] = []
+
+    async def fake_process_batch(user_id: int, messages: list[str]) -> None:
+        processed_batches.append(list(messages))
+        if len(processed_batches) == 1:
+            bot.user_message_queues.setdefault(user_id, []).append("second")
+
+    bot._process_user_messages_batch = fake_process_batch
+
+    queue_task = asyncio.create_task(bot._process_user_queue(123))
+    bot.user_message_tasks[123] = queue_task
+
+    await queue_task
+
+    assert processed_batches == [["first"], ["second"]]
+    assert bot.user_message_tasks == {}
+    assert bot.user_message_queues == {}
+
+
+def test_start_new_conversation_clears_queue_and_pauses_active_execution() -> None:
+    bot = object.__new__(TelegramBotInstance)
+    bot.user_message_queues = {123: ["old queued message"]}
+    bot.active_tasks = {123: 456}
+    bot.saved = False
+
+    class FakeAgentService:
+        def __init__(self) -> None:
+            self.pause_calls: list[tuple[str, str | None]] = []
+
+        def pause_execution_by_id(
+            self, execution_id: str, reason: str | None = None
+        ) -> bool:
+            self.pause_calls.append((execution_id, reason))
+            return True
+
+    agent_service = FakeAgentService()
+    bot.user_active_executions = {123: (456, agent_service)}
+
+    def fake_save_active_tasks() -> None:
+        bot.saved = True
+
+    bot._save_active_tasks = fake_save_active_tasks
+
+    assert bot._start_new_conversation(123) is True
+    assert 123 not in bot.user_message_queues
+    assert bot.active_tasks[123] == -1
+    assert bot.saved is True
+    assert agent_service.pause_calls == [("456", "new Telegram conversation requested")]
+
+
+def test_stop_current_conversation_preserves_active_task() -> None:
+    bot = object.__new__(TelegramBotInstance)
+    bot.user_message_queues = {123: ["old queued message"]}
+    bot.active_tasks = {123: 456}
+    bot.saved = False
+
+    class FakeAgentService:
+        def __init__(self) -> None:
+            self.pause_calls: list[tuple[str, str | None]] = []
+
+        def pause_execution_by_id(
+            self, execution_id: str, reason: str | None = None
+        ) -> bool:
+            self.pause_calls.append((execution_id, reason))
+            return True
+
+    agent_service = FakeAgentService()
+    bot.user_active_executions = {123: (456, agent_service)}
+
+    def fake_save_active_tasks() -> None:
+        bot.saved = True
+
+    bot._save_active_tasks = fake_save_active_tasks
+
+    assert bot._stop_current_conversation(123) is True
+    assert 123 not in bot.user_message_queues
+    assert bot.active_tasks[123] == 456
+    assert bot.saved is False
+    assert agent_service.pause_calls == [("456", "Telegram stop requested")]
+
+
+def test_stop_current_conversation_clears_pending_queue_without_active_run() -> None:
+    bot = object.__new__(TelegramBotInstance)
+    bot.user_message_queues = {123: ["queued before execution"]}
+    bot.user_active_executions = {}
+    bot.active_tasks = {123: 456}
+
+    assert bot._stop_current_conversation(123) is True
+    assert bot.user_message_queues == {}
+    assert bot.active_tasks[123] == 456
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/stop", True),
+        ("/stop@xagent_bot", True),
+        ("/pause now", True),
+        ("STOP", True),
+        ("暂停", True),
+        ("停止", True),
+        ("请暂停一下", False),
+        ("/new", False),
+    ],
+)
+def test_stop_request_text_aliases(text: str, expected: bool) -> None:
+    bot = object.__new__(TelegramBotInstance)
+
+    assert bot._is_stop_request_text(text) is expected


### PR DESCRIPTION
## Summary
- add Telegram /stop handling, with /pause and stop/pause text aliases, while preserving the active task for follow-up messages
- drain queued Telegram messages added while a prior batch is still running
- send generated non-image file references as Telegram documents, while keeping image references as photos

## Tests
- ruff check src/xagent/web/channels/telegram/bot.py src/xagent/web/channels/telegram/utils.py tests/web/test_telegram_image_output.py tests/web/test_telegram_message_queue.py
- PYTHONPATH=src pytest tests/web/test_telegram_image_output.py tests/web/test_telegram_message_queue.py -q