### PR TITLE
fix: return file refs for generated table outputs

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/sql_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/sql_tool.py
@@ -114,6 +114,7 @@ class SqlQueryTool:
                             - row_count: number of rows returned or affected
                             - columns: column names in the result
                             - message: what happened (includes export info when applicable)
+                            - file_ref/file_id/download_url when output_file exports results
                 """),
                     "" * 4,
                 ),

--- a/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/workspace_file_tool.py
@@ -116,7 +116,7 @@ class WorkspaceFileTools(WorkspaceFileOperations):
         data: Dict[str, Any],
         encoding: str = "utf-8",
         indent: int = 2,
-    ) -> bool:
+    ) -> Dict[str, Any]:
         """Write JSON file in workspace"""
         return self.inner.write_json_file(file_path, data, encoding, indent)
 
@@ -132,7 +132,7 @@ class WorkspaceFileTools(WorkspaceFileOperations):
         data: List[Dict[str, str]],
         encoding: str = "utf-8",
         delimiter: str = ",",
-    ) -> bool:
+    ) -> Dict[str, Any]:
         """Write CSV file in workspace"""
         return self.inner.write_csv_file(file_path, data, encoding, delimiter)
 
@@ -217,7 +217,7 @@ class WorkspaceFileTools(WorkspaceFileOperations):
             FileTool(
                 self.write_json_file,
                 name="write_json_file",
-                description="Write JSON file in workspace",
+                description="Write JSON file in workspace. Use relative paths (e.g., 'data.json'), not absolute paths. Returns a FileRef with file_id, preview_url, download_url, and markdown_link.",
             ),
             FileTool(
                 self.read_csv_file,
@@ -227,7 +227,7 @@ class WorkspaceFileTools(WorkspaceFileOperations):
             FileTool(
                 self.write_csv_file,
                 name="write_csv_file",
-                description="Write CSV file in workspace",
+                description="Write CSV file in workspace. Use relative paths (e.g., 'data.csv'), not absolute paths. Returns a FileRef with file_id, preview_url, download_url, and markdown_link.",
             ),
             FileTool(
                 self.get_workspace_output_files,

--- a/src/xagent/core/tools/core/sql_tool.py
+++ b/src/xagent/core/tools/core/sql_tool.py
@@ -394,5 +394,9 @@ def _stream_export_to_parquet(
     # Close writer to finalize file
     if writer:
         writer.close()
+    else:
+        schema = pa.schema([pa.field(str(column), pa.string()) for column in columns])
+        empty_table = pa.Table.from_batches([], schema=schema)
+        pq.write_table(empty_table, resolved_path)
 
     return str(resolved_path), row_count, columns

--- a/src/xagent/core/tools/core/sql_tool.py
+++ b/src/xagent/core/tools/core/sql_tool.py
@@ -25,6 +25,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy import URL, create_engine, text
 from sqlalchemy.engine import CursorResult, Row, make_url
 
+from ...file_ref import build_workspace_file_ref
+
 if TYPE_CHECKING:
     from ...workspace import TaskWorkspace
 
@@ -126,6 +128,7 @@ def execute_sql_query(
             - row_count: number of rows returned or affected
             - columns: column names in the result
             - message: what happened
+            - file_ref/file_id/download_url when output_file exports results
     """
     # Get connection URL from environment
     url = _get_connection_url(connection_name, connection_url)
