### PR TITLE
fix: stabilize task deletion and planner failures

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -808,12 +808,7 @@ class AutoPattern(AgentPattern):
                 decision = self._parse_decision(response, attempts=attempt + 1)
             except RequiredToolCallError:
                 if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
-                    raise RequiredToolCallError(
-                        owner="AutoPattern decision",
-                        tool_name=DECISION_TOOL_NAME,
-                        attempts=MAX_DECISION_PARSE_ATTEMPTS,
-                        user_message=AUTO_DECISION_REQUIRED_TOOL_MESSAGE,
-                    )
+                    raise
                 retry_feedback = self._required_tool_call_retry_feedback(
                     DECISION_TOOL_NAME
                 )

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -25,7 +25,13 @@ from ...language import (
     output_language_policy,
 )
 from ...runtime import LLMCallInterrupted, PatternRuntime
-from ..base import AgentPattern, PatternResult
+from ..base import (
+    REQUIRED_TOOL_CALL_FAILURE_REASON,
+    AgentPattern,
+    PatternResult,
+    RequiredToolCallError,
+    extract_required_tool_arguments,
+)
 from ..dag import DAGPattern
 from ..final_answer_stream import (
     FinalAnswerStreamSession,
@@ -109,6 +115,10 @@ class AutoDecisionResult:
 
 DECISION_TOOL_NAME = "select_execution_pattern"
 MAX_DECISION_PARSE_ATTEMPTS = 2
+AUTO_DECISION_REQUIRED_TOOL_MESSAGE = (
+    "Auto routing failed because the model did not return the required "
+    "decision tool call. Please retry."
+)
 
 
 class AutoDecisionArgumentsError(ValueError):
@@ -405,6 +415,17 @@ class AutoPattern(AgentPattern):
                 memory_similarity_threshold=kwargs.get("memory_similarity_threshold"),
                 compact_llm=kwargs.get("compact_llm"),
             )
+        except RequiredToolCallError as exc:
+            result = await self._fail(
+                context=context,
+                runtime=runtime,
+                error=exc.user_message,
+                failure_reason=exc.failure_reason,
+                checkpoint_label="auto_decision_failed",
+                extra_metadata=exc.to_metadata(),
+            )
+            await runtime.on_pattern_end(context=context, pattern=self, result=result)
+            return result
         except Exception as exc:
             self.status = "failed"
             await runtime.on_pattern_error(context=context, pattern=self, error=exc)
@@ -594,6 +615,38 @@ class AutoPattern(AgentPattern):
         self.last_result = result
         return result
 
+    async def _fail(
+        self,
+        *,
+        context: Any,
+        runtime: PatternRuntime,
+        error: str,
+        failure_reason: str,
+        checkpoint_label: str,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.status = "failed"
+        metadata: dict[str, Any] = {
+            "status": self.status,
+            "failure_reason": failure_reason,
+        }
+        if extra_metadata:
+            metadata.update(extra_metadata)
+        result = PatternResult(
+            success=False,
+            error=error,
+            metadata=metadata,
+        ).to_dict()
+        self.last_result = result
+        await runtime.checkpoint(
+            checkpoint_label,
+            context=context,
+            pattern=self,
+            status=self.status,
+            metadata=metadata,
+        )
+        return result
+
     def _normalize_decision(self) -> None:
         if self.decision is None:
             return
@@ -752,7 +805,36 @@ class AutoPattern(AgentPattern):
                 context=context, response=response, metadata=metadata
             )
             try:
-                decision = self._parse_decision(response)
+                decision = self._parse_decision(response, attempts=attempt + 1)
+            except RequiredToolCallError:
+                if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
+                    raise RequiredToolCallError(
+                        owner="AutoPattern decision",
+                        tool_name=DECISION_TOOL_NAME,
+                        attempts=MAX_DECISION_PARSE_ATTEMPTS,
+                        user_message=AUTO_DECISION_REQUIRED_TOOL_MESSAGE,
+                    )
+                retry_feedback = self._required_tool_call_retry_feedback(
+                    DECISION_TOOL_NAME
+                )
+                logger.warning(
+                    "AutoPattern decision response omitted required %s tool call; "
+                    "retrying decision. execution_id=%s attempt=%s",
+                    DECISION_TOOL_NAME,
+                    getattr(context, "execution_id", None),
+                    attempt + 1,
+                )
+                await runtime.checkpoint(
+                    "auto_decision_retry",
+                    context=context,
+                    pattern=self,
+                    metadata={
+                        "attempt": attempt + 1,
+                        "failure_reason": REQUIRED_TOOL_CALL_FAILURE_REASON,
+                        "required_tool_name": DECISION_TOOL_NAME,
+                    },
+                )
+                continue
             except AutoDecisionArgumentsError as exc:
                 if attempt + 1 >= MAX_DECISION_PARSE_ATTEMPTS:
                     raise
@@ -782,6 +864,13 @@ class AutoPattern(AgentPattern):
                 ),
             )
         raise RuntimeError("AutoPattern decision retry loop exited unexpectedly.")
+
+    def _required_tool_call_retry_feedback(self, tool_name: str) -> str:
+        return (
+            f"The previous response did not call the required {tool_name} tool. "
+            f"Call {tool_name} exactly once with a complete routing decision. "
+            "Do not answer in natural language."
+        )
 
     def _decision_retry_feedback(self, error: AutoDecisionArgumentsError) -> str:
         argument_preview = self._truncate_retry_preview(error.arguments or "")
