### PR TITLE
ref(kb): add coordinator skeleton

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -1,0 +1,30 @@
+"""KB semantic coordinator public surface."""
+
+from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
+from .coordinator import (
+    KBCoordinator,
+    get_kb_coordinator,
+    reset_kb_coordinator_for_tests,
+)
+from .models import (
+    KBAccessMode,
+    KBBackendCapabilities,
+    KBCollectionContext,
+    KBContextRequest,
+    KBStorageBackend,
+    KBUserScope,
+)
+
+__all__ = [
+    "KBAccessMode",
+    "KBBackendCapabilities",
+    "KBCollectionContext",
+    "KBContextRequest",
+    "KBHandleProvider",
+    "KBCoordinator",
+    "KBStorageBackend",
+    "KBUserScope",
+    "LanceDBCollectionHandle",
+    "get_kb_coordinator",
+    "reset_kb_coordinator_for_tests",
+]

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -1,0 +1,48 @@
+"""Collection-scoped KB backend handle skeletons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..storage.contracts import MetadataStore, VectorIndexStore
+from .models import KBBackendCapabilities, KBCollectionContext, KBStorageBackend
+
+
+class KBHandleProvider:
+    """Open collection-scoped handles for resolved KB contexts."""
+
+    def open(self, context: KBCollectionContext) -> LanceDBCollectionHandle:
+        """Return a backend-specific handle for the resolved collection context."""
+        if context.backend is KBStorageBackend.LANCEDB:
+            return LanceDBCollectionHandle(context)
+        raise ValueError(
+            f"KB storage backend {context.backend.value!r} is not supported by "
+            "KBHandleProvider"
+        )
+
+
+@dataclass(frozen=True)
+class LanceDBCollectionHandle:
+    """Thin LanceDB-backed collection handle for #495 compatibility wiring."""
+
+    context: KBCollectionContext
+
+    @property
+    def metadata_store(self) -> MetadataStore:
+        """Return the metadata store bound to this collection context."""
+        return self.context.metadata_store
+
+    @property
+    def vector_index_store(self) -> VectorIndexStore:
+        """Return the vector index store bound to this collection context."""
+        return self.context.vector_index_store
+
+    @property
+    def backend(self) -> KBStorageBackend:
+        """Return the collection storage backend."""
+        return self.context.backend
+
+    @property
+    def capabilities(self) -> KBBackendCapabilities:
+        """Return backend capabilities for this collection."""
+        return self.context.capabilities

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -187,7 +187,7 @@ def _run_in_separate_loop(awaitable: Coroutine[Any, Any, T]) -> T:
         except BaseException as exc:  # noqa: BLE001 - propagate from worker thread
             error = exc
 
-    thread = threading.Thread(target=target)
+    thread = threading.Thread(target=target, daemon=True)
     thread.start()
     thread.join()
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Coroutine
+from contextvars import copy_context
 from typing import Any, Optional, TypeVar
 
 from ..storage.factory import StorageFactory
@@ -38,6 +39,7 @@ class KBCoordinator:
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""
         collection = self._normalize_collection(request.collection)
+        access_mode = self._normalize_access_mode(request.access_mode)
         user_scope = self._resolve_user_scope(request)
         metadata_store = self._storage_factory.get_metadata_store()
         vector_index_store = self._storage_factory.get_vector_index_store()
@@ -45,7 +47,9 @@ class KBCoordinator:
         collection_info = None
         try:
             collection_info = await metadata_store.get_collection(collection)
-        except Exception as exc:  # noqa: BLE001 - missing table/row compatibility
+        except ValueError as exc:
+            if not self._is_missing_collection_error(collection, exc):
+                raise
             if not (request.hide_missing or request.allow_create):
                 raise ValueError(f"Collection '{collection}' not found") from exc
 
