### PR TITLE
fix: limit telegram file delivery to final answer refs

### DIFF
--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -648,15 +648,8 @@ class TelegramBotInstance:
                     message_type=projection.message_type,
                 )
 
-                output = projection.visible_text
-                output, image_refs = strip_telegram_image_refs(output)
-                output, file_refs = strip_telegram_file_refs(output)
-                output_image_refs, output_file_refs = (
-                    self._telegram_refs_from_file_outputs(result.get("file_outputs"))
-                )
-                image_refs, file_refs = self._dedupe_telegram_output_refs(
-                    [*image_refs, *output_image_refs],
-                    [*file_refs, *output_file_refs],
+                output, image_refs, file_refs = self._extract_telegram_output_refs(
+                    projection.visible_text,
                 )
                 if not output and (image_refs or file_refs):
                     output = "Task completed."
@@ -803,62 +796,20 @@ class TelegramBotInstance:
 
         return failed_refs
 
-    def _telegram_refs_from_file_outputs(
-        self, file_outputs: Any
-    ) -> tuple[list[TelegramImageRef], list[TelegramFileRef]]:
-        """Convert structured execution file outputs into Telegram attachments."""
-        if isinstance(file_outputs, dict):
-            file_outputs = [file_outputs]
-        if not isinstance(file_outputs, list):
-            return [], []
+    def _extract_telegram_output_refs(
+        self, output: Optional[str]
+    ) -> tuple[str, list[TelegramImageRef], list[TelegramFileRef]]:
+        """Extract only local attachments explicitly referenced in the final answer."""
+        if not output:
+            return "", [], []
 
-        image_refs: list[TelegramImageRef] = []
-        file_refs: list[TelegramFileRef] = []
-        for item in file_outputs:
-            if not isinstance(item, dict):
-                continue
-            raw_file_id = item.get("file_id")
-            file_id = str(raw_file_id).strip() if raw_file_id is not None else ""
-            if not file_id:
-                continue
-
-            label = self._file_output_label(item)
-            if self._file_output_is_image(item, label):
-                image_refs.append(TelegramImageRef(file_id=file_id, alt_text=label))
-            else:
-                file_refs.append(TelegramFileRef(file_id=file_id, label=label))
-
-        return image_refs, file_refs
-
-    def _file_output_label(self, file_output: dict[str, Any]) -> str:
-        for key in ("filename", "name", "relative_path", "path", "file_path"):
-            raw_value = file_output.get(key)
-            if isinstance(raw_value, str) and raw_value.strip():
-                label = Path(raw_value).name.strip()
-                if label:
-                    return label
-        return "file"
-
-    def _file_output_is_image(self, file_output: dict[str, Any], label: str) -> bool:
-        raw_mime_type = file_output.get("mime_type") or file_output.get("type")
-        mime_type = str(raw_mime_type or "").lower()
-        if mime_type.startswith("image/"):
-            return True
-
-        extension = str(file_output.get("extension") or Path(label).suffix).lower()
-        return extension in {
-            ".apng",
-            ".bmp",
-            ".gif",
-            ".heic",
-            ".heif",
-            ".jpeg",
-            ".jpg",
-            ".png",
-            ".tif",
-            ".tiff",
-            ".webp",
-        }
+        output, image_refs = strip_telegram_image_refs(output)
+        output, file_refs = strip_telegram_file_refs(output)
+        image_refs, file_refs = self._dedupe_telegram_output_refs(
+            image_refs,
+            file_refs,
+        )
+        return output, image_refs, file_refs
 
     def _dedupe_telegram_output_refs(
         self,

--- a/tests/web/test_telegram_image_output.py
+++ b/tests/web/test_telegram_image_output.py
@@ -131,25 +131,20 @@ async def test_send_output_files_uploads_documents(tmp_path) -> None:
     assert reply.documents[0][1] == "report.csv"
 
 
-def test_telegram_refs_from_file_outputs_classifies_structured_outputs() -> None:
+def test_extract_telegram_output_refs_uses_final_answer_links_only() -> None:
     bot = object.__new__(TelegramBotInstance)
 
-    image_refs, file_refs = bot._telegram_refs_from_file_outputs(
-        [
-            {
-                "file_id": "image-1",
-                "filename": "plot.png",
-                "mime_type": "image/png",
-            },
-            {
-                "file_id": "file-1",
-                "filename": "report.csv",
-                "mime_type": "text/csv",
-            },
-            {"file_id": "", "filename": "ignored.txt"},
-        ]
+    assert bot._extract_telegram_output_refs(None) == ("", [], [])
+    assert bot._extract_telegram_output_refs("") == ("", [], [])
+
+    cleaned, image_refs, file_refs = bot._extract_telegram_output_refs(
+        "Final files:\n"
+        "- [report.csv](file:file-1)\n"
+        "- [draft.csv](https://example.com/draft.csv)\n"
+        "![plot.png](file:image-1)"
     )
 
+    assert cleaned == "Final files:\n- [draft.csv](https://example.com/draft.csv)"
     assert [(ref.file_id, ref.alt_text) for ref in image_refs] == [
         ("image-1", "plot.png")
     ]


### PR DESCRIPTION
## Summary
- stop sending every structured `file_outputs` entry as Telegram attachments
- send only local image/file refs explicitly present in the final visible answer
- update Telegram output tests for final-answer-only attachment extraction

## Tests
- `ruff check src/xagent/web/channels/telegram/bot.py tests/web/test_telegram_image_output.py`
- `PYTHONPATH=src pytest tests/web/test_telegram_message_queue.py tests/web/test_telegram_image_output.py -q`
- pre-commit hooks during commit