### PR TITLE
fix: preserve KB embedding model identity

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_kb_service.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_kb_service.py
@@ -1,6 +1,10 @@
 import logging
 
 from ...core.RAG_tools.core.schemas import IngestionConfig
+from ...core.RAG_tools.management.ingestion_prepare import (
+    PreparedKnowledgeBaseIngestion,
+    prepare_kb_ingestion,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -12,38 +16,42 @@ class AgentKnowledgeBaseError(RuntimeError):
 class AgentKnowledgeBaseService:
     """Shared collection setup/refresh flow for agent-triggered KB creation."""
 
-    def __init__(self, user_id: int, is_admin: bool = False) -> None:
+    def __init__(
+        self,
+        user_id: int,
+        is_admin: bool = False,
+        default_embedding_model_id: str | None = None,
+    ) -> None:
         self.user_id = user_id
         self.is_admin = is_admin
+        self.default_embedding_model_id = default_embedding_model_id
 
     async def prepare_collection(
         self,
         collection_name: str,
         ingestion_config: IngestionConfig,
-    ) -> str:
+    ) -> PreparedKnowledgeBaseIngestion:
         from .....web.config import sanitize_path_component
-        from ...core.RAG_tools.storage.factory import get_metadata_store
 
         safe_collection = sanitize_path_component(collection_name, "collection")
-        metadata_store = get_metadata_store()
 
         try:
-            await metadata_store.save_collection_config(
-                collection=safe_collection,
-                config_json=ingestion_config.model_dump_json(exclude_unset=True),
+            return await prepare_kb_ingestion(
+                collection_name=safe_collection,
+                ingestion_config=ingestion_config,
                 user_id=self.user_id,
+                is_admin=self.is_admin,
+                fallback_embedding_model_id=self.default_embedding_model_id,
             )
         except Exception as exc:
             logger.error(
-                "Failed to save collection config for agent knowledge base %s: %s",
+                "Failed to prepare agent knowledge base %s: %s",
                 safe_collection,
                 exc,
             )
             raise AgentKnowledgeBaseError(
-                f"Failed to save collection config for knowledge base '{safe_collection}'"
+                f"Failed to prepare knowledge base '{safe_collection}'"
             ) from exc
-
-        return safe_collection
 
     async def refresh_collection_metadata(self, collection_name: str) -> None:
         from ...core.RAG_tools.management.collections import list_collections

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -37,10 +37,16 @@ class CreateKnowledgeBaseFromFileTool(AbstractBaseTool):
 
     category = ToolCategory.KNOWLEDGE
 
-    def __init__(self, user_id: int, is_admin: bool = False) -> None:
+    def __init__(
+        self,
+        user_id: int,
+        is_admin: bool = False,
+        default_embedding_model_id: Optional[str] = None,
+    ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.user_id = user_id
         self.is_admin = is_admin
+        self.default_embedding_model_id = default_embedding_model_id
 
     @property
     def name(self) -> str:
@@ -74,10 +80,7 @@ class CreateKnowledgeBaseFromFileTool(AbstractBaseTool):
                 DurableStorageOperationError,
                 ensure_uploaded_file_local_path,
             )
-            from ...core.RAG_tools.core.schemas import (
-                DEFAULT_EMBEDDING_MODEL_ID,
-                IngestionConfig,
-            )
+            from ...core.RAG_tools.core.schemas import IngestionConfig
             from ...core.RAG_tools.pipelines.document_ingestion import (
                 run_document_ingestion,
             )
@@ -114,15 +117,18 @@ class CreateKnowledgeBaseFromFileTool(AbstractBaseTool):
                     )[:30]
                     collection_name = f"{base_name}_{int(time.time())}"
 
-                config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+                config = IngestionConfig()
                 kb_service = AgentKnowledgeBaseService(
                     user_id=self.user_id,
                     is_admin=self.is_admin,
+                    default_embedding_model_id=self.default_embedding_model_id,
                 )
