### PR TITLE
feat(workforce): add builder services

### DIFF
--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -142,9 +142,51 @@ class AgentStore:
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
         status: AgentStatus = AgentStatus.DRAFT,
+        published_at: datetime | None = None,
         widget_enabled: bool = True,
         allowed_domains: list[str] | None = None,
     ) -> Agent:
+        agent = self.add_agent(
+            user_id=user_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            status=status,
+            published_at=published_at,
+            widget_enabled=widget_enabled,
+            allowed_domains=allowed_domains,
+        )
+        self.db.commit()
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, int(agent.id))
+        return agent
+
+    def add_agent(
+        self,
+        *,
+        user_id: int,
+        name: str,
+        description: str | None,
+        instructions: str | None,
+        execution_mode: str | None = None,
+        models: dict[str, Any] | None = None,
+        knowledge_bases: list[str] | None = None,
+        skills: list[str] | None = None,
+        tool_categories: list[str] | None = None,
+        suggested_prompts: list[str] | None = None,
+        status: AgentStatus = AgentStatus.DRAFT,
+        published_at: datetime | None = None,
+        widget_enabled: bool = True,
+        allowed_domains: list[str] | None = None,
+    ) -> Agent:
+        if status == AgentStatus.PUBLISHED and published_at is None:
+            published_at = datetime.now(timezone.utc)
         agent = Agent(
             user_id=user_id,
             name=name,
@@ -157,13 +199,12 @@ class AgentStore:
             tool_categories=tool_categories or [],
             suggested_prompts=suggested_prompts or [],
             status=status,
+            published_at=published_at,
             widget_enabled=widget_enabled,
             allowed_domains=allowed_domains or [],
         )
         self.db.add(agent)
