### PR TITLE
fix(preview): high-fidelity .pptx preview via LibreOffice→PDF (fallback to pptxviewjs)

### DIFF
--- a/frontend/src/components/file/file-viewer.tsx
+++ b/frontend/src/components/file/file-viewer.tsx
@@ -82,7 +82,7 @@ export function FileViewer({
   return (
     <div className="flex-1 overflow-auto bg-muted/30 rounded border h-full">
       {fileName.toLowerCase().endsWith('.pptx') ? (
-        <PptxPreviewRenderer base64Content={content || ''} />
+        <PptxPreviewRenderer base64Content={content || ''} fileId={fileId} />
       ) : mimeType?.startsWith('image/') || fileName.match(/\.(jpg|jpeg|png|gif|webp|svg)$/i) ? (
         <div className="flex items-center justify-center h-full p-4">
           <img

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -58,15 +58,14 @@ describe('InlineFilePreview', () => {
     )
   })
 
-  it('renders presentation previews through PptxPreviewRenderer with fetched bytes', async () => {
-    // Arbitrary sentinel bytes; base64 encodes to "AQI=". Avoid the
-    // ZIP magic-number 0x50 0x4B because its base64 encoding trips the
-    // repo's codespell hook (false-positive on the 3-letter sequence).
-    apiRequestMock.mockResolvedValue({
-      ok: true,
-      arrayBuffer: async () => new Uint8Array([0x01, 0x02]).buffer,
-    })
-
+  it('mounts PptxPreviewRenderer immediately with fileId without eager byte fetch', () => {
+    // PDF-first path: when a managed fileId is available, InlineFilePreview
+    // skips the eager /api/files/public/preview bytes download and mounts
+    // PptxPreviewRenderer directly with the fileId.  The renderer then probes
+    // /api/files/preview-pdf/{fileId} (LibreOffice PDF) first and only
+    // lazy-fetches raw bytes if that 503s.  This avoids paying the full PPTX
+    // download + base64 memory cost for large decks when LibreOffice is
+    // available.
     render(
       <InlineFilePreview
         source={{
@@ -77,14 +76,12 @@ describe('InlineFilePreview', () => {
       />
     )
 
-    // Browsers can't render raw .pptx in an iframe, and the backend's
-    // /api/files/public/preview endpoint now returns the raw bytes, so
-    // we mirror the document/spreadsheet path: fetch the bytes, base64
-    // them, hand to PptxPreviewRenderer (canvas-based, pptxviewjs).
-    expect(await screen.findByTestId('pptx-preview')).toHaveTextContent('AQI=')
-    expect(apiRequestMock).toHaveBeenCalledWith(
+    // Renderer is mounted synchronously — no async wait needed.
+    expect(screen.getByTestId('pptx-preview')).toBeInTheDocument()
+    // No eager byte fetch — the renderer lazy-fetches on its own if needed.
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
       'http://api.local/api/files/public/preview/slides-file-id',
-      expect.objectContaining({ cache: 'no-cache' })
+      expect.anything()
     )
   })
 

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -108,10 +108,13 @@ function InlineOfficeContent({
   kind,
   previewUrl,
   loadErrorText,
+  fileId,
 }: {
   kind: 'presentation' | 'document' | 'spreadsheet'
   previewUrl: string
   loadErrorText: string
+  /** Optional fileId; when set, enables server-side PDF preview for .pptx. */
+  fileId?: string
 }) {
   const [base64Content, setBase64Content] = useState('')
   const [error, setError] = useState(false)
@@ -165,12 +168,13 @@ function InlineOfficeContent({
     )
   }
 
-  // Presentation now goes through PptxPreviewRenderer (canvas-based,
-  // pptxviewjs) instead of an iframe — browsers can't render raw .pptx
-  // bytes in an iframe, and the backend's /api/files/public/preview
-  // endpoint now returns those raw bytes (rogercloud review on #465).
+  // Presentation goes through PptxPreviewRenderer. The renderer tries the
+  // server's LibreOffice-backed /api/files/preview-pdf endpoint first
+  // (vector, text-selectable, perfect font metrics) and falls back to the
+  // canvas-based pptxviewjs path on 503 — so the previous behaviour from
+  // #465 is preserved when LibreOffice isn't installed.
   if (kind === 'presentation') {
-    return <PptxPreviewRenderer base64Content={base64Content} />
+    return <PptxPreviewRenderer base64Content={base64Content} fileId={fileId} />
   }
 
   if (kind === 'document') {
@@ -300,6 +304,7 @@ export function InlineFilePreview({
           kind={kind}
           previewUrl={previewUrl}
           loadErrorText={loadErrorText}
+          fileId={source.fileId}
         />
       </div>
     </div>

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -120,6 +120,10 @@ function InlineOfficeContent({
   const [error, setError] = useState(false)
 
   useEffect(() => {
+    // Presentation + fileId: skip the eager bytes download. Hooks must be
+    // called unconditionally, so we guard here rather than relying on the
+    // early render return below.  PptxPreviewRenderer lazy-fetches if needed.
+    if (kind === 'presentation' && fileId) return
     if (!previewUrl) return
 
     let isCancelled = false
@@ -156,6 +160,16 @@ function InlineOfficeContent({
     }
   }, [previewUrl])
 
+  // Fast path: presentation with a managed fileId — skip the eager PPTX
+  // download and mount the renderer immediately.  PptxPreviewRenderer will
+  // probe the LibreOffice PDF endpoint first; only if that 503s does it
+  // lazy-fetch the raw bytes from /api/files/public/preview/{fileId}.  For
+  // large decks this means the PDF iframe can appear without ever paying the
+  // base64 download + memory cost.  Per PR #542 review (rogercloud).
+  if (kind === 'presentation' && fileId) {
+    return <PptxPreviewRenderer fileId={fileId} />
+  }
+
   if (error) {
     return <div className="p-3 text-xs text-muted-foreground">{loadErrorText}</div>
   }
@@ -168,13 +182,10 @@ function InlineOfficeContent({
     )
   }
 
-  // Presentation goes through PptxPreviewRenderer. The renderer tries the
-  // server's LibreOffice-backed /api/files/preview-pdf endpoint first
-  // (vector, text-selectable, perfect font metrics) and falls back to the
-  // canvas-based pptxviewjs path on 503 — so the previous behaviour from
-  // #465 is preserved when LibreOffice isn't installed.
+  // Presentation without a managed fileId (external previewUrl path) falls
+  // through here with pre-loaded bytes.
   if (kind === 'presentation') {
-    return <PptxPreviewRenderer base64Content={base64Content} fileId={fileId} />
+    return <PptxPreviewRenderer base64Content={base64Content} />
   }
 
   if (kind === 'document') {

--- a/frontend/src/components/file/pptx-preview-renderer.tsx
+++ b/frontend/src/components/file/pptx-preview-renderer.tsx
@@ -189,6 +189,10 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
       // decks don't pay the download cost when LibreOffice is available.
       let effectiveBase64 = base64Content ?? ""
       if (!effectiveBase64 && fileId && pdfChecked && !pdfUrl) {
+        // PDF probe failed (503 or network error) and no bytes were pre-loaded.
+        // Lazy-fetch the raw PPTX so the canvas renderer can take over.
+        // Surface a visible error on failure so the user isn't left with a
+        // blank canvas and no message (regression flagged in PR #542 review).
         setIsLoading(true)
         try {
           const res = await apiRequest(
@@ -197,14 +201,20 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
           )
           if (cancelled) return
           if (!res.ok) {
-            setIsLoading(false)
+            if (!cancelled) {
+              setError(t("files.previewDialog.errors.loadFailed"))
+              setIsLoading(false)
+            }
             return
           }
           const buf = await res.arrayBuffer()
           if (cancelled) return
           effectiveBase64 = arrayBufferToBase64(buf)
         } catch {
-          if (!cancelled) setIsLoading(false)
+          if (!cancelled) {
+            setError(t("files.previewDialog.errors.loadFailed"))
+            setIsLoading(false)
+          }
           return
         }
       }

--- a/frontend/src/components/file/pptx-preview-renderer.tsx
+++ b/frontend/src/components/file/pptx-preview-renderer.tsx
@@ -3,9 +3,21 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
+import { apiRequest } from "@/lib/api-wrapper"
+import { getApiUrl } from "@/lib/utils"
 
 interface PptxPreviewRendererProps {
   base64Content: string
+  /**
+   * Optional fileId. When provided, the renderer tries the high-fidelity
+   * server-rendered PDF preview first (LibreOffice → PDF, displayed in an
+   * iframe with the browser's native PDF viewer — vector, text-selectable,
+   * correct font metrics). On a 503 (LibreOffice not installed on the
+   * server) or any other failure, the renderer transparently falls back
+   * to the canvas-based pptxviewjs rendering that ships with the bundle,
+   * so developer machines without LibreOffice still get a working preview.
+   */
+  fileId?: string
 }
 
 // Minimal subset of the runtime API we rely on. We avoid pulling in the
@@ -36,7 +48,7 @@ function base64ToUint8Array(b64: string): Uint8Array {
   return bytes
 }
 
-export function PptxPreviewRenderer({ base64Content }: PptxPreviewRendererProps) {
+export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRendererProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const viewerRef = useRef<PPTXViewerHandle | null>(null)
@@ -45,7 +57,49 @@ export function PptxPreviewRenderer({ base64Content }: PptxPreviewRendererProps)
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [slideCount, setSlideCount] = useState<number>(0)
   const [currentSlide, setCurrentSlide] = useState<number>(0)
+  // PDF-first preview: when the server can produce a LibreOffice-rendered
+  // PDF we display that in an iframe instead of the canvas. `pdfUrl` is set
+  // by the effect below; until it resolves we render the canvas pipeline,
+  // and on 503 / fetch failure we leave it null and keep the canvas.
+  // `pdfChecked` flips to true once the probe finishes (either way) so the
+  // canvas effect can decide whether to bother loading pptxviewjs.
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
+  const [pdfChecked, setPdfChecked] = useState<boolean>(!fileId)
   const { t } = useI18n()
+
+  // Probe the server-rendered PDF endpoint. If it 200s, use the PDF in an
+  // iframe (high fidelity). If it 503s — LibreOffice not on PATH server-side
+  // — silently fall back to the canvas renderer. Any other error also falls
+  // back, so the UX never regresses below today's behaviour.
+  useEffect(() => {
+    if (!fileId) return
+    let cancelled = false
+    let objectUrl: string | null = null
+    ;(async () => {
+      try {
+        const res = await apiRequest(
+          `${getApiUrl()}/api/files/preview-pdf/${encodeURIComponent(fileId)}`,
+          { cache: "no-cache" },
+        )
+        if (cancelled) return
+        if (res.ok) {
+          const blob = await res.blob()
+          if (cancelled) return
+          objectUrl = URL.createObjectURL(blob)
+          setPdfUrl(objectUrl)
+          setIsLoading(false)
+        }
+      } catch {
+        // network error — just fall back
+      } finally {
+        if (!cancelled) setPdfChecked(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [fileId])
 
   // Size the canvas backing store to the container before each render.
   // pptxviewjs uses the canvas's pixel dimensions to lay out slides in
@@ -88,6 +142,17 @@ export function PptxPreviewRenderer({ base64Content }: PptxPreviewRendererProps)
     let createdViewer: PPTXViewerHandle | null = null
 
     const load = async () => {
+      // PDF path is winning: skip the canvas pipeline entirely so we don't
+      // download pptxviewjs (~1MB chunk), parse the deck, or paint the
+      // canvas that the iframe is going to cover anyway.
+      if (pdfUrl) {
+        setIsLoading(false)
+        return
+      }
+      // We have a fileId but haven't finished probing the PDF endpoint
+      // yet. Wait — kicking off pptxviewjs now would race the PDF probe
+      // and could leave both pipelines fighting for the same canvas.
+      if (fileId && !pdfChecked) return
       // Empty payload: nothing to render. Drop the loading spinner so we
       // don't hang the UI in an infinite loading state.
       if (!base64Content) {
@@ -172,7 +237,7 @@ export function PptxPreviewRenderer({ base64Content }: PptxPreviewRendererProps)
         viewerRef.current = null
       }
     }
-  }, [base64Content, syncCanvasSize, t])
+  }, [base64Content, syncCanvasSize, t, pdfUrl, pdfChecked, fileId])
 
   // Re-render the current slide when the container is resized.
   useEffect(() => {
@@ -211,6 +276,22 @@ export function PptxPreviewRenderer({ base64Content }: PptxPreviewRendererProps)
 
   if (error) {
     return <div className="p-4 text-sm text-muted-foreground">{error}</div>
+  }
+
+  // High-fidelity path: server-rendered PDF in an iframe. Browsers (Chrome,
+  // Safari, Firefox) all ship a built-in PDF viewer, so no JS library is
+  // needed. The viewer comes with its own pagination + zoom controls; we
+  // skip our prev/next bar so we don't have two competing controls.
+  if (pdfUrl) {
+    return (
+      <div className="flex flex-col h-full bg-muted/30">
+        <iframe
+          src={pdfUrl}
+          title="pptx preview (server-rendered PDF)"
+          className="flex-1 w-full border-0"
+        />
+      </div>
+    )
   }
 
   const hasNav = slideCount > 1

--- a/frontend/src/components/file/pptx-preview-renderer.tsx
+++ b/frontend/src/components/file/pptx-preview-renderer.tsx
@@ -7,7 +7,15 @@ import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
 
 interface PptxPreviewRendererProps {
-  base64Content: string
+  /**
+   * Pre-loaded PPTX bytes as base64.  Optional: when omitted (or empty)
+   * and a `fileId` is provided, the renderer lazy-fetches the raw bytes
+   * from `/api/files/public/preview/{fileId}` only if the PDF probe fails.
+   * Callers with a `fileId` should omit this prop to skip the eager
+   * download; callers without a `fileId` (external previewUrl path) must
+   * supply it since the renderer has no URL to fall back to.
+   */
+  base64Content?: string
   /**
    * Optional fileId. When provided, the renderer tries the high-fidelity
    * server-rendered PDF preview first (LibreOffice → PDF, displayed in an
@@ -48,6 +56,16 @@ function base64ToUint8Array(b64: string): Uint8Array {
   return bytes
 }
 
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let binary = ""
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
 export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRendererProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -72,15 +90,15 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
   // — silently fall back to the canvas renderer. Any other error also falls
   // back, so the UX never regresses below today's behaviour.
   useEffect(() => {
-    if (!fileId) return
-    // Reset state for the new file: a parent that swaps fileId (e.g.
-    // navigating between two .pptx artifacts in a chat thread) reuses
-    // this component instance. Without the reset we'd keep showing the
-    // *previous* PDF in the iframe (the old object URL was revoked, so
-    // it would just break) and `pdfChecked = true` would also block the
-    // canvas fallback from running for the new file. Per PR #542 review.
+    // Reset PDF/error state whenever fileId changes (including going to
+    // null).  Placed before the `!fileId` guard so switching from a
+    // PDF-backed file to a raw/base64-only source (fileId → undefined)
+    // doesn't inherit stale pdfUrl, pdfChecked, or error state.
+    // Per PR #542 review (rogercloud).
     setPdfUrl(null)
-    setPdfChecked(false)
+    setPdfChecked(!fileId)
+    setError(null)
+    if (!fileId) return
     setIsLoading(true)
     let cancelled = false
     let objectUrl: string | null = null
@@ -162,9 +180,38 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
       // yet. Wait — kicking off pptxviewjs now would race the PDF probe
       // and could leave both pipelines fighting for the same canvas.
       if (fileId && !pdfChecked) return
+
+      // Lazy-fetch raw bytes when the caller didn't pre-supply base64Content
+      // (PDF-first path skips the eager download) and the PDF probe has now
+      // finished without producing a URL.  Per PR #542 review (rogercloud):
+      // when `kind === 'presentation'` and a fileId is available, the parent
+      // mounts this renderer immediately without pre-loading bytes so large
+      // decks don't pay the download cost when LibreOffice is available.
+      let effectiveBase64 = base64Content ?? ""
+      if (!effectiveBase64 && fileId && pdfChecked && !pdfUrl) {
+        setIsLoading(true)
+        try {
+          const res = await apiRequest(
+            `${getApiUrl()}/api/files/public/preview/${encodeURIComponent(fileId)}`,
+            { cache: "no-cache" },
+          )
+          if (cancelled) return
+          if (!res.ok) {
+            setIsLoading(false)
+            return
+          }
+          const buf = await res.arrayBuffer()
+          if (cancelled) return
+          effectiveBase64 = arrayBufferToBase64(buf)
+        } catch {
+          if (!cancelled) setIsLoading(false)
+          return
+        }
+      }
+
       // Empty payload: nothing to render. Drop the loading spinner so we
       // don't hang the UI in an infinite loading state.
-      if (!base64Content) {
+      if (!effectiveBase64) {
         setIsLoading(false)
         return
       }
@@ -173,7 +220,7 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
       setError(null)
 
       try {
-        const bytes = base64ToUint8Array(base64Content)
+        const bytes = base64ToUint8Array(effectiveBase64)
 
         const mod = await import("pptxviewjs")
         if (cancelled) return

--- a/frontend/src/components/file/pptx-preview-renderer.tsx
+++ b/frontend/src/components/file/pptx-preview-renderer.tsx
@@ -73,6 +73,15 @@ export function PptxPreviewRenderer({ base64Content, fileId }: PptxPreviewRender
   // back, so the UX never regresses below today's behaviour.
   useEffect(() => {
     if (!fileId) return
+    // Reset state for the new file: a parent that swaps fileId (e.g.
+    // navigating between two .pptx artifacts in a chat thread) reuses
+    // this component instance. Without the reset we'd keep showing the
+    // *previous* PDF in the iframe (the old object URL was revoked, so
+    // it would just break) and `pdfChecked = true` would also block the
+    // canvas fallback from running for the new file. Per PR #542 review.
+    setPdfUrl(null)
+    setPdfChecked(false)
+    setIsLoading(true)
     let cancelled = false
     let objectUrl: string | null = null
     ;(async () => {

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -591,7 +591,13 @@ async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
     import tempfile
 
     try:
-        with tempfile.TemporaryDirectory() as temp_dir:
+        # Pin the temp dir to the same directory as `cache_path` so the final
+        # rename is a single intra-filesystem syscall. Without `dir=...`,
+        # `tempfile.TemporaryDirectory()` uses the system default (typically
+        # /tmp), which on Docker/production layouts is a different mount than
+        # the uploads volume — the later `replace()` would then fail with
+        # EXDEV (Invalid cross-device link). Per PR #542 review.
+        with tempfile.TemporaryDirectory(dir=cache_path.parent) as temp_dir:
             proc = await asyncio.create_subprocess_exec(
                 "soffice",
                 "--headless",
@@ -623,22 +629,19 @@ async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
             pdf_files = list(Path(temp_dir).glob("*.pdf"))
             if not pdf_files:
                 return None
-            # Atomic move into cache so partial reads can't race a half-written file.
-            tmp_dest = cache_path.with_suffix(cache_path.suffix + ".tmp")
+            # The PDF is already fully written and closed inside the temp dir,
+            # and the temp dir lives in the same filesystem as `cache_path`
+            # (see `dir=` above), so `replace()` is a single atomic rename.
+            # No `.tmp` intermediate needed — that previous two-step dance
+            # could leave orphans if a concurrent request raced. Per PR #542
+            # review.
             try:
-                pdf_files[0].replace(tmp_dest)
-                tmp_dest.replace(cache_path)
+                pdf_files[0].replace(cache_path)
             except OSError as exc:
                 logger.warning(
                     "Failed to cache pptx preview PDF at %s: %s", cache_path, exc
                 )
-                # Even if we can't cache, return the temp file's contents to
-                # the caller — but we can't, the tempdir is about to vanish.
-                # Best effort: try a direct read+write copy.
-                try:
-                    cache_path.write_bytes(pdf_files[0].read_bytes())
-                except OSError:
-                    return None
+                return None
             return cache_path
     except FileNotFoundError:
         # soffice binary is missing — this is the expected "fallback" path

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -551,6 +551,108 @@ def _pptx_text_preview(path: Path) -> str:
     return "\n\n".join(blocks)
 
 
+def _pptx_pdf_cache_path(pptx_path: Path) -> Path:
+    """Return the on-disk cache path for a converted PDF preview.
+
+    Caches sit beside the original .pptx with a ``.preview.pdf`` suffix so
+    they're cleaned up automatically when the source file is deleted (e.g.
+    by ``uploaded_files_reconcile`` for orphans). Re-converts when the
+    cache is missing or older than the source.
+    """
+    return pptx_path.with_suffix(pptx_path.suffix + ".preview.pdf")
+
+
+async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
+    """Convert a .pptx to PDF via LibreOffice with on-disk caching.
+
+    Returns the path to the cached PDF on success, or ``None`` when soffice
+    isn't available / conversion failed. The caller decides whether to
+    surface a 503 (so the frontend can fall back) or just keep going.
+
+    The fact that this can return ``None`` is the whole point of the
+    preview-pdf endpoint: on developer machines without LibreOffice we
+    don't break the UX — we let the frontend fall back to its canvas
+    renderer. Production images (Docker) pre-install libreoffice so this
+    path always succeeds there.
+    """
+    if pptx_path.suffix.lower() != ".pptx":
+        return None
+
+    cache_path = _pptx_pdf_cache_path(pptx_path)
+    try:
+        if (
+            cache_path.exists()
+            and cache_path.stat().st_mtime >= pptx_path.stat().st_mtime
+        ):
+            return cache_path
+    except OSError:
+        pass
+
+    import tempfile
+
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proc = await asyncio.create_subprocess_exec(
+                "soffice",
+                "--headless",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                temp_dir,
+                str(pptx_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning(
+                    "pptx→pdf conversion timed out for %s", pptx_path
+                )
+                return None
+            if proc.returncode != 0:
+                logger.warning(
+                    "soffice exited %s for %s: %s",
+                    proc.returncode,
+                    pptx_path,
+                    stderr.decode("utf-8", "replace")[:200],
+                )
+                return None
+            pdf_files = list(Path(temp_dir).glob("*.pdf"))
+            if not pdf_files:
+                return None
+            # Atomic move into cache so partial reads can't race a half-written file.
+            tmp_dest = cache_path.with_suffix(cache_path.suffix + ".tmp")
+            try:
+                pdf_files[0].replace(tmp_dest)
+                tmp_dest.replace(cache_path)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to cache pptx preview PDF at %s: %s", cache_path, exc
+                )
+                # Even if we can't cache, return the temp file's contents to
+                # the caller — but we can't, the tempdir is about to vanish.
+                # Best effort: try a direct read+write copy.
+                try:
+                    cache_path.write_bytes(pdf_files[0].read_bytes())
+                except OSError:
+                    return None
+            return cache_path
+    except FileNotFoundError:
+        # soffice binary is missing — this is the expected "fallback" path
+        # on developer machines. Log once at INFO so it doesn't spam.
+        logger.info(
+            "soffice not on PATH; .pptx PDF previews will fall back to "
+            "client-side rendering"
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("pptx→pdf conversion failed for %s: %s", pptx_path, exc)
+        return None
+
+
 @file_router.post("/upload")
 async def upload_file(
     file: UploadFile | None = File(None),
@@ -991,6 +1093,56 @@ async def preview_file(
         path=str(full_path),
         filename=file_name,
         media_type=media_type,
+        headers={"Content-Disposition": "inline"},
+    )
+
+
+@file_router.get("/preview-pdf/{file_id:path}", response_model=None)
+async def preview_pptx_as_pdf(
+    file_id: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Any:
+    """Return a PDF rendering of a .pptx for high-fidelity in-browser preview.
+
+    The frontend hits this endpoint first; if it succeeds it shows the PDF
+    in an ``<iframe>`` (vector, text-selectable, perfect font metrics).
+    On a 503 response — meaning the server doesn't have LibreOffice on
+    PATH — the frontend falls back to the existing ``pptxviewjs`` canvas
+    renderer so the UX still works on developer machines without soffice
+    installed.
+    """
+    file_record, full_path, owner_user_id = _resolve_file_path(
+        db, file_id, _user_id_value(user)
+    )
+    if file_record:
+        _check_file_access(file_record, user)
+        file_name = str(file_record.filename)
+    else:
+        if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
+            raise HTTPException(status_code=403, detail="Access denied")
+        file_name = full_path.name
+    _ensure_under_uploads(full_path, owner_user_id)
+    if not full_path.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    if full_path.suffix.lower() != ".pptx":
+        raise HTTPException(
+            status_code=400, detail="preview-pdf only supports .pptx files"
+        )
+
+    pdf_path = await _convert_pptx_to_pdf(full_path)
+    if pdf_path is None:
+        # Distinct 503 lets the frontend fall back gracefully instead of
+        # showing an error banner.
+        raise HTTPException(
+            status_code=503,
+            detail="LibreOffice unavailable; client should fall back to canvas renderer",
+        )
+
+    return FileResponse(
+        path=str(pdf_path),
+        filename=Path(file_name).stem + ".pdf",
+        media_type="application/pdf",
         headers={"Content-Disposition": "inline"},
     )
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -1112,26 +1112,52 @@ async def preview_pptx_as_pdf(
     PATH — the frontend falls back to the existing ``pptxviewjs`` canvas
     renderer so the UX still works on developer machines without soffice
     installed.
+
+    Mirrors the durable-storage restore path that ``/preview`` uses: for
+    files whose local copy was reaped but whose ``storage_key`` is still in
+    durable storage, we materialize before conversion (returning 409 on
+    checksum mismatch, 503 on durable backend failure — same semantics as
+    ``/preview``). Without this, durable-only ``.pptx`` files would 404 here
+    and silently fall back to the canvas renderer, which is exactly the
+    UX regression flagged in PR #542 review.
     """
     file_record, full_path, owner_user_id = _resolve_file_path(
         db, file_id, _user_id_value(user)
     )
+
+    # Resolve the local .pptx path. If the file is backed by durable
+    # storage and not currently on disk, restore it first.
+    pptx_path = full_path
     if file_record:
         _check_file_access(file_record, user)
         file_name = str(file_record.filename)
+        _ensure_under_uploads(full_path, owner_user_id)
+        file_ref = ManagedFileRef(file_record)
+        if file_ref.has_durable_object:
+            try:
+                pptx_path = file_ref.materialize()
+            except DurableObjectIntegrityError as exc:
+                raise _file_integrity_failed() from exc
+            except DurableStorageOperationError as exc:
+                raise _durable_storage_unavailable() from exc
+            except DurableObjectMissingError:
+                # Durable record points at nothing; fall back to whatever
+                # is on disk (or 404 below if it's gone too).
+                pptx_path = file_ref.local_path
     else:
         if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
             raise HTTPException(status_code=403, detail="Access denied")
         file_name = full_path.name
-    _ensure_under_uploads(full_path, owner_user_id)
-    if not full_path.exists():
+        _ensure_under_uploads(full_path, owner_user_id)
+
+    if pptx_path is None or not pptx_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
-    if full_path.suffix.lower() != ".pptx":
+    if pptx_path.suffix.lower() != ".pptx":
         raise HTTPException(
             status_code=400, detail="preview-pdf only supports .pptx files"
         )
 
-    pdf_path = await _convert_pptx_to_pdf(full_path)
+    pdf_path = await _convert_pptx_to_pdf(pptx_path)
     if pdf_path is None:
         # Distinct 503 lets the frontend fall back gracefully instead of
         # showing an error banner.

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -46,7 +46,7 @@ from ..services.managed_file_ref import (
     ManagedFileRef,
     guess_media_type,
 )
-from ..services.uploaded_file_store import UploadedFileStore
+from ..services.uploaded_file_store import UploadedFileStore, delete_pptx_pdf_cache
 from .legacy_file import (
     infer_user_id_from_legacy_path,
     is_valid_uuid,
@@ -1430,14 +1430,10 @@ async def delete_file(
         file_path.unlink()
 
     # Remove any server-side PDF preview cache so derived content doesn't
-    # outlive the source upload.  Only UUID file_ids have a managed cache
-    # entry; legacy paths use a path-hash key that has no lifecycle contract.
-    if is_valid_uuid(file_id):
-        pdf_cache = get_storage_root() / "pptx_pdf_cache" / f"{file_id}.preview.pdf"
-        try:
-            pdf_cache.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("Failed to remove PDF preview cache for %s", file_id)
+    # outlive the source upload.  Uses the same helper as UploadedFileStore.delete()
+    # so this HTTP route and every other deletion path (reconcile, orphan cleanup)
+    # behave identically.  Non-UUID ids are silently ignored by the helper.
+    delete_pptx_pdf_cache(file_id)
 
     return {
         "success": True,

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -20,6 +20,7 @@ from ...config import (
     get_file_delivery_accel_redirect_prefix,
     get_file_delivery_redirect_enabled,
     get_file_delivery_signed_url_ttl_seconds,
+    get_storage_root,
     get_uploads_dir,
 )
 from ...core.file_storage.factory import get_file_storage
@@ -551,18 +552,37 @@ def _pptx_text_preview(path: Path) -> str:
     return "\n\n".join(blocks)
 
 
-def _pptx_pdf_cache_path(pptx_path: Path) -> Path:
+def _pptx_pdf_cache_path(pptx_path: Path, file_id: Optional[str] = None) -> Path:
     """Return the on-disk cache path for a converted PDF preview.
 
-    Caches sit beside the original .pptx with a ``.preview.pdf`` suffix so
-    they're cleaned up automatically when the source file is deleted (e.g.
-    by ``uploaded_files_reconcile`` for orphans). Re-converts when the
-    cache is missing or older than the source.
+    Caches are stored in ``<storage_root>/pptx_pdf_cache/`` — a dedicated
+    directory outside the uploads tree.  Keeping them out of uploads:
+
+    * prevents reconcile / backfill from treating ``.pptx.preview.pdf``
+      sidecars as normal user-uploaded files;
+    * avoids leaking derived content after a source upload is deleted
+      (delete_file() explicitly removes the cache entry by file_id);
+    * lets the uploads tree stay clean — only files written by users or
+      the upload endpoint live there.
+
+    For registered UUID files the cache key is the ``file_id``, which lets
+    ``delete_file()`` remove it with a single unlink.  For legacy / non-UUID
+    paths (no lifecycle management) we fall back to a SHA-256 prefix of the
+    resolved source path — entries there age out naturally.
     """
-    return pptx_path.with_suffix(pptx_path.suffix + ".preview.pdf")
+    import hashlib
+
+    cache_dir = get_storage_root() / "pptx_pdf_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    if file_id:
+        return cache_dir / f"{file_id}.preview.pdf"
+    path_key = hashlib.sha256(str(pptx_path.resolve()).encode()).hexdigest()[:24]
+    return cache_dir / f"{path_key}.preview.pdf"
 
 
-async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
+async def _convert_pptx_to_pdf(
+    pptx_path: Path, file_id: Optional[str] = None
+) -> Optional[Path]:
     """Convert a .pptx to PDF via LibreOffice with on-disk caching.
 
     Returns the path to the cached PDF on success, or ``None`` when soffice
@@ -574,11 +594,15 @@ async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
     don't break the UX — we let the frontend fall back to its canvas
     renderer. Production images (Docker) pre-install libreoffice so this
     path always succeeds there.
+
+    ``file_id`` is forwarded to ``_pptx_pdf_cache_path`` so the cache entry
+    lands in the managed cache directory (keyed by file_id) rather than as
+    a sidecar next to the source file.
     """
     if pptx_path.suffix.lower() != ".pptx":
         return None
 
-    cache_path = _pptx_pdf_cache_path(pptx_path)
+    cache_path = _pptx_pdf_cache_path(pptx_path, file_id)
     try:
         if (
             cache_path.exists()
@@ -1157,7 +1181,12 @@ async def preview_pptx_as_pdf(
             status_code=400, detail="preview-pdf only supports .pptx files"
         )
 
-    pdf_path = await _convert_pptx_to_pdf(pptx_path)
+    # Pass the UUID file_id so the cache entry lands in the managed
+    # cache directory (keyed by file_id) rather than as a sidecar next to
+    # the source file.  Legacy / non-UUID ids pass None and fall back to
+    # the path-hash key.
+    managed_file_id = file_id if is_valid_uuid(file_id) else None
+    pdf_path = await _convert_pptx_to_pdf(pptx_path, file_id=managed_file_id)
     if pdf_path is None:
         # Distinct 503 lets the frontend fall back gracefully instead of
         # showing an error banner.
@@ -1399,6 +1428,16 @@ async def delete_file(
             logger.warning("Failed to clean up deleted local file: %s", file_path)
     elif file_path.exists() and file_path.is_file():
         file_path.unlink()
+
+    # Remove any server-side PDF preview cache so derived content doesn't
+    # outlive the source upload.  Only UUID file_ids have a managed cache
+    # entry; legacy paths use a path-hash key that has no lifecycle contract.
+    if is_valid_uuid(file_id):
+        pdf_cache = get_storage_root() / "pptx_pdf_cache" / f"{file_id}.preview.pdf"
+        try:
+            pdf_cache.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Failed to remove PDF preview cache for %s", file_id)
 
     return {
         "success": True,

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -614,9 +614,7 @@ async def _convert_pptx_to_pdf(pptx_path: Path) -> Optional[Path]:
             except asyncio.TimeoutError:
                 proc.kill()
                 await proc.wait()
-                logger.warning(
-                    "pptx→pdf conversion timed out for %s", pptx_path
-                )
+                logger.warning("pptx→pdf conversion timed out for %s", pptx_path)
                 return None
             if proc.returncode != 0:
                 logger.warning(

--- a/src/xagent/web/services/uploaded_file_store.py
+++ b/src/xagent/web/services/uploaded_file_store.py
@@ -1,14 +1,34 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
+from ...config import get_storage_root
 from ..models.uploaded_file import UploadedFile
 from .managed_file_ref import ManagedFileRef, guess_media_type
+
+logger = logging.getLogger(__name__)
+
+
+def delete_pptx_pdf_cache(file_id: str) -> None:
+    """Remove the server-side LibreOffice PDF preview cache for a .pptx upload.
+
+    Must be called from every path that deletes an ``UploadedFile`` row so
+    the derived cache entry does not outlive the source artifact.  Silently
+    no-ops when the file does not exist (first delete, non-PPTX uploads, etc.).
+    """
+    if not file_id:
+        return
+    cache_path = get_storage_root() / "pptx_pdf_cache" / f"{file_id}.preview.pdf"
+    try:
+        cache_path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to remove PDF preview cache for %s", file_id)
 
 
 def create_unbound_uploaded_file_from_local_path(
@@ -198,6 +218,12 @@ class UploadedFileStore:
         ManagedFileRef(file_record).delete_durable()
         if delete_local:
             self._delete_local(file_record, local_root=local_root)
+        # Remove any server-side PDF preview cache so derived content doesn't
+        # outlive the source upload.  Called here (not only in the HTTP route)
+        # so reconcile / orphan-cleanup paths that go through this service also
+        # clean up the cache.
+        file_id = str(getattr(file_record, "file_id", "") or "")
+        delete_pptx_pdf_cache(file_id)
         self.db.delete(file_record)
         self.db.flush()
 


### PR DESCRIPTION
## Summary

Soft-restores the pre-#465 LibreOffice → PDF path as the preferred renderer for in-browser `.pptx` previews; keeps `pptxviewjs` as fallback when `soffice` isn't on PATH. Fixes the text-overlap / clipping bug that #465 documented as a known issue with pptxviewjs@1.1.9.

## What changes

**Backend (`src/xagent/web/api/files.py`)**
- `_convert_pptx_to_pdf()` helper: shells out to `soffice --headless --convert-to pdf`, 60s timeout, atomic on-disk cache at `<name>.pptx.preview.pdf`, returns `None` on missing/failure
- `GET /api/files/preview-pdf/{file_id}`: returns the cached PDF on success; **503** (not 500) when soffice unavailable so the frontend can fall back gracefully

**Frontend**
- `PptxPreviewRenderer` gets an optional `fileId` prop. Probes the PDF endpoint first; on 200 renders the PDF in an `<iframe>` (browser's native PDF viewer — vector, text-selectable, perfect font metrics, native pagination + zoom). On 503/error stays on the canvas path
- Skips `pptxviewjs` chunk download entirely when PDF mode wins
- `inline-file-preview.tsx` and `file-viewer.tsx` thread `fileId` through

**Ops**
- `docker/Dockerfile.backend` already has `libreoffice` installed (line 168), so production previews always go through PDF
- Local dev: `brew install --cask libreoffice` / `apt-get install libreoffice`

## Why not just delete pptxviewjs?

Keeping the canvas fallback preserves the no-server-deps story #465 was built on. Devs who haven't installed LibreOffice locally still get a working preview; users with LibreOffice (or Docker deployments) get the high-fidelity path automatically. Zero regression vs. #465 baseline.

## Test plan

- [x] `curl GET /api/files/preview-pdf/<id>` → 200 PDF, 10 pages; second call hits cache in ~18ms
- [x] In-chat preview: native PDF viewer with thumbnail sidebar replaces the previously broken canvas with overlapping titles
- [x] soffice removed from PATH → 503, frontend silently falls back to canvas (verified via React fiber: `fileId` set but `pdfUrl` null)
- [x] No new dependencies