### PR TITLE
fix: guard repeated ReAct tool loops

### DIFF
--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -310,9 +310,10 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               } else if (data.event_type === "agent_message") {
                 const displayReply = data.data?.message || ""
                 const interactions = data.data?.metadata?.interactions
-                if (data.data?.expect_response) {
-                  setIsLoading(false)
+                if (!data.data?.expect_response && data.data?.message_type !== "question") {
+                  return
                 }
+                setIsLoading(false)
                 setMessages(prev => {
                   const updated = [...prev]
                   const lastMsg = updated[updated.length - 1]

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -327,6 +327,117 @@ describe("TraceEventRenderer", () => {
     expect(screen.queryByText("traceEventRenderer.toolCallNote")).not.toBeInTheDocument()
   })
 
+  it("interleaves agent progress into the active thinking process", () => {
+    render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "start",
+            event_type: "react_task_start",
+            step_id: "step-1",
+            timestamp: 1000,
+            data: {},
+          },
+          {
+            event_id: "first-tool",
+            event_type: "tool_execution_start",
+            step_id: "step-1",
+            timestamp: 2000,
+            data: { tool_name: "first_tool", tool_params: { query: "first" } },
+          },
+          {
+            event_id: "second-tool",
+            event_type: "tool_execution_start",
+            step_id: "step-1",
+            timestamp: 4000,
+            data: { tool_name: "second_tool", tool_params: { query: "second" } },
+          },
+          {
+            event_id: "end",
+            event_type: "react_task_end",
+            step_id: "step-1",
+            timestamp: 5000,
+            data: {},
+          },
+          {
+            event_id: "progress",
+            event_type: "agent_progress",
+            step_id: "step-1",
+            timestamp: 3000,
+            data: {
+              message: "Still searching the remaining sources.",
+              message_type: "progress",
+            },
+          },
+          {
+            event_id: "legacy-progress",
+            event_type: "agent_message",
+            timestamp: 3500,
+            data: {
+              message: "Legacy progress also stays in the process.",
+              message_type: "progress",
+              expect_response: false,
+            },
+          },
+        ]}
+      />,
+    )
+
+    const stepToggles = screen.getAllByRole("button", {
+      name: /traceEventRenderer\.(thoughtProcess|taskExecution)/,
+    })
+    expect(stepToggles).toHaveLength(1)
+
+    fireEvent.click(stepToggles[0])
+
+    expect(screen.getByText("Legacy progress also stays in the process.")).toBeInTheDocument()
+    expect(screen.getByText("Still searching the remaining sources.")).toBeInTheDocument()
+    expect(screen.queryByText("traceEventRenderer.progressMessage")).not.toBeInTheDocument()
+
+    const renderedText = document.body.textContent || ""
+    expect(renderedText.indexOf("traceEventRenderer.executeTool:first_tool")).toBeLessThan(
+      renderedText.indexOf("Still searching the remaining sources."),
+    )
+    expect(renderedText.indexOf("Legacy progress also stays in the process.")).toBeLessThan(
+      renderedText.indexOf("traceEventRenderer.executeTool:second_tool"),
+    )
+  })
+
+  it("keeps trace event ordering stable when timestamps are invalid", () => {
+    render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "start",
+            event_type: "react_task_start",
+            step_id: "step-1",
+            timestamp: -1,
+            data: {},
+          },
+          {
+            event_id: "invalid-start",
+            event_type: "tool_execution_start",
+            step_id: "step-1",
+            timestamp: "not-a-date" as unknown as number,
+            data: { tool_name: "invalid_time_tool", tool_params: { query: "invalid" } },
+          },
+          {
+            event_id: "also-invalid-start",
+            event_type: "tool_execution_start",
+            step_id: "step-1",
+            timestamp: undefined as unknown as number,
+            data: { tool_name: "missing_time_tool", tool_params: { query: "missing" } },
+          },
+        ]}
+      />,
+    )
+
+    const renderedText = document.body.textContent || ""
+    expect(renderedText.indexOf("traceEventRenderer.executeTool:invalid_time_tool")).toBeLessThan(
+      renderedText.indexOf("traceEventRenderer.executeTool:missing_time_tool"),
+    )
+  })
+
   it("collapses completed thinking process and keeps it visibly expandable", () => {
     render(
       <TraceEventRenderer

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -168,12 +168,31 @@ const getWaitingQuestionFromEvents = (events: TraceEvent[]): string | null => {
   return null;
 };
 
+const isAgentProgressEvent = (event: TraceEvent): boolean => (
+  event.event_type === 'agent_progress' ||
+  (
+    event.event_type === 'agent_message' &&
+    event.data?.expect_response !== true &&
+    event.data?.message_type !== 'question'
+  )
+);
+
 // Process trace events into steps
 function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
   const { t } = useI18n();
   return useMemo(() => {
     const stepsMap = new Map<string, ProcessedStep>();
     let currentReactStepId: string | null = null;
+    const orderedEvents = events
+      .map((event, index) => {
+        const timestamp = normalizeTimestampMs(event.timestamp)
+        return {
+          event,
+          index,
+          timestamp: Number.isFinite(timestamp) ? timestamp : 0,
+        }
+      })
+      .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index);
 
     // Helper to find the last running action of a specific type
     const findLastRunningAction = (step: ProcessedStep, type: 'llm' | 'tool') => {
@@ -185,18 +204,23 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
       return null;
     };
 
-    events.forEach((event, index) => {
+    orderedEvents.forEach(({ event, index, timestamp }) => {
       if (event.event_type?.startsWith('skill_select')) {
         return;
       }
 
       let stepId = event.step_id || (event.data?.step_id as string) || 'default';
+      const isProgressMessage = isAgentProgressEvent(event);
 
       if (event.event_type === 'react_task_start' || event.event_type === 'task_start_react') {
         currentReactStepId = stepId;
       }
 
       if ((event.event_type === 'react_task_end' || event.event_type === 'task_end_react' || event.event_type === 'task_completion' || event.event_type === 'react_task_failed' || event.event_type === 'task_failed_react') && stepId === 'default' && currentReactStepId) {
+        stepId = currentReactStepId;
+      }
+
+      if (isProgressMessage && stepId === 'default' && currentReactStepId) {
         stepId = currentReactStepId;
       }
 
@@ -216,7 +240,6 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
       }
 
       const step = stepsMap.get(stepId)!;
-      const timestamp = normalizeTimestampMs(event.timestamp);
       const eventId = event.event_id || `event-${index}`;
 
       // Process different event types
@@ -270,6 +293,29 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
             data: {
               reasoning: event.data?.response?.reasoning,
               tool_calls: event.data?.tools
+            }
+          });
+        }
+      }
+
+      if (isProgressMessage) {
+        const message = event.data?.message || event.data?.content;
+        if (typeof message === 'string' && message.trim()) {
+          if (!step.stepName) {
+            step.stepName = t('traceEventRenderer.taskExecution');
+          }
+          if (step.status === 'pending') {
+            step.status = 'running';
+          }
+          step.actions.push({
+            id: eventId,
+            type: 'info',
+            title: t('traceEventRenderer.progressMessage'),
+            status: 'completed',
+            timestamp,
+            data: {
+              output: message.trim(),
+              inline: true,
             }
           });
         }

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1,0 +1,152 @@
+import React from "react"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+type TestWebSocketMessage = {
+  type: string
+  timestamp: string
+  data: unknown
+}
+
+const webSocketOptions = vi.hoisted(() => ({
+  current: null as null | { onMessage?: (message: TestWebSocketMessage) => void },
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token" }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/hooks/use-websocket", () => ({
+  useWebSocket: (options: {
+    onMessage?: (message: TestWebSocketMessage) => void
+  }) => {
+    webSocketOptions.current = options
+    return {
+      isConnected: true,
+      connectionError: null,
+      sendChatMessage: vi.fn(),
+      executeTask: vi.fn(),
+      pauseTask: vi.fn(),
+      resumeTask: vi.fn(),
+      requestStatus: vi.fn(),
+      connect: vi.fn(),
+    }
+  },
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+import { AppProvider, useApp } from "./app-context-chat"
+
+function StateProbe() {
+  const { state } = useApp()
+  const allTraceEvents = [
+    ...state.traceEvents,
+    ...state.messages.flatMap((message) => message.traceEvents || []),
+  ]
+  return (
+    <>
+      <div data-testid="messages">
+        {JSON.stringify(
+          state.messages.map((message) => ({
+            role: message.role,
+            content:
+              typeof message.content === "string" ? message.content : "react-node",
+          }))
+        )}
+      </div>
+      <div data-testid="trace-events">
+        {JSON.stringify(
+          allTraceEvents.map((event) => {
+            const data = event.data as { message?: string } | undefined
+            return {
+              event_type: event.event_type,
+              message: data?.message,
+            }
+          })
+        )}
+      </div>
+    </>
+  )
+}
+
+describe("AppProvider websocket message routing", () => {
+  beforeEach(() => {
+    webSocketOptions.current = null
+  })
+
+  it("routes historical assistant transcript rows to chat and progress events to trace", async () => {
+    render(
+      <AppProvider token="token">
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        data: {
+          event_id: "chat-message-1",
+          event_type: "agent_message",
+          data: {
+            message: "Final answer",
+            content: "Final answer",
+            role: "assistant",
+            expect_response: false,
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Final answer"
+      )
+    })
+    expect(screen.getByTestId("trace-events").textContent).not.toContain(
+      "Final answer"
+    )
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        data: {
+          event_id: "progress-1",
+          event_type: "agent_progress",
+          step_id: "react",
+          data: {
+            message: "Searching",
+            display: "timeline",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trace-events").textContent).toContain(
+        "agent_progress"
+      )
+    })
+    expect(screen.getByTestId("messages").textContent).not.toContain("Searching")
+  })
+})

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1380,6 +1380,20 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             }
           }
 
+          // Agent progress messages belong in the execution timeline, not the chat transcript.
+          else if (eventType === "agent_progress") {
+            dispatch({
+              type: "ADD_TRACE_EVENT",
+              payload: {
+                event_id: message.event_id || eventData.event_id || generateMessageId("trace-agent-progress"),
+                event_type: eventType,
+                step_id: message.step_id || eventData.step_id,
+                timestamp: message.timestamp?.toString() || Date.now().toString(),
+                data: eventData,
+              }
+            })
+          }
+
           // Agent-to-user messages, including ask_user_question prompts.
           else if (eventType === "agent_message" || eventType === "ai_message") {
             const rawMessageContent = eventData.message || eventData.content || ""
@@ -1395,6 +1409,19 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               eventType === "agent_message" &&
               (eventData.expect_response === true ||
                 eventData.message_type === "question")
+            if (eventType === "agent_message" && !expectsResponse) {
+              dispatch({
+                type: "ADD_TRACE_EVENT",
+                payload: {
+                  event_id: message.event_id || eventData.event_id || generateMessageId("trace-agent-progress"),
+                  event_type: "agent_progress",
+                  step_id: message.step_id || eventData.step_id,
+                  timestamp: message.timestamp?.toString() || Date.now().toString(),
+                  data: eventData,
+                }
+              })
+              return
+            }
             if (expectsResponse) {
               dispatch({
                 type: "UPDATE_TASK_STATUS",

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1409,7 +1409,16 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
               eventType === "agent_message" &&
               (eventData.expect_response === true ||
                 eventData.message_type === "question")
-            if (eventType === "agent_message" && !expectsResponse) {
+            const agentMessageDisplay = eventData.display || eventData.metadata?.display
+            const isExplicitTranscriptMessage =
+              agentMessageDisplay === "chat" ||
+              eventData.source === "chat_history" ||
+              eventData.role === "assistant"
+            const isTimelineAgentMessage =
+              eventType === "agent_message" &&
+              !isExplicitTranscriptMessage &&
+              agentMessageDisplay === "timeline"
+            if (isTimelineAgentMessage) {
               dispatch({
                 type: "ADD_TRACE_EVENT",
                 payload: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2843,6 +2843,7 @@ Build when you need.`
     searchQuery: "Search Query",
     content: "Content",
     toolCallNote: "Tool note",
+    progressMessage: "Progress",
     copy: "Copy",
     previewFile: "Preview File",
     filePrefix: "File:",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2843,6 +2843,7 @@ Build when you need.`
     searchQuery: "搜索查询",
     content: "内容",
     toolCallNote: "工具说明",
+    progressMessage: "进度",
     copy: "复制",
     previewFile: "预览文件",
     filePrefix: "文件:",

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import uuid4
 
+from ...file_ref import FILE_REF_OUTPUT_INSTRUCTIONS
 from ...tools.artifacts import (
     format_tool_result_for_observation,
     sanitize_tool_result_for_public_context,
@@ -356,7 +357,7 @@ class ExecutionContext:
         return str(self.metadata.get("task") or "").strip()
 
     def _system_context(self) -> str:
-        parts = [self._current_time_context()]
+        parts = [self._current_time_context(), FILE_REF_OUTPUT_INSTRUCTIONS]
         dag_step_id = self.metadata.get("dag_step_id")
         current_task = self._current_user_request_text()
         if current_task and not dag_step_id:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -101,11 +101,14 @@ class _DAGStepRuntime:
         expect_response: bool = False,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        outbound_metadata = dict(metadata or {})
+        outbound_metadata.setdefault("step_id", self.step_id)
+        outbound_metadata.setdefault("dag_step_id", self.step_id)
         return await self.parent.send_message(
             message=message,
             message_type=message_type,
             expect_response=expect_response,
-            metadata=metadata,
+            metadata=outbound_metadata,
         )
 
     async def checkpoint(

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -93,6 +93,18 @@ class _DAGStepRuntime:
     async def stream_final_answer(self, llm: Any, **kwargs: Any) -> Any:
         return await self.parent.run_llm_call(llm, **kwargs)
 
+    async def start_final_answer_stream(self) -> str | None:
+        return None
+
+    async def emit_final_answer_delta(self, message_id: str, delta: str) -> None:
+        del message_id, delta
+
+    async def end_final_answer_stream(self, message_id: str, content: str) -> None:
+        del message_id, content
+
+    async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
+        del message_id, error
+
     async def send_message(
         self,
         *,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -18,7 +18,11 @@ from ...language import final_answer_language_rule
 from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
 from ..base import AgentPattern, PatternResult
-from ..final_answer_stream import ReActFinalAnswerStreamer
+from ..final_answer_stream import (
+    FinalAnswerStreamSession,
+    ReActFinalAnswerStreamer,
+    ToolCallStringFieldStreamer,
+)
 
 
 class ReActReasoningMode(str, Enum):
@@ -26,6 +30,13 @@ class ReActReasoningMode(str, Enum):
 
     TOOL_CALLING = "tool_calling"
     REASONING_ACTION = "reasoning_action"
+
+
+REPEATED_TOOL_DECISION_REQUESTED_STATUS = "repeated_tool_decision_requested"
+DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_TOOL_CALLS = 4
+REACT_DECISION_TOOL_NAME = "react_decision"
+REACT_DECISION_FINAL_ANSWER = "final_answer"
+REACT_DECISION_TOOL_CALL = "tool_call"
 
 
 @dataclass
@@ -123,12 +134,18 @@ class ReActPattern(AgentPattern):
         tool_choice: str | dict[str, Any] | None = "required",
         reasoning_mode: ReActReasoningMode | str = ReActReasoningMode.TOOL_CALLING,
         finalize_after_tool_result: bool = False,
+        repeated_tool_decision_after_consecutive_tool_calls: int | None = (
+            DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_TOOL_CALLS
+        ),
     ) -> None:
         self.llm = llm
         self.max_iterations = max_iterations
         self.tool_choice = tool_choice
         self.reasoning_mode = ReActReasoningMode(reasoning_mode)
         self.finalize_after_tool_result = finalize_after_tool_result
+        self.repeated_tool_decision_after_consecutive_tool_calls = (
+            repeated_tool_decision_after_consecutive_tool_calls
+        )
         self.status = "idle"
         self.current_iteration = 0
         self.last_response: Any = None
@@ -136,6 +153,7 @@ class ReActPattern(AgentPattern):
         self.pending_tool_call_content: dict[str, str] = {}
         self.tool_ledger: dict[str, ToolCallRecord] = {}
         self.force_final_answer_next = False
+        self.repeated_tool_decision: dict[str, Any] | None = None
         self.waiting_for_user_request: dict[str, Any] | None = None
         self.task_text: str | None = None
         self._memory_store: Any | None = None
@@ -267,6 +285,15 @@ class ReActPattern(AgentPattern):
                 self.status = "thinking"
                 continue
 
+            if self.repeated_tool_decision:
+                decision_result = await self._run_repeated_tool_decision(
+                    context=context,
+                    llm=llm,
+                    runtime=runtime,
+                )
+                if decision_result is not None:
+                    return decision_result
+
             force_final_answer_now = self.force_final_answer_next or (
                 self.finalize_after_tool_result
                 and not self.pending_tool_calls
@@ -336,6 +363,7 @@ class ReActPattern(AgentPattern):
                 response=response,
                 metadata={"iteration": iteration},
             )
+            self.repeated_tool_decision = None
             self.last_response = response
             normalized = self._normalize_llm_response(response)
             if force_final_answer_now and not normalized.get("tool_calls"):
@@ -505,7 +533,11 @@ class ReActPattern(AgentPattern):
             "current_iteration": self.current_iteration,
             "max_iterations": self.max_iterations,
             "finalize_after_tool_result": self.finalize_after_tool_result,
+            "repeated_tool_decision_after_consecutive_tool_calls": (
+                self.repeated_tool_decision_after_consecutive_tool_calls
+            ),
             "force_final_answer_next": self.force_final_answer_next,
+            "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
             "task_text": self.task_text,
             "last_response": self.last_response,
@@ -527,7 +559,21 @@ class ReActPattern(AgentPattern):
         self.finalize_after_tool_result = bool(
             state.get("finalize_after_tool_result", self.finalize_after_tool_result)
         )
+        raw_threshold = state.get("repeated_tool_decision_after_consecutive_tool_calls")
+        if raw_threshold is None:
+            raw_threshold = state.get("auto_reroute_after_consecutive_tool_calls")
+        self.repeated_tool_decision_after_consecutive_tool_calls = (
+            int(raw_threshold)
+            if raw_threshold is not None
+            else self.repeated_tool_decision_after_consecutive_tool_calls
+        )
         self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
+        repeated_tool_decision = state.get("repeated_tool_decision")
+        self.repeated_tool_decision = (
+            dict(repeated_tool_decision)
+            if isinstance(repeated_tool_decision, dict)
+            else None
+        )
         waiting_request = state.get("waiting_for_user_request")
         self.waiting_for_user_request = (
             dict(waiting_request) if isinstance(waiting_request, dict) else None
@@ -1080,10 +1126,290 @@ class ReActPattern(AgentPattern):
             )
             if self._tool_result_success(result):
                 successful_tool_result = True
+                requested_decision = (
+                    await self._request_repeated_tool_decision_if_needed(
+                        tool_call=tool_call,
+                        context=context,
+                        runtime=runtime,
+                    )
+                )
+                if requested_decision:
+                    self.pending_tool_calls = []
+                    successful_tool_result = False
+                    return None
 
         if self.finalize_after_tool_result and successful_tool_result:
             self.force_final_answer_next = True
         return None
+
+    async def _request_repeated_tool_decision_if_needed(
+        self,
+        *,
+        tool_call: dict[str, Any],
+        context: Any,
+        runtime: PatternRuntime,
+    ) -> bool:
+        metadata = self._repeated_tool_call_metadata(tool_call)
+        if metadata is None:
+            return False
+
+        self.repeated_tool_decision = metadata
+        await runtime.checkpoint(
+            REPEATED_TOOL_DECISION_REQUESTED_STATUS,
+            context=context,
+            pattern=self,
+            metadata=metadata,
+        )
+        return True
+
+    async def _run_repeated_tool_decision(
+        self,
+        *,
+        context: Any,
+        llm: Any,
+        runtime: PatternRuntime,
+    ) -> dict[str, Any] | None:
+        metadata = dict(self.repeated_tool_decision or {})
+        if not metadata:
+            return None
+
+        messages = self._messages_for_repeated_tool_decision(context, metadata)
+        decision_tools = [self._react_decision_tool_schema()]
+        llm_metadata = {
+            "phase": REPEATED_TOOL_DECISION_REQUESTED_STATUS,
+            **metadata,
+        }
+        await runtime.on_llm_start(
+            context=context,
+            messages=messages,
+            tools=decision_tools,
+            metadata=llm_metadata,
+        )
+        answer_emitter = FinalAnswerStreamSession(runtime, enabled=True)
+        answer_streamer = ToolCallStringFieldStreamer(
+            runtime=runtime,
+            tool_name=REACT_DECISION_TOOL_NAME,
+            field_name="answer",
+            guard_field="action",
+            guard_value=REACT_DECISION_FINAL_ANSWER,
+            emitter=answer_emitter,
+        )
+        try:
+            response = await runtime.run_streaming_llm_call(
+                llm,
+                messages=messages,
+                tools=decision_tools,
+                tool_choice="required",
+                thinking={"type": "disabled", "enable": False},
+                on_chunk=answer_streamer.handle_chunk,
+            )
+        except LLMCallInterrupted:
+            await answer_streamer.fail("interrupted during repeated tool decision")
+            raise
+        except Exception as exc:
+            await answer_streamer.fail(str(exc))
+            await runtime.on_llm_error(
+                context=context,
+                error=exc,
+                metadata=llm_metadata,
+            )
+            raise
+
+        await runtime.on_llm_end(
+            context=context,
+            response=response,
+            metadata=llm_metadata,
+        )
+        self.last_response = response
+        self.repeated_tool_decision = None
+
+        decision = self._parse_react_decision(response)
+        if decision is None:
+            await runtime.checkpoint(
+                "repeated_tool_decision_invalid",
+                context=context,
+                pattern=self,
+                metadata={"response": response, **metadata},
+            )
+            return None
+
+        if decision["action"] == REACT_DECISION_FINAL_ANSWER:
+            answer = decision["answer"]
+            if not answer.strip():
+                await answer_streamer.fail("empty final answer")
+                await runtime.checkpoint(
+                    "repeated_tool_decision_invalid",
+                    context=context,
+                    pattern=self,
+                    metadata={"reason": "empty final answer", **metadata},
+                )
+                return None
+            await answer_streamer.finish(answer)
+            context.add_assistant_message(answer)
+            return await self._finalize_success(
+                context=context,
+                llm=llm,
+                runtime=runtime,
+                response=answer,
+            )
+
+        await runtime.checkpoint(
+            "repeated_tool_decision_continue",
+            context=context,
+            pattern=self,
+            metadata={**metadata, "decision": decision},
+        )
+        missing_verification = decision.get("missing_verification", "").strip()
+        if missing_verification:
+            context.add_system_message(
+                "Repeated tool decision continuation guidance:\n"
+                "The previous repeated-tool decision chose to continue. The next "
+                "work-tool call should retrieve or verify this specific missing "
+                f"information: {missing_verification}",
+                metadata={
+                    "source": "repeated_tool_decision",
+                    "missing_verification": missing_verification,
+                },
+            )
+        return None
+
+    def _repeated_tool_call_metadata(
+        self,
+        tool_call: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        threshold = self.repeated_tool_decision_after_consecutive_tool_calls
+        if threshold is None or threshold <= 0:
+            return None
+
+        tool_name = str(tool_call.get("name") or "")
+        if not tool_name or tool_name in self._control_tool_names():
+            return None
+
+        count = self._consecutive_successful_tool_count(tool_name)
+        if count < threshold:
+            return None
+        return {
+            "tool_name": tool_name,
+            "consecutive_tool_calls": count,
+            "threshold": threshold,
+        }
+
+    def _messages_for_repeated_tool_decision(
+        self,
+        context: Any,
+        metadata: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        messages = list(context.get_messages_for_llm())
+        tool_name = str(metadata.get("tool_name") or "the tool")
+        count = int(metadata.get("consecutive_tool_calls") or 0)
+        count_text = (
+            f"{count} consecutive successful calls"
+            if count > 0
+            else "repeated successful calls"
+        )
+        prompt = (
+            f"You must call {REACT_DECISION_TOOL_NAME} exactly once. Decide whether "
+            "the current ReAct run should finish or make another work-tool call. "
+            f"You have just made {count_text} to {tool_name}. action must be "
+            f"{REACT_DECISION_FINAL_ANSWER} or {REACT_DECISION_TOOL_CALL}. Choose "
+            f"{REACT_DECISION_FINAL_ANSWER} when the conversation and accumulated "
+            "tool results are sufficient to answer the latest user request; include "
+            "the complete answer in the same tool call. Choose "
+            f"{REACT_DECISION_TOOL_CALL} only when a specific missing fact, source, "
+            "or verification remains; the next ReAct turn will choose and call the "
+            "actual work tool. Treat the completed-call count in this instruction "
+            "as authoritative; do not count the user's requested number as already "
+            "completed. If the latest user request explicitly requires more "
+            "completed work-tool calls or results than the current context contains, "
+            f"choose {REACT_DECISION_TOOL_CALL}. Do not call work tools in this "
+            "decision."
+        )
+        return [*messages, {"role": "user", "content": prompt}]
+
+    def _react_decision_tool_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": REACT_DECISION_TOOL_NAME,
+                "description": (
+                    "Decide whether ReAct should finish with a final answer or "
+                    "continue to one more work-tool call."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                REACT_DECISION_FINAL_ANSWER,
+                                REACT_DECISION_TOOL_CALL,
+                            ],
+                            "description": (
+                                "final_answer when current context is sufficient; "
+                                "tool_call when one more work-tool call is needed."
+                            ),
+                        },
+                        "reason": {
+                            "type": "string",
+                            "description": "Brief reason for this decision.",
+                        },
+                        "answer": {
+                            "type": "string",
+                            "description": (
+                                "Required when action is final_answer: complete "
+                                f"user-facing answer. {final_answer_language_rule()}"
+                            ),
+                        },
+                        "missing_verification": {
+                            "type": "string",
+                            "description": (
+                                "When action is tool_call, the specific missing "
+                                "fact, source, or verification that requires "
+                                "another tool call."
+                            ),
+                        },
+                    },
+                    "required": ["action", "reason"],
+                },
+            },
+        }
+
+    def _parse_react_decision(self, response: Any) -> dict[str, str] | None:
+        normalized = self._normalize_llm_response(response)
+        for tool_call in normalized.get("tool_calls", []):
+            if tool_call.get("name") != REACT_DECISION_TOOL_NAME:
+                continue
+            args = tool_call.get("args")
+            if not isinstance(args, dict):
+                return None
+            action = str(args.get("action") or "").strip()
+            if action not in {
+                REACT_DECISION_FINAL_ANSWER,
+                REACT_DECISION_TOOL_CALL,
+            }:
+                return None
+            return {
+                "action": action,
+                "reason": str(args.get("reason") or ""),
+                "answer": str(args.get("answer") or ""),
+                "missing_verification": str(args.get("missing_verification") or ""),
+            }
+        return None
+
+    def _consecutive_successful_tool_count(self, tool_name: str) -> int:
+        count = 0
+        control_tool_names = self._control_tool_names()
+        for record in reversed(list(self.tool_ledger.values())):
+            if record.tool_name in control_tool_names:
+                continue
+            if record.tool_name != tool_name:
+                break
+            if record.status != "completed" or not self._tool_result_success(
+                record.result
+            ):
+                break
+            count += 1
+        return count
 
     async def _finalize_success(
         self,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1134,11 +1134,13 @@ class ReActPattern(AgentPattern):
                     )
                 )
                 if requested_decision:
-                    self.pending_tool_calls = []
                     successful_tool_result = False
-                    return None
 
-        if self.finalize_after_tool_result and successful_tool_result:
+        if (
+            self.finalize_after_tool_result
+            and successful_tool_result
+            and not self.repeated_tool_decision
+        ):
             self.force_final_answer_next = True
         return None
 
@@ -1149,6 +1151,9 @@ class ReActPattern(AgentPattern):
         context: Any,
         runtime: PatternRuntime,
     ) -> bool:
+        if self.repeated_tool_decision is not None:
+            return False
+
         metadata = self._repeated_tool_call_metadata(tool_call)
         if metadata is None:
             return False

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -434,14 +434,25 @@ class PatternRuntime:
     ) -> dict[str, Any]:
         """Emit an agent-to-user message through the runtime boundary."""
 
+        outbound_metadata = dict(metadata or {})
+        step_id = (
+            outbound_metadata.get("step_id")
+            or outbound_metadata.get("dag_step_id")
+            or self.active_react_step_id
+        )
+        if step_id:
+            outbound_metadata.setdefault("step_id", str(step_id))
+
         payload = {
             "type": "agent_message",
             "execution_id": self.execution_id,
             "message": message,
             "message_type": message_type,
             "expect_response": expect_response,
-            "metadata": metadata or {},
+            "metadata": outbound_metadata,
         }
+        if step_id:
+            payload["step_id"] = str(step_id)
         self.outbound_messages.append(payload)
 
         if self.outbound_message_handler is not None:

--- a/src/xagent/core/agent/utils/context_builder.py
+++ b/src/xagent/core/agent/utils/context_builder.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS
+from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS, FILE_REF_OUTPUT_INSTRUCTIONS
 from ...model.chat.basic.base import BaseLLM
 from ..trace import Tracer, trace_compact_end, trace_compact_start
 from .compact import CompactConfig, CompactUtils
@@ -617,12 +617,14 @@ CRITICAL REQUIREMENTS:
 4. Only analysis steps without tool requirements can be completed without tool calls
 5. After completing tool calls, provide a clear final answer confirming the actual results
 
-FILE REFERENCES:
-- You may see file references in the format: [filename](file://fileId)
+{FILE_REF_OUTPUT_INSTRUCTIONS}
+
+FILE REFERENCE INPUTS:
+- You may see file references in the format: [filename](file:fileId) or [filename](file://fileId)
 - The referenced file may NOT be in the current workspace.
 - The 'fileId' part is the only valid identifier for reading the file.
 - When using tools to read files, pass the fileId directly.
-- Example: If you see [data.csv](file://123), use '123' to read the file.
+- Example: If you see [data.csv](file:123), use '123' to read the file.
 
 Remember: Describing what you will do is NOT equivalent to actual execution. You must call the appropriate tools to complete the task.
 

--- a/src/xagent/core/file_ref.py
+++ b/src/xagent/core/file_ref.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-FILE_REF_MODEL_INSTRUCTIONS = """## FILE REFERENCES
+FILE_REF_OUTPUT_INSTRUCTIONS = """## FILE REFERENCE OUTPUTS
+When mentioning a generated or uploaded file that has a file_id, render it as a Markdown file reference:
+- Files: [filename](file:file_id)
+- Images intended for inline display: ![filename](file:file_id)
+Do not mention only the filename when a file_id or markdown_link is available. Prefer an existing markdown_link value when one is present."""
+
+FILE_REF_MODEL_INSTRUCTIONS = f"""## FILE REFERENCES
 Files are referenced by FileRef objects. Treat file_id as the canonical file handle.
 
 Rules:
@@ -13,7 +19,9 @@ Rules:
 - Do not guess storage paths such as /uploads/... or user_id/... paths.
 - For HTML assets, call prepare_html_asset(file_id, html_path, alias) first.
 - Use the returned html_src inside HTML, CSS, script, or image references.
-- For user-visible output links, use markdown_link or file:{file_id}."""
+- For user-visible output links, follow the file reference output rules below.
+
+{FILE_REF_OUTPUT_INSTRUCTIONS}"""
 
 
 def guess_mime_type(filename: str) -> str:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -455,7 +455,7 @@ def _stream_timestamp(timestamp: Optional[Any] = None) -> float:
 
 
 def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
-    """Persist v2 agent-to-user messages so waiting prompts survive reloads."""
+    """Persist agent outbound events and durable waiting prompts."""
 
     from ..models.task import Task as DatabaseTask
     from ..models.task import TraceEvent as DatabaseTraceEvent
@@ -518,6 +518,13 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
         db.close()
 
 
+def _agent_outbound_event_type(payload: Dict[str, Any]) -> str:
+    message_type = str(payload.get("message_type") or "info")
+    if bool(payload.get("expect_response")) or message_type == "question":
+        return "agent_message"
+    return "agent_progress"
+
+
 def make_agent_outbound_handler(task_id: int) -> Any:
     """Create a web bridge for agent agent-to-user messages."""
 
@@ -536,7 +543,7 @@ def make_agent_outbound_handler(task_id: int) -> Any:
             return
 
         event = create_stream_event(
-            "agent_message",
+            _agent_outbound_event_type(payload),
             task_id,
             {
                 "event_id": payload.get("event_id"),
@@ -4120,7 +4127,7 @@ clarification questions as plain assistant text.
             await websocket.send_text(
                 json.dumps(
                     create_stream_event(
-                        "agent_message",
+                        _agent_outbound_event_type(payload),
                         builder_task_id,
                         {
                             "event_id": payload.get("event_id"),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -542,8 +542,9 @@ def make_agent_outbound_handler(task_id: int) -> Any:
             )
             return
 
+        event_type = _agent_outbound_event_type(payload)
         event = create_stream_event(
-            _agent_outbound_event_type(payload),
+            event_type,
             task_id,
             {
                 "event_id": payload.get("event_id"),
@@ -552,6 +553,7 @@ def make_agent_outbound_handler(task_id: int) -> Any:
                 "message": payload.get("message"),
                 "message_type": payload.get("message_type", "info"),
                 "expect_response": bool(payload.get("expect_response", False)),
+                "display": "chat" if event_type == "agent_message" else "timeline",
                 "metadata": payload.get("metadata") or {},
             },
         )
@@ -3426,6 +3428,8 @@ async def send_historical_data_as_stream(
                         "message": content,
                         "content": content,
                         "role": "assistant",
+                        "source": "chat_history",
+                        "display": "chat",
                         # Historical assistant questions are transcript entries.
                         # The current WAITING_FOR_USER state is reasserted separately
                         # after replay, so old questions must not flip status back.

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 from xagent.core.agent import (
     Agent,
@@ -21,6 +22,11 @@ from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRu
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
+
+
+class SearchArgs(BaseModel):
+    query: str
+    count: int = 10
 
 
 class FakeWorkspace:
@@ -214,6 +220,24 @@ class CapturingChildPattern:
 
     def get_state(self) -> dict[str, Any]:
         return {"captured": True}
+
+
+class FakeSearchTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "zhipu_web_search"
+            description = "Search the web."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return SearchArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(args)
+        return {"results": [{"title": args["query"], "link": "https://example.com"}]}
 
 
 def test_auto_child_runtime_forwards_clear_interrupt() -> None:
@@ -714,6 +738,8 @@ async def test_auto_pattern_does_not_stream_non_final_decision() -> None:
     assert result["output"] == "child done"
     assert collector.events == []
     assert pattern.selected_pattern == "react"
+    assert child.kwargs is not None
+    assert "allow_auto_reroute" not in child.kwargs
 
 
 @pytest.mark.asyncio
@@ -799,6 +825,83 @@ async def test_auto_pattern_does_not_emit_general_task_start_or_completion() -> 
         "action_end_llm",
         "task_update_general",
     }
+
+
+@pytest.mark.asyncio
+async def test_auto_react_repetition_stays_in_single_react_trace() -> None:
+    llm = FakeLLM(
+        [
+            decision_tool_response("react", "Needs current search."),
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news","count":10}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news latest","count":5}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"已有结果足够回答",'
+                                '"answer":"可以基于已有搜索结果回答。"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tracer = RecordingTracer()
+    runtime = PatternRuntime(tracer=tracer)
+    pattern = AutoPattern(
+        react_pattern=ReActPattern(
+            max_iterations=4,
+            repeated_tool_decision_after_consecutive_tool_calls=2,
+        )
+    )
+    context = ExecutionContext(execution_id="auto-react-repeat")
+    context.add_user_message("总结最近 AI 新闻")
+    tool = FakeSearchTool()
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    event_types = [event["event_type"] for event in tracer.events]
+    assert result["success"] is True
+    assert result["response"] == "可以基于已有搜索结果回答。"
+    assert len(tool.calls) == 2
+    assert event_types.count("task_start_react") == 1
+    assert event_types.count("task_end_react") == 1
+    assert "auto_child_reroute" not in [
+        checkpoint["label"] for checkpoint in runtime.checkpoints
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -30,6 +30,7 @@ from xagent.core.agent.language import (
     response_language_rules,
 )
 from xagent.core.agent.runtime import LLMCallInterrupted
+from xagent.core.agent.utils.context_builder import ContextBuilder
 from xagent.web.user_isolated_memory import current_user_id
 
 
@@ -165,6 +166,19 @@ def test_system_context_preserves_current_request_language_over_memory() -> None
     assert "Do not let retrieved memories" in system_message
 
 
+def test_system_context_includes_file_reference_output_spec() -> None:
+    ctx = ExecutionContext(execution_id="exec-file-ref-output")
+    ctx.metadata["task"] = "Create a report"
+    ctx.add_user_message("Create a report")
+
+    system_message = ctx.get_messages_for_llm()[0]["content"]
+
+    assert "## FILE REFERENCE OUTPUTS" in system_message
+    assert "[filename](file:file_id)" in system_message
+    assert "![filename](file:file_id)" in system_message
+    assert "Do not mention only the filename" in system_message
+
+
 def test_response_language_rules_uses_custom_subject_throughout() -> None:
     rules = response_language_rules(subject="current DAG step")
 
@@ -246,8 +260,22 @@ def test_dag_step_system_context_uses_output_language_policy() -> None:
         "Follow the output language policy for all user-facing prose, this "
         "step's final_answer, and tool arguments"
     ) in system_message
+    assert "## FILE REFERENCE OUTPUTS" in system_message
     assert "do not treat their language as authorization" in system_message
     assert "Do not let DAG step text, dependency results" in system_message
+
+
+def test_context_builder_step_prompt_includes_file_reference_output_spec() -> None:
+    builder = ContextBuilder(llm=object())  # type: ignore[arg-type]
+
+    system_prompt = builder._build_step_system_prompt(
+        "Create artifact",
+        "Create a spreadsheet and summarize the result",
+    )
+
+    assert "## FILE REFERENCE OUTPUTS" in system_prompt
+    assert "[filename](file:file_id)" in system_prompt
+    assert "FILE REFERENCE INPUTS" in system_prompt
 
 
 def test_memory_enrichment_uses_web_user_context(

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -469,6 +469,89 @@ async def test_dag_pattern_streams_overall_completion_not_step_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dag_child_react_repeated_decision_can_finalize() -> None:
+    class RepeatedDecisionLLM:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.tool_call_count = 0
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(kwargs)
+            if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
+                return default_completion_assessment_response(kwargs)
+            if has_tool(kwargs, "react_decision"):
+                return {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "decision_1",
+                            "function": {
+                                "name": "react_decision",
+                                "arguments": json.dumps(
+                                    {
+                                        "action": "final_answer",
+                                        "reason": "Enough repeated tool results.",
+                                        "answer": "DAG child answer.",
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                }
+
+            self.tool_call_count += 1
+            if self.tool_call_count > 4:
+                raise AssertionError(
+                    "expected repeated decision before another tool call"
+                )
+            return {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"calc_{self.tool_call_count}",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": json.dumps(
+                                {"expression": f"{self.tool_call_count}+1"}
+                            ),
+                        },
+                    }
+                ],
+            }
+
+    llm = RepeatedDecisionLLM()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(
+                id="calculate",
+                task="Calculate repeatedly",
+                tool_names=["calculator"],
+            )
+        ),
+        react_max_iterations=6,
+    )
+    context = ExecutionContext(execution_id="dag-repeated-decision")
+    context.add_user_message("Use DAG and calculate.")
+    tool = FakeTool()
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(
+        execution_id="dag-repeated-decision",
+        outbound_message_handler=outbound,
+    )
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["output"] == "DAG child answer."
+    assert len(tool.calls) == 4
+    assert [event["type"] for event in outbound.events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dag_completion_assessment_replans_when_goal_incomplete() -> None:
     class CompletionReplanGenerator(PlanGenerator):
         def __init__(self) -> None:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -871,16 +871,14 @@ async def test_execution_adapter_forwards_outbound_messages() -> None:
 
     assert result["success"] is True
     assert result["output"] == "done"
-    assert sent_messages == [
-        {
-            "type": "agent_message",
-            "execution_id": "outbound-exec",
-            "message": "Still working",
-            "message_type": "progress",
-            "expect_response": False,
-            "metadata": {},
-        }
-    ]
+    assert len(sent_messages) == 1
+    outbound_message = sent_messages[0]
+    assert outbound_message["type"] == "agent_message"
+    assert outbound_message["execution_id"] == "outbound-exec"
+    assert outbound_message["message"] == "Still working"
+    assert outbound_message["message_type"] == "progress"
+    assert outbound_message["expect_response"] is False
+    assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
 
 
 def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -836,6 +836,71 @@ async def test_react_pattern_uses_decision_for_repeated_tools() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_repeated_decision_drains_current_tool_call_batch() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":10}',
+                        },
+                    },
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"OpenAI news May 2026","count":5}',
+                        },
+                    },
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"The current batch is enough.",'
+                                '"answer":"Both pending searches were executed."}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=3,
+        repeated_tool_decision_after_consecutive_tool_calls=1,
+    )
+    tool = FakeSearchTool()
+    context = ExecutionContext()
+    context.add_user_message("最近 AI 新闻")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "Both pending searches were executed."
+    assert len(tool.calls) == 2
+    assert len(llm.calls) == 2
+    tool_result_ids = [
+        message.tool_call_id for message in context.messages if message.role == "tool"
+    ]
+    assert tool_result_ids[-2:] == ["search_1", "search_2"]
+    assert [schema["function"]["name"] for schema in llm.calls[1]["tools"]] == [
+        "react_decision"
+    ]
+    assert pattern.pending_tool_calls == []
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_accepts_legacy_auto_reroute_kwarg() -> None:
     llm = FakeLLM(
         responses=[

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -30,6 +30,11 @@ class WriteFileArgs(BaseModel):
     content: str
 
 
+class SearchArgs(BaseModel):
+    query: str
+    count: int = 10
+
+
 class FakeTool:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -70,6 +75,39 @@ class FakeWriteFileTool:
             "filename": path.split("/")[-1],
             "relative_path": f"output/{path.split('/')[-1]}",
             "file_path": f"/workspace/output/{path.split('/')[-1]}",
+        }
+
+
+class FakeSearchTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "zhipu_web_search"
+            description = "Search the web."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return SearchArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {
+            "results": [
+                {
+                    "title": "用不了NotebookLM,试试这个国产知识库工具",
+                    "link": "https://example.com/a",
+                },
+                {
+                    "title": "AnyGen真能取代NotebookLM?",
+                    "link": "https://example.com/b",
+                },
+                {
+                    "title": "Open NotebookLM",
+                    "link": "https://example.com/c",
+                },
+            ]
         }
 
 
@@ -305,6 +343,64 @@ class StreamingMixedFinalAnswerAndToolLLM:
                 },
             ],
         )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class StreamingRepeatedDecisionEmptyAnswerLLM:
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("streaming repeated decision path should not call chat()")
+
+    async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        call_index = len(self.stream_calls) - 1
+        if call_index == 0:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news","count":10}',
+                        },
+                    }
+                ],
+            )
+        elif call_index == 1:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news latest","count":5}',
+                        },
+                    }
+                ],
+            )
+        elif call_index == 2:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"empty answer",'
+                                '"answer":"   "}'
+                            ),
+                        },
+                    }
+                ],
+            )
+        else:
+            yield StreamChunk(type=ChunkType.TOKEN, delta="Fallback answer.")
         yield StreamChunk(type=ChunkType.END)
 
 