@@ -962,39 +1051,29 @@ class AutoPattern(AgentPattern):
             actions.append(AutoAction.PLAN_EXECUTE.value)
         return actions
 
-    def _parse_decision(self, response: Any) -> AutoDecision:
-        payload = self._extract_tool_arguments(response, DECISION_TOOL_NAME)
+    def _parse_decision(self, response: Any, *, attempts: int = 1) -> AutoDecision:
+        payload = self._extract_tool_arguments(
+            response,
+            DECISION_TOOL_NAME,
+            attempts=attempts,
+        )
         return AutoDecision.from_dict(payload)
 
-    def _extract_tool_arguments(self, response: Any, tool_name: str) -> dict[str, Any]:
-        tool_calls = self._response_tool_calls(response)
-        for tool_call in tool_calls:
-            function_payload = self._function_payload(tool_call)
-            if not function_payload:
-                continue
-            if function_payload.get("name") != tool_name:
-                continue
-            return self._coerce_arguments(function_payload.get("arguments", {}))
-        raise ValueError(
-            f"AutoPattern decision requires a {tool_name} tool call response."
+    def _extract_tool_arguments(
+        self,
+        response: Any,
+        tool_name: str,
+        *,
+        attempts: int = 1,
+    ) -> dict[str, Any]:
+        arguments = extract_required_tool_arguments(
+            response,
+            tool_name=tool_name,
+            owner="AutoPattern decision",
+            attempts=attempts,
+            user_message=AUTO_DECISION_REQUIRED_TOOL_MESSAGE,
         )
-
-    def _response_tool_calls(self, response: Any) -> list[Any]:
-        if isinstance(response, dict):
-            return list(response.get("tool_calls") or [])
-        return list(getattr(response, "tool_calls", []) or [])
-
-    def _function_payload(self, tool_call: Any) -> dict[str, Any] | None:
-        if isinstance(tool_call, dict):
-            function_payload = tool_call.get("function")
-            return function_payload if isinstance(function_payload, dict) else None
-        function_payload = getattr(tool_call, "function", None)
-        if function_payload is None:
-            return None
-        return {
-            "name": getattr(function_payload, "name", None),
-            "arguments": getattr(function_payload, "arguments", {}),
-        }
+        return self._coerce_arguments(arguments)
 
     def _coerce_arguments(self, arguments: Any) -> dict[str, Any]:
         if isinstance(arguments, dict):

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -30,6 +30,7 @@ from ..base import (
     AgentPattern,
     PatternResult,
     RequiredToolCallError,
+    append_user_message_preserving_turns,
     extract_required_tool_arguments,
 )
 from ..dag import DAGPattern
@@ -761,10 +762,17 @@ class AutoPattern(AgentPattern):
         decision_tools = [self._decision_tool_schema()]
         retry_feedback: str | None = None
         for attempt in range(MAX_DECISION_PARSE_ATTEMPTS):
-            messages = list(base_messages)
-            messages.append({"role": "user", "content": decision_prompt})
+            messages = append_user_message_preserving_turns(
+                base_messages,
+                content=decision_prompt,
+                section_title="Auto routing instruction",
+            )
             if retry_feedback:
-                messages.append({"role": "user", "content": retry_feedback})
+                messages = append_user_message_preserving_turns(
+                    messages,
+                    content=retry_feedback,
+                    section_title="Auto routing retry feedback",
+                )
             metadata: dict[str, Any] = {"phase": "auto_decision"}
             if attempt:
                 metadata["attempt"] = attempt + 1

--- a/src/xagent/core/agent/pattern/base.py
+++ b/src/xagent/core/agent/pattern/base.py
@@ -61,6 +61,41 @@ def extract_required_tool_arguments(
     )
 
 
+def append_user_message_preserving_turns(
+    messages: list[dict[str, Any]],
+    *,
+    content: str,
+    section_title: str | None = None,
+) -> list[dict[str, Any]]:
+    """Append user-scoped pattern feedback without creating adjacent user turns."""
+
+    updated = [dict(message) for message in messages]
+    if not updated or updated[-1].get("role") != "user":
+        updated.append({"role": "user", "content": content})
+        return updated
+
+    last_message = dict(updated[-1])
+    previous_content = last_message.get("content")
+    if isinstance(previous_content, str):
+        title = section_title or "Additional instruction"
+        last_message["content"] = (
+            f"{previous_content.rstrip()}\n\n{title}:\n{content}"
+            if previous_content.strip()
+            else content
+        )
+        updated[-1] = last_message
+        return updated
+
+    updated.append(
+        {
+            "role": "assistant",
+            "content": "Acknowledged. I will follow the next instruction.",
+        }
+    )
+    updated.append({"role": "user", "content": content})
+    return updated
+
+
 def iter_tool_function_payloads(response: Any) -> list[dict[str, Any]]:
     tool_calls = _response_tool_calls(response)
     function_payloads: list[dict[str, Any]] = []

--- a/src/xagent/core/agent/pattern/base.py
+++ b/src/xagent/core/agent/pattern/base.py
@@ -6,6 +6,89 @@ from typing import Any
 
 from ..context import ExecutionContext
 
+REQUIRED_TOOL_CALL_FAILURE_REASON = "missing_required_tool_call"
+
+
+class RequiredToolCallError(ValueError):
+    """Raised when an LLM response omits a tool call the caller requires."""
+
+    def __init__(
+        self,
+        *,
+        owner: str,
+        tool_name: str,
+        attempts: int = 1,
+        user_message: str | None = None,
+    ) -> None:
+        self.owner = owner
+        self.tool_name = tool_name
+        self.attempts = attempts
+        self.failure_reason = REQUIRED_TOOL_CALL_FAILURE_REASON
+        self.user_message = user_message or (
+            "The model did not return the required tool call. Please retry."
+        )
+        super().__init__(
+            f"{owner} did not receive the required {tool_name} tool call "
+            f"after {attempts} attempt(s)."
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "failure_reason": self.failure_reason,
+            "required_tool_name": self.tool_name,
+            "attempts": self.attempts,
+        }
+
+
+def extract_required_tool_arguments(
+    response: Any,
+    *,
+    tool_name: str,
+    owner: str,
+    attempts: int = 1,
+    user_message: str | None = None,
+) -> Any:
+    """Return arguments for a named required tool call or raise a structured error."""
+
+    for function_payload in iter_tool_function_payloads(response):
+        if function_payload.get("name") == tool_name:
+            return function_payload.get("arguments", {})
+    raise RequiredToolCallError(
+        owner=owner,
+        tool_name=tool_name,
+        attempts=attempts,
+        user_message=user_message,
+    )
+
+
+def iter_tool_function_payloads(response: Any) -> list[dict[str, Any]]:
+    tool_calls = _response_tool_calls(response)
+    function_payloads: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        function_payload = _function_payload(tool_call)
+        if function_payload:
+            function_payloads.append(function_payload)
+    return function_payloads
+
+
+def _response_tool_calls(response: Any) -> list[Any]:
+    if isinstance(response, dict):
+        return list(response.get("tool_calls") or [])
+    return list(getattr(response, "tool_calls", []) or [])
+
+
+def _function_payload(tool_call: Any) -> dict[str, Any] | None:
+    if isinstance(tool_call, dict):
+        function_payload = tool_call.get("function")
+        return function_payload if isinstance(function_payload, dict) else None
+    function_payload = getattr(tool_call, "function", None)
+    if function_payload is None:
+        return None
+    return {
+        "name": getattr(function_payload, "name", None),
+        "arguments": getattr(function_payload, "arguments", {}),
+    }
+
 
 @dataclass
 class PatternResult:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -19,7 +19,7 @@ from ...language import (
 )
 from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
-from ..base import AgentPattern, PatternResult
+from ..base import AgentPattern, PatternResult, RequiredToolCallError
 from ..final_answer_stream import FinalAnswerStreamSession, ToolCallStringFieldStreamer
 from ..react import ReActPattern, ReActReasoningMode
 from .plan_generator import (
@@ -327,6 +327,17 @@ class DAGPattern(AgentPattern):
                 skill_manager=kwargs.get("skill_manager"),
                 allowed_skills=kwargs.get("allowed_skills"),
             )
+        except RequiredToolCallError as exc:
+            result = await self._fail(
+                context=context,
+                runtime=runtime,
+                error=exc.user_message,
+                failure_reason=exc.failure_reason,
+                checkpoint_label="dag_plan_generation_failed",
+                extra_metadata=exc.to_metadata(),
+            )
+            await runtime.on_pattern_end(context=context, pattern=self, result=result)
+            return result
         except Exception as exc:
             await runtime.on_pattern_error(context=context, pattern=self, error=exc)
             raise
@@ -424,6 +435,8 @@ class DAGPattern(AgentPattern):
             if interrupted is not None:
                 return interrupted
             raise
+        except RequiredToolCallError:
+            raise
         except Exception as exc:  # noqa: BLE001
             return await self._fail(
                 context=context,
@@ -464,6 +477,8 @@ class DAGPattern(AgentPattern):
                         )
                         if interrupted is not None:
                             return interrupted
+                        raise
+                    except RequiredToolCallError:
                         raise
                     except Exception as exc:  # noqa: BLE001
                         return await self._fail(
@@ -1056,12 +1071,15 @@ class DAGPattern(AgentPattern):
         failure_reason: str,
         checkpoint_label: str,
         failed_step_id: str | None = None,
+        extra_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         self.status = "failed"
         metadata: dict[str, Any] = {
             "status": self.status,
             "failure_reason": failure_reason,
         }
+        if extra_metadata:
+            metadata.update(extra_metadata)
         if failed_step_id is not None:
             metadata["failed_step_id"] = failed_step_id
         await runtime.checkpoint(
@@ -1206,6 +1224,8 @@ class DAGPattern(AgentPattern):
             )
             if interrupted is not None:
                 return interrupted
+            raise
+        except RequiredToolCallError:
             raise
         except Exception as exc:  # noqa: BLE001
             return await self._fail(

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -305,12 +305,7 @@ class LLMPlanGenerator(PlanGenerator):
                 )
             except RequiredToolCallError:
                 if attempt + 1 >= MAX_PLAN_TOOL_CALL_ATTEMPTS:
-                    raise RequiredToolCallError(
-                        owner="LLMPlanGenerator",
-                        tool_name=self.PLAN_TOOL_NAME,
-                        attempts=MAX_PLAN_TOOL_CALL_ATTEMPTS,
-                        user_message=PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
-                    )
+                    raise
                 retry_feedback = self._required_tool_call_retry_feedback(
                     self.PLAN_TOOL_NAME
                 )

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -13,8 +13,15 @@ from ...language import (
     output_language_policy,
     plan_language_rules,
 )
+from ..base import RequiredToolCallError, extract_required_tool_arguments
 
 logger = logging.getLogger(__name__)
+
+MAX_PLAN_TOOL_CALL_ATTEMPTS = 2
+PLAN_GENERATION_REQUIRED_TOOL_MESSAGE = (
+    "Plan generation failed because the model did not return the required "
+    "planning tool call. Please retry."
+)
 
 
 class PlanValidationError(ValueError):
@@ -210,87 +217,118 @@ class LLMPlanGenerator(PlanGenerator):
         llm: Any,
     ) -> ExecutionPlan:
         plan_tools = [self._plan_tool_schema()]
-        response = await llm.chat(
-            messages=[
-                {
-                    "role": "system",
-                    "content": (
-                        "Generate a DAG execution plan by calling the "
-                        f"{self.PLAN_TOOL_NAME} tool exactly once. Each step requires "
-                        '"id", "task", "dependencies", "termination_condition", '
-                        '"completion_evidence", and "tool_names"; "description" is '
-                        "optional but strongly recommended. "
-                        "dependencies is required for every step; "
-                        "use an empty array only for true entry steps that do not "
-                        "need any prior output. If a step uses data, files, decisions, "
-                        "analysis, or artifacts produced by another step, it must "
-                        "depend on that producing step. For example, screenshot or "
-                        "render steps must depend on the step that creates the HTML "
-                        "or file they render, and final synthesis steps must depend "
-                        "on the research or build steps they summarize. Use task as "
-                        "the short node title, "
-                        "description for the concrete work to perform, and tool_names "
-                        "for the step's suggested execution tool scope. Use "
-                        "termination_condition for the exact stop rule that tells the "
-                        "step executor when this step is done and what it must report. "
-                        "The termination_condition must be concrete and action-specific; "
-                        "do not use vague wording such as 'when complete' or 'when the "
-                        "task is done'. For artifact-producing steps, name an exact path "
-                        "only when the user requires that path or the tool accepts it as "
-                        "an argument; otherwise refer to the artifact returned by the "
-                        "tool. State that the step must call final_answer after the "
-                        "condition is satisfied. Put review, "
-                        "verification, rendering, optimization, and final synthesis in "
-                        "separate dependent steps unless this step explicitly owns that "
-                        "work. Use completion_evidence for a short natural-language "
-                        "proof that this specific step is done, usually naming the "
-                        "successful tool result fields to check. Do not use global "
-                        "effect labels or invented fixed filenames. For auto-named "
-                        "outputs, say that the tool returned a usable path. Keep "
-                        "completion_evidence under 160 characters. If a workflow needs "
-                        "several tool actions and only the last one proves completion, "
-                        "split those actions into dependent steps. Few-shot examples: "
-                        "auto-named output evidence: 'The generator returned success=true "
-                        "and a non-empty path or URL for the created asset.' explicit "
-                        "path evidence: 'The writer returned success=true for the "
-                        "requested output path.' non-file evidence: 'The tool returned "
-                        "the requested answer data successfully.' tool_names "
-                        "must only contain exact names from available_tool_names. "
-                        "Include the best matching available tools for every step "
-                        "that needs tool use. Leave tool_names empty only for pure "
-                        "reasoning, summarization, or formatting steps that can be "
-                        "completed from provided context and dependency results. Do "
-                        "not put skill names, artifact types, programming languages, "
-                        "or made-up tools in tool_names. tool_names are not hard "
-                        "limits, but they define the expected tool scope for the "
-                        "step executor; choose them carefully so the executor does "
-                        "not need to perform sibling or downstream step work. "
-                        "Set response_language to the natural language that "
-                        "user-facing prose should use for this request. If the "
-                        "user prompt includes an output_language_policy field, "
-                        "follow it exactly and make response_language match it. "
-                        "The messages array, selected skill context, retrieved "
-                        "memories, examples, URLs, and source content are "
-                        "supporting context only and must not change the plan "
-                        "language. "
-                        f"{plan_language_rules()} "
-                        "Keep ids stable "
-                        "across replans when a completed step can be reused."
-                    ),
-                },
-                {"role": "user", "content": self._build_prompt(request)},
-            ],
-            tools=plan_tools,
-            tool_choice="required",
-            thinking={"type": "disabled", "enable": False},
-        )
-        plan_arguments = self._extract_tool_arguments(response, self.PLAN_TOOL_NAME)
-        self._apply_response_language(request.context, plan_arguments)
-        plan = coerce_execution_plan(plan_arguments)
-        return self._filter_suggested_tools(
-            plan=plan,
-            available_tool_names=request.available_tool_names,
-        )
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Generate a DAG execution plan by calling the "
+                    f"{self.PLAN_TOOL_NAME} tool exactly once. Each step requires "
+                    '"id", "task", "dependencies", "termination_condition", '
+                    '"completion_evidence", and "tool_names"; "description" is '
+                    "optional but strongly recommended. "
+                    "dependencies is required for every step; "
+                    "use an empty array only for true entry steps that do not "
+                    "need any prior output. If a step uses data, files, decisions, "
+                    "analysis, or artifacts produced by another step, it must "
+                    "depend on that producing step. For example, screenshot or "
+                    "render steps must depend on the step that creates the HTML "
+                    "or file they render, and final synthesis steps must depend "
+                    "on the research or build steps they summarize. Use task as "
+                    "the short node title, "
+                    "description for the concrete work to perform, and tool_names "
+                    "for the step's suggested execution tool scope. Use "
+                    "termination_condition for the exact stop rule that tells the "
+                    "step executor when this step is done and what it must report. "
+                    "The termination_condition must be concrete and action-specific; "
+                    "do not use vague wording such as 'when complete' or 'when the "
+                    "task is done'. For artifact-producing steps, name an exact path "
+                    "only when the user requires that path or the tool accepts it as "
+                    "an argument; otherwise refer to the artifact returned by the "
+                    "tool. State that the step must call final_answer after the "
+                    "condition is satisfied. Put review, "
+                    "verification, rendering, optimization, and final synthesis in "
+                    "separate dependent steps unless this step explicitly owns that "
+                    "work. Use completion_evidence for a short natural-language "
+                    "proof that this specific step is done, usually naming the "
+                    "successful tool result fields to check. Do not use global "
+                    "effect labels or invented fixed filenames. For auto-named "
+                    "outputs, say that the tool returned a usable path. Keep "
+                    "completion_evidence under 160 characters. If a workflow needs "
+                    "several tool actions and only the last one proves completion, "
+                    "split those actions into dependent steps. Few-shot examples: "
+                    "auto-named output evidence: 'The generator returned success=true "
+                    "and a non-empty path or URL for the created asset.' explicit "
+                    "path evidence: 'The writer returned success=true for the "
+                    "requested output path.' non-file evidence: 'The tool returned "
+                    "the requested answer data successfully.' tool_names "
+                    "must only contain exact names from available_tool_names. "
+                    "Include the best matching available tools for every step "
+                    "that needs tool use. Leave tool_names empty only for pure "
+                    "reasoning, summarization, or formatting steps that can be "
+                    "completed from provided context and dependency results. Do "
+                    "not put skill names, artifact types, programming languages, "
+                    "or made-up tools in tool_names. tool_names are not hard "
+                    "limits, but they define the expected tool scope for the "
+                    "step executor; choose them carefully so the executor does "
+                    "not need to perform sibling or downstream step work. "
+                    "Set response_language to the natural language that "
+                    "user-facing prose should use for this request. If the "
+                    "user prompt includes an output_language_policy field, "
+                    "follow it exactly and make response_language match it. "
+                    "The messages array, selected skill context, retrieved "
+                    "memories, examples, URLs, and source content are "
+                    "supporting context only and must not change the plan "
+                    "language. "
+                    f"{plan_language_rules()} "
+                    "Keep ids stable "
+                    "across replans when a completed step can be reused."
+                ),
+            },
+            {"role": "user", "content": self._build_prompt(request)},
+        ]
+        retry_feedback: str | None = None
+        for attempt in range(MAX_PLAN_TOOL_CALL_ATTEMPTS):
+            attempt_messages = list(messages)
+            if retry_feedback:
+                attempt_messages.append({"role": "user", "content": retry_feedback})
+            response = await llm.chat(
+                messages=attempt_messages,
+                tools=plan_tools,
+                tool_choice="required",
+                thinking={"type": "disabled", "enable": False},
+            )
+            try:
+                plan_arguments = self._extract_tool_arguments(
+                    response,
+                    self.PLAN_TOOL_NAME,
+                    attempts=attempt + 1,
+                )
+            except RequiredToolCallError:
+                if attempt + 1 >= MAX_PLAN_TOOL_CALL_ATTEMPTS:
+                    raise RequiredToolCallError(
+                        owner="LLMPlanGenerator",
+                        tool_name=self.PLAN_TOOL_NAME,
+                        attempts=MAX_PLAN_TOOL_CALL_ATTEMPTS,
+                        user_message=PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
+                    )
+                retry_feedback = self._required_tool_call_retry_feedback(
+                    self.PLAN_TOOL_NAME
+                )
+                logger.warning(
+                    "LLMPlanGenerator response omitted required %s tool call; "
+                    "retrying plan generation. execution_id=%s attempt=%s",
+                    self.PLAN_TOOL_NAME,
+                    request.execution_id,
+                    attempt + 1,
+                )
+                continue
+            self._apply_response_language(request.context, plan_arguments)
+            plan = coerce_execution_plan(plan_arguments)
+            return self._filter_suggested_tools(
+                plan=plan,
+                available_tool_names=request.available_tool_names,
+            )
+        raise RuntimeError("LLMPlanGenerator retry loop exited unexpectedly.")
 
     def _filter_suggested_tools(
         self,
@@ -452,33 +490,28 @@ class LLMPlanGenerator(PlanGenerator):
         ):
             metadata[OUTPUT_LANGUAGE_METADATA_KEY] = response_language
 
