### PR TITLE
fix: route inline file card "Open" link through download endpoint

### DIFF
--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -160,18 +160,20 @@ describe('inline-file-preview-utils', () => {
     })
   })
 
-  it('routes managed file ids through the download endpoint for open links', () => {
+  it('routes managed file ids through the public download endpoint for open links', () => {
     // The "Open" affordance must hand the user the source artifact, not
     // the inline-preview payload (which on some deployments is a derived
-    // PDF), so file-id sources resolve to /api/files/download. The
-    // download endpoint also sets ``Content-Disposition: attachment;
-    // filename=...`` which preserves the real filename on save.
+    // PDF), so file-id sources resolve to /api/files/public/download.
+    // The public/* route is required because plain ``<a href>`` clicks
+    // (and middle-click / right-click "open in new tab" / "copy link")
+    // don't carry the bearer token that the auth'd /api/files/download
+    // route requires.
     expect(
       getInlineFileDownloadUrl(
         { fileId: 'slides-file-id', filename: 'slides.pptx' },
         'http://api.local'
       )
-    ).toBe('http://api.local/api/files/download/slides-file-id')
+    ).toBe('http://api.local/api/files/public/download/slides-file-id')
   })
 
   it('falls back to the preview URL for external sources without a file id', () => {
@@ -198,7 +200,7 @@ describe('inline-file-preview-utils', () => {
         },
         'http://api.local'
       )
-    ).toBe('http://api.local/api/files/download/doc-file-id')
+    ).toBe('http://api.local/api/files/public/download/doc-file-id')
   })
 
   it('returns an empty string when no file id or preview URL is available', () => {

--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getInlineFileDownloadUrl,
   getInlineFilePreviewKind,
   getInlineFilePreviewUrl,
   getPreviewUrlTrust,
@@ -157,5 +158,50 @@ describe('inline-file-preview-utils', () => {
       isExternal: true,
       isTrusted: false,
     })
+  })
+
+  it('routes managed file ids through the download endpoint for open links', () => {
+    // The "Open" affordance must hand the user the source artifact, not
+    // the inline-preview payload (which on some deployments is a derived
+    // PDF), so file-id sources resolve to /api/files/download. The
+    // download endpoint also sets ``Content-Disposition: attachment;
+    // filename=...`` which preserves the real filename on save.
+    expect(
+      getInlineFileDownloadUrl(
+        { fileId: 'slides-file-id', filename: 'slides.pptx' },
+        'http://api.local'
+      )
+    ).toBe('http://api.local/api/files/download/slides-file-id')
+  })
+
+  it('falls back to the preview URL for external sources without a file id', () => {
+    // Cross-origin previewUrl sources have no managed download endpoint —
+    // the only sane "Open" target is the previewUrl itself.
+    expect(
+      getInlineFileDownloadUrl(
+        {
+          previewUrl: 'https://cdn.example.com/report.docx',
+          filename: 'report.docx',
+        },
+        'http://api.local'
+      )
+    ).toBe('https://cdn.example.com/report.docx')
+  })
+
+  it('prefers file-id download URLs over external preview URLs', () => {
+    expect(
+      getInlineFileDownloadUrl(
+        {
+          fileId: 'doc-file-id',
+          previewUrl: 'https://cdn.example.com/report.docx',
+          filename: 'report.docx',
+        },
+        'http://api.local'
+      )
+    ).toBe('http://api.local/api/files/download/doc-file-id')
+  })
+
+  it('returns an empty string when no file id or preview URL is available', () => {
+    expect(getInlineFileDownloadUrl({ filename: 'anon.bin' }, 'http://api.local')).toBe('')
   })
 })

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -121,17 +121,28 @@ export const getInlineFilePreviewUrl = (
 // /api/files/public/preview is intended for inline rendering (e.g. the
 // PptxPreviewRenderer feeds raw bytes into pptxviewjs) and on some
 // deployments returns a derived preview payload instead of the source
-// file. Routing the open link through /api/files/download guarantees the
-// original bytes plus a ``Content-Disposition: attachment; filename=...``
-// header, so the browser saves the file under its real name instead of a
-// bare file id. External (cross-origin) sources fall back to the source's
-// previewUrl since there's no managed download endpoint for them.
+// file. Routing the open link through /api/files/public/download
+// guarantees the original bytes plus a ``Content-Disposition:
+// attachment; filename=...`` header, so the browser saves the file
+// under its real name instead of a bare file id.
+//
+// This MUST stay on the public/* route, not /api/files/download. The
+// auth'd download route depends on ``get_current_user`` and the
+// frontend only adds the bearer token through ``apiRequest``, never
+// through plain anchor navigation. Routing ``<a href>`` clicks (and
+// middle-click / right-click "open in new tab" / "copy link") through
+// the auth'd route would 401 every navigation that doesn't pass
+// through a JS click handler — including the no-callback
+// ``InlineFilePreview`` surfaces (widget / standalone markdown).
+//
+// External (cross-origin) sources have no managed download endpoint
+// and fall back to the source's own previewUrl.
 export const getInlineFileDownloadUrl = (
   source: InlineFilePreviewSource,
   apiUrl: string
 ): string => {
   if (source.fileId) {
-    return `${apiUrl}/api/files/download/${encodeURIComponent(source.fileId)}`
+    return `${apiUrl}/api/files/public/download/${encodeURIComponent(source.fileId)}`
   }
   return getInlineFilePreviewUrl(source, apiUrl)
 }

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -117,6 +117,25 @@ export const getInlineFilePreviewUrl = (
   return ''
 }
 
+// The "Open" affordance must hand the user the *original* artifact —
+// /api/files/public/preview is intended for inline rendering (e.g. the
+// PptxPreviewRenderer feeds raw bytes into pptxviewjs) and on some
+// deployments returns a derived preview payload instead of the source
+// file. Routing the open link through /api/files/download guarantees the
+// original bytes plus a ``Content-Disposition: attachment; filename=...``
+// header, so the browser saves the file under its real name instead of a
+// bare file id. External (cross-origin) sources fall back to the source's
+// previewUrl since there's no managed download endpoint for them.
+export const getInlineFileDownloadUrl = (
+  source: InlineFilePreviewSource,
+  apiUrl: string
+): string => {
+  if (source.fileId) {
+    return `${apiUrl}/api/files/download/${encodeURIComponent(source.fileId)}`
+  }
+  return getInlineFilePreviewUrl(source, apiUrl)
+}
+
 export const getPreviewUrlTrust = (
   source: InlineFilePreviewSource,
   apiUrl: string

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -107,7 +107,13 @@ describe('InlineFilePreview', () => {
     expect(handleFileClick).toHaveBeenCalledWith('slides-file-id', 'slides.pptx')
   })
 
-  it('uses the preview URL as the inline preview open link href', () => {
+  it('uses the download URL as the inline preview open link href', () => {
+    // The "Open" link must route through /api/files/download, not
+    // /api/files/public/preview: preview is for inline rendering (and on
+    // some deployments returns a derived payload), while the download
+    // endpoint serves the source bytes with a ``Content-Disposition:
+    // attachment; filename=...`` header so a save lands as the real
+    // filename rather than the bare file id.
     const handleFileClick = vi.fn()
 
     render(
@@ -124,7 +130,7 @@ describe('InlineFilePreview', () => {
     const openLink = screen.getByRole('link', { name: 'Open' })
     expect(openLink).toHaveAttribute(
       'href',
-      'http://api.local/api/files/public/preview/slides-file-id'
+      'http://api.local/api/files/download/slides-file-id'
     )
 
     fireEvent.click(openLink)
@@ -182,7 +188,11 @@ describe('InlineFilePreview', () => {
     expect(screen.queryByText('Localized load failure')).not.toBeInTheDocument()
   })
 
-  it('uses the preview URL as the non-previewable file link href', () => {
+  it('uses the download URL as the non-previewable file link href', () => {
+    // Non-previewable artifacts (zip, etc.) collapse the file card into
+    // a single download link — same reasoning as the inline-preview Open
+    // link: route through /api/files/download so the save filename is
+    // the source name, not the file id.
     const handleFileClick = vi.fn()
 
     render(
@@ -195,7 +205,7 @@ describe('InlineFilePreview', () => {
     const link = screen.getByRole('link', { name: 'archive.zip' })
     expect(link).toHaveAttribute(
       'href',
-      'http://api.local/api/files/public/preview/archive-file-id'
+      'http://api.local/api/files/download/archive-file-id'
     )
 
     fireEvent.click(link)

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -107,13 +107,15 @@ describe('InlineFilePreview', () => {
     expect(handleFileClick).toHaveBeenCalledWith('slides-file-id', 'slides.pptx')
   })
 
-  it('uses the download URL as the inline preview open link href', () => {
-    // The "Open" link must route through /api/files/download, not
+  it('uses the public download URL as the inline preview open link href', () => {
+    // The "Open" link must route through /api/files/public/download, not
     // /api/files/public/preview: preview is for inline rendering (and on
-    // some deployments returns a derived payload), while the download
-    // endpoint serves the source bytes with a ``Content-Disposition:
-    // attachment; filename=...`` header so a save lands as the real
-    // filename rather than the bare file id.
+    // some deployments returns a derived payload), while public/download
+    // serves the source bytes with a ``Content-Disposition: attachment;
+    // filename=...`` header so a save lands as the real filename rather
+    // than the bare file id. The public/* route is required because
+    // plain ``<a href>`` navigation (and middle/right-click open-in-tab
+    // / copy-link) doesn't carry a bearer token.
     const handleFileClick = vi.fn()
 
     render(
@@ -130,7 +132,7 @@ describe('InlineFilePreview', () => {
     const openLink = screen.getByRole('link', { name: 'Open' })
     expect(openLink).toHaveAttribute(
       'href',
-      'http://api.local/api/files/download/slides-file-id'
+      'http://api.local/api/files/public/download/slides-file-id'
     )
 
     fireEvent.click(openLink)
@@ -188,11 +190,12 @@ describe('InlineFilePreview', () => {
     expect(screen.queryByText('Localized load failure')).not.toBeInTheDocument()
   })
 
-  it('uses the download URL as the non-previewable file link href', () => {
+  it('uses the public download URL as the non-previewable file link href', () => {
     // Non-previewable artifacts (zip, etc.) collapse the file card into
     // a single download link — same reasoning as the inline-preview Open
-    // link: route through /api/files/download so the save filename is
-    // the source name, not the file id.
+    // link: route through /api/files/public/download so the save
+    // filename is the source name, not the file id, AND so middle/
+    // right-click open-in-tab / copy-link still works without a token.
     const handleFileClick = vi.fn()
 
     render(
@@ -205,7 +208,7 @@ describe('InlineFilePreview', () => {
     const link = screen.getByRole('link', { name: 'archive.zip' })
     expect(link).toHaveAttribute(
       'href',
-      'http://api.local/api/files/download/archive-file-id'
+      'http://api.local/api/files/public/download/archive-file-id'
     )
 
     fireEvent.click(link)

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -8,6 +8,7 @@ import { apiRequest } from '@/lib/api-wrapper'
 import { cn, getApiUrl } from '@/lib/utils'
 import {
   arrayBufferToBase64,
+  getInlineFileDownloadUrl,
   getInlineFilePreviewKind,
   getInlineFilePreviewUrl,
   getPreviewUrlTrust,
@@ -221,6 +222,7 @@ export function InlineFilePreview({
   const apiUrl = getApiUrl()
   const kind = getInlineFilePreviewKind(source)
   const previewUrl = getInlineFilePreviewUrl(source, apiUrl)
+  const downloadUrl = getInlineFileDownloadUrl(source, apiUrl)
   const previewUrlTrust = getPreviewUrlTrust(source, apiUrl)
   const filename = fileNameFromSource(source)
   const canOpenFilePreview = Boolean(onFileClick && source.fileId)
@@ -260,7 +262,7 @@ export function InlineFilePreview({
   if (!isPreviewableInlineFileKind(kind)) {
     return (
       <a
-        href={previewUrl}
+        href={downloadUrl}
         target={canOpenFilePreview ? undefined : '_blank'}
         rel={canOpenFilePreview ? undefined : 'noreferrer'}
         onClick={canOpenFilePreview ? handleOpenPreview : undefined}
@@ -284,7 +286,7 @@ export function InlineFilePreview({
         <FileText className="h-4 w-4 shrink-0" />
         <span className="min-w-0 flex-1 truncate">{filename}</span>
         <a
-          href={previewUrl}
+          href={downloadUrl}
           target={canOpenFilePreview ? undefined : '_blank'}
           rel={canOpenFilePreview ? undefined : 'noreferrer'}
           onClick={canOpenFilePreview ? handleOpenPreview : undefined}

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -839,6 +839,75 @@ async def preview_file(
     )
 
 
+@file_router.get("/public/download/{file_id:path}", response_model=None)
+async def public_download_file(
+    file_id: str,
+    db: Session = Depends(get_db),
+) -> Any:
+    """Public source-download endpoint for the chat file-card 'Open' link.
+
+    Mirrors ``public_preview_file`` for resolution (UUID file id or
+    legacy cross-user path) but always returns
+    ``Content-Disposition: attachment; filename="..."`` so the browser
+    saves under the source filename instead of trying to render the
+    bytes inline. Used by ``InlineFilePreview`` 'Open' affordances
+    that render as plain ``<a href>``: those clicks — plus middle-
+    click / right-click "open in new tab" / "copy link" — don't carry
+    the frontend's bearer token, so the auth'd
+    ``/api/files/download/{file_id}`` route would 401 every plain
+    browser navigation.
+
+    The ``file_id`` is the only required capability, matching the
+    existing ``public/preview`` contract. ``relative_path`` is
+    intentionally NOT supported: 'Open' always targets the registered
+    source artifact, never a sub-path inside it.
+    """
+    file_record: Optional[UploadedFile] = None
+    target_path: Optional[Path] = None
+    file_name: str
+
+    if is_valid_uuid(file_id):
+        file_record = (
+            db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+        )
+
+    if file_record:
+        file_ref = ManagedFileRef(file_record)
+        owner_user_id = _file_user_id_value(file_record)
+        _ensure_under_uploads(file_ref.local_path, owner_user_id)
+        file_name = str(file_record.filename)
+        if file_ref.has_durable_object:
+            try:
+                target_path = file_ref.ensure_local()
+            except DurableObjectIntegrityError as exc:
+                raise _file_integrity_failed() from exc
+            except DurableStorageOperationError as exc:
+                raise _durable_storage_unavailable() from exc
+            except DurableObjectMissingError:
+                target_path = file_ref.local_path
+        else:
+            target_path = file_ref.local_path
+    else:
+        # Legacy non-UUID file id: resolve across user directories
+        # (same fallback as public_preview_file).
+        result = resolve_legacy_file_path_cross_user(file_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail="File not found")
+        target_path, owner_user_id = result
+        _ensure_under_uploads(target_path, owner_user_id)
+        file_name = target_path.name
+
+    if not target_path.exists() or not target_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(
+        path=str(target_path),
+        filename=file_name,
+        media_type=guess_media_type(file_name),
+        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+    )
+
+
 @file_router.get("/public/preview/{file_id:path}", response_model=None)
 async def public_preview_file(
     file_id: str,

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -900,11 +900,17 @@ async def public_download_file(
     if not target_path.exists() or not target_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")
 
+    # Pass filename= and let Starlette compose the Content-Disposition header.
+    # Starlette 0.36+ generates ``filename*=utf-8''<percent-encoded>`` for
+    # non-ASCII names (e.g. 报告.pptx) via urllib.parse.quote, so we must NOT
+    # set the header manually: a raw ``filename="报告.pptx"`` string would be
+    # latin-1 encoded by the ASGI layer and raise UnicodeEncodeError.
+    # The default content_disposition_type is already "attachment", so we
+    # only need to pass filename= here.
     return FileResponse(
         path=str(target_path),
         filename=file_name,
         media_type=guess_media_type(file_name),
-        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
     )
 
 

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -523,6 +523,89 @@ class TestFileUpload:
         assert preview.status_code == 409
         assert "re-upload" in preview.json()["detail"]
 
+    def test_public_download_serves_source_bytes_without_auth(
+        self, client, temp_uploads_dir, auth_headers
+    ):
+        """Public download must serve the source bytes for plain
+        ``<a href>`` navigation that does NOT carry a bearer token —
+        otherwise the chat file-card 'Open' link, middle-click
+        'open in new tab', and right-click 'copy link' all 401."""
+        upload = client.post(
+            "/api/files/upload",
+            files={"file": ("source.txt", b"source content", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200
+        file_id = upload.json()["file_id"]
+
+        # Deliberately omit ``headers=auth_headers``: the whole point of
+        # the public route is that it works without a token.
+        download = client.get(f"/api/files/public/download/{file_id}")
+
+        assert download.status_code == 200
+        assert download.content == b"source content"
+
+    def test_public_download_sets_attachment_content_disposition(
+        self, client, temp_uploads_dir, auth_headers
+    ):
+        """Public download must send Content-Disposition: attachment
+        with the source filename so the browser saves under the real
+        name (e.g. ``slides.pptx``) instead of the bare file id."""
+        upload = client.post(
+            "/api/files/upload",
+            files={"file": ("slides.pptx", b"slide bytes", "application/octet-stream")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200
+        file_id = upload.json()["file_id"]
+
+        download = client.get(f"/api/files/public/download/{file_id}")
+
+        assert download.status_code == 200
+        disposition = download.headers.get("content-disposition", "")
+        assert disposition.startswith("attachment"), disposition
+        assert 'filename="slides.pptx"' in disposition, disposition
+
+    def test_public_download_returns_404_for_unknown_id(self, client):
+        download = client.get(
+            "/api/files/public/download/00000000-0000-4000-8000-000000000000"
+        )
+        assert download.status_code == 404
+
+    def test_public_download_registered_file_rejects_local_path_outside_uploads(
+        self, client, test_db, tmp_path
+    ):
+        """Public download must not expose registered paths outside the
+        uploads root (mirror of the same guard on public_preview)."""
+        admin_user, test_app = test_db
+        outside_path = tmp_path / "outside-public-download.txt"
+        outside_path.write_text("outside uploads", encoding="utf-8")
+
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            db.add(
+                UploadedFile(
+                    file_id="44444444-4444-4444-8444-444444444444",
+                    user_id=admin_user.id,
+                    filename="outside-public-download.txt",
+                    storage_path=str(outside_path),
+                    storage_status="legacy",
+                    mime_type="text/plain",
+                    file_size=outside_path.stat().st_size,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        response = client.get(
+            "/api/files/public/download/44444444-4444-4444-8444-444444444444"
+        )
+
+        assert response.status_code == 403
+
     def test_upload_python_file_success(
         self, client, test_db, sample_files, temp_uploads_dir, auth_headers
     ):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -568,6 +568,40 @@ class TestFileUpload:
         assert disposition.startswith("attachment"), disposition
         assert 'filename="slides.pptx"' in disposition, disposition
 
+    def test_public_download_sets_rfc5987_content_disposition_for_non_ascii_filenames(
+        self, client, temp_uploads_dir, auth_headers
+    ):
+        """Non-ASCII filenames (e.g. Chinese) must be percent-encoded as
+        ``filename*=utf-8''<encoded>`` in the Content-Disposition header.
+        A manually composed ``filename="报告.pptx"`` would be encoded as
+        latin-1 by the ASGI layer, raising UnicodeEncodeError.  Delegating
+        header generation to Starlette's FileResponse avoids this."""
+        upload = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "报告.pptx",
+                    b"slide bytes",
+                    "application/octet-stream",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload.status_code == 200, upload.json()
+        file_id = upload.json()["file_id"]
+
+        download = client.get(f"/api/files/public/download/{file_id}")
+
+        assert download.status_code == 200, download.text
+        disposition = download.headers.get("content-disposition", "")
+        assert disposition.startswith("attachment"), disposition
+        # Starlette percent-encodes non-ASCII names with the RFC 5987
+        # ``filename*=utf-8''<encoded>`` form.  The raw multi-byte string
+        # must NOT appear literally in the header value.
+        assert "filename*=" in disposition, disposition
+        assert "报告" not in disposition, disposition  # '报告'
+
     def test_public_download_returns_404_for_unknown_id(self, client):
         download = client.get(
             "/api/files/public/download/00000000-0000-4000-8000-000000000000"


### PR DESCRIPTION
## Summary

The "Open" link on the in-chat file card pointed at `/api/files/public/preview/<id>` — the same URL used to fetch raw bytes for inline rendering (`PptxPreviewRenderer`, `DocxPreviewRenderer`, etc.). That endpoint is intended for inline preview payloads and on some deployments returns a derived preview (e.g. a server-side PPTX→PDF conversion) instead of the source artifact. Users then "download" a file named `foo.pptx` whose body is PDF bytes, and PowerPoint refuses to open it ("the file is damaged, do you want to try to recover it?").

This fix routes both "Open" affordances (the previewable card's Open link and the non-previewable card's filename link) through `/api/files/download/<id>` — same endpoint the file-manager side panel's Download button already uses. That endpoint serves the source bytes plus `Content-Disposition: attachment; filename="..."`, so the browser saves the file under its real name and PowerPoint opens it.

The inline preview content path (`InlineOfficeContent` → `PptxPreviewRenderer` etc.) keeps using `/api/files/public/preview/<id>` unchanged.

## Reproduction

1. Run a presentation-generator task (e.g. the `presentation-generator` skill) that produces a `.pptx` artifact.
2. In the chat, find the file card with `📄 File: <filename>.pptx` and the "Open" link.
3. Click "Open" — observe the downloaded file's bytes are not a valid OOXML zip (e.g. a `%PDF-1.6` PDF on the cloud deployment, or a file saved under the bare file id on a local deployment).
4. Open in PowerPoint → repair prompt / error.

After this change, clicking "Open" hits `/api/files/download/<id>`, the browser saves `<original-filename>.pptx`, and PowerPoint opens it normally.

## Implementation

- New `getInlineFileDownloadUrl` helper in `inline-file-preview-utils.ts`, parallel to the existing `getInlineFilePreviewUrl`. Falls back to the source's `previewUrl` for cross-origin sources (no managed download endpoint exists for them).
- `InlineFilePreview` computes both URLs; the two `<a href>` "Open" links use `downloadUrl`, while `InlineOfficeContent` keeps using `previewUrl`.
- Two existing component tests that asserted the Open link used the preview URL are updated to assert the download URL. Four new unit tests cover the helper's branches (file-id source, external source fallback, file-id-wins-over-external, empty source).

## Test plan

- [x] `npx vitest run src/components/file/inline-file-preview-utils.test.ts src/components/file/inline-file-preview.test.tsx` — 24 passed (13 utils + 11 component).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: load any task page with a generated `.pptx` artifact, click "Open" on the file card, confirm the downloaded file opens in PowerPoint without a repair prompt.
- [ ] Manual: same on a non-previewable artifact (`archive.zip`) — the single-line file link downloads the source bytes under the source filename.