### PR TITLE
fix: stabilize KB model resolution and website import

### DIFF
--- a/src/xagent/core/model/storage/__init__.py
+++ b/src/xagent/core/model/storage/__init__.py
@@ -1,2 +1,15 @@
 # Storage package for model management
 # This package provides database-backed model storage without abstraction layers
+from .error import (
+    InvalidModelRecordError,
+    ModelHubError,
+    ModelNotFoundError,
+    UnsupportedModelCategoryError,
+)
+
+__all__ = [
+    "InvalidModelRecordError",
+    "ModelHubError",
+    "ModelNotFoundError",
+    "UnsupportedModelCategoryError",
+]

--- a/src/xagent/core/model/storage/db/__init__.py
+++ b/src/xagent/core/model/storage/db/__init__.py
@@ -2,6 +2,6 @@ from .adapter import SQLAlchemyModelHub
 from .db_models import create_model_table
 
 __all__ = [
-    "create_model_table",
     "SQLAlchemyModelHub",
+    "create_model_table",
 ]

--- a/src/xagent/core/model/storage/db/adapter.py
+++ b/src/xagent/core/model/storage/db/adapter.py
@@ -11,6 +11,10 @@ from xagent.core.model.model import (
     VectorDBConfig,
     VectorDBType,
 )
+from xagent.core.model.storage.error import (
+    ModelNotFoundError,
+    UnsupportedModelCategoryError,
+)
 
 
 class SQLAlchemyModelHub:
@@ -26,6 +30,16 @@ class SQLAlchemyModelHub:
         """
         self.db = db_session
         self.Model = model_class
+
+    def close(self) -> None:
+        """Close the underlying SQLAlchemy session."""
+        self.db.close()
+
+    def __enter__(self) -> "SQLAlchemyModelHub":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.close()
 
     @staticmethod
     def _normalize_vector_db_type(raw_value: Any) -> str:
@@ -132,7 +146,7 @@ class SQLAlchemyModelHub:
                 .first()
             )
         if not db_model:
-            raise ValueError(f"Model not found: {model_id}")
+            raise ModelNotFoundError(model_id)
 
         common = {
             "id": db_model.model_id,
@@ -170,7 +184,7 @@ class SQLAlchemyModelHub:
         elif db_model.category == "vector_db":
             return self._load_vector_db_config(db_model, common)
         else:
-            raise ValueError(f"Unknown model category: {db_model.category}")
+            raise UnsupportedModelCategoryError(db_model.model_id, db_model.category)
 
     def list(self) -> dict[str, ModelConfig]:
         db_models = self.db.query(self.Model).filter(self.Model.is_active).all()
@@ -214,6 +228,10 @@ class SQLAlchemyModelHub:
                 config = RerankModelConfig(**common_fields)
             elif db_model.category == "vector_db":
                 config = self._load_vector_db_config(db_model, common_fields)
+            else:
+                raise UnsupportedModelCategoryError(
+                    db_model.model_id, db_model.category
+                )
 
             if config:
                 result[db_model.model_id] = config

--- a/src/xagent/core/model/storage/error.py
+++ b/src/xagent/core/model/storage/error.py
@@ -4,6 +4,36 @@ class StorageError(Exception):
     pass
 
 
+class ModelHubError(StorageError):
+    """Base class for model hub storage errors."""
+
+
+class ModelNotFoundError(ModelHubError, ValueError):
+    """Raised when a model cannot be found in the model hub."""
+
+    model_id: str
+
+    def __init__(self, model_id: str):
+        self.model_id = model_id
+        super().__init__(f"Model not found: {model_id}")
+
+
+class InvalidModelRecordError(ModelHubError):
+    """Raised when a persisted model hub row cannot be converted."""
+
+
+class UnsupportedModelCategoryError(InvalidModelRecordError):
+    """Raised when a model hub row has an unsupported category."""
+
+    model_id: str
+    category: object
+
+    def __init__(self, model_id: str, category: object):
+        self.model_id = model_id
+        self.category = category
+        super().__init__(f"Unknown model category for {model_id}: {category}")
+
+
 class StorageWriteError(StorageError):
     """Raised when writing to storage fails."""
 

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -821,27 +821,25 @@ async def rebuild_collection_metadata() -> None:
         from xagent.core.model.model import EmbeddingModelConfig
 
         from ..LanceDB.model_tag_utils import to_model_tag
-        from ..utils.model_resolver import _get_or_init_model_hub
+        from ..utils.model_resolver import _list_model_hub_configs
 
-        hub = _get_or_init_model_hub()
-        if hub is not None:
-            for cfg in hub.list().values():
-                if not isinstance(cfg, EmbeddingModelConfig):
-                    continue
-                register_tag_mapping(
-                    hub_tag_to_id,
-                    to_model_tag(cfg.id),
-                    (cfg.id, cfg.dimension),
-                    get_identity=lambda item: item[0],
-                    logger=logger,
-                )
-                register_tag_mapping(
-                    hub_tag_to_id,
-                    to_model_tag(cfg.model_name),
-                    (cfg.id, cfg.dimension),
-                    get_identity=lambda item: item[0],
-                    logger=logger,
-                )
+        for cfg in _list_model_hub_configs().values():
+            if not isinstance(cfg, EmbeddingModelConfig):
+                continue
+            register_tag_mapping(
+                hub_tag_to_id,
+                to_model_tag(cfg.id),
+                (cfg.id, cfg.dimension),
+                get_identity=lambda item: item[0],
+                logger=logger,
+            )
+            register_tag_mapping(
+                hub_tag_to_id,
+                to_model_tag(cfg.model_name),
+                (cfg.id, cfg.dimension),
+                get_identity=lambda item: item[0],
+                logger=logger,
+            )
     except Exception as e:
         logger.warning(
             "Model hub initialization failed during collection metadata rebuild: "

--- a/src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py
@@ -287,29 +287,27 @@ def _infer_embedding_config_from_collection(
         try:
             from xagent.core.model.model import EmbeddingModelConfig
 
-            from .model_resolver import _get_or_init_model_hub
+            from .model_resolver import _list_model_hub_configs
 
-            hub = _get_or_init_model_hub()
-            if hub is not None:
-                hub_tag_to_id: Dict[str, str] = {}
-                for cfg in hub.list().values():
-                    if not isinstance(cfg, EmbeddingModelConfig):
-                        continue
-                    register_tag_mapping(
-                        hub_tag_to_id,
-                        to_model_tag(cfg.id),
-                        cfg.id,
-                        get_identity=lambda item: item,
-                        logger=logger,
-                    )
-                    register_tag_mapping(
-                        hub_tag_to_id,
-                        to_model_tag(cfg.model_name),
-                        cfg.id,
-                        get_identity=lambda item: item,
-                        logger=logger,
-                    )
-                embedding_model_id = hub_tag_to_id.get(model_tag)
+            hub_tag_to_id: Dict[str, str] = {}
+            for cfg in _list_model_hub_configs().values():
+                if not isinstance(cfg, EmbeddingModelConfig):
+                    continue
+                register_tag_mapping(
+                    hub_tag_to_id,
+                    to_model_tag(cfg.id),
+                    cfg.id,
+                    get_identity=lambda item: item,
+                    logger=logger,
+                )
+                register_tag_mapping(
+                    hub_tag_to_id,
+                    to_model_tag(cfg.model_name),
+                    cfg.id,
+                    get_identity=lambda item: item,
+                    logger=logger,
+                )
+            embedding_model_id = hub_tag_to_id.get(model_tag)
         except Exception as e:
             logger.warning(
                 "Model hub initialization failed during embedding config inference: "

--- a/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
@@ -5,13 +5,26 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Type, TypeVar, Union
+import threading
+from contextlib import contextmanager
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
     from langchain_core.runnables import Runnable
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import OperationalError as SAOperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -31,6 +44,7 @@ from xagent.core.model.rerank.adapter import create_rerank_adapter
 from xagent.core.model.rerank.base import BaseRerank
 from xagent.core.model.storage.db.adapter import SQLAlchemyModelHub
 from xagent.core.model.storage.db.db_models import create_model_table
+from xagent.core.model.storage.error import ModelNotFoundError
 from xagent.core.storage.manager import get_default_db_url
 
 from ..core.exceptions import EmbeddingAdapterError, RagCoreException
@@ -44,6 +58,31 @@ ExceptionType = TypeVar("ExceptionType", bound=RagCoreException)
 
 # Special placeholder values
 _PLACEHOLDER_NONE = {"none", ""}
+_MODEL_HUB_ENGINE: Any = None
+_MODEL_HUB_SESSION_LOCAL: Any = None
+_MODEL_HUB_MODEL: Any = None
+_MODEL_HUB_DB_URL: Optional[str] = None
+_MODEL_HUB_LOCK = threading.Lock()
+
+
+def _reset_model_hub_cache() -> None:
+    """Reset cached model hub DB resources.
+
+    This is primarily useful for tests that switch database URLs. Production
+    code normally keeps the engine/sessionmaker for the process lifetime.
+    """
+    global _MODEL_HUB_ENGINE
+    global _MODEL_HUB_SESSION_LOCAL
+    global _MODEL_HUB_MODEL
+    global _MODEL_HUB_DB_URL
+
+    with _MODEL_HUB_LOCK:
+        if _MODEL_HUB_ENGINE is not None:
+            _MODEL_HUB_ENGINE.dispose()
+        _MODEL_HUB_ENGINE = None
+        _MODEL_HUB_SESSION_LOCAL = None
+        _MODEL_HUB_MODEL = None
+        _MODEL_HUB_DB_URL = None
 
 
 def _hub_init_failure_is_benign_optional_sqlite(exc: BaseException) -> bool:
@@ -63,6 +102,24 @@ def _hub_init_failure_is_benign_optional_sqlite(exc: BaseException) -> bool:
     if "unable to open database file" not in msg:
         return False
     return isinstance(exc, (SAOperationalError, sqlite3.OperationalError))
+
+
+def _is_recoverable_model_hub_db_error(exc: BaseException) -> bool:
+    """Return True for DB connection failures where env fallback is appropriate."""
+    if isinstance(exc, sqlite3.OperationalError):
+        return True
+    if isinstance(exc, SAOperationalError):
+        return True
+    if isinstance(exc, DBAPIError):
+        return bool(getattr(exc, "connection_invalidated", False))
+    return False
+
+
+def _is_recoverable_model_hub_init_error(exc: BaseException) -> bool:
+    """Return True for model hub init failures that may use env fallback."""
+    return _hub_init_failure_is_benign_optional_sqlite(
+        exc
+    ) or _is_recoverable_model_hub_db_error(exc)
 
 
 def _is_placeholder_default(model_id: Optional[str]) -> bool:
@@ -100,30 +157,56 @@ def _get_or_init_model_hub() -> Any:
     Returns:
         Initialized model hub instance or None if database is not available
     """