@@ -55,7 +59,7 @@ class KBCoordinator:
         return KBCollectionContext(
             collection=collection,
             user_scope=user_scope,
-            access_mode=self._normalize_access_mode(request.access_mode),
+            access_mode=access_mode,
             allow_create=bool(request.allow_create),
             hide_missing=bool(request.hide_missing),
             metadata_store=metadata_store,
@@ -100,6 +104,14 @@ class KBCoordinator:
             raise ValueError(
                 f"Invalid KB access mode {access_mode!r}; choose one of: {allowed}"
             ) from exc
+
+    @staticmethod
+    def _is_missing_collection_error(collection: str, exc: ValueError) -> bool:
+        message = str(exc)
+        return message in {
+            f"Collection '{collection}' not found",
+            "Table 'collection_metadata' was not found",
+        }
 
     @staticmethod
     def _resolve_user_scope(request: KBContextRequest) -> KBUserScope:
@@ -179,11 +191,12 @@ def _run_in_separate_loop(awaitable: Coroutine[Any, Any, T]) -> T:
 
     result: Optional[T] = None
     error: Optional[BaseException] = None
+    context = copy_context()
 
     def target() -> None:
         nonlocal result, error
         try:
-            result = asyncio.run(awaitable)
+            result = context.run(lambda: asyncio.run(awaitable))
         except BaseException as exc:  # noqa: BLE001 - propagate from worker thread
             error = exc
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -1,0 +1,196 @@
+"""Semantic KB coordinator skeleton."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Coroutine
+from typing import Any, Optional, TypeVar
+
+from ..storage.factory import StorageFactory
+from ..utils.user_scope import resolve_user_scope
+from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
+from .models import (
+    KBAccessMode,
+    KBBackendCapabilities,
+    KBCollectionContext,
+    KBContextRequest,
+    KBStorageBackend,
+    KBUserScope,
+)
+
+T = TypeVar("T")
+
+KB_STORAGE_METADATA_KEY = "kb_storage"
+
+
+class KBCoordinator:
+    """KB-level semantic entry point for future compatibility facades."""
+
+    def __init__(
+        self,
+        storage_factory: Optional[StorageFactory] = None,
+        handle_provider: Optional[KBHandleProvider] = None,
+    ) -> None:
+        self._storage_factory = storage_factory or StorageFactory.get_factory()
+        self._handle_provider = handle_provider or KBHandleProvider()
+
+    async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
+        """Resolve collection, caller scope, stores, backend, and capabilities."""
+        collection = self._normalize_collection(request.collection)
+        user_scope = self._resolve_user_scope(request)
+        metadata_store = self._storage_factory.get_metadata_store()
+        vector_index_store = self._storage_factory.get_vector_index_store()
+
+        collection_info = None
+        try:
+            collection_info = await metadata_store.get_collection(collection)
+        except Exception as exc:  # noqa: BLE001 - missing table/row compatibility
+            if not (request.hide_missing or request.allow_create):
+                raise ValueError(f"Collection '{collection}' not found") from exc
+
+        backend = self._resolve_backend(collection_info)
+        capabilities = self._capabilities_for_backend(backend)
+
+        return KBCollectionContext(
+            collection=collection,
+            user_scope=user_scope,
+            access_mode=self._normalize_access_mode(request.access_mode),
+            allow_create=bool(request.allow_create),
+            hide_missing=bool(request.hide_missing),
+            metadata_store=metadata_store,
+            vector_index_store=vector_index_store,
+            backend=backend,
+            capabilities=capabilities,
+            collection_info=collection_info,
+        )
+
+    def get_context_sync(self, request: KBContextRequest) -> KBCollectionContext:
+        """Synchronous wrapper for legacy compatibility surfaces."""
+        return _run_in_separate_loop(self.get_context(request))
+
+    async def open_collection(
+        self, request: KBContextRequest
+    ) -> LanceDBCollectionHandle:
+        """Open a thin collection handle for the resolved context."""
+        context = await self.get_context(request)
+        return self._handle_provider.open(context)
+
+    def open_collection_sync(
+        self, request: KBContextRequest
+    ) -> LanceDBCollectionHandle:
+        """Synchronous wrapper for opening a collection handle."""
+        return _run_in_separate_loop(self.open_collection(request))
+
+    @staticmethod
+    def _normalize_collection(collection: str) -> str:
+        normalized = collection.strip() if isinstance(collection, str) else ""
+        if not normalized:
+            raise ValueError("collection must be a non-empty string")
+        return normalized
+
+    @staticmethod
+    def _normalize_access_mode(access_mode: KBAccessMode | str) -> KBAccessMode:
+        if isinstance(access_mode, KBAccessMode):
+            return access_mode
+        try:
+            return KBAccessMode(str(access_mode).strip().lower())
+        except ValueError as exc:
+            allowed = ", ".join(mode.value for mode in KBAccessMode)
+            raise ValueError(
+                f"Invalid KB access mode {access_mode!r}; choose one of: {allowed}"
+            ) from exc
+
+    @staticmethod
+    def _resolve_user_scope(request: KBContextRequest) -> KBUserScope:
+        scope = resolve_user_scope(user_id=request.user_id, is_admin=request.is_admin)
+        return KBUserScope(user_id=scope.user_id, is_admin=bool(scope.is_admin))
+
+    def _resolve_backend(self, collection_info: object | None) -> KBStorageBackend:
+        if collection_info is None:
+            return KBStorageBackend.LANCEDB
+
+        extra_metadata = getattr(collection_info, "extra_metadata", None) or {}
+        binding = extra_metadata.get(KB_STORAGE_METADATA_KEY)
+        if binding is None:
+            return KBStorageBackend.LANCEDB
+
+        if isinstance(binding, str):
+            return self._parse_backend(binding)
+
+        if isinstance(binding, dict):
+            raw_backend = binding.get("backend")
+            if raw_backend is None or str(raw_backend).strip() == "":
+                return KBStorageBackend.LANCEDB
+            return self._parse_backend(str(raw_backend))
+
+        raise ValueError(
+            f"Invalid {KB_STORAGE_METADATA_KEY} binding shape: {type(binding).__name__}"
+        )
+
+    @staticmethod
+    def _parse_backend(raw_backend: str) -> KBStorageBackend:
+        try:
+            return KBStorageBackend(raw_backend.strip().lower())
+        except ValueError as exc:
+            allowed = ", ".join(backend.value for backend in KBStorageBackend)
+            raise ValueError(
+                f"Invalid {KB_STORAGE_METADATA_KEY} backend {raw_backend!r}; "
+                f"choose one of: {allowed}"
+            ) from exc
+
+    @staticmethod
+    def _capabilities_for_backend(backend: KBStorageBackend) -> KBBackendCapabilities:
+        if backend is KBStorageBackend.LANCEDB:
+            return KBBackendCapabilities.lancedb()
+        return KBBackendCapabilities.unsupported()
+
+
+_coordinator_lock = threading.RLock()
+_coordinator: Optional[KBCoordinator] = None
+
+
+def get_kb_coordinator() -> KBCoordinator:
+    """Return the process-global KB semantic coordinator."""
+    global _coordinator
+    if _coordinator is None:
+        with _coordinator_lock:
+            if _coordinator is None:
+                _coordinator = KBCoordinator()
+    return _coordinator
+
+
+def reset_kb_coordinator_for_tests() -> None:
+    """Reset process-global KB coordinator state for tests."""
+    global _coordinator
+    with _coordinator_lock:
+        _coordinator = None
+
+
+def _run_in_separate_loop(awaitable: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine from sync code, including inside an existing event loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(awaitable)
+
+    if not loop.is_running():
+        return asyncio.run(awaitable)
+
+    result: Optional[T] = None
+    error: Optional[BaseException] = None
+
+    def target() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(awaitable)
+        except BaseException as exc:  # noqa: BLE001 - propagate from worker thread
+            error = exc
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+
+    if error is not None:
+        raise error
+    return result  # type: ignore[return-value]

--- a/src/xagent/core/tools/core/RAG_tools/kb/models.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/models.py
@@ -26,8 +26,6 @@ class KBStorageBackend(StrEnum):
     """Collection-level KB storage backend binding."""
 
     LANCEDB = "lancedb"
-    MILVUS = "milvus"
-    QDRANT = "qdrant"
 
 
 @dataclass(frozen=True)

--- a/src/xagent/core/tools/core/RAG_tools/kb/models.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/models.py
@@ -1,0 +1,105 @@
+"""Semantic KB coordinator models.
+
+These types describe collection-level KB context without moving existing
+storage, API, pipeline, or tool behavior into the coordinator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Optional
+
+from ..core.schemas import CollectionInfo
+from ..storage.contracts import MetadataStore, VectorIndexStore
+
+
+class KBAccessMode(StrEnum):
+    """Semantic access mode requested by a KB caller."""
+
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+class KBStorageBackend(StrEnum):
+    """Collection-level KB storage backend binding."""
+
+    LANCEDB = "lancedb"
+    MILVUS = "milvus"
+    QDRANT = "qdrant"
+
+
+@dataclass(frozen=True)
+class KBBackendCapabilities:
+    """Capabilities exposed by a collection backend handle."""
+
+    supports_documents: bool
+    supports_parses: bool
+    supports_chunks: bool
+    supports_embeddings: bool
+    supports_search: bool
+    supports_versions: bool
+    supports_raw_connection: bool
+
+    @classmethod
+    def lancedb(cls) -> KBBackendCapabilities:
+        """Return current LanceDB-compatible KB capabilities."""
+        return cls(
+            supports_documents=True,
+            supports_parses=True,
+            supports_chunks=True,
+            supports_embeddings=True,
+            supports_search=True,
+            supports_versions=True,
+            supports_raw_connection=True,
+        )
+
+    @classmethod
+    def unsupported(cls) -> KBBackendCapabilities:
+        """Return capabilities for a known but unavailable backend."""
+        return cls(
+            supports_documents=False,
+            supports_parses=False,
+            supports_chunks=False,
+            supports_embeddings=False,
+            supports_search=False,
+            supports_versions=False,
+            supports_raw_connection=False,
+        )
+
+
+@dataclass(frozen=True)
+class KBUserScope:
+    """Resolved caller scope for KB context operations."""
+
+    user_id: Optional[int]
+    is_admin: bool
+
+
+@dataclass(frozen=True)
+class KBContextRequest:
+    """Request for resolving collection-level KB context."""
+
+    collection: str
+    user_id: Optional[int] = None
+    is_admin: Optional[bool] = None
+    access_mode: KBAccessMode = KBAccessMode.READ
+    allow_create: bool = False
+    hide_missing: bool = False
+
+
+@dataclass(frozen=True)
+class KBCollectionContext:
+    """Resolved collection-level context for coordinator and handle callers."""
+
+    collection: str
+    user_scope: KBUserScope
+    access_mode: KBAccessMode
+    allow_create: bool
+    hide_missing: bool
+    metadata_store: MetadataStore
+    vector_index_store: VectorIndexStore
+    backend: KBStorageBackend
+    capabilities: KBBackendCapabilities
+    collection_info: Optional[CollectionInfo] = None

--- a/src/xagent/core/tools/core/RAG_tools/storage/factory.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/factory.py
@@ -270,6 +270,12 @@ def reset_rag_storage_for_tests() -> None:
         pass
     reset_kb_write_coordinator()
 
+    # Clear semantic coordinator state without introducing a storage -> kb
+    # import cycle at module import time.
+    from xagent.core.tools.core.RAG_tools.kb import reset_kb_coordinator_for_tests
+
+    reset_kb_coordinator_for_tests()
+
     # Clear global collection locks to prevent test-to-test lock contamination
     from xagent.core.tools.core.RAG_tools.management import collection_manager
 

--- a/src/xagent/core/tools/core/RAG_tools/storage/factory.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/factory.py
@@ -96,6 +96,11 @@ class StorageFactory:
             self._main_pointer_store = None
             self._coordinator = None
 
+        # Keep semantic KB coordinator state aligned with factory-backed stores.
+        from ..kb import reset_kb_coordinator_for_tests
+
+        reset_kb_coordinator_for_tests()
+
     # --- VectorIndexStore ---
 
     def get_vector_index_store(self) -> VectorIndexStore:
@@ -272,7 +277,7 @@ def reset_rag_storage_for_tests() -> None:
 
     # Clear semantic coordinator state without introducing a storage -> kb
     # import cycle at module import time.
-    from xagent.core.tools.core.RAG_tools.kb import reset_kb_coordinator_for_tests
+    from ..kb import reset_kb_coordinator_for_tests
 
     reset_kb_coordinator_for_tests()
 

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
@@ -7,6 +7,8 @@ isolation. They must not depend on API, pipeline, search, or lifecycle migration
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
@@ -314,6 +316,25 @@ async def test_get_context_resolves_string_kb_storage_binding() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_context_rejects_invalid_kb_storage_backend_string() -> None:
+    """Given an unknown kb_storage backend, get_context fails explicitly."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(
+        CollectionInfo(name="broken_backend", extra_metadata={"kb_storage": "postgres"})
+    )
+
+    with pytest.raises(ValueError, match="postgres"):
+        await get_kb_coordinator().get_context(
+            KBContextRequest(collection="broken_backend")
+        )
+
+
+@pytest.mark.asyncio
 async def test_get_context_rejects_invalid_kb_storage_binding_shape() -> None:
     """Given invalid kb_storage shape, get_context fails explicitly."""
     from xagent.core.tools.core.RAG_tools.kb import (
@@ -330,6 +351,36 @@ async def test_get_context_rejects_invalid_kb_storage_binding_shape() -> None:
         await get_kb_coordinator().get_context(KBContextRequest(collection="broken"))
 
 
+@pytest.mark.asyncio
+async def test_get_context_normalizes_string_access_mode() -> None:
+    """Given a string access mode, get_context normalizes it to the enum."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBAccessMode,
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="docs", access_mode="WRITE", hide_missing=True)
+    )
+
+    assert context.access_mode is KBAccessMode.WRITE
+
+
+@pytest.mark.asyncio
+async def test_get_context_rejects_invalid_access_mode() -> None:
+    """Given an unsupported access mode, get_context fails explicitly."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    with pytest.raises(ValueError, match="Invalid KB access mode"):
+        await get_kb_coordinator().get_context(
+            KBContextRequest(collection="docs", access_mode="delete", hide_missing=True)
+        )
+
+
 def test_open_collection_rejects_unsupported_backend() -> None:
     """Given an unsupported backend, the handle provider raises a clear error."""
     from xagent.core.tools.core.RAG_tools.kb import (
@@ -341,6 +392,9 @@ def test_open_collection_rejects_unsupported_backend() -> None:
         KBUserScope,
     )
 
+    class UnsupportedBackend:
+        value = "future"
+
     factory = StorageFactory.get_factory()
     context = KBCollectionContext(
         collection="future",
@@ -350,12 +404,12 @@ def test_open_collection_rejects_unsupported_backend() -> None:
         hide_missing=False,
         metadata_store=factory.get_metadata_store(),
         vector_index_store=factory.get_vector_index_store(),
-        backend=KBStorageBackend.MILVUS,
+        backend=cast(KBStorageBackend, UnsupportedBackend()),
         capabilities=KBBackendCapabilities.unsupported(),
         collection_info=None,
     )
 
-    with pytest.raises(ValueError, match="milvus"):
+    with pytest.raises(ValueError, match="future"):
         KBHandleProvider().open(context)
 
 
@@ -425,6 +479,21 @@ def test_open_collection_sync_returns_lancedb_handle() -> None:
     assert isinstance(handle, LanceDBCollectionHandle)
 
 
+@pytest.mark.asyncio
+async def test_get_context_sync_resolves_inside_running_event_loop() -> None:
+    """Given async caller context, sync wrapper resolves via a worker event loop."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    context = get_kb_coordinator().get_context_sync(
+        KBContextRequest(collection="docs", hide_missing=True)
+    )
+
+    assert context.collection == "docs"
+
+
 def test_reset_rag_storage_for_tests_resets_kb_coordinator_state() -> None:
     """Given storage reset, KB coordinator state is reset as part of test isolation."""
     from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
