### PR TITLE
fix: batch tenant-scoped KB collection deletes

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/config.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/config.py
@@ -65,6 +65,9 @@ DEFAULT_VECTOR_STORE_SCAN_LIMIT: Final[int] = 10_000
 DEFAULT_VECTOR_STORE_EXTENDED_SCAN_LIMIT: Final[int] = 1_000_000
 """Higher limit for operations like listing all documents in a collection or deleting a collection."""
 
+DEFAULT_VECTOR_STORE_DELETE_BATCH_SIZE: Final[int] = 100
+"""Default doc_id batch size for vector-store delete predicates."""
+
 DEFAULT_BACKFILL_BATCH_SIZE: Final[int] = 1000
 """Default batch size for backfill operations (rows per iteration).
 

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -1297,30 +1297,16 @@ def delete_collection(
                     warnings_out=warnings,
                 )
             )
-        else:
-            for doc_id in doc_ids:
-                _merge_deleted_counts(
-                    vector_store.delete_document_data(
-                        collection_name=collection,
-                        doc_id=doc_id,
-                        user_id=user_id,
-                        is_admin=is_admin,
-                    )
-                )
-
-        # Clear ingestion status for all documents
-        for doc_id in doc_ids:
-            try:
-                clear_ingestion_status(
-                    collection,
-                    doc_id,
+        elif doc_ids:
+            _merge_deleted_counts(
+                vector_store.delete_documents_data(
+                    collection_name=collection,
+                    doc_ids=doc_ids,
                     user_id=user_id,
                     is_admin=is_admin,
+                    warnings_out=warnings,
                 )
-            except Exception as exc:  # noqa: BLE001
-                warning = f"Failed to clear ingestion status for '{doc_id}': {exc}"
-                logger.warning(warning)
-                warnings.append(warning)
+            )
 
         remaining_collection_records = vector_store.list_document_records(
             collection_name=collection,

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -1261,6 +1261,18 @@ def delete_collection(
 
     warnings: List[str] = []
     metadata_cleanup_counts: dict[str, int] = {}
+    deleted_counts: Dict[str, int] = {}
+    doc_ids: List[str] = []
+
+    def _merge_deleted_counts(counts: Dict[str, int]) -> None:
+        for key, value in dict(counts).items():
+            deleted_count = int(value)
+            if deleted_count <= 0:
+                continue
+            table_name = str(key)
+            deleted_counts[table_name] = (
+                deleted_counts.get(table_name, 0) + deleted_count
+            )
 
     try:
         # Use storage abstraction for deletion
@@ -1275,18 +1287,6 @@ def delete_collection(
             max_results=DEFAULT_VECTOR_STORE_EXTENDED_SCAN_LIMIT,  # Higher limit for collection deletion
         )
         doc_ids = sorted({r.doc_id for r in doc_records})
-
-        deleted_counts: Dict[str, int] = {}
-
-        def _merge_deleted_counts(counts: Dict[str, int]) -> None:
-            for key, value in dict(counts).items():
-                deleted_count = int(value)
-                if deleted_count <= 0:
-                    continue
-                table_name = str(key)
-                deleted_counts[table_name] = (
-                    deleted_counts.get(table_name, 0) + deleted_count
-                )
 
         if is_admin:
             _merge_deleted_counts(
@@ -1323,9 +1323,36 @@ def delete_collection(
         )
 
     except Exception as exc:  # noqa: BLE001 - convert to structured failure
+        details = getattr(exc, "details", {})
+        partial_doc_ids: list[str] = []
+        if isinstance(details, dict):
+            raw_counts = details.get("deleted_counts")
+            if isinstance(raw_counts, dict):
+                _merge_deleted_counts(raw_counts)
+            raw_doc_ids = details.get("deleted_doc_ids")
+            if isinstance(raw_doc_ids, list):
+                partial_doc_ids = [str(doc_id) for doc_id in raw_doc_ids]
+
         logger.error(
             "Failed to delete collection '%s': %s", collection, exc, exc_info=True
         )
+        if deleted_counts:
+            partial_affected = [
+                CollectionOperationDetail(
+                    doc_id=doc_id,
+                    status=DocumentProcessingStatus.FAILED,
+                    message="Document deleted successfully before cleanup stopped.",
+                )
+                for doc_id in partial_doc_ids
+            ]
+            return CollectionOperationResult(
+                status="partial_success",
+                collection=collection,
+                message=f"Partially deleted collection '{collection}': {exc}",
+                warnings=warnings,
+                affected_documents=partial_affected,
+                deleted_counts=dict(deleted_counts),
+            )
         return CollectionOperationResult(
             status="error",
             collection=collection,

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -515,6 +515,32 @@ class VectorIndexStore(ABC):
         """
 
     @abstractmethod