-        self.db.commit()
-        self.db.refresh(agent)
-        invalidate_agent_cache(user_id, int(agent.id))
+        self.db.flush()
         return agent
 
     def update_agent_fields(

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -1,7 +1,8 @@
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from xagent.web.models.agent import Agent, AgentStatus
@@ -184,6 +185,36 @@ def ensure_agent_access(
             )
         return agent
     raise HTTPException(status_code=403, detail="Access denied to agent")
+
+
+def list_accessible_published_agents(
+    db: Session,
+    user: User,
+    *,
+    purpose: str = "workforce_select",
+    exclude_agent_ids: Iterable[int] | None = None,
+) -> list[Agent]:
+    excluded = set(exclude_agent_ids or [])
+    query = db.query(Agent).filter(cast(Any, Agent.status) == AgentStatus.PUBLISHED)
+
+    if not user.is_admin:
+        visible_agent_ids = get_visible_agent_ids(db, user, purpose)
+        if visible_agent_ids is None:
+            query = query.filter(Agent.user_id == int(user.id))
+        elif visible_agent_ids:
+            query = query.filter(
+                or_(
+                    Agent.user_id == int(user.id),
+                    Agent.id.in_(visible_agent_ids),
+                )
+            )
+        else:
+            query = query.filter(Agent.user_id == int(user.id))
+
+    if excluded:
+        query = query.filter(Agent.id.notin_(excluded))
+
+    return [agent for agent in query.order_by(Agent.id.asc()).all()]
 
 
 def ensure_workforce_agent_run_access(

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
@@ -17,6 +17,7 @@ from .workforce_access import (
     ensure_workforce_access,
     list_accessible_published_agents,
 )
+from .workforce_names import workforce_name_exists
 from .workforce_snapshot import normalize_text
 from .workforce_workers import create_workforce_worker
 
@@ -72,6 +73,34 @@ def list_builder_messages(
         .order_by(WorkforceBuilderMessage.id.asc())
         .all()
     )
+
+
+def _load_builder_workforce(db: Session, workforce: Workforce) -> Workforce:
+    if workforce.id is None:
+        return workforce
+    loaded = (
+        db.query(Workforce)
+        .options(
+            selectinload(Workforce.manager_agent),
+            selectinload(Workforce.workers).selectinload(WorkforceAgent.agent),
+        )
+        .filter(Workforce.id == workforce.id)
+        .first()
+    )
+    if loaded is None:
+        raise HTTPException(status_code=404, detail="Workforce not found")
+    return loaded
+
+
+def _ensure_builder_workforce_access(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    *,
+    action: str,
+) -> Workforce:
+    workforce = ensure_workforce_access(db, user, workforce, action=action)
+    return _load_builder_workforce(db, workforce)
 
 
 def _serialize_workers_for_prompt(workforce: Workforce) -> list[dict[str, Any]]:
@@ -281,15 +310,16 @@ def _fallback_patch_from_message(
         )
         summary_parts.append(f'Rename workforce to "{workforce_name_target}"')
 
-    if (
-        ("description" in lower or "desc" in lower)
-        and workforce_name_target
-        and len(quoted_texts) >= 2
-    ):
+    description_match = re.search(
+        r"(?:description|desc)\s*(?:to|as|=)?\s*\"([^\"]+)\"",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if description_match:
         operations.append(
             {
                 "op": "update_workforce",
-                "fields": {"description": quoted_texts[1].strip()},
+                "fields": {"description": description_match.group(1).strip()},
             }
         )
         summary_parts.append("Update workforce description")
@@ -460,7 +490,7 @@ async def generate_builder_patch(
     workforce: Workforce,
     message: str,
 ) -> tuple[str, dict[str, Any]]:
-    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    workforce = _ensure_builder_workforce_access(db, user, workforce, action="edit")
     normalized_message = normalize_text(message, "message", required=True)
 
     llm_patch = await _llm_generate_patch(db, user, workforce, normalized_message)
@@ -515,17 +545,13 @@ def _apply_update_workforce(
         )
     if "name" in fields:
         name = normalize_text(cast(str | None, fields.get("name")), "name", True)
-        duplicate = (
-            db.query(Workforce)
-            .filter(
-                Workforce.id != workforce.id,
-                Workforce.scope_type == workforce.scope_type,
-                Workforce.scope_id == workforce.scope_id,
-                Workforce.name == name,
-            )
-            .first()
-        )
-        if duplicate:
+        if workforce_name_exists(
+            db,
+            scope_type=str(workforce.scope_type),
+            scope_id=str(workforce.scope_id),
+            name=name,
+            exclude_workforce_id=int(workforce.id),
+        ):
             raise HTTPException(status_code=409, detail="Workforce name already exists")
         workforce_row.name = name
     if "description" in fields:
@@ -757,6 +783,13 @@ async def propose_workforce_builder_changes(
     workforce = ensure_workforce_access(db, user, workforce, action="edit")
     user_message_text = normalize_text(message, "message", required=True)
 
+    assistant_message_text, patch = await generate_builder_patch(
+        db,
+        user,
+        workforce,
+        user_message_text,
+    )
+
     try:
         user_message = WorkforceBuilderMessage(
             workforce_id=int(workforce.id),
@@ -766,12 +799,6 @@ async def propose_workforce_builder_changes(
             status="message",
         )
         db.add(user_message)
-        assistant_message_text, patch = await generate_builder_patch(
-            db,
-            user,
-            workforce,
-            user_message_text,
-        )
         assistant_message = WorkforceBuilderMessage(
             workforce_id=int(workforce.id),
             user_id=int(user.id),

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -1,0 +1,769 @@
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import UserAwareModelStorage
+
+from ..models.workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage
+from .workforce_access import (
+    ensure_agent_access,
+    ensure_workforce_access,
+    list_accessible_published_agents,
+)
+from .workforce_snapshot import (
+    build_workforce_snapshot,
+    normalize_text,
+    normalize_workforce_status,
+)
+from .workforce_workers import create_workforce_worker
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_BUILDER_OPS = {
+    "update_workforce",
+    "add_existing_worker",
+    "update_worker",
+    "remove_worker",
+}
+
+PLACEHOLDER_PATCH_WARNING = (
+    "Could not confidently infer a structured change. "
+    "Please refine the instruction or edit manually."
+)
+
+
+@dataclass(frozen=True)
+class WorkforceBuilderProposalResult:
+    user_message: WorkforceBuilderMessage
+    assistant_message: WorkforceBuilderMessage
+    proposed_patch: dict[str, Any]
+    requires_confirmation: bool = True
+
+
+@dataclass(frozen=True)
+class WorkforceBuilderApplyResult:
+    workforce: Workforce
+    message: WorkforceBuilderMessage
+
+
+def serialize_builder_message(message: WorkforceBuilderMessage) -> dict[str, Any]:
+    return {
+        "id": message.id,
+        "role": message.role,
+        "content": message.content,
+        "status": message.status,
+        "proposed_patch": message.proposed_patch,
+        "created_at": message.created_at.isoformat() if message.created_at else None,
+    }
+
+
+def list_builder_messages(
+    db: Session,
+    workforce_id: int,
+) -> list[WorkforceBuilderMessage]:
+    return (
+        db.query(WorkforceBuilderMessage)
+        .filter(WorkforceBuilderMessage.workforce_id == workforce_id)
+        .order_by(WorkforceBuilderMessage.id.asc())
+        .all()
+    )
+
+
+def _serialize_workers_for_prompt(workforce: Workforce) -> list[dict[str, Any]]:
+    workers = sorted(
+        workforce.workers,
+        key=lambda item: (item.sort_order or 0, item.id or 0),
+    )
+    return [
+        {
+            "member_id": worker.id,
+            "agent_id": worker.agent_id,
+            "agent_name": worker.agent.name,
+            "alias": worker.alias,
+            "assignment_instructions": worker.assignment_instructions,
+            "enabled": worker.enabled,
+            "sort_order": worker.sort_order,
+        }
+        for worker in workers
+    ]
+
+
+def _make_builder_context(workforce: Workforce) -> dict[str, Any]:
+    return {
+        "workforce": {
+            "id": workforce.id,
+            "name": workforce.name,
+            "description": workforce.description,
+            "status": workforce.status,
+            "manager_agent_id": workforce.manager_agent_id,
+            "manager_agent_name": workforce.manager_agent.name
+            if workforce.manager_agent
+            else None,
+            "manager_instructions": workforce.manager_instructions,
+        },
+        "workers": _serialize_workers_for_prompt(workforce),
+    }
+
+
+def _available_published_worker_agents(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+) -> list[Agent]:
+    excluded_agent_ids = {int(workforce.manager_agent_id)}
+    excluded_agent_ids.update(int(worker.agent_id) for worker in workforce.workers)
+    return list_accessible_published_agents(
+        db,
+        user,
+        exclude_agent_ids=excluded_agent_ids,
+    )
+
+
+def _serialize_available_agents_for_prompt(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "agent_id": agent.id,
+            "name": agent.name,
+            "description": agent.description,
+            "status": getattr(agent.status, "value", str(agent.status)),
+        }
+        for agent in _available_published_worker_agents(db, user, workforce)
+    ]
+
+
+def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
+    summary = (
+        str(candidate.get("summary") or "").strip() or "Update workforce configuration."
+    )
+    warnings = candidate.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    clean_warnings = [str(item).strip() for item in warnings if str(item).strip()]
+    clarification = str(candidate.get("clarification") or "").strip() or None
+
+    operations = candidate.get("operations")
+    if not isinstance(operations, list):
+        operations = []
+
+    clean_operations: list[dict[str, Any]] = []
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        op_name = str(operation.get("op") or "").strip()
+        if op_name not in SUPPORTED_BUILDER_OPS:
+            continue
+        clean_operations.append(operation)
+
+    return {
+        "summary": summary,
+        "operations": clean_operations,
+        "warnings": clean_warnings,
+        "clarification": clarification,
+    }
+
+
+def _has_meaningful_operations(patch: dict[str, Any]) -> bool:
+    operations = patch.get("operations")
+    if not isinstance(operations, list) or not operations:
+        return False
+    if len(operations) != 1:
+        return True
+
+    only_operation = operations[0]
+    if not isinstance(only_operation, dict):
+        return False
+    if only_operation.get("op") != "update_workforce":
+        return True
+
+    fields = only_operation.get("fields")
+    return isinstance(fields, dict) and bool(fields)
+
+
+def _find_worker_by_name(workforce: Workforce, raw_name: str) -> WorkforceAgent | None:
+    target = raw_name.strip().lower()
+    if not target:
+        return None
+    for raw_worker in workforce.workers:
+        worker = cast(WorkforceAgent, raw_worker)
+        candidates = [
+            worker.alias or "",
+            worker.agent.name if worker.agent else "",
+        ]
+        for candidate in candidates:
+            if candidate and candidate.lower() == target:
+                return worker
+    for raw_worker in workforce.workers:
+        worker = cast(WorkforceAgent, raw_worker)
+        candidates = [
+            worker.alias or "",
+            worker.agent.name if worker.agent else "",
+        ]
+        for candidate in candidates:
+            if candidate and target in candidate.lower():
+                return worker
+    return None
+
+
+def _find_agent_candidate_for_message(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> Agent | None:
+    lower = message.lower()
+    for agent in _available_published_worker_agents(db, user, workforce):
+        if agent.name.lower() in lower:
+            return agent
+    return None
+
+
+def _extract_assignment_instructions(message: str) -> str | None:
+    quoted = [str(item).strip() for item in re.findall(r'"([^"]+)"', message)]
+    if quoted:
+        return quoted[-1] or None
+
+    match = re.search(
+        r"(?:to|for)\s+(?:handle|focus on|work on|cover)\s+(.+)$",
+        message,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip().rstrip(".")
+    return None
+
+
+def _fallback_patch_from_message(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> dict[str, Any]:
+    text = message.strip()
+    lower = text.lower()
+    operations: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    summary_parts: list[str] = []
+
+    quoted_texts = re.findall(r'"([^"]+)"', text)
+    workforce_name_target = quoted_texts[0].strip() if quoted_texts else None
+
+    rename_match = re.search(r"\brename\b|\brenamed\b|\bname it\b|\bcall it\b", lower)
+    if rename_match and workforce_name_target:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {"name": workforce_name_target},
+            }
+        )
+        summary_parts.append(f'Rename workforce to "{workforce_name_target}"')
+
+    if (
+        ("description" in lower or "desc" in lower)
+        and workforce_name_target
+        and len(quoted_texts) >= 2
+    ):
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {"description": quoted_texts[1].strip()},
+            }
+        )
+        summary_parts.append("Update workforce description")
+
+    manager_instructions_match = re.search(
+        r"(manager instructions?|manager prompt)\s*(?:to|as|=)?\s*\"([^\"]+)\"",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if manager_instructions_match:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {
+                    "manager_instructions": manager_instructions_match.group(2).strip()
+                },
+            }
+        )
+        summary_parts.append("Update manager instructions")
+
+    remove_match = re.search(
+        r"\bremove\b\s+([a-zA-Z0-9 _-]+)",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if remove_match:
+        raw_target = remove_match.group(1).strip().rstrip(".")
+        matched_worker = _find_worker_by_name(workforce, raw_target)
+        if matched_worker is not None:
+            operations.append({"op": "remove_worker", "member_id": matched_worker.id})
+            warnings.append(
+                f'Removing worker "{matched_worker.alias or matched_worker.agent.name}".'
+            )
+            summary_parts.append(
+                f'Remove worker "{matched_worker.alias or matched_worker.agent.name}"'
+            )
+
+    update_match = re.search(
+        (
+            r"(?:make|update|change)\s+([a-zA-Z0-9 _-]+?)\s+"
+            r"(?:focus on|to handle|to work on|to)\s+(.+)"
+        ),
+        text,
+        flags=re.IGNORECASE,
+    )
+    if update_match:
+        target_name = update_match.group(1).strip()
+        instructions = update_match.group(2).strip().rstrip(".")
+        matched_worker = _find_worker_by_name(workforce, target_name)
+        if matched_worker is not None and instructions:
+            operations.append(
+                {
+                    "op": "update_worker",
+                    "member_id": matched_worker.id,
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(
+                f'Update worker "{matched_worker.alias or matched_worker.agent.name}"'
+            )
+
+    if "add" in lower and "worker" in lower:
+        agent = _find_agent_candidate_for_message(db, user, workforce, text)
+        instructions = _extract_assignment_instructions(text)
+        if agent is not None and instructions:
+            operations.append(
+                {
+                    "op": "add_existing_worker",
+                    "agent_id": int(agent.id),
+                    "alias": agent.name,
+                    "assignment_instructions": instructions,
+                }
+            )
+            summary_parts.append(f'Add worker "{agent.name}"')
+
+    if not operations:
+        operations.append(
+            {
+                "op": "update_workforce",
+                "fields": {},
+            }
+        )
+        warnings.append(PLACEHOLDER_PATCH_WARNING)
+        summary_parts.append("No safe structured changes inferred")
+
+    return {
+        "summary": ". ".join(summary_parts) + ".",
+        "operations": operations,
+        "warnings": warnings,
+        "clarification": None,
+    }
+
+
+async def _llm_generate_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> dict[str, Any] | None:
+    try:
+        storage = UserAwareModelStorage(db)
+        default_llm, _, _, _ = storage.get_configured_defaults(int(user.id))
+        llm = default_llm
+        if not llm:
+            default_llm, _, _, _ = storage.get_configured_defaults(None)
+            llm = default_llm
+        if not llm:
+            return None
+
+        system_prompt = (
+            "You are a Workforce Builder assistant. "
+            "Team means human organization and must never be modified. "
+            "Workforce means AI orchestration and may be modified only at the relationship layer. "
+            "You may only output JSON for a proposed patch. "
+            "You can modify workforce name, description, manager instructions, "
+            "worker membership, worker alias, worker assignment instructions, "
+            "and worker order. "
+            "Do not modify underlying agent instructions, models, tools, skills, "
+            "or knowledge bases. "
+            "Supported operations are: update_workforce, add_existing_worker, "
+            "update_worker, remove_worker. "
+            "Workers must be existing published agents from available_published_agents. "
+            "Do not create new agents or add workers from templates. "
+            "For destructive operations like remove_worker, include a warning. "
+            "If the user's intent is unclear, return no operations and include a "
+            "clarification question. "
+            "Return a JSON object with keys summary, operations, warnings, "
+            "clarification. No markdown fences."
+        )
+        user_prompt = json.dumps(
+            {
+                "request": message,
+                "current_state": _make_builder_context(workforce),
+                "available_published_agents": _serialize_available_agents_for_prompt(
+                    db,
+                    user,
+                    workforce,
+                ),
+            },
+            ensure_ascii=False,
+        )
+        response = await llm.chat(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        content = (
+            response["content"]
+            if isinstance(response, dict) and "content" in response
+            else response
+        )
+        if not isinstance(content, str):
+            content = str(content)
+        parsed = json.loads(content)
+        if not isinstance(parsed, dict):
+            return None
+        return _clean_patch(parsed)
+    except Exception as exc:
+        logger.warning("Failed to generate builder patch with LLM: %s", exc)
+        return None
+
+
+async def generate_builder_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    message: str,
+) -> tuple[str, dict[str, Any]]:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    normalized_message = normalize_text(message, "message", required=True)
+
+    llm_patch = await _llm_generate_patch(db, user, workforce, normalized_message)
+    if llm_patch is not None:
+        if _has_meaningful_operations(llm_patch):
+            return (
+                f"I prepared {len(llm_patch['operations'])} change(s) for review.",
+                llm_patch,
+            )
+        clarification = llm_patch.get("clarification")
+        if clarification:
+            return (str(clarification), llm_patch)
+        return (
+            "I could not translate the request into an executable Workforce change. "
+            "Review the proposal details and refine the prompt if needed.",
+            llm_patch,
+        )
+
+    fallback_patch = _clean_patch(
+        _fallback_patch_from_message(db, user, workforce, normalized_message)
+    )
+    if _has_meaningful_operations(fallback_patch):
+        return (
+            f"I prepared {len(fallback_patch['operations'])} change(s) using rule-based parsing because no LLM was available.",
+            fallback_patch,
+        )
+
+    return (
+        "I could not confidently translate the request into a safe structured change. "
+        "Review the warning and refine the prompt if needed.",
+        fallback_patch,
+    )
+
+
+def _apply_update_workforce(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+) -> None:
+    workforce_row = cast(Any, workforce)
+    fields = operation.get("fields")
+    if not isinstance(fields, dict):
+        return
+    if "name" in fields:
+        name = normalize_text(cast(str | None, fields.get("name")), "name", True)
+        duplicate = (
+            db.query(Workforce)
+            .filter(
+                Workforce.id != workforce.id,
+                Workforce.scope_type == workforce.scope_type,
+                Workforce.scope_id == workforce.scope_id,
+                Workforce.name == name,
+            )
+            .first()
+        )
+        if duplicate:
+            raise HTTPException(status_code=409, detail="Workforce name already exists")
+        workforce_row.name = name
+    if "description" in fields:
+        workforce_row.description = normalize_text(
+            cast(str | None, fields.get("description")),
+            "description",
+        )
+    if "manager_instructions" in fields:
+        workforce_row.manager_instructions = normalize_text(
+            cast(str | None, fields.get("manager_instructions")),
+            "manager_instructions",
+        )
+    if "status" in fields:
+        workforce_row.status = normalize_workforce_status(
+            cast(str | None, fields.get("status"))
+        )
+
+
+def _apply_add_existing_worker(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+    user: User,
+) -> None:
+    agent_id = operation.get("agent_id")
+    if not isinstance(agent_id, int):
+        raise HTTPException(
+            status_code=400,
+            detail="agent_id is required for add_existing_worker",
+        )
+
+    agent = ensure_agent_access(
+        db.query(Agent).filter(Agent.id == agent_id).first(),
+        user,
+        db,
+        require_published=True,
+    )
+    agent_id_value = int(agent.id)
+    if agent_id_value == int(workforce.manager_agent_id):
+        raise HTTPException(
+            status_code=400,
+            detail="Manager agent cannot also be a worker",
+        )
+    existing = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.workforce_id == workforce.id,
+            WorkforceAgent.agent_id == agent.id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="Agent already added to workforce")
+
+    assignment_instructions = normalize_text(
+        cast(str | None, operation.get("assignment_instructions")),
+        "assignment_instructions",
+        required=True,
+    )
+    create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type="existing",
+        assignment_instructions=assignment_instructions,
+        alias=cast(str | None, operation.get("alias")),
+        agent_id=agent_id_value,
+        enabled=bool(operation.get("enabled", True)),
+        sort_order=operation.get("sort_order")
+        if isinstance(operation.get("sort_order"), int)
+        else None,
+    )
+
+
+def _apply_update_worker(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+) -> None:
+    member_id = operation.get("member_id")
+    if not isinstance(member_id, int):
+        raise HTTPException(
+            status_code=400,
+            detail="member_id is required for update_worker",
+        )
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.id == member_id,
+            WorkforceAgent.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+    worker_row = cast(Any, worker)
+
+    if "alias" in operation:
+        worker_row.alias = normalize_text(
+            cast(str | None, operation.get("alias")),
+            "alias",
+        )
+    if "assignment_instructions" in operation:
+        worker_row.assignment_instructions = normalize_text(
+            cast(str | None, operation.get("assignment_instructions")),
+            "assignment_instructions",
+            required=True,
+        )
+    if "enabled" in operation:
+        worker_row.enabled = bool(operation.get("enabled"))
+    if "sort_order" in operation and isinstance(operation.get("sort_order"), int):
+        worker_row.sort_order = int(operation["sort_order"])
+
+
+def _apply_remove_worker(
+    workforce: Workforce,
+    operation: dict[str, Any],
+    db: Session,
+) -> None:
+    member_id = operation.get("member_id")
+    if not isinstance(member_id, int):
+        raise HTTPException(
+            status_code=400,
+            detail="member_id is required for remove_worker",
+        )
+    worker = (
+        db.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.id == member_id,
+            WorkforceAgent.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+    db.delete(worker)
+    db.flush()
+
+
+def apply_builder_patch(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    patch: dict[str, Any],
+) -> Workforce:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    clean_patch = _clean_patch(patch)
+    operations = clean_patch["operations"]
+
+    for operation in operations:
+        op_name = operation["op"]
+        if op_name == "update_workforce":
+            _apply_update_workforce(workforce, operation, db)
+        elif op_name == "add_existing_worker":
+            _apply_add_existing_worker(workforce, operation, db, user)
+        elif op_name == "update_worker":
+            _apply_update_worker(workforce, operation, db)
+        elif op_name == "remove_worker":
+            _apply_remove_worker(workforce, operation, db)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported builder operation: {op_name}",
+            )
+
+    db.flush()
+    if workforce.status == "active":
+        build_workforce_snapshot(db, user, workforce)
+    return workforce
+
+
+async def propose_workforce_builder_changes(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    *,
+    message: str,
+) -> WorkforceBuilderProposalResult:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    user_message_text = normalize_text(message, "message", required=True)
+
+    try:
+        user_message = WorkforceBuilderMessage(
+            workforce_id=int(workforce.id),
+            user_id=int(user.id),
+            role="user",
+            content=user_message_text,
+            status="message",
+        )
+        db.add(user_message)
+        assistant_message_text, patch = await generate_builder_patch(
+            db,
+            user,
+            workforce,
+            user_message_text,
+        )
+        assistant_message = WorkforceBuilderMessage(
+            workforce_id=int(workforce.id),
+            user_id=int(user.id),
+            role="assistant",
+            content=assistant_message_text,
+            proposed_patch=patch,
+            status="proposed",
+        )
+        db.add(assistant_message)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(user_message)
+    db.refresh(assistant_message)
+    return WorkforceBuilderProposalResult(
+        user_message=user_message,
+        assistant_message=assistant_message,
+        proposed_patch=cast(dict[str, Any], assistant_message.proposed_patch),
+    )
+
+
+def apply_workforce_builder_changes(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    *,
+    message_id: int,
+    proposed_patch: dict[str, Any],
+) -> WorkforceBuilderApplyResult:
+    workforce = ensure_workforce_access(db, user, workforce, action="edit")
+    message = (
+        db.query(WorkforceBuilderMessage)
+        .filter(
+            WorkforceBuilderMessage.id == message_id,
+            WorkforceBuilderMessage.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if message is None:
+        raise HTTPException(status_code=404, detail="Builder message not found")
+    if message.role != "assistant":
+        raise HTTPException(status_code=400, detail="Builder message is not applicable")
+    if message.status != "proposed" or not isinstance(message.proposed_patch, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="Builder message has no pending patch",
+        )
+    if proposed_patch != message.proposed_patch:
+        raise HTTPException(
+            status_code=400,
+            detail="Proposed patch does not match message",
+        )
+
+    try:
+        workforce = apply_builder_patch(db, user, workforce, proposed_patch)
+        message.status = "applied"
+        message.proposed_patch = proposed_patch
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(workforce)
+    db.refresh(message)
+    return WorkforceBuilderApplyResult(workforce=workforce, message=message)

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from xagent.web.models.agent import Agent
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
@@ -17,11 +17,7 @@ from .workforce_access import (
     ensure_workforce_access,
     list_accessible_published_agents,
 )
-from .workforce_snapshot import (
-    build_workforce_snapshot,
-    normalize_text,
-    normalize_workforce_status,
-)
+from .workforce_snapshot import normalize_text, normalize_workforce_status
 from .workforce_workers import create_workforce_worker
 
 logger = logging.getLogger(__name__)
@@ -171,6 +167,21 @@ def _clean_patch(candidate: dict[str, Any]) -> dict[str, Any]:
         "warnings": clean_warnings,
         "clarification": clarification,
     }
+
+
+def _normalize_optional_bool(
+    operation: dict[str, Any],
+    field_name: str,
+) -> bool | None:
+    if field_name not in operation:
+        return None
+    value = operation.get(field_name)
+    if not isinstance(value, bool):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field_name} must be a boolean",
+        )
+    return value
 
 
 def _has_meaningful_operations(patch: dict[str, Any]) -> bool:
@@ -563,6 +574,7 @@ def _apply_add_existing_worker(
         "assignment_instructions",
         required=True,
     )
+    enabled = _normalize_optional_bool(operation, "enabled")
     create_workforce_worker(
         db,
         workforce,
@@ -571,7 +583,7 @@ def _apply_add_existing_worker(
         assignment_instructions=assignment_instructions,
         alias=cast(str | None, operation.get("alias")),
         agent_id=agent_id_value,
-        enabled=bool(operation.get("enabled", True)),
+        enabled=True if enabled is None else enabled,
         sort_order=operation.get("sort_order")
         if isinstance(operation.get("sort_order"), int)
         else None,
@@ -601,19 +613,27 @@ def _apply_update_worker(
         raise HTTPException(status_code=404, detail="Workforce worker not found")
     worker_row = cast(Any, worker)
 
+    alias = None
     if "alias" in operation:
-        worker_row.alias = normalize_text(
+        alias = normalize_text(
             cast(str | None, operation.get("alias")),
             "alias",
         )
+    assignment_instructions = None
     if "assignment_instructions" in operation:
-        worker_row.assignment_instructions = normalize_text(
+        assignment_instructions = normalize_text(
             cast(str | None, operation.get("assignment_instructions")),
             "assignment_instructions",
             required=True,
         )
-    if "enabled" in operation:
-        worker_row.enabled = bool(operation.get("enabled"))
+    enabled = _normalize_optional_bool(operation, "enabled")
+
+    if "alias" in operation:
+        worker_row.alias = alias
+    if "assignment_instructions" in operation:
+        worker_row.assignment_instructions = assignment_instructions
+    if enabled is not None:
+        worker_row.enabled = enabled
     if "sort_order" in operation and isinstance(operation.get("sort_order"), int):
         worker_row.sort_order = int(operation["sort_order"])
 
@@ -643,6 +663,52 @@ def _apply_remove_worker(
     db.flush()
 
 
+def _ensure_published_agent(agent: Agent | None) -> Agent:
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.status != AgentStatus.PUBLISHED:
+        raise HTTPException(
+            status_code=400,
+            detail="Workforce agents must be published",
+        )
+    return agent
+
+
+def _validate_active_workforce_configuration(
+    db: Session,
+    workforce: Workforce,
+) -> None:
+    if workforce.status != "active":
+        return
+
+    _ensure_published_agent(db.get(Agent, int(workforce.manager_agent_id)))
+    workers = (
+        db.query(WorkforceAgent)
+        .filter(WorkforceAgent.workforce_id == workforce.id)
+        .order_by(WorkforceAgent.sort_order.asc(), WorkforceAgent.id.asc())
+        .all()
+    )
+    enabled_workers = [worker for worker in workers if worker.enabled]
+    if not enabled_workers:
+        raise HTTPException(
+            status_code=400,
+            detail="Workforce requires at least one enabled worker",
+        )
+
+    for worker in enabled_workers:
+        _ensure_published_agent(worker.agent)
+        normalize_text(
+            cast(str | None, worker.assignment_instructions),
+            "assignment_instructions",
+            required=True,
+        )
+        if int(worker.agent_id) == int(workforce.manager_agent_id):
+            raise HTTPException(
+                status_code=400,
+                detail="Manager agent cannot also be a worker",
+            )
+
+
 def apply_builder_patch(
     db: Session,
     user: User,
@@ -670,8 +736,7 @@ def apply_builder_patch(
             )
 
     db.flush()
-    if workforce.status == "active":
-        build_workforce_snapshot(db, user, workforce)
+    _validate_active_workforce_configuration(db, workforce)
     return workforce
 
 

--- a/src/xagent/web/services/workforce_builder.py
+++ b/src/xagent/web/services/workforce_builder.py
@@ -17,7 +17,7 @@ from .workforce_access import (
     ensure_workforce_access,
     list_accessible_published_agents,
 )
-from .workforce_snapshot import normalize_text, normalize_workforce_status
+from .workforce_snapshot import normalize_text
 from .workforce_workers import create_workforce_worker
 
 logger = logging.getLogger(__name__)
@@ -62,11 +62,13 @@ def serialize_builder_message(message: WorkforceBuilderMessage) -> dict[str, Any
 
 def list_builder_messages(
     db: Session,
-    workforce_id: int,
+    user: User,
+    workforce: Workforce,
 ) -> list[WorkforceBuilderMessage]:
+    workforce = ensure_workforce_access(db, user, workforce, action="view")
     return (
         db.query(WorkforceBuilderMessage)
-        .filter(WorkforceBuilderMessage.workforce_id == workforce_id)
+        .filter(WorkforceBuilderMessage.workforce_id == workforce.id)
         .order_by(WorkforceBuilderMessage.id.asc())
         .all()
     )
@@ -502,6 +504,15 @@ def _apply_update_workforce(
     fields = operation.get("fields")
     if not isinstance(fields, dict):
         return
+    unsupported_fields = set(fields) - {"name", "description", "manager_instructions"}
+    if unsupported_fields:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Unsupported workforce update fields: "
+                + ", ".join(sorted(unsupported_fields))
+            ),
+        )
     if "name" in fields:
         name = normalize_text(cast(str | None, fields.get("name")), "name", True)
         duplicate = (
@@ -526,10 +537,6 @@ def _apply_update_workforce(
         workforce_row.manager_instructions = normalize_text(
             cast(str | None, fields.get("manager_instructions")),
             "manager_instructions",
-        )
-    if "status" in fields:
-        workforce_row.status = normalize_workforce_status(
-            cast(str | None, fields.get("status"))
         )
 
 

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -1,0 +1,427 @@
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import UserAwareModelStorage
+
+from ..models.workforce import Workforce, WorkforceBuilderMessage
+from .workforce_access import (
+    can_create_workforce,
+    list_accessible_published_agents,
+    resolve_create_scope,
+)
+from .workforce_snapshot import normalize_text
+from .workforce_workers import create_workforce_worker
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkforcePromptCreationResult:
+    workforce: Workforce
+    plan: dict[str, Any]
+    messages: list[WorkforceBuilderMessage]
+
+
+def _serialize_available_agents(agents: list[Agent]) -> list[dict[str, Any]]:
+    return [
+        {
+            "agent_id": agent.id,
+            "name": agent.name,
+            "description": agent.description,
+            "status": getattr(agent.status, "value", str(agent.status)),
+        }
+        for agent in agents
+    ]
+
+
+def _short_name_from_prompt(prompt: str) -> str:
+    words = re.findall(r"[\w-]+", prompt, flags=re.UNICODE)
+    if not words:
+        return "New Workforce"
+    name = " ".join(words[:6]).strip()
+    if len(name) > 80:
+        name = name[:80].rstrip()
+    return f"{name} Workforce" if "workforce" not in name.lower() else name
+
+
+def _clean_creation_plan(
+    candidate: dict[str, Any],
+    available_agent_ids: set[int],
+    prompt: str,
+) -> dict[str, Any]:
+    name = str(candidate.get("name") or "").strip() or _short_name_from_prompt(prompt)
+    description = str(candidate.get("description") or "").strip() or prompt.strip()
+
+    manager = candidate.get("manager")
+    if not isinstance(manager, dict):
+        manager = {}
+    manager_name = str(manager.get("name") or "").strip() or f"{name} Manager"
+    manager_description = (
+        str(manager.get("description") or "").strip()
+        or "Coordinates this Workforce and synthesizes worker outputs."
+    )
+    manager_instructions = str(manager.get("instructions") or "").strip() or (
+        "Understand the user's goal, delegate focused work to the available workers, "
+        "compare their outputs, and return one coherent final answer."
+    )
+
+    workers = candidate.get("workers")
+    if not isinstance(workers, list):
+        workers = []
+    clean_workers: list[dict[str, Any]] = []
+    seen_agent_ids: set[int] = set()
+    for item in workers:
+        if not isinstance(item, dict):
+            continue
+        agent_id = item.get("agent_id")
+        if not isinstance(agent_id, int):
+            continue
+        if agent_id not in available_agent_ids or agent_id in seen_agent_ids:
+            continue
+        instructions = str(item.get("assignment_instructions") or "").strip()
+        if not instructions:
+            continue
+        enabled = item.get("enabled", True)
+        clean_workers.append(
+            {
+                "agent_id": agent_id,
+                "alias": str(item.get("alias") or "").strip() or None,
+                "assignment_instructions": instructions,
+                "enabled": enabled if isinstance(enabled, bool) else True,
+            }
+        )
+        seen_agent_ids.add(agent_id)
+
+    warnings = candidate.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    clean_warnings = [str(item).strip() for item in warnings if str(item).strip()]
+    if not clean_workers:
+        clean_warnings.append(
+            "No published worker agents were selected. Add workers before running."
+        )
+
+    return {
+        "name": name[:200],
+        "description": description,
+        "manager": {
+            "name": manager_name[:200],
+            "description": manager_description,
+            "instructions": manager_instructions,
+        },
+        "manager_instructions": manager_instructions,
+        "workers": clean_workers,
+        "warnings": clean_warnings,
+    }
+
+
+def _fallback_creation_plan(prompt: str, agents: list[Agent]) -> dict[str, Any]:
+    lower_prompt = prompt.lower()
+    selected: list[Agent] = []
+    for agent in agents:
+        haystack = f"{agent.name} {agent.description or ''}".lower()
+        if any(
+            token and token in haystack
+            for token in re.findall(r"[a-z0-9]+", lower_prompt)
+        ):
+            selected.append(agent)
+        if len(selected) >= 3:
+            break
+    if not selected:
+        selected = agents[: min(3, len(agents))]
+
+    name = _short_name_from_prompt(prompt)
+    return _clean_creation_plan(
+        {
+            "name": name,
+            "description": prompt,
+            "manager": {
+                "name": f"{name} Manager",
+                "description": "Coordinates this Workforce and synthesizes worker outputs.",
+                "instructions": (
+                    "Break the user request into worker assignments, call the right "
+                    "workers, reconcile their outputs, and provide a concise final answer."
+                ),
+            },
+            "workers": [
+                {
+                    "agent_id": int(agent.id),
+                    "alias": agent.name,
+                    "assignment_instructions": (
+                        f"Contribute to the Workforce goal using the strengths of {agent.name}."
+                    ),
+                    "enabled": True,
+                }
+                for agent in selected
+            ],
+            "warnings": [
+                "Created from a rule-based fallback because no LLM plan was available."
+            ],
+        },
+        {int(agent.id) for agent in agents},
+        prompt,
+    )
+
+
+async def generate_workforce_creation_plan(
+    db: Session,
+    user: User,
+    prompt: str,
+) -> dict[str, Any]:
+    normalized_prompt = normalize_text(prompt, "prompt", required=True)
+    agents = list_accessible_published_agents(db, user)
+    available_agent_ids = {int(agent.id) for agent in agents}
+
+    try:
+        storage = UserAwareModelStorage(db)
+        default_llm, _, _, _ = storage.get_configured_defaults(int(user.id))
+        llm = default_llm
+        if not llm:
+            default_llm, _, _, _ = storage.get_configured_defaults(None)
+            llm = default_llm
+        if not llm:
+            return _fallback_creation_plan(normalized_prompt, agents)
+
+        system_prompt = (
+            "You create initial AI Workforce drafts from a user's goal. "
+            "A Workforce is AI orchestration, not a human team. "
+            "Create a manager spec that can coordinate workers and synthesize results. "
+            "Select workers only from available_published_agents. "
+            "Do not create worker agents. If no worker fits, return no workers and add a warning. "
+            "Return JSON only with keys: name, description, manager, manager_instructions, workers, warnings. "
+            "manager has name, description, instructions. "
+            "Each worker has agent_id, alias, assignment_instructions, enabled. "
+            "Keep instructions concrete and task-oriented."
+        )
+        user_prompt = json.dumps(
+            {
+                "request": normalized_prompt,
+                "available_published_agents": _serialize_available_agents(agents),
+            },
+            ensure_ascii=False,
+        )
+        response = await llm.chat(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        content = (
+            response["content"]
+            if isinstance(response, dict) and "content" in response
+            else response
+        )
+        if not isinstance(content, str):
+            content = str(content)
+        parsed = json.loads(content)
+        if not isinstance(parsed, dict):
+            return _fallback_creation_plan(normalized_prompt, agents)
+        return _clean_creation_plan(parsed, available_agent_ids, normalized_prompt)
+    except Exception as exc:
+        logger.warning("Failed to generate Workforce creation plan with LLM: %s", exc)
+        return _fallback_creation_plan(normalized_prompt, agents)
+
+
+def _resolve_unique_workforce_name(
+    db: Session,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    existing = (
+        db.query(Workforce)
+        .filter(
+            Workforce.scope_type == scope_type,
+            Workforce.scope_id == scope_id,
+            Workforce.name == normalized_name,
+        )
+        .first()
+    )
+    if existing is None:
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        conflict = (
+            db.query(Workforce)
+            .filter(
+                Workforce.scope_type == scope_type,
+                Workforce.scope_id == scope_id,
+                Workforce.name == candidate,
+            )
+            .first()
+        )
+        if conflict is None:
+            return candidate
+        suffix += 1
+
+
+def _resolve_unique_agent_name(db: Session, user: User, name: str) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    existing = (
+        db.query(Agent)
+        .filter(Agent.user_id == int(user.id), Agent.name == normalized_name)
+        .first()
+    )
+    if existing is None:
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        conflict = (
+            db.query(Agent)
+            .filter(Agent.user_id == int(user.id), Agent.name == candidate)
+            .first()
+        )
+        if conflict is None:
+            return candidate
+        suffix += 1
+
+
+def _create_manager_agent_from_plan(
+    db: Session,
+    user: User,
+    name: str,
+    manager_plan: dict[str, Any],
+) -> Agent:
+    agent = Agent(
+        user_id=int(user.id),
+        name=_resolve_unique_agent_name(
+            db,
+            user,
+            str(manager_plan.get("name") or f"{name} Manager"),
+        ),
+        description=normalize_text(
+            cast(str | None, manager_plan.get("description")),
+            "description",
+        ),
+        instructions=normalize_text(
+            cast(str | None, manager_plan.get("instructions")),
+            "instructions",
+        ),
+        execution_mode="think",
+        models=None,
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=[],
+        suggested_prompts=[],
+        status=AgentStatus.PUBLISHED,
+        published_at=datetime.now(timezone.utc),
+        widget_enabled=True,
+        allowed_domains=[],
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+async def create_workforce_from_prompt(
+    db: Session,
+    user: User,
+    *,
+    prompt: str,
+) -> WorkforcePromptCreationResult:
+    normalized_prompt = normalize_text(prompt, "prompt", required=True)
+    scope_type, scope_id = resolve_create_scope(db, user)
+    if not can_create_workforce(db, user, scope_type, scope_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    try:
+        plan = await generate_workforce_creation_plan(db, user, normalized_prompt)
+        name = _resolve_unique_workforce_name(
+            db,
+            scope_type,
+            scope_id,
+            str(plan["name"]),
+        )
+        manager_plan = cast(dict[str, Any], plan["manager"])
+        manager_agent = _create_manager_agent_from_plan(db, user, name, manager_plan)
+
+        workforce = Workforce(
+            owner_user_id=int(user.id),
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=name,
+            description=normalize_text(
+                cast(str | None, plan.get("description")),
+                "description",
+            ),
+            manager_agent_id=int(manager_agent.id),
+            manager_instructions=normalize_text(
+                cast(str | None, plan.get("manager_instructions")),
+                "manager_instructions",
+            ),
+            status="draft",
+        )
+        db.add(workforce)
+        db.flush()
+
+        for index, worker in enumerate(
+            cast(list[dict[str, Any]], plan.get("workers") or [])
+        ):
+            create_workforce_worker(
+                db,
+                workforce,
+                user,
+                source_type="existing",
+                agent_id=cast(int, worker["agent_id"]),
+                alias=cast(str | None, worker.get("alias")),
+                assignment_instructions=str(worker["assignment_instructions"]),
+                enabled=bool(worker.get("enabled", True)),
+                sort_order=index + 1,
+            )
+
+        user_message = WorkforceBuilderMessage(
+            workforce_id=int(workforce.id),
+            user_id=int(user.id),
+            role="user",
+            content=normalized_prompt,
+            status="message",
+        )
+        db.add(user_message)
+        warnings = cast(list[str], plan.get("warnings") or [])
+        assistant_content = "Created an initial Workforce draft from your prompt."
+        if warnings:
+            assistant_content = f"{assistant_content}\n\n" + "\n".join(
+                f"- {warning}" for warning in warnings
+            )
+        assistant_message = WorkforceBuilderMessage(
+            workforce_id=int(workforce.id),
+            user_id=int(user.id),
+            role="assistant",
+            content=assistant_content,
+            status="message",
+        )
+        db.add(assistant_message)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(workforce)
+    db.refresh(user_message)
+    db.refresh(assistant_message)
+    return WorkforcePromptCreationResult(
+        workforce=workforce,
+        plan=plan,
+        messages=[user_message, assistant_message],
+    )

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, cast
 
 from fastapi import HTTPException
@@ -13,6 +12,8 @@ from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
 from ..models.workforce import Workforce, WorkforceBuilderMessage
+from .agent_store import AgentStore
+from .hot_path_cache import invalidate_agent_cache
 from .workforce_access import (
     can_create_workforce,
     list_accessible_published_agents,
@@ -303,7 +304,7 @@ def _create_manager_agent_from_plan(
     name: str,
     manager_plan: dict[str, Any],
 ) -> Agent:
-    agent = Agent(
+    return AgentStore(db).add_agent(
         user_id=int(user.id),
         name=_resolve_unique_agent_name(
             db,
@@ -325,13 +326,19 @@ def _create_manager_agent_from_plan(
         tool_categories=[],
         suggested_prompts=[],
         status=AgentStatus.PUBLISHED,
-        published_at=datetime.now(timezone.utc),
         widget_enabled=True,
         allowed_domains=[],
     )
-    db.add(agent)
-    db.flush()
-    return agent
+
+
+def invalidate_workforce_creation_cache(
+    *,
+    owner_user_id: int,
+    manager_agent_id: int,
+    workforce_id: int,
+) -> None:
+    del workforce_id
+    invalidate_agent_cache(owner_user_id, manager_agent_id)
 
 
 async def create_workforce_from_prompt(
@@ -345,6 +352,7 @@ async def create_workforce_from_prompt(
     if not can_create_workforce(db, user, scope_type, scope_id):
         raise HTTPException(status_code=403, detail="Access denied")
 
+    owner_user_id = int(user.id)
     try:
         plan = await generate_workforce_creation_plan(db, user, normalized_prompt)
         name = _resolve_unique_workforce_name(
@@ -412,11 +420,18 @@ async def create_workforce_from_prompt(
             status="message",
         )
         db.add(assistant_message)
+        manager_agent_id = int(manager_agent.id)
+        workforce_id = int(workforce.id)
         db.commit()
     except Exception:
         db.rollback()
         raise
-
+    else:
+        invalidate_workforce_creation_cache(
+            owner_user_id=owner_user_id,
+            manager_agent_id=manager_agent_id,
+            workforce_id=workforce_id,
+        )
     db.refresh(workforce)
     db.refresh(user_message)
     db.refresh(assistant_message)

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -19,6 +19,7 @@ from .workforce_access import (
     list_accessible_published_agents,
     resolve_create_scope,
 )
+from .workforce_names import resolve_unique_agent_name, resolve_unique_workforce_name
 from .workforce_snapshot import normalize_text
 from .workforce_workers import create_workforce_worker
 
@@ -233,71 +234,6 @@ async def generate_workforce_creation_plan(
         return _fallback_creation_plan(normalized_prompt, agents)
 
 
-def _resolve_unique_workforce_name(
-    db: Session,
-    scope_type: str,
-    scope_id: str,
-    name: str,
-) -> str:
-    normalized_name = normalize_text(name, "name", required=True)
-    existing = (
-        db.query(Workforce)
-        .filter(
-            Workforce.scope_type == scope_type,
-            Workforce.scope_id == scope_id,
-            Workforce.name == normalized_name,
-        )
-        .first()
-    )
-    if existing is None:
-        return normalized_name
-
-    base_name = normalized_name
-    suffix = 2
-    while True:
-        suffix_text = f" {suffix}"
-        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
-        candidate = f"{candidate_base}{suffix_text}"
-        conflict = (
-            db.query(Workforce)
-            .filter(
-                Workforce.scope_type == scope_type,
-                Workforce.scope_id == scope_id,
-                Workforce.name == candidate,
-            )
-            .first()
-        )
-        if conflict is None:
-            return candidate
-        suffix += 1
-
-
-def _resolve_unique_agent_name(db: Session, user: User, name: str) -> str:
-    normalized_name = normalize_text(name, "name", required=True)
-    existing = (
-        db.query(Agent)
-        .filter(Agent.user_id == int(user.id), Agent.name == normalized_name)
-        .first()
-    )
-    if existing is None:
-        return normalized_name
-
-    base_name = normalized_name
-    suffix = 2
-    while True:
-        suffix_text = f" {suffix}"
-        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
-        candidate = f"{candidate_base}{suffix_text}"
-        conflict = (
-            db.query(Agent)
-            .filter(Agent.user_id == int(user.id), Agent.name == candidate)
-            .first()
-        )
-        if conflict is None:
-            return candidate
-        suffix += 1
-
-
 def _create_manager_agent_from_plan(
     db: Session,
     user: User,
@@ -306,10 +242,10 @@ def _create_manager_agent_from_plan(
 ) -> Agent:
     return AgentStore(db).add_agent(
         user_id=int(user.id),
-        name=_resolve_unique_agent_name(
+        name=resolve_unique_agent_name(
             db,
-            user,
-            str(manager_plan.get("name") or f"{name} Manager"),
+            user_id=int(user.id),
+            name=str(manager_plan.get("name") or f"{name} Manager"),
         ),
         description=normalize_text(
             cast(str | None, manager_plan.get("description")),
@@ -355,11 +291,11 @@ async def create_workforce_from_prompt(
     owner_user_id = int(user.id)
     try:
         plan = await generate_workforce_creation_plan(db, user, normalized_prompt)
-        name = _resolve_unique_workforce_name(
+        name = resolve_unique_workforce_name(
             db,
-            scope_type,
-            scope_id,
-            str(plan["name"]),
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=str(plan["name"]),
         )
         manager_plan = cast(dict[str, Any], plan["manager"])
         manager_agent = _create_manager_agent_from_plan(db, user, name, manager_plan)

--- a/src/xagent/web/services/workforce_names.py
+++ b/src/xagent/web/services/workforce_names.py
@@ -1,0 +1,98 @@
+from typing import Any, cast
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from xagent.web.models.agent import Agent
+
+from ..models.workforce import Workforce
+from .workforce_snapshot import normalize_text
+
+
+def workforce_name_exists(
+    db: Session,
+    *,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+    exclude_workforce_id: int | None = None,
+) -> bool:
+    normalized_name = normalize_text(name, "name", required=True)
+    query = db.query(Workforce.id).filter(
+        Workforce.scope_type == scope_type,
+        Workforce.scope_id == scope_id,
+        func.lower(cast(Any, Workforce.name)) == normalized_name.lower(),
+    )
+    if exclude_workforce_id is not None:
+        query = query.filter(Workforce.id != exclude_workforce_id)
+    return query.first() is not None
+
+
+def resolve_unique_workforce_name(
+    db: Session,
+    *,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    if not workforce_name_exists(
+        db,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        name=normalized_name,
+    ):
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        if not workforce_name_exists(
+            db,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=candidate,
+        ):
+            return candidate
+        suffix += 1
+
+
+def agent_name_exists(
+    db: Session,
+    *,
+    user_id: int,
+    name: str,
+    exclude_agent_id: int | None = None,
+) -> bool:
+    normalized_name = normalize_text(name, "name", required=True)
+    query = db.query(Agent.id).filter(
+        Agent.user_id == user_id,
+        func.lower(cast(Any, Agent.name)) == normalized_name.lower(),
+    )
+    if exclude_agent_id is not None:
+        query = query.filter(Agent.id != exclude_agent_id)
+    return query.first() is not None
+
+
+def resolve_unique_agent_name(
+    db: Session,
+    *,
+    user_id: int,
+    name: str,
+) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    if not agent_name_exists(db, user_id=user_id, name=normalized_name):
+        return normalized_name
+
+    base_name = normalized_name
+    suffix = 2
+    while True:
+        suffix_text = f" {suffix}"
+        candidate_base = base_name[: max(1, 200 - len(suffix_text))].rstrip()
+        candidate = f"{candidate_base}{suffix_text}"
+        if not agent_name_exists(db, user_id=user_id, name=candidate):
+            return candidate
+        suffix += 1

--- a/tests/web/test_workforce_builder_services.py
+++ b/tests/web/test_workforce_builder_services.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -263,10 +263,10 @@ async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
     async def fake_plan(db: Session, user: User, prompt: str) -> dict[str, Any]:
         del db, user
         return {
-            "name": "Launch Workforce",
+            "name": "launch workforce",
             "description": prompt,
             "manager": {
-                "name": "Launch Manager",
+                "name": "launch manager",
                 "description": "Coordinates launch work.",
                 "instructions": "Delegate and summarize.",
             },
@@ -296,9 +296,9 @@ async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
 
     workforce = result.workforce
     assert workforce.id != existing_workforce.id
-    assert workforce.name == "Launch Workforce 2"
+    assert workforce.name == "launch workforce 2"
     assert workforce.status == "draft"
-    assert workforce.manager_agent.name == "Launch Manager 2"
+    assert workforce.manager_agent.name == "launch manager 2"
     assert workforce.manager_agent.status == AgentStatus.PUBLISHED
     assert workforce.manager_agent.published_at is not None
     assert workforce.manager_agent.execution_mode == "think"
@@ -433,6 +433,63 @@ async def test_generate_builder_patch_uses_llm_and_filters_available_agents(
     }
 
 
+def test_load_builder_workforce_preloads_prompt_relationships(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    analyst = _create_agent(db_session, owner, "Analyst")
+    editor = _create_agent(db_session, owner, "Editor")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, analyst)
+    _add_worker(db_session, owner, workforce, editor, alias="Editor")
+    workforce_id = int(workforce.id)
+    db_session.commit()
+    db_session.expire_all()
+
+    unloaded_workforce = db_session.get(Workforce, workforce_id)
+    assert unloaded_workforce is not None
+
+    loaded = builder_module._load_builder_workforce(db_session, unloaded_workforce)
+
+    assert "manager_agent" not in inspect(loaded).unloaded
+    assert "workers" not in inspect(loaded).unloaded
+    assert {worker.agent.name for worker in loaded.workers} == {"Analyst", "Editor"}
+    assert all("agent" not in inspect(worker).unloaded for worker in loaded.workers)
+
+
+@pytest.mark.asyncio
+async def test_builder_fallback_can_update_description_without_rename(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, worker_agent)
+    monkeypatch.setattr(
+        builder_module,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(db, None),
+    )
+
+    assistant_text, patch = await generate_builder_patch(
+        db_session,
+        owner,
+        workforce,
+        'Set description to "Focus on launch planning"',
+    )
+
+    assert "rule-based parsing" in assistant_text
+    assert patch["operations"] == [
+        {
+            "op": "update_workforce",
+            "fields": {"description": "Focus on launch planning"},
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_builder_fallback_can_add_policy_visible_agent(
     db_session: Session,
@@ -517,6 +574,9 @@ async def test_propose_builder_changes_persists_user_and_assistant_messages(
         message: str,
     ) -> tuple[str, dict[str, Any]]:
         del db, user, target_workforce
+        assert not db_session.new
+        assert not db_session.dirty
+        assert not db_session.deleted
         return (
             f"Prepared patch for {message}",
             {
@@ -674,6 +734,44 @@ def test_apply_builder_patch_rejects_workforce_status_update(
     assert invalid.value.status_code == 400
     assert invalid.value.detail == "Unsupported workforce update fields: status"
     assert db_session.get(Workforce, workforce.id).status == "draft"
+
+
+def test_apply_builder_patch_rejects_case_insensitive_workforce_name_duplicate(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    first_workforce = _create_workforce(
+        db_session,
+        owner,
+        manager,
+        name="Launch Workforce",
+    )
+    second_workforce = _create_workforce(
+        db_session,
+        owner,
+        manager,
+        name="Research Team",
+    )
+    patch = {
+        "summary": "Rename workforce.",
+        "operations": [
+            {
+                "op": "update_workforce",
+                "fields": {"name": "launch workforce"},
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+
+    with pytest.raises(HTTPException) as conflict:
+        builder_module.apply_builder_patch(db_session, owner, second_workforce, patch)
+
+    assert first_workforce.name == "Launch Workforce"
+    assert second_workforce.name == "Research Team"
+    assert conflict.value.status_code == 409
+    assert conflict.value.detail == "Workforce name already exists"
 
 
 def test_admin_can_apply_active_workforce_metadata_patch_without_run_scope(

--- a/tests/web/test_workforce_builder_services.py
+++ b/tests/web/test_workforce_builder_services.py
@@ -1,0 +1,612 @@
+import json
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.web.models import (
+    Agent,
+    Base,
+    User,
+    Workforce,
+    WorkforceAgent,
+    WorkforceBuilderMessage,
+)
+from xagent.web.models.agent import AgentStatus
+from xagent.web.services import workforce_builder as builder_module
+from xagent.web.services import workforce_creator as creator_module
+from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
+from xagent.web.services.workforce_builder import (
+    apply_workforce_builder_changes,
+    generate_builder_patch,
+    list_builder_messages,
+    propose_workforce_builder_changes,
+    serialize_builder_message,
+)
+from xagent.web.services.workforce_creator import (
+    create_workforce_from_prompt,
+    generate_workforce_creation_plan,
+)
+from xagent.web.services.workforce_workers import create_workforce_worker
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_workforce_policy() -> None:
+    set_workforce_policy(WorkforcePolicy())
+    yield
+    set_workforce_policy(WorkforcePolicy())
+
+
+def _create_user(db: Session, username: str, *, is_admin: bool = False) -> User:
+    user = User(
+        username=username,
+        password_hash="hash",
+        is_admin=is_admin,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_agent(
+    db: Session,
+    user: User,
+    name: str,
+    *,
+    execution_mode: str = "balanced",
+    status: AgentStatus = AgentStatus.PUBLISHED,
+) -> Agent:
+    agent = Agent(
+        user_id=int(user.id),
+        name=name,
+        description=f"{name} description",
+        instructions=f"{name} instructions",
+        execution_mode=execution_mode,
+        models={"general": "test-model"},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=[],
+        suggested_prompts=[],
+        status=status,
+    )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _create_workforce(
+    db: Session,
+    user: User,
+    manager: Agent,
+    *,
+    status: str = "draft",
+    name: str = "Research Team",
+) -> Workforce:
+    workforce = Workforce(
+        owner_user_id=int(user.id),
+        scope_type="user",
+        scope_id=str(user.id),
+        name=name,
+        description="Coordinates research tasks",
+        manager_agent_id=int(manager.id),
+        manager_instructions="Prefer concise synthesis.",
+        status=status,
+    )
+    db.add(workforce)
+    db.flush()
+    return workforce
+
+
+def _add_worker(
+    db: Session,
+    user: User,
+    workforce: Workforce,
+    worker_agent: Agent,
+    *,
+    alias: str = "Research Analyst",
+    enabled: bool = True,
+) -> WorkforceAgent:
+    return create_workforce_worker(
+        db,
+        workforce,
+        user,
+        source_type="existing",
+        agent_id=int(worker_agent.id),
+        alias=alias,
+        assignment_instructions="Collect evidence and cite sources.",
+        enabled=enabled,
+    )
+
+
+class _FakeLLM:
+    def __init__(self, response: dict[str, Any]):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> dict[str, str]:
+        self.calls.append(kwargs)
+        return {"content": json.dumps(self.response)}
+
+
+class _FakeModelStorage:
+    def __init__(self, db: Session, llm: _FakeLLM | None = None):
+        del db
+        self.llm = llm
+
+    def get_configured_defaults(
+        self, user_id: int | None
+    ) -> tuple[_FakeLLM | None, None, None, None]:
+        del user_id
+        return (self.llm, None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_generate_workforce_creation_plan_cleans_llm_output(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    analyst = _create_agent(db_session, owner, "Analyst")
+    draft_agent = _create_agent(
+        db_session,
+        owner,
+        "Draft Worker",
+        status=AgentStatus.DRAFT,
+    )
+    other_agent = _create_agent(db_session, other, "Other Worker")
+    fake_llm = _FakeLLM(
+        {
+            "name": " Launch Research ",
+            "description": "Coordinate launch analysis",
+            "manager": {
+                "name": "Launch Manager",
+                "description": "Runs the workflow",
+                "instructions": "Synthesize worker findings.",
+            },
+            "workers": [
+                {
+                    "agent_id": int(analyst.id),
+                    "alias": "Analyst",
+                    "assignment_instructions": "Gather research.",
+                    "enabled": True,
+                },
+                {
+                    "agent_id": int(draft_agent.id),
+                    "assignment_instructions": "Should be ignored.",
+                },
+                {
+                    "agent_id": int(other_agent.id),
+                    "assignment_instructions": "Should be ignored.",
+                },
+                {
+                    "agent_id": int(analyst.id),
+                    "assignment_instructions": "Duplicate should be ignored.",
+                },
+                {"agent_id": "bad", "assignment_instructions": "Invalid."},
+            ],
+            "warnings": [" keep this "],
+        }
+    )
+    monkeypatch.setattr(
+        creator_module,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(db, fake_llm),
+    )
+
+    plan = await generate_workforce_creation_plan(
+        db_session,
+        owner,
+        "Launch research",
+    )
+
+    sent_prompt = json.loads(fake_llm.calls[0]["messages"][1]["content"])
+    sent_agent_ids = {
+        item["agent_id"] for item in sent_prompt["available_published_agents"]
+    }
+    assert sent_agent_ids == {analyst.id}
+    assert plan["name"] == "Launch Research"
+    assert plan["manager"]["name"] == "Launch Manager"
+    assert plan["workers"] == [
+        {
+            "agent_id": analyst.id,
+            "alias": "Analyst",
+            "assignment_instructions": "Gather research.",
+            "enabled": True,
+        }
+    ]
+    assert plan["warnings"] == ["keep this"]
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    existing_manager = _create_agent(db_session, owner, "Launch Manager")
+    existing_workforce = _create_workforce(
+        db_session,
+        owner,
+        existing_manager,
+        name="Launch Workforce",
+    )
+    db_session.commit()
+
+    async def fake_plan(db: Session, user: User, prompt: str) -> dict[str, Any]:
+        del db, user
+        return {
+            "name": "Launch Workforce",
+            "description": prompt,
+            "manager": {
+                "name": "Launch Manager",
+                "description": "Coordinates launch work.",
+                "instructions": "Delegate and summarize.",
+            },
+            "manager_instructions": "Delegate and summarize.",
+            "workers": [
+                {
+                    "agent_id": int(worker_agent.id),
+                    "alias": "Analyst",
+                    "assignment_instructions": "Collect launch research.",
+                    "enabled": True,
+                }
+            ],
+            "warnings": ["Review before publishing."],
+        }
+
+    monkeypatch.setattr(
+        creator_module,
+        "generate_workforce_creation_plan",
+        fake_plan,
+    )
+
+    result = await create_workforce_from_prompt(
+        db_session,
+        owner,
+        prompt="Plan a product launch",
+    )
+
+    workforce = result.workforce
+    assert workforce.id != existing_workforce.id
+    assert workforce.name == "Launch Workforce 2"
+    assert workforce.status == "draft"
+    assert workforce.manager_agent.name == "Launch Manager 2"
+    assert workforce.manager_agent.status == AgentStatus.PUBLISHED
+    assert workforce.manager_agent.published_at is not None
+    assert workforce.manager_agent.execution_mode == "think"
+    assert len(workforce.workers) == 1
+    assert workforce.workers[0].agent_id == worker_agent.id
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert "Review before publishing." in result.messages[1].content
+    assert db_session.query(WorkforceBuilderMessage).count() == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_builder_patch_uses_llm_and_filters_available_agents(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    existing_worker_agent = _create_agent(db_session, owner, "Analyst")
+    available_agent = _create_agent(db_session, owner, "Editor")
+    draft_agent = _create_agent(
+        db_session,
+        owner,
+        "Draft Worker",
+        status=AgentStatus.DRAFT,
+    )
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, existing_worker_agent)
+    fake_llm = _FakeLLM(
+        {
+            "summary": "Update the workforce.",
+            "operations": [
+                {"op": "unknown", "fields": {"name": "ignored"}},
+                {
+                    "op": "add_existing_worker",
+                    "agent_id": int(available_agent.id),
+                    "assignment_instructions": "Edit the final brief.",
+                },
+            ],
+            "warnings": [" check "],
+        }
+    )
+    monkeypatch.setattr(
+        builder_module,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(db, fake_llm),
+    )
+
+    assistant_text, patch = await generate_builder_patch(
+        db_session,
+        owner,
+        workforce,
+        "Add an editor",
+    )
+
+    sent_prompt = json.loads(fake_llm.calls[0]["messages"][1]["content"])
+    sent_agent_ids = {
+        item["agent_id"] for item in sent_prompt["available_published_agents"]
+    }
+    assert sent_agent_ids == {available_agent.id}
+    assert draft_agent.id not in sent_agent_ids
+    assert "1 change" in assistant_text
+    assert patch == {
+        "summary": "Update the workforce.",
+        "operations": [
+            {
+                "op": "add_existing_worker",
+                "agent_id": available_agent.id,
+                "assignment_instructions": "Edit the final brief.",
+            }
+        ],
+        "warnings": ["check"],
+        "clarification": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_builder_fallback_can_add_policy_visible_agent(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class VisibleAgentPolicy(WorkforcePolicy):
+        def __init__(self, visible_agent_ids: set[int]):
+            self.visible_agent_ids = visible_agent_ids
+
+        def get_visible_agent_ids(
+            self,
+            db: Session,
+            user: User,
+            purpose: str,
+        ) -> set[int]:
+            del db, user, purpose
+            return self.visible_agent_ids
+
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    manager = _create_agent(db_session, owner, "Manager")
+    existing_worker_agent = _create_agent(db_session, owner, "Analyst")
+    visible_agent = _create_agent(db_session, other, "Data Miner")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, existing_worker_agent)
+    set_workforce_policy(VisibleAgentPolicy({int(visible_agent.id)}))
+    monkeypatch.setattr(
+        builder_module,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(db, None),
+    )
+
+    assistant_text, patch = await generate_builder_patch(
+        db_session,
+        owner,
+        workforce,
+        'Add worker Data Miner to handle "dataset analysis"',
+    )
+    apply_builder_result = builder_module.apply_builder_patch(
+        db_session,
+        owner,
+        workforce,
+        patch,
+    )
+
+    assert "rule-based parsing" in assistant_text
+    assert patch["operations"] == [
+        {
+            "op": "add_existing_worker",
+            "agent_id": visible_agent.id,
+            "alias": "Data Miner",
+            "assignment_instructions": "dataset analysis",
+        }
+    ]
+    worker_agent_ids = {
+        worker.agent_id
+        for worker in db_session.query(WorkforceAgent)
+        .filter(WorkforceAgent.workforce_id == apply_builder_result.id)
+        .all()
+    }
+    assert worker_agent_ids == {
+        existing_worker_agent.id,
+        visible_agent.id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_propose_builder_changes_persists_user_and_assistant_messages(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, worker_agent)
+
+    async def fake_patch(
+        db: Session,
+        user: User,
+        target_workforce: Workforce,
+        message: str,
+    ) -> tuple[str, dict[str, Any]]:
+        del db, user, target_workforce
+        return (
+            f"Prepared patch for {message}",
+            {
+                "summary": "Rename workforce.",
+                "operations": [
+                    {
+                        "op": "update_workforce",
+                        "fields": {"name": "Launch Team"},
+                    }
+                ],
+                "warnings": [],
+                "clarification": None,
+            },
+        )
+
+    monkeypatch.setattr(builder_module, "generate_builder_patch", fake_patch)
+
+    result = await propose_workforce_builder_changes(
+        db_session,
+        owner,
+        workforce,
+        message="rename it",
+    )
+
+    messages = list_builder_messages(db_session, int(workforce.id))
+    assert [message.role for message in messages] == ["user", "assistant"]
+    assert result.user_message.id == messages[0].id
+    assert result.assistant_message.status == "proposed"
+    assert result.requires_confirmation is True
+    assert result.proposed_patch["operations"][0]["fields"]["name"] == "Launch Team"
+    assert (
+        serialize_builder_message(result.assistant_message)["proposed_patch"]["summary"]
+        == "Rename workforce."
+    )
+
+
+def test_apply_builder_changes_validates_patch_and_updates_message(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager, status="active")
+    _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Rename workforce.",
+        "operations": [
+            {
+                "op": "update_workforce",
+                "fields": {"name": "Launch Workforce"},
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as mismatch:
+        apply_workforce_builder_changes(
+            db_session,
+            owner,
+            workforce,
+            message_id=int(message.id),
+            proposed_patch={**patch, "summary": "Different"},
+        )
+    assert mismatch.value.status_code == 400
+    assert mismatch.value.detail == "Proposed patch does not match message"
+
+    result = apply_workforce_builder_changes(
+        db_session,
+        owner,
+        workforce,
+        message_id=int(message.id),
+        proposed_patch=patch,
+    )
+
+    assert result.workforce.name == "Launch Workforce"
+    assert result.message.status == "applied"
+    assert result.message.proposed_patch == patch
+
+
+def test_apply_builder_patch_revalidates_active_workforce_run_scope(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager, status="active")
+    worker = _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Disable the only worker.",
+        "operations": [
+            {
+                "op": "update_worker",
+                "member_id": int(worker.id),
+                "enabled": False,
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as invalid:
+        apply_workforce_builder_changes(
+            db_session,
+            owner,
+            workforce,
+            message_id=int(message.id),
+            proposed_patch=patch,
+        )
+
+    assert invalid.value.status_code == 400
+    assert invalid.value.detail == "Workforce requires at least one enabled worker"
+    assert db_session.get(WorkforceAgent, worker.id).enabled is True
+
+
+@pytest.mark.asyncio
+async def test_builder_services_require_workforce_edit_access(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, worker_agent)
+
+    with pytest.raises(HTTPException) as denied:
+        await propose_workforce_builder_changes(
+            db_session,
+            other,
+            workforce,
+            message="rename it",
+        )
+
+    assert denied.value.status_code == 403
+    assert denied.value.detail == "Access denied"
+    assert db_session.query(WorkforceBuilderMessage).count() == 0

--- a/tests/web/test_workforce_builder_services.py
+++ b/tests/web/test_workforce_builder_services.py
@@ -18,6 +18,11 @@ from xagent.web.models import (
 from xagent.web.models.agent import AgentStatus
 from xagent.web.services import workforce_builder as builder_module
 from xagent.web.services import workforce_creator as creator_module
+from xagent.web.services.agent_store import AgentStore
+from xagent.web.services.hot_path_cache import (
+    InMemoryTTLCache,
+    set_cache_backend_for_testing,
+)
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 from xagent.web.services.workforce_builder import (
     apply_workforce_builder_changes,
@@ -305,6 +310,65 @@ async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
 
 
 @pytest.mark.asyncio
+async def test_create_workforce_from_prompt_invalidates_agent_list_cache(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        owner = _create_user(db_session, "owner")
+        worker_agent = _create_agent(db_session, owner, "Analyst")
+        db_session.commit()
+        store = AgentStore(db_session)
+        cached_agent_names = {
+            item["name"] for item in store.list_agent_items(int(owner.id))
+        }
+        assert cached_agent_names == {"Analyst"}
+
+        async def fake_plan(db: Session, user: User, prompt: str) -> dict[str, Any]:
+            del db, user, prompt
+            return {
+                "name": "Launch Workforce",
+                "description": "Plan a product launch",
+                "manager": {
+                    "name": "Launch Manager",
+                    "description": "Coordinates launch work.",
+                    "instructions": "Delegate and summarize.",
+                },
+                "manager_instructions": "Delegate and summarize.",
+                "workers": [
+                    {
+                        "agent_id": int(worker_agent.id),
+                        "alias": "Analyst",
+                        "assignment_instructions": "Collect launch research.",
+                        "enabled": True,
+                    }
+                ],
+                "warnings": [],
+            }
+
+        monkeypatch.setattr(
+            creator_module,
+            "generate_workforce_creation_plan",
+            fake_plan,
+        )
+
+        result = await create_workforce_from_prompt(
+            db_session,
+            owner,
+            prompt="Plan a product launch",
+        )
+
+        refreshed_agent_names = {
+            item["name"] for item in store.list_agent_items(int(owner.id))
+        }
+        assert result.workforce.manager_agent.name == "Launch Manager"
+        assert refreshed_agent_names == {"Analyst", "Launch Manager"}
+    finally:
+        set_cache_backend_for_testing(None)
+
+
+@pytest.mark.asyncio
 async def test_generate_builder_patch_uses_llm_and_filters_available_agents(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
@@ -477,7 +541,7 @@ async def test_propose_builder_changes_persists_user_and_assistant_messages(
         message="rename it",
     )
 
-    messages = list_builder_messages(db_session, int(workforce.id))
+    messages = list_builder_messages(db_session, owner, workforce)
     assert [message.role for message in messages] == ["user", "assistant"]
     assert result.user_message.id == messages[0].id
     assert result.assistant_message.status == "proposed"
@@ -487,6 +551,31 @@ async def test_propose_builder_changes_persists_user_and_assistant_messages(
         serialize_builder_message(result.assistant_message)["proposed_patch"]["summary"]
         == "Rename workforce."
     )
+
+
+def test_list_builder_messages_requires_workforce_view_access(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    other = _create_user(db_session, "other")
+    manager = _create_agent(db_session, owner, "Manager")
+    workforce = _create_workforce(db_session, owner, manager)
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        status="message",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    assert list_builder_messages(db_session, owner, workforce) == [message]
+    with pytest.raises(HTTPException) as denied:
+        list_builder_messages(db_session, other, workforce)
+
+    assert denied.value.status_code == 403
+    assert denied.value.detail == "Access denied"
 
 
 def test_apply_builder_changes_validates_patch_and_updates_message(
@@ -541,6 +630,50 @@ def test_apply_builder_changes_validates_patch_and_updates_message(
     assert result.workforce.name == "Launch Workforce"
     assert result.message.status == "applied"
     assert result.message.proposed_patch == patch
+
+
+def test_apply_builder_patch_rejects_workforce_status_update(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager, status="draft")
+    _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Publish workforce.",
+        "operations": [
+            {
+                "op": "update_workforce",
+                "fields": {"status": "active"},
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as invalid:
+        apply_workforce_builder_changes(
+            db_session,
+            owner,
+            workforce,
+            message_id=int(message.id),
+            proposed_patch=patch,
+        )
+
+    assert invalid.value.status_code == 400
+    assert invalid.value.detail == "Unsupported workforce update fields: status"
+    assert db_session.get(Workforce, workforce.id).status == "draft"
 
 
 def test_admin_can_apply_active_workforce_metadata_patch_without_run_scope(

--- a/tests/web/test_workforce_builder_services.py
+++ b/tests/web/test_workforce_builder_services.py
@@ -543,7 +543,50 @@ def test_apply_builder_changes_validates_patch_and_updates_message(
     assert result.message.proposed_patch == patch
 
 
-def test_apply_builder_patch_revalidates_active_workforce_run_scope(
+def test_admin_can_apply_active_workforce_metadata_patch_without_run_scope(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    admin = _create_user(db_session, "admin", is_admin=True)
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager, status="active")
+    _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Rename workforce.",
+        "operations": [
+            {
+                "op": "update_workforce",
+                "fields": {"name": "Admin Renamed Workforce"},
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(admin.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    result = apply_workforce_builder_changes(
+        db_session,
+        admin,
+        workforce,
+        message_id=int(message.id),
+        proposed_patch=patch,
+    )
+
+    assert result.workforce.name == "Admin Renamed Workforce"
+    assert result.message.status == "applied"
+
+
+def test_apply_builder_patch_revalidates_active_workforce_configuration(
     db_session: Session,
 ) -> None:
     owner = _create_user(db_session, "owner")
@@ -586,6 +629,106 @@ def test_apply_builder_patch_revalidates_active_workforce_run_scope(
     assert invalid.value.status_code == 400
     assert invalid.value.detail == "Workforce requires at least one enabled worker"
     assert db_session.get(WorkforceAgent, worker.id).enabled is True
+
+
+def test_apply_builder_patch_rejects_non_boolean_worker_enabled(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    workforce = _create_workforce(db_session, owner, manager)
+    worker = _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Disable worker.",
+        "operations": [
+            {
+                "op": "update_worker",
+                "member_id": int(worker.id),
+                "enabled": "false",
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as invalid:
+        apply_workforce_builder_changes(
+            db_session,
+            owner,
+            workforce,
+            message_id=int(message.id),
+            proposed_patch=patch,
+        )
+
+    assert invalid.value.status_code == 400
+    assert invalid.value.detail == "enabled must be a boolean"
+    assert db_session.get(WorkforceAgent, worker.id).enabled is True
+
+
+def test_apply_builder_patch_rejects_non_boolean_added_worker_enabled(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session, "owner")
+    manager = _create_agent(db_session, owner, "Manager")
+    worker_agent = _create_agent(db_session, owner, "Analyst")
+    editor_agent = _create_agent(db_session, owner, "Editor")
+    workforce = _create_workforce(db_session, owner, manager)
+    _add_worker(db_session, owner, workforce, worker_agent)
+    patch = {
+        "summary": "Add editor.",
+        "operations": [
+            {
+                "op": "add_existing_worker",
+                "agent_id": int(editor_agent.id),
+                "assignment_instructions": "Edit the final brief.",
+                "enabled": "false",
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    message = WorkforceBuilderMessage(
+        workforce_id=int(workforce.id),
+        user_id=int(owner.id),
+        role="assistant",
+        content="Prepared patch.",
+        proposed_patch=patch,
+        status="proposed",
+    )
+    db_session.add(message)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as invalid:
+        apply_workforce_builder_changes(
+            db_session,
+            owner,
+            workforce,
+            message_id=int(message.id),
+            proposed_patch=patch,
+        )
+
+    assert invalid.value.status_code == 400
+    assert invalid.value.detail == "enabled must be a boolean"
+    assert (
+        db_session.query(WorkforceAgent)
+        .filter(
+            WorkforceAgent.workforce_id == workforce.id,
+            WorkforceAgent.agent_id == editor_agent.id,
+        )
+        .first()
+        is None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add workforce builder services for prompt-based workforce creation and patch application.
- Add service-level access checks for builder messages and editable workforce operations.
- Route prompt-created manager agents through the shared agent store cache path and invalidate cache after successful creation.

## Validation

- `uv run pytest tests/web/test_workforce_builder_services.py tests/web/test_workforce_foundation.py tests/web/test_workforce_run_service.py tests/core/tools/test_create_agent_tool.py -q`
- `uv run pre-commit run --all-files`