@@ -432,6 +501,18 @@ def test_reset_rag_storage_for_tests_resets_kb_coordinator_state() -> None:
     first = get_kb_coordinator()
 
     reset_rag_storage_for_tests()
+    second = get_kb_coordinator()
+
+    assert second is not first
+
+
+def test_storage_factory_reset_all_resets_kb_coordinator_state() -> None:
+    """Given factory reset, semantic KB coordinator state is also reset."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+
+    first = get_kb_coordinator()
+
+    StorageFactory.get_factory().reset_all()
     second = get_kb_coordinator()
 
     assert second is not first

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
@@ -1,0 +1,450 @@
+"""Tests for the KB semantic coordinator skeleton.
+
+The scenarios in this file intentionally exercise only the #495 skeleton:
+context resolution, backend binding resolution, handle creation, and test reset
+isolation. They must not depend on API, pipeline, search, or lifecycle migration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.storage.factory import (
+    StorageFactory,
+    reset_rag_storage_for_tests,
+)
+from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
+
+
+def test_kb_public_surface_imports() -> None:
+    """Given the new semantic package, all #495 public symbols are importable."""
+    import xagent.core.tools.core.RAG_tools.kb as kb
+
+    expected_symbols = [
+        "KBCoordinator",
+        "get_kb_coordinator",
+        "reset_kb_coordinator_for_tests",
+        "KBContextRequest",
+        "KBUserScope",
+        "KBAccessMode",
+        "KBCollectionContext",
+        "KBStorageBackend",
+        "KBBackendCapabilities",
+        "KBHandleProvider",
+        "LanceDBCollectionHandle",
+    ]
+
+    for symbol in expected_symbols:
+        assert hasattr(kb, symbol)
+
+
+def test_kb_access_mode_values_are_stable() -> None:
+    """Given #495 access modes, their persisted string values stay stable."""
+    from xagent.core.tools.core.RAG_tools.kb import KBAccessMode
+
+    assert KBAccessMode.READ.value == "read"
+    assert KBAccessMode.WRITE.value == "write"
+    assert KBAccessMode.ADMIN.value == "admin"
+
+
+def test_lancedb_backend_capabilities_are_explicit() -> None:
+    """Given LanceDB fallback, capabilities explicitly describe supported areas."""
+    from xagent.core.tools.core.RAG_tools.kb import KBBackendCapabilities
+
+    capabilities = KBBackendCapabilities.lancedb()
+
+    assert capabilities.supports_documents is True
+    assert capabilities.supports_parses is True
+    assert capabilities.supports_chunks is True
+    assert capabilities.supports_embeddings is True
+    assert capabilities.supports_search is True
+    assert capabilities.supports_versions is True
+    assert capabilities.supports_raw_connection is True
+
+
+def test_get_kb_coordinator_returns_process_singleton() -> None:
+    """Given process-global access, get_kb_coordinator returns a singleton."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+
+    reset_kb_coordinator_for_tests()
+
+    first = get_kb_coordinator()
+    second = get_kb_coordinator()
+
+    assert first is second
+
+
+def test_reset_kb_coordinator_for_tests_clears_singleton() -> None:
+    """Given a coordinator singleton, reset creates a fresh instance."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+
+    reset_kb_coordinator_for_tests()
+    first = get_kb_coordinator()
+
+    reset_kb_coordinator_for_tests()
+    second = get_kb_coordinator()
+
+    assert second is not first
+
+
+@pytest.mark.asyncio
+async def test_get_context_uses_explicit_user_scope() -> None:
+    """Given explicit user scope, get_context uses it over context defaults."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    request = KBContextRequest(
+        collection="docs", user_id=123, is_admin=True, hide_missing=True
+    )
+
+    context = await get_kb_coordinator().get_context(request)
+
+    assert context.user_scope.user_id == 123
+    assert context.user_scope.is_admin is True
+
+
+@pytest.mark.asyncio
+async def test_get_context_falls_back_to_request_user_scope() -> None:
+    """Given request context scope, get_context uses it when request omits scope."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    with user_scope_context(user_id=456, is_admin=False):
+        context = await get_kb_coordinator().get_context(
+            KBContextRequest(collection="docs", hide_missing=True)
+        )
+
+    assert context.user_scope.user_id == 456
+    assert context.user_scope.is_admin is False
+
+
+@pytest.mark.asyncio
+async def test_get_context_strips_collection_name() -> None:
+    """Given whitespace around collection, get_context normalizes it."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="  docs  ", hide_missing=True)
+    )
+
+    assert context.collection == "docs"
+
+
+@pytest.mark.asyncio
+async def test_get_context_rejects_empty_collection_name() -> None:
+    """Given an empty collection name, get_context raises a clear ValueError."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    with pytest.raises(ValueError, match="collection"):
+        await get_kb_coordinator().get_context(
+            KBContextRequest(collection="   ", hide_missing=True)
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_context_hides_missing_collection_when_requested() -> None:
+    """Given hide_missing, a missing collection returns a LanceDB fallback context."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        KBStorageBackend,
+        get_kb_coordinator,
+    )
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="missing", hide_missing=True)
+    )
+
+    assert context.collection_info is None
+    assert context.backend is KBStorageBackend.LANCEDB
+
+
+@pytest.mark.asyncio
+async def test_get_context_allows_missing_collection_for_create_without_writing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given allow_create, missing collection returns context without metadata writes."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    save_calls = 0
+
+    async def fail_if_saved(collection: CollectionInfo) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        raise AssertionError(f"unexpected metadata write: {collection.name}")
+
+    monkeypatch.setattr(metadata_store, "save_collection", fail_if_saved)
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="new_collection", allow_create=True)
+    )
+
+    assert context.collection_info is None
+    assert save_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_get_context_raises_for_missing_collection_by_default() -> None:
+    """Given default flags, missing collection is a visible error."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    with pytest.raises(ValueError, match="missing"):
+        await get_kb_coordinator().get_context(KBContextRequest(collection="missing"))
+
+
+@pytest.mark.asyncio
+async def test_get_context_defaults_legacy_collection_without_kb_storage_to_lancedb() -> (
+    None
+):
+    """Given legacy metadata without kb_storage, context falls back to LanceDB."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        KBStorageBackend,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(CollectionInfo(name="legacy"))
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="legacy")
+    )
+
+    assert context.collection_info is not None
+    assert context.collection_info.name == "legacy"
+    assert context.backend is KBStorageBackend.LANCEDB
+
+
+@pytest.mark.asyncio
+async def test_get_context_does_not_write_default_binding_for_legacy_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given missing binding, get_context does not persist an implicit default."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(CollectionInfo(name="legacy"))
+
+    save_calls = 0
+
+    async def fail_if_saved(collection: CollectionInfo) -> None:
+        nonlocal save_calls
+        save_calls += 1
+        raise AssertionError(f"unexpected metadata write: {collection.name}")
+
+    monkeypatch.setattr(metadata_store, "save_collection", fail_if_saved)
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="legacy")
+    )
+
+    assert context.collection_info is not None
+    assert save_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_get_context_resolves_dict_kb_storage_binding() -> None:
+    """Given dict kb_storage binding, get_context resolves its backend."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        KBStorageBackend,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(
+        CollectionInfo(
+            name="bound",
+            extra_metadata={"kb_storage": {"backend": "lancedb", "version": 1}},
+        )
+    )
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="bound")
+    )
+
+    assert context.backend is KBStorageBackend.LANCEDB
+
+
+@pytest.mark.asyncio
+async def test_get_context_resolves_string_kb_storage_binding() -> None:
+    """Given string kb_storage binding, get_context resolves its backend."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        KBStorageBackend,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(
+        CollectionInfo(name="bound", extra_metadata={"kb_storage": "lancedb"})
+    )
+
+    context = await get_kb_coordinator().get_context(
+        KBContextRequest(collection="bound")
+    )
+
+    assert context.backend is KBStorageBackend.LANCEDB
+
+
+@pytest.mark.asyncio
+async def test_get_context_rejects_invalid_kb_storage_binding_shape() -> None:
+    """Given invalid kb_storage shape, get_context fails explicitly."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    metadata_store = StorageFactory.get_factory().get_metadata_store()
+    await metadata_store.save_collection(
+        CollectionInfo(name="broken", extra_metadata={"kb_storage": ["lancedb"]})
+    )
+
+    with pytest.raises(ValueError, match="kb_storage"):
+        await get_kb_coordinator().get_context(KBContextRequest(collection="broken"))
+
+
+def test_open_collection_rejects_unsupported_backend() -> None:
+    """Given an unsupported backend, the handle provider raises a clear error."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBAccessMode,
+        KBBackendCapabilities,
+        KBCollectionContext,
+        KBHandleProvider,
+        KBStorageBackend,
+        KBUserScope,
+    )
+
+    factory = StorageFactory.get_factory()
+    context = KBCollectionContext(
+        collection="future",
+        user_scope=KBUserScope(user_id=1, is_admin=False),
+        access_mode=KBAccessMode.READ,
+        allow_create=False,
+        hide_missing=False,
+        metadata_store=factory.get_metadata_store(),
+        vector_index_store=factory.get_vector_index_store(),
+        backend=KBStorageBackend.MILVUS,
+        capabilities=KBBackendCapabilities.unsupported(),
+        collection_info=None,
+    )
+
+    with pytest.raises(ValueError, match="milvus"):
+        KBHandleProvider().open(context)
+
+
+@pytest.mark.asyncio
+async def test_open_collection_returns_lancedb_handle() -> None:
+    """Given LanceDB context, open_collection returns a LanceDB handle."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        LanceDBCollectionHandle,
+        get_kb_coordinator,
+    )
+
+    handle = await get_kb_coordinator().open_collection(
+        KBContextRequest(collection="docs", hide_missing=True)
+    )
+
+    assert isinstance(handle, LanceDBCollectionHandle)
+
+
+@pytest.mark.asyncio
+async def test_lancedb_collection_handle_exposes_context_and_stores() -> None:
+    """Given a LanceDB handle, it exposes context and its factory-backed stores."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    factory = StorageFactory.get_factory()
+
+    handle = await get_kb_coordinator().open_collection(
+        KBContextRequest(collection="docs", hide_missing=True)
+    )
+
+    assert handle.context.collection == "docs"
+    assert handle.metadata_store is factory.get_metadata_store()
+    assert handle.vector_index_store is factory.get_vector_index_store()
+    assert handle.backend is handle.context.backend
+    assert handle.capabilities is handle.context.capabilities
+
+
+def test_get_context_sync_resolves_context() -> None:
+    """Given sync legacy code, get_context_sync resolves equivalent context."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    context = get_kb_coordinator().get_context_sync(
+        KBContextRequest(collection="docs", hide_missing=True)
+    )
+
+    assert context.collection == "docs"
+
+
+def test_open_collection_sync_returns_lancedb_handle() -> None:
+    """Given sync legacy code, open_collection_sync returns a LanceDB handle."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        LanceDBCollectionHandle,
+        get_kb_coordinator,
+    )
+
+    handle = get_kb_coordinator().open_collection_sync(
+        KBContextRequest(collection="docs", hide_missing=True)
+    )
+
+    assert isinstance(handle, LanceDBCollectionHandle)
+
+
+def test_reset_rag_storage_for_tests_resets_kb_coordinator_state() -> None:
+    """Given storage reset, KB coordinator state is reset as part of test isolation."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+
+    first = get_kb_coordinator()
+
+    reset_rag_storage_for_tests()
+    second = get_kb_coordinator()
+
+    assert second is not first
+
+
+def test_existing_rag_storage_and_management_imports_still_work() -> None:
+    """Given legacy callers, old storage and management imports still work."""
+    import xagent.core.tools.core.RAG_tools.management.collection_manager as manager
+    import xagent.core.tools.core.RAG_tools.management.collections as collections
+    import xagent.core.tools.core.RAG_tools.storage as storage
+
+    assert hasattr(storage, "get_metadata_store")
+    assert hasattr(storage, "get_vector_index_store")
+    assert hasattr(collections, "list_collections")
+    assert hasattr(collections, "delete_collection")
+    assert hasattr(manager, "get_collection_sync")

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
@@ -19,6 +19,35 @@ from xagent.core.tools.core.RAG_tools.storage.factory import (
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 
 
+class _FakeMetadataStore:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def get_collection(self, collection: str) -> CollectionInfo:
+        self.calls += 1
+        raise self.error
+
+
+class _FakeStorageFactory:
+    def __init__(self, metadata_store: _FakeMetadataStore) -> None:
+        self.metadata_store = metadata_store
+
+    def get_metadata_store(self) -> _FakeMetadataStore:
+        return self.metadata_store
+
+    def get_vector_index_store(self) -> object:
+        return object()
+
+
+class _StorageAccessSentinel:
+    def get_metadata_store(self) -> object:
+        raise AssertionError("metadata store should not be requested")
+
+    def get_vector_index_store(self) -> object:
+        raise AssertionError("vector index store should not be requested")
+
+
 def test_kb_public_surface_imports() -> None:
     """Given the new semantic package, all #495 public symbols are importable."""
     import xagent.core.tools.core.RAG_tools.kb as kb
@@ -218,6 +247,38 @@ async def test_get_context_raises_for_missing_collection_by_default() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_context_propagates_unexpected_metadata_runtime_error() -> None:
+    """Given storage failure, hide_missing must not return a fallback context."""
+    from xagent.core.tools.core.RAG_tools.kb import KBContextRequest, KBCoordinator
+
+    metadata_store = _FakeMetadataStore(RuntimeError("db offline"))
+    factory = _FakeStorageFactory(metadata_store)
+
+    with pytest.raises(RuntimeError, match="db offline"):
+        await KBCoordinator(storage_factory=cast(StorageFactory, factory)).get_context(
+            KBContextRequest(collection="docs", hide_missing=True)
+        )
+
+    assert metadata_store.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_context_propagates_non_missing_metadata_value_error() -> None:
+    """Given corrupt metadata, ValueError must not be treated as collection missing."""
+    from xagent.core.tools.core.RAG_tools.kb import KBContextRequest, KBCoordinator
+
+    metadata_store = _FakeMetadataStore(ValueError("invalid metadata json"))
+    factory = _FakeStorageFactory(metadata_store)
+
+    with pytest.raises(ValueError, match="invalid metadata json"):
+        await KBCoordinator(storage_factory=cast(StorageFactory, factory)).get_context(
+            KBContextRequest(collection="docs", hide_missing=True)
+        )
+
+    assert metadata_store.calls == 1
+
+
+@pytest.mark.asyncio
 async def test_get_context_defaults_legacy_collection_without_kb_storage_to_lancedb() -> (
     None
 ):
@@ -381,6 +442,21 @@ async def test_get_context_rejects_invalid_access_mode() -> None:
         )
 
 
