### PR TITLE
fix: resolve embedding model id before `initialize_collection_embedding`

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -40,6 +40,46 @@ def reset_locks_for_testing() -> None:
         _collection_locks.clear()
 
 
+def _normalize_model_id(model_id: Optional[str]) -> Optional[str]:
+    if not isinstance(model_id, str):
+        return None
+    normalized = model_id.strip()
+    if not normalized or normalized.lower() == "none":
+        return None
+    return normalized
+
+
+def _model_dimension(model_config: Any) -> Optional[int]:
+    dimension = getattr(model_config, "dimension", None)
+    return dimension if isinstance(dimension, int) else None
+
+
+def _embedding_model_ids_equivalent(
+    existing_model_id: str, requested_model_id: str
+) -> tuple[bool, Optional[str], Optional[int]]:
+    """Return whether two IDs resolve to the same embedding model.
+
+    The model hub supports loading by both model_id and model_name, so this lets
+    legacy name/alias bindings migrate to the canonical hub ID without treating
+    the operation as a model switch.
+    """
+    existing_config, _ = resolve_embedding_adapter(existing_model_id)
+    requested_config, _ = resolve_embedding_adapter(requested_model_id)
+
+    existing_canonical_id = _normalize_model_id(getattr(existing_config, "id", None))
+    requested_canonical_id = _normalize_model_id(getattr(requested_config, "id", None))
+    dimension = _model_dimension(requested_config)
+    if dimension is None:
+        dimension = _model_dimension(existing_config)
+
+    return (
+        existing_canonical_id is not None
+        and existing_canonical_id == requested_canonical_id,
+        requested_canonical_id,
+        dimension,
+    )
+
+
 def _run_in_separate_loop(coro: Awaitable[T]) -> T:
     """Safely run an async coroutine synchronously, even if an event loop is already running.
 
@@ -374,7 +414,49 @@ class CollectionManager:
 
             # Check if already initialized
             if collection.is_initialized:
-                if collection.embedding_model_id != embedding_model_id:
+                existing_model_id = _normalize_model_id(collection.embedding_model_id)
+                requested_model_id = _normalize_model_id(embedding_model_id)
+                if existing_model_id != requested_model_id:
+                    equivalent = False
+                    canonical_model_id: Optional[str] = None
+                    canonical_dimension: Optional[int] = None
+                    if existing_model_id and requested_model_id:
+                        try:
+                            (
+                                equivalent,
+                                canonical_model_id,
+                                canonical_dimension,
+                            ) = _embedding_model_ids_equivalent(
+                                existing_model_id, requested_model_id
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "Failed to compare embedding model IDs for collection '%s': %s",
+                                collection_name,
+                                exc,
+                            )
+
+                    if equivalent and canonical_model_id:
+                        updated_collection = collection.model_copy(
+                            update={
+                                "embedding_model_id": canonical_model_id,
+                                "embedding_dimension": canonical_dimension
+                                if canonical_dimension is not None
+                                else collection.embedding_dimension,
+                                "updated_at": datetime.now(timezone.utc).replace(
+                                    tzinfo=None
+                                ),
+                            }
+                        )
+                        await self._save_collection_with_retry(updated_collection)
+                        logger.info(
+                            "Migrated collection '%s' embedding model from '%s' to canonical ID '%s'",
+                            collection_name,
+                            existing_model_id,
+                            canonical_model_id,
+                        )
+                        return updated_collection
+
                     raise ValueError(
                         f"Collection '{collection_name}' already initialized with "
                         f"model '{collection.embedding_model_id}'. Cannot change to '{embedding_model_id}'."
@@ -384,11 +466,15 @@ class CollectionManager:
 
             # Initialize embedding config
             embedding_config, _ = resolve_embedding_adapter(embedding_model_id)
+            canonical_model_id = (
+                _normalize_model_id(getattr(embedding_config, "id", None))
+                or embedding_model_id
+            )
 
             # Update collection
             updated_collection = collection.model_copy(
                 update={
-                    "embedding_model_id": embedding_model_id,
+                    "embedding_model_id": canonical_model_id,
                     "embedding_dimension": embedding_config.dimension,
                     "updated_at": datetime.now(timezone.utc).replace(tzinfo=None),
                 }
@@ -400,7 +486,7 @@ class CollectionManager:
             logger.info(
                 "Initialized collection '%s' with embedding model '%s'",
                 collection_name,
-                embedding_model_id,
+                canonical_model_id,
             )
             logger.debug("[COLLECTION_INIT] Releasing lock for '%s'", collection_name)
             return updated_collection
@@ -674,14 +760,6 @@ def resolve_effective_embedding_model_sync(
     Raises:
         ValueError: If model cannot be resolved or collection not found.
     """
