### PR TITLE
fix(mcp): handle MCP array arguments correctly in dynamic tool validation

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -193,25 +193,110 @@ class MCPToolAdapter(AbstractBaseTool):
         return MCPToolResult
 
     def _json_schema_to_python_type(self, schema: Dict[str, Any]) -> Type:
-        """Convert JSON schema type to Python type."""
-        schema_type = schema.get("type", "string")
+        """Convert JSON schema type to a Python type for Pydantic model creation."""
+        if not isinstance(schema, dict):
+            return Any
 
-        # Handle list types (e.g. ["string", "null"])
+        for union_key in ("anyOf", "oneOf"):
+            options = schema.get(union_key)
+            if isinstance(options, list) and options:
+                non_null_options = [
+                    option for option in options if not self._is_null_schema(option)
+                ]
+                if len(non_null_options) == 1:
+                    return self._json_schema_to_python_type(non_null_options[0])
+                for option in non_null_options:
+                    if self._schema_accepts_array(option):
+                        return self._json_schema_to_python_type(option)
+                for option in non_null_options:
+                    resolved_type = self._json_schema_to_python_type(option)
+                    if resolved_type is not Any:
+                        return resolved_type
+                return Any
+
+        all_of = schema.get("allOf")
+        if isinstance(all_of, list) and all_of:
+            for option in all_of:
+                resolved_type = self._json_schema_to_python_type(option)
+                if resolved_type is not Any:
+                    return resolved_type
+
+        schema_type = schema.get("type")
         if isinstance(schema_type, list):
-            # Pick the first non-null type
-            types = [t for t in schema_type if t != "null"]
-            schema_type = types[0] if types else "string"
+            concrete_types = [item for item in schema_type if item != "null"]
+            if "array" in concrete_types:
+                schema_type = "array"
+            elif concrete_types:
+                schema_type = concrete_types[0]
+            else:
+                return Any
 
-        type_mapping = {
-            "string": str,
-            "integer": int,
-            "number": float,
-            "boolean": bool,
-            "array": List[Any],
-            "object": Dict[str, Any],
-        }
+        if schema_type == "array":
+            return list
+        if schema_type == "object":
+            return Dict[str, Any]
+        if schema_type == "string":
+            return str
+        if schema_type == "integer":
+            return int
+        if schema_type == "number":
+            return float
+        if schema_type == "boolean":
+            return bool
+        return Any
 