+@pytest.mark.asyncio
+async def test_get_context_rejects_invalid_access_mode_before_storage_access() -> None:
+    """Given invalid request shape, get_context fails before touching storage."""
+    from xagent.core.tools.core.RAG_tools.kb import KBContextRequest, KBCoordinator
+
+    coordinator = KBCoordinator(
+        storage_factory=cast(StorageFactory, _StorageAccessSentinel())
+    )
+
+    with pytest.raises(ValueError, match="Invalid KB access mode"):
+        await coordinator.get_context(
+            KBContextRequest(collection="docs", access_mode="delete", hide_missing=True)
+        )
+
+
 def test_open_collection_rejects_unsupported_backend() -> None:
     """Given an unsupported backend, the handle provider raises a clear error."""
     from xagent.core.tools.core.RAG_tools.kb import (
@@ -492,6 +568,25 @@ async def test_get_context_sync_resolves_inside_running_event_loop() -> None:
     )
 
     assert context.collection == "docs"
+
+
+@pytest.mark.asyncio
+async def test_get_context_sync_preserves_user_scope_inside_running_event_loop() -> (
+    None
+):
+    """Given async caller scope, sync wrapper preserves request ContextVars."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBContextRequest,
+        get_kb_coordinator,
+    )
+
+    with user_scope_context(user_id=789, is_admin=True):
+        context = get_kb_coordinator().get_context_sync(
+            KBContextRequest(collection="docs", hide_missing=True)
+        )
+
+    assert context.user_scope.user_id == 789
+    assert context.user_scope.is_admin is True
 
 
 def test_reset_rag_storage_for_tests_resets_kb_coordinator_state() -> None:


### PR DESCRIPTION
## Summary
- Add a KB semantic coordinator skeleton and collection context models for the #494 compatibility-layer refactor.
- Add a thin LanceDB collection handle and backend binding resolution for current LanceDB-compatible collections.
- Keep existing KB/RAG imports and behavior unchanged while resetting coordinator state with storage test resets.

## Test plan
- `uv run pytest tests/core/tools/core/RAG_tools/kb/test_coordinator.py tests/core/tools/core/RAG_tools/storage/test_factory.py tests/core/tools/core/RAG_tools/storage/test_vector_backend.py tests/core/tools/core/RAG_tools/storage/test_lancedb_isolation.py -q`

Closes #495.