-
-    def _normalize_model_id(model_id: Optional[str]) -> Optional[str]:
-        if not isinstance(model_id, str):
-            return None
-        normalized = model_id.strip()
-        if not normalized or normalized.lower() == "none":
-            return None
-        return normalized
 
     # Treat empty/whitespace-only IDs and the tool-layer "none" placeholder as missing.
     config_model_id = _normalize_model_id(config_model_id)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -596,14 +596,12 @@ def process_document(
             provider or "unknown",
         )
         resolve_elapsed = int((time.time() - resolve_start) * 1000)
-        completed_steps.append(
-            IngestionStepResult(
-                name="resolve_embedding_adapter",
-                metadata={
-                    "model_id": selected_model_id,
-                    "elapsed_ms": resolve_elapsed,
-                },
-            )
+        resolve_step = IngestionStepResult(
+            name="resolve_embedding_adapter",
+            metadata={
+                "model_id": selected_model_id,
+                "elapsed_ms": resolve_elapsed,
+            },
         )
 
         # Step 0: Initialize collection embedding config if needed.
@@ -638,6 +636,8 @@ def process_document(
                 # Metadata doesn't exist, create basic entry
                 update_collection_stats_sync(collection_name=collection)
                 logger.info("Created basic metadata for collection '%s'", collection)
+
+        completed_steps.append(resolve_step)
 
         init_elapsed = int((time.time() - init_start) * 1000)
         completed_steps.append(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -41,6 +41,7 @@ from ..core.schemas import (
 from ..file.register_document import register_document
 from ..management.collection_manager import (
     initialize_collection_embedding_sync,
+    resolve_effective_embedding_model_sync,
     update_collection_stats_sync,
     validate_document_processing_sync,
 )
@@ -202,7 +203,9 @@ def run_document_ingestion(
         collection: Target collection where the document should be ingested.
         source_path: Filesystem path to the document to ingest.
         ingestion_config: Optional configuration overrides or mapping supplied
-            by external callers.
+            by external callers. ``embedding_model_id`` may be a model-hub ID,
+            a legacy model name/alias, or omitted; ingestion resolves it to the
+            canonical model-hub ID before collection initialization.
         progress_manager: Optional progress manager for tracking.
         user_id: Optional user ID for ownership tracking.
         is_admin: Optional admin override; when omitted, falls back to request scope.
@@ -549,19 +552,12 @@ def process_document(
     chunk_count = 0
     embedding_count = 0
     vector_count = 0
-    current_step = "initialize_collection"
+    current_step = "resolve_embedding_adapter"
     embedding_config: Optional[EmbeddingModelConfig] = None
     embedding_adapter: Optional[BaseEmbedding] = None
     selected_model_id: Optional[str] = None
 
     try:
-        # Step 0: Initialize/validate collection embedding configuration
-        logger.info(
-            "Step initialize_collection started",
-            extra={"collection": collection, "source_path": source_path},
-        )
-        init_start = time.time()
-
         # Validate document processing config against collection settings
         validate_document_processing_sync(
             collection_name=collection,
@@ -570,8 +566,54 @@ def process_document(
             chunking_method=str(cfg.chunk_method),
         )
 
-        # Initialize collection embedding config if needed
-        selected_model_id = cfg.embedding_model_id
+        logger.info(
+            "Step resolve_embedding_adapter started",
+            extra={"collection": collection, "source_path": source_path},
+        )
+        resolve_start = time.time()
+
+        # Resolve the effective embedding model before collection initialization.
+        # This keeps caller aliases such as "text-embedding-v4" from conflicting
+        # with collection metadata stored under the canonical model-hub ID.
+        requested_model_id = cfg.embedding_model_id
+        try:
+            selected_model_id = resolve_effective_embedding_model_sync(
+                collection, requested_model_id
+            )
+        except ValueError:
+            selected_model_id = requested_model_id
+
+        effective_cfg = cfg.model_copy(update={"embedding_model_id": selected_model_id})
+        embedding_config, embedding_adapter = _resolve_embedding_adapter(effective_cfg)
+        selected_model_id = (embedding_config.id or selected_model_id or "").strip()
+        cfg = effective_cfg.model_copy(update={"embedding_model_id": selected_model_id})
+
+        provider = getattr(embedding_config, "model_provider", None)
+        logger.info(
+            "Using embedding model: id=%s, name=%s, provider=%s",
+            selected_model_id,
+            embedding_config.model_name,
+            provider or "unknown",
+        )
+        resolve_elapsed = int((time.time() - resolve_start) * 1000)
+        completed_steps.append(
+            IngestionStepResult(
+                name="resolve_embedding_adapter",
+                metadata={
+                    "model_id": selected_model_id,
+                    "elapsed_ms": resolve_elapsed,
+                },
+            )
+        )
+
+        # Step 0: Initialize collection embedding config if needed.
+        current_step = "initialize_collection"
+        logger.info(
+            "Step initialize_collection started",
+            extra={"collection": collection, "source_path": source_path},
+        )
+        init_start = time.time()
+
         logger.info(
             "Collection initialization: collection='%s', embedding_model_id='%s'",
             collection,
@@ -614,33 +656,6 @@ def process_document(
                 "embedding_model_id": selected_model_id,
                 "elapsed_ms": init_elapsed,
             },
-        )
-
-        current_step = "resolve_embedding_adapter"
-        # Step 0: Resolve embedding adapter
-        # Note: Parameters passed to _resolve_embedding_adapter have priority over environment variables
-        resolve_start = time.time()
-        embedding_config, embedding_adapter = _resolve_embedding_adapter(cfg)
-        selected_model_id = (
-            cfg.embedding_model_id or embedding_config.id or ""
-        ).strip()
-
-        provider = getattr(embedding_config, "model_provider", None)
-        logger.info(
-            "Using embedding model: id=%s, name=%s, provider=%s",
-            selected_model_id,
-            embedding_config.model_name,
-            provider or "unknown",
-        )
-        resolve_elapsed = int((time.time() - resolve_start) * 1000)
-        completed_steps.append(
-            IngestionStepResult(
-                name="resolve_embedding_adapter",
-                metadata={
-                    "model_id": selected_model_id,
-                    "elapsed_ms": resolve_elapsed,
-                },
-            )
         )
 
         # Step 1: Register document

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -115,6 +115,78 @@ class TestCollectionManager:
         assert saved.embedding_model_id == "text-embedding-ada-002"
 
     @pytest.mark.asyncio
+    async def test_initialize_collection_embedding_migrates_alias_to_canonical(
+        self, manager
+    ):
+        """Existing alias bindings should migrate when they match the canonical ID."""
+        collection_name = "alias_migration_test"
+        alias_model_id = "text-embedding-v4"
+        canonical_model_id = "text-embedding-v4-dashscope-1-37c6d7dd"
+        initial = CollectionInfo(
+            name=collection_name,
+            embedding_model_id=alias_model_id,
+            embedding_dimension=2,
+        )
+        await manager.save_collection(initial)
+
+        def _resolve_embedding(model_id: str):
+            mock_config = Mock()
+            mock_config.id = canonical_model_id
+            mock_config.dimension = 2
+            mock_config.model_name = alias_model_id
+            return mock_config, Mock()
+
+        mock_resolve = Mock(side_effect=_resolve_embedding)
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_embedding_adapter",
+            mock_resolve,
+        ):
+            result = await manager.initialize_collection_embedding(
+                collection_name, canonical_model_id
+            )
+
+        assert result.embedding_model_id == canonical_model_id
+        assert result.embedding_dimension == 2
+        saved = await manager.get_collection(collection_name)
+        assert saved.embedding_model_id == canonical_model_id
+        assert [call.args[0] for call in mock_resolve.call_args_list] == [
+            alias_model_id,
+            canonical_model_id,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_initialize_collection_embedding_rejects_different_model(
+        self, manager
+    ):
+        """Non-equivalent model changes should still be rejected."""
+        collection_name = "model_change_test"
+        initial = CollectionInfo(
+            name=collection_name,
+            embedding_model_id="embedding-old",
+            embedding_dimension=2,
+        )
+        await manager.save_collection(initial)
+
+        def _resolve_embedding(model_id: str):
+            mock_config = Mock()
+            mock_config.id = f"{model_id}-canonical"
+            mock_config.dimension = 2
+            return mock_config, Mock()
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.management.collection_manager.resolve_embedding_adapter",
+            Mock(side_effect=_resolve_embedding),
+        ):
+            with pytest.raises(ValueError, match="Cannot change to 'embedding-new'"):
+                await manager.initialize_collection_embedding(
+                    collection_name, "embedding-new"
+                )
+
+        saved = await manager.get_collection(collection_name)
+        assert saved.embedding_model_id == "embedding-old"
+
+    @pytest.mark.asyncio
     async def test_update_collection_stats_success(self, manager):
         """Test successful collection stats update in real storage."""
         collection_name = "stats_test"

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -394,6 +394,55 @@ def test_process_document_reuses_existing_collection_embedding_model_before_init
     assert initialized_model_ids == [canonical_model_id]
 
 
+def test_process_document_init_failure_after_resolve_is_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight model resolution should not make init failures partial."""
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    canonical_model_id = "text-embedding-v4-dashscope-1-37c6d7dd"
+    stub_config = EmbeddingModelConfig(
+        id=canonical_model_id,
+        model_name="text-embedding-v4",
+        model_provider="dashscope",
+        dimension=2,
+    )
+    stub_adapter = _StubEmbeddingAdapter()
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "resolve_effective_embedding_model_sync",
+        lambda _collection, _model_id=None: canonical_model_id,
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "_resolve_embedding_adapter",
+        lambda _cfg: (stub_config, stub_adapter),
+    )
+
+    def _raise_init_error(*, collection_name: str, embedding_model_id: str) -> None:
+        raise ValueError("collection already initialized with another model")
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "initialize_collection_embedding_sync",
+        _raise_init_error,
+    )
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/tmp/doc.pdf",
+        config=IngestionConfig(embedding_model_id="text-embedding-v4"),
+    )
+
+    assert result.status == "error"
+    assert result.failed_step == "initialize_collection"
+    assert result.completed_steps == []
+    assert result.doc_id is None
+    assert STATUS_EVENTS == []
+
+
 def test_process_document_applies_spreadsheet_safeguards(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py
@@ -15,6 +15,7 @@ from xagent.core.tools.core.RAG_tools.core.exceptions import (
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     ChunkForEmbedding,
     ChunkStrategy,
+    CollectionInfo,
     DocumentProcessingStatus,
     EmbeddingReadResponse,
     EmbeddingWriteResponse,
@@ -261,6 +262,136 @@ def test_process_document_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.status == "success"
     assert result.embedding_count == 2
     assert result.vector_count == 2
+
+
+def test_process_document_initializes_with_canonical_embedding_model_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Alias/default embedding IDs are canonicalized before collection init."""
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    canonical_model_id = "text-embedding-v4-dashscope-1-37c6d7dd"
+    initialized_model_ids: List[str] = []
+
+    stub_config = EmbeddingModelConfig(
+        id=canonical_model_id,
+        model_name="text-embedding-v4",
+        model_provider="dashscope",
+        dimension=2,
+    )
+    stub_adapter = _StubEmbeddingAdapter()
+
+    def _resolve_effective_embedding_model_sync(
+        collection_name: str, config_model_id: str | None = None
+    ) -> str:
+        raise ValueError("collection not found")
+
+    def _resolve_adapter(
+        config: IngestionConfig,
+    ) -> tuple[EmbeddingModelConfig, BaseEmbedding]:
+        assert config.embedding_model_id == "text-embedding-v4"
+        return stub_config, stub_adapter
+
+    def _initialize_collection_embedding_sync(
+        *, collection_name: str, embedding_model_id: str
+    ) -> CollectionInfo:
+        initialized_model_ids.append(embedding_model_id)
+        return CollectionInfo(
+            name=collection_name,
+            embedding_model_id=embedding_model_id,
+            embedding_dimension=2,
+        )
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "resolve_effective_embedding_model_sync",
+        _resolve_effective_embedding_model_sync,
+    )
+    monkeypatch.setattr(
+        document_ingestion, "_resolve_embedding_adapter", _resolve_adapter
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "initialize_collection_embedding_sync",
+        _initialize_collection_embedding_sync,
+    )
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/tmp/doc.pdf",
+        config=IngestionConfig(embedding_model_id="text-embedding-v4"),
+    )
+
+    assert result.status == "success"
+    assert initialized_model_ids == [canonical_model_id]
+    assert result.completed_steps[0].metadata["model_id"] == canonical_model_id
+
+
+def test_process_document_reuses_existing_collection_embedding_model_before_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing collection model wins over a caller-provided alias."""
+
+    _patch_pipeline_dependencies(monkeypatch)
+
+    canonical_model_id = "text-embedding-v4-dashscope-1-37c6d7dd"
+    initialized_model_ids: List[str] = []
+    resolved_config_model_ids: List[str | None] = []
+
+    stub_config = EmbeddingModelConfig(
+        id=canonical_model_id,
+        model_name="text-embedding-v4",
+        model_provider="dashscope",
+        dimension=2,
+    )
+    stub_adapter = _StubEmbeddingAdapter()
+
+    def _resolve_effective_embedding_model_sync(
+        collection_name: str, config_model_id: str | None = None
+    ) -> str:
+        resolved_config_model_ids.append(config_model_id)
+        return canonical_model_id
+
+    def _resolve_adapter(
+        config: IngestionConfig,
+    ) -> tuple[EmbeddingModelConfig, BaseEmbedding]:
+        assert config.embedding_model_id == canonical_model_id
+        return stub_config, stub_adapter
+
+    def _initialize_collection_embedding_sync(
+        *, collection_name: str, embedding_model_id: str
+    ) -> CollectionInfo:
+        initialized_model_ids.append(embedding_model_id)
+        return CollectionInfo(
+            name=collection_name,
+            embedding_model_id=embedding_model_id,
+            embedding_dimension=2,
+        )
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "resolve_effective_embedding_model_sync",
+        _resolve_effective_embedding_model_sync,
+    )
+    monkeypatch.setattr(
+        document_ingestion, "_resolve_embedding_adapter", _resolve_adapter
+    )
+    monkeypatch.setattr(
+        document_ingestion,
+        "initialize_collection_embedding_sync",
+        _initialize_collection_embedding_sync,
+    )
+
+    result = document_ingestion.process_document(
+        collection="demo",
+        source_path="/tmp/doc.pdf",
+        config=IngestionConfig(embedding_model_id="text-embedding-v4"),
+    )
+
+    assert result.status == "success"
+    assert resolved_config_model_ids == ["text-embedding-v4"]
+    assert initialized_model_ids == [canonical_model_id]
 
 
 def test_process_document_applies_spreadsheet_safeguards(
@@ -607,7 +738,7 @@ def test_process_document_partial_on_write_failure(
 def test_process_document_failed_before_register(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Initialization errors should surface with failed_step='initialize'."""
+    """Adapter resolution errors before registration should surface as errors."""
 
     # Mock validate_document_processing_sync to pass validation
     from unittest.mock import AsyncMock
@@ -633,10 +764,8 @@ def test_process_document_failed_before_register(
         config=IngestionConfig(parse_method="deepdoc"),
     )
 
-    assert result.status == "partial"
-    # Failure can occur in initialize_collection (if resolve_embedding_adapter fails there)
-    # or in resolve_embedding_adapter step
-    assert result.failed_step in ("initialize_collection", "resolve_embedding_adapter")
+    assert result.status == "error"
+    assert result.failed_step == "resolve_embedding_adapter"
     assert "adapter missing" in result.message
     assert STATUS_EVENTS == []
 


### PR DESCRIPTION
## Summary

  - Resolve the effective embedding model ID before initializing collection metadata during document ingestion.
  - Canonicalize caller-provided aliases/defaults, such as `text-embedding-v4`, to the model-hub ID returned by the embedding adapter.
  - Reuse an existing collection’s bound embedding model before initialization to avoid alias/canonical ID conflicts.
  - Add regression coverage for canonical model initialization and existing-collection model reuse.

## Why

  Ingestion could initialize a collection with the caller-provided embedding ID before resolving the actual model-hub ID. That allowed aliases like `text-embedding-v4` to conflict with canonical IDs such as
  provider-specific DashScope model IDs on later ingestion/search paths.