+    def delete_documents_data(
+        self,
+        collection_name: str,
+        doc_ids: Sequence[str],
+        user_id: Optional[int],
+        is_admin: bool,
+        warnings_out: Optional[List[str]] = None,
+    ) -> Dict[str, int]:
+        """Delete vector-side data for multiple documents in one storage call.
+
+        Implementations should batch internally and preserve document-scoped
+        tenant safety: predicates must include collection and doc_id constraints,
+        and add user_id filtering where the backend table supports it.
+
+        Args:
+            collection_name: Name of the collection.
+            doc_ids: Document identifiers to delete.
+            user_id: User ID for tenant-scoped deletion.
+            is_admin: Whether the caller can delete across tenants.
+            warnings_out: Optional list to append best-effort deletion warnings to.
+
+        Returns:
+            Dictionary mapping table names to deleted row counts.
+        """
+
+    @abstractmethod
     def aggregate_collection_stats(
         self,
         user_id: Optional[int],

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -879,34 +879,47 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
         batch_size = DEFAULT_VECTOR_STORE_DELETE_BATCH_SIZE
         merged: Dict[str, int] = {}
-        for start in range(0, len(normalized_doc_ids), batch_size):
-            batch = normalized_doc_ids[start : start + batch_size]
-            try:
-                counts = cascade_delete_documents(
-                    collection=collection_name,
-                    doc_ids=batch,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    preview_only=False,
-                    confirm=True,
-                    conn=conn,
-                )
-            except Exception as exc:
-                if warnings_out is not None:
-                    warnings_out.append(
-                        "Failed to delete document batch "
-                        f"{start // batch_size + 1}: {exc}"
+        deleted_doc_ids: List[str] = []
+        try:
+            for start in range(0, len(normalized_doc_ids), batch_size):
+                batch = normalized_doc_ids[start : start + batch_size]
+                try:
+                    counts = cascade_delete_documents(
+                        collection=collection_name,
+                        doc_ids=batch,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                        preview_only=False,
+                        confirm=True,
+                        conn=conn,
                     )
-                raise
-            for key, value in counts.items():
-                deleted_count = int(value)
-                if deleted_count <= 0:
-                    continue
-                merged[str(key)] = merged.get(str(key), 0) + deleted_count
+                except Exception as exc:
+                    if warnings_out is not None:
+                        warnings_out.append(
+                            "Failed to delete document batch "
+                            f"{start // batch_size + 1}: {exc}"
+                        )
+                    from ..core.exceptions import DatabaseOperationError
 
-        # Ensure subsequent reads don't observe stale cached table handles.
-        self.invalidate_table_cache()
-        return merged
+                    raise DatabaseOperationError(
+                        "Failed to delete document batch",
+                        details={
+                            "deleted_counts": dict(merged),
+                            "deleted_doc_ids": list(deleted_doc_ids),
+                            "failed_batch_index": start // batch_size + 1,
+                        },
+                    ) from exc
+                for key, value in counts.items():
+                    deleted_count = int(value)
+                    if deleted_count <= 0:
+                        continue
+                    merged[str(key)] = merged.get(str(key), 0) + deleted_count
+                deleted_doc_ids.extend(batch)
+
+            return merged
+        finally:
+            # Ensure subsequent reads don't observe stale cached table handles.
+            self.invalidate_table_cache()
 
     def _count_collections_fast(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -15,7 +15,11 @@ from lancedb.db import DBConnection
 
 from xagent.providers.vector_store.lancedb import get_connection_from_env
 
-from ..core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT, IndexPolicy
+from ..core.config import (
+    DEFAULT_VECTOR_STORE_DELETE_BATCH_SIZE,
+    DEFAULT_VECTOR_STORE_SCAN_LIMIT,
+    IndexPolicy,
+)
 from ..core.schemas import CollectionInfo, IndexResult
 from ..LanceDB.schema_manager import ensure_documents_table
 from ..utils.lancedb_query_utils import list_table_names, query_to_list
@@ -856,6 +860,53 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         # Ensure subsequent reads don't observe stale cached table handles.
         self.invalidate_table_cache()
         return counts
+
+    def delete_documents_data(
+        self,
+        collection_name: str,
+        doc_ids: Sequence[str],
+        user_id: Optional[int],
+        is_admin: bool,
+        warnings_out: Optional[List[str]] = None,
+    ) -> Dict[str, int]:
+        """Delete vector-side data for multiple documents in batches."""
+        normalized_doc_ids = sorted({str(doc_id) for doc_id in doc_ids if str(doc_id)})
+        if not normalized_doc_ids:
+            return {}
+
+        conn = self._get_connection()
+        from ..version_management.cascade_cleaner import cascade_delete_documents
+
+        batch_size = DEFAULT_VECTOR_STORE_DELETE_BATCH_SIZE
+        merged: Dict[str, int] = {}
+        for start in range(0, len(normalized_doc_ids), batch_size):
+            batch = normalized_doc_ids[start : start + batch_size]
+            try:
+                counts = cascade_delete_documents(
+                    collection=collection_name,
+                    doc_ids=batch,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    preview_only=False,
+                    confirm=True,
+                    conn=conn,
+                )
+            except Exception as exc:
+                if warnings_out is not None:
+                    warnings_out.append(
+                        "Failed to delete document batch "
+                        f"{start // batch_size + 1}: {exc}"
+                    )
+                raise
+            for key, value in counts.items():
+                deleted_count = int(value)
+                if deleted_count <= 0:
+                    continue
+                merged[str(key)] = merged.get(str(key), 0) + deleted_count
+
+        # Ensure subsequent reads don't observe stale cached table handles.
+        self.invalidate_table_cache()
+        return merged
 
     def _count_collections_fast(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -27,6 +27,7 @@ from ..utils.string_utils import (
     build_user_id_filter_for_table,
     escape_lancedb_string,
 )
+from ..utils.user_permissions import UserPermissions
 from ..utils.user_scope import resolve_user_scope
 from .main_pointer_manager import get_main_pointer
 
@@ -106,6 +107,51 @@ def _build_document_filter(
     except Exception:
         # If table introspection fails, keep tenant-safe fallback.
         return build_lancedb_filter_expression(base, user_id=user_id, is_admin=is_admin)
+    finally:
+        _safe_close_table(table)
+
+
+def _doc_ids_filter(doc_ids: list[str]) -> str:
+    if len(doc_ids) == 1:
+        return f"doc_id == '{escape_lancedb_string(doc_ids[0])}'"
+    values = ", ".join(f"'{escape_lancedb_string(doc_id)}'" for doc_id in doc_ids)
+    return f"doc_id IN ({values})"
+
+
+def _build_documents_filter(
+    *,
+    conn: Any,
+    table_name: str,
+    collection: str,
+    doc_ids: list[str],
+    user_id: Optional[int],
+    is_admin: bool,
+) -> str:
+    """Build a safe filter for deleting multiple document-scoped rows."""
+    base_expr = build_lancedb_filter_expression(
+        {"collection": collection}, skip_user_filter=True
+    )
+    doc_expr = _doc_ids_filter(doc_ids)
+    scoped_expr = f"{base_expr} AND {doc_expr}"
+
+    if is_admin:
+        return scoped_expr
+    if user_id is None:
+        return f"{scoped_expr} AND ({UserPermissions.get_no_access_filter()})"
+
+    table = None
+    try:
+        table = conn.open_table(table_name)
+        if _table_has_column(table, "user_id"):
+            return (
+                f"{scoped_expr} AND "
+                f"{build_user_id_filter_for_table(table, int(user_id))}"
+            )
+        # Legacy schemas without user_id stay document-scoped by doc_id.
+        return scoped_expr
+    except Exception:
+        # If introspection fails, fail closed with an explicit user_id predicate.
+        return f"{scoped_expr} AND user_id == {int(user_id)}"
     finally:
         _safe_close_table(table)
 
@@ -443,6 +489,72 @@ def cascade_delete(
                 user_id=user_id,
                 is_admin=is_admin,
             )
+
+    if preview_only and not confirm:
+        return _plan_by_predicates(conn, predicates, model_tag=None)
+
+    return _delete_by_predicates(conn, predicates, model_tag=None)
+
+
+def cascade_delete_documents(
+    *,
+    collection: str,
+    doc_ids: list[str],
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    preview_only: bool = True,
+    confirm: bool = False,
+    conn: Any | None = None,
+) -> Dict[str, int]:
+    """Cascade delete several documents using one predicate set.
+
+    This keeps non-admin deletes document-scoped even for legacy tables that do
+    not expose user_id, avoiding collection-wide mutation while reducing the
+    number of full cascade passes.
+    """
+    normalized_doc_ids = sorted({str(doc_id) for doc_id in doc_ids if str(doc_id)})
+    if not normalized_doc_ids:
+        return {}
+
+    user_scope = resolve_user_scope(user_id=user_id, is_admin=is_admin)
+    user_id = user_scope.user_id
+    is_admin = user_scope.is_admin
+
+    if conn is None:
+        conn = get_vector_store_raw_connection()
+    ensure_documents_table(conn)
+    ensure_parses_table(conn)
+    ensure_chunks_table(conn)
+    ensure_main_pointers_table(conn)
+    ensure_ingestion_runs_table(conn)
+
+    table_names = _get_table_names(conn)
+    predicates: Dict[str, str] = {}
+
+    core_tables = ["documents", "parses", "chunks", "main_pointers", "ingestion_runs"]
+    for table_name in core_tables:
+        if table_name not in table_names:
+            continue
+        predicates[table_name] = _build_documents_filter(
+            conn=conn,
+            table_name=table_name,
+            collection=collection,
+            doc_ids=normalized_doc_ids,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    for table_name in table_names:
+        if not table_name.startswith("embeddings_"):
+            continue
+        predicates[table_name] = _build_documents_filter(
+            conn=conn,
+            table_name=table_name,
+            collection=collection,
+            doc_ids=normalized_doc_ids,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
 
     if preview_only and not confirm:
         return _plan_by_predicates(conn, predicates, model_tag=None)

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -519,6 +519,8 @@ def cascade_delete_documents(
     user_scope = resolve_user_scope(user_id=user_id, is_admin=is_admin)
     user_id = user_scope.user_id
     is_admin = user_scope.is_admin
+    if not is_admin and user_id is None:
+        return {}
 
     if conn is None:
         conn = get_vector_store_raw_connection()

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -556,14 +556,14 @@ def test_delete_collection_preserves_partial_vector_cleanup(
     assert result.warnings == [warnings_from_store]
 
 
-def test_delete_collection_non_admin_uses_document_scoped_deletes(
+def test_delete_collection_non_admin_uses_batched_document_scoped_delete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Non-admin collection delete should avoid collection-wide legacy cleanup."""
 
     class FakeVectorStore:
         def __init__(self) -> None:
-            self.document_delete_calls: list[tuple[str, str, int | None, bool]] = []
+            self.documents_delete_calls: list[dict[str, object]] = []
 
         def list_document_records(self, **_kwargs: object) -> list[DocumentRecord]:
             return [
@@ -576,6 +576,10 @@ def test_delete_collection_non_admin_uses_document_scoped_deletes(
                 "non-admin delete must not use collection-wide cleanup"
             )
 
+        def delete_documents_data(self, **_kwargs: object) -> dict[str, int]:
+            self.documents_delete_calls.append(dict(_kwargs))
+            return {"chunks": 2}
+
         def delete_document_data(
             self,
             *,
@@ -584,10 +588,7 @@ def test_delete_collection_non_admin_uses_document_scoped_deletes(
             user_id: int | None,
             is_admin: bool,
         ) -> dict[str, int]:
-            self.document_delete_calls.append(
-                (collection_name, doc_id, user_id, is_admin)
-            )
-            return {"chunks": 1}
+            raise AssertionError("collection delete should not fan out per document")
 
     store = FakeVectorStore()
     monkeypatch.setattr(collections_module, "get_vector_index_store", lambda: store)
@@ -600,10 +601,11 @@ def test_delete_collection_non_admin_uses_document_scoped_deletes(
     result = delete_collection("shared", user_id=7, is_admin=False)
 
     assert result.status == "success"
-    assert store.document_delete_calls == [
-        ("shared", "doc-1", 7, False),
-        ("shared", "doc-2", 7, False),
-    ]
+    assert len(store.documents_delete_calls) == 1
+    assert store.documents_delete_calls[0]["collection_name"] == "shared"
+    assert store.documents_delete_calls[0]["doc_ids"] == ["doc-1", "doc-2"]
+    assert store.documents_delete_calls[0]["user_id"] == 7
+    assert store.documents_delete_calls[0]["is_admin"] is False
 
 
 def test_delete_collection_reports_success_when_only_orphan_artifacts_deleted(

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
 from src.xagent.core.tools.core.RAG_tools.core.schemas import DocumentProcessingStatus
 from src.xagent.core.tools.core.RAG_tools.LanceDB.model_tag_utils import (
     embeddings_table_name,
@@ -606,6 +607,47 @@ def test_delete_collection_non_admin_uses_batched_document_scoped_delete(
     assert store.documents_delete_calls[0]["doc_ids"] == ["doc-1", "doc-2"]
     assert store.documents_delete_calls[0]["user_id"] == 7
     assert store.documents_delete_calls[0]["is_admin"] is False
+
+
+def test_delete_collection_reports_partial_batched_delete_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prior successful batches should be visible when a later batch fails."""
+
+    class FakeVectorStore:
+        def list_document_records(self, **kwargs: object) -> list[DocumentRecord]:
+            if kwargs.get("is_admin") is True:
+                return []
+            return [
+                DocumentRecord(doc_id="doc-1", file_id=None, source_path=None),
+                DocumentRecord(doc_id="doc-2", file_id=None, source_path=None),
+            ]
+
+        def delete_collection_data(self, **_kwargs: object) -> dict[str, int]:
+            raise AssertionError(
+                "non-admin delete must not use collection-wide cleanup"
+            )
+
+        def delete_documents_data(self, **kwargs: object) -> dict[str, int]:
+            kwargs["warnings_out"].append("Failed to delete document batch 2: boom")
+            raise DatabaseOperationError(
+                "Failed to delete document batch",
+                details={
+                    "deleted_counts": {"documents": 1, "chunks": 2},
+                    "deleted_doc_ids": ["doc-1"],
+                },
+            )
+
+    monkeypatch.setattr(
+        collections_module, "get_vector_index_store", lambda: FakeVectorStore()
+    )
+
+    result = delete_collection("shared", user_id=7, is_admin=False)
+
+    assert result.status == "partial_success"
+    assert result.deleted_counts == {"documents": 1, "chunks": 2}
+    assert result.warnings == ["Failed to delete document batch 2: boom"]
+    assert [detail.doc_id for detail in result.affected_documents] == ["doc-1"]
 
 
 def test_delete_collection_reports_success_when_only_orphan_artifacts_deleted(

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -574,6 +574,47 @@ def test_delete_collection_data_delegates_to_cascade_delete(
     assert warnings == []
 
 
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.cascade_delete_documents"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_delete_documents_data_delegates_to_batched_cascade_delete(
+    mock_get_connection: Mock,
+    mock_cascade_delete_documents: Mock,
+) -> None:
+    """delete_documents_data should batch document-scoped cascade deletes."""
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_cascade_delete_documents.return_value = {"documents": 2, "chunks": 4}
+
+    store = LanceDBVectorIndexStore()
+    warnings: List[str] = []
+
+    deleted_counts = store.delete_documents_data(
+        "demo",
+        ["doc-2", "doc-1", "doc-1"],
+        user_id=7,
+        is_admin=False,
+        warnings_out=warnings,
+    )
+
+    mock_cascade_delete_documents.assert_called_once()
+    called = mock_cascade_delete_documents.call_args.kwargs
+    assert called["collection"] == "demo"
+    assert called["doc_ids"] == ["doc-1", "doc-2"]
+    assert called["user_id"] == 7
+    assert called["is_admin"] is False
+    assert called["preview_only"] is False
+    assert called["confirm"] is True
+    assert called["conn"] is mock_conn
+
+    assert deleted_counts == {"documents": 2, "chunks": 4}
+    assert warnings == []
+
+
 # --- Upsert Fallback Tests ---
 
 

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
 from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
     LanceDBIngestionStatusStore,
     LanceDBMainPointerStore,
@@ -613,6 +614,50 @@ def test_delete_documents_data_delegates_to_batched_cascade_delete(
 
     assert deleted_counts == {"documents": 2, "chunks": 4}
     assert warnings == []
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.cascade_delete_documents"
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
+def test_delete_documents_data_invalidates_cache_and_reports_partial_counts_on_failure(
+    mock_get_connection: Mock,
+    mock_cascade_delete_documents: Mock,
+) -> None:
+    """A later batch failure should not hide prior batch progress."""
+
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+    mock_cascade_delete_documents.side_effect = [
+        {"documents": 100, "chunks": 200},
+        RuntimeError("batch failed"),
+    ]
+
+    store = LanceDBVectorIndexStore()
+    store.invalidate_table_cache = Mock()  # type: ignore[method-assign]
+    warnings: List[str] = []
+    doc_ids = [f"doc-{idx:03d}" for idx in range(101)]
+
+    with pytest.raises(DatabaseOperationError) as exc_info:
+        store.delete_documents_data(
+            "demo",
+            doc_ids,
+            user_id=7,
+            is_admin=False,
+            warnings_out=warnings,
+        )
+
+    assert mock_cascade_delete_documents.call_count == 2
+    store.invalidate_table_cache.assert_called_once()
+    assert warnings == ["Failed to delete document batch 2: batch failed"]
+    assert exc_info.value.details["deleted_counts"] == {
+        "documents": 100,
+        "chunks": 200,
+    }
+    assert exc_info.value.details["deleted_doc_ids"] == doc_ids[:100]
+    assert exc_info.value.details["failed_batch_index"] == 2
 
 
 # --- Upsert Fallback Tests ---

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -10,6 +10,7 @@ import pytest
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner import (
     cascade_delete,
+    cascade_delete_documents,
     cleanup_chunk_cascade,
     cleanup_document_cascade,
     cleanup_embed_cascade,
@@ -903,6 +904,80 @@ def test_cascade_delete_document_multitable_predicates_are_consistent(
     assert "collection == 'c_multi'" in pointers_filter
     assert "doc_id == 'd_multi'" in pointers_filter
     assert "user_id ==" not in pointers_filter
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_documents_builds_doc_id_batched_predicates(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Batched document delete should stay document-scoped across all tables."""
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = [
+        "documents",
+        "parses",
+        "chunks",
+        "main_pointers",
+        "ingestion_runs",
+        "embeddings_m1",
+        "embeddings_legacy",
+    ]
+
+    table_map = {
+        "documents": _create_mock_table_with_columns(
+            ["collection", "doc_id", "user_id"]
+        ),
+        "parses": _create_mock_table_with_columns(["collection", "doc_id", "user_id"]),
+        "chunks": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "main_pointers": _create_mock_table_with_columns(["collection", "doc_id"]),
+        "ingestion_runs": _create_mock_table_with_columns(
+            ["collection", "doc_id", "status", "user_id"]
+        ),
+        "embeddings_m1": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "embeddings_legacy": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash"]
+        ),
+    }
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {}
+        cascade_delete_documents(
+            collection="c_batch",
+            doc_ids=["d2", "d1", "d1"],
+            user_id=5,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+
+    for table_name in (
+        "documents",
+        "parses",
+        "chunks",
+        "ingestion_runs",
+        "embeddings_m1",
+    ):
+        filt = predicates[table_name]
+        assert "collection == 'c_batch'" in filt
+        assert "doc_id IN ('d1', 'd2')" in filt
+        assert "user_id == 5" in filt
+
+    for table_name in ("main_pointers", "embeddings_legacy"):
+        filt = predicates[table_name]
+        assert "collection == 'c_batch'" in filt
+        assert "doc_id IN ('d1', 'd2')" in filt
+        assert "user_id ==" not in filt
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -983,6 +983,26 @@ def test_cascade_delete_documents_builds_doc_id_batched_predicates(
 @patch(
     "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
 )
+def test_cascade_delete_documents_noops_for_unauthenticated_non_admin(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Unauthenticated callers should not build predicates for legacy tables."""
+    result = cascade_delete_documents(
+        collection="c_batch",
+        doc_ids=["d1"],
+        user_id=None,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert result == {}
+    mock_get_conn.assert_not_called()
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
 def test_cascade_delete_document_model_tag_only_builds_target_embeddings_predicate(
     mock_get_conn: MagicMock,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a vector-store contract for batched document-scoped KB data deletion.
- Use the batched delete path for non-admin collection deletes instead of running one cascade per document.
- Keep tenant scoping intact by combining collection and doc_id predicates, adding user_id filters where tables support them.
- Remove the redundant per-document ingestion status cleanup because collection/document cascade already covers ingestion_runs.

## Root Cause
Deleting a knowledge base as a regular user fanned out into one full cascade pass per document. Large collections therefore paid repeated table scans and repeated ingestion status cleanup even though the delete scope was already known up front.

## Validation
- `uv run pytest tests/core/tools/core/RAG_tools/management/test_collections.py tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py::test_delete_collection_data_delegates_to_cascade_delete tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py::test_delete_documents_data_delegates_to_batched_cascade_delete tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py::test_cascade_delete_documents_builds_doc_id_batched_predicates tests/core/tools/core/RAG_tools/test_multitenancy.py` - 72 passed
- Local LanceDB end-to-end benchmark:
  - 50 docs, 3 chunks/doc: 1.317s -> 0.030s, 43.96x faster, remaining rows 0/0
  - 200 docs, 2 chunks/doc: 6.419s -> 0.053s, 121.03x faster, remaining rows 0/0
  - 500 docs, 1 chunk/doc: 24.406s -> 0.118s, 206.34x faster, remaining rows 0/0
