### PR TITLE
fix: extend web ingestion proxy timeout

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,6 +21,21 @@ server {
         alias /root/.xagent/uploads/;
     }
 
+    location = /api/kb/ingest-web {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_connect_timeout 75s;
+    }
+
     # Proxy to backend API
     location /api/ {
         proxy_pass http://backend;


### PR DESCRIPTION
## Summary
- add a dedicated nginx location for /api/kb/ingest-web
- extend read/send timeouts for website ingestion without changing the default /api/ timeout

## Context
Website ingestion can run longer than the generic API proxy timeout while the backend continues processing. The dedicated location keeps the longer timeout scoped to this endpoint.

## Verification
- git diff --check
- pre-commit hooks during commit