### PR TITLE
feat(workforce): expose workforce API surface

### DIFF
--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -382,11 +382,7 @@ async def create_workforce_from_prompt_endpoint(
 ) -> dict[str, Any]:
     result = await create_workforce_from_prompt(db, user, prompt=request.prompt)
     workforce = _reload_workforce(db, result.workforce)
-    return {
-        "workforce": _serialize_workforce_detail(workforce),
-        "plan": result.plan,
-        "messages": [serialize_builder_message(message) for message in result.messages],
-    }
+    return _serialize_workforce_detail(workforce)
 
 
 @router.get("/{workforce_id}")
@@ -691,9 +687,12 @@ async def propose_workforce_changes(
         ),
         message=request.message,
     )
+    assistant_message = serialize_builder_message(result.assistant_message)
     return {
+        "message_id": result.assistant_message.id,
         "user_message": serialize_builder_message(result.user_message),
-        "assistant_message": serialize_builder_message(result.assistant_message),
+        "assistant_message": result.assistant_message.content,
+        "message": assistant_message,
         "proposed_patch": result.proposed_patch,
         "requires_confirmation": result.requires_confirmation,
     }
@@ -721,6 +720,7 @@ async def apply_workforce_changes(
     workforce = _reload_workforce(db, result.workforce)
     return {
         "status": "applied",
+        "message_id": result.message.id,
         "message": serialize_builder_message(result.message),
         "workforce": _serialize_workforce_detail(workforce),
     }

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -1,0 +1,775 @@
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, selectinload
+
+from ..auth_dependencies import get_current_user
+from ..models.agent import Agent
+from ..models.database import get_db
+from ..models.user import User
+from ..models.workforce import (
+    Workforce,
+    WorkforceAgent,
+    WorkforceRun,
+)
+from ..services.workforce_access import (
+    can_create_workforce,
+    can_view_workforce,
+    ensure_agent_access,
+    ensure_workforce_access,
+    resolve_create_scope,
+)
+from ..services.workforce_builder import (
+    apply_workforce_builder_changes,
+    list_builder_messages,
+    propose_workforce_builder_changes,
+    serialize_builder_message,
+)
+from ..services.workforce_creator import create_workforce_from_prompt
+from ..services.workforce_names import workforce_name_exists
+from ..services.workforce_runs import create_workforce_run as start_workforce_run
+from ..services.workforce_snapshot import (
+    normalize_text,
+    normalize_workforce_status,
+    validate_workforce_for_run,
+)
+from ..services.workforce_workers import create_workforce_worker
+
+router = APIRouter(prefix="/api/workforces", tags=["workforces"])
+
+
+class WorkforceWorkerInput(BaseModel):
+    source_type: str = Field(default="existing")
+    agent_id: int | None = None
+    alias: str | None = Field(None, max_length=200)
+    assignment_instructions: str = Field(..., min_length=1)
+    enabled: bool = True
+    sort_order: int | None = None
+    canvas_position: dict[str, Any] | None = None
+
+
+class WorkforceCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = None
+    manager_agent_id: int
+    manager_instructions: str | None = None
+    canvas_layout: dict[str, Any] | None = None
+    workers: list[WorkforceWorkerInput] = Field(default_factory=list)
+
+
+class WorkforcePromptCreateRequest(BaseModel):
+    prompt: str = Field(..., min_length=1)
+
+
+class WorkforceUpdateRequest(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=200)
+    description: str | None = None
+    manager_agent_id: int | None = None
+    manager_instructions: str | None = None
+    canvas_layout: dict[str, Any] | None = None
+
+
+class WorkforceWorkerUpdateRequest(BaseModel):
+    alias: str | None = Field(None, max_length=200)
+    assignment_instructions: str | None = Field(None, min_length=1)
+    enabled: bool | None = None
+    sort_order: int | None = None
+    canvas_position: dict[str, Any] | None = None
+
+
+class WorkforceRunRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+    files: list[str] = Field(default_factory=list)
+    execution_mode: str | None = None
+
+
+class WorkforceBuilderProposeRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+
+
+class WorkforceBuilderApplyRequest(BaseModel):
+    message_id: int
+    proposed_patch: dict[str, Any]
+
+
+def _field_supplied(model: BaseModel, field_name: str) -> bool:
+    return field_name in model.model_fields_set
+
+
+def _load_workforce(db: Session, workforce_id: int) -> Workforce | None:
+    return (
+        db.query(Workforce)
+        .options(
+            selectinload(Workforce.manager_agent),
+            selectinload(Workforce.workers).selectinload(WorkforceAgent.agent),
+        )
+        .filter(Workforce.id == workforce_id)
+        .first()
+    )
+
+
+def _reload_workforce(db: Session, workforce: Workforce) -> Workforce:
+    workforce_id = int(workforce.id)
+    loaded = _load_workforce(db, workforce_id)
+    if loaded is None:
+        raise HTTPException(status_code=404, detail="Workforce not found")
+    return loaded
+
+
+def _agent_status_value(agent: Agent) -> str:
+    value = getattr(agent.status, "value", None)
+    if isinstance(value, str):
+        return value
+    return str(agent.status or "")
+
+
+def _serialize_datetime(value: Any) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _serialize_agent(agent: Agent) -> dict[str, Any]:
+    return {
+        "id": agent.id,
+        "name": agent.name,
+        "description": agent.description,
+        "logo_url": agent.logo_url,
+        "status": _agent_status_value(agent),
+    }
+
+
+def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
+    return sorted(
+        workforce.workers,
+        key=lambda item: (item.sort_order or 0, item.id or 0),
+    )
+
+
+def _serialize_worker(worker: WorkforceAgent) -> dict[str, Any]:
+    return {
+        "id": worker.id,
+        "agent": _serialize_agent(worker.agent),
+        "alias": worker.alias,
+        "assignment_instructions": worker.assignment_instructions,
+        "source_type": worker.source_type,
+        "template_id": worker.template_id,
+        "enabled": worker.enabled,
+        "sort_order": worker.sort_order,
+        "canvas_position": worker.canvas_position,
+        "created_at": _serialize_datetime(worker.created_at),
+        "updated_at": _serialize_datetime(worker.updated_at),
+    }
+
+
+def _serialize_workforce_detail(workforce: Workforce) -> dict[str, Any]:
+    return {
+        "id": workforce.id,
+        "name": workforce.name,
+        "description": workforce.description,
+        "status": workforce.status,
+        "manager": _serialize_agent(workforce.manager_agent),
+        "manager_instructions": workforce.manager_instructions,
+        "workers": [_serialize_worker(worker) for worker in _sorted_workers(workforce)],
+        "canvas_layout": workforce.canvas_layout,
+        "scope_type": workforce.scope_type,
+        "scope_id": workforce.scope_id,
+        "owner_user_id": workforce.owner_user_id,
+        "created_at": _serialize_datetime(workforce.created_at),
+        "updated_at": _serialize_datetime(workforce.updated_at),
+    }
+
+
+def _serialize_workforce_list_item(db: Session, workforce: Workforce) -> dict[str, Any]:
+    last_run = (
+        db.query(WorkforceRun)
+        .filter(WorkforceRun.workforce_id == workforce.id)
+        .order_by(WorkforceRun.created_at.desc(), WorkforceRun.id.desc())
+        .first()
+    )
+    return {
+        "id": workforce.id,
+        "name": workforce.name,
+        "description": workforce.description,
+        "status": workforce.status,
+        "manager": {
+            "id": workforce.manager_agent.id,
+            "name": workforce.manager_agent.name,
+            "logo_url": workforce.manager_agent.logo_url,
+        },
+        "worker_count": len(workforce.workers),
+        "last_run": (
+            {
+                "id": last_run.id,
+                "task_id": last_run.task_id,
+                "status": last_run.status,
+                "created_at": _serialize_datetime(last_run.created_at),
+            }
+            if last_run
+            else None
+        ),
+        "created_at": _serialize_datetime(workforce.created_at),
+        "updated_at": _serialize_datetime(workforce.updated_at),
+    }
+
+
+def _ensure_unique_workforce_name(
+    db: Session,
+    workforce: Workforce | None,
+    *,
+    scope_type: str,
+    scope_id: str,
+    name: str,
+) -> str:
+    normalized_name = normalize_text(name, "name", required=True)
+    if workforce_name_exists(
+        db,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        name=normalized_name,
+        exclude_workforce_id=int(workforce.id) if workforce is not None else None,
+    ):
+        raise HTTPException(status_code=409, detail="Workforce name already exists")
+    return normalized_name
+
+
+def _ensure_publish_state_mutable(workforce: Workforce) -> None:
+    if workforce.status == "archived":
+        raise HTTPException(
+            status_code=409,
+            detail="Archived workforce cannot change publish state",
+        )
+
+
+def _validate_if_active(db: Session, user: User, workforce: Workforce) -> None:
+    if workforce.status != "active":
+        return
+    db.flush()
+    db.expire(workforce, ["manager_agent", "workers"])
+    validate_workforce_for_run(db, user, workforce)
+
+
+def _load_worker(db: Session, workforce: Workforce, member_id: int) -> WorkforceAgent:
+    worker = (
+        db.query(WorkforceAgent)
+        .options(selectinload(WorkforceAgent.agent))
+        .filter(
+            WorkforceAgent.id == member_id,
+            WorkforceAgent.workforce_id == workforce.id,
+        )
+        .first()
+    )
+    if worker is None:
+        raise HTTPException(status_code=404, detail="Workforce worker not found")
+    return worker
+
+
+@router.get("")
+async def list_workforces(
+    search: str = "",
+    page: int = 1,
+    size: int = 20,
+    status: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    if page < 1 or size < 1 or size > 100:
+        raise HTTPException(status_code=400, detail="Invalid pagination parameters")
+
+    query = db.query(Workforce).options(
+        selectinload(Workforce.manager_agent),
+        selectinload(Workforce.workers).selectinload(WorkforceAgent.agent),
+    )
+    normalized_search = search.strip()
+    if normalized_search:
+        query = query.filter(
+            or_(
+                Workforce.name.ilike(f"%{normalized_search}%"),
+                Workforce.description.ilike(f"%{normalized_search}%"),
+            )
+        )
+    if status:
+        query = query.filter(Workforce.status == normalize_workforce_status(status))
+
+    workforces = query.order_by(Workforce.updated_at.desc(), Workforce.id.desc()).all()
+    visible_workforces = [
+        workforce for workforce in workforces if can_view_workforce(db, user, workforce)
+    ]
+    total = len(visible_workforces)
+    offset = (page - 1) * size
+    paged_workforces = visible_workforces[offset : offset + size]
+    return {
+        "items": [
+            _serialize_workforce_list_item(db, workforce)
+            for workforce in paged_workforces
+        ],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": (total + size - 1) // size,
+    }
+
+
+@router.post("")
+async def create_workforce(
+    request: WorkforceCreateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    scope_type, scope_id = resolve_create_scope(db, user)
+    if not can_create_workforce(db, user, scope_type, scope_id):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    name = _ensure_unique_workforce_name(
+        db,
+        None,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        name=request.name,
+    )
+    manager_agent = ensure_agent_access(
+        db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
+        user,
+        db,
+        require_published=True,
+    )
+
+    try:
+        workforce = Workforce(
+            owner_user_id=int(user.id),
+            scope_type=scope_type,
+            scope_id=scope_id,
+            name=name,
+            description=normalize_text(request.description, "description"),
+            manager_agent_id=int(manager_agent.id),
+            manager_instructions=normalize_text(
+                request.manager_instructions,
+                "manager_instructions",
+            ),
+            status="draft",
+            canvas_layout=request.canvas_layout,
+        )
+        db.add(workforce)
+        db.flush()
+
+        for worker_input in request.workers:
+            create_workforce_worker(
+                db,
+                workforce,
+                user,
+                source_type=worker_input.source_type,
+                assignment_instructions=worker_input.assignment_instructions,
+                alias=worker_input.alias,
+                agent_id=worker_input.agent_id,
+                enabled=worker_input.enabled,
+                sort_order=worker_input.sort_order,
+                canvas_position=worker_input.canvas_position,
+            )
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return _serialize_workforce_detail(_reload_workforce(db, workforce))
+
+
+@router.post("/from-prompt")
+async def create_workforce_from_prompt_endpoint(
+    request: WorkforcePromptCreateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    result = await create_workforce_from_prompt(db, user, prompt=request.prompt)
+    workforce = _reload_workforce(db, result.workforce)
+    return {
+        "workforce": _serialize_workforce_detail(workforce),
+        "plan": result.plan,
+        "messages": [serialize_builder_message(message) for message in result.messages],
+    }
+
+
+@router.get("/{workforce_id}")
+async def get_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="view",
+    )
+    return _serialize_workforce_detail(workforce)
+
+
+@router.patch("/{workforce_id}")
+async def update_workforce(
+    workforce_id: int,
+    request: WorkforceUpdateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    workforce_row = cast(Any, workforce)
+
+    if _field_supplied(request, "name"):
+        workforce_row.name = _ensure_unique_workforce_name(
+            db,
+            workforce,
+            scope_type=str(workforce.scope_type),
+            scope_id=str(workforce.scope_id),
+            name=cast(str, request.name),
+        )
+    if _field_supplied(request, "description"):
+        workforce_row.description = normalize_text(request.description, "description")
+    if _field_supplied(request, "manager_instructions"):
+        workforce_row.manager_instructions = normalize_text(
+            request.manager_instructions,
+            "manager_instructions",
+        )
+    if _field_supplied(request, "canvas_layout"):
+        workforce_row.canvas_layout = request.canvas_layout
+    if _field_supplied(request, "manager_agent_id"):
+        if request.manager_agent_id is None:
+            raise HTTPException(status_code=400, detail="manager_agent_id is required")
+        manager_agent = ensure_agent_access(
+            db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
+            user,
+            db,
+            require_published=True,
+        )
+        if any(
+            int(worker.agent_id) == int(manager_agent.id)
+            for worker in workforce.workers
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Manager agent cannot also be a worker",
+            )
+        workforce_row.manager_agent_id = int(manager_agent.id)
+
+    try:
+        _validate_if_active(db, user, workforce)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return _serialize_workforce_detail(_reload_workforce(db, workforce))
+
+
+@router.delete("/{workforce_id}")
+async def archive_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    cast(Any, workforce).status = "archived"
+    db.commit()
+    return {"id": workforce.id, "status": workforce.status}
+
+
+@router.post("/{workforce_id}/publish")
+async def publish_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    _ensure_publish_state_mutable(workforce)
+    cast(Any, workforce).status = "active"
+
+    try:
+        _validate_if_active(db, user, workforce)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return _serialize_workforce_detail(_reload_workforce(db, workforce))
+
+
+@router.post("/{workforce_id}/unpublish")
+async def unpublish_workforce(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    _ensure_publish_state_mutable(workforce)
+    cast(Any, workforce).status = "draft"
+    db.commit()
+    return _serialize_workforce_detail(_reload_workforce(db, workforce))
+
+
+@router.post("/{workforce_id}/agents")
+async def add_workforce_agent(
+    workforce_id: int,
+    request: WorkforceWorkerInput,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    try:
+        worker = create_workforce_worker(
+            db,
+            workforce,
+            user,
+            source_type=request.source_type,
+            assignment_instructions=request.assignment_instructions,
+            alias=request.alias,
+            agent_id=request.agent_id,
+            enabled=request.enabled,
+            sort_order=request.sort_order,
+            canvas_position=request.canvas_position,
+        )
+        _validate_if_active(db, user, workforce)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(worker)
+    return _serialize_worker(worker)
+
+
+@router.patch("/{workforce_id}/agents/{member_id}")
+async def update_workforce_agent(
+    workforce_id: int,
+    member_id: int,
+    request: WorkforceWorkerUpdateRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    worker = _load_worker(db, workforce, member_id)
+    worker_row = cast(Any, worker)
+
+    if _field_supplied(request, "alias"):
+        worker_row.alias = normalize_text(request.alias, "alias")
+    if _field_supplied(request, "assignment_instructions"):
+        worker_row.assignment_instructions = normalize_text(
+            request.assignment_instructions,
+            "assignment_instructions",
+            required=True,
+        )
+    if _field_supplied(request, "enabled"):
+        if request.enabled is None:
+            raise HTTPException(status_code=400, detail="enabled is required")
+        worker_row.enabled = bool(request.enabled)
+    if _field_supplied(request, "sort_order"):
+        worker_row.sort_order = request.sort_order
+    if _field_supplied(request, "canvas_position"):
+        worker_row.canvas_position = request.canvas_position
+
+    try:
+        _validate_if_active(db, user, workforce)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(worker)
+    return _serialize_worker(worker)
+
+
+@router.delete("/{workforce_id}/agents/{member_id}")
+async def remove_workforce_agent(
+    workforce_id: int,
+    member_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, str]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="edit",
+    )
+    worker = _load_worker(db, workforce, member_id)
+
+    try:
+        db.delete(worker)
+        db.flush()
+        db.expire(workforce, ["workers"])
+        _validate_if_active(db, user, workforce)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return {"status": "deleted"}
+
+
+@router.post("/{workforce_id}/runs")
+async def create_workforce_run(
+    workforce_id: int,
+    request: WorkforceRunRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    result = await start_workforce_run(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        message=request.message,
+        selected_file_ids=request.files,
+        execution_mode=request.execution_mode,
+    )
+    return {
+        "workforce_run_id": result.workforce_run.id,
+        "task_id": result.task.id,
+        "status": result.workforce_run.status,
+        "redirect_url": f"/task/{result.task.id}",
+    }
+
+
+@router.get("/{workforce_id}/builder/messages")
+async def get_workforce_builder_messages(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="view",
+    )
+    messages = list_builder_messages(db, user, workforce)
+    return {"items": [serialize_builder_message(message) for message in messages]}
+
+
+@router.post("/{workforce_id}/builder/propose")
+async def propose_workforce_changes(
+    workforce_id: int,
+    request: WorkforceBuilderProposeRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    result = await propose_workforce_builder_changes(
+        db,
+        user,
+        ensure_workforce_access(
+            db,
+            user,
+            _load_workforce(db, workforce_id),
+            action="edit",
+        ),
+        message=request.message,
+    )
+    return {
+        "user_message": serialize_builder_message(result.user_message),
+        "assistant_message": serialize_builder_message(result.assistant_message),
+        "proposed_patch": result.proposed_patch,
+        "requires_confirmation": result.requires_confirmation,
+    }
+
+
+@router.post("/{workforce_id}/builder/apply")
+async def apply_workforce_changes(
+    workforce_id: int,
+    request: WorkforceBuilderApplyRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    result = apply_workforce_builder_changes(
+        db,
+        user,
+        ensure_workforce_access(
+            db,
+            user,
+            _load_workforce(db, workforce_id),
+            action="edit",
+        ),
+        message_id=request.message_id,
+        proposed_patch=request.proposed_patch,
+    )
+    workforce = _reload_workforce(db, result.workforce)
+    return {
+        "status": "applied",
+        "message": serialize_builder_message(result.message),
+        "workforce": _serialize_workforce_detail(workforce),
+    }
+
+
+@router.get("/{workforce_id}/canvas")
+async def get_workforce_canvas(
+    workforce_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    workforce = ensure_workforce_access(
+        db,
+        user,
+        _load_workforce(db, workforce_id),
+        action="view",
+    )
+    manager_node_id = f"manager-{workforce.manager_agent.id}"
+    nodes: list[dict[str, Any]] = [
+        {"id": "human", "type": "human", "label": "Human"},
+        {
+            "id": manager_node_id,
+            "type": "manager",
+            "agent_id": workforce.manager_agent.id,
+            "label": workforce.manager_agent.name,
+        },
+    ]
+    edges: list[dict[str, Any]] = [
+        {"id": "human-manager", "source": "human", "target": manager_node_id}
+    ]
+
+    for worker in _sorted_workers(workforce):
+        worker_node_id = f"worker-{worker.id}"
+        nodes.append(
+            {
+                "id": worker_node_id,
+                "type": "worker",
+                "agent_id": worker.agent_id,
+                "label": worker.alias or worker.agent.name,
+                "position": worker.canvas_position,
+                "enabled": worker.enabled,
+            }
+        )
+        edges.append(
+            {
+                "id": f"manager-worker-{worker.id}",
+                "source": manager_node_id,
+                "target": worker_node_id,
+            }
+        )
+
+    return {"nodes": nodes, "edges": edges, "layout": workforce.canvas_layout or {}}

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -587,6 +587,8 @@ async def update_workforce_agent(
             raise HTTPException(status_code=400, detail="enabled is required")
         worker_row.enabled = bool(request.enabled)
     if _field_supplied(request, "sort_order"):
+        if request.sort_order is None:
+            raise HTTPException(status_code=400, detail="sort_order is required")
         worker_row.sort_order = request.sort_order
     if _field_supplied(request, "canvas_position"):
         worker_row.canvas_position = request.canvas_position

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -2,7 +2,7 @@ from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, selectinload
 
 from ..auth_dependencies import get_current_user
@@ -16,9 +16,9 @@ from ..models.workforce import (
 )
 from ..services.workforce_access import (
     can_create_workforce,
-    can_view_workforce,
     ensure_agent_access,
     ensure_workforce_access,
+    filter_visible_workforces,
     resolve_create_scope,
 )
 from ..services.workforce_builder import (
@@ -180,13 +180,10 @@ def _serialize_workforce_detail(workforce: Workforce) -> dict[str, Any]:
     }
 
 
-def _serialize_workforce_list_item(db: Session, workforce: Workforce) -> dict[str, Any]:
-    last_run = (
-        db.query(WorkforceRun)
-        .filter(WorkforceRun.workforce_id == workforce.id)
-        .order_by(WorkforceRun.created_at.desc(), WorkforceRun.id.desc())
-        .first()
-    )
+def _serialize_workforce_list_item(
+    workforce: Workforce,
+    last_run: WorkforceRun | None,
+) -> dict[str, Any]:
     return {
         "id": workforce.id,
         "name": workforce.name,
@@ -211,6 +208,35 @@ def _serialize_workforce_list_item(db: Session, workforce: Workforce) -> dict[st
         "created_at": _serialize_datetime(workforce.created_at),
         "updated_at": _serialize_datetime(workforce.updated_at),
     }
+
+
+def _load_latest_runs_by_workforce(
+    db: Session,
+    workforce_ids: list[int],
+) -> dict[int, WorkforceRun]:
+    if not workforce_ids:
+        return {}
+
+    ranked_runs = (
+        db.query(
+            WorkforceRun.id.label("id"),
+            func.row_number()
+            .over(
+                partition_by=WorkforceRun.workforce_id,
+                order_by=(WorkforceRun.created_at.desc(), WorkforceRun.id.desc()),
+            )
+            .label("rank"),
+        )
+        .filter(WorkforceRun.workforce_id.in_(workforce_ids))
+        .subquery()
+    )
+    latest_runs = (
+        db.query(WorkforceRun)
+        .join(ranked_runs, WorkforceRun.id == ranked_runs.c.id)
+        .filter(ranked_runs.c.rank == 1)
+        .all()
+    )
+    return {int(run.workforce_id): run for run in latest_runs}
 
 
 def _ensure_unique_workforce_name(
@@ -276,10 +302,7 @@ async def list_workforces(
     if page < 1 or size < 1 or size > 100:
         raise HTTPException(status_code=400, detail="Invalid pagination parameters")
 
-    query = db.query(Workforce).options(
-        selectinload(Workforce.manager_agent),
-        selectinload(Workforce.workers).selectinload(WorkforceAgent.agent),
-    )
+    query = db.query(Workforce)
     normalized_search = search.strip()
     if normalized_search:
         query = query.filter(
@@ -290,17 +313,30 @@ async def list_workforces(
         )
     if status:
         query = query.filter(Workforce.status == normalize_workforce_status(status))
+    query = filter_visible_workforces(db, user, query)
 
-    workforces = query.order_by(Workforce.updated_at.desc(), Workforce.id.desc()).all()
-    visible_workforces = [
-        workforce for workforce in workforces if can_view_workforce(db, user, workforce)
-    ]
-    total = len(visible_workforces)
+    total = query.count()
     offset = (page - 1) * size
-    paged_workforces = visible_workforces[offset : offset + size]
+    paged_workforces = (
+        query.options(
+            selectinload(Workforce.manager_agent),
+            selectinload(Workforce.workers).selectinload(WorkforceAgent.agent),
+        )
+        .order_by(Workforce.updated_at.desc(), Workforce.id.desc())
+        .offset(offset)
+        .limit(size)
+        .all()
+    )
+    latest_runs = _load_latest_runs_by_workforce(
+        db,
+        [int(workforce.id) for workforce in paged_workforces],
+    )
     return {
         "items": [
-            _serialize_workforce_list_item(db, workforce)
+            _serialize_workforce_list_item(
+                workforce,
+                latest_runs.get(int(workforce.id)),
+            )
             for workforce in paged_workforces
         ],
         "total": total,

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -41,6 +41,7 @@ from .api.v1 import v1_router
 from .api.v1.errors import V1ApiError, v1_api_error_handler
 from .api.websocket import ws_router
 from .api.widget import widget_router
+from .api.workforces import router as workforces_router
 from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
@@ -453,6 +454,7 @@ app.include_router(skills_router)
 app.include_router(system_router)
 app.include_router(templates_router)
 app.include_router(agents_router)
+app.include_router(workforces_router)
 app.include_router(channel_router, prefix="/api/channels", tags=["Channels"])
 app.include_router(widget_router)
 # Public SDK surface, mounted under /v1. Auth via xag_* API key,

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 from fastapi import HTTPException
 from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.user import User
@@ -29,6 +29,17 @@ class WorkforcePolicy:
     def can_view_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
         del db
         return bool(user.is_admin or int(workforce.owner_user_id) == int(user.id))
+
+    def filter_visible_workforces(
+        self,
+        db: Session,
+        user: User,
+        query: Query[Workforce],
+    ) -> Query[Workforce]:
+        del db
+        if user.is_admin:
+            return query
+        return query.filter(Workforce.owner_user_id == int(user.id))
 
     def can_run_workforce(self, db: Session, user: User, workforce: Workforce) -> bool:
         return self.can_view_workforce(db, user, workforce)
@@ -128,6 +139,14 @@ def can_view_workforce(db: Session, user: User, workforce: Workforce) -> bool:
     return get_workforce_policy().can_view_workforce(db, user, workforce)
 
 
+def filter_visible_workforces(
+    db: Session,
+    user: User,
+    query: Query[Workforce],
+) -> Query[Workforce]:
+    return get_workforce_policy().filter_visible_workforces(db, user, query)
+
+
 def can_run_workforce(db: Session, user: User, workforce: Workforce) -> bool:
     return get_workforce_policy().can_run_workforce(db, user, workforce)
 
@@ -157,6 +176,11 @@ def ensure_workforce_access(
 
     if not allowed:
         raise HTTPException(status_code=403, detail="Access denied")
+    if action == "edit" and workforce.status == "archived":
+        raise HTTPException(
+            status_code=409,
+            detail="Archived workforce cannot be edited",
+        )
     return workforce
 
 

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -36,6 +36,7 @@ from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
 from xagent.web.api.v1 import v1_router
 from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
+from xagent.web.api.workforces import router as workforces_router
 from xagent.web.models.database import Base, get_db, get_engine
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ def _override_get_db() -> Iterator[Session]:
 app_for_tests = FastAPI()
 app_for_tests.include_router(auth_router)
 app_for_tests.include_router(agents_router)
+app_for_tests.include_router(workforces_router)
 app_for_tests.include_router(v1_router)
 app_for_tests.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: ignore[arg-type]
 

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -1,0 +1,367 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.web.api import workforces as workforces_api
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.user import User
+from xagent.web.models.workforce import WorkforceBuilderMessage
+
+from .conftest import (
+    _admin_headers,
+    _direct_db_session,
+    _register_second_user,
+    client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _db(_test_db: None) -> None:
+    pass
+
+
+def _user_id(username: str = "admin") -> int:
+    db = _direct_db_session()
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        assert user is not None
+        return int(user.id)
+    finally:
+        db.close()
+
+
+def _create_published_agent(user_id: int, name: str) -> int:
+    db = _direct_db_session()
+    try:
+        agent = Agent(
+            user_id=user_id,
+            name=name,
+            description=f"{name} description",
+            instructions=f"{name} instructions",
+            execution_mode="balanced",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        return int(agent.id)
+    finally:
+        db.close()
+
+
+def _create_workforce(
+    headers: dict[str, str],
+    *,
+    name: str = "Support Workforce",
+    worker_count: int = 1,
+    canvas_layout: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    owner_id = _user_id()
+    manager_agent_id = _create_published_agent(owner_id, f"{name} Manager")
+    workers = []
+    for index in range(worker_count):
+        workers.append(
+            {
+                "source_type": "existing",
+                "agent_id": _create_published_agent(
+                    owner_id, f"{name} Worker {index + 1}"
+                ),
+                "alias": f"worker-{index + 1}",
+                "assignment_instructions": f"Handle area {index + 1}",
+                "enabled": True,
+                "sort_order": index + 1,
+                "canvas_position": {"x": 100 + index, "y": 200 + index},
+            }
+        )
+
+    response = client.post(
+        "/api/workforces",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Coordinates support work",
+            "manager_agent_id": manager_agent_id,
+            "manager_instructions": "Delegate and synthesize.",
+            "canvas_layout": canvas_layout,
+            "workers": workers,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_workforce_endpoints_require_authentication() -> None:
+    response = client.get("/api/workforces")
+    assert response.status_code == 403
+
+
+def test_create_list_get_and_cross_user_access_control() -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(headers)
+
+    assert workforce["status"] == "draft"
+    assert workforce["manager"]["name"] == "Support Workforce Manager"
+    assert workforce["workers"][0]["agent"]["name"] == "Support Workforce Worker 1"
+
+    list_response = client.get("/api/workforces", headers=headers)
+    assert list_response.status_code == 200
+    list_payload = list_response.json()
+    assert list_payload["total"] == 1
+    assert list_payload["items"][0]["id"] == workforce["id"]
+
+    detail_response = client.get(f"/api/workforces/{workforce['id']}", headers=headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["id"] == workforce["id"]
+
+    other_headers = _register_second_user()
+    denied_response = client.get(
+        f"/api/workforces/{workforce['id']}", headers=other_headers
+    )
+    assert denied_response.status_code == 403
+
+
+def test_publish_unpublish_and_active_validation() -> None:
+    headers = _admin_headers()
+    empty_workforce = _create_workforce(headers, name="Empty Workforce", worker_count=0)
+
+    invalid_publish = client.post(
+        f"/api/workforces/{empty_workforce['id']}/publish",
+        headers=headers,
+    )
+    assert invalid_publish.status_code == 400
+    assert "at least one enabled worker" in invalid_publish.json()["detail"]
+
+    workforce = _create_workforce(headers, name="Runnable Workforce")
+    publish_response = client.post(
+        f"/api/workforces/{workforce['id']}/publish",
+        headers=headers,
+    )
+    assert publish_response.status_code == 200
+    assert publish_response.json()["status"] == "active"
+
+    unpublish_response = client.post(
+        f"/api/workforces/{workforce['id']}/unpublish",
+        headers=headers,
+    )
+    assert unpublish_response.status_code == 200
+    assert unpublish_response.json()["status"] == "draft"
+
+
+def test_worker_add_update_remove_and_active_rollback() -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(headers, name="Worker Edit Workforce")
+    owner_id = _user_id()
+
+    add_response = client.post(
+        f"/api/workforces/{workforce['id']}/agents",
+        headers=headers,
+        json={
+            "source_type": "existing",
+            "agent_id": _create_published_agent(owner_id, "Additional Worker"),
+            "alias": "extra",
+            "assignment_instructions": "Handle overflow work",
+            "enabled": True,
+            "sort_order": 2,
+        },
+    )
+    assert add_response.status_code == 200, add_response.text
+    added_worker_id = add_response.json()["id"]
+
+    update_response = client.patch(
+        f"/api/workforces/{workforce['id']}/agents/{added_worker_id}",
+        headers=headers,
+        json={
+            "alias": "overflow",
+            "assignment_instructions": "Handle escalations",
+            "canvas_position": {"x": 9, "y": 10},
+        },
+    )
+    assert update_response.status_code == 200
+    updated_worker = update_response.json()
+    assert updated_worker["alias"] == "overflow"
+    assert updated_worker["canvas_position"] == {"x": 9, "y": 10}
+
+    delete_response = client.delete(
+        f"/api/workforces/{workforce['id']}/agents/{added_worker_id}",
+        headers=headers,
+    )
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"status": "deleted"}
+
+    publish_response = client.post(
+        f"/api/workforces/{workforce['id']}/publish",
+        headers=headers,
+    )
+    assert publish_response.status_code == 200
+    only_worker_id = publish_response.json()["workers"][0]["id"]
+
+    invalid_disable = client.patch(
+        f"/api/workforces/{workforce['id']}/agents/{only_worker_id}",
+        headers=headers,
+        json={"enabled": False},
+    )
+    assert invalid_disable.status_code == 400
+
+    detail_response = client.get(f"/api/workforces/{workforce['id']}", headers=headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["workers"][0]["enabled"] is True
+
+
+def test_builder_propose_apply_requires_stored_patch_match() -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(headers, name="Builder Workforce")
+
+    propose_response = client.post(
+        f"/api/workforces/{workforce['id']}/builder/propose",
+        headers=headers,
+        json={"message": 'rename "Renamed Workforce"'},
+    )
+    assert propose_response.status_code == 200, propose_response.text
+    assert propose_response.json()["assistant_message"]["status"] == "proposed"
+
+    patch = {
+        "summary": "Rename Workforce.",
+        "operations": [
+            {
+                "op": "update_workforce",
+                "fields": {"name": "Renamed Workforce"},
+            }
+        ],
+        "warnings": [],
+        "clarification": None,
+    }
+    owner_id = _user_id()
+    db = _direct_db_session()
+    try:
+        message = WorkforceBuilderMessage(
+            workforce_id=workforce["id"],
+            user_id=owner_id,
+            role="assistant",
+            content="I prepared 1 change for review.",
+            proposed_patch=patch,
+            status="proposed",
+        )
+        db.add(message)
+        db.commit()
+        db.refresh(message)
+        message_id = int(message.id)
+    finally:
+        db.close()
+
+    tampered_patch = {**patch, "summary": "tampered"}
+    bad_apply = client.post(
+        f"/api/workforces/{workforce['id']}/builder/apply",
+        headers=headers,
+        json={"message_id": message_id, "proposed_patch": tampered_patch},
+    )
+    assert bad_apply.status_code == 400
+    assert "does not match" in bad_apply.json()["detail"]
+
+    apply_response = client.post(
+        f"/api/workforces/{workforce['id']}/builder/apply",
+        headers=headers,
+        json={"message_id": message_id, "proposed_patch": patch},
+    )
+    assert apply_response.status_code == 200, apply_response.text
+    assert apply_response.json()["workforce"]["name"] == "Renamed Workforce"
+
+    messages_response = client.get(
+        f"/api/workforces/{workforce['id']}/builder/messages",
+        headers=headers,
+    )
+    assert messages_response.status_code == 200
+    message_roles = [item["role"] for item in messages_response.json()["items"]]
+    assert message_roles.count("user") == 1
+    assert message_roles.count("assistant") == 2
+
+
+def test_from_prompt_creates_draft_workforce() -> None:
+    headers = _admin_headers()
+    _create_published_agent(_user_id(), "Research Worker")
+
+    response = client.post(
+        "/api/workforces/from-prompt",
+        headers=headers,
+        json={"prompt": "Create a research workforce for product analysis"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["workforce"]["status"] == "draft"
+    assert payload["workforce"]["manager"]["status"] == "published"
+    assert len(payload["messages"]) == 2
+    assert payload["plan"]["workers"]
+
+
+def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(headers, name="Run Workforce")
+    captured: dict[str, Any] = {}
+
+    async def fake_start_workforce_run(
+        db: Any,
+        user: User,
+        workforce_arg: Any,
+        *,
+        message: str,
+        selected_file_ids: list[str] | None = None,
+        execution_mode: str | None = None,
+    ) -> Any:
+        captured.update(
+            {
+                "user_id": int(user.id),
+                "workforce_id": int(workforce_arg.id),
+                "message": message,
+                "selected_file_ids": selected_file_ids,
+                "execution_mode": execution_mode,
+            }
+        )
+        return SimpleNamespace(
+            workforce_run=SimpleNamespace(id=99, status="pending"),
+            task=SimpleNamespace(id=123),
+        )
+
+    monkeypatch.setattr(
+        workforces_api,
+        "start_workforce_run",
+        fake_start_workforce_run,
+    )
+
+    response = client.post(
+        f"/api/workforces/{workforce['id']}/runs",
+        headers=headers,
+        json={"message": "go", "files": ["file-1"], "execution_mode": "think"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "workforce_run_id": 99,
+        "task_id": 123,
+        "status": "pending",
+        "redirect_url": "/task/123",
+    }
+    assert captured == {
+        "user_id": _user_id(),
+        "workforce_id": workforce["id"],
+        "message": "go",
+        "selected_file_ids": ["file-1"],
+        "execution_mode": "think",
+    }
+
+
+def test_canvas_read_returns_nodes_edges_and_layout() -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(
+        headers,
+        name="Canvas Workforce",
+        canvas_layout={"zoom": 0.8},
+    )
+
+    response = client.get(f"/api/workforces/{workforce['id']}/canvas", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["layout"] == {"zoom": 0.8}
+    assert [node["type"] for node in payload["nodes"]] == ["human", "manager", "worker"]
+    assert [edge["source"] for edge in payload["edges"]] == [
+        "human",
+        f"manager-{workforce['manager']['id']}",
+    ]

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -1,12 +1,15 @@
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from sqlalchemy import event
 
 from xagent.web.api import workforces as workforces_api
 from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import get_engine
 from xagent.web.models.user import User
-from xagent.web.models.workforce import WorkforceBuilderMessage
+from xagent.web.models.workforce import WorkforceBuilderMessage, WorkforceRun
 
 from .conftest import (
     _admin_headers,
@@ -56,8 +59,9 @@ def _create_workforce(
     name: str = "Support Workforce",
     worker_count: int = 1,
     canvas_layout: dict[str, Any] | None = None,
+    username: str = "admin",
 ) -> dict[str, Any]:
-    owner_id = _user_id()
+    owner_id = _user_id(username)
     manager_agent_id = _create_published_agent(owner_id, f"{name} Manager")
     workers = []
     for index in range(worker_count):
@@ -91,6 +95,31 @@ def _create_workforce(
     return response.json()
 
 
+def _create_workforce_run(
+    *,
+    workforce_id: int,
+    user_id: int,
+    status: str,
+    created_at: datetime,
+) -> int:
+    db = _direct_db_session()
+    try:
+        run = WorkforceRun(
+            workforce_id=workforce_id,
+            task_id=None,
+            user_id=user_id,
+            status=status,
+            snapshot={"workforce": {"id": workforce_id}},
+            created_at=created_at,
+        )
+        db.add(run)
+        db.commit()
+        db.refresh(run)
+        return int(run.id)
+    finally:
+        db.close()
+
+
 def test_workforce_endpoints_require_authentication() -> None:
     response = client.get("/api/workforces")
     assert response.status_code == 403
@@ -119,6 +148,76 @@ def test_create_list_get_and_cross_user_access_control() -> None:
         f"/api/workforces/{workforce['id']}", headers=other_headers
     )
     assert denied_response.status_code == 403
+
+    other_workforce = _create_workforce(
+        other_headers,
+        name="Other User Workforce",
+        username="bob",
+    )
+    other_list_response = client.get("/api/workforces", headers=other_headers)
+    assert other_list_response.status_code == 200
+    other_list_payload = other_list_response.json()
+    assert other_list_payload["total"] == 1
+    assert other_list_payload["items"][0]["id"] == other_workforce["id"]
+
+
+def test_list_workforces_paginates_visible_query_and_bulk_loads_last_runs() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id()
+    workforces = [
+        _create_workforce(headers, name=f"Paged Workforce {index}")
+        for index in range(3)
+    ]
+    now = datetime.now(timezone.utc)
+    expected_latest_status: dict[int, str] = {}
+    for index, workforce in enumerate(workforces):
+        workforce_id = int(workforce["id"])
+        _create_workforce_run(
+            workforce_id=workforce_id,
+            user_id=owner_id,
+            status="failed",
+            created_at=now + timedelta(minutes=index),
+        )
+        expected_latest_status[workforce_id] = "completed"
+        _create_workforce_run(
+            workforce_id=workforce_id,
+            user_id=owner_id,
+            status="completed",
+            created_at=now + timedelta(minutes=10 + index),
+        )
+
+    workforce_run_selects: list[str] = []
+
+    def track_workforce_run_queries(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        del conn, cursor, parameters, context, executemany
+        if "from workforce_runs" in statement.lower():
+            workforce_run_selects.append(statement)
+
+    event.listen(get_engine(), "before_cursor_execute", track_workforce_run_queries)
+    try:
+        response = client.get(
+            "/api/workforces",
+            headers=headers,
+            params={"page": 1, "size": 2},
+        )
+    finally:
+        event.remove(get_engine(), "before_cursor_execute", track_workforce_run_queries)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 3
+    assert payload["pages"] == 2
+    assert len(payload["items"]) == 2
+    assert len(workforce_run_selects) == 1
+    for item in payload["items"]:
+        assert item["last_run"]["status"] == expected_latest_status[item["id"]]
 
 
 def test_publish_unpublish_and_active_validation() -> None:
@@ -222,6 +321,85 @@ def test_worker_add_update_remove_and_active_rollback() -> None:
     detail_response = client.get(f"/api/workforces/{workforce['id']}", headers=headers)
     assert detail_response.status_code == 200
     assert detail_response.json()["workers"][0]["enabled"] is True
+
+
+def test_archived_workforce_rejects_all_edit_boundaries() -> None:
+    headers = _admin_headers()
+    workforce = _create_workforce(headers, name="Archived Workforce")
+    owner_id = _user_id()
+    worker_id = workforce["workers"][0]["id"]
+
+    archive_response = client.delete(
+        f"/api/workforces/{workforce['id']}",
+        headers=headers,
+    )
+    assert archive_response.status_code == 200
+
+    patch_response = client.patch(
+        f"/api/workforces/{workforce['id']}",
+        headers=headers,
+        json={"description": "updated"},
+    )
+    assert patch_response.status_code == 409
+
+    add_response = client.post(
+        f"/api/workforces/{workforce['id']}/agents",
+        headers=headers,
+        json={
+            "source_type": "existing",
+            "agent_id": _create_published_agent(owner_id, "Archived Late Worker"),
+            "assignment_instructions": "Should not be added",
+        },
+    )
+    assert add_response.status_code == 409
+
+    update_worker_response = client.patch(
+        f"/api/workforces/{workforce['id']}/agents/{worker_id}",
+        headers=headers,
+        json={"alias": "blocked"},
+    )
+    assert update_worker_response.status_code == 409
+
+    remove_worker_response = client.delete(
+        f"/api/workforces/{workforce['id']}/agents/{worker_id}",
+        headers=headers,
+    )
+    assert remove_worker_response.status_code == 409
+
+    db = _direct_db_session()
+    try:
+        message = WorkforceBuilderMessage(
+            workforce_id=workforce["id"],
+            user_id=owner_id,
+            role="assistant",
+            content="Prepared patch.",
+            proposed_patch={
+                "summary": "Rename archived workforce.",
+                "operations": [
+                    {
+                        "op": "update_workforce",
+                        "fields": {"name": "Renamed Archived Workforce"},
+                    }
+                ],
+                "warnings": [],
+                "clarification": None,
+            },
+            status="proposed",
+        )
+        db.add(message)
+        db.commit()
+        db.refresh(message)
+        message_id = int(message.id)
+        proposed_patch = message.proposed_patch
+    finally:
+        db.close()
+
+    apply_response = client.post(
+        f"/api/workforces/{workforce['id']}/builder/apply",
+        headers=headers,
+        json={"message_id": message_id, "proposed_patch": proposed_patch},
+    )
+    assert apply_response.status_code == 409
 
 
 def test_builder_propose_apply_requires_stored_patch_match() -> None:

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -182,6 +182,22 @@ def test_worker_add_update_remove_and_active_rollback() -> None:
     assert updated_worker["alias"] == "overflow"
     assert updated_worker["canvas_position"] == {"x": 9, "y": 10}
 
+    invalid_sort_order = client.patch(
+        f"/api/workforces/{workforce['id']}/agents/{added_worker_id}",
+        headers=headers,
+        json={"sort_order": None},
+    )
+    assert invalid_sort_order.status_code == 400
+
+    detail_response = client.get(f"/api/workforces/{workforce['id']}", headers=headers)
+    assert detail_response.status_code == 200
+    added_worker = next(
+        worker
+        for worker in detail_response.json()["workers"]
+        if worker["id"] == added_worker_id
+    )
+    assert added_worker["sort_order"] == 2
+
     delete_response = client.delete(
         f"/api/workforces/{workforce['id']}/agents/{added_worker_id}",
         headers=headers,

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -218,7 +218,14 @@ def test_builder_propose_apply_requires_stored_patch_match() -> None:
         json={"message": 'rename "Renamed Workforce"'},
     )
     assert propose_response.status_code == 200, propose_response.text
-    assert propose_response.json()["assistant_message"]["status"] == "proposed"
+    propose_payload = propose_response.json()
+    assert isinstance(propose_payload["assistant_message"], str)
+    assert propose_payload["message_id"] == propose_payload["message"]["id"]
+    assert propose_payload["message"]["status"] == "proposed"
+    assert (
+        propose_payload["message"]["proposed_patch"]
+        == propose_payload["proposed_patch"]
+    )
 
     patch = {
         "summary": "Rename Workforce.",
@@ -264,7 +271,10 @@ def test_builder_propose_apply_requires_stored_patch_match() -> None:
         json={"message_id": message_id, "proposed_patch": patch},
     )
     assert apply_response.status_code == 200, apply_response.text
-    assert apply_response.json()["workforce"]["name"] == "Renamed Workforce"
+    apply_payload = apply_response.json()
+    assert apply_payload["message_id"] == message_id
+    assert apply_payload["message"]["status"] == "applied"
+    assert apply_payload["workforce"]["name"] == "Renamed Workforce"
 
     messages_response = client.get(
         f"/api/workforces/{workforce['id']}/builder/messages",
@@ -287,10 +297,16 @@ def test_from_prompt_creates_draft_workforce() -> None:
     )
     assert response.status_code == 200, response.text
     payload = response.json()
-    assert payload["workforce"]["status"] == "draft"
-    assert payload["workforce"]["manager"]["status"] == "published"
-    assert len(payload["messages"]) == 2
-    assert payload["plan"]["workers"]
+    assert payload["id"]
+    assert payload["status"] == "draft"
+    assert payload["manager"]["status"] == "published"
+
+    messages_response = client.get(
+        f"/api/workforces/{payload['id']}/builder/messages",
+        headers=headers,
+    )
+    assert messages_response.status_code == 200
+    assert len(messages_response.json()["items"]) == 2
 
 
 def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Expose the `/api/workforces` router and register the first user-accessible Workforce API surface.
- Add endpoints for Workforce create/list/detail/update/archive, publish/unpublish, worker add/update/remove, run creation, builder messages/propose/apply, canvas read, and from-prompt draft creation.
- Keep the router thin by delegating run, builder, worker creation, name uniqueness, cache invalidation, and permission-sensitive behavior to the Workforce service layer.
- Add API coverage for authentication, cross-user access control, publish validation, active-workforce rollback behavior, builder patch equality, from-prompt draft creation, run delegation, canvas output, and worker sort-order validation.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests/web/api/test_workforces_api.py`
- `uv run pytest tests/web/test_workforce_foundation.py tests/web/test_workforce_run_service.py tests/web/test_workforce_builder_services.py tests/web/api/test_workforces_api.py`