+    global _MODEL_HUB_ENGINE
+    global _MODEL_HUB_SESSION_LOCAL
+    global _MODEL_HUB_MODEL
+    global _MODEL_HUB_DB_URL
+
     try:
-        # Create database engine
         database_url = get_default_db_url()
-        engine = create_engine(
-            database_url,
-            connect_args={"check_same_thread": False}
-            if "sqlite" in database_url
-            else {},
-        )
-        # Create session factory
-        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-        # Create base model class
-        Base = declarative_base()
-        Model = create_model_table(Base)
-        db = SessionLocal()
-        Base.metadata.create_all(engine)
-        return SQLAlchemyModelHub(db, Model)
+        if _MODEL_HUB_ENGINE is None or _MODEL_HUB_DB_URL != database_url:
+            with _MODEL_HUB_LOCK:
+                if _MODEL_HUB_ENGINE is None or _MODEL_HUB_DB_URL != database_url:
+                    old_engine = _MODEL_HUB_ENGINE
+                    engine = create_engine(
+                        database_url,
+                        connect_args={"check_same_thread": False}
+                        if "sqlite" in database_url
+                        else {},
+                        pool_pre_ping="sqlite" not in database_url,
+                    )
+                    Base = declarative_base()
+                    Model = create_model_table(Base)
+                    try:
+                        Base.metadata.create_all(engine)
+                    except Exception:
+                        engine.dispose()
+                        raise
+                    session_local = sessionmaker(
+                        autocommit=False, autoflush=False, bind=engine
+                    )
+                    _MODEL_HUB_ENGINE = engine
+                    _MODEL_HUB_SESSION_LOCAL = session_local
+                    _MODEL_HUB_MODEL = Model
+                    _MODEL_HUB_DB_URL = database_url
+                    if old_engine is not None:
+                        old_engine.dispose()
+
+        session_local = _MODEL_HUB_SESSION_LOCAL
+        model = _MODEL_HUB_MODEL
+        if session_local is None or model is None:
+            raise RuntimeError("Model hub cache was not initialized")
+
+        db = session_local()
+        return SQLAlchemyModelHub(db, model)
     except Exception as e:
         if _hub_init_failure_is_benign_optional_sqlite(e):
             logger.debug(
                 "Model hub SQLite not available yet (optional component): %s",
                 e,
             )
-        else:
+            return None
+        if _is_recoverable_model_hub_db_error(e):
             logger.warning(
                 "Model hub database initialization failed; hub-backed model "
                 "resolution is disabled until this is fixed. "
@@ -132,7 +215,71 @@ def _get_or_init_model_hub() -> Any:
                 e,
                 exc_info=True,
             )