-    def _extract_tool_arguments(self, response: Any, tool_name: str) -> dict[str, Any]:
-        tool_calls = self._response_tool_calls(response)
-        for tool_call in tool_calls:
-            function_payload = self._function_payload(tool_call)
-            if not function_payload:
-                continue
-            if function_payload.get("name") != tool_name:
-                continue
-            return self._coerce_arguments(function_payload.get("arguments", {}))
-        raise ValueError(f"LLMPlanGenerator requires a {tool_name} tool call response.")
+    def _required_tool_call_retry_feedback(self, tool_name: str) -> str:
+        return (
+            f"The previous response did not call the required {tool_name} tool. "
+            f"Call {tool_name} exactly once with a complete executable plan. "
+            "Do not answer in natural language."
+        )
 
-    def _response_tool_calls(self, response: Any) -> list[Any]:
-        if isinstance(response, dict):
-            return list(response.get("tool_calls") or [])
-        return list(getattr(response, "tool_calls", []) or [])
-
-    def _function_payload(self, tool_call: Any) -> dict[str, Any] | None:
-        if isinstance(tool_call, dict):
-            function_payload = tool_call.get("function")
-            return function_payload if isinstance(function_payload, dict) else None
-        function_payload = getattr(tool_call, "function", None)
-        if function_payload is None:
-            return None
-        return {
-            "name": getattr(function_payload, "name", None),
-            "arguments": getattr(function_payload, "arguments", {}),
-        }
+    def _extract_tool_arguments(
+        self,
+        response: Any,
+        tool_name: str,
+        *,
+        attempts: int = 1,
+    ) -> dict[str, Any]:
+        arguments = extract_required_tool_arguments(
+            response,
+            tool_name=tool_name,
+            owner="LLMPlanGenerator",
+            attempts=attempts,
+            user_message=PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
+        )
+        return self._coerce_arguments(arguments)
 
     def _coerce_arguments(self, arguments: Any) -> dict[str, Any]:
         if isinstance(arguments, dict):

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -13,7 +13,11 @@ from ...language import (
     output_language_policy,
     plan_language_rules,
 )