-                collection_name = await kb_service.prepare_collection(
+                prepared = await kb_service.prepare_collection(
                     collection_name=collection_name,
                     ingestion_config=config,
                 )
+                collection_name = prepared.collection_name
+                config = prepared.ingestion_config
 
                 ingested_count = 0
                 errors = []
@@ -214,6 +220,7 @@ async def create_file_ingestion_tools(config: WebToolConfig) -> list[AbstractBas
         tool = CreateKnowledgeBaseFromFileTool(
             user_id=user_id,
             is_admin=is_admin,
+            default_embedding_model_id=config.get_embedding_model(),
         )
         logger.debug("Created CreateKnowledgeBaseFromFileTool for user %s", user_id)
         return [tool]

--- a/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
@@ -37,10 +37,12 @@ class CreateKnowledgeBaseFromUrlTool(AbstractBaseTool):
         self,
         user_id: int,
         is_admin: bool = False,
+        default_embedding_model_id: Optional[str] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.user_id = user_id
         self.is_admin = is_admin
+        self.default_embedding_model_id = default_embedding_model_id
 
     @property
     def name(self) -> str:
@@ -68,11 +70,7 @@ class CreateKnowledgeBaseFromUrlTool(AbstractBaseTool):
         try:
             import time
 
-            from ...core.RAG_tools.core.schemas import (
-                DEFAULT_EMBEDDING_MODEL_ID,
-                IngestionConfig,
-                WebCrawlConfig,
-            )
+            from ...core.RAG_tools.core.schemas import IngestionConfig, WebCrawlConfig
             from ...core.RAG_tools.pipelines.web_ingestion import run_web_ingestion
             from .agent_kb_service import AgentKnowledgeBaseService
 
@@ -99,17 +97,18 @@ class CreateKnowledgeBaseFromUrlTool(AbstractBaseTool):
                 max_depth=2,
             )
 
-            ingest_config = IngestionConfig(
-                embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID
-            )
+            ingest_config = IngestionConfig()
             kb_service = AgentKnowledgeBaseService(
                 user_id=self.user_id,
                 is_admin=self.is_admin,
+                default_embedding_model_id=self.default_embedding_model_id,
             )
-            collection_name = await kb_service.prepare_collection(
+            prepared = await kb_service.prepare_collection(
                 collection_name=collection_name,
                 ingestion_config=ingest_config,
             )
+            collection_name = prepared.collection_name
+            ingest_config = prepared.ingestion_config
 
             logger.info(
                 f"Starting background web ingestion for {tool_args.url} into {collection_name}"
@@ -175,6 +174,7 @@ async def create_web_ingestion_tools(config: WebToolConfig) -> list[AbstractBase
         tool = CreateKnowledgeBaseFromUrlTool(
             user_id=user_id,
             is_admin=is_admin,
+            default_embedding_model_id=config.get_embedding_model(),
         )
         logger.debug(f"Created CreateKnowledgeBaseFromUrlTool for user {user_id}")
         return [tool]

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -158,6 +158,35 @@ def _get_collection_lock(collection_name: str) -> asyncio.Lock:
         return _collection_locks[lock_key]
 
 
+def embedding_model_ids_equivalent(
+    left_model_id: Optional[str], right_model_id: Optional[str]
+) -> bool:
+    """Return whether two model identifiers resolve to the same embedding model."""
+    if not left_model_id or not right_model_id:
+        return False
+
+    left = left_model_id.strip()
+    right = right_model_id.strip()
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+
+    try:
+        left_config, _ = resolve_embedding_adapter(left)
+        right_config, _ = resolve_embedding_adapter(right)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "Failed to compare embedding model IDs %r and %r: %s",
+            left,
+            right,
+            exc,
+        )
+        return False
+
+    return bool(left_config.id and left_config.id == right_config.id)
+
+
 class CollectionManager:
     """Manager for collection metadata operations with LanceDB storage.
 
@@ -374,12 +403,14 @@ class CollectionManager:
 
             # Check if already initialized
             if collection.is_initialized:
-                if collection.embedding_model_id != embedding_model_id:
+                if not embedding_model_ids_equivalent(
+                    collection.embedding_model_id, embedding_model_id
+                ):
                     raise ValueError(
                         f"Collection '{collection_name}' already initialized with "
                         f"model '{collection.embedding_model_id}'. Cannot change to '{embedding_model_id}'."
                     )
-                # Already initialized with same model, return as-is
+                # Already initialized with the same model identity, return bound config.
                 return collection
 
             # Initialize embedding config

--- a/src/xagent/core/tools/core/RAG_tools/management/ingestion_prepare.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/ingestion_prepare.py
@@ -1,0 +1,135 @@
+"""Shared preparation for knowledge-base ingestion entry points."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from ..core.schemas import DEFAULT_EMBEDDING_MODEL_ID, CollectionInfo, IngestionConfig
+from ..storage.factory import get_metadata_store
+from .collection_manager import collection_manager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedKnowledgeBaseIngestion:
+    """Resolved collection name and config for an ingestion request."""
+
+    collection_name: str
+    ingestion_config: IngestionConfig
+    collection_existed_before: bool
+    should_save_config: bool
+
+
+def _normalize_model_id(model_id: Optional[str]) -> Optional[str]:
+    if not isinstance(model_id, str):
+        return None
+    normalized = model_id.strip()
+    if not normalized or normalized.lower() == "none":
+        return None
+    return normalized
+
+
+def _config_with_embedding_model(
+    config: IngestionConfig, embedding_model_id: str
+) -> IngestionConfig:
+    if config.embedding_model_id == embedding_model_id:
+        return config
+    return config.model_copy(update={"embedding_model_id": embedding_model_id})
+
+
+def _parse_ingestion_config(config_json: Optional[str]) -> Optional[IngestionConfig]:
+    if not config_json:
+        return None
+    try:
+        payload = json.loads(config_json)
+        if not isinstance(payload, dict):
+            return None
+        return IngestionConfig(**payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to parse saved collection ingestion config: %s", exc)
+        return None
+
+
+async def prepare_kb_ingestion(
+    *,
+    collection_name: str,
+    ingestion_config: IngestionConfig,
+    user_id: int,
+    is_admin: bool = False,
+    fallback_embedding_model_id: Optional[str] = None,
+    save_config: bool = True,
+) -> PreparedKnowledgeBaseIngestion:
+    """Resolve the effective ingestion config for a knowledge-base collection.
+
+    The collection's existing binding is the source of truth once initialized.
+    For uninitialized collections, preserve the user's saved or requested model
+    identifier; only fall back to a default when no user choice exists.
+    """
+
+    metadata_store = get_metadata_store()
+
+    collection_info: Optional[CollectionInfo]
+    try:
+        collection_info = await collection_manager.get_collection(collection_name)
+    except ValueError:
+        collection_info = None
+
+    stored_config = _parse_ingestion_config(
+        await metadata_store.get_collection_config(
+            collection=collection_name,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+    )
+
+    bound_model_id = _normalize_model_id(
+        collection_info.embedding_model_id if collection_info is not None else None
+    )
+    stored_model_id = _normalize_model_id(
+        stored_config.embedding_model_id if stored_config is not None else None
+    )
+    requested_model_id = _normalize_model_id(ingestion_config.embedding_model_id)
+    fallback_model_id = _normalize_model_id(fallback_embedding_model_id)
+
+    if (
+        collection_info is not None
+        and collection_info.is_initialized
+        and bound_model_id
+    ):
+        effective_config = _config_with_embedding_model(
+            ingestion_config, bound_model_id
+        )
+        collection_existed_before = True
+        should_save_config = False
+    else:
+        selected_model_id = (
+            stored_model_id
+            or requested_model_id
+            or fallback_model_id
+            or DEFAULT_EMBEDDING_MODEL_ID
+        )
+        effective_config = _config_with_embedding_model(
+            ingestion_config, selected_model_id
+        )
+        collection_existed_before = (
+            collection_info is not None or stored_config is not None
+        )
+        should_save_config = True
+
+    if save_config and should_save_config:
+        await metadata_store.save_collection_config(
+            collection=collection_name,
+            config_json=effective_config.model_dump_json(exclude_unset=True),
+            user_id=user_id,
+        )
+
+    return PreparedKnowledgeBaseIngestion(
+        collection_name=collection_name,
+        ingestion_config=effective_config,
+        collection_existed_before=collection_existed_before,
+        should_save_config=should_save_config,
+    )

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -578,9 +578,12 @@ def process_document(
             selected_model_id,
         )
         if selected_model_id:
-            initialize_collection_embedding_sync(
+            initialized_collection = initialize_collection_embedding_sync(
                 collection_name=collection, embedding_model_id=selected_model_id
             )
+            if initialized_collection.embedding_model_id:
+                selected_model_id = initialized_collection.embedding_model_id
+                cfg = cfg.model_copy(update={"embedding_model_id": selected_model_id})
         else:
             # Even without embedding_model_id, ensure basic metadata exists
             logger.info(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -49,6 +49,7 @@ from ...core.tools.core.RAG_tools.core.parser_registry import (
     validate_parser_compatibility,
 )
 from ...core.tools.core.RAG_tools.core.schemas import (
+    DEFAULT_EMBEDDING_MODEL_ID,
     ChunkStrategy,
     CollectionDocumentMetadata,
     CollectionOperationResult,
@@ -73,6 +74,10 @@ from ...core.tools.core.RAG_tools.management.collections import (
     delete_document,
     list_collections,
     list_documents,
+)
+from ...core.tools.core.RAG_tools.management.ingestion_prepare import (
+    PreparedKnowledgeBaseIngestion,
+    prepare_kb_ingestion,
 )
 from ...core.tools.core.RAG_tools.management.status import clear_ingestion_status
 from ...core.tools.core.RAG_tools.parse.parse_display import (
@@ -328,14 +333,26 @@ def _build_user_actionable_ingestion_message(
     embedding_model_id: Optional[str] = None,
 ) -> str:
     normalized = str(message).strip() or "Unknown ingestion failure"
+    resolved_model_id = (
+        embedding_model_id
+        or _extract_embedding_model_id_from_error(normalized)
+        or DEFAULT_EMBEDDING_MODEL_ID
+    )
     if "How to fix:" in normalized:
+        if (
+            _is_embedding_configuration_error(normalized)
+            and resolved_model_id
+            and "Current embedding_model_id:" not in normalized
+        ):
+            return normalized.replace(
+                " How to fix:",
+                f" Current embedding_model_id: '{resolved_model_id}'. How to fix:",
+                1,
+            )
         return normalized
     if not _is_embedding_configuration_error(normalized):
         return normalized
 
-    resolved_model_id = embedding_model_id or _extract_embedding_model_id_from_error(
-        normalized
-    )
     current_model_hint = (
         f" Current embedding_model_id: '{resolved_model_id}'."
         if resolved_model_id
@@ -1104,6 +1121,77 @@ def with_kb_user_scope(func: T) -> T:
 kb_router = APIRouter(prefix="/api/kb", tags=["kb"])
 
 
+def _get_user_default_embedding_model_id(user: User, db: Session) -> Optional[str]:
+    from ..models.model import Model as DBModel
+    from ..models.user import UserDefaultModel, UserModel
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        _is_model_visible_to_user,
+    )
+
+    def _extract_model_id(default_model: Any) -> Optional[str]:
+        model = getattr(default_model, "model", None)
+        model_id = getattr(model, "model_id", None)
+        if isinstance(model_id, str) and model_id.strip():
+            return model_id
+        return None
+
+    user_id = int(user.id)
+    embedding_default = (
+        db.query(UserDefaultModel)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == "embedding",
+            DBModel.is_active,
+        )
+        .first()
+    )
+    embedding_default_model_id = _extract_model_id(embedding_default)
+    if (
+        embedding_default
+        and embedding_default_model_id
+        and getattr(embedding_default, "model", None)
+        and _is_model_visible_to_user(db, embedding_default.model.id, user_id)
+    ):
+        return embedding_default_model_id
+
+    admin_embedding_defaults = (
+        db.query(UserDefaultModel)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+        .filter(
+            UserDefaultModel.config_type == "embedding",
+            DBModel.is_active,
+            UserModel.is_shared.is_(True),
+            UserDefaultModel.user_id.in_(_get_visible_user_ids(db, user_id)),
+        )
+        .limit(1)
+        .all()
+    )
+    if isinstance(admin_embedding_defaults, list) and admin_embedding_defaults:
+        return _extract_model_id(admin_embedding_defaults[0])
+
+    return None
+
+
+async def _prepare_user_kb_ingestion(
+    *,
+    collection_name: str,
+    ingestion_config: IngestionConfig,
+    user: User,
+    db: Session,
+) -> PreparedKnowledgeBaseIngestion:
+    return await prepare_kb_ingestion(
+        collection_name=collection_name,
+        ingestion_config=ingestion_config,
+        user_id=int(user.id),
+        is_admin=bool(user.is_admin),
+        fallback_embedding_model_id=_get_user_default_embedding_model_id(user, db),
+        save_config=False,
+    )
+
+
 class CloudFile(BaseModel):
     provider: str
     fileId: str
@@ -1118,7 +1206,7 @@ class CloudIngestRequest(BaseModel):
     chunk_size: Optional[int] = None
     chunk_overlap: Optional[int] = None
     separators: Optional[List[str]] = None
-    embedding_model_id: str = "text-embedding-v4"
+    embedding_model_id: Optional[str] = None
     embedding_batch_size: Optional[int] = None
     max_retries: Optional[int] = None
     retry_delay: Optional[float] = None
@@ -1382,9 +1470,9 @@ async def ingest(
             "Omit or empty to use default separators."
         ),
     ),
-    embedding_model_id: str = Form(
-        "text-embedding-v4",
-        description="Embedding model ID (default: text-embedding-v4)",
+    embedding_model_id: Optional[str] = Form(
+        None,
+        description="Embedding model ID. Omit to use the user's default.",
     ),
     embedding_batch_size: Optional[int] = Form(
         None,
@@ -1587,15 +1675,25 @@ async def ingest(
 
     progress_manager = get_progress_manager()
 
-    try:
-        from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
+    prepared_ingestion = await _prepare_user_kb_ingestion(
+        collection_name=safe_collection,
+        ingestion_config=config,
+        user=_user,
+        db=db,
+    )
+    config = prepared_ingestion.ingestion_config
+    collection_existed_before = (
+        collection_existed_before or prepared_ingestion.collection_existed_before
+    )
 
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
+    try:
+        if prepared_ingestion.should_save_config:
+            metadata_store = get_metadata_store()
+            await metadata_store.save_collection_config(
+                collection=safe_collection,
+                config_json=config.model_dump_json(exclude_unset=True),
+                user_id=int(_user.id),
+            )
     except Exception as e:
         logger.warning("Failed to save collection config during ingest: %s", e)
 
@@ -1624,7 +1722,7 @@ async def ingest(
         result: IngestionResult = await loop.run_in_executor(None, _run_ingestion)
         result = _with_user_actionable_ingestion_message(
             result,
-            embedding_model_id=embedding_model_id,
+            embedding_model_id=config.embedding_model_id,
         )
 
         if result.status in {"error", "partial"}:
@@ -1639,7 +1737,7 @@ async def ingest(
                 uploaded_file_existed_before=uploaded_file_existed_before,
                 file_backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
-                embedding_model_id=embedding_model_id,
+                embedding_model_id=config.embedding_model_id,
             )
 
         if result.status == "error":
@@ -1690,7 +1788,7 @@ async def ingest(
                 uploaded_file_existed_before=uploaded_file_existed_before,
                 file_backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
-                embedding_model_id=embedding_model_id,
+                embedding_model_id=config.embedding_model_id,
             )
         elif not collection_existed_before:
             _restore_ingest_file_backup(
@@ -1726,6 +1824,8 @@ async def ingest_cloud(
             status_code=422, detail=f"Invalid collection name: {str(e)}"
         ) from e
 
+    await _ensure_collection_access(safe_collection, _user, allow_create=True)
+
     results = []
 
     # Common configuration setup
@@ -1760,17 +1860,25 @@ async def ingest_cloud(
     except ValueError:
         collection_existed_before = False
 
-    await _ensure_collection_access(safe_collection, _user, allow_create=True)
+    prepared_ingestion = await _prepare_user_kb_ingestion(
+        collection_name=safe_collection,
+        ingestion_config=config,
+        user=_user,
+        db=db,
+    )
+    config = prepared_ingestion.ingestion_config
+    collection_existed_before = (
+        collection_existed_before or prepared_ingestion.collection_existed_before
+    )
 
     try:
-        from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
+        if prepared_ingestion.should_save_config:
+            metadata_store = get_metadata_store()
+            await metadata_store.save_collection_config(
+                collection=safe_collection,
+                config_json=config.model_dump_json(exclude_unset=True),
+                user_id=int(_user.id),
+            )
     except Exception as e:
         logger.warning("Failed to save collection config during ingest_cloud: %s", e)
 
@@ -1905,7 +2013,7 @@ async def ingest_cloud(
                         )
                         result = _with_user_actionable_ingestion_message(
                             result,
-                            embedding_model_id=request.embedding_model_id,
+                            embedding_model_id=file_config.embedding_model_id,
                         )
                         if result.status in {"error", "partial"}:
                             await _rollback_failed_cloud_ingestion(
@@ -1919,7 +2027,7 @@ async def ingest_cloud(
                                 uploaded_file_existed_before=uploaded_file_existed_before,
                                 file_backup_path=file_backup_path,
                                 had_existing_file=had_existing_file,
-                                embedding_model_id=request.embedding_model_id,
+                                embedding_model_id=file_config.embedding_model_id,
                             )
                         elif file_backup_path is not None:
                             try:
@@ -1950,7 +2058,7 @@ async def ingest_cloud(
                             uploaded_file_existed_before=uploaded_file_existed_before,
                             file_backup_path=file_backup_path,
                             had_existing_file=had_existing_file,
-                            embedding_model_id=request.embedding_model_id,
+                            embedding_model_id=config.embedding_model_id,
                         )
                         return IngestionResult(
                             status="error",
@@ -2493,9 +2601,9 @@ async def ingest_web(
             "only used when chunk_strategy is recursive."
         ),
     ),
-    embedding_model_id: str = Form(
-        "text-embedding-v4",
-        description="Embedding model ID",
+    embedding_model_id: Optional[str] = Form(
+        None,
+        description="Embedding model ID. Omit to use the user's default.",
     ),
     embedding_batch_size: Optional[int] = Form(
         None,
@@ -2649,15 +2757,25 @@ async def ingest_web(
         except ValueError:
             collection_existed_before = False
 
-        try:
-            from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
+        prepared_ingestion = await _prepare_user_kb_ingestion(
+            collection_name=safe_collection,
+            ingestion_config=ingestion_config,
+            user=_user,
+            db=db,
+        )
+        ingestion_config = prepared_ingestion.ingestion_config
+        collection_existed_before = (
+            collection_existed_before or prepared_ingestion.collection_existed_before
+        )
 
-            metadata_store = get_metadata_store()
-            await metadata_store.save_collection_config(
-                collection=safe_collection,
-                config_json=ingestion_config.model_dump_json(exclude_unset=True),
-                user_id=int(_user.id),
-            )
+        try:
+            if prepared_ingestion.should_save_config:
+                metadata_store = get_metadata_store()
+                await metadata_store.save_collection_config(
+                    collection=safe_collection,
+                    config_json=ingestion_config.model_dump_json(exclude_unset=True),
+                    user_id=int(_user.id),
+                )
         except Exception as e:
             logger.warning("Failed to save collection config during ingest_web: %s", e)
 
@@ -2870,7 +2988,9 @@ async def ingest_web(
         )
         web_updated_message = _build_user_actionable_ingestion_message(
             result.message,
-            embedding_model_id=embedding_model_id,
+            embedding_model_id=(
+                ingestion_config.embedding_model_id or DEFAULT_EMBEDDING_MODEL_ID
+            ),
         )
         if web_updated_message != result.message:
             result = result.model_copy(update={"message": web_updated_message})

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1,4 +1,3 @@
-import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -21,31 +20,37 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     IngestionResult,
     WebIngestionResult,
 )
+from xagent.core.tools.core.RAG_tools.management.ingestion_prepare import (
+    PreparedKnowledgeBaseIngestion,
+)
 
 
 @pytest.mark.asyncio
 async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes():
-    metadata_store = MagicMock()
-    metadata_store.save_collection_config = AsyncMock()
     service = AgentKnowledgeBaseService(user_id=71, is_admin=False)
     ingest_config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+    prepared = PreparedKnowledgeBaseIngestion(
+        collection_name="agent url kb",
+        ingestion_config=ingest_config,
+        collection_existed_before=False,
+        should_save_config=True,
+    )
+    prepare_kb_ingestion = AsyncMock(return_value=prepared)
 
     with patch(
-        "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
-        return_value=metadata_store,
+        "xagent.core.tools.adapters.vibe.agent_kb_service.prepare_kb_ingestion",
+        new=prepare_kb_ingestion,
     ):
-        collection_name = await service.prepare_collection(
-            "  agent url kb  ", ingest_config
-        )
+        result = await service.prepare_collection("  agent url kb  ", ingest_config)
 
-    assert collection_name == "agent url kb"
-    metadata_store.save_collection_config.assert_awaited_once()
-    _, save_kwargs = metadata_store.save_collection_config.await_args
-    assert save_kwargs["collection"] == "agent url kb"
-    assert save_kwargs["user_id"] == 71
-    assert json.loads(save_kwargs["config_json"]) == {
-        "embedding_model_id": DEFAULT_EMBEDDING_MODEL_ID
-    }
+    assert result == prepared
+    prepare_kb_ingestion.assert_awaited_once_with(
+        collection_name="agent url kb",
+        ingestion_config=ingest_config,
+        user_id=71,
+        is_admin=False,
+        fallback_embedding_model_id=None,
+    )
 
 
 @pytest.mark.asyncio
@@ -82,20 +87,16 @@ async def test_agent_kb_service_refresh_collection_metadata_skips_non_admin_refr
 
 @pytest.mark.asyncio
 async def test_agent_kb_service_prepare_collection_raises_on_config_save_failure():
-    metadata_store = MagicMock()
-    metadata_store.save_collection_config = AsyncMock(
-        side_effect=RuntimeError("config save failed")
-    )
     service = AgentKnowledgeBaseService(user_id=71, is_admin=False)
     ingest_config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
 
     with (
         patch(
-            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
-            return_value=metadata_store,
+            "xagent.core.tools.adapters.vibe.agent_kb_service.prepare_kb_ingestion",
+            new=AsyncMock(side_effect=RuntimeError("config save failed")),
         ),
         pytest.raises(
-            AgentKnowledgeBaseError, match="Failed to save collection config"
+            AgentKnowledgeBaseError, match="Failed to prepare knowledge base"
         ),
     ):
         await service.prepare_collection("agent kb", ingest_config)
@@ -138,8 +139,14 @@ async def test_create_kb_from_url_uses_shared_service(monkeypatch):
         warnings=[],
         elapsed_time_ms=123,
     )
+    prepared = PreparedKnowledgeBaseIngestion(
+        collection_name="agent_url_kb",
+        ingestion_config=IngestionConfig(embedding_model_id="bound-model"),
+        collection_existed_before=True,
+        should_save_config=False,
+    )
     service = MagicMock()
-    service.prepare_collection = AsyncMock(return_value="agent_url_kb")
+    service.prepare_collection = AsyncMock(return_value=prepared)
     service.refresh_collection_metadata = AsyncMock()
     run_web_ingestion_mock = AsyncMock(return_value=ingest_result)
 
@@ -162,13 +169,10 @@ async def test_create_kb_from_url_uses_shared_service(monkeypatch):
     service.prepare_collection.assert_awaited_once()
     _, prepare_kwargs = service.prepare_collection.await_args
     assert prepare_kwargs["collection_name"] == "agent_url_kb"
-    assert (
-        prepare_kwargs["ingestion_config"].embedding_model_id
-        == DEFAULT_EMBEDDING_MODEL_ID
-    )
     service.refresh_collection_metadata.assert_awaited_once_with("agent_url_kb")
     run_web_ingestion_mock.assert_awaited_once()
     _, run_kwargs = run_web_ingestion_mock.await_args
+    assert run_kwargs["ingestion_config"].embedding_model_id == "bound-model"
     assert run_kwargs["crawl_config"].tls_impersonate == "auto"
 
 
@@ -250,8 +254,14 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
         warnings=[],
         file_id="file-1",
     )
+    prepared = PreparedKnowledgeBaseIngestion(
+        collection_name="agent_file_kb",
+        ingestion_config=IngestionConfig(embedding_model_id="bound-model"),
+        collection_existed_before=True,
+        should_save_config=False,
+    )
     service = MagicMock()
-    service.prepare_collection = AsyncMock(return_value="agent_file_kb")
+    service.prepare_collection = AsyncMock(return_value=prepared)
     service.refresh_collection_metadata = AsyncMock()
 
     with (
@@ -274,10 +284,6 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
     service.prepare_collection.assert_awaited_once()
     _, prepare_kwargs = service.prepare_collection.await_args
     assert prepare_kwargs["collection_name"] == "agent_file_kb"
-    assert (
-        prepare_kwargs["ingestion_config"].embedding_model_id
-        == DEFAULT_EMBEDDING_MODEL_ID
-    )
     service.refresh_collection_metadata.assert_awaited_once_with("agent_file_kb")
     db.close.assert_called_once()
 
@@ -318,8 +324,14 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
         warnings=[],
         file_id="file-1",
     )
+    prepared = PreparedKnowledgeBaseIngestion(
+        collection_name="agent_file_kb",
+        ingestion_config=IngestionConfig(embedding_model_id="bound-model"),
+        collection_existed_before=True,
+        should_save_config=False,
+    )
     service = MagicMock()
-    service.prepare_collection = AsyncMock(return_value="agent_file_kb")
+    service.prepare_collection = AsyncMock(return_value=prepared)
     service.refresh_collection_metadata = AsyncMock()
     run_ingestion = Mock(return_value=ingest_result)
 
@@ -347,6 +359,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
     ensure_local.assert_called_once_with(file_record)
     _, ingestion_kwargs = run_ingestion.call_args
     assert ingestion_kwargs["source_path"] == str(restored_source)
+    assert ingestion_kwargs["ingestion_config"].embedding_model_id == "bound-model"
     db.close.assert_called_once()
 
 
@@ -383,8 +396,14 @@ async def test_create_kb_from_file_returns_error_when_metadata_refresh_fails(tmp
         warnings=[],
         file_id="file-1",
     )
+    prepared = PreparedKnowledgeBaseIngestion(
+        collection_name="agent_file_kb",
+        ingestion_config=IngestionConfig(embedding_model_id="bound-model"),
+        collection_existed_before=True,
+        should_save_config=False,
+    )
     service = MagicMock()
-    service.prepare_collection = AsyncMock(return_value="agent_file_kb")
+    service.prepare_collection = AsyncMock(return_value=prepared)
     service.refresh_collection_metadata = AsyncMock(
         side_effect=AgentKnowledgeBaseError("metadata refresh failed")
     )

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -115,6 +115,61 @@ class TestCollectionManager:
         assert saved.embedding_model_id == "text-embedding-ada-002"
 
     @pytest.mark.asyncio
+    async def test_initialize_collection_embedding_allows_equivalent_model_id(
+        self, manager
+    ):
+        collection_name = "equivalent_model"
+        initial = CollectionInfo(
+            name=collection_name,
+            embedding_model_id="text-embedding-v4-dashscope-1",
+            embedding_dimension=1024,
+        )
+        await manager.save_collection(initial)
+
+        def _resolve(model_id: str):
+            cfg = Mock()
+            cfg.id = "text-embedding-v4-dashscope-1"
+            cfg.dimension = 1024
+            return cfg, Mock()
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_embedding_adapter",
+            side_effect=_resolve,
+        ):
+            result = await manager.initialize_collection_embedding(
+                collection_name, "text-embedding-v4"
+            )
+
+        assert result.embedding_model_id == "text-embedding-v4-dashscope-1"
+
+    @pytest.mark.asyncio
+    async def test_initialize_collection_embedding_rejects_different_model_id(
+        self, manager
+    ):
+        collection_name = "different_model"
+        initial = CollectionInfo(
+            name=collection_name,
+            embedding_model_id="model-a",
+            embedding_dimension=1024,
+        )
+        await manager.save_collection(initial)
+
+        def _resolve(model_id: str):
+            cfg = Mock()
+            cfg.id = model_id
+            cfg.dimension = 1024
+            return cfg, Mock()
+
+        with (
+            patch(
+                "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_embedding_adapter",
+                side_effect=_resolve,
+            ),
+            pytest.raises(ValueError, match="Cannot change to 'model-b'"),
+        ):
+            await manager.initialize_collection_embedding(collection_name, "model-b")
+
+    @pytest.mark.asyncio
     async def test_update_collection_stats_success(self, manager):
         """Test successful collection stats update in real storage."""
         collection_name = "stats_test"

--- a/tests/core/tools/core/RAG_tools/management/test_ingestion_prepare.py
+++ b/tests/core/tools/core/RAG_tools/management/test_ingestion_prepare.py
@@ -1,0 +1,156 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    DEFAULT_EMBEDDING_MODEL_ID,
+    CollectionInfo,
+    IngestionConfig,
+)
+from xagent.core.tools.core.RAG_tools.management.ingestion_prepare import (
+    prepare_kb_ingestion,
+)
+
+
+@pytest.mark.asyncio
+async def test_prepare_uses_initialized_collection_bound_model():
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(
+        return_value=json.dumps({"embedding_model_id": "stored-short"})
+    )
+    metadata_store.save_collection_config = AsyncMock()
+    collection = CollectionInfo(
+        name="faq",
+        embedding_model_id="bound-long",
+        embedding_dimension=1024,
+    )
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.collection_manager.get_collection",
+            new=AsyncMock(return_value=collection),
+        ),
+    ):
+        prepared = await prepare_kb_ingestion(
+            collection_name="faq",
+            ingestion_config=IngestionConfig(embedding_model_id="request-short"),
+            user_id=7,
+            fallback_embedding_model_id="user-default",
+        )
+
+    assert prepared.ingestion_config.embedding_model_id == "bound-long"
+    assert prepared.collection_existed_before is True
+    assert prepared.should_save_config is False
+    metadata_store.save_collection_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_uninitialized_collection_uses_saved_config():
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(
+        return_value=json.dumps({"embedding_model_id": "stored-choice"})
+    )
+    metadata_store.save_collection_config = AsyncMock()
+    collection = CollectionInfo(name="faq")
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.collection_manager.get_collection",
+            new=AsyncMock(return_value=collection),
+        ),
+    ):
+        prepared = await prepare_kb_ingestion(
+            collection_name="faq",
+            ingestion_config=IngestionConfig(embedding_model_id="request-choice"),
+            user_id=7,
+            save_config=False,
+        )
+
+    assert prepared.ingestion_config.embedding_model_id == "stored-choice"
+    assert prepared.collection_existed_before is True
+    assert prepared.should_save_config is True
+    metadata_store.save_collection_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_new_collection_preserves_requested_model_id():
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
+    metadata_store.save_collection_config = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.collection_manager.get_collection",
+            new=AsyncMock(side_effect=ValueError("not found")),
+        ),
+    ):
+        prepared = await prepare_kb_ingestion(
+            collection_name="faq",
+            ingestion_config=IngestionConfig(embedding_model_id="text-embedding-v4"),
+            user_id=7,
+        )
+
+    assert prepared.ingestion_config.embedding_model_id == "text-embedding-v4"
+    metadata_store.save_collection_config.assert_awaited_once()
+    _, kwargs = metadata_store.save_collection_config.await_args
+    assert json.loads(kwargs["config_json"]) == {
+        "embedding_model_id": "text-embedding-v4"
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_new_collection_falls_back_to_user_default_then_system_default():
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
+    metadata_store.save_collection_config = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.collection_manager.get_collection",
+            new=AsyncMock(side_effect=ValueError("not found")),
+        ),
+    ):
+        prepared = await prepare_kb_ingestion(
+            collection_name="faq",
+            ingestion_config=IngestionConfig(),
+            user_id=7,
+            fallback_embedding_model_id="user-default",
+        )
+
+    assert prepared.ingestion_config.embedding_model_id == "user-default"
+
+    metadata_store.save_collection_config.reset_mock()
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.management.ingestion_prepare.collection_manager.get_collection",
+            new=AsyncMock(side_effect=ValueError("not found")),
+        ),
+    ):
+        prepared = await prepare_kb_ingestion(
+            collection_name="faq",
+            ingestion_config=IngestionConfig(),
+            user_id=7,
+        )
+
+    assert prepared.ingestion_config.embedding_model_id == DEFAULT_EMBEDDING_MODEL_ID

--- a/tests/e2e/test_file_api_minio.py
+++ b/tests/e2e/test_file_api_minio.py
@@ -24,7 +24,13 @@ from tests.e2e.minio_harness import MinioStorage, run_minio_storage
 from xagent.core.tools.adapters.vibe.file_ingestion_tool import (
     CreateKnowledgeBaseFromFileTool,
 )
-from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    IngestionConfig,
+    IngestionResult,
+)
+from xagent.core.tools.core.RAG_tools.management.ingestion_prepare import (
+    PreparedKnowledgeBaseIngestion,
+)
 from xagent.core.workspace import TaskWorkspace
 from xagent.web.models.task import Task
 from xagent.web.models.uploaded_file import UploadedFile
@@ -436,12 +442,17 @@ async def test_create_kb_from_file_tool_restores_durable_only_upload_from_minio(
         return ingest_result
 
     service = AsyncMock()
-    service.prepare_collection.return_value = "agent_file_kb"
+    service.prepare_collection.return_value = PreparedKnowledgeBaseIngestion(
+        collection_name="agent_file_kb",
+        ingestion_config=IngestionConfig(embedding_model_id="bound-model"),
+        collection_existed_before=True,
+        should_save_config=False,
+    )
     service.refresh_collection_metadata.return_value = None
 
     monkeypatch.setattr(
         "xagent.core.tools.adapters.vibe.agent_kb_service.AgentKnowledgeBaseService",
-        lambda user_id, is_admin: service,
+        lambda user_id, is_admin, default_embedding_model_id=None: service,
     )
     monkeypatch.setattr(
         "xagent.core.tools.core.RAG_tools.pipelines.document_ingestion.run_document_ingestion",

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2258,6 +2258,10 @@ def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(
             new_callable=AsyncMock,
             side_effect=HTTPException(status_code=403, detail="Forbidden"),
         ),
+        patch(
+            "xagent.web.api.kb._prepare_user_kb_ingestion",
+            new_callable=AsyncMock,
+        ) as prepare_ingestion,
     ):
         response = client.post(
             "/api/kb/ingest-cloud",
@@ -2275,6 +2279,7 @@ def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(
         )
 
     assert response.status_code == 403
+    prepare_ingestion.assert_not_awaited()
     metadata_store.save_collection_config.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
- Add shared KB ingestion preparation so file, cloud, web, and agent ingestion resolve embedding model selection consistently.
- Preserve the embedding model already bound in collection metadata when appending to initialized knowledge bases.
- Compare embedding model identity through the model resolver so equivalent short and canonical hub IDs do not trigger false model-change errors.
- Keep new knowledge bases aligned with user choice, user defaults, or the system fallback without forcing short IDs to canonical IDs.

## Root Cause
Existing ingestion entry points could pass or persist the default short embedding model ID when appending to a collection that had already been initialized with a canonical hub model ID. The collection manager compared raw strings, so equivalent model identifiers were treated as an attempted model switch.

## Validation
- `uv run pytest tests/core/tools/core/RAG_tools/management/test_ingestion_prepare.py tests/core/tools/core/RAG_tools/management/test_collection_manager.py tests/core/tools/adapters/vibe/test_kb_creation_tools.py tests/web/api/test_kb_dir.py tests/web/api/test_kb_ingest_separators.py`
- `uv run pytest tests/web/api/test_kb_dir.py tests/web/api/test_kb_ingest_separators.py tests/core/tools/core/RAG_tools/management/test_ingestion_prepare.py`
- `uv run pytest tests/web_integration/test_kb_file_ingestion_e2e.py tests/web_integration/test_kb_web_ingestion_e2e.py`
- `uv run ruff check src/xagent/web/api/kb.py`
- Commit hooks: ruff check, ruff format, mypy, isort, codespell

## Notes
The Docker/MinIO special E2E was attempted locally with `--run-special`, but it failed while seeding the MinIO object with an S3 read timeout before reaching the KB ingestion path.