### PR TITLE
feat: compact checkpoint trace storage with blob refs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,76 @@
+# Scripts
+
+Operational helper scripts for local development, upgrades, and release checks.
+Run commands from the repository root unless a script says otherwise.
+
+## `backfill_uploaded_files.py`
+
+Registers files already present under the configured uploads directory into the
+`uploaded_files` table. Useful after upgrading from an older build that wrote
+files to disk but did not create database records for them.
+
+Common usage:
+
+```bash
+PYTHONPATH=src python scripts/backfill_uploaded_files.py --dry-run
+PYTHONPATH=src python scripts/backfill_uploaded_files.py
+PYTHONPATH=src python scripts/backfill_uploaded_files.py --user-id 1
+```
+
+## `check_alembic_heads.sh`
+
+Verifies that Alembic currently has exactly one migration head. This is a quick
+CI/local guard for accidental migration branching.
+
+Common usage:
+
+```bash
+PYTHONPATH=src scripts/check_alembic_heads.sh
+```
+
+## `convert_trace_checkpoint_messages.py`
+
+Converts historical checkpoint trace rows from legacy inline payloads to refs
+backed by blob tables. It currently covers `snapshot.context.messages`,
+`snapshot.pattern_state.tool_ledger`, and `snapshot.context.metadata`. This is
+an internal storage migration only: API/runtime readers still decode refs back
+into normal checkpoint objects.
+
+The script is dry-run by default. Use `--execute` to write changes.
+
+Common usage:
+
+```bash
+# Preview all configured database rows without writing changes.
+PYTHONPATH=src python scripts/convert_trace_checkpoint_messages.py
+
+# Convert all historical checkpoint rows.
+PYTHONPATH=src python scripts/convert_trace_checkpoint_messages.py --execute
+
+# Convert only one task.
+PYTHONPATH=src python scripts/convert_trace_checkpoint_messages.py --execute --task-id 467
+
+# Resume after a known trace_events id or process in smaller batches.
+PYTHONPATH=src python scripts/convert_trace_checkpoint_messages.py --execute --start-id 100000 --batch-size 100
+```
+
+Notes:
+
+- The configured database comes from `DATABASE_URL`, or the normal xagent
+  default database path if `DATABASE_URL` is unset.
+- Existing refs rows are skipped, so it is safe to rerun.
+- New writes from the upgraded app already use refs and will be skipped.
+- Row-level conversion failures are logged and counted, then the script
+  continues with later rows. A run with any row errors exits non-zero.
+- For SQLite, the database file may not physically shrink until you run
+  `VACUUM` after conversion.
+
+## `export_openapi.py`
+
+Exports the FastAPI OpenAPI schema to JSON.
+
+Common usage:
+
+```bash
+PYTHONPATH=src python scripts/export_openapi.py -o openapi.json
+```