-from ..base import RequiredToolCallError, extract_required_tool_arguments
+from ..base import (
+    RequiredToolCallError,
+    append_user_message_preserving_turns,
+    extract_required_tool_arguments,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +294,11 @@ class LLMPlanGenerator(PlanGenerator):
         for attempt in range(MAX_PLAN_TOOL_CALL_ATTEMPTS):
             attempt_messages = list(messages)
             if retry_feedback:
-                attempt_messages.append({"role": "user", "content": retry_feedback})
+                attempt_messages = append_user_message_preserving_turns(
+                    attempt_messages,
+                    content=retry_feedback,
+                    section_title="Required tool retry feedback",
+                )
             response = await llm.chat(
                 messages=attempt_messages,
                 tools=plan_tools,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2833,24 +2833,26 @@ async def delete_task(
             # Delete related data in correct order to respect foreign key constraints
             logger.info(f"Deleting task {task_id} and all related data")
 
-            # Delete DAG execution (if any)
-            from ..models.task import DAGExecution
-
-            dag_execution = (
-                db.query(DAGExecution).filter(DAGExecution.task_id == task_id).first()
+            # Delete task-owned rows that do not all have DB-level cascades.
+            from ..models.task import (
+                DAGExecution,
+                TraceCheckpointBlob,
+                TraceEvent,
+                TraceMessageBlob,
             )
-            if dag_execution:
-                db.delete(dag_execution)
 
-            # Note: execution_logs table has been removed - replaced by trace_events
-
-            # Delete trace events (only VIBE phase, BUILD sessions are separate)
-            from ..models.task import TraceEvent
-
-            db.query(TraceEvent).filter(
-                TraceEvent.task_id == task_id,
-                TraceEvent.build_id.is_(None),  # ← Only delete VIBE events
-            ).delete()
+            db.query(TraceCheckpointBlob).filter(
+                TraceCheckpointBlob.task_id == task_id
+            ).delete(synchronize_session=False)
+            db.query(TraceMessageBlob).filter(
+                TraceMessageBlob.task_id == task_id
+            ).delete(synchronize_session=False)
+            db.query(TraceEvent).filter(TraceEvent.task_id == task_id).delete(
+                synchronize_session=False
+            )
+            db.query(DAGExecution).filter(DAGExecution.task_id == task_id).delete(
+                synchronize_session=False
+            )
 
             # Note: tool_usages, agents, and agent_tools tables have been removed
 

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -1216,19 +1216,70 @@ async def test_auto_pattern_final_answer_redecision_refreshes_enrichment() -> No
 
 
 @pytest.mark.asyncio
-async def test_auto_pattern_missing_decision_tool_call_fails() -> None:
-    llm = FakeLLM(["not a tool call"])
+async def test_auto_pattern_retries_missing_decision_tool_call() -> None:
+    llm = FakeLLM(
+        [
+            "not a tool call",
+            decision_tool_response(
+                "final_answer",
+                "Greeting only.",
+                answer="Complete answer after retry.",
+            ),
+        ]
+    )
     pattern = AutoPattern()
     context = ExecutionContext()
     context.add_user_message("Continue")
 
-    with pytest.raises(ValueError, match=DECISION_TOOL_NAME):
-        await pattern.run(
-            context=context,
-            tools=[],
-            llm=llm,
-            runtime=PatternRuntime(),
-        )
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=PatternRuntime(),
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "Complete answer after retry."
+    assert len(llm.calls) == 2
+    retry_message = llm.calls[1]["messages"][-1]["content"]
+    assert f"did not call the required {DECISION_TOOL_NAME} tool" in retry_message
+
+
+@pytest.mark.asyncio
+async def test_auto_pattern_missing_decision_tool_call_fails() -> None:
+    llm = FakeLLM(["not a tool call", {"tool_calls": []}])
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    context.add_user_message("Continue")
+    runtime = PatternRuntime()
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "missing_required_tool_call"
+    assert result["required_tool_name"] == DECISION_TOOL_NAME
+    assert result["attempts"] == 2
+    assert result["error"] == (
+        "Auto routing failed because the model did not return the required "
+        "decision tool call. Please retry."
+    )
+    assert "AutoPattern decision requires" not in result["error"]
+    assert pattern.last_result == result
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["label"] == "auto_decision_failed"
+    assert runtime.last_checkpoint["metadata"]["failure_reason"] == (
+        "missing_required_tool_call"
+    )
+    assert runtime.last_checkpoint["metadata"]["required_tool_name"] == (
+        DECISION_TOOL_NAME
+    )
+    assert runtime.last_checkpoint["metadata"]["attempts"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -542,6 +542,11 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert [message["role"] for message in llm.calls[0]["messages"]].count(
         "system"
     ) == 1
+    first_call_roles = [message["role"] for message in llm.calls[0]["messages"]]
+    assert not any(
+        current == previous == "user"
+        for previous, current in zip(first_call_roles, first_call_roles[1:])
+    )
     decision_prompt = llm.calls[0]["messages"][-1]["content"]
     assert llm.calls[0]["messages"][-1]["role"] == "user"
     assert "must include a complete non-empty answer field" in decision_prompt
@@ -1241,6 +1246,11 @@ async def test_auto_pattern_retries_missing_decision_tool_call() -> None:
     assert result["success"] is True
     assert result["response"] == "Complete answer after retry."
     assert len(llm.calls) == 2
+    retry_roles = [message["role"] for message in llm.calls[1]["messages"]]
+    assert not any(
+        current == previous == "user"
+        for previous, current in zip(retry_roles, retry_roles[1:])
+    )
     retry_message = llm.calls[1]["messages"][-1]["content"]
     assert f"did not call the required {DECISION_TOOL_NAME} tool" in retry_message
 

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -21,6 +21,10 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
+from xagent.core.agent.pattern.base import RequiredToolCallError
+from xagent.core.agent.pattern.dag.plan_generator import (
+    PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
+)
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
@@ -1442,6 +1446,77 @@ async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     assert "response_format" not in llm.calls[0]
 
 
+@pytest.mark.asyncio
+async def test_llm_plan_generator_retries_missing_required_tool_call() -> None:
+    generator = LLMPlanGenerator()
+    context = ExecutionContext(execution_id="dag-llm-plan-retry")
+    context.add_user_message("Create a short plan")
+    llm = SequenceLLM(
+        [
+            {"content": "plain text instead of a tool call"},
+            plan_tool_response(
+                [
+                    {
+                        "id": "final",
+                        "task": "Finalize answer",
+                        "dependencies": [],
+                        "termination_condition": (
+                            "Stop after final_answer returns the answer."
+                        ),
+                        "completion_evidence": (
+                            "The final answer has been returned successfully."
+                        ),
+                        "tool_names": [],
+                    }
+                ]
+            ),
+        ]
+    )
+
+    plan = await generator.generate_plan(
+        request=PlanGenerationRequest(
+            context=context,
+            execution_id="dag-llm-plan-retry",
+            available_tool_names=[],
+        ),
+        llm=llm,
+    )
+
+    assert [step.id for step in plan.steps] == ["final"]
+    assert llm.calls == 2
+    retry_message = llm.seen_messages[1][-1]["content"]
+    assert "did not call the required generate_execution_plan tool" in retry_message
+
+
+@pytest.mark.asyncio
+async def test_llm_plan_generator_reports_missing_required_tool_call() -> None:
+    generator = LLMPlanGenerator()
+    context = ExecutionContext(execution_id="dag-llm-plan-missing")
+    context.add_user_message("Create a short plan")
+    llm = SequenceLLM(
+        [
+            {"content": "plain text instead of a tool call"},
+            {"tool_calls": []},
+        ]
+    )
+
+    with pytest.raises(RequiredToolCallError) as exc_info:
+        await generator.generate_plan(
+            request=PlanGenerationRequest(
+                context=context,
+                execution_id="dag-llm-plan-missing",
+                available_tool_names=[],
+            ),
+            llm=llm,
+        )
+
+    assert exc_info.value.tool_name == "generate_execution_plan"
+    assert exc_info.value.attempts == 2
+    assert exc_info.value.user_message == PLAN_GENERATION_REQUIRED_TOOL_MESSAGE
+    assert "LLMPlanGenerator requires" not in str(exc_info.value)
+    assert llm.calls == 2
+
+
 def test_dag_output_language_reads_dict_context_metadata() -> None:
     assert (
         DAGPattern._output_language({"metadata": {"output_language": "English"}})
@@ -1638,6 +1713,45 @@ async def test_dag_pattern_returns_failed_result_for_plan_generator_exception() 
     assert (
         runtime.last_checkpoint["metadata"]["failure_reason"] == "plan_generation_error"
     )
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_returns_friendly_missing_required_tool_failure() -> None:
+    runtime = PatternRuntime(execution_id="dag-plan-tool-missing")
+    pattern = DAGPattern(LLMPlanGenerator())
+    context = ExecutionContext(execution_id="dag-plan-tool-missing")
+    context.add_user_message("Create a short plan")
+    llm = SequenceLLM(
+        [
+            {"content": "plain text instead of a tool call"},
+            {"tool_calls": []},
+        ]
+    )
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "missing_required_tool_call"
+    assert result["required_tool_name"] == "generate_execution_plan"
+    assert result["attempts"] == 2
+    assert result["error"] == PLAN_GENERATION_REQUIRED_TOOL_MESSAGE
+    assert "LLMPlanGenerator requires" not in result["error"]
+    assert runtime.last_checkpoint is not None
+    assert runtime.last_checkpoint["label"] == "dag_plan_generation_failed"
+    assert runtime.last_checkpoint["metadata"]["failure_reason"] == (
+        "missing_required_tool_call"
+    )
+    assert (
+        runtime.last_checkpoint["metadata"]["required_tool_name"]
+        == "generate_execution_plan"
+    )
+    assert runtime.last_checkpoint["metadata"]["attempts"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1484,6 +1484,11 @@ async def test_llm_plan_generator_retries_missing_required_tool_call() -> None:
 
     assert [step.id for step in plan.steps] == ["final"]
     assert llm.calls == 2
+    retry_roles = [message["role"] for message in llm.seen_messages[1]]
+    assert not any(
+        current == previous == "user"
+        for previous, current in zip(retry_roles, retry_roles[1:])
+    )
     retry_message = llm.seen_messages[1][-1]["content"]
     assert "did not call the required generate_execution_plan tool" in retry_message
 

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import tempfile
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -703,5 +704,136 @@ def test_task_create_rejects_agent_id_from_another_user(
 
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Agent not found or access denied"
+    finally:
+        db.close()
+
+
+def test_delete_task_removes_trace_blobs_and_task_owned_rows(test_db, user1_headers):
+    from xagent.web.models.chat_message import TaskChatMessage
+    from xagent.web.models.database import get_db
+    from xagent.web.models.task import (
+        DAGExecution,
+        DAGExecutionPhase,
+        Task,
+        TaskStatus,
+        TraceCheckpointBlob,
+        TraceEvent,
+        TraceMessageBlob,
+    )
+    from xagent.web.models.uploaded_file import UploadedFile
+    from xagent.web.models.user import User
+
+    db = next(get_db())
+    try:
+        user = db.query(User).filter(User.username == "user1").first()
+        assert user is not None
+
+        task = Task(
+            user_id=user.id,
+            title="delete me",
+            description="task with task-owned rows",
+            status=TaskStatus.COMPLETED,
+        )
+        db.add(task)
+        db.flush()
+
+        db.add_all(
+            [
+                DAGExecution(
+                    task_id=task.id,
+                    phase=DAGExecutionPhase.COMPLETED,
+                ),
+                TraceEvent(
+                    task_id=task.id,
+                    build_id=None,
+                    event_id="vibe-event",
+                    event_type="dag_execute_end",
+                    timestamp=datetime.now(timezone.utc),
+                    data={"ok": True},
+                ),
+                TraceEvent(
+                    task_id=task.id,
+                    build_id="builder-session",
+                    event_id="build-event",
+                    event_type="agent_message",
+                    timestamp=datetime.now(timezone.utc),
+                    data={"ok": True},
+                ),
+                TraceMessageBlob(
+                    task_id=task.id,
+                    execution_id="exec-delete",
+                    message_hash="message-hash",
+                    message_data={"role": "user", "content": "hello"},
+                    message_bytes=42,
+                ),
+                TraceCheckpointBlob(
+                    task_id=task.id,
+                    execution_id="exec-delete",
+                    blob_kind="messages",
+                    blob_hash="checkpoint-hash",
+                    blob_data={"messages": []},
+                    blob_bytes=17,
+                ),
+                TaskChatMessage(
+                    task_id=task.id,
+                    user_id=user.id,
+                    role="user",
+                    content="hello",
+                    message_type="user_message",
+                ),
+                UploadedFile(
+                    user_id=user.id,
+                    task_id=task.id,
+                    filename="input.txt",
+                    storage_path=f"/tmp/task-{task.id}/input.txt",
+                    file_size=5,
+                ),
+            ]
+        )
+        db.commit()
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    resp = client.delete(f"/api/chat/task/{task_id}", headers=user1_headers)
+
+    assert resp.status_code == 200, resp.text
+    db = next(get_db())
+    try:
+        assert db.query(Task).filter(Task.id == task_id).count() == 0
+        assert db.query(TraceMessageBlob).filter_by(task_id=task_id).count() == 0
+        assert db.query(TraceCheckpointBlob).filter_by(task_id=task_id).count() == 0
+        assert db.query(TraceEvent).filter_by(task_id=task_id).count() == 0
+        assert db.query(DAGExecution).filter_by(task_id=task_id).count() == 0
+        assert db.query(TaskChatMessage).filter_by(task_id=task_id).count() == 0
+        assert db.query(UploadedFile).filter_by(task_id=task_id).count() == 0
+    finally:
+        db.close()
+
+
+def test_delete_task_keeps_cross_user_access_denied(
+    test_db, user1_headers, user2_headers
+):
+    from xagent.web.models.database import get_db
+    from xagent.web.models.task import Task
+    from xagent.web.models.user import User
+
+    db = next(get_db())
+    try:
+        user2 = db.query(User).filter(User.username == "user2").first()
+        assert user2 is not None
+        task = Task(user_id=user2.id, title="private", description="private")
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    resp = client.delete(f"/api/chat/task/{task_id}", headers=user1_headers)
+
+    assert resp.status_code == 404
+    db = next(get_db())
+    try:
+        assert db.query(Task).filter(Task.id == task_id).count() == 1
     finally:
         db.close()


### PR DESCRIPTION
## Summary

- Fix task deletion by clearing task-owned trace blobs, trace events, and DAG execution rows before deleting the task.
- Add one retry when required planner or auto-routing tool calls are missing.
- Return structured friendly failures with terminal checkpoints instead of surfacing internal required-tool-call errors.

## Root Cause

Task deletion could fail when task-owned rows without database-level cascades still referenced the task. Planner creation could intermittently expose an internal error when the model did not return the required tool call despite required tool choice being requested.

## Impact

Users should be able to delete conversations with trace/checkpoint data attached. Agent creation should retry once for missing required planning or routing tool calls, then fail with a stable user-facing message and useful checkpoint metadata if the model still omits the required tool call.

## Validation

- `uv run pytest tests/core/agent/test_dag.py tests/core/agent/test_auto.py tests/web/test_chat_task_model_ids.py -q`
- Commit hooks: ruff check, ruff format, mypy, isort, codespell