-        return type_mapping.get(schema_type, Any)
+    def _is_null_schema(self, schema: Any) -> bool:
+        """Return True when the schema represents a JSON null type."""
+        if not isinstance(schema, dict):
+            return False
+        schema_type = schema.get("type")
+        if schema_type == "null":
+            return True
+        if isinstance(schema_type, list):
+            return all(item == "null" for item in schema_type)
+        return False
+
+    def _normalize_args_by_schema(self, args: Mapping[str, Any]) -> Dict[str, Any]:
+        """Normalize common LLM argument shape mistakes using the MCP input schema."""
+        normalized_args = dict(args)
+        schema = self.mcp_tool.inputSchema
+        if not isinstance(schema, dict):
+            return normalized_args
+
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            return normalized_args
+
+        for field_name, field_schema in properties.items():
+            if field_name not in normalized_args:
+                continue
+            value = normalized_args[field_name]
+            if value is None:
+                continue
+            if self._schema_accepts_array(field_schema) and not isinstance(value, list):
+                normalized_args[field_name] = [value]
+
+        return normalized_args
+
+    def _schema_accepts_array(self, schema: Any) -> bool:
+        """Return True when a JSON schema allows array input."""
+        if not isinstance(schema, dict):
+            return False
+
+        schema_type = schema.get("type")
+        if schema_type == "array":
+            return True
+        if isinstance(schema_type, list) and "array" in schema_type:
+            return True
+
+        for composite_key in ("anyOf", "oneOf", "allOf"):
+            variants = schema.get(composite_key)
+            if isinstance(variants, list) and any(
+                self._schema_accepts_array(variant) for variant in variants
+            ):
+                return True
+
+        return False
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Execute MCP tool asynchronously with user validation and context."""
@@ -229,7 +314,8 @@ class MCPToolAdapter(AbstractBaseTool):
                 }
 
             # Validate arguments
-            parsed_args = self._args_type(**args)
+            normalized_args = self._normalize_args_by_schema(args)
+            parsed_args = self._args_type(**normalized_args)
             tool_args = parsed_args.model_dump(exclude_none=True)
 
             logger.debug(

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -284,7 +284,7 @@ class MCPToolAdapter(AbstractBaseTool):
             value = normalized_args[field_name]
             if value is None:
                 continue
-            if self._schema_accepts_array(field_schema) and not isinstance(value, list):
+            if self._schema_is_array_only(field_schema) and not isinstance(value, list):
                 normalized_args[field_name] = [value]
 
         return normalized_args
@@ -306,6 +306,32 @@ class MCPToolAdapter(AbstractBaseTool):
                 self._schema_accepts_array(variant) for variant in variants
             ):
                 return True
+
+        return False
+
+    def _schema_is_array_only(self, schema: Any) -> bool:
+        """Return True when array is the only accepted non-null JSON shape."""
+        if not isinstance(schema, dict):
+            return False
+
+        schema_type = schema.get("type")
+        if schema_type == "array":
+            return True
+        if isinstance(schema_type, list):
+            concrete_types = [item for item in schema_type if item != "null"]
+            return bool(concrete_types) and all(
+                concrete_type == "array" for concrete_type in concrete_types
+            )
+
+        for union_key in ("anyOf", "oneOf"):
+            options = schema.get(union_key)
+            if isinstance(options, list) and options:
+                non_null_options = [
+                    option for option in options if not self._is_null_schema(option)
+                ]
+                return bool(non_null_options) and all(
+                    self._schema_is_array_only(option) for option in non_null_options
+                )
 
         return False
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -7,7 +7,7 @@ enabling MCP tools to be used in DAG plan-execute patterns and other agent workf
 import asyncio
 import logging
 import os
-from typing import Any, Dict, List, Mapping, Optional, Type
+from typing import Any, Dict, List, Mapping, Optional, Type, Union, cast
 
 from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, Field, create_model
@@ -205,14 +205,12 @@ class MCPToolAdapter(AbstractBaseTool):
                 ]
                 if len(non_null_options) == 1:
                     return self._json_schema_to_python_type(non_null_options[0])
-                for option in non_null_options:
-                    if self._schema_accepts_array(option):
-                        return self._json_schema_to_python_type(option)
+                resolved_types: list[Type[Any]] = []
                 for option in non_null_options:
                     resolved_type = self._json_schema_to_python_type(option)
-                    if resolved_type is not Any:
-                        return resolved_type
-                return Any
+                    if resolved_type is not Any and resolved_type not in resolved_types:
+                        resolved_types.append(resolved_type)
+                return self._build_union_type(resolved_types)
 
         all_of = schema.get("allOf")
         if isinstance(all_of, list) and all_of:
@@ -224,12 +222,17 @@ class MCPToolAdapter(AbstractBaseTool):
         schema_type = schema.get("type")
         if isinstance(schema_type, list):
             concrete_types = [item for item in schema_type if item != "null"]
-            if "array" in concrete_types:
-                schema_type = "array"
-            elif concrete_types:
-                schema_type = concrete_types[0]
-            else:
-                return Any
+            concrete_resolved_types: list[Type[Any]] = []
+            for concrete_type in concrete_types:
+                resolved_type = self._json_schema_to_python_type(
+                    {"type": concrete_type}
+                )
+                if (
+                    resolved_type is not Any
+                    and resolved_type not in concrete_resolved_types
+                ):
+                    concrete_resolved_types.append(resolved_type)
+            return self._build_union_type(concrete_resolved_types)
 
         if schema_type == "array":
             return list
@@ -244,6 +247,14 @@ class MCPToolAdapter(AbstractBaseTool):
         if schema_type == "boolean":
             return bool
         return Any
+
+    def _build_union_type(self, resolved_types: list[Type[Any]]) -> Type[Any]:
+        """Build a runtime union for multiple candidate schema types."""
+        if not resolved_types:
+            return Any
+        if len(resolved_types) == 1:
+            return resolved_types[0]
+        return cast(Type[Any], Union.__getitem__(tuple(resolved_types)))
 
     def _is_null_schema(self, schema: Any) -> bool:
         """Return True when the schema represents a JSON null type."""

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,40 +1,6 @@
-import sys
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 
-mcp_module = ModuleType("mcp")
-mcp_module.ClientSession = object
-mcp_module.StdioServerParameters = object
-mcp_types_module = ModuleType("mcp.types")
-mcp_types_module.Tool = object
-mcp_client_module = ModuleType("mcp.client")
-mcp_client_sse_module = ModuleType("mcp.client.sse")
-mcp_client_sse_module.sse_client = object
-mcp_client_stdio_module = ModuleType("mcp.client.stdio")
-mcp_client_stdio_module.stdio_client = object
-mcp_client_streamable_http_module = ModuleType("mcp.client.streamable_http")
-mcp_client_streamable_http_module.streamablehttp_client = object
-mcp_shared_module = ModuleType("mcp.shared")
-mcp_shared_httpx_utils_module = ModuleType("mcp.shared._httpx_utils")
-mcp_shared_httpx_utils_module.create_mcp_http_client = object
-sandbox_helper_module = ModuleType(
-    "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper"
-)
-sandbox_helper_module.load_sandboxed_mcp_tools = object
-sandbox_helper_module.should_sandbox_mcp_connection = object
-mcp_module.types = mcp_types_module
-sys.modules.setdefault("mcp", mcp_module)
-sys.modules["mcp.types"] = mcp_types_module
-sys.modules["mcp.client"] = mcp_client_module
-sys.modules["mcp.client.sse"] = mcp_client_sse_module
-sys.modules["mcp.client.stdio"] = mcp_client_stdio_module
-sys.modules["mcp.client.streamable_http"] = mcp_client_streamable_http_module
-sys.modules["mcp.shared"] = mcp_shared_module
-sys.modules["mcp.shared._httpx_utils"] = mcp_shared_httpx_utils_module
-sys.modules[
-    "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper"
-] = sandbox_helper_module
-
-from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter  # noqa: E402
+from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter
 
 
 def test_build_args_model_handles_optional_array_schema():
@@ -67,7 +33,7 @@ def test_build_args_model_handles_optional_array_schema():
     assert parsed.add_label_ids == ["TRASH"]
 
 
-def test_normalize_args_by_schema_wraps_scalar_for_array_field():
+def test_normalize_args_by_schema_wraps_scalar_for_array_only_field():
     mcp_tool = SimpleNamespace(
         name="gmail_manage_labels",
         description="Manage Gmail labels",
@@ -96,6 +62,33 @@ def test_normalize_args_by_schema_wraps_scalar_for_array_field():
     )
 
     assert normalized["add_label_ids"] == ["TRASH"]
+
+
+def test_normalize_args_by_schema_keeps_scalar_for_union_scalar_or_array_field():
+    mcp_tool = SimpleNamespace(
+        name="multi_shape_tool",
+        description="Accept string or string array input",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "string"}},
+                    ]
+                }
+            },
+            "required": ["value"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema({"value": "abc"})
+
+    assert normalized["value"] == "abc"
 
 
 def test_build_args_model_handles_anyof_multi_type_schema():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,0 +1,98 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+mcp_module = ModuleType("mcp")
+mcp_module.ClientSession = object
+mcp_module.StdioServerParameters = object
+mcp_types_module = ModuleType("mcp.types")
+mcp_types_module.Tool = object
+mcp_client_module = ModuleType("mcp.client")
+mcp_client_sse_module = ModuleType("mcp.client.sse")
+mcp_client_sse_module.sse_client = object
+mcp_client_stdio_module = ModuleType("mcp.client.stdio")
+mcp_client_stdio_module.stdio_client = object
+mcp_client_streamable_http_module = ModuleType("mcp.client.streamable_http")
+mcp_client_streamable_http_module.streamablehttp_client = object
+mcp_shared_module = ModuleType("mcp.shared")
+mcp_shared_httpx_utils_module = ModuleType("mcp.shared._httpx_utils")
+mcp_shared_httpx_utils_module.create_mcp_http_client = object
+sandbox_helper_module = ModuleType(
+    "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper"
+)
+sandbox_helper_module.load_sandboxed_mcp_tools = object
+sandbox_helper_module.should_sandbox_mcp_connection = object
+mcp_module.types = mcp_types_module
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules["mcp.types"] = mcp_types_module
+sys.modules["mcp.client"] = mcp_client_module
+sys.modules["mcp.client.sse"] = mcp_client_sse_module
+sys.modules["mcp.client.stdio"] = mcp_client_stdio_module
+sys.modules["mcp.client.streamable_http"] = mcp_client_streamable_http_module
+sys.modules["mcp.shared"] = mcp_shared_module
+sys.modules["mcp.shared._httpx_utils"] = mcp_shared_httpx_utils_module
+sys.modules[
+    "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper"
+] = sandbox_helper_module
+
+from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter  # noqa: E402
+
+
+def test_build_args_model_handles_optional_array_schema():
+    mcp_tool = SimpleNamespace(
+        name="gmail_manage_labels",
+        description="Manage Gmail labels",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "add_label_ids": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                },
+            },
+            "required": ["action"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    args_model = adapter.args_type()
+    parsed = args_model(action="modify_message", add_label_ids=["TRASH"])
+
+    assert parsed.add_label_ids == ["TRASH"]
+
+
+def test_normalize_args_by_schema_wraps_scalar_for_array_field():
+    mcp_tool = SimpleNamespace(
+        name="gmail_manage_labels",
+        description="Manage Gmail labels",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "add_label_ids": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                },
+            },
+            "required": ["action"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema(
+        {"action": "modify_message", "add_label_ids": "TRASH"}
+    )
+
+    assert normalized["add_label_ids"] == ["TRASH"]

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -96,3 +96,52 @@ def test_normalize_args_by_schema_wraps_scalar_for_array_field():
     )
 
     assert normalized["add_label_ids"] == ["TRASH"]
+
+
+def test_build_args_model_handles_anyof_multi_type_schema():
+    mcp_tool = SimpleNamespace(
+        name="multi_type_tool",
+        description="Accept string or integer input",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ]
+                }
+            },
+            "required": ["value"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    args_model = adapter.args_type()
+
+    assert args_model(value="abc").value == "abc"
+    assert args_model(value=123).value == 123
+
+
+def test_build_args_model_handles_multi_value_type_list():
+    mcp_tool = SimpleNamespace(
+        name="multi_value_type_tool",
+        description="Accept string or integer input",
+        inputSchema={
+            "type": "object",
+            "properties": {"value": {"type": ["string", "integer", "null"]}},
+            "required": ["value"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    args_model = adapter.args_type()
+
+    assert args_model(value="abc").value == "abc"
+    assert args_model(value=123).value == 123


### PR DESCRIPTION
## Background
Some MCP tools expose array-shaped inputs in their `inputSchema`, for example
`gmail_manage_labels.add_label_ids` and `remove_label_ids`.

In practice, these fields could be rejected during dynamic Pydantic model creation
with errors like:

- `Input should be a valid string`
- `input_value=['TRASH'], input_type=list`

This happened before the tool execution phase, so the request never reached the
actual MCP tool implementation.

## Root Cause
`MCPToolAdapter` dynamically converts MCP JSON schema into Python/Pydantic field types.

For array schemas, the previous implementation attempted to build a dynamic
generic type from a runtime variable:

- `List[item_type]`

This was fragile for static typing and contributed to incorrect modeling behavior
around optional array fields, especially when combined with `anyOf`/`null` schemas.

As a result, some MCP tool arguments that should accept arrays were effectively
validated as scalar strings.

## Changes
- Update `MCPToolAdapter._json_schema_to_python_type()` to preserve array fields
  as runtime `list` types during dynamic model generation.
- Keep the existing schema-based normalization that wraps scalar values into
  arrays when the MCP schema allows array input.
- Add adapter tests covering:
  - optional array schema handling
  - scalar-to-array normalization for array-compatible fields
- Mark the late import in the adapter test with `# noqa: E402` because the test
  intentionally injects stub modules into `sys.modules` before importing the target.

## Impact
- MCP tools with array inputs now validate correctly in dynamic argument parsing.
- Fixes validation failures for tools such as `mcp_Gmail_gmail_manage_labels`
  when passing values like:
  - `add_label_ids=["TRASH"]`
  - `remove_label_ids=["DRAFT"]`