@@ -671,6 +767,283 @@ async def test_react_pattern_finalizes_with_completion_evidence() -> None:
         in (llm.calls[1]["messages"][0]["content"])
     )
     assert "Do not repeat the same work" in llm.calls[1]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_uses_decision_for_repeated_tools() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":10}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":5}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"已有结果足够回答",'
+                                '"answer":"可以基于已有搜索结果回答。"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=3,
+        repeated_tool_decision_after_consecutive_tool_calls=2,
+    )
+    tool = FakeSearchTool()
+    context = ExecutionContext()
+    context.add_user_message("最近 AI 新闻")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "可以基于已有搜索结果回答。"
+    assert len(llm.calls) == 3
+    assert len(tool.calls) == 2
+    assert [schema["function"]["name"] for schema in llm.calls[2]["tools"]] == [
+        "react_decision"
+    ]
+    assert pattern.pending_tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_accepts_legacy_auto_reroute_kwarg() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":10}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":5}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"已有结果足够回答",'
+                                '"answer":"可以基于已有搜索结果回答。"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=3,
+        repeated_tool_decision_after_consecutive_tool_calls=2,
+    )
+    tool = FakeSearchTool()
+    context = ExecutionContext()
+    context.add_user_message("最近 AI 新闻")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        allow_auto_reroute=True,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "可以基于已有搜索结果回答。"
+    assert len(llm.calls) == 3
+    assert len(tool.calls) == 2
+    next_tool_names = [
+        tool_schema["function"]["name"] for tool_schema in llm.calls[2]["tools"]
+    ]
+    assert next_tool_names == ["react_decision"]
+    assert (
+        "action must be final_answer or tool_call"
+        in (llm.calls[2]["messages"][-1]["content"])
+    )
+    assert llm.calls[2]["tool_choice"] == "required"
+    assert pattern.force_final_answer_next is False
+    assert pattern.repeated_tool_decision is None
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_repeated_decision_can_continue_to_tool_call() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"AI news May 2026","count":10}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"Google AI news May 2026","count":5}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_1",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"tool_call",'
+                                '"reason":"Need one more source",'
+                                '"missing_verification":"official source"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "search_3",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": '{"query":"OpenAI news May 2026 official","count":3}',
+                        },
+                    }
+                ],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "decision_2",
+                        "function": {
+                            "name": "react_decision",
+                            "arguments": (
+                                '{"action":"final_answer",'
+                                '"reason":"Now enough sources",'
+                                '"answer":"第三次搜索后信息足够。"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=5,
+        repeated_tool_decision_after_consecutive_tool_calls=2,
+    )
+    tool = FakeSearchTool()
+    context = ExecutionContext()
+    context.add_user_message("最近 AI 新闻")
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["success"] is True
+    assert result["response"] == "第三次搜索后信息足够。"
+    assert len(tool.calls) == 3
+    assert len(llm.calls) == 5
+    assert [schema["function"]["name"] for schema in llm.calls[2]["tools"]] == [
+        "react_decision"
+    ]
+    assert "zhipu_web_search" in [
+        schema["function"]["name"] for schema in llm.calls[3]["tools"]
+    ]
+    assert any(
+        "official source" in str(message.get("content") or "")
+        for message in llm.calls[3]["messages"]
+    )
+    assert [schema["function"]["name"] for schema in llm.calls[4]["tools"]] == [
+        "react_decision"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_react_pattern_fails_empty_repeated_decision_answer_stream() -> None:
+    llm = StreamingRepeatedDecisionEmptyAnswerLLM()
+    pattern = ReActPattern(
+        max_iterations=4,
+        repeated_tool_decision_after_consecutive_tool_calls=2,
+    )
+    tool = FakeSearchTool()
+    context = ExecutionContext(execution_id="task-1")
+    context.add_user_message("Search AI news")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "Fallback answer."
+    assert [event["type"] for event in outbound.events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_error",
+    ]
+    assert outbound.events[-1]["error"] == "empty final answer"
 
 
 @pytest.mark.asyncio
@@ -1194,16 +1567,14 @@ async def test_react_pattern_send_message_without_response_continues() -> None:
 
     assert result["success"] is True
     assert result["response"] == "All done."
-    assert runtime.outbound_messages == [
-        {
-            "type": "agent_message",
-            "execution_id": context.execution_id,
-            "message": "Still working",
-            "message_type": "progress",
-            "expect_response": False,
-            "metadata": {},
-        }
-    ]
+    assert len(runtime.outbound_messages) == 1
+    outbound_message = runtime.outbound_messages[0]
+    assert outbound_message["type"] == "agent_message"
+    assert outbound_message["execution_id"] == context.execution_id
+    assert outbound_message["message"] == "Still working"
+    assert outbound_message["message_type"] == "progress"
+    assert outbound_message["expect_response"] is False
+    assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
     tool_messages = context.get_messages_by_role("tool")
     assert len(tool_messages) == 1
     assert tool_messages[0].metadata["tool_name"] == "send_message"
@@ -1279,22 +1650,19 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
     assert result["success"] is False
     assert result["status"] == "waiting_for_user"
     assert result["message"] == "Pick one"
-    assert runtime.outbound_messages == [
+    assert len(runtime.outbound_messages) == 1
+    outbound_message = runtime.outbound_messages[0]
+    assert outbound_message["type"] == "agent_message"
+    assert outbound_message["execution_id"] == "exec-1"
+    assert outbound_message["message"] == "Pick one"
+    assert outbound_message["message_type"] == "question"
+    assert outbound_message["expect_response"] is True
+    assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
+    assert outbound_message["metadata"]["interactions"] == [
         {
-            "type": "agent_message",
-            "execution_id": "exec-1",
-            "message": "Pick one",
-            "message_type": "question",
-            "expect_response": True,
-            "metadata": {
-                "interactions": [
-                    {
-                        "type": "select_one",
-                        "field": "choice",
-                        "label": "Choice",
-                    }
-                ]
-            },
+            "type": "select_one",
+            "field": "choice",
+            "label": "Choice",
         }
     ]
     assert pattern.tool_ledger["call_question_form"].status == "completed"

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -256,6 +256,39 @@ async def test_runtime_stream_final_answer_emits_ui_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_send_message_includes_active_step_id() -> None:
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-123", outbound_message_handler=outbound)
+    runtime.active_react_step_id = "react-step-1"
+
+    payload = await runtime.send_message(
+        message="Still working",
+        message_type="progress",
+        expect_response=False,
+    )
+
+    assert payload["step_id"] == "react-step-1"
+    assert payload["metadata"]["step_id"] == "react-step-1"
+    assert outbound.events[0]["step_id"] == "react-step-1"
+
+
+@pytest.mark.asyncio
+async def test_runtime_send_message_metadata_step_id_takes_precedence() -> None:
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-123", outbound_message_handler=outbound)
+    runtime.active_react_step_id = "react-step-1"
+
+    payload = await runtime.send_message(
+        message="Still working",
+        metadata={"step_id": "dag-step-1"},
+    )
+
+    assert payload["step_id"] == "dag-step-1"
+    assert payload["metadata"]["step_id"] == "dag-step-1"
+    assert outbound.events[0]["step_id"] == "dag-step-1"
+
+
+@pytest.mark.asyncio
 async def test_runtime_stream_final_answer_preserves_usage_metadata() -> None:
     outbound = OutboundCollector()
     runtime = PatternRuntime(execution_id="task-123", outbound_message_handler=outbound)

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -626,6 +626,71 @@ async def test_historical_replay_skips_checkpoint_rows_before_streaming(
 
 
 @pytest.mark.asyncio
+async def test_historical_replay_marks_assistant_chat_history_for_chat_display(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _create_trace_handler_test_task("chat-history-display")
+    try:
+        task_id = int(task.id)
+        user_id = int(task.user_id)
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=user_id,
+                role="assistant",
+                content="Final answer",
+                message_type="assistant",
+                created_at=datetime(2026, 5, 27, tzinfo=timezone.utc),
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    assistant_events = [
+        event
+        for event in sent_events
+        if event.get("type") == "trace_event"
+        and event.get("event_type") == "agent_message"
+        and event.get("data", {}).get("message") == "Final answer"
+    ]
+    assert len(assistant_events) == 1
+    assistant_data = assistant_events[0]["data"]
+    assert assistant_data["role"] == "assistant"
+    assert assistant_data["expect_response"] is False
+    assert assistant_data["source"] == "chat_history"
+    assert assistant_data["display"] == "chat"
+
+
+@pytest.mark.asyncio
 async def test_historical_replay_orders_equal_timestamps_by_id(
     monkeypatch,
 ) -> None:

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -18,6 +18,7 @@ from xagent.core.agent.trace import (
 )
 from xagent.web.api.trace_handlers import DatabaseTraceHandler
 from xagent.web.api.websocket import (
+    _agent_outbound_event_type,
     _is_agent_checkpoint_data,
     _is_duplicate_user_message_turn,
     _persist_agent_outbound_event,
@@ -114,6 +115,39 @@ def test_final_answer_stream_event_is_not_trace_event() -> None:
     assert "data" not in event
 
 
+def test_agent_outbound_event_type_separates_progress_from_questions() -> None:
+    assert (
+        _agent_outbound_event_type(
+            {
+                "message": "Still working",
+                "message_type": "progress",
+                "expect_response": False,
+            }
+        )
+        == "agent_progress"
+    )
+    assert (
+        _agent_outbound_event_type(
+            {
+                "message": "Need input",
+                "message_type": "question",
+                "expect_response": False,
+            }
+        )
+        == "agent_message"
+    )
+    assert (
+        _agent_outbound_event_type(
+            {
+                "message": "Need input",
+                "message_type": "info",
+                "expect_response": True,
+            }
+        )
+        == "agent_message"
+    )
+
+
 def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -146,12 +180,12 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     monkeypatch.setattr("xagent.web.api.websocket.get_db", get_test_db)
 
     event = create_stream_event(
-        "agent_message",
+        "agent_progress",
         int(task.id),
         {
             "event_id": "agent-event-1",
             "step_id": "react-step-1",
-            "message": "Need input",
+            "message": "Still working",
             "expect_response": False,
         },
     )
@@ -162,7 +196,7 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     try:
         trace_event = db.query(DatabaseTraceEvent).filter_by(task_id=int(task.id)).one()
         assert trace_event.event_id == "agent-event-1"
-        assert trace_event.event_type == "agent_message"
+        assert trace_event.event_type == "agent_progress"
         assert trace_event.step_id == "react-step-1"
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- add a generic repeated-tool decision guard for ReAct: after consecutive successful calls to the same work tool, ReAct must choose `final_answer` or one more `tool_call` via the `react_decision` tool instead of looping blindly
- keep interrupted/forced ReAct decision output inside the active thought timeline and fix trace rendering/call-count regressions from the repeated-tool flow
- add file-reference output rules to the shared system context and DAG step prompt so generated/uploaded files with `file_id` are rendered as Markdown file refs instead of plain filenames

## Tests
- `ruff check src/xagent/core/agent/pattern/auto/auto.py src/xagent/core/agent/pattern/react/react.py tests/core/agent/test_auto.py tests/core/agent/test_react.py src/xagent/core/agent/context/execution.py src/xagent/core/agent/utils/context_builder.py src/xagent/core/file_ref.py tests/core/agent/test_context.py`
- `PYTHONPATH=src pytest tests/core/agent/test_react.py::test_react_pattern_fails_empty_repeated_decision_answer_stream tests/core/agent/test_react.py::test_react_pattern_uses_decision_for_repeated_tools tests/core/agent/test_react.py::test_react_pattern_repeated_decision_can_continue_to_tool_call tests/core/agent/test_runtime.py tests/web/test_agent_checkpoint_stream.py -q`
- `PYTHONPATH=src pytest tests/core/agent/test_context.py::test_system_context_includes_file_reference_output_spec tests/core/agent/test_context.py::test_dag_step_system_context_uses_output_language_policy tests/core/agent/test_context.py::test_context_builder_step_prompt_includes_file_reference_output_spec tests/web/test_websocket_uploaded_files_context.py::test_build_uploaded_files_context_includes_agent_builder_kb_instruction -q`
- `npm run test:run -- TraceEventRenderer.test.tsx task-conversation-panel.test.tsx`
- `npm run type-check`