-        return None
+            return None
+
+        logger.exception(
+            "Model hub initialization failed due to a non-recoverable error; "
+            "not falling back to environment configuration: %s",
+            e,
+        )
+        raise
+
+
+def _close_model_hub(hub: Any) -> None:
+    close = getattr(hub, "close", None)
+    if callable(close):
+        close()
+        return
+
+    db = getattr(hub, "db", None)
+    db_close = getattr(db, "close", None)
+    if callable(db_close):
+        db_close()
+
+
+@contextmanager
+def _managed_model_hub(model_type_name: str) -> Any:
+    """Yield a model hub and always close its DB session after use."""
+    hub = None
+    unavailable_error: Optional[str] = None
+    try:
+        try:
+            hub = _get_or_init_model_hub()
+        except Exception as hub_error:
+            if not _is_recoverable_model_hub_init_error(hub_error):
+                raise
+            logger.warning(
+                "Model hub not available for %s: %s. Falling back to environment configuration.",
+                model_type_name,
+                hub_error,
+                exc_info=True,
+            )
+            unavailable_error = str(hub_error)
+
+        if hub is None and unavailable_error is None:
+            unavailable_error = "model hub database unavailable"
+        yield hub, unavailable_error
+    finally:
+        if hub is not None:
+            _close_model_hub(hub)
+
+
+def _list_model_hub_configs() -> dict[str, ModelConfig]:
+    """List hub configs through a short-lived managed DB session."""
+    with _managed_model_hub("model hub list") as (hub, _unavailable_error):
+        if hub is None:
+            return {}
+        try:
+            return cast(dict[str, ModelConfig], hub.list())
+        except Exception as exc:
+            if _is_recoverable_model_hub_db_error(exc):
+                logger.warning(
+                    "Model hub database unavailable while listing configs: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return {}
+            raise
 
 
 def _load_model_from_hub(
@@ -153,27 +300,46 @@ def _load_model_from_hub(
     Raises:
         exception_cls: If model loading or type validation fails
     """
-    # Get or initialize hub
-    hub = _get_or_init_model_hub()
-    if hub is None:
-        raise exception_cls(
-            f"Failed to load {config_type.__name__}: model hub database not available",
-            details={"model_id": model_id, "error": "Database not available"},
-        )
+    with _managed_model_hub(config_type.__name__) as (hub, unavailable_error):
+        if hub is None:
+            raise exception_cls(
+                f"Failed to load {config_type.__name__}: model hub database unavailable",
+                details={
+                    "model_id": model_id,
+                    "error": unavailable_error or "Database unavailable",
+                },
+            )
 
-    # Load model configuration first
-    try:
-        cfg = hub.load(model_id)
-    except ValueError as exc:
-        # SQLAlchemyModelHub may raise ValueError (model not found or unknown category)
-        raise exception_cls(
-            f"Failed to load {config_type.__name__} from model hub",
-            details={
-                "model_id": model_id,
-                "error": str(exc),
-                "error_type": type(exc).__name__,
-            },
-        ) from exc
+        # Load model configuration first
+        try:
+            cfg = hub.load(model_id)
+        except ModelNotFoundError as exc:
+            raise exception_cls(
+                f"Failed to load {config_type.__name__} from model hub",
+                details={
+                    "model_id": model_id,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            ) from exc
+        except Exception as exc:
+            if _is_recoverable_model_hub_db_error(exc):
+                raise exception_cls(
+                    f"Failed to load {config_type.__name__}: model hub database unavailable",
+                    details={
+                        "model_id": model_id,
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                ) from exc
+            raise exception_cls(
+                f"Failed to load {config_type.__name__} from model hub",
+                details={
+                    "model_id": model_id,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            ) from exc
 
     # Validate configuration type
     if not isinstance(cfg, config_type):
@@ -351,161 +517,100 @@ def _resolve_adapter_generic(
     """
     adapter_kwargs = adapter_kwargs or {}
 
-    # Try to get hub, but fallback to env if hub is not available
-    hub = None
-    try:
-        hub = _get_or_init_model_hub()
-    except Exception as hub_error:
-        # Hub not available, will fallback to environment
-        logger.warning(
-            "Model hub not available for %s: %s. Falling back to environment configuration.",
-            model_type_name,
-            hub_error,
-        )
-        hub = None
+    hub_unavailable_error: Optional[str] = None
+    hub_missing_model = False
+    lookup_id = "default"
+    if not (_is_placeholder_default(model_id) or _is_placeholder_none(model_id)):
+        assert model_id is not None
+        lookup_id = model_id
 
-    # Strategy 1: "default" placeholder
-    # Priority: "default" ID in Hub -> Environment (no auto-selection)
-    if _is_placeholder_default(model_id):
+    with _managed_model_hub(model_type_name) as (hub, unavailable_error):
+        hub_unavailable_error = unavailable_error
         if hub is not None:
             try:
-                cfg = hub.load("default")
-                if isinstance(cfg, config_type):
-                    adapter = _create_adapter_safe(
-                        cfg, adapter_factory, exception_type, **adapter_kwargs
-                    )
-                    return cfg, adapter
-                else:
-                    # Found "default" but wrong type
-                    raise exception_type(
-                        f"Model 'default' exists but is not a {config_type.__name__}",
-                        details={
-                            "model_id": "default",
-                            "actual_type": type(cfg).__name__,
-                        },
-                    )
-            except ValueError:
-                # "default" model not found in hub, fallback to env
-                logger.warning(
-                    "Model 'default' not found in hub for %s, falling back to environment",
-                    model_type_name,
-                )
-
-        # Fallback to Environment
-        env_cfg = env_resolver(**env_kwargs)
-        if env_cfg:
-            adapter = _create_adapter_safe(
-                env_cfg,
-                adapter_factory,
-                exception_type,
-                " from environment configuration",
-                **adapter_kwargs,
-            )
-            return env_cfg, adapter
-
-        # All failed
-        raise exception_type(
-            f"No {model_type_name} model available: 'default' not found in hub and no environment configuration"
-        )
-
-    # Strategy 2: "none" or empty placeholder
-    # Priority: "default" ID in Hub -> Environment (same as "default", no auto-selection)
-    if _is_placeholder_none(model_id):
-        if hub is not None:
-            try:
-                cfg = hub.load("default")
-                if isinstance(cfg, config_type):
-                    adapter = _create_adapter_safe(
-                        cfg, adapter_factory, exception_type, **adapter_kwargs
-                    )
-                    return cfg, adapter
-                else:
-                    # Found "default" but wrong type
-                    raise exception_type(
-                        f"Model 'default' exists but is not a {config_type.__name__}",
-                        details={
-                            "model_id": "default",
-                            "actual_type": type(cfg).__name__,
-                        },
-                    )
-            except ValueError:
-                # "default" model not found in hub, fallback to env
-                logger.warning(
-                    "Model 'default' not found in hub for %s, falling back to environment",
-                    model_type_name,
-                )
-
-        # Fallback to Environment
-        env_cfg = env_resolver(**env_kwargs)
-        if env_cfg:
-            adapter = _create_adapter_safe(
-                env_cfg,
-                adapter_factory,
-                exception_type,
-                " from environment configuration",
-                **adapter_kwargs,
-            )
-            return env_cfg, adapter
-
-        # All failed
-        raise exception_type(
-            f"No {model_type_name} model available: 'default' not found in hub and no environment configuration"
-        )
-
-    # Strategy 3: Explicit ID Intent
-    # Priority: Explicit ID in Hub -> Environment (fallback)
-    # Note: We do NOT auto-select here. If user asks for "my-model", we don't give them "other-model".
-    else:
-        # 3.1 Try Explicit ID in Hub
-        if hub is not None:
-            try:
-                # We use _load_model_from_hub here mainly for its error wrapping/handling logic,
-                # but we can also just use hub.load directly since we have hub.
-                # Using try-except block to catch load errors.
-                cfg = hub.load(model_id)
-                if isinstance(cfg, config_type):
-                    adapter = _create_adapter_safe(
-                        cfg, adapter_factory, exception_type, **adapter_kwargs
-                    )
-                    return cfg, adapter
-                else:
-                    # Found model but wrong type
-                    raise exception_type(
-                        f"Model '{model_id}' exists but is not a {config_type.__name__}",
-                        details={
-                            "model_id": model_id,
-                            "actual_type": type(cfg).__name__,
-                        },
-                    )
-            except ValueError as hub_error:
-                # Explicit ID not found in Hub
+                cfg = hub.load(lookup_id)
+            except ModelNotFoundError as hub_error:
+                hub_missing_model = True
                 logger.warning(
                     "Model '%s' not found in hub for %s: %s. Falling back to environment configuration.",
-                    model_id,
+                    lookup_id,
                     model_type_name,
                     hub_error,
                 )
+            except Exception as hub_error:
+                if not _is_recoverable_model_hub_db_error(hub_error):
+                    raise exception_type(
+                        f"Failed to resolve {model_type_name} model from model hub",
+                        details={
+                            "model_id": lookup_id,
+                            "error": str(hub_error),
+                            "error_type": type(hub_error).__name__,
+                        },
+                    ) from hub_error
 
-        # 3.2 Fallback to Environment
-        # Logic: If the explicit ID isn't in the hub, maybe the env vars are set up
-        # to provide a model that the user *intends* to use, or maybe the code that called this
-        # passed a model_id that is actually meant to be used with env vars (though less likely in this design).
-        # We allow env fallback to be safe, but we don't auto-select a random model from Hub.
-        env_cfg = env_resolver(**env_kwargs)
-        if env_cfg:
-            adapter = _create_adapter_safe(
-                env_cfg,
-                adapter_factory,
-                exception_type,
-                " from environment configuration",
-                **adapter_kwargs,
-            )
-            return env_cfg, adapter
+                hub_unavailable_error = str(hub_error)
+                logger.warning(
+                    "Model hub database unavailable while resolving %s model '%s': %s. Falling back to environment configuration.",
+                    model_type_name,
+                    lookup_id,
+                    hub_error,
+                    exc_info=True,
+                )
+            else:
+                if isinstance(cfg, config_type):
+                    adapter = _create_adapter_safe(
+                        cfg, adapter_factory, exception_type, **adapter_kwargs
+                    )
+                    return cfg, adapter
 
-        # All failed
-        raise exception_type(
-            f"Model '{model_id}' not found in hub and no environment configuration available for {model_type_name}."
+                raise exception_type(
+                    f"Model '{lookup_id}' exists but is not a {config_type.__name__}",
+                    details={
+                        "model_id": lookup_id,
+                        "actual_type": type(cfg).__name__,
+                    },
+                )
+
+    env_cfg = env_resolver(**env_kwargs)
+    if env_cfg:
+        adapter = _create_adapter_safe(
+            env_cfg,
+            adapter_factory,
+            exception_type,
+            " from environment configuration",
+            **adapter_kwargs,
         )
+        return env_cfg, adapter
+
+    if hub_unavailable_error:
+        logger.warning(
+            "No environment configuration available for %s after model hub database was unavailable.",
+            model_type_name,
+        )
+        raise exception_type(
+            f"No {model_type_name} model available: model hub database unavailable and no environment configuration available",
+            details={"model_id": model_id, "hub_error": hub_unavailable_error},
+        )
+
+    if _is_placeholder_default(model_id) or _is_placeholder_none(model_id):
+        logger.warning(
+            "No environment configuration available for %s after default model was not found in hub.",
+            model_type_name,
+        )
+        raise exception_type(
+            f"No {model_type_name} model available: 'default' not found in hub and no environment configuration",
+            details={"model_id": model_id, "hub_missing_model": hub_missing_model},
+        )
+
+    logger.warning(
+        "No environment configuration available for %s after model '%s' was not found in hub.",
+        model_type_name,
+        model_id,
+    )
+    raise exception_type(
+        f"Model '{model_id}' not found in hub and no environment configuration available for {model_type_name}.",
+        details={"model_id": model_id, "hub_missing_model": hub_missing_model},
+    )
 
 
 def resolve_embedding_adapter(

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import importlib
+import importlib.util
 import logging
 import time
 from collections import deque
@@ -359,6 +360,51 @@ _DEFAULT_USER_AGENT: str = (
     "Chrome/130.0.0.0 Safari/537.36"
 )
 
+
+def _get_httpx_accept_encoding() -> str:
+    """Return encodings httpx can actually decode in this environment."""
+    encodings = ["gzip", "deflate"]
+    if importlib.util.find_spec("brotli") or importlib.util.find_spec("brotlicffi"):
+        encodings.append("br")
+    return ", ".join(encodings)
+
+
+def _response_log_metadata(
+    response: Any,
+    report: Optional[_ContentQualityReport] = None,
+) -> Dict[str, Any]:
+    """Build safe response metadata for crawl quality logs."""
+    headers = getattr(response, "headers", {}) or {}
+    header_get = getattr(headers, "get", None)
+
+    def _get_header(name: str) -> Optional[str]:
+        if callable(header_get):
+            value = header_get(name)
+            return value if isinstance(value, str) else None
+        return None
+
+    metadata: Dict[str, Any] = {
+        "status_code": getattr(response, "status_code", None),
+        "content_encoding": _get_header("content-encoding"),
+        "content_type": _get_header("content-type"),
+    }
+    if report is not None:
+        metadata.update(
+            {
+                "quality_code": report.code,
+                "text_length": report.text_length,
+                "null_count": report.null_count,
+                "replacement_count": report.replacement_count,
+                "control_count": report.control_count,
+                "unreadable_count": report.unreadable_count,
+                "replacement_ratio": report.replacement_ratio,
+                "control_ratio": report.control_ratio,
+                "readable_ratio": report.readable_ratio,
+            }
+        )
+    return metadata
+
+
 # Mapping from a curl_cffi impersonate spec to the User-Agent that spec
 # actually puts on the wire. We need this for policy code (robots.txt)
 # which has to reason about the identity we are presenting -- since
@@ -505,7 +551,7 @@ class WebCrawler:
                     "image/avif,image/webp,*/*;q=0.8"
                 ),
                 "Accept-Language": "en-US,en;q=0.9",
-                "Accept-Encoding": "gzip, deflate, br",
+                "Accept-Encoding": _get_httpx_accept_encoding(),
                 "Sec-Fetch-Dest": "document",
                 "Sec-Fetch-Mode": "navigate",
                 "Sec-Fetch-Site": "none",
@@ -848,7 +894,21 @@ class WebCrawler:
                         error_msg = fetch_result.markdown_quality.reason
                     else:
                         error_msg = raw_quality.reason or "TLS fallback exhausted"
-                    logger.error("Failed to crawl %s: %s", url, error_msg)
+                    quality_report = raw_quality
+                    if (
+                        fetch_result.markdown_quality
+                        and not fetch_result.markdown_quality.ok
+                    ):
+                        quality_report = fetch_result.markdown_quality
+                    logger.error(
+                        "Failed to crawl %s: %s",
+                        url,
+                        error_msg,
+                        extra={
+                            "crawl_url": url,
+                            **_response_log_metadata(response, quality_report),
+                        },
+                    )
                     self.failed_urls[url] = error_msg
                     return None, set()
 
@@ -870,6 +930,10 @@ class WebCrawler:
                         "Rejected crawl content at %s: %s",
                         url,
                         raw_quality.reason,
+                        extra={
+                            "crawl_url": url,
+                            **_response_log_metadata(response, raw_quality),
+                        },
                     )
                     self.failed_urls[url] = raw_quality.reason
                     return None, set()
@@ -895,6 +959,10 @@ class WebCrawler:
                         "Rejected extracted crawl content at %s: %s",
                         url,
                         markdown_quality.reason,
+                        extra={
+                            "crawl_url": url,
+                            **_response_log_metadata(response, markdown_quality),
+                        },
                     )
                     self.failed_urls[url] = markdown_quality.reason
                     return None, set()

--- a/tests/core/model/test_vector_db_config.py
+++ b/tests/core/model/test_vector_db_config.py
@@ -10,6 +10,10 @@ from xagent.core.model.model import (
 )
 from xagent.core.model.storage.db.adapter import SQLAlchemyModelHub
 from xagent.core.model.storage.db.db_models import create_model_table
+from xagent.core.model.storage.error import (
+    ModelNotFoundError,
+    UnsupportedModelCategoryError,
+)
 
 Base = declarative_base()
 Model = create_model_table(Base)
@@ -217,8 +221,56 @@ def test_vector_db_config_delete(db_session):
     assert hub.exists("to-delete")
     hub.delete("to-delete")
     assert not hub.exists("to-delete")
-    with pytest.raises(ValueError, match="Model not found"):
+    with pytest.raises(ModelNotFoundError, match="Model not found"):
         hub.load("to-delete")
+
+
+def test_model_hub_load_unknown_category_raises_domain_error(
+    db_session, setup_encryption_key
+):
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"k").decode()
+    db_record = Model(
+        model_id="bad-category",
+        category="audio",
+        model_provider="none",
+        model_name="BadCategory",
+        _api_key_encrypted=valid_encrypted,
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+
+    with pytest.raises(
+        UnsupportedModelCategoryError,
+        match="Unknown model category for bad-category: audio",
+    ):
+        hub.load("bad-category")
+
+
+def test_model_hub_list_unknown_category_raises_domain_error(
+    db_session, setup_encryption_key
+):
+    hub = SQLAlchemyModelHub(db_session, Model)
+    cipher = Fernet(setup_encryption_key.encode())
+    valid_encrypted = cipher.encrypt(b"k").decode()
+    db_record = Model(
+        model_id="bad-list-category",
+        category="audio",
+        model_provider="none",
+        model_name="BadListCategory",
+        _api_key_encrypted=valid_encrypted,
+        is_active=True,
+    )
+    db_session.add(db_record)
+    db_session.commit()
+
+    with pytest.raises(
+        UnsupportedModelCategoryError,
+        match="Unknown model category for bad-list-category: audio",
+    ):
+        hub.list()
 
 
 def test_vector_db_config_normalize_case(db_session, setup_encryption_key):

--- a/tests/core/tools/core/RAG_tools/pipelines/test_model_resolver_legacy.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_model_resolver_legacy.py
@@ -5,6 +5,7 @@ from typing import Dict
 import pytest
 
 from xagent.core.model.model import EmbeddingModelConfig, RerankModelConfig
+from xagent.core.model.storage.error import ModelNotFoundError
 from xagent.core.tools.core.RAG_tools.core.schemas import SearchType
 from xagent.core.tools.core.RAG_tools.utils import model_resolver
 from xagent.core.tools.core.RAG_tools.utils.config_utils import coerce_search_config
@@ -19,7 +20,7 @@ class _StubHub:
 
     def load(self, model_id: str) -> object:
         if model_id not in self._models:
-            raise ValueError(f"Model {model_id} not found")
+            raise ModelNotFoundError(model_id)
         return self._models[model_id]
 
 
@@ -50,12 +51,8 @@ def test_resolve_embedding_hub_priority(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_resolve_embedding_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that env is used as fallback when hub fails."""
-
-    # Mock hub to raise exception
-    def failing_hub():
-        raise Exception("Hub not available")
-
-    monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+    # Mock recoverable hub unavailability.
+    monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
     # Set env vars for fallback
     monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
@@ -113,12 +110,8 @@ def test_resolve_rerank_hub_priority(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_resolve_rerank_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that env is used as fallback when hub fails."""
-
-    # Mock hub to raise exception
-    def failing_hub():
-        raise Exception("Hub not available")
-
-    monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+    # Mock recoverable hub unavailability.
+    monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
     # Set env vars for fallback
     monkeypatch.setenv("DASHSCOPE_RERANK_MODEL", "env-rerank")

--- a/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Dict
 
 import pytest
+from sqlalchemy.exc import InvalidRequestError
+from sqlalchemy.exc import OperationalError as SAOperationalError
 
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.embedding.base import BaseEmbedding
@@ -14,6 +16,10 @@ from xagent.core.model.model import (
     RerankModelConfig,
 )
 from xagent.core.model.rerank.base import BaseRerank
+from xagent.core.model.storage.error import (
+    ModelNotFoundError,
+    UnsupportedModelCategoryError,
+)
 from xagent.core.tools.core.RAG_tools.core.exceptions import (
     EmbeddingAdapterError,
     RagCoreException,
@@ -26,14 +32,79 @@ class _StubHub:
 
     def __init__(self, models: Dict[str, object]) -> None:
         self._models = models
+        self.close_calls = 0
 
     def list(self) -> Dict[str, object]:
         return self._models
 
     def load(self, model_id: str) -> object:
-        if model_id not in self._models:
-            raise ValueError(f"Model {model_id} not found")
-        return self._models[model_id]
+        if model_id in self._models:
+            return self._models[model_id]
+
+        for model in self._models.values():
+            if getattr(model, "model_name", None) == model_id:
+                return model
+
+        raise ModelNotFoundError(model_id)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FailingLoadHub:
+    """Stub hub that fails with a DB error during query execution."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def load(self, model_id: str) -> object:
+        raise SAOperationalError(
+            "SELECT models",
+            {},
+            Exception("too many clients already"),
+        )
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _BuggyLoadHub:
+    """Stub hub that fails with a non-recoverable SQLAlchemy error."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def load(self, model_id: str) -> object:
+        raise InvalidRequestError("invalid model hub row")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _UnsupportedCategoryHub:
+    """Stub hub that finds a row but cannot convert its category."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def load(self, model_id: str) -> object:
+        raise UnsupportedModelCategoryError(model_id, "audio")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _BuggyListHub:
+    """Stub hub that fails with a non-recoverable SQLAlchemy error while listing."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def list(self) -> Dict[str, object]:
+        raise InvalidRequestError("invalid model hub query")
+
+    def close(self) -> None:
+        self.close_calls += 1
 
 
 class TestGetOrInitModelHub:
@@ -74,6 +145,18 @@ class TestGetOrInitModelHub:
         assert result == stub_hub
         assert hasattr(result, "list")
 
+    def test_list_model_hub_configs_does_not_hide_non_db_sqlalchemy_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test SQLAlchemy non-DB errors are not converted to an empty config list."""
+        stub_hub = _BuggyListHub()
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
+
+        with pytest.raises(InvalidRequestError):
+            model_resolver._list_model_hub_configs()
+
+        assert stub_hub.close_calls == 1
+
 
 class TestResolveEmbeddingAdapter:
     """Test resolve_embedding_adapter function with strict priority."""
@@ -102,6 +185,34 @@ class TestResolveEmbeddingAdapter:
         cfg, adapter = model_resolver.resolve_embedding_adapter(model_id="hub-model")
         assert cfg.id == "hub-model"
         assert isinstance(adapter, BaseEmbedding)
+        assert stub_hub.close_calls == 1
+
+    def test_resolve_embedding_by_model_name_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test resolving embedding by provider model_name fallback."""
+        stub_hub = _StubHub(
+            {
+                "hub-id": EmbeddingModelConfig(
+                    id="hub-id",
+                    model_name="text-embedding-v4",
+                    model_provider="dashscope",
+                    api_key="hub-key",
+                    abilities=["embedding"],
+                )
+            }
+        )
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
+        monkeypatch.delenv("DASHSCOPE_EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+
+        cfg, adapter = model_resolver.resolve_embedding_adapter(
+            model_id="text-embedding-v4"
+        )
+
+        assert cfg.id == "hub-id"
+        assert isinstance(adapter, BaseEmbedding)
+        assert stub_hub.close_calls == 1
 
     def test_resolve_embedding_default_placeholder(
         self, monkeypatch: pytest.MonkeyPatch
@@ -165,12 +276,8 @@ class TestResolveEmbeddingAdapter:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test resolving embedding from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback
         monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
@@ -186,14 +293,63 @@ class TestResolveEmbeddingAdapter:
         assert cfg.dimension == 1536
         assert isinstance(adapter, BaseEmbedding)
 
+    def test_resolve_embedding_env_fallback_when_hub_query_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test env fallback and session close when hub query fails."""
+        stub_hub = _FailingLoadHub()
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
+
+        monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "env-key")
+
+        cfg, adapter = model_resolver.resolve_embedding_adapter(model_id=None)
+
+        assert cfg.id == "env-model"
+        assert isinstance(adapter, BaseEmbedding)
+        assert stub_hub.close_calls == 1
+
+    def test_resolve_embedding_does_not_fallback_for_non_db_hub_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test non-DB hub errors are not hidden by env fallback."""
+        stub_hub = _BuggyLoadHub()
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
+
+        monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "env-key")
+
+        with pytest.raises(
+            EmbeddingAdapterError,
+            match="Failed to resolve embedding model from model hub",
+        ):
+            model_resolver.resolve_embedding_adapter(model_id=None)
+
+        assert stub_hub.close_calls == 1
+
+    def test_resolve_embedding_does_not_fallback_for_unsupported_hub_category(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed hub rows should not be treated as not-found fallback."""
+        stub_hub = _UnsupportedCategoryHub()
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
+
+        monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "env-key")
+
+        with pytest.raises(
+            EmbeddingAdapterError,
+            match="Failed to resolve embedding model from model hub",
+        ) as exc_info:
+            model_resolver.resolve_embedding_adapter(model_id=None)
+
+        assert exc_info.value.details["error_type"] == "UnsupportedModelCategoryError"
+        assert stub_hub.close_calls == 1
+
     def test_resolve_embedding_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in [
@@ -203,7 +359,10 @@ class TestResolveEmbeddingAdapter:
         ]:
             monkeypatch.delenv(key, raising=False)
 
-        with pytest.raises(EmbeddingAdapterError):
+        with pytest.raises(
+            EmbeddingAdapterError,
+            match="model hub database unavailable and no environment configuration",
+        ):
             model_resolver.resolve_embedding_adapter(model_id=None)
 
 
@@ -266,12 +425,8 @@ class TestResolveRerankAdapter:
 
     def test_resolve_rerank_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test resolving rerank from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback
         monkeypatch.setenv("DASHSCOPE_RERANK_MODEL", "env-rerank")
@@ -288,12 +443,8 @@ class TestResolveRerankAdapter:
 
     def test_resolve_rerank_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in [
@@ -367,12 +518,8 @@ class TestResolveLLMAdapter:
 
     def test_resolve_llm_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test resolving LLM from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback (OpenAI)
         monkeypatch.setenv("OPENAI_API_KEY", "env-key")
@@ -388,12 +535,8 @@ class TestResolveLLMAdapter:
 
     def test_resolve_llm_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in ["OPENAI_API_KEY", "ZHIPU_API_KEY", "DEEPSEEK_API_KEY"]:
@@ -408,12 +551,8 @@ class TestResolveLLMAdapter:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test resolving LLM from Zhipu env when hub fails and OpenAI is not configured."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear OpenAI env vars, set Zhipu env vars
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/core/tools/core/RAG_tools/utils/test_model_resolver_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_model_resolver_utils.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import sqlite3
+import threading
+import time
 from typing import Dict
 
 import pytest
@@ -16,6 +19,7 @@ from xagent.core.model.model import (
     RerankModelConfig,
 )
 from xagent.core.model.rerank.base import BaseRerank
+from xagent.core.model.storage.error import ModelNotFoundError
 from xagent.core.tools.core.RAG_tools.core.exceptions import (
     EmbeddingAdapterError,
     RagCoreException,
@@ -34,7 +38,7 @@ class _StubHub:
 
     def load(self, model_id: str) -> object:
         if model_id not in self._models:
-            raise ValueError(f"Model {model_id} not found")
+            raise ModelNotFoundError(model_id)
         return self._models[model_id]
 
 
@@ -72,6 +76,217 @@ class TestGetOrInitModelHub:
         monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: stub_hub)
         result = model_resolver._get_or_init_model_hub()
         assert result == stub_hub
+
+    def test_get_or_init_model_hub_initializes_cache_once_concurrently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Concurrent callers should share one initialized engine/sessionmaker."""
+        model_resolver._reset_model_hub_cache()
+
+        worker_count = 5
+        barrier = threading.Barrier(worker_count)
+        guard = threading.Lock()
+        create_calls: list[object] = []
+        sessionmaker_calls: list[object] = []
+        sessions: list[object] = []
+
+        class FakeEngine:
+            def __init__(self) -> None:
+                self.disposed = False
+
+            def dispose(self) -> None:
+                self.disposed = True
+
+        class FakeMetadata:
+            def create_all(self, engine: object) -> None:
+                time.sleep(0.02)
+
+        class FakeBase:
+            metadata = FakeMetadata()
+
+        class FakeSessionLocal:
+            def __call__(self) -> object:
+                session = object()
+                with guard:
+                    sessions.append(session)
+                return session
+
+        class FakeHub:
+            def __init__(self, db: object, model: object) -> None:
+                self.db = db
+                self.model = model
+
+        fake_session_local = FakeSessionLocal()
+        fake_model = object()
+
+        def fake_create_engine(*args: object, **kwargs: object) -> FakeEngine:
+            engine = FakeEngine()
+            with guard:
+                create_calls.append(engine)
+            time.sleep(0.05)
+            return engine
+
+        def fake_sessionmaker(*args: object, **kwargs: object) -> FakeSessionLocal:
+            with guard:
+                sessionmaker_calls.append(kwargs.get("bind"))
+            return fake_session_local
+
+        def worker() -> FakeHub:
+            barrier.wait(timeout=5)
+            hub = model_resolver._get_or_init_model_hub()
+            assert isinstance(hub, FakeHub)
+            return hub
+
+        monkeypatch.setattr(
+            model_resolver, "get_default_db_url", lambda: "sqlite:///concurrent.db"
+        )
+        monkeypatch.setattr(model_resolver, "create_engine", fake_create_engine)
+        monkeypatch.setattr(model_resolver, "declarative_base", lambda: FakeBase)
+        monkeypatch.setattr(
+            model_resolver, "create_model_table", lambda Base: fake_model
+        )
+        monkeypatch.setattr(model_resolver, "sessionmaker", fake_sessionmaker)
+        monkeypatch.setattr(model_resolver, "SQLAlchemyModelHub", FakeHub)
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=worker_count
+            ) as executor:
+                hubs = list(executor.map(lambda _: worker(), range(worker_count)))
+
+            assert len(create_calls) == 1
+            assert len(sessionmaker_calls) == 1
+            assert len(sessions) == worker_count
+            assert all(hub.model is fake_model for hub in hubs)
+        finally:
+            model_resolver._reset_model_hub_cache()
+
+    def test_reset_model_hub_cache_disposes_engine(self) -> None:
+        """Reset should dispose the active engine and clear the resource group."""
+
+        class FakeEngine:
+            def __init__(self) -> None:
+                self.disposed = False
+
+            def dispose(self) -> None:
+                self.disposed = True
+
+        engine = FakeEngine()
+        model_resolver._MODEL_HUB_ENGINE = engine
+        model_resolver._MODEL_HUB_SESSION_LOCAL = object()
+        model_resolver._MODEL_HUB_MODEL = object()
+        model_resolver._MODEL_HUB_DB_URL = "sqlite:///old.db"
+
+        model_resolver._reset_model_hub_cache()
+
+        assert engine.disposed is True
+        assert model_resolver._MODEL_HUB_ENGINE is None
+        assert model_resolver._MODEL_HUB_SESSION_LOCAL is None
+        assert model_resolver._MODEL_HUB_MODEL is None
+        assert model_resolver._MODEL_HUB_DB_URL is None
+
+    def test_get_or_init_model_hub_re_raises_non_db_reinit_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-DB init failures should not be hidden as hub unavailability."""
+
+        class FakeEngine:
+            def __init__(self) -> None:
+                self.disposed = False
+
+            def dispose(self) -> None:
+                self.disposed = True
+
+        class FakeMetadata:
+            def create_all(self, engine: object) -> None:
+                raise RuntimeError("create failed")
+
+        class FakeBase:
+            metadata = FakeMetadata()
+
+        old_engine = FakeEngine()
+        new_engine = FakeEngine()
+        old_session_local = object()
+        old_model = object()
+        model_resolver._MODEL_HUB_ENGINE = old_engine
+        model_resolver._MODEL_HUB_SESSION_LOCAL = old_session_local
+        model_resolver._MODEL_HUB_MODEL = old_model
+        model_resolver._MODEL_HUB_DB_URL = "sqlite:///old.db"
+
+        monkeypatch.setattr(
+            model_resolver, "get_default_db_url", lambda: "sqlite:///new.db"
+        )
+        monkeypatch.setattr(
+            model_resolver, "create_engine", lambda *args, **kwargs: new_engine
+        )
+        monkeypatch.setattr(model_resolver, "declarative_base", lambda: FakeBase)
+        monkeypatch.setattr(model_resolver, "create_model_table", lambda Base: object())
+
+        try:
+            with pytest.raises(RuntimeError, match="create failed"):
+                model_resolver._get_or_init_model_hub()
+
+            assert new_engine.disposed is True
+            assert old_engine.disposed is False
+            assert model_resolver._MODEL_HUB_ENGINE is old_engine
+            assert model_resolver._MODEL_HUB_SESSION_LOCAL is old_session_local
+            assert model_resolver._MODEL_HUB_MODEL is old_model
+            assert model_resolver._MODEL_HUB_DB_URL == "sqlite:///old.db"
+        finally:
+            model_resolver._reset_model_hub_cache()
+
+    def test_get_or_init_model_hub_returns_none_for_recoverable_db_reinit_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recoverable DB init failures may fall back without polluting cache."""
+
+        class FakeEngine:
+            def __init__(self) -> None:
+                self.disposed = False
+
+            def dispose(self) -> None:
+                self.disposed = True
+
+        class FakeMetadata:
+            def create_all(self, engine: object) -> None:
+                raise SAOperationalError(
+                    "SELECT models",
+                    {},
+                    Exception("too many clients already"),
+                )
+
+        class FakeBase:
+            metadata = FakeMetadata()
+
+        old_engine = FakeEngine()
+        new_engine = FakeEngine()
+        old_session_local = object()
+        old_model = object()
+        model_resolver._MODEL_HUB_ENGINE = old_engine
+        model_resolver._MODEL_HUB_SESSION_LOCAL = old_session_local
+        model_resolver._MODEL_HUB_MODEL = old_model
+        model_resolver._MODEL_HUB_DB_URL = "sqlite:///old.db"
+
+        monkeypatch.setattr(
+            model_resolver, "get_default_db_url", lambda: "sqlite:///new.db"
+        )
+        monkeypatch.setattr(
+            model_resolver, "create_engine", lambda *args, **kwargs: new_engine
+        )
+        monkeypatch.setattr(model_resolver, "declarative_base", lambda: FakeBase)
+        monkeypatch.setattr(model_resolver, "create_model_table", lambda Base: object())
+
+        try:
+            assert model_resolver._get_or_init_model_hub() is None
+
+            assert new_engine.disposed is True
+            assert old_engine.disposed is False
+            assert model_resolver._MODEL_HUB_ENGINE is old_engine
+            assert model_resolver._MODEL_HUB_SESSION_LOCAL is old_session_local
+            assert model_resolver._MODEL_HUB_MODEL is old_model
+            assert model_resolver._MODEL_HUB_DB_URL == "sqlite:///old.db"
+        finally:
+            model_resolver._reset_model_hub_cache()
 
 
 class TestResolveEmbeddingAdapter:
@@ -135,12 +350,8 @@ class TestResolveEmbeddingAdapter:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test resolving embedding from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback
         monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
@@ -156,14 +367,25 @@ class TestResolveEmbeddingAdapter:
         assert cfg.dimension == 1536
         assert isinstance(adapter, BaseEmbedding)
 
+    def test_resolve_embedding_does_not_fallback_for_non_db_init_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-DB hub initialization errors should surface even when env exists."""
+
+        def buggy_hub() -> object:
+            raise RuntimeError("broken model hub initialization")
+
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", buggy_hub)
+        monkeypatch.setenv("DASHSCOPE_EMBEDDING_MODEL", "env-model")
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "env-key")
+
+        with pytest.raises(RuntimeError, match="broken model hub initialization"):
+            model_resolver.resolve_embedding_adapter(model_id=None)
+
     def test_resolve_embedding_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in [
@@ -236,12 +458,8 @@ class TestResolveRerankAdapter:
 
     def test_resolve_rerank_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test resolving rerank from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback
         monkeypatch.setenv("DASHSCOPE_RERANK_MODEL", "env-rerank")
@@ -258,12 +476,8 @@ class TestResolveRerankAdapter:
 
     def test_resolve_rerank_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in [
@@ -337,12 +551,8 @@ class TestResolveLLMAdapter:
 
     def test_resolve_llm_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test resolving LLM from env when hub fails (fallback)."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Set env vars for fallback (OpenAI)
         monkeypatch.setenv("OPENAI_API_KEY", "env-key")
@@ -358,12 +568,8 @@ class TestResolveLLMAdapter:
 
     def test_resolve_llm_both_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that error is raised when both hub and env fail."""
-
-        # Mock hub to raise exception
-        def failing_hub():
-            raise Exception("Hub not available")
-
-        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", failing_hub)
+        # Mock recoverable hub unavailability.
+        monkeypatch.setattr(model_resolver, "_get_or_init_model_hub", lambda: None)
 
         # Clear env vars
         for key in ["OPENAI_API_KEY", "ZHIPU_API_KEY", "DEEPSEEK_API_KEY"]:

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -1,6 +1,7 @@
 """Unit tests for web crawler."""
 
 import logging
+import subprocess
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,7 +10,10 @@ import httpx
 import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
-from xagent.core.tools.core.RAG_tools.web_crawler.crawler import WebCrawler
+from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
+    WebCrawler,
+    _get_httpx_accept_encoding,
+)
 
 
 class TestWebCrawler:
@@ -63,6 +67,53 @@ class TestWebCrawler:
         config = WebCrawlConfig(start_url="https://example.com")
 
         assert config.tls_impersonate is None
+
+    def test_httpx_accept_encoding_excludes_brotli_without_decoder(self):
+        """Do not advertise Brotli unless httpx can decode it."""
+        with patch(
+            "xagent.core.tools.core.RAG_tools.web_crawler.crawler."
+            "importlib.util.find_spec",
+            return_value=None,
+        ):
+            assert _get_httpx_accept_encoding() == "gzip, deflate"
+
+    def test_httpx_accept_encoding_includes_brotli_with_decoder(self):
+        """Advertise Brotli when a supported decoder package is installed."""
+
+        def fake_find_spec(name):
+            return object() if name == "brotlicffi" else None
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.web_crawler.crawler."
+            "importlib.util.find_spec",
+            side_effect=fake_find_spec,
+        ):
+            assert _get_httpx_accept_encoding() == "gzip, deflate, br"
+
+    def test_httpx_accept_encoding_works_in_clean_interpreter(self):
+        """Crawler should explicitly load importlib.util before using find_spec."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import importlib, sys; "
+                    "sys.modules.pop('importlib.util', None); "
+                    "delattr(importlib, 'util') if hasattr(importlib, 'util') else None; "
+                    "from xagent.core.tools.core.RAG_tools.web_crawler.crawler "
+                    "import _get_httpx_accept_encoding; "
+                    "print(_get_httpx_accept_encoding())"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout.strip() in {
+            "gzip, deflate",
+            "gzip, deflate, br",
+        }
 
     @pytest.mark.asyncio
     async def test_crawl_single_page(self, crawl_config, sample_html):


### PR DESCRIPTION
## Summary

This fixes two independent KB stability issues observed in production:

1. KB model resolution could surface a misleading "model not found in hub" error when the model hub database was unavailable due to exhausted Postgres connections.
2. Website import could fail with null-byte extracted content because the plain httpx crawler advertised Brotli support even when the runtime had no Brotli decoder installed.

No public API or database schema changes are included.

## Production Evidence

### 1. KB model resolution failure

Production reported:

- `Knowledge base search failed for one or more collections`
- `initialize failed: Model 'text-embedding-v4-dashscope-1-37c6d7dd' not found in hub and no environment configuration available for embedding`
- File ingestion also failed with `Model 'text-embedding-v4' not found in hub and no environment configuration available for embedding`

The model was present in the production model table:

- `model_id = text-embedding-v4-dashscope-1-37c6d7dd`
- `category = embedding`
- `provider = dashscope`
- `model_name = text-embedding-v4`
- `is_active = true`

When the database was reachable, production container checks showed both identifiers resolved successfully:

- `resolve_embedding_adapter("text-embedding-v4-dashscope-1-37c6d7dd")`
- `resolve_embedding_adapter("text-embedding-v4")`

The failure log sequence showed the real underlying condition:

- collection initialization used `embedding_model_id='text-embedding-v4'`
- model hub initialization failed with Postgres `FATAL: sorry, too many clients already`
- resolver then reported `Model 'text-embedding-v4' not found in hub and no environment configuration available for embedding`

At the time of investigation, production Postgres still showed many idle connections and idle-in-transaction sessions, including sessions whose last query was against `models`.

### 2. Website import null-byte failure

Production website import reported:

- `Web ingestion failed: https://www.detrack.com returned extracted content contains null bytes`

Runtime checks showed:

- default website crawling did not enable TLS impersonation
- production image did not have `brotli` or `brotlicffi` installed
- the plain httpx crawler explicitly sent `Accept-Encoding: gzip, deflate, br`

A production-container comparison against the same URL and user agent showed:

- `Accept-Encoding: gzip, deflate, br`
  - response `content-encoding: br`
  - raw/text/markdown content contained null bytes
- `Accept-Encoding: gzip, deflate`
  - response `content-encoding: gzip`
  - raw/text/markdown content had no null bytes
- httpx default headers
  - response `content-encoding: gzip`
  - raw/text/markdown content had no null bytes

## Code Facts

### Model resolver

`model_resolver._get_or_init_model_hub()` created a new SQLAlchemy engine, sessionmaker, model table class, and session for each call. The returned `SQLAlchemyModelHub` owned an open session, but resolver/listing callers did not close that session after `load()` or `list()`.

Direct hub-listing paths in collection metadata rebuild and migration inference also read from the hub without a managed session lifecycle.

### Web crawler

The plain httpx crawler path always set:

```python
"Accept-Encoding": "gzip, deflate, br"
```

That header advertised Brotli support independently of whether the runtime could decode Brotli. The TLS impersonation / curl_cffi path is separate and remains unchanged.

## Changes

- Reuse a process-level model hub engine/sessionmaker instead of creating a new engine for every resolver call.
- Add managed model hub helpers so each `load()` / `list()` call uses a short-lived session and always closes it.
- Add `SQLAlchemyModelHub.close()` and context manager support.
- Route collection metadata rebuild and migration inference through the managed hub listing helper.
- Preserve lookup compatibility:
  - first resolve by hub `model_id`
  - then resolve by provider `model_name`
- Improve resolver behavior and errors:
  - DB availability failures are reported as model hub database unavailable
  - model-not-found remains distinct
  - non-DB hub errors are not hidden by env fallback
  - env fallback behavior is preserved when the hub database is unavailable
- Change plain httpx crawler headers so `br` is only advertised when `brotli` or `brotlicffi` is installed.
- Add safe crawl quality metadata to logs for rejected raw/extracted content:
  - URL
  - status
  - content encoding
  - content type
  - null/replacement/control character counts and ratios

## Verification

```bash
uv run pytest tests/core/tools/core/RAG_tools/utils/test_model_resolver.py tests/core/tools/core/RAG_tools/utils/test_model_resolver_utils.py -q
uv run pytest tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py -q
uv run pytest tests/core/tools/core/RAG_tools/pipelines/test_model_resolver_legacy.py -q
uv run ruff check src/xagent/core/model/storage/db/adapter.py src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py src/xagent/core/tools/core/RAG_tools/management/collection_manager.py src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py tests/core/tools/core/RAG_tools/utils/test_model_resolver.py tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
uv run ruff format --check src/xagent/core/model/storage/db/adapter.py src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py src/xagent/core/tools/core/RAG_tools/management/collection_manager.py src/xagent/core/tools/core/RAG_tools/utils/migration_utils.py tests/core/tools/core/RAG_tools/utils/test_model_resolver.py tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
```