@@ -140,46 +143,52 @@ def execute_sql_query(
                 if file_ext == ".csv":
                     # Streaming export for large datasets
                     result = conn.execute(stmt)
-                    _, exported_count, columns = _stream_export_to_csv(
-                        workspace, output_file, result
-                    )
-                    return SQLQueryResult(
-                        success=True,
-                        rows=[],
-                        row_count=exported_count,
+                    with workspace.auto_register_files():
+                        exported_path, exported_count, columns = _stream_export_to_csv(
+                            workspace, output_file, result
+                        )
+                    return _build_export_result(
+                        workspace=workspace,
+                        exported_path=exported_path,
+                        connection_name=connection_name,
+                        output_file=output_file,
+                        exported_count=exported_count,
                         columns=columns,
-                        message=f"Query executed successfully on '{connection_name}', exported {exported_count} row(s) to {output_file}",
-                    ).model_dump()
+                    )
                 elif file_ext == ".parquet":
                     # Streaming export with Parquet (better compression & type preservation)
                     result = conn.execute(stmt)
-                    (
-                        _,
-                        exported_count,
-                        columns,
-                    ) = _stream_export_to_parquet(workspace, output_file, result)
-                    return SQLQueryResult(
-                        success=True,
-                        rows=[],
-                        row_count=exported_count,
+                    with workspace.auto_register_files():
+                        (
+                            exported_path,
+                            exported_count,
+                            columns,
+                        ) = _stream_export_to_parquet(workspace, output_file, result)
+                    return _build_export_result(
+                        workspace=workspace,
+                        exported_path=exported_path,
+                        connection_name=connection_name,
+                        output_file=output_file,
+                        exported_count=exported_count,
                         columns=columns,
-                        message=f"Query executed successfully on '{connection_name}', exported {exported_count} row(s) to {output_file}",
-                    ).model_dump()
+                    )
                 elif file_ext in (".json", ".jsonl", ".ndjson"):
                     # Streaming JSON Lines (NDJSON) export
                     result = conn.execute(stmt)
-                    (
-                        _,
-                        exported_count,
-                        columns,
-                    ) = _stream_export_to_jsonlines(workspace, output_file, result)
-                    return SQLQueryResult(
-                        success=True,
-                        rows=[],
-                        row_count=exported_count,
+                    with workspace.auto_register_files():
+                        (
+                            exported_path,
+                            exported_count,
+                            columns,
+                        ) = _stream_export_to_jsonlines(workspace, output_file, result)
+                    return _build_export_result(
+                        workspace=workspace,
+                        exported_path=exported_path,
+                        connection_name=connection_name,
+                        output_file=output_file,
+                        exported_count=exported_count,
                         columns=columns,
-                        message=f"Query executed successfully on '{connection_name}', exported {exported_count} row(s) to {output_file}",
-                    ).model_dump()
+                    )
                 else:
                     raise ValueError(
                         f"Unsupported file format: {file_ext}. "
@@ -222,6 +231,36 @@ def execute_sql_query(
         engine.dispose()
 
 
+def _build_export_result(
+    *,
+    workspace: "TaskWorkspace",
+    exported_path: str,
+    connection_name: str,
+    output_file: str,
+    exported_count: int,
+    columns: list[str],
+) -> dict[str, Any]:
+    file_ref = build_workspace_file_ref(
+        workspace=workspace,
+        file_path=exported_path,
+    )
+    payload = SQLQueryResult(
+        success=True,
+        rows=[],
+        row_count=exported_count,
+        columns=columns,
+        message=f"Query executed successfully on '{connection_name}', exported {exported_count} row(s) to {output_file}",
+    ).model_dump()
+    payload.update(
+        {
+            "output_file": output_file,
+            **file_ref,
+            "file_ref": file_ref,
+        }
+    )
+    return payload
+
+
 def _stream_export_to_csv(
     workspace: "TaskWorkspace",
     file_path: str,
@@ -234,6 +273,7 @@ def _stream_export_to_csv(
         Tuple of (exported_file_path, row_count, column_names)
     """
     resolved_path = workspace.resolve_path(file_path, default_dir="output")
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Get column names BEFORE iteration
     columns = list(result.keys())
@@ -276,6 +316,7 @@ def _stream_export_to_jsonlines(
         Tuple of (exported_file_path, row_count, column_names)
     """
     resolved_path = workspace.resolve_path(file_path, default_dir="output")
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Get column names BEFORE iteration
     columns = list(result.keys())
@@ -322,6 +363,7 @@ def _stream_export_to_parquet(
         )
 
     resolved_path = workspace.resolve_path(file_path, default_dir="output")
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Get column names BEFORE iteration
     columns = list(result.keys())

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -321,6 +321,17 @@ class WorkspaceFileOperations:
             "file_ref": file_ref,
         }
 
+    def _registered_write_result(self, file_path: Path) -> Dict[str, Any]:
+        file_ref = build_workspace_file_ref(
+            workspace=self.workspace,
+            file_path=file_path,
+        )
+        return {
+            "success": True,
+            **file_ref,
+            "file_ref": file_ref,
+        }
+
     def prepare_html_asset(
         self,
         file_id: str,
@@ -547,12 +558,17 @@ class WorkspaceFileOperations:
         data: Dict[str, Any],
         encoding: str = "utf-8",
         indent: int = 2,
-    ) -> bool:
+    ) -> Dict[str, Any]:
         """Write JSON file in workspace"""
         from .file_tool import write_json_file as basic_write_json_file
 
         resolved_path = self._resolve_path(file_path, "output")
-        return basic_write_json_file(str(resolved_path), data, encoding, indent)
+        resolved_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with self.workspace.auto_register_files():
+            basic_write_json_file(str(resolved_path), data, encoding, indent)
+
+        return self._registered_write_result(resolved_path)
 
     def read_csv_file(
         self,
@@ -584,12 +600,20 @@ class WorkspaceFileOperations:
         data: List[Dict[str, str]],
         encoding: str = "utf-8",
         delimiter: str = ",",
-    ) -> bool:
+    ) -> Dict[str, Any]:
         """Write CSV file in workspace"""
         from .file_tool import write_csv_file as basic_write_csv_file
 
         resolved_path = self._resolve_path(file_path, "output")
-        return basic_write_csv_file(str(resolved_path), data, encoding, delimiter)
+        resolved_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with self.workspace.auto_register_files():
+            if data:
+                basic_write_csv_file(str(resolved_path), data, encoding, delimiter)
+            else:
+                resolved_path.write_text("", encoding=encoding)
+
+        return self._registered_write_result(resolved_path)
 
     def get_workspace_output_files(self) -> Dict[str, Any]:
         """Get output file list from current workspace"""
@@ -940,10 +964,8 @@ def workspace_write_json_file(
         True if the write operation was successful.
     """
     ops = _get_workspace_ops(workspace_id)
-    # Note: The original ops.write_json_file signature uses 'indent', not 'create_dirs' as the 4th arg.
-    # We rely on ops.write_file's default behavior for create_dirs or adjust the call if necessary.
-    # Assuming the internal implementation handles directory creation via write_file.
-    return ops.write_json_file(file_path, data, encoding, indent)
+    result = ops.write_json_file(file_path, data, encoding, indent)
+    return bool(result.get("success", False))
 
 
 def workspace_read_csv_file(
@@ -986,9 +1008,8 @@ def workspace_write_csv_file(
         True if the write operation was successful.
     """
     ops = _get_workspace_ops(workspace_id)
-    # The original ops.write_csv_file signature uses List[Dict[str, str]], not List[List[Any]].
-    # Also, the original signature takes 'delimiter' instead of 'create_dirs' as the last positional arg.
-    return ops.write_csv_file(file_path, data, encoding, delimiter)
+    result = ops.write_csv_file(file_path, data, encoding, delimiter)
+    return bool(result.get("success", False))
 
 
 def workspace_edit_file(

--- a/tests/core/tools/core/test_sql_tool.py
+++ b/tests/core/tools/core/test_sql_tool.py
@@ -228,3 +228,47 @@ class TestExecuteSqlQuery:
                     output_file="test.parquet",
                     workspace=mock_workspace,
                 )
+
+    @patch("xagent.core.tools.core.sql_tool.create_engine")
+    def test_execute_sql_query_with_empty_parquet_export(
+        self, mock_create_engine, monkeypatch, tmp_path
+    ):
+        """Test empty Parquet export still writes a registered file."""
+        pq = pytest.importorskip("pyarrow.parquet")
+        monkeypatch.setenv("XAGENT_EXTERNAL_DB_TEST", "sqlite:///:memory:")
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+        mock_create_engine.return_value = mock_engine
+
+        mock_result = MagicMock()
+        mock_result.keys.return_value = ["id", "name"]
+        mock_result.fetchmany.return_value = []
+        mock_conn.execute.return_value = mock_result
+
+        def mock_create_record(self, file_id, file_path, db_session=None):
+            return None
+
+        monkeypatch.setattr(TaskWorkspace, "_create_file_record", mock_create_record)
+        workspace = TaskWorkspace("test_sql_empty_parquet_export", str(tmp_path))
+
+        result = execute_sql_query(
+            "test",
+            "SELECT * FROM users WHERE 1 = 0",
+            output_file="empty.parquet",
+            workspace=workspace,
+        )
+
+        output_file = workspace.output_dir / "empty.parquet"
+        exported_table = pq.read_table(output_file)
+
+        assert result["success"] is True
+        assert result["row_count"] == 0
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "empty.parquet"
+        assert result["relative_path"] == "output/empty.parquet"
+        assert result["file_ref"]["file_id"] == result["file_id"]
+        assert output_file.exists()
+        assert exported_table.num_rows == 0
+        assert exported_table.column_names == ["id", "name"]

--- a/tests/core/tools/core/test_sql_tool.py
+++ b/tests/core/tools/core/test_sql_tool.py
@@ -13,6 +13,7 @@ from xagent.core.tools.core.sql_tool import (
     execute_sql_query,
     get_database_type,
 )
+from xagent.core.workspace import TaskWorkspace
 
 
 class TestGetConnectionUrl:
@@ -184,22 +185,27 @@ class TestExecuteSqlQuery:
         ]
         mock_conn.execute.return_value = mock_result
 
-        # Mock workspace
-        mock_workspace = MagicMock()
-        output_dir = tmp_path / "output"
-        output_dir.mkdir()
-        output_file = output_dir / "test.csv"
-        mock_workspace.resolve_path.return_value = str(output_file)
+        def mock_create_record(self, file_id, file_path, db_session=None):
+            return None
+
+        monkeypatch.setattr(TaskWorkspace, "_create_file_record", mock_create_record)
+        workspace = TaskWorkspace("test_sql_export", str(tmp_path))
 
         result = execute_sql_query(
             "test",
             "SELECT * FROM users",
             output_file="test.csv",
-            workspace=mock_workspace,
+            workspace=workspace,
         )
         assert result["success"] is True
         assert result["row_count"] == 2
         assert "exported" in result["message"].lower()
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "test.csv"
+        assert result["mime_type"] == "text/csv"
+        assert result["relative_path"] == "output/test.csv"
+        assert result["file_ref"]["file_id"] == result["file_id"]
+        assert (workspace.output_dir / "test.csv").exists()
 
     @patch("xagent.core.tools.core.sql_tool.create_engine")
     def test_execute_sql_query_export_parquet_no_pyarrow(

--- a/tests/core/tools/test_workspace_file_operations.py
+++ b/tests/core/tools/test_workspace_file_operations.py
@@ -2,8 +2,7 @@
 Tests for WorkspaceFileOperations core class.
 
 This module tests the core workspace file operations functionality,
-focusing on the JSON and CSV file operations that were optimized
-to delegate to the basic file_tool functions.
+focusing on JSON and CSV workspace writes and reads.
 """
 
 import pytest
@@ -36,8 +35,8 @@ class TestWorkspaceFileOperations:
         read_data = ops.read_json_file("test.json")
         assert read_data == test_data
 
-    def test_write_json_file_delegation(self, tmp_path):
-        """Test that write_json_file correctly delegates to basic file_tool function."""
+    def test_write_json_file_returns_registered_file_ref(self, tmp_path):
+        """Test that write_json_file returns a registered FileRef."""
         workspace = TaskWorkspace("test_json", str(tmp_path))
         ops = WorkspaceFileOperations(workspace)
 
@@ -46,7 +45,12 @@ class TestWorkspaceFileOperations:
 
         # Write using workspace operation
         result = ops.write_json_file("test.json", test_data)
-        assert result is True
+        assert result["success"] is True
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "test.json"
+        assert result["mime_type"] == "application/json"
+        assert result["relative_path"] == "output/test.json"
+        assert result["file_ref"]["file_id"] == result["file_id"]
 
         # Verify file was written to output directory
         test_file = workspace.output_dir / "test.json"
@@ -85,8 +89,8 @@ class TestWorkspaceFileOperations:
         read_data = ops.read_csv_file("test.csv")
         assert read_data == test_data
 
-    def test_write_csv_file_delegation(self, tmp_path):
-        """Test that write_csv_file correctly delegates to basic file_tool function."""
+    def test_write_csv_file_returns_registered_file_ref(self, tmp_path):
+        """Test that write_csv_file returns a registered FileRef."""
         workspace = TaskWorkspace("test_csv", str(tmp_path))
         ops = WorkspaceFileOperations(workspace)
 
@@ -99,7 +103,12 @@ class TestWorkspaceFileOperations:
 
         # Write using workspace operation
         result = ops.write_csv_file("test.csv", test_data)
-        assert result is True
+        assert result["success"] is True
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "test.csv"
+        assert result["mime_type"] == "text/csv"
+        assert result["relative_path"] == "output/test.csv"
+        assert result["file_ref"]["file_id"] == result["file_id"]
 
         # Verify file was written to output directory
         test_file = workspace.output_dir / "test.csv"
@@ -122,7 +131,7 @@ class TestWorkspaceFileOperations:
 
         # Write should go to output directory
         result = ops.write_json_file("output_test.json", test_data)
-        assert result is True
+        assert result["success"] is True
 
         # Verify file is in output directory
         output_file = workspace.output_dir / "output_test.json"
@@ -142,7 +151,7 @@ class TestWorkspaceFileOperations:
 
         # Write should go to output directory
         result = ops.write_csv_file("output_test.csv", test_data)
-        assert result is True
+        assert result["success"] is True
 
         # Verify file is in output directory
         output_file = workspace.output_dir / "output_test.csv"
@@ -177,7 +186,7 @@ class TestWorkspaceFileOperations:
 
         # Write with custom indent
         result = ops.write_json_file("test.json", test_data, indent=4)
-        assert result is True
+        assert result["success"] is True
 
         # Verify file content has 4-space indentation
         test_file = workspace.output_dir / "test.json"
@@ -222,13 +231,26 @@ class TestWorkspaceFileOperations:
 
         # Write with tab delimiter
         result = ops.write_csv_file("test.tsv", test_data, delimiter="\t")
-        assert result is True
+        assert result["success"] is True
 
         # Verify file content uses tabs
         test_file = workspace.output_dir / "test.tsv"
         content = test_file.read_text(encoding="utf-8")
         assert "\t" in content, "File should contain tab characters"
         assert "," not in content, "File should not contain comma characters"
+
+    def test_write_empty_csv_file_creates_registered_file_ref(self, tmp_path):
+        """Test that empty CSV data still creates a registered output file."""
+        workspace = TaskWorkspace("test_empty_csv", str(tmp_path))
+        ops = WorkspaceFileOperations(workspace)
+
+        result = ops.write_csv_file("empty.csv", [])
+
+        assert result["success"] is True
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "empty.csv"
+        assert result["relative_path"] == "output/empty.csv"
+        assert (workspace.output_dir / "empty.csv").read_text(encoding="utf-8") == ""
 
     def test_json_roundtrip_consistency(self, tmp_path):
         """Test that JSON data can be written and read back consistently."""

--- a/tests/core/tools/test_workspace_file_tool_consistency.py
+++ b/tests/core/tools/test_workspace_file_tool_consistency.py
@@ -68,6 +68,47 @@ class TestWorkspaceFileToolConsistency:
         assert read_content == test_content
 
     @pytest.mark.usefixtures("mock_workspace_db")
+    def test_write_json_returns_file_ref(self, tmp_path):
+        """Test that JSON writes expose FileRef metadata to the model."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        result = tools.write_json_file("data/report.json", {"answer": 42})
+
+        assert result["success"] is True
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "report.json"
+        assert result["mime_type"] == "application/json"
+        assert result["relative_path"] == "output/data/report.json"
+        assert result["preview_url"].endswith(result["file_id"])
+        assert result["download_url"].endswith(result["file_id"])
+        assert result["markdown_link"] == f"[report.json](file:{result['file_id']})"
+        assert result["file_ref"]["file_id"] == result["file_id"]
+        assert (workspace.output_dir / "data" / "report.json").exists()
+
+    @pytest.mark.usefixtures("mock_workspace_db")
+    def test_write_csv_returns_file_ref(self, tmp_path):
+        """Test that CSV writes expose FileRef metadata to the model."""
+        workspace = TaskWorkspace("test_task", str(tmp_path))
+        tools = WorkspaceFileTools(workspace)
+
+        result = tools.write_csv_file(
+            "data/report.csv",
+            [{"name": "Alice", "score": "10"}, {"name": "Bob", "score": "11"}],
+        )
+
+        assert result["success"] is True
+        assert isinstance(result.get("file_id"), str)
+        assert result["filename"] == "report.csv"
+        assert result["mime_type"] == "text/csv"
+        assert result["relative_path"] == "output/data/report.csv"
+        assert result["preview_url"].endswith(result["file_id"])
+        assert result["download_url"].endswith(result["file_id"])
+        assert result["markdown_link"] == f"[report.csv](file:{result['file_id']})"
+        assert result["file_ref"]["file_id"] == result["file_id"]
+        assert (workspace.output_dir / "data" / "report.csv").exists()
+
+    @pytest.mark.usefixtures("mock_workspace_db")
     def test_write_then_read_with_relative_path(self, tmp_path):
         """Test that relative paths work consistently."""
         workspace = TaskWorkspace("test_task", str(tmp_path))


### PR DESCRIPTION
## Summary
- Return registered FileRef metadata from workspace write_json_file/write_csv_file, including file_id, preview/download URLs, and markdown link.
- Auto-register JSON/CSV workspace writes, including empty CSV outputs, while preserving bool-return compatibility in workspace_write_* helpers.
- Return FileRef metadata for SQL output_file exports and document that behavior in the SQL tool description.
- Handle empty SQL Parquet exports so they still create a registered output file with FileRef metadata.

## Similar tools checked
- Existing generated-output tools for Python/JavaScript, image, audio, browser, PPTX, logo overlay, and translate JSON already use auto registration plus FileRef/artifact metadata.
- Legacy basic file_tool write helpers do not have workspace context and are not the active workspace file tools registered by the vibe tool factory.

## Tests
- PYTHONPATH=src python -m pytest tests/core/tools/test_workspace_file_tool_consistency.py tests/core/tools/test_workspace_file_operations.py tests/core/tools/core/test_sql_tool.py
- PYTHONPATH=src python -m ruff check src/xagent/core/tools/core/workspace_file_tool.py src/xagent/core/tools/adapters/vibe/workspace_file_tool.py src/xagent/core/tools/core/sql_tool.py src/xagent/core/tools/adapters/vibe/sql_tool.py tests/core/tools/test_workspace_file_operations.py tests/core/tools/test_workspace_file_tool_consistency.py tests/core/tools/core/test_sql_tool.py
- PYTHONPATH=src python -m ruff format --check src/xagent/core/tools/core/workspace_file_tool.py src/xagent/core/tools/adapters/vibe/workspace_file_tool.py src/xagent/core/tools/core/sql_tool.py src/xagent/core/tools/adapters/vibe/sql_tool.py tests/core/tools/test_workspace_file_operations.py tests/core/tools/test_workspace_file_tool_consistency.py tests/core/tools/core/test_sql_tool.py