--- a/scripts/convert_trace_checkpoint_messages.py
+++ b/scripts/convert_trace_checkpoint_messages.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Convert historical checkpoint payloads to refs.
+
+This script rewrites legacy checkpoint trace rows whose optimized storage
+fields are still inline. New refs-format rows are left unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+for import_path in (SRC_ROOT, PROJECT_ROOT):
+    import_path_str = str(import_path)
+    if import_path_str not in sys.path:
+        sys.path.insert(0, import_path_str)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger("convert_trace_checkpoint_messages")
+
+
+@dataclass
+class ConversionStats:
+    scanned_rows: int = 0
+    converted_rows: int = 0
+    already_refs_rows: int = 0
+    skipped_rows: int = 0
+    error_rows: int = 0
+    inline_payload_bytes: int = 0
+    refs_payload_bytes: int = 0
+
+    @property
+    def estimated_payload_bytes_saved(self) -> int:
+        return max(0, self.inline_payload_bytes - self.refs_payload_bytes)
+
+
+def convert_trace_checkpoint_messages(
+    db: "Session",
+    *,
+    dry_run: bool = True,
+    batch_size: int = 500,
+    task_id: int | None = None,
+    limit: int | None = None,
+    start_id: int = 0,
+) -> ConversionStats:
+    """Convert legacy inline checkpoint payloads in trace_events.
+
+    ``limit`` bounds the number of system trace rows scanned, not the number of
+    rows converted.
+    """
+
+    from xagent.web.models.task import TraceEvent
+    from xagent.web.services.trace_message_storage import (
+        checkpoint_storage_payload_bytes,
+        encode_checkpoint_data_for_storage,
+        get_checkpoint_storage_state,
+    )
+
+    stats = ConversionStats()
+    last_seen_id = start_id
+    remaining = limit
+
+    while remaining is None or remaining > 0:
+        page_size = batch_size if remaining is None else min(batch_size, remaining)
+        filters = [
+            TraceEvent.id > last_seen_id,
+            TraceEvent.event_type == "system_update_general",
+        ]
+        if task_id is not None:
+            filters.append(TraceEvent.task_id == task_id)
+
+        rows = (
+            db.query(TraceEvent)
+            .filter(*filters)
+            .order_by(TraceEvent.id.asc())
+            .limit(page_size)
+            .all()
+        )
+        if not rows:
+            break
+
+        converted_in_batch = 0
+        for row in rows:
+            stats.scanned_rows += 1
+            last_seen_id = int(row.id)
+            data = row.data if isinstance(row.data, dict) else None
+            state = get_checkpoint_storage_state(data)
+            if state == "refs":
+                stats.already_refs_rows += 1
+                continue
+            if state == "none":
+                stats.skipped_rows += 1
+                continue
+
+            try:
+                assert isinstance(data, dict)
+                with db.begin_nested():
+                    inline_payload_bytes = checkpoint_storage_payload_bytes(data)
+                    encoded = encode_checkpoint_data_for_storage(
+                        db,
+                        task_id=int(row.task_id),
+                        data=data,
+                    )
+                    encoded_state = get_checkpoint_storage_state(encoded)
+                    if encoded_state != "refs":
+                        stats.skipped_rows += 1
+                        continue
+
+                    if not dry_run:
+                        row.data = encoded
+                stats.converted_rows += 1
+                converted_in_batch += 1
+                stats.inline_payload_bytes += inline_payload_bytes
+                stats.refs_payload_bytes += checkpoint_storage_payload_bytes(encoded)
+            except Exception:
+                stats.error_rows += 1
+                logger.exception(
+                    "Failed to convert trace event id=%s task_id=%s",
+                    row.id,
+                    row.task_id,
+                )
+                continue
+
+        if dry_run:
+            db.rollback()
+        elif converted_in_batch:
+            db.commit()
+        else:
+            db.rollback()
+
+        if remaining is not None:
+            remaining -= len(rows)
+
+        logger.info(
+            "Scanned %s rows, converted %s, already refs %s, skipped %s",
+            stats.scanned_rows,
+            stats.converted_rows,
+            stats.already_refs_rows,
+            stats.skipped_rows,
+        )
+
+    return stats
+
+
+def _load_dotenv() -> None:
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+
+    env_path = PROJECT_ROOT / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
+        logger.info("Loaded environment from %s", env_path)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert legacy checkpoint payloads to trace storage refs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Dry-run against the configured database
+  python scripts/convert_trace_checkpoint_messages.py
+
+  # Convert all historical checkpoints
+  python scripts/convert_trace_checkpoint_messages.py --execute
+
+  # Convert one task in small batches
+  python scripts/convert_trace_checkpoint_messages.py --execute --task-id 467 --batch-size 100
+        """,
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write converted trace rows. Default is dry-run.",
+    )
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan and report without writing changes. This is the default.",
+    )
+    parser.add_argument(
+        "--database-url",
+        help="Override DATABASE_URL for this run.",
+    )
+    parser.add_argument(
+        "--task-id",
+        type=int,
+        help="Only convert checkpoints for one task.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Number of system trace rows to scan per batch.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of system trace rows to scan.",
+    )
+    parser.add_argument(
+        "--start-id",
+        type=int,
+        default=0,
+        help="Only scan trace_events rows with id greater than this value.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    args = _parse_args()
+    if args.batch_size < 1:
+        logger.error("--batch-size must be positive")
+        return 2
+    if args.limit is not None and args.limit < 1:
+        logger.error("--limit must be positive")
+        return 2
+    if args.start_id < 0:
+        logger.error("--start-id cannot be negative")
+        return 2
+
+    dry_run = not args.execute
+    _load_dotenv()
+    from xagent.web.models.database import get_session_local, init_db
+
+    init_db(args.database_url)
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    try:
+        if dry_run:
+            logger.info("Dry-run mode: no database changes will be committed")
+        else:
+            logger.info("Execute mode: converted rows will be committed")
+
+        stats = convert_trace_checkpoint_messages(
+            db,
+            dry_run=dry_run,
+            batch_size=args.batch_size,
+            task_id=args.task_id,
+            limit=args.limit,
+            start_id=args.start_id,
+        )
+    finally:
+        db.close()
+
+    logger.info("=" * 72)
+    logger.info("Trace checkpoint message conversion summary")
+    logger.info("Rows scanned:         %s", stats.scanned_rows)
+    logger.info("Rows converted:       %s", stats.converted_rows)
+    logger.info("Rows already refs:    %s", stats.already_refs_rows)
+    logger.info("Rows skipped:         %s", stats.skipped_rows)
+    logger.info("Rows errored:         %s", stats.error_rows)
+    logger.info("Inline payload bytes: %s", stats.inline_payload_bytes)
+    logger.info("Refs payload bytes:   %s", stats.refs_payload_bytes)
+    logger.info("Estimated trace row saved: %s", stats.estimated_payload_bytes_saved)
+    logger.info("=" * 72)
+    return 1 if stats.error_rows else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/xagent/migrations/versions/20260524_add_trace_message_blobs.py
+++ b/src/xagent/migrations/versions/20260524_add_trace_message_blobs.py
@@ -1,0 +1,105 @@
+"""add trace message blobs
+
+Revision ID: 20260524_add_trace_message_blobs
+Revises: 20260523_add_workforce_core_tables
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260524_add_trace_message_blobs"
+down_revision: Union[str, None] = "20260523_add_workforce_core_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _inspector() -> sa.Inspector:
+    from alembic import context
+
+    return sa.inspect(context.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {idx["name"] for idx in _inspector().get_indexes(table_name)}
+
+
+def _drop_index_if_exists(index_name: str, table_name: str) -> None:
+    if _index_exists(table_name, index_name):
+        op.drop_index(op.f(index_name), table_name=table_name)
+
+
+def _foreign_key_if_table_exists(
+    table_name: str,
+    local_cols: list[str],
+    remote_cols: list[str],
+) -> list[sa.ForeignKeyConstraint]:
+    if not _table_exists(table_name):
+        return []
+    return [sa.ForeignKeyConstraint(local_cols, remote_cols)]
+
+
+def upgrade() -> None:
+    if _table_exists("trace_message_blobs"):
+        return
+
+    op.create_table(
+        "trace_message_blobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("task_id", sa.Integer(), nullable=False),
+        sa.Column("execution_id", sa.String(length=255), nullable=False),
+        sa.Column("message_hash", sa.String(length=80), nullable=False),
+        sa.Column("message_data", sa.JSON(), nullable=False),
+        sa.Column("message_bytes", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        *_foreign_key_if_table_exists("tasks", ["task_id"], ["tasks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "task_id",
+            "message_hash",
+            name="uq_trace_message_blobs_task_hash",
+        ),
+    )
+    op.create_index(
+        op.f("ix_trace_message_blobs_id"),
+        "trace_message_blobs",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_trace_message_blobs_task_id"),
+        "trace_message_blobs",
+        ["task_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_trace_message_blobs_execution_id"),
+        "trace_message_blobs",
+        ["execution_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    if not _table_exists("trace_message_blobs"):
+        return
+
+    _drop_index_if_exists("ix_trace_message_blobs_execution_id", "trace_message_blobs")
+    _drop_index_if_exists("ix_trace_message_blobs_task_id", "trace_message_blobs")
+    _drop_index_if_exists("ix_trace_message_blobs_id", "trace_message_blobs")
+    op.drop_table("trace_message_blobs")

--- a/src/xagent/migrations/versions/20260525_add_trace_checkpoint_blobs.py
+++ b/src/xagent/migrations/versions/20260525_add_trace_checkpoint_blobs.py
@@ -1,0 +1,118 @@
+"""add trace checkpoint blobs
+
+Revision ID: 20260525_add_trace_checkpoint_blobs
+Revises: 20260524_add_trace_message_blobs
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260525_add_trace_checkpoint_blobs"
+down_revision: Union[str, None] = "20260524_add_trace_message_blobs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _inspector() -> sa.Inspector:
+    from alembic import context
+
+    return sa.inspect(context.get_bind())
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in _inspector().get_table_names()
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    return index_name in {idx["name"] for idx in _inspector().get_indexes(table_name)}
+
+
+def _drop_index_if_exists(index_name: str, table_name: str) -> None:
+    if _index_exists(table_name, index_name):
+        op.drop_index(op.f(index_name), table_name=table_name)
+
+
+def _foreign_key_if_table_exists(
+    table_name: str,
+    local_cols: list[str],
+    remote_cols: list[str],
+) -> list[sa.ForeignKeyConstraint]:
+    if not _table_exists(table_name):
+        return []
+    return [sa.ForeignKeyConstraint(local_cols, remote_cols)]
+
+
+def upgrade() -> None:
+    if _table_exists("trace_checkpoint_blobs"):
+        return
+
+    op.create_table(
+        "trace_checkpoint_blobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("task_id", sa.Integer(), nullable=False),
+        sa.Column("execution_id", sa.String(length=255), nullable=False),
+        sa.Column("blob_kind", sa.String(length=255), nullable=False),
+        sa.Column("blob_hash", sa.String(length=80), nullable=False),
+        sa.Column("blob_data", sa.JSON(), nullable=False),
+        sa.Column("blob_bytes", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        *_foreign_key_if_table_exists("tasks", ["task_id"], ["tasks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "task_id",
+            "blob_kind",
+            "blob_hash",
+            name="uq_trace_checkpoint_blobs_task_kind_hash",
+        ),
+    )
+    op.create_index(
+        op.f("ix_trace_checkpoint_blobs_id"),
+        "trace_checkpoint_blobs",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_trace_checkpoint_blobs_task_id"),
+        "trace_checkpoint_blobs",
+        ["task_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_trace_checkpoint_blobs_execution_id"),
+        "trace_checkpoint_blobs",
+        ["execution_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_trace_checkpoint_blobs_blob_kind"),
+        "trace_checkpoint_blobs",
+        ["blob_kind"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    if not _table_exists("trace_checkpoint_blobs"):
+        return
+
+    _drop_index_if_exists(
+        "ix_trace_checkpoint_blobs_blob_kind", "trace_checkpoint_blobs"
+    )
+    _drop_index_if_exists(
+        "ix_trace_checkpoint_blobs_execution_id", "trace_checkpoint_blobs"
+    )
+    _drop_index_if_exists("ix_trace_checkpoint_blobs_task_id", "trace_checkpoint_blobs")
+    _drop_index_if_exists("ix_trace_checkpoint_blobs_id", "trace_checkpoint_blobs")
+    op.drop_table("trace_checkpoint_blobs")

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -57,6 +57,7 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     stop_task_lease_heartbeat,
 )
+from ..services.trace_message_storage import decode_trace_events_data
 from ..tools.config import WebToolConfig
 from ..tracing import create_task_tracer
 from ..user_isolated_memory import UserContext
@@ -1498,7 +1499,13 @@ class AgentServiceManager:
                 )
                 .all()
             )
-            for event in trace_events:
+            decoded_event_data = decode_trace_events_data(
+                db,
+                task_id=task_id,
+                data_items=[event.data for event in trace_events],
+                strict=False,
+            )
+            for event, event_data in zip(trace_events, decoded_event_data):
                 tracer_events.append(
                     {
                         "id": event.event_id,
@@ -1508,7 +1515,7 @@ class AgentServiceManager:
                         "timestamp": event.timestamp.timestamp()
                         if event.timestamp
                         else None,
-                        "data": event.data,
+                        "data": event_data,
                         "parent_id": event.parent_event_id,
                     }
                 )

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -15,6 +15,11 @@ from ...web.models.database import get_db
 from ...web.models.task import Task
 from ...web.models.task import TraceEvent as DatabaseTraceEvent
 from ...web.models.tool_config import ToolUsage
+from ...web.services.trace_message_storage import (
+    CheckpointMessageDecodeError,
+    decode_trace_event_data,
+    encode_checkpoint_data_for_storage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +131,21 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     data.get("root_execution_id") or data.get("execution_id")
                 ) != str(execution_id):
                     continue
+                try:
+                    data = decode_trace_event_data(
+                        db,
+                        task_id=self.task_id,
+                        data=data,
+                        strict=True,
+                    )
+                except CheckpointMessageDecodeError as exc:
+                    logger.warning(
+                        "Skipping unreadable checkpoint trace event %s for task %s: %s",
+                        row.event_id,
+                        self.task_id,
+                        exc,
+                    )
+                    continue
                 snapshot = data.get("snapshot")
                 return dict(snapshot) if isinstance(snapshot, dict) else None
             return None
@@ -162,6 +182,16 @@ class DatabaseTraceHandler(BaseTraceHandler):
                     self.task_id,
                 )
                 return
+            if (
+                event_type_str == "system_update_general"
+                and isinstance(data, dict)
+                and data.get("checkpoint_type") == CHECKPOINT_TYPE
+            ):
+                data = encode_checkpoint_data_for_storage(
+                    db,
+                    task_id=self.task_id,
+                    data=data,
+                )
 
             # Create trace event record
             trace_event = DatabaseTraceEvent(

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -267,3 +268,66 @@ class TraceEvent(Base):  # type: ignore
 
     def __repr__(self) -> str:
         return f"<TraceEvent(id={self.id}, event_type='{self.event_type}', task_id={self.task_id})>"
+
+
+class TraceMessageBlob(Base):  # type: ignore
+    """Deduplicated message payload referenced by checkpoint trace events."""
+
+    __tablename__ = "trace_message_blobs"
+    __table_args__ = (
+        UniqueConstraint(
+            "task_id",
+            "message_hash",
+            name="uq_trace_message_blobs_task_hash",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, index=True)
+    execution_id = Column(String(255), nullable=False, index=True)
+    message_hash = Column(String(80), nullable=False)
+    message_data = Column(JSON, nullable=False)
+    message_bytes = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    task = relationship("Task")
+
+    def __repr__(self) -> str:
+        return (
+            "<TraceMessageBlob("
+            f"id={self.id}, task_id={self.task_id}, message_hash='{self.message_hash}'"
+            ")>"
+        )
+
+
+class TraceCheckpointBlob(Base):  # type: ignore
+    """Deduplicated checkpoint field payload referenced by trace events."""
+
+    __tablename__ = "trace_checkpoint_blobs"
+    __table_args__ = (
+        UniqueConstraint(
+            "task_id",
+            "blob_kind",
+            "blob_hash",
+            name="uq_trace_checkpoint_blobs_task_kind_hash",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, index=True)
+    execution_id = Column(String(255), nullable=False, index=True)
+    blob_kind = Column(String(255), nullable=False, index=True)
+    blob_hash = Column(String(80), nullable=False)
+    blob_data = Column(JSON, nullable=False)
+    blob_bytes = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    task = relationship("Task")
+
+    def __repr__(self) -> str:
+        return (
+            "<TraceCheckpointBlob("
+            f"id={self.id}, task_id={self.task_id}, "
+            f"blob_kind='{self.blob_kind}', blob_hash='{self.blob_hash}'"
+            ")>"
+        )

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -1,0 +1,924 @@
+"""Storage codec for checkpoint message refs.
+
+The refs shape is an internal database representation only. Runtime code and
+public APIs should see decoded inline message lists.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy.orm import Session
+
+from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
+from ..models.task import TraceCheckpointBlob, TraceMessageBlob
+
+MESSAGE_REFS_ENCODING = "xagent.message_refs_v1"
+CHECKPOINT_BLOB_REF_ENCODING = "xagent.checkpoint_blob_ref_v1"
+MESSAGE_HASH_PREFIX = "sha256:"
+MESSAGE_REFS_DECODE_ERROR_KEY = "_decode_error"
+SQL_IN_CLAUSE_CHUNK_SIZE = 900
+CheckpointMessageStorageState = Literal["inline", "refs", "none"]
+CheckpointStorageState = Literal["inline", "refs", "mixed", "none"]
+
+
+@dataclass(frozen=True)
+class CheckpointBlobField:
+    kind: str
+    path: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BlobCandidate:
+    data: Any
+    payload_bytes: int
+
+
+@dataclass(frozen=True)
+class TraceBlobLookup:
+    message_data_by_hash: dict[str, Any]
+    checkpoint_data_by_ref: dict[tuple[str, str], Any]
+
+
+CHECKPOINT_BLOB_FIELDS: tuple[CheckpointBlobField, ...] = (
+    CheckpointBlobField(
+        "pattern_state.tool_ledger", ("snapshot", "pattern_state", "tool_ledger")
+    ),
+    CheckpointBlobField("context.metadata", ("snapshot", "context", "metadata")),
+)
+
+
+class CheckpointMessageDecodeError(ValueError):
+    """Raised when checkpoint message refs cannot be restored."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def canonical_json_hash(value: Any) -> str:
+    digest = hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+    return f"{MESSAGE_HASH_PREFIX}{digest}"
+
+
+def canonical_json_hash_from_bytes(payload: bytes) -> str:
+    digest = hashlib.sha256(payload).hexdigest()
+    return f"{MESSAGE_HASH_PREFIX}{digest}"
+
+
+def get_checkpoint_messages_storage_state(
+    data: Any,
+) -> CheckpointMessageStorageState:
+    """Return how checkpoint context messages are currently stored."""
+
+    messages_payload = _get_checkpoint_messages_payload(data)
+    if isinstance(messages_payload, list):
+        return "inline"
+    if _is_message_refs_payload(messages_payload):
+        return "refs"
+    return "none"
+
+
+def get_checkpoint_storage_state(data: Any) -> CheckpointStorageState:
+    """Return whether all checkpoint-optimized fields are inline or refs."""
+
+    field_states = _checkpoint_storage_field_states(data)
+    has_inline = "inline" in field_states
+    has_refs = "refs" in field_states
+    if has_inline and has_refs:
+        return "mixed"
+    if has_inline:
+        return "inline"
+    if has_refs:
+        return "refs"
+    return "none"
+
+
+def checkpoint_storage_payload_bytes(data: Any) -> int:
+    """Measure optimized checkpoint payload bytes inside one trace event."""
+
+    if not _is_readable_checkpoint_data(data):
+        return 0
+
+    total = 0
+    messages = _get_checkpoint_messages_payload(data)
+    if isinstance(messages, list) or _is_message_refs_payload(messages):
+        total += len(canonical_json_bytes(messages))
+
+    for field in CHECKPOINT_BLOB_FIELDS:
+        payload = _get_nested(data, field.path)
+        if _should_store_checkpoint_blob_payload(
+            payload
+        ) or _is_checkpoint_blob_ref_payload(payload):
+            total += len(canonical_json_bytes(payload))
+    return total
+
+
+def encode_checkpoint_data_for_storage(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+) -> Any:
+    """Encode all storage-optimized checkpoint fields."""
+
+    should_encode_messages = get_checkpoint_messages_storage_state(data) == "inline"
+    fields_to_encode = _checkpoint_blob_fields_to_encode(data)
+    if not should_encode_messages and not fields_to_encode:
+        return data
+
+    encoded = copy.deepcopy(data)
+    if should_encode_messages:
+        _encode_checkpoint_messages_in_place(db, task_id=task_id, data=encoded)
+    if fields_to_encode:
+        _encode_checkpoint_blob_fields_in_place(
+            db,
+            task_id=task_id,
+            data=encoded,
+            fields_to_encode=fields_to_encode,
+        )
+    return encoded
+
+
+def encode_checkpoint_messages_for_storage(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+) -> Any:
+    """Replace checkpoint context messages with refs and upsert message blobs."""
+
+    if get_checkpoint_messages_storage_state(data) != "inline":
+        return data
+
+    messages = _get_checkpoint_messages_payload(data)
+    if not isinstance(messages, list):
+        return data
+
+    encoded = copy.deepcopy(data)
+    _encode_checkpoint_messages_in_place(db, task_id=task_id, data=encoded)
+    return encoded
+
+
+def _encode_checkpoint_messages_in_place(
+    db: Session,
+    *,
+    task_id: int,
+    data: dict[str, Any],
+) -> None:
+    messages = _get_checkpoint_messages_payload(data)
+    if not isinstance(messages, list):
+        return
+
+    encoded_context = data["snapshot"]["context"]
+    execution_id = _checkpoint_execution_id(data)
+    refs: list[str] = []
+    blobs_by_hash: dict[str, BlobCandidate] = {}
+    for message in messages:
+        message_payload = canonical_json_bytes(message)
+        message_hash = canonical_json_hash_from_bytes(message_payload)
+        message_bytes = len(message_payload)
+        _remember_blob_candidate(
+            blobs_by_hash,
+            blob_hash=message_hash,
+            data=message,
+            payload_bytes=message_bytes,
+            collision_message=(
+                f"trace message blob hash collision for task {task_id}: {message_hash}"
+            ),
+        )
+        refs.append(message_hash)
+
+    _upsert_message_blobs(
+        db,
+        task_id=task_id,
+        execution_id=execution_id,
+        blobs_by_hash=blobs_by_hash,
+    )
+
+    encoded_context["messages"] = {
+        "__encoding": MESSAGE_REFS_ENCODING,
+        "count": len(refs),
+        "hash": canonical_json_hash(refs),
+        "refs": refs,
+    }
+
+
+def encode_checkpoint_blob_fields_for_storage(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+) -> Any:
+    """Replace selected checkpoint fields with blob refs."""
+
+    fields_to_encode = _checkpoint_blob_fields_to_encode(data)
+    if not fields_to_encode:
+        return data
+
+    encoded = copy.deepcopy(data)
+    _encode_checkpoint_blob_fields_in_place(
+        db,
+        task_id=task_id,
+        data=encoded,
+        fields_to_encode=fields_to_encode,
+    )
+    return encoded
+
+
+def _checkpoint_blob_fields_to_encode(
+    data: Any,
+) -> list[tuple[CheckpointBlobField, Any]]:
+    if not _is_readable_checkpoint_data(data):
+        return []
+
+    fields_to_encode: list[tuple[CheckpointBlobField, Any]] = []
+    for field in CHECKPOINT_BLOB_FIELDS:
+        payload = _get_nested(data, field.path)
+        if _should_store_checkpoint_blob_payload(payload):
+            fields_to_encode.append((field, payload))
+    return fields_to_encode
+
+
+def _checkpoint_execution_id(data: dict[str, Any]) -> str:
+    return str(
+        data.get("root_execution_id")
+        or data.get("execution_id")
+        or _get_nested(data, ("snapshot", "execution_id"))
+        or ""
+    )
+
+
+def _encode_checkpoint_blob_fields_in_place(
+    db: Session,
+    *,
+    task_id: int,
+    data: dict[str, Any],
+    fields_to_encode: list[tuple[CheckpointBlobField, Any]],
+) -> None:
+    execution_id = _checkpoint_execution_id(data)
+
+    blobs_by_ref: dict[tuple[str, str], BlobCandidate] = {}
+    refs_by_field: dict[CheckpointBlobField, str] = {}
+    for field, payload in fields_to_encode:
+        blob_payload = canonical_json_bytes(payload)
+        blob_hash = canonical_json_hash_from_bytes(blob_payload)
+        _remember_blob_candidate(
+            blobs_by_ref,
+            blob_hash=(field.kind, blob_hash),
+            data=payload,
+            payload_bytes=len(blob_payload),
+            collision_message=(
+                f"trace checkpoint blob hash collision for task {task_id}: "
+                f"{field.kind} {blob_hash}"
+            ),
+        )
+        refs_by_field[field] = blob_hash
+
+    _upsert_checkpoint_blobs(
+        db,
+        task_id=task_id,
+        execution_id=execution_id,
+        blobs_by_ref=blobs_by_ref,
+    )
+
+    for field, _payload in fields_to_encode:
+        blob_hash = refs_by_field[field]
+        _set_nested(
+            data,
+            field.path,
+            {
+                "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+                "kind": field.kind,
+                "hash": blob_hash,
+            },
+        )
+
+
+def decode_trace_event_data(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+    strict: bool = False,
+    verify_blob_hashes: bool = True,
+) -> Any:
+    """Decode checkpoint message refs inside trace event data.
+
+    Non-checkpoint data and old inline-list checkpoints pass through unchanged.
+    With ``strict=False``, decode failures preserve the stored refs and attach a
+    decode error marker for debug/raw API callers.
+    """
+
+    try:
+        return _decode_trace_event_data(
+            db,
+            task_id=task_id,
+            data=data,
+            lookup=None,
+            verify_blob_hashes=verify_blob_hashes,
+        )
+    except CheckpointMessageDecodeError as exc:
+        if strict:
+            raise
+        if not isinstance(data, dict):
+            return data
+        fallback = copy.deepcopy(data)
+        fallback[MESSAGE_REFS_DECODE_ERROR_KEY] = str(exc)
+        return fallback
+
+
+def decode_trace_events_data(
+    db: Session,
+    *,
+    task_id: int,
+    data_items: list[Any],
+    strict: bool = False,
+    verify_blob_hashes: bool | None = None,
+) -> list[Any]:
+    """Decode checkpoint refs for many trace event payloads with bulk blob loads."""
+
+    if verify_blob_hashes is None:
+        verify_blob_hashes = strict
+
+    lookup = _load_trace_blob_lookup(db, task_id=task_id, data_items=data_items)
+    decoded_items: list[Any] = []
+    for data in data_items:
+        try:
+            decoded_items.append(
+                _decode_trace_event_data(
+                    db,
+                    task_id=task_id,
+                    data=data,
+                    lookup=lookup,
+                    verify_blob_hashes=verify_blob_hashes,
+                )
+            )
+        except CheckpointMessageDecodeError as exc:
+            if strict:
+                raise
+            if not isinstance(data, dict):
+                decoded_items.append(data)
+                continue
+            fallback = copy.deepcopy(data)
+            fallback[MESSAGE_REFS_DECODE_ERROR_KEY] = str(exc)
+            decoded_items.append(fallback)
+    return decoded_items
+
+
+def _decode_trace_event_data(
+    db: Session,
+    *,
+    task_id: int,
+    data: Any,
+    lookup: TraceBlobLookup | None,
+    verify_blob_hashes: bool,
+) -> Any:
+    decoded = data
+
+    messages_payload = _get_checkpoint_messages_payload(data)
+    if isinstance(messages_payload, list):
+        pass
+    elif (
+        isinstance(messages_payload, dict)
+        and messages_payload.get("__encoding") == MESSAGE_REFS_ENCODING
+        and not _is_message_refs_payload(messages_payload)
+    ):
+        raise CheckpointMessageDecodeError(
+            "checkpoint message refs payload is malformed"
+        )
+    elif _is_message_refs_payload(messages_payload):
+        refs = messages_payload["refs"]
+        expected_count = messages_payload["count"]
+        if expected_count != len(refs):
+            raise CheckpointMessageDecodeError(
+                f"checkpoint message refs count mismatch: expected {expected_count}, got {len(refs)}"
+            )
+
+        expected_sequence_hash = messages_payload["hash"]
+        actual_sequence_hash = canonical_json_hash(refs)
+        if expected_sequence_hash != actual_sequence_hash:
+            raise CheckpointMessageDecodeError(
+                "checkpoint message refs sequence hash mismatch"
+            )
+
+        messages = _load_messages_by_refs(
+            db,
+            task_id=task_id,
+            refs=refs,
+            lookup=lookup,
+            verify_blob_hashes=verify_blob_hashes,
+        )
+        decoded = _ensure_decoded_copy(data, decoded)
+        decoded["snapshot"]["context"]["messages"] = messages
+
+    for field in CHECKPOINT_BLOB_FIELDS:
+        payload = _get_nested(decoded, field.path)
+        if (
+            isinstance(payload, dict)
+            and payload.get("__encoding") == CHECKPOINT_BLOB_REF_ENCODING
+            and not _is_checkpoint_blob_ref_payload(payload)
+        ):
+            raise CheckpointMessageDecodeError(
+                f"checkpoint blob refs payload is malformed for {field.kind}"
+            )
+        if not _is_checkpoint_blob_ref_payload(payload):
+            continue
+        if payload["kind"] != field.kind:
+            raise CheckpointMessageDecodeError(
+                f"checkpoint blob refs kind mismatch: expected {field.kind}, got {payload['kind']}"
+            )
+
+        blob_data = _load_checkpoint_blob_by_ref(
+            db,
+            task_id=task_id,
+            blob_kind=field.kind,
+            blob_hash=payload["hash"],
+            lookup=lookup,
+            verify_blob_hashes=verify_blob_hashes,
+        )
+        decoded = _ensure_decoded_copy(data, decoded)
+        _set_nested(decoded, field.path, blob_data)
+    return decoded
+
+
+def _is_readable_checkpoint_data(data: Any) -> bool:
+    return (
+        isinstance(data, dict)
+        and data.get("checkpoint_type") in READABLE_CHECKPOINT_TYPES
+    )
+
+
+def _checkpoint_storage_field_states(data: Any) -> list[Literal["inline", "refs"]]:
+    states: list[Literal["inline", "refs"]] = []
+    messages_state = get_checkpoint_messages_storage_state(data)
+    if messages_state == "inline":
+        states.append("inline")
+    elif messages_state == "refs":
+        states.append("refs")
+
+    if not _is_readable_checkpoint_data(data):
+        return states
+
+    for field in CHECKPOINT_BLOB_FIELDS:
+        payload = _get_nested(data, field.path)
+        if _is_checkpoint_blob_ref_payload(payload):
+            states.append("refs")
+        elif _should_store_checkpoint_blob_payload(payload):
+            states.append("inline")
+    return states
+
+
+def _get_checkpoint_messages_payload(data: Any) -> Any:
+    if not _is_readable_checkpoint_data(data):
+        return None
+
+    snapshot = data.get("snapshot")
+    if not isinstance(snapshot, dict):
+        return None
+    context = snapshot.get("context")
+    if not isinstance(context, dict):
+        return None
+    return context.get("messages")
+
+
+def _get_nested(data: Any, path: tuple[str, ...]) -> Any:
+    current = data
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _set_nested(data: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    current: dict[str, Any] = data
+    for key in path[:-1]:
+        child = current.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            current[key] = child
+        current = child
+    current[path[-1]] = value
+
+
+def _is_message_refs_payload(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("__encoding") != MESSAGE_REFS_ENCODING:
+        return False
+    return (
+        isinstance(value.get("refs"), list)
+        and isinstance(value.get("count"), int)
+        and isinstance(value.get("hash"), str)
+    )
+
+
+def _is_checkpoint_blob_ref_payload(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("__encoding") != CHECKPOINT_BLOB_REF_ENCODING:
+        return False
+    return isinstance(value.get("kind"), str) and isinstance(value.get("hash"), str)
+
+
+def _should_store_checkpoint_blob_payload(value: Any) -> bool:
+    if _is_checkpoint_blob_ref_payload(value):
+        return False
+    return isinstance(value, dict) and bool(value)
+
+
+def _ensure_decoded_copy(original: Any, current: Any) -> Any:
+    if current is original:
+        return copy.deepcopy(original)
+    return current
+
+
+def _chunks(values: list[Any], size: int) -> Iterator[list[Any]]:
+    for index in range(0, len(values), size):
+        yield values[index : index + size]
+
+
+def _sql_in_clause_chunk_size(
+    db: Session,
+    *,
+    reserved_binds: int,
+) -> int:
+    bind = db.get_bind()
+    if bind is None or bind.dialect.name != "sqlite":
+        return SQL_IN_CLAUSE_CHUNK_SIZE
+
+    try:
+        import sqlite3
+
+        raw_connection = db.connection().connection
+        driver_connection = (
+            getattr(raw_connection, "driver_connection", None)
+            or getattr(raw_connection, "connection", None)
+            or raw_connection
+        )
+        limit = int(driver_connection.getlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER))
+    except Exception:
+        return SQL_IN_CLAUSE_CHUNK_SIZE
+
+    return max(1, min(SQL_IN_CLAUSE_CHUNK_SIZE, limit - reserved_binds))
+
+
+def _load_trace_blob_lookup(
+    db: Session,
+    *,
+    task_id: int,
+    data_items: list[Any],
+) -> TraceBlobLookup:
+    message_refs: set[str] = set()
+    checkpoint_refs: set[tuple[str, str]] = set()
+
+    for data in data_items:
+        item_message_refs, item_checkpoint_refs = _collect_trace_blob_refs(data)
+        message_refs.update(item_message_refs)
+        checkpoint_refs.update(item_checkpoint_refs)
+
+    message_data_by_hash: dict[str, Any] = {}
+    if message_refs:
+        chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
+        for refs_chunk in _chunks(sorted(message_refs), chunk_size):
+            rows = (
+                db.query(TraceMessageBlob)
+                .filter(
+                    TraceMessageBlob.task_id == task_id,
+                    TraceMessageBlob.message_hash.in_(refs_chunk),
+                )
+                .all()
+            )
+            message_data_by_hash.update(
+                {str(row.message_hash): row.message_data for row in rows}
+            )
+
+    checkpoint_data_by_ref: dict[tuple[str, str], Any] = {}
+    if checkpoint_refs:
+        refs_by_kind: dict[str, set[str]] = {}
+        for kind, blob_hash in checkpoint_refs:
+            refs_by_kind.setdefault(kind, set()).add(blob_hash)
+
+        for kind, blob_hashes in refs_by_kind.items():
+            chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=2)
+            for hash_chunk in _chunks(sorted(blob_hashes), chunk_size):
+                rows = (
+                    db.query(TraceCheckpointBlob)
+                    .filter(
+                        TraceCheckpointBlob.task_id == task_id,
+                        TraceCheckpointBlob.blob_kind == kind,
+                        TraceCheckpointBlob.blob_hash.in_(hash_chunk),
+                    )
+                    .all()
+                )
+                checkpoint_data_by_ref.update(
+                    {
+                        (str(row.blob_kind), str(row.blob_hash)): row.blob_data
+                        for row in rows
+                    }
+                )
+    return TraceBlobLookup(
+        message_data_by_hash=message_data_by_hash,
+        checkpoint_data_by_ref=checkpoint_data_by_ref,
+    )
+
+
+def _collect_trace_blob_refs(data: Any) -> tuple[set[str], set[tuple[str, str]]]:
+    message_refs: set[str] = set()
+    checkpoint_refs: set[tuple[str, str]] = set()
+
+    messages_payload = _get_checkpoint_messages_payload(data)
+    if _is_message_refs_payload(messages_payload):
+        message_refs.update(
+            ref for ref in messages_payload["refs"] if isinstance(ref, str)
+        )
+
+    for field in CHECKPOINT_BLOB_FIELDS:
+        payload = _get_nested(data, field.path)
+        if not _is_checkpoint_blob_ref_payload(payload):
+            continue
+        if payload["kind"] != field.kind:
+            continue
+        blob_hash = payload["hash"]
+        if isinstance(blob_hash, str):
+            checkpoint_refs.add((field.kind, blob_hash))
+
+    return message_refs, checkpoint_refs
+
+
+def _load_messages_by_refs(
+    db: Session,
+    *,
+    task_id: int,
+    refs: list[str],
+    lookup: TraceBlobLookup | None,
+    verify_blob_hashes: bool,
+) -> list[Any]:
+    if not refs:
+        return []
+    if any(not isinstance(ref, str) for ref in refs):
+        raise CheckpointMessageDecodeError(
+            "checkpoint message refs contain non-string hash"
+        )
+
+    unique_refs = sorted(set(refs))
+    if lookup is None:
+        by_hash: dict[str, Any] = {}
+        chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
+        for refs_chunk in _chunks(unique_refs, chunk_size):
+            rows = (
+                db.query(TraceMessageBlob)
+                .filter(
+                    TraceMessageBlob.task_id == task_id,
+                    TraceMessageBlob.message_hash.in_(refs_chunk),
+                )
+                .all()
+            )
+            by_hash.update({str(row.message_hash): row.message_data for row in rows})
+    else:
+        by_hash = lookup.message_data_by_hash
+
+    missing = [ref for ref in unique_refs if ref not in by_hash]
+    if missing:
+        raise CheckpointMessageDecodeError(
+            f"checkpoint message blobs missing for {len(missing)} refs"
+        )
+
+    messages: list[Any] = []
+    for ref in refs:
+        message = by_hash[ref]
+        if verify_blob_hashes and canonical_json_hash(message) != ref:
+            raise CheckpointMessageDecodeError("checkpoint message blob hash mismatch")
+        messages.append(copy.deepcopy(message))
+    return messages
+
+
+def _load_checkpoint_blob_by_ref(
+    db: Session,
+    *,
+    task_id: int,
+    blob_kind: str,
+    blob_hash: str,
+    lookup: TraceBlobLookup | None,
+    verify_blob_hashes: bool,
+) -> Any:
+    if lookup is None:
+        row = (
+            db.query(TraceCheckpointBlob)
+            .filter(
+                TraceCheckpointBlob.task_id == task_id,
+                TraceCheckpointBlob.blob_kind == blob_kind,
+                TraceCheckpointBlob.blob_hash == blob_hash,
+            )
+            .first()
+        )
+        blob_data = row.blob_data if row is not None else None
+    else:
+        blob_data = lookup.checkpoint_data_by_ref.get((blob_kind, blob_hash))
+
+    if blob_data is None:
+        raise CheckpointMessageDecodeError(
+            f"checkpoint blob missing for kind {blob_kind}: {blob_hash}"
+        )
+    if verify_blob_hashes and canonical_json_hash(blob_data) != blob_hash:
+        raise CheckpointMessageDecodeError("checkpoint blob hash mismatch")
+    return copy.deepcopy(blob_data)
+
+
+def _remember_blob_candidate(
+    candidates: dict[Any, BlobCandidate],
+    *,
+    blob_hash: Any,
+    data: Any,
+    payload_bytes: int,
+    collision_message: str,
+) -> None:
+    existing = candidates.get(blob_hash)
+    if existing is not None:
+        if existing.payload_bytes != payload_bytes or existing.data != data:
+            raise ValueError(collision_message)
+        return
+    candidates[blob_hash] = BlobCandidate(data=data, payload_bytes=payload_bytes)
+
+
+def _pending_message_hashes(
+    db: Session,
+    *,
+    task_id: int,
+    blobs_by_hash: dict[str, BlobCandidate],
+) -> set[str]:
+    pending_hashes: set[str] = set()
+    for pending in db.new:
+        if not isinstance(pending, TraceMessageBlob):
+            continue
+        if pending.task_id != task_id:
+            continue
+        message_hash = str(pending.message_hash)
+        candidate = blobs_by_hash.get(message_hash)
+        if candidate is None:
+            continue
+        pending_hashes.add(message_hash)
+        if (
+            pending.message_bytes != candidate.payload_bytes
+            or pending.message_data != candidate.data
+        ):
+            raise ValueError(
+                f"trace message blob hash collision for task {task_id}: {message_hash}"
+            )
+    return pending_hashes
+
+
+def _upsert_message_blobs(
+    db: Session,
+    *,
+    task_id: int,
+    execution_id: str,
+    blobs_by_hash: dict[str, BlobCandidate],
+) -> None:
+    if not blobs_by_hash:
+        return
+
+    pending_hashes = _pending_message_hashes(
+        db,
+        task_id=task_id,
+        blobs_by_hash=blobs_by_hash,
+    )
+    hashes_to_query = sorted(set(blobs_by_hash) - pending_hashes)
+    existing_hashes: set[str] = set()
+    chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=1)
+    for hashes_chunk in _chunks(hashes_to_query, chunk_size):
+        rows = (
+            db.query(TraceMessageBlob.message_hash, TraceMessageBlob.message_bytes)
+            .filter(
+                TraceMessageBlob.task_id == task_id,
+                TraceMessageBlob.message_hash.in_(hashes_chunk),
+            )
+            .all()
+        )
+        for message_hash, message_bytes in rows:
+            message_hash = str(message_hash)
+            candidate = blobs_by_hash[message_hash]
+            if message_bytes != candidate.payload_bytes:
+                raise ValueError(
+                    f"trace message blob hash collision for task {task_id}: "
+                    f"{message_hash}"
+                )
+            existing_hashes.add(message_hash)
+
+    for message_hash, candidate in blobs_by_hash.items():
+        if message_hash in pending_hashes or message_hash in existing_hashes:
+            continue
+        db.add(
+            TraceMessageBlob(
+                task_id=task_id,
+                execution_id=execution_id,
+                message_hash=message_hash,
+                message_data=copy.deepcopy(candidate.data),
+                message_bytes=candidate.payload_bytes,
+            )
+        )
+
+
+def _pending_checkpoint_blob_refs(
+    db: Session,
+    *,
+    task_id: int,
+    blobs_by_ref: dict[tuple[str, str], BlobCandidate],
+) -> set[tuple[str, str]]:
+    pending_refs: set[tuple[str, str]] = set()
+    for pending in db.new:
+        if not isinstance(pending, TraceCheckpointBlob):
+            continue
+        if pending.task_id != task_id:
+            continue
+        blob_ref = (str(pending.blob_kind), str(pending.blob_hash))
+        candidate = blobs_by_ref.get(blob_ref)
+        if candidate is None:
+            continue
+        pending_refs.add(blob_ref)
+        if (
+            pending.blob_bytes != candidate.payload_bytes
+            or pending.blob_data != candidate.data
+        ):
+            raise ValueError(
+                f"trace checkpoint blob hash collision for task {task_id}: "
+                f"{blob_ref[0]} {blob_ref[1]}"
+            )
+    return pending_refs
+
+
+def _upsert_checkpoint_blobs(
+    db: Session,
+    *,
+    task_id: int,
+    execution_id: str,
+    blobs_by_ref: dict[tuple[str, str], BlobCandidate],
+) -> None:
+    if not blobs_by_ref:
+        return
+
+    pending_refs = _pending_checkpoint_blob_refs(
+        db,
+        task_id=task_id,
+        blobs_by_ref=blobs_by_ref,
+    )
+    refs_to_query = sorted(set(blobs_by_ref) - pending_refs)
+    existing_refs: set[tuple[str, str]] = set()
+    if refs_to_query:
+        refs_by_kind: dict[str, set[str]] = {}
+        for kind, blob_hash in refs_to_query:
+            refs_by_kind.setdefault(kind, set()).add(blob_hash)
+
+        for kind, blob_hashes in refs_by_kind.items():
+            chunk_size = _sql_in_clause_chunk_size(db, reserved_binds=2)
+            for hash_chunk in _chunks(sorted(blob_hashes), chunk_size):
+                rows = (
+                    db.query(
+                        TraceCheckpointBlob.blob_kind,
+                        TraceCheckpointBlob.blob_hash,
+                        TraceCheckpointBlob.blob_bytes,
+                    )
+                    .filter(
+                        TraceCheckpointBlob.task_id == task_id,
+                        TraceCheckpointBlob.blob_kind == kind,
+                        TraceCheckpointBlob.blob_hash.in_(hash_chunk),
+                    )
+                    .all()
+                )
+                for blob_kind, blob_hash, blob_bytes in rows:
+                    blob_ref = (str(blob_kind), str(blob_hash))
+                    candidate = blobs_by_ref.get(blob_ref)
+                    if candidate is None:
+                        continue
+                    if blob_bytes != candidate.payload_bytes:
+                        raise ValueError(
+                            f"trace checkpoint blob hash collision for task {task_id}: "
+                            f"{blob_ref[0]} {blob_ref[1]}"
+                        )
+                    existing_refs.add(blob_ref)
+
+    for blob_ref, candidate in blobs_by_ref.items():
+        if blob_ref in pending_refs or blob_ref in existing_refs:
+            continue
+        blob_kind, blob_hash = blob_ref
+        db.add(
+            TraceCheckpointBlob(
+                task_id=task_id,
+                execution_id=execution_id,
+                blob_kind=blob_kind,
+                blob_hash=blob_hash,
+                blob_data=copy.deepcopy(candidate.data),
+                blob_bytes=candidate.payload_bytes,
+            )
+        )

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -1,0 +1,882 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from scripts.convert_trace_checkpoint_messages import convert_trace_checkpoint_messages
+from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
+from xagent.core.agent.trace import TraceEvent
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
+from xagent.web.models.database import Base
+from xagent.web.models.task import (
+    Task,
+    TaskStatus,
+    TraceCheckpointBlob,
+)
+from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.task import (
+    TraceMessageBlob,
+)
+from xagent.web.models.user import User
+from xagent.web.services.trace_message_storage import (
+    CHECKPOINT_BLOB_REF_ENCODING,
+    MESSAGE_REFS_DECODE_ERROR_KEY,
+    MESSAGE_REFS_ENCODING,
+    CheckpointMessageDecodeError,
+    canonical_json_hash,
+    decode_trace_event_data,
+    decode_trace_events_data,
+    encode_checkpoint_data_for_storage,
+    encode_checkpoint_messages_for_storage,
+)
+
+
+def _session_factory() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _sqlite_driver_connection(db: Session) -> sqlite3.Connection:
+    raw_connection = db.connection().connection
+    return (
+        getattr(raw_connection, "driver_connection", None)
+        or getattr(raw_connection, "connection", None)
+        or raw_connection
+    )
+
+
+def _create_task(db: Session) -> Task:
+    user = User(username="tester", password_hash="hashed_password", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    task = Task(
+        user_id=int(user.id),
+        title="Checkpoint task",
+        description="Checkpoint task",
+        status=TaskStatus.PENDING,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _checkpoint_data(execution_id: str, messages: Any) -> dict[str, Any]:
+    return {
+        "checkpoint_type": CHECKPOINT_TYPE,
+        "root_execution_id": execution_id,
+        "execution_id": execution_id,
+        "label": "after_llm",
+        "snapshot": {
+            "type": "checkpoint",
+            "label": "after_llm",
+            "execution_id": execution_id,
+            "context": {"messages": messages},
+            "pattern": "ReActPattern",
+            "pattern_state": {"current_iteration": 1},
+        },
+    }
+
+
+def _checkpoint_data_with_large_fields(
+    execution_id: str,
+    messages: Any,
+    *,
+    tool_ledger: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data = _checkpoint_data(execution_id, messages)
+    data["snapshot"]["pattern_state"]["tool_ledger"] = tool_ledger or {
+        "tool-1": {"result": "large tool output"}
+    }
+    data["snapshot"]["context"]["metadata"] = metadata or {
+        "retrieved_memories": {"react_memory": "large memory context"}
+    }
+    return data
+
+
+def _get_db_factory(SessionLocal: sessionmaker[Session]) -> Iterator[Session]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_message_refs_codec_round_trips_and_dedupes_blobs() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "hello"},
+        ]
+
+        encoded = encode_checkpoint_messages_for_storage(
+            db,
+            task_id=int(task.id),
+            data=_checkpoint_data("exec-1", messages),
+        )
+        db.flush()
+
+        refs_payload = encoded["snapshot"]["context"]["messages"]
+        assert refs_payload["__encoding"] == MESSAGE_REFS_ENCODING
+        assert refs_payload["count"] == 3
+        assert refs_payload["hash"] == canonical_json_hash(refs_payload["refs"])
+        assert len(refs_payload["refs"]) == 3
+        assert db.query(TraceMessageBlob).count() == 2
+
+        decoded = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=encoded,
+            strict=True,
+        )
+        assert decoded["snapshot"]["context"]["messages"] == messages
+    finally:
+        db.close()
+
+
+def test_message_refs_decoder_passes_old_inline_messages_through() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        data = _checkpoint_data("exec-old", [{"role": "user", "content": "old"}])
+
+        decoded = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=data,
+            strict=True,
+        )
+
+        assert decoded == data
+    finally:
+        db.close()
+
+
+def test_message_refs_decoder_rejects_missing_blob() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        data = _checkpoint_data(
+            "exec-missing",
+            {
+                "__encoding": MESSAGE_REFS_ENCODING,
+                "count": 1,
+                "hash": canonical_json_hash(["sha256:missing"]),
+                "refs": ["sha256:missing"],
+            },
+        )
+
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_event_data(db, task_id=int(task.id), data=data, strict=True)
+
+        fallback = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=data,
+            strict=False,
+        )
+        assert MESSAGE_REFS_DECODE_ERROR_KEY in fallback
+    finally:
+        db.close()
+
+
+def test_message_refs_decoder_rejects_malformed_refs_payload() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        data = _checkpoint_data(
+            "exec-malformed",
+            {
+                "__encoding": MESSAGE_REFS_ENCODING,
+                "count": "1",
+                "refs": ["sha256:missing"],
+            },
+        )
+
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_event_data(db, task_id=int(task.id), data=data, strict=True)
+    finally:
+        db.close()
+
+
+def test_message_refs_decoder_rejects_count_and_sequence_mismatch() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        count_mismatch = _checkpoint_data(
+            "exec-bad-count",
+            {
+                "__encoding": MESSAGE_REFS_ENCODING,
+                "count": 2,
+                "hash": canonical_json_hash(["sha256:missing"]),
+                "refs": ["sha256:missing"],
+            },
+        )
+        sequence_mismatch = _checkpoint_data(
+            "exec-bad-sequence",
+            {
+                "__encoding": MESSAGE_REFS_ENCODING,
+                "count": 1,
+                "hash": canonical_json_hash(["sha256:different"]),
+                "refs": ["sha256:missing"],
+            },
+        )
+
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_event_data(
+                db,
+                task_id=int(task.id),
+                data=count_mismatch,
+                strict=True,
+            )
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_event_data(
+                db,
+                task_id=int(task.id),
+                data=sequence_mismatch,
+                strict=True,
+            )
+    finally:
+        db.close()
+
+
+def test_checkpoint_blob_refs_round_trip_and_dedupe() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        messages = [{"role": "user", "content": "hello"}]
+        tool_ledger = {"call-1": {"result": "same output"}}
+        metadata = {"retrieved_memories": {"react_memory": "same memory"}}
+        data = _checkpoint_data_with_large_fields(
+            "exec-fields",
+            messages,
+            tool_ledger=tool_ledger,
+            metadata=metadata,
+        )
+
+        encoded = encode_checkpoint_data_for_storage(
+            db,
+            task_id=int(task.id),
+            data=data,
+        )
+        db.flush()
+
+        stored_messages = encoded["snapshot"]["context"]["messages"]
+        stored_tool_ledger = encoded["snapshot"]["pattern_state"]["tool_ledger"]
+        stored_metadata = encoded["snapshot"]["context"]["metadata"]
+        assert stored_messages["__encoding"] == MESSAGE_REFS_ENCODING
+        assert stored_tool_ledger == {
+            "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+            "kind": "pattern_state.tool_ledger",
+            "hash": canonical_json_hash(tool_ledger),
+        }
+        assert stored_metadata == {
+            "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+            "kind": "context.metadata",
+            "hash": canonical_json_hash(metadata),
+        }
+        assert db.query(TraceMessageBlob).count() == 1
+        assert db.query(TraceCheckpointBlob).count() == 2
+
+        encoded_again = encode_checkpoint_data_for_storage(
+            db,
+            task_id=int(task.id),
+            data=data,
+        )
+        db.flush()
+        assert (
+            encoded_again["snapshot"]["pattern_state"]["tool_ledger"]
+            == stored_tool_ledger
+        )
+        assert db.query(TraceCheckpointBlob).count() == 2
+
+        decoded = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=encoded,
+            strict=True,
+        )
+        assert decoded["snapshot"]["context"]["messages"] == messages
+        assert decoded["snapshot"]["pattern_state"]["tool_ledger"] == tool_ledger
+        assert decoded["snapshot"]["context"]["metadata"] == metadata
+    finally:
+        db.close()
+
+
+def test_decode_trace_events_data_batches_blob_queries() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        first_messages = [{"role": "user", "content": "hello"}]
+        second_messages = [
+            *first_messages,
+            {"role": "assistant", "content": "hi"},
+        ]
+        shared_tool_ledger = {"call-1": {"result": "same output"}}
+        first = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields(
+                "exec-batch",
+                first_messages,
+                tool_ledger=shared_tool_ledger,
+            ),
+        )
+        second = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields(
+                "exec-batch",
+                second_messages,
+                tool_ledger=shared_tool_ledger,
+            ),
+        )
+        db.flush()
+
+        statements: list[str] = []
+        engine = SessionLocal.kw["bind"]
+
+        def capture_statement(
+            conn: Any,
+            cursor: Any,
+            statement: str,
+            parameters: Any,
+            context: Any,
+            executemany: bool,
+        ) -> None:
+            if (
+                "trace_message_blobs" in statement
+                or "trace_checkpoint_blobs" in statement
+            ):
+                statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", capture_statement)
+        try:
+            decoded = decode_trace_events_data(
+                db,
+                task_id=task_id,
+                data_items=[first, second],
+                strict=True,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_statement)
+
+        assert decoded[0]["snapshot"]["context"]["messages"] == first_messages
+        assert decoded[1]["snapshot"]["context"]["messages"] == second_messages
+        assert len(statements) == 3
+    finally:
+        db.close()
+
+
+def test_blob_lookups_respect_sqlite_bind_parameter_limit() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    raw_connection = _sqlite_driver_connection(db)
+    previous_limit = raw_connection.setlimit(
+        sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER,
+        50,
+    )
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        big_messages = [
+            {"role": "user", "content": f"large-history-{index}"} for index in range(60)
+        ]
+        big_checkpoint = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields(
+                "exec-limit-big",
+                big_messages,
+                metadata={"memory": "big"},
+            ),
+        )
+
+        checkpoints = [big_checkpoint]
+        for index in range(60):
+            checkpoints.append(
+                encode_checkpoint_data_for_storage(
+                    db,
+                    task_id=task_id,
+                    data=_checkpoint_data_with_large_fields(
+                        f"exec-limit-{index}",
+                        [{"role": "user", "content": f"small-history-{index}"}],
+                        tool_ledger={f"tool-{index}": {"result": f"value-{index}"}},
+                        metadata={"memory": f"value-{index}"},
+                    ),
+                )
+            )
+        db.flush()
+
+        decoded = decode_trace_events_data(
+            db,
+            task_id=task_id,
+            data_items=checkpoints,
+            strict=True,
+        )
+        assert decoded[0]["snapshot"]["context"]["messages"] == big_messages
+
+        single_decoded = decode_trace_event_data(
+            db,
+            task_id=task_id,
+            data=big_checkpoint,
+            strict=True,
+        )
+        assert single_decoded["snapshot"]["context"]["messages"] == big_messages
+    finally:
+        raw_connection.setlimit(
+            sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER,
+            previous_limit,
+        )
+        db.close()
+
+
+def test_bulk_decode_can_skip_blob_hash_verification() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        messages = [{"role": "user", "content": "original"}]
+        encoded = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data("exec-tampered", messages),
+        )
+        db.flush()
+
+        message_ref = encoded["snapshot"]["context"]["messages"]["refs"][0]
+        blob = (
+            db.query(TraceMessageBlob)
+            .filter(
+                TraceMessageBlob.task_id == task_id,
+                TraceMessageBlob.message_hash == message_ref,
+            )
+            .one()
+        )
+        blob.message_data = {"role": "user", "content": "tampered"}
+        db.flush()
+
+        decoded = decode_trace_events_data(
+            db,
+            task_id=task_id,
+            data_items=[encoded],
+            strict=False,
+        )
+        assert decoded[0]["snapshot"]["context"]["messages"] == [
+            {"role": "user", "content": "tampered"}
+        ]
+
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_events_data(
+                db,
+                task_id=task_id,
+                data_items=[encoded],
+                strict=True,
+            )
+    finally:
+        db.close()
+
+
+def test_checkpoint_blob_refs_decoder_passes_old_inline_fields_through() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        data = _checkpoint_data_with_large_fields(
+            "exec-old-fields",
+            [{"role": "user", "content": "old"}],
+        )
+
+        decoded = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=data,
+            strict=True,
+        )
+
+        assert decoded == data
+    finally:
+        db.close()
+
+
+def test_checkpoint_blob_refs_decoder_rejects_missing_blob() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        data = _checkpoint_data(
+            "exec-missing-field", [{"role": "user", "content": "x"}]
+        )
+        data["snapshot"]["pattern_state"]["tool_ledger"] = {
+            "__encoding": CHECKPOINT_BLOB_REF_ENCODING,
+            "kind": "pattern_state.tool_ledger",
+            "hash": "sha256:missing",
+        }
+
+        with pytest.raises(CheckpointMessageDecodeError):
+            decode_trace_event_data(db, task_id=int(task.id), data=data, strict=True)
+
+        fallback = decode_trace_event_data(
+            db,
+            task_id=int(task.id),
+            data=data,
+            strict=False,
+        )
+        assert MESSAGE_REFS_DECODE_ERROR_KEY in fallback
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_stores_checkpoint_messages_as_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        handler = DatabaseTraceHandler(task_id)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "working"},
+        ]
+        event = TraceEvent(
+            CHECKPOINT_EVENT_TYPE,
+            task_id=str(task_id),
+            data=_checkpoint_data_with_large_fields("exec-handler", messages),
+            require_persisted=True,
+        )
+
+        handler._save_trace_event(db, event)
+
+        row = db.query(DatabaseTraceEvent).filter_by(task_id=task_id).one()
+        stored_messages = row.data["snapshot"]["context"]["messages"]
+        stored_tool_ledger = row.data["snapshot"]["pattern_state"]["tool_ledger"]
+        assert stored_messages["__encoding"] == MESSAGE_REFS_ENCODING
+        assert stored_tool_ledger["__encoding"] == CHECKPOINT_BLOB_REF_ENCODING
+        assert db.query(TraceMessageBlob).count() == 2
+        assert db.query(TraceCheckpointBlob).count() == 2
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        loaded = handler._sync_load_latest_checkpoint("exec-handler")
+        assert loaded is not None
+        assert loaded["context"]["messages"] == messages
+        assert loaded["pattern_state"]["tool_ledger"] == {
+            "tool-1": {"result": "large tool output"}
+        }
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_shares_blobs_across_checkpoints() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        handler = DatabaseTraceHandler(task_id)
+        first = [{"role": "user", "content": "task"}]
+        second = [*first, {"role": "assistant", "content": "done"}]
+        shared_tool_ledger = {"tool-1": {"result": "same"}}
+        shared_metadata = {"retrieved_memories": {"react_memory": "same"}}
+
+        handler._save_trace_event(
+            db,
+            TraceEvent(
+                CHECKPOINT_EVENT_TYPE,
+                task_id=str(task_id),
+                data=_checkpoint_data_with_large_fields(
+                    "exec-shared",
+                    first,
+                    tool_ledger=shared_tool_ledger,
+                    metadata=shared_metadata,
+                ),
+            ),
+        )
+        handler._save_trace_event(
+            db,
+            TraceEvent(
+                CHECKPOINT_EVENT_TYPE,
+                task_id=str(task_id),
+                data=_checkpoint_data_with_large_fields(
+                    "exec-shared",
+                    second,
+                    tool_ledger=shared_tool_ledger,
+                    metadata=shared_metadata,
+                ),
+            ),
+        )
+
+        assert db.query(DatabaseTraceEvent).count() == 2
+        assert db.query(TraceMessageBlob).count() == 2
+        assert db.query(TraceCheckpointBlob).count() == 2
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_reads_old_inline_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        messages = [{"role": "user", "content": "old"}]
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="old-inline",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=_checkpoint_data("exec-old-inline", messages),
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+            "exec-old-inline"
+        )
+
+        assert loaded is not None
+        assert loaded["context"]["messages"] == messages
+    finally:
+        db.close()
+
+
+def test_database_trace_handler_falls_back_when_latest_refs_are_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        now = datetime.now(timezone.utc)
+        old_messages = [{"role": "user", "content": "old"}]
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="old-readable",
+                event_type="system_update_general",
+                timestamp=now,
+                data=_checkpoint_data("exec-fallback", old_messages),
+            )
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="new-unreadable",
+                event_type="system_update_general",
+                timestamp=now + timedelta(seconds=1),
+                data=_checkpoint_data(
+                    "exec-fallback",
+                    {
+                        "__encoding": MESSAGE_REFS_ENCODING,
+                        "count": 1,
+                        "hash": canonical_json_hash(["sha256:missing"]),
+                        "refs": ["sha256:missing"],
+                    },
+                ),
+            )
+        )
+        db.commit()
+
+        monkeypatch.setattr(
+            "xagent.web.api.trace_handlers.get_db",
+            lambda: _get_db_factory(SessionLocal),
+        )
+        loaded = DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
+            "exec-fallback"
+        )
+
+        assert loaded is not None
+        assert loaded["context"]["messages"] == old_messages
+    finally:
+        db.close()
+
+
+def test_convert_trace_checkpoint_messages_script_dry_run_and_execute() -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        inline_messages = [{"role": "user", "content": "convert me"}]
+        already_encoded = encode_checkpoint_messages_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data("exec-convert", inline_messages),
+        )
+        mixed_encoded = encode_checkpoint_messages_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields("exec-convert", inline_messages),
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="inline",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=_checkpoint_data("exec-convert", inline_messages),
+            )
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="refs",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=already_encoded,
+            )
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="mixed",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=mixed_encoded,
+            )
+        )
+        db.commit()
+
+        dry_run_stats = convert_trace_checkpoint_messages(
+            db,
+            dry_run=True,
+            batch_size=1,
+        )
+        assert dry_run_stats.converted_rows == 2
+        assert dry_run_stats.already_refs_rows == 1
+        inline_row = db.query(DatabaseTraceEvent).filter_by(event_id="inline").one()
+        assert isinstance(inline_row.data["snapshot"]["context"]["messages"], list)
+        mixed_row = db.query(DatabaseTraceEvent).filter_by(event_id="mixed").one()
+        assert isinstance(
+            mixed_row.data["snapshot"]["pattern_state"]["tool_ledger"], dict
+        )
+        assert (
+            mixed_row.data["snapshot"]["pattern_state"]["tool_ledger"].get("__encoding")
+            != CHECKPOINT_BLOB_REF_ENCODING
+        )
+
+        execute_stats = convert_trace_checkpoint_messages(
+            db,
+            dry_run=False,
+            batch_size=1,
+        )
+        assert execute_stats.converted_rows == 2
+        assert execute_stats.already_refs_rows == 1
+
+        converted_row = db.query(DatabaseTraceEvent).filter_by(event_id="inline").one()
+        stored_messages = converted_row.data["snapshot"]["context"]["messages"]
+        assert stored_messages["__encoding"] == MESSAGE_REFS_ENCODING
+        mixed_row = db.query(DatabaseTraceEvent).filter_by(event_id="mixed").one()
+        assert (
+            mixed_row.data["snapshot"]["pattern_state"]["tool_ledger"]["__encoding"]
+            == CHECKPOINT_BLOB_REF_ENCODING
+        )
+        assert db.query(TraceMessageBlob).count() == 1
+        assert db.query(TraceCheckpointBlob).count() == 2
+
+        repeat_stats = convert_trace_checkpoint_messages(db, dry_run=False)
+        assert repeat_stats.converted_rows == 0
+        assert repeat_stats.already_refs_rows == 3
+    finally:
+        db.close()
+
+
+def test_convert_trace_checkpoint_messages_continues_after_row_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        messages = [{"role": "user", "content": "convert me"}]
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="bad",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=_checkpoint_data("exec-bad", messages),
+            )
+        )
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="good",
+                event_type="system_update_general",
+                timestamp=datetime.now(timezone.utc),
+                data=_checkpoint_data("exec-good", messages),
+            )
+        )
+        db.commit()
+
+        from xagent.web.services import trace_message_storage
+
+        original_encode = trace_message_storage.encode_checkpoint_data_for_storage
+
+        def flaky_encode(db: Session, *, task_id: int, data: Any) -> Any:
+            if data.get("execution_id") == "exec-bad":
+                raise RuntimeError("synthetic conversion failure")
+            return original_encode(db, task_id=task_id, data=data)
+
+        monkeypatch.setattr(
+            trace_message_storage,
+            "encode_checkpoint_data_for_storage",
+            flaky_encode,
+        )
+
+        stats = convert_trace_checkpoint_messages(
+            db,
+            dry_run=False,
+            batch_size=10,
+        )
+
+        assert stats.error_rows == 1
+        assert stats.converted_rows == 1
+        bad_row = db.query(DatabaseTraceEvent).filter_by(event_id="bad").one()
+        assert isinstance(bad_row.data["snapshot"]["context"]["messages"], list)
+        good_row = db.query(DatabaseTraceEvent).filter_by(event_id="good").one()
+        assert (
+            good_row.data["snapshot"]["context"]["messages"]["__encoding"]
+            == MESSAGE_REFS_ENCODING
+        )
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add checkpoint message refs backed by deduplicated message blobs
- add checkpoint field blob refs for large checkpoint payloads while keeping runtime/API responses decoded to the legacy inline shape
- add a converter script plus scripts README for migrating existing trace checkpoint rows
- batch checkpoint blob reads/writes to avoid N+1 query patterns during history decode and checkpoint persistence

## Compatibility
- new code reads old inline checkpoint storage
- external/raw/API consumers still receive decoded checkpoint data
- old code reading the new refs format is intentionally not supported

## Local conversion sample
Using a local SQLite sample after conversion and VACUUM. Numbers are aggregate storage metrics only; no task IDs, paths, or payload contents are included.

Message refs stage:
- DB file size: 9.9G -> 8.0G
- DB bytes: 10,605,129,728 -> 8,591,405,056
- reclaimed: 2,013,724,672 bytes (~1.88 GiB, ~18.99%)
- freelist bytes after VACUUM: 0
- quick_check: ok

Checkpoint field refs stage:
- DB file size: 8.1G -> 5.4G
- DB bytes: 8,724,029,440 -> 5,830,725,632
- reclaimed: 2,893,303,808 bytes (~2.69 GiB, ~33.16% for this stage)
- checkpoint trace JSON: 6486.42 MiB -> 2838.27 MiB
- checkpoint blob payload: 0.03 MiB -> 624.76 MiB
- refs integrity: 0 missing message refs, 0 missing field refs, 0 count/hash mismatches
- freelist bytes after VACUUM: 0
- quick_check: ok

Overall local sample impact:
- DB bytes: 10,605,129,728 -> 5,830,725,632
- reclaimed: 4,774,404,096 bytes (~4.45 GiB, ~45.02%)

## Tests
- PYTHONPATH=src ruff check src/xagent/web/api/chat.py src/xagent/web/api/trace_handlers.py src/xagent/web/models/task.py src/xagent/web/services/trace_message_storage.py scripts/convert_trace_checkpoint_messages.py tests/web/test_trace_message_storage.py
- PYTHONPATH=src alembic heads
- PYTHONPATH=src pytest tests/web/test_trace_message_storage.py tests/web/test_agent_checkpoint_stream.py tests/web/test_task_lease_service.py tests/core/agent/test_checkpoint.py
- PYTHONPATH=src pytest tests/migrations/test_migration_integration.py::TestMigrations::test_sqlite_upgrade
- PYTHONPATH=src python tests/migrations/test_migration_integration.py --db sqlite upgrade
- pre-commit hooks on commit
