### PR TITLE
feat(workforce): add user-facing workforce UI

### DIFF
--- a/frontend/src/app/workforces/[id]/builder/page.tsx
+++ b/frontend/src/app/workforces/[id]/builder/page.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import React, { useEffect, useMemo, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { useI18n } from "@/contexts/i18n-context"
+import {
+  applyWorkforceChanges,
+  getWorkforce,
+  getWorkforceBuilderMessages,
+  proposeWorkforceChanges,
+} from "@/lib/workforces-api"
+import type {
+  WorkforceBuilderMessage,
+  WorkforceBuilderPatch,
+  WorkforceDetail,
+  WorkforceRunResponse,
+} from "@/types/workforce"
+import {
+  ProposedPatchCard,
+  WorkforceBuilderChat,
+  WorkforceSummary,
+  WorkforceTestPanel,
+} from "@/components/workforce"
+
+function latestProposedAssistantMessage(
+  messages: WorkforceBuilderMessage[],
+): WorkforceBuilderMessage | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const item = messages[index]
+    if (item.role === "assistant" && item.proposed_patch) {
+      return item
+    }
+  }
+  return null
+}
+
+export default function WorkforceBuilderPage() {
+  const { t } = useI18n()
+  const router = useRouter()
+  const params = useParams()
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [messages, setMessages] = useState<WorkforceBuilderMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [applying, setApplying] = useState(false)
+
+  const activeProposal = useMemo(() => latestProposedAssistantMessage(messages), [messages])
+
+  useEffect(() => {
+    if (!id) return
+
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const [workforceData, historyData] = await Promise.all([
+          getWorkforce(id),
+          getWorkforceBuilderMessages(id),
+        ])
+        setWorkforce(workforceData)
+        setMessages(historyData.items)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("workforces.errors.loadBuilder"))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void load()
+  }, [id, t])
+
+  const handleSubmit = async (message: string) => {
+    if (!id) return
+    try {
+      setSubmitting(true)
+      const result = await proposeWorkforceChanges(id, { message })
+      const history = await getWorkforceBuilderMessages(id)
+      setMessages(history.items)
+      toast.success(result.assistant_message || t("workforces.messages.proposalCreated"))
+    } catch (err) {
+      const nextError = err instanceof Error ? err.message : t("workforces.errors.proposeChanges")
+      toast.error(nextError)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleApply = async (messageId: number, patch: WorkforceBuilderPatch) => {
+    if (!id) return
+    try {
+      setApplying(true)
+      const result = await applyWorkforceChanges(id, {
+        message_id: messageId,
+        proposed_patch: patch,
+      })
+      setWorkforce(result.workforce)
+      const history = await getWorkforceBuilderMessages(id)
+      setMessages(history.items)
+      toast.success(t("workforces.messages.changesApplied"))
+    } catch (err) {
+      const nextError = err instanceof Error ? err.message : t("workforces.errors.applyChanges")
+      toast.error(nextError)
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const handleRunCreated = (result: WorkforceRunResponse) => {
+    router.push(result.redirect_url || `/task/${result.task_id}`)
+  }
+
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.builder")}</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto grid w-full max-w-[1600px] gap-6 p-4 sm:p-8 xl:grid-cols-[0.95fr_1.05fr_0.8fr]">
+        <div className="min-h-[640px]">
+          <WorkforceBuilderChat
+            messages={messages}
+            loading={loading}
+            submitting={submitting}
+            onSubmit={handleSubmit}
+          />
+        </div>
+        <div className="space-y-6">
+          <WorkforceSummary workforce={workforce} />
+          <ProposedPatchCard
+            patch={activeProposal?.proposed_patch ?? null}
+            messageId={activeProposal?.id ?? null}
+            status={activeProposal?.status ?? null}
+            applying={applying}
+            onApply={handleApply}
+          />
+        </div>
+        <div>
+          <WorkforceTestPanel
+            workforceId={workforce.id}
+            disabled={workforce.status !== "active"}
+            onRunCreated={handleRunCreated}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/builder/page.tsx
+++ b/frontend/src/app/workforces/[id]/builder/page.tsx
@@ -22,6 +22,7 @@ import {
   WorkforceSummary,
   WorkforceTestPanel,
 } from "@/components/workforce"
+import { getBuilderReadOnlyReason, getRunDisabledReason } from "../../workforce-ui-state"
 
 function latestProposedAssistantMessage(
   messages: WorkforceBuilderMessage[],
@@ -116,6 +117,9 @@ export default function WorkforceBuilderPage() {
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
   if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
+  const builderReadOnlyReason = getBuilderReadOnlyReason(workforce.status, t)
+  const runDisabledReason = getRunDisabledReason(workforce.status, t)
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto grid w-full max-w-[1600px] gap-6 p-4 sm:p-8 xl:grid-cols-[0.95fr_1.05fr_0.8fr]">
@@ -124,6 +128,8 @@ export default function WorkforceBuilderPage() {
             messages={messages}
             loading={loading}
             submitting={submitting}
+            readOnly={Boolean(builderReadOnlyReason)}
+            readOnlyReason={builderReadOnlyReason || undefined}
             onSubmit={handleSubmit}
           />
         </div>
@@ -134,13 +140,15 @@ export default function WorkforceBuilderPage() {
             messageId={activeProposal?.id ?? null}
             status={activeProposal?.status ?? null}
             applying={applying}
+            readOnly={Boolean(builderReadOnlyReason)}
             onApply={handleApply}
           />
         </div>
         <div>
           <WorkforceTestPanel
             workforceId={workforce.id}
-            disabled={workforce.status !== "active"}
+            disabled={Boolean(runDisabledReason)}
+            disabledReason={runDisabledReason || undefined}
             onRunCreated={handleRunCreated}
           />
         </div>

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -13,6 +13,7 @@ import { WorkforceCanvas } from "@/components/workforce"
 export default function WorkforceCanvasPage() {
   const { t } = useI18n()
   const params = useParams()
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
   const [canvas, setCanvas] = useState<WorkforceCanvasResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -22,7 +23,6 @@ export default function WorkforceCanvasPage() {
       try {
         setLoading(true)
         setError(null)
-        const id = Array.isArray(params.id) ? params.id[0] : params.id
         if (!id) {
           setCanvas(null)
           return
@@ -36,9 +36,8 @@ export default function WorkforceCanvasPage() {
       }
     }
     void load()
-  }, [params.id, t])
+  }, [id, t])
 
-  const id = Array.isArray(params.id) ? params.id[0] : params.id
   const backHref = id ? `/workforces/${id}` : "/workforces"
 
   if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.canvas")}</div>

--- a/frontend/src/app/workforces/[id]/canvas/page.tsx
+++ b/frontend/src/app/workforces/[id]/canvas/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import Link from "next/link"
+import React, { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useI18n } from "@/contexts/i18n-context"
+import { getWorkforceCanvas } from "@/lib/workforces-api"
+import type { WorkforceCanvasResponse } from "@/types/workforce"
+import { WorkforceCanvas } from "@/components/workforce"
+
+export default function WorkforceCanvasPage() {
+  const { t } = useI18n()
+  const params = useParams()
+  const [canvas, setCanvas] = useState<WorkforceCanvasResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const id = Array.isArray(params.id) ? params.id[0] : params.id
+        if (!id) {
+          setCanvas(null)
+          return
+        }
+        const data = await getWorkforceCanvas(id)
+        setCanvas(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("workforces.errors.loadCanvas"))
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [params.id, t])
+
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const backHref = id ? `/workforces/${id}` : "/workforces"
+
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.canvas")}</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!canvas) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.canvasUnavailable")}</div>
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-4 sm:p-8">
+        <div>
+          <Link href={backHref}>
+            <Button variant="outline" size="sm">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t("workforces.canvas.backToDetails")}
+            </Button>
+          </Link>
+        </div>
+        <WorkforceCanvas canvas={canvas} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -258,6 +258,10 @@ export default function WorkforceDetailPage() {
             }
           : current,
       )
+      setWorkerEdits((current) => ({
+        ...current,
+        [updated.id]: workerEditState(updated),
+      }))
       setMessage(t("workforces.messages.workerUpdated"))
     } catch (err) {
       setError(err instanceof Error ? err.message : t("workforces.errors.updateWorker"))

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -1,0 +1,547 @@
+"use client"
+
+import Link from "next/link"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import { useParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useI18n } from "@/contexts/i18n-context"
+import {
+  addWorkforceAgent,
+  archiveWorkforce,
+  getWorkforce,
+  listAgentOptions,
+  publishWorkforce,
+  removeWorkforceAgent,
+  unpublishWorkforce,
+  updateWorkforce,
+  updateWorkforceAgent,
+} from "@/lib/workforces-api"
+import type {
+  WorkforceAgentOption,
+  WorkforceDetail,
+  WorkforceWorker,
+} from "@/types/workforce"
+import { WorkforceSummary } from "@/components/workforce"
+import { canEditAgent } from "@/lib/agent-ui-access"
+
+interface WorkerEditState {
+  alias: string
+  assignment_instructions: string
+  enabled: boolean
+  sort_order: number
+}
+
+function workerEditState(worker: WorkforceWorker): WorkerEditState {
+  return {
+    alias: worker.alias || "",
+    assignment_instructions: worker.assignment_instructions,
+    enabled: worker.enabled,
+    sort_order: worker.sort_order ?? 1,
+  }
+}
+
+function buildWorkerEditState(workers: WorkforceWorker[]): Record<number, WorkerEditState> {
+  return workers.reduce<Record<number, WorkerEditState>>((accumulator, worker) => {
+    accumulator[worker.id] = workerEditState(worker)
+    return accumulator
+  }, {})
+}
+
+export default function WorkforceDetailPage() {
+  const { t } = useI18n()
+  const params = useParams()
+  const id = Array.isArray(params.id) ? params.id[0] : params.id
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [agents, setAgents] = useState<WorkforceAgentOption[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [managerAgentId, setManagerAgentId] = useState("")
+  const [managerInstructions, setManagerInstructions] = useState("")
+  const [workerEdits, setWorkerEdits] = useState<Record<number, WorkerEditState>>({})
+  const [newWorkerAgentId, setNewWorkerAgentId] = useState("")
+  const [newWorkerAlias, setNewWorkerAlias] = useState("")
+  const [newWorkerInstructions, setNewWorkerInstructions] = useState("")
+
+  const publishedAgents = useMemo(
+    () => agents.filter((agent) => agent.status === "published"),
+    [agents],
+  )
+  const isArchived = workforce?.status === "archived"
+
+  const syncForm = useCallback((nextWorkforce: WorkforceDetail) => {
+    setName(nextWorkforce.name)
+    setDescription(nextWorkforce.description || "")
+    setManagerAgentId(String(nextWorkforce.manager.id))
+    setManagerInstructions(nextWorkforce.manager_instructions || "")
+    setWorkerEdits(buildWorkerEditState(nextWorkforce.workers))
+  }, [])
+
+  const load = useCallback(async () => {
+    if (!id) return
+    try {
+      setLoading(true)
+      setError(null)
+      const [workforceData, agentData] = await Promise.all([
+        getWorkforce(id),
+        listAgentOptions(),
+      ])
+      setWorkforce(workforceData)
+      setAgents(agentData)
+      syncForm(workforceData)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.load"))
+    } finally {
+      setLoading(false)
+    }
+  }, [id, syncForm, t])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const managerOptions = publishedAgents
+    .filter((agent) => !workforce?.workers.some((worker) => worker.agent.id === agent.id))
+    .map((agent) => ({
+      value: String(agent.id),
+      label: agent.name,
+      description: agent.description || undefined,
+    }))
+
+  const workerOptions = publishedAgents
+    .filter(
+      (agent) =>
+        String(agent.id) !== managerAgentId &&
+        !workforce?.workers.some((worker) => worker.agent.id === agent.id),
+    )
+    .map((agent) => ({
+      value: String(agent.id),
+      label: agent.name,
+      description: agent.description || undefined,
+    }))
+
+  const saveWorkforce = async () => {
+    if (!id || !name.trim() || !managerAgentId) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await updateWorkforce(id, {
+        name: name.trim(),
+        description: description.trim() || null,
+        manager_agent_id: Number(managerAgentId),
+        manager_instructions: managerInstructions.trim() || null,
+      })
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.updated"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.update"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const addWorker = async () => {
+    if (!id || !newWorkerAgentId || !newWorkerInstructions.trim()) return
+    try {
+      setSaving(true)
+      setError(null)
+      await addWorkforceAgent(id, {
+        source_type: "existing",
+        agent_id: Number(newWorkerAgentId),
+        alias: newWorkerAlias.trim() || undefined,
+        assignment_instructions: newWorkerInstructions.trim(),
+        enabled: true,
+        sort_order: (workforce?.workers.length || 0) + 1,
+      })
+      setNewWorkerAgentId("")
+      setNewWorkerAlias("")
+      setNewWorkerInstructions("")
+      await load()
+      setMessage(t("workforces.messages.workerAdded"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.addWorker"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveWorker = async (worker: WorkforceWorker) => {
+    if (!id) return
+    const edit = workerEdits[worker.id]
+    if (!edit || !edit.assignment_instructions.trim()) return
+    try {
+      setSaving(true)
+      setError(null)
+      const updated = await updateWorkforceAgent(id, worker.id, {
+        alias: edit.alias.trim() || null,
+        assignment_instructions: edit.assignment_instructions.trim(),
+        enabled: edit.enabled,
+        sort_order: edit.sort_order,
+      })
+      setWorkforce((current) =>
+        current
+          ? {
+              ...current,
+              workers: current.workers.map((item) =>
+                item.id === updated.id ? updated : item,
+              ),
+            }
+          : current,
+      )
+      setMessage(t("workforces.messages.workerUpdated"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.updateWorker"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const removeWorker = async (workerId: number) => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      await removeWorkforceAgent(id, workerId)
+      await load()
+      setMessage(t("workforces.messages.workerRemoved"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.removeWorker"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const publishCurrentWorkforce = async () => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await publishWorkforce(id)
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.published"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.publish"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const unpublishCurrentWorkforce = async () => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      const next = await unpublishWorkforce(id)
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.unpublished"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.unpublish"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const archiveCurrentWorkforce = async () => {
+    if (!id) return
+    try {
+      setSaving(true)
+      setError(null)
+      await archiveWorkforce(id)
+      const next = await getWorkforce(id)
+      setWorkforce(next)
+      syncForm(next)
+      setMessage(t("workforces.messages.archived"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.archive"))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.detail")}</div>
+  if (error && !workforce) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">{workforce.name}</h1>
+          <p className="mt-2 text-muted-foreground">
+            {t("workforces.detail.description")}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          {workforce.status === "draft" ? (
+            <Button onClick={() => void publishCurrentWorkforce()} disabled={saving}>
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.publish")}
+            </Button>
+          ) : null}
+          {workforce.status === "active" ? (
+            <Button
+              variant="outline"
+              onClick={() => void unpublishCurrentWorkforce()}
+              disabled={saving}
+            >
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.unpublish")}
+            </Button>
+          ) : null}
+          <Link href={`/workforces/${workforce.id}/builder`}>
+            <Button variant="outline">{t("workforces.actions.builder")}</Button>
+          </Link>
+          <Link href={`/workforces/${workforce.id}/canvas`}>
+            <Button variant="outline">{t("workforces.actions.canvas")}</Button>
+          </Link>
+          <Link href={`/workforces/${workforce.id}/run`}>
+            <Button>{t("workforces.actions.runWorkforce")}</Button>
+          </Link>
+          {!isArchived ? (
+            <Button
+              variant="outline"
+              onClick={() => void archiveCurrentWorkforce()}
+              disabled={saving}
+            >
+              {t("workforces.actions.archive")}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? <div className="text-sm text-red-500">{error}</div> : null}
+      {message ? <div className="text-sm text-emerald-600">{message}</div> : null}
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("workforces.detail.editTitle")}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.name")}</Label>
+                <Input
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  disabled={isArchived}
+                />
+            </div>
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.description")}</Label>
+              <Textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={3}
+                disabled={isArchived}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.manager")}</Label>
+              <Select
+                value={managerAgentId}
+                onValueChange={setManagerAgentId}
+                options={managerOptions}
+                disabled={isArchived}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.managerInstructions")}</Label>
+              <Textarea
+                value={managerInstructions}
+                onChange={(event) => setManagerInstructions(event.target.value)}
+                rows={5}
+                disabled={isArchived}
+              />
+            </div>
+            <Button
+              onClick={saveWorkforce}
+              disabled={saving || isArchived || !name.trim() || !managerAgentId}
+            >
+              {saving ? t("workforces.loading.saving") : t("workforces.actions.saveWorkforce")}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <WorkforceSummary workforce={workforce} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("workforces.workers.addTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t("workforces.fields.publishedAgent")}</Label>
+            <Select
+              value={newWorkerAgentId}
+              onValueChange={setNewWorkerAgentId}
+              placeholder={t("workforces.workers.chooseAgent")}
+              options={workerOptions}
+              disabled={isArchived}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.alias")}</Label>
+              <Input
+                value={newWorkerAlias}
+                onChange={(event) => setNewWorkerAlias(event.target.value)}
+                placeholder={t("workforces.workers.aliasPlaceholder")}
+                disabled={isArchived}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t("workforces.fields.assignmentInstructions")}</Label>
+              <Textarea
+                value={newWorkerInstructions}
+                onChange={(event) => setNewWorkerInstructions(event.target.value)}
+                rows={3}
+                disabled={isArchived}
+              />
+            </div>
+          </div>
+          <Button
+            onClick={addWorker}
+            disabled={saving || isArchived || !newWorkerAgentId || !newWorkerInstructions.trim()}
+          >
+            {t("workforces.actions.addWorker")}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("workforces.workers.manageTitle")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {workforce.workers.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+              {t("workforces.workers.noneConfigured")}
+            </div>
+          ) : (
+            workforce.workers
+              .slice()
+              .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+              .map((worker) => {
+                const edit = workerEdits[worker.id] || workerEditState(worker)
+                return (
+                  <div key={worker.id} className="rounded-xl border p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div>
+                        <div className="font-medium">
+                          {worker.alias || worker.agent.name}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {worker.agent.name} · {t(`workforces.status.${worker.agent.status}`)}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {canEditAgent(worker.agent) ? (
+                          <Link href={`/build/${worker.agent.id}`} target="_blank">
+                            <Button variant="outline" size="sm">
+                              {t("workforces.actions.openAgent")}
+                            </Button>
+                          </Link>
+                        ) : null}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void removeWorker(worker.id)}
+                          disabled={saving || isArchived}
+                        >
+                          {t("workforces.actions.remove")}
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="mt-4 grid gap-4 md:grid-cols-[1fr_140px_140px]">
+                      <div className="space-y-2">
+                        <Label>{t("workforces.fields.alias")}</Label>
+                        <Input
+                          value={edit.alias}
+                          onChange={(event) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: { ...edit, alias: event.target.value },
+                            }))
+                          }
+                          disabled={isArchived}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>{t("workforces.fields.order")}</Label>
+                        <Input
+                          type="number"
+                          value={String(edit.sort_order)}
+                          onChange={(event) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: {
+                                ...edit,
+                                sort_order: Number(event.target.value) || worker.sort_order || 1,
+                              },
+                            }))
+                          }
+                          disabled={isArchived}
+                        />
+                      </div>
+                      <div className="flex items-center justify-between rounded-lg border px-3 py-2">
+                        <div className="font-medium">{t("workforces.fields.enabled")}</div>
+                        <Switch
+                          checked={edit.enabled}
+                          onCheckedChange={(checked) =>
+                            setWorkerEdits((current) => ({
+                              ...current,
+                              [worker.id]: { ...edit, enabled: checked },
+                            }))
+                          }
+                          disabled={isArchived}
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-4 space-y-2">
+                      <Label>{t("workforces.fields.assignmentInstructions")}</Label>
+                      <Textarea
+                        value={edit.assignment_instructions}
+                        onChange={(event) =>
+                          setWorkerEdits((current) => ({
+                            ...current,
+                            [worker.id]: {
+                              ...edit,
+                              assignment_instructions: event.target.value,
+                            },
+                          }))
+                        }
+                        rows={4}
+                        disabled={isArchived}
+                      />
+                    </div>
+                    <Button
+                      className="mt-4"
+                      variant="outline"
+                      onClick={() => void saveWorker(worker)}
+                      disabled={saving || isArchived || !edit.assignment_instructions.trim()}
+                    >
+                      {t("workforces.actions.saveWorker")}
+                    </Button>
+                  </div>
+                )
+              })
+          )}
+        </CardContent>
+      </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -42,6 +42,10 @@ interface LoadOptions {
   silent?: boolean
 }
 
+interface SyncFormOptions {
+  preserveEditableState?: boolean
+}
+
 function workerEditState(worker: WorkforceWorker): WorkerEditState {
   return {
     alias: worker.alias || "",
@@ -93,12 +97,29 @@ export default function WorkforceDetailPage() {
   )
   const isArchived = workforce?.status === "archived"
 
-  const syncForm = useCallback((nextWorkforce: WorkforceDetail) => {
-    setName(nextWorkforce.name)
-    setDescription(nextWorkforce.description || "")
-    setManagerAgentId(String(nextWorkforce.manager.id))
-    setManagerInstructions(nextWorkforce.manager_instructions || "")
-    setWorkerEdits(buildWorkerEditState(nextWorkforce.workers))
+  const syncForm = useCallback((
+    nextWorkforce: WorkforceDetail,
+    options: SyncFormOptions = {},
+  ) => {
+    if (!options.preserveEditableState) {
+      setName(nextWorkforce.name)
+      setDescription(nextWorkforce.description || "")
+      setManagerAgentId(String(nextWorkforce.manager.id))
+      setManagerInstructions(nextWorkforce.manager_instructions || "")
+      setWorkerEdits(buildWorkerEditState(nextWorkforce.workers))
+      return
+    }
+
+    const serverWorkerEdits = buildWorkerEditState(nextWorkforce.workers)
+    setWorkerEdits((current) =>
+      nextWorkforce.workers.reduce<Record<number, WorkerEditState>>(
+        (accumulator, worker) => {
+          accumulator[worker.id] = current[worker.id] ?? serverWorkerEdits[worker.id]
+          return accumulator
+        },
+        {},
+      ),
+    )
   }, [])
 
   const load = useCallback(async (options: LoadOptions = {}) => {
@@ -115,7 +136,7 @@ export default function WorkforceDetailPage() {
       ])
       setWorkforce(workforceData)
       setAgents(agentData)
-      syncForm(workforceData)
+      syncForm(workforceData, { preserveEditableState: silent })
     } catch (err) {
       setError(err instanceof Error ? err.message : t("workforces.errors.load"))
     } finally {

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -186,11 +186,16 @@ export default function WorkforceDetailPage() {
       description: agent.description || undefined,
     }))
 
+  const beginMutation = () => {
+    setSaving(true)
+    setError(null)
+    setMessage(null)
+  }
+
   const saveWorkforce = async () => {
     if (!id || !name.trim() || !managerAgentId) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       const next = await updateWorkforce(id, {
         name: name.trim(),
         description: description.trim() || null,
@@ -210,8 +215,7 @@ export default function WorkforceDetailPage() {
   const addWorker = async () => {
     if (!id || !newWorkerAgentId || !newWorkerInstructions.trim()) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       await addWorkforceAgent(id, {
         source_type: "existing",
         agent_id: Number(newWorkerAgentId),
@@ -234,11 +238,10 @@ export default function WorkforceDetailPage() {
 
   const saveWorker = async (worker: WorkforceWorker) => {
     if (!id) return
-    const edit = workerEdits[worker.id]
-    if (!edit || !edit.assignment_instructions.trim()) return
+    const edit = workerEdits[worker.id] ?? workerEditState(worker)
+    if (!edit.assignment_instructions.trim()) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       const updated = await updateWorkforceAgent(id, worker.id, {
         alias: edit.alias.trim() || null,
         assignment_instructions: edit.assignment_instructions.trim(),
@@ -266,8 +269,7 @@ export default function WorkforceDetailPage() {
   const removeWorker = async (workerId: number) => {
     if (!id) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       await removeWorkforceAgent(id, workerId)
       await load({ silent: true })
       setMessage(t("workforces.messages.workerRemoved"))
@@ -281,8 +283,7 @@ export default function WorkforceDetailPage() {
   const publishCurrentWorkforce = async () => {
     if (!id) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       const next = await publishWorkforce(id)
       setWorkforce(next)
       syncForm(next)
@@ -297,8 +298,7 @@ export default function WorkforceDetailPage() {
   const unpublishCurrentWorkforce = async () => {
     if (!id) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       const next = await unpublishWorkforce(id)
       setWorkforce(next)
       syncForm(next)
@@ -313,8 +313,7 @@ export default function WorkforceDetailPage() {
   const archiveCurrentWorkforce = async () => {
     if (!id) return
     try {
-      setSaving(true)
-      setError(null)
+      beginMutation()
       await archiveWorkforce(id)
       const next = await getWorkforce(id)
       setWorkforce(next)

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -29,6 +29,7 @@ import type {
 } from "@/types/workforce"
 import { WorkforceSummary } from "@/components/workforce"
 import { canEditAgent } from "@/lib/agent-ui-access"
+import { getRunDisabledReason } from "../workforce-ui-state"
 
 interface WorkerEditState {
   alias: string
@@ -275,6 +276,8 @@ export default function WorkforceDetailPage() {
   if (error && !workforce) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
   if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
+  const runDisabledReason = getRunDisabledReason(workforce.status, t)
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-8">
@@ -306,9 +309,18 @@ export default function WorkforceDetailPage() {
           <Link href={`/workforces/${workforce.id}/canvas`}>
             <Button variant="outline">{t("workforces.actions.canvas")}</Button>
           </Link>
-          <Link href={`/workforces/${workforce.id}/run`}>
-            <Button>{t("workforces.actions.runWorkforce")}</Button>
-          </Link>
+          <div className="flex flex-col gap-1">
+            {runDisabledReason ? (
+              <Button disabled>{t("workforces.actions.runWorkforce")}</Button>
+            ) : (
+              <Link href={`/workforces/${workforce.id}/run`}>
+                <Button>{t("workforces.actions.runWorkforce")}</Button>
+              </Link>
+            )}
+            {runDisabledReason ? (
+              <span className="max-w-48 text-xs text-muted-foreground">{runDisabledReason}</span>
+            ) : null}
+          </div>
           {!isArchived ? (
             <Button
               variant="outline"

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -38,6 +38,10 @@ interface WorkerEditState {
   sort_order: string
 }
 
+interface LoadOptions {
+  silent?: boolean
+}
+
 function workerEditState(worker: WorkforceWorker): WorkerEditState {
   return {
     alias: worker.alias || "",
@@ -55,8 +59,9 @@ function buildWorkerEditState(workers: WorkforceWorker[]): Record<number, Worker
 }
 
 function normalizeWorkerSortOrder(value: string, fallback: number | null | undefined): number {
-  const parsed = Number(value)
-  if (Number.isFinite(parsed) && parsed > 0) {
+  const normalized = value.trim()
+  const parsed = /^\d+$/.test(normalized) ? Number.parseInt(normalized, 10) : NaN
+  if (Number.isInteger(parsed) && parsed > 0) {
     return parsed
   }
   return fallback ?? 1
@@ -96,10 +101,13 @@ export default function WorkforceDetailPage() {
     setWorkerEdits(buildWorkerEditState(nextWorkforce.workers))
   }, [])
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (options: LoadOptions = {}) => {
     if (!id) return
+    const { silent = false } = options
     try {
-      setLoading(true)
+      if (!silent) {
+        setLoading(true)
+      }
       setError(null)
       const [workforceData, agentData] = await Promise.all([
         getWorkforce(id),
@@ -111,7 +119,9 @@ export default function WorkforceDetailPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : t("workforces.errors.load"))
     } finally {
-      setLoading(false)
+      if (!silent) {
+        setLoading(false)
+      }
     }
   }, [id, syncForm, t])
 
@@ -192,7 +202,7 @@ export default function WorkforceDetailPage() {
       setNewWorkerAgentId("")
       setNewWorkerAlias("")
       setNewWorkerInstructions("")
-      await load()
+      await load({ silent: true })
       setMessage(t("workforces.messages.workerAdded"))
     } catch (err) {
       setError(err instanceof Error ? err.message : t("workforces.errors.addWorker"))
@@ -238,7 +248,7 @@ export default function WorkforceDetailPage() {
       setSaving(true)
       setError(null)
       await removeWorkforceAgent(id, workerId)
-      await load()
+      await load({ silent: true })
       setMessage(t("workforces.messages.workerRemoved"))
     } catch (err) {
       setError(err instanceof Error ? err.message : t("workforces.errors.removeWorker"))
@@ -519,6 +529,8 @@ export default function WorkforceDetailPage() {
                         <Label>{t("workforces.fields.order")}</Label>
                         <Input
                           type="number"
+                          min={1}
+                          step={1}
                           value={edit.sort_order}
                           onChange={(event) =>
                             setWorkerEdits((current) => ({

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -119,13 +119,29 @@ export default function WorkforceDetailPage() {
     void load()
   }, [load])
 
-  const managerOptions = publishedAgents
-    .filter((agent) => !workforce?.workers.some((worker) => worker.agent.id === agent.id))
-    .map((agent) => ({
-      value: String(agent.id),
-      label: agent.name,
-      description: agent.description || undefined,
-    }))
+  const managerOptions = useMemo(() => {
+    const options = publishedAgents
+      .filter((agent) => !workforce?.workers.some((worker) => worker.agent.id === agent.id))
+      .map((agent) => ({
+        value: String(agent.id),
+        label: agent.name,
+        description: agent.description || undefined,
+      }))
+
+    const currentManager = workforce?.manager
+    if (
+      currentManager?.status === "published" &&
+      !options.some((option) => option.value === String(currentManager.id))
+    ) {
+      options.unshift({
+        value: String(currentManager.id),
+        label: currentManager.name,
+        description: currentManager.description || undefined,
+      })
+    }
+
+    return options
+  }, [publishedAgents, workforce])
 
   const workerOptions = publishedAgents
     .filter(

--- a/frontend/src/app/workforces/[id]/page.tsx
+++ b/frontend/src/app/workforces/[id]/page.tsx
@@ -35,7 +35,7 @@ interface WorkerEditState {
   alias: string
   assignment_instructions: string
   enabled: boolean
-  sort_order: number
+  sort_order: string
 }
 
 function workerEditState(worker: WorkforceWorker): WorkerEditState {
@@ -43,7 +43,7 @@ function workerEditState(worker: WorkforceWorker): WorkerEditState {
     alias: worker.alias || "",
     assignment_instructions: worker.assignment_instructions,
     enabled: worker.enabled,
-    sort_order: worker.sort_order ?? 1,
+    sort_order: String(worker.sort_order ?? 1),
   }
 }
 
@@ -52,6 +52,14 @@ function buildWorkerEditState(workers: WorkforceWorker[]): Record<number, Worker
     accumulator[worker.id] = workerEditState(worker)
     return accumulator
   }, {})
+}
+
+function normalizeWorkerSortOrder(value: string, fallback: number | null | undefined): number {
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed
+  }
+  return fallback ?? 1
 }
 
 export default function WorkforceDetailPage() {
@@ -188,7 +196,7 @@ export default function WorkforceDetailPage() {
         alias: edit.alias.trim() || null,
         assignment_instructions: edit.assignment_instructions.trim(),
         enabled: edit.enabled,
-        sort_order: edit.sort_order,
+        sort_order: normalizeWorkerSortOrder(edit.sort_order, worker.sort_order),
       })
       setWorkforce((current) =>
         current
@@ -495,13 +503,13 @@ export default function WorkforceDetailPage() {
                         <Label>{t("workforces.fields.order")}</Label>
                         <Input
                           type="number"
-                          value={String(edit.sort_order)}
+                          value={edit.sort_order}
                           onChange={(event) =>
                             setWorkerEdits((current) => ({
                               ...current,
                               [worker.id]: {
                                 ...edit,
-                                sort_order: Number(event.target.value) || worker.sort_order || 1,
+                                sort_order: event.target.value,
                               },
                             }))
                           }

--- a/frontend/src/app/workforces/[id]/run/page.tsx
+++ b/frontend/src/app/workforces/[id]/run/page.tsx
@@ -6,6 +6,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { getWorkforce } from "@/lib/workforces-api"
 import type { WorkforceDetail, WorkforceRunResponse } from "@/types/workforce"
 import { WorkforceSummary, WorkforceTestPanel } from "@/components/workforce"
+import { getRunDisabledReason } from "../../workforce-ui-state"
 
 export default function WorkforceRunPage() {
   const { t } = useI18n()
@@ -40,6 +41,8 @@ export default function WorkforceRunPage() {
   if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
   if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
 
+  const runDisabledReason = getRunDisabledReason(workforce.status, t)
+
   const handleRunCreated = (result: WorkforceRunResponse) => {
     router.push(result.redirect_url || `/task/${result.task_id}`)
   }
@@ -50,7 +53,8 @@ export default function WorkforceRunPage() {
         <WorkforceSummary workforce={workforce} />
         <WorkforceTestPanel
           workforceId={workforce.id}
-          disabled={workforce.status !== "active"}
+          disabled={Boolean(runDisabledReason)}
+          disabledReason={runDisabledReason || undefined}
           onRunCreated={handleRunCreated}
         />
       </div>

--- a/frontend/src/app/workforces/[id]/run/page.tsx
+++ b/frontend/src/app/workforces/[id]/run/page.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { useI18n } from "@/contexts/i18n-context"
+import { getWorkforce } from "@/lib/workforces-api"
+import type { WorkforceDetail, WorkforceRunResponse } from "@/types/workforce"
+import { WorkforceSummary, WorkforceTestPanel } from "@/components/workforce"
+
+export default function WorkforceRunPage() {
+  const { t } = useI18n()
+  const router = useRouter()
+  const params = useParams()
+  const [workforce, setWorkforce] = useState<WorkforceDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const id = Array.isArray(params.id) ? params.id[0] : params.id
+        if (!id) {
+          setWorkforce(null)
+          return
+        }
+        const data = await getWorkforce(id)
+        setWorkforce(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("workforces.errors.load"))
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [params.id, t])
+
+  if (loading) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.loading.runView")}</div>
+  if (error) return <div className="h-full overflow-y-auto p-4 text-red-500 sm:p-8">{error}</div>
+  if (!workforce) return <div className="h-full overflow-y-auto p-4 text-muted-foreground sm:p-8">{t("workforces.errors.notFound")}</div>
+
+  const handleRunCreated = (result: WorkforceRunResponse) => {
+    router.push(result.redirect_url || `/task/${result.task_id}`)
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto grid w-full max-w-7xl gap-6 p-4 sm:p-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <WorkforceSummary workforce={workforce} />
+        <WorkforceTestPanel
+          workforceId={workforce.id}
+          disabled={workforce.status !== "active"}
+          onRunCreated={handleRunCreated}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/new/page.tsx
+++ b/frontend/src/app/workforces/new/page.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import React, { useState } from "react"
+import { useRouter } from "next/navigation"
+import { WorkforcePromptCreator, WorkforceWizard } from "@/components/workforce"
+
+export default function NewWorkforcePage() {
+  const router = useRouter()
+  const [mode, setMode] = useState<"prompt" | "manual">("prompt")
+  const onCreated = (workforce: { id: number }) => {
+    router.push(`/workforces/${workforce.id}`)
+  }
+  const onBack = () => {
+    router.push("/workforces")
+  }
+
+  if (mode === "manual") {
+    return (
+      <WorkforceWizard
+        onCreated={onCreated}
+        onBack={onBack}
+        onPromptSetup={() => setMode("prompt")}
+      />
+    )
+  }
+
+  return (
+    <WorkforcePromptCreator
+      onCreated={onCreated}
+      onBack={onBack}
+      onManualSetup={() => setMode("manual")}
+    />
+  )
+}

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -118,7 +118,7 @@ export default function WorkforcesPage() {
                           <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
                             <span>{t("workforces.list.manager", { name: item.manager.name })}</span>
                             <span>{t("workforces.list.workers", { count: item.worker_count })}</span>
-                            <span>
+                            <span suppressHydrationWarning>
                               {t("workforces.list.lastUpdate", {
                                 value: item.updated_at
                                   ? new Date(item.updated_at).toLocaleString(locale)

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import Link from "next/link"
+import React, { useCallback, useEffect, useState } from "react"
+import { ChevronLeft, ChevronRight, Layers, Play, Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { SearchInput } from "@/components/ui/search-input"
+import { useI18n } from "@/contexts/i18n-context"
+import { listWorkforces } from "@/lib/workforces-api"
+import type { WorkforceListItem } from "@/types/workforce"
+
+export default function WorkforcesPage() {
+  const { locale, t } = useI18n()
+  const [items, setItems] = useState<WorkforceListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(1)
+  const [pages, setPages] = useState(1)
+  const [total, setTotal] = useState(0)
+  const pageSize = 10
+
+  const load = useCallback(async (nextPage: number, nextSearch: string) => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await listWorkforces({ page: nextPage, size: pageSize, search: nextSearch })
+      setItems(data.items)
+      setPages(data.pages)
+      setTotal(data.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("workforces.errors.loadList"))
+      setItems([])
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    void load(page, search)
+  }, [load, page, search])
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 sm:p-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+            <Layers className="h-3.5 w-3.5" />
+            {t("workforces.list.badge")}
+          </div>
+          <h1 className="mt-4 text-3xl font-bold">{t("workforces.list.title")}</h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            {t("workforces.list.description")}
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <SearchInput
+            placeholder={t("workforces.list.searchPlaceholder")}
+            value={search}
+            onChange={(value) => {
+              setSearch(value)
+              setPage(1)
+            }}
+            containerClassName="w-full sm:w-80"
+          />
+          <Link href="/workforces/new">
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              {t("workforces.actions.new")}
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {loading ? <div className="p-8 text-muted-foreground">{t("workforces.loading.list")}</div> : null}
+      {error ? <div className="p-8 text-red-500">{error}</div> : null}
+
+      {!loading && !error ? (
+        items.length === 0 ? (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center gap-4 p-12 text-center">
+              <div className="text-lg font-medium">{t("workforces.list.emptyTitle")}</div>
+              <p className="max-w-xl text-sm text-muted-foreground">
+                {t("workforces.list.emptyDescription")}
+              </p>
+              <Link href="/workforces/new">
+                <Button>{t("workforces.list.createFirst")}</Button>
+              </Link>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <div className="grid gap-4">
+              {items.map((item) => (
+                <Card key={item.id} className="overflow-hidden">
+                  <CardContent className="p-0">
+                    <div className="grid gap-6 p-6 lg:grid-cols-[1.4fr_0.6fr] lg:items-center">
+                      <div className="space-y-4">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <Link
+                            href={`/workforces/${item.id}`}
+                            className="text-xl font-semibold hover:underline"
+                          >
+                            {item.name}
+                          </Link>
+                          <span className="rounded-full border px-2.5 py-1 text-xs capitalize text-muted-foreground">
+                            {t(`workforces.status.${item.status}`)}
+                          </span>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {item.description || t("workforces.common.noDescription")}
+                        </p>
+                        <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
+                          <span>{t("workforces.list.manager", { name: item.manager.name })}</span>
+                          <span>{t("workforces.list.workers", { count: item.worker_count })}</span>
+                          <span>
+                            {t("workforces.list.lastUpdate", {
+                              value: item.updated_at
+                                ? new Date(item.updated_at).toLocaleString(locale)
+                                : t("workforces.common.notAvailable"),
+                            })}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex flex-col gap-3 lg:items-end">
+                        <Link href={`/workforces/${item.id}/run`}>
+                          <Button className="w-full lg:w-auto">
+                            <Play className="mr-2 h-4 w-4" />
+                            {t("workforces.actions.run")}
+                          </Button>
+                        </Link>
+                        <div className="flex gap-3">
+                          <Link href={`/workforces/${item.id}`}>
+                            <Button variant="outline">{t("workforces.actions.details")}</Button>
+                          </Link>
+                          <Link href={`/workforces/${item.id}/builder`}>
+                            <Button variant="outline">{t("workforces.actions.builder")}</Button>
+                          </Link>
+                          <Link href={`/workforces/${item.id}/canvas`}>
+                            <Button variant="outline">{t("workforces.actions.canvas")}</Button>
+                          </Link>
+                        </div>
+                        {item.last_run ? (
+                          <div className="text-xs text-muted-foreground">
+                            {item.last_run.task_id != null
+                              ? t("workforces.list.lastRunWithTask", {
+                                  runId: item.last_run.id,
+                                  taskId: item.last_run.task_id,
+                                  status: item.last_run.status,
+                                })
+                              : t("workforces.list.lastRun", {
+                                  runId: item.last_run.id,
+                                  status: item.last_run.status,
+                                })}
+                          </div>
+                        ) : (
+                          <div className="text-xs text-muted-foreground">{t("workforces.list.noRuns")}</div>
+                        )}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {pages > 1 ? (
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-muted-foreground">
+                  {t("workforces.pagination.showing", {
+                    start: (page - 1) * pageSize + 1,
+                    end: Math.min(page * pageSize, total),
+                    total,
+                  })}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((current) => current - 1)}
+                    disabled={page <= 1}
+                  >
+                    <ChevronLeft className="mr-1 h-4 w-4" />
+                    {t("workforces.pagination.prev")}
+                  </Button>
+                  <span className="text-sm text-muted-foreground">
+                    {t("workforces.pagination.page", { page, pages })}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((current) => current + 1)}
+                    disabled={page >= pages}
+                  >
+                    {t("workforces.pagination.next")}
+                    <ChevronRight className="ml-1 h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )
+      ) : null}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workforces/page.tsx
+++ b/frontend/src/app/workforces/page.tsx
@@ -9,6 +9,7 @@ import { SearchInput } from "@/components/ui/search-input"
 import { useI18n } from "@/contexts/i18n-context"
 import { listWorkforces } from "@/lib/workforces-api"
 import type { WorkforceListItem } from "@/types/workforce"
+import { getRunDisabledReason } from "./workforce-ui-state"
 
 export default function WorkforcesPage() {
   const { locale, t } = useI18n()
@@ -93,76 +94,91 @@ export default function WorkforcesPage() {
         ) : (
           <>
             <div className="grid gap-4">
-              {items.map((item) => (
-                <Card key={item.id} className="overflow-hidden">
-                  <CardContent className="p-0">
-                    <div className="grid gap-6 p-6 lg:grid-cols-[1.4fr_0.6fr] lg:items-center">
-                      <div className="space-y-4">
-                        <div className="flex flex-wrap items-center gap-3">
-                          <Link
-                            href={`/workforces/${item.id}`}
-                            className="text-xl font-semibold hover:underline"
-                          >
-                            {item.name}
-                          </Link>
-                          <span className="rounded-full border px-2.5 py-1 text-xs capitalize text-muted-foreground">
-                            {t(`workforces.status.${item.status}`)}
-                          </span>
-                        </div>
-                        <p className="text-sm text-muted-foreground">
-                          {item.description || t("workforces.common.noDescription")}
-                        </p>
-                        <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
-                          <span>{t("workforces.list.manager", { name: item.manager.name })}</span>
-                          <span>{t("workforces.list.workers", { count: item.worker_count })}</span>
-                          <span>
-                            {t("workforces.list.lastUpdate", {
-                              value: item.updated_at
-                                ? new Date(item.updated_at).toLocaleString(locale)
-                                : t("workforces.common.notAvailable"),
-                            })}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="flex flex-col gap-3 lg:items-end">
-                        <Link href={`/workforces/${item.id}/run`}>
-                          <Button className="w-full lg:w-auto">
-                            <Play className="mr-2 h-4 w-4" />
-                            {t("workforces.actions.run")}
-                          </Button>
-                        </Link>
-                        <div className="flex gap-3">
-                          <Link href={`/workforces/${item.id}`}>
-                            <Button variant="outline">{t("workforces.actions.details")}</Button>
-                          </Link>
-                          <Link href={`/workforces/${item.id}/builder`}>
-                            <Button variant="outline">{t("workforces.actions.builder")}</Button>
-                          </Link>
-                          <Link href={`/workforces/${item.id}/canvas`}>
-                            <Button variant="outline">{t("workforces.actions.canvas")}</Button>
-                          </Link>
-                        </div>
-                        {item.last_run ? (
-                          <div className="text-xs text-muted-foreground">
-                            {item.last_run.task_id != null
-                              ? t("workforces.list.lastRunWithTask", {
-                                  runId: item.last_run.id,
-                                  taskId: item.last_run.task_id,
-                                  status: item.last_run.status,
-                                })
-                              : t("workforces.list.lastRun", {
-                                  runId: item.last_run.id,
-                                  status: item.last_run.status,
-                                })}
+              {items.map((item) => {
+                const runDisabledReason = getRunDisabledReason(item.status, t)
+                return (
+                  <Card key={item.id} className="overflow-hidden">
+                    <CardContent className="p-0">
+                      <div className="grid gap-6 p-6 lg:grid-cols-[1.4fr_0.6fr] lg:items-center">
+                        <div className="space-y-4">
+                          <div className="flex flex-wrap items-center gap-3">
+                            <Link
+                              href={`/workforces/${item.id}`}
+                              className="text-xl font-semibold hover:underline"
+                            >
+                              {item.name}
+                            </Link>
+                            <span className="rounded-full border px-2.5 py-1 text-xs capitalize text-muted-foreground">
+                              {t(`workforces.status.${item.status}`)}
+                            </span>
                           </div>
-                        ) : (
-                          <div className="text-xs text-muted-foreground">{t("workforces.list.noRuns")}</div>
-                        )}
+                          <p className="text-sm text-muted-foreground">
+                            {item.description || t("workforces.common.noDescription")}
+                          </p>
+                          <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
+                            <span>{t("workforces.list.manager", { name: item.manager.name })}</span>
+                            <span>{t("workforces.list.workers", { count: item.worker_count })}</span>
+                            <span>
+                              {t("workforces.list.lastUpdate", {
+                                value: item.updated_at
+                                  ? new Date(item.updated_at).toLocaleString(locale)
+                                  : t("workforces.common.notAvailable"),
+                              })}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex flex-col gap-3 lg:items-end">
+                          <div className="flex w-full flex-col gap-1 lg:w-auto lg:items-end">
+                            {runDisabledReason ? (
+                              <Button className="w-full lg:w-auto" disabled>
+                                <Play className="mr-2 h-4 w-4" />
+                                {t("workforces.actions.run")}
+                              </Button>
+                            ) : (
+                              <Link href={`/workforces/${item.id}/run`}>
+                                <Button className="w-full lg:w-auto">
+                                  <Play className="mr-2 h-4 w-4" />
+                                  {t("workforces.actions.run")}
+                                </Button>
+                              </Link>
+                            )}
+                            {runDisabledReason ? (
+                              <div className="text-xs text-muted-foreground">{runDisabledReason}</div>
+                            ) : null}
+                          </div>
+                          <div className="flex gap-3">
+                            <Link href={`/workforces/${item.id}`}>
+                              <Button variant="outline">{t("workforces.actions.details")}</Button>
+                            </Link>
+                            <Link href={`/workforces/${item.id}/builder`}>
+                              <Button variant="outline">{t("workforces.actions.builder")}</Button>
+                            </Link>
+                            <Link href={`/workforces/${item.id}/canvas`}>
+                              <Button variant="outline">{t("workforces.actions.canvas")}</Button>
+                            </Link>
+                          </div>
+                          {item.last_run ? (
+                            <div className="text-xs text-muted-foreground">
+                              {item.last_run.task_id != null
+                                ? t("workforces.list.lastRunWithTask", {
+                                    runId: item.last_run.id,
+                                    taskId: item.last_run.task_id,
+                                    status: item.last_run.status,
+                                  })
+                                : t("workforces.list.lastRun", {
+                                    runId: item.last_run.id,
+                                    status: item.last_run.status,
+                                  })}
+                            </div>
+                          ) : (
+                            <div className="text-xs text-muted-foreground">{t("workforces.list.noRuns")}</div>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
+                    </CardContent>
+                  </Card>
+                )
+              })}
             </div>
 
             {pages > 1 ? (

--- a/frontend/src/app/workforces/workforce-ui-state.ts
+++ b/frontend/src/app/workforces/workforce-ui-state.ts
@@ -1,0 +1,12 @@
+type Translate = (key: string) => string
+
+export function getRunDisabledReason(status: string | null | undefined, t: Translate) {
+  if (status === "active") return null
+  if (status === "archived") return t("workforces.run.archivedDisabled")
+  return t("workforces.run.inactiveDisabled")
+}
+
+export function getBuilderReadOnlyReason(status: string | null | undefined, t: Translate) {
+  if (status === "archived") return t("workforces.builder.archivedReadOnly")
+  return null
+}

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -330,6 +330,47 @@ describe("workforce route entry points", () => {
     expect(screen.getByRole("button", { name: /workforces.actions.runWorkforce/ })).toBeDisabled()
   })
 
+  it("allows clearing and replacing worker sort order before saving", async () => {
+    const worker = {
+      id: 100,
+      agent: {
+        id: 8,
+        name: "Worker Agent",
+        description: null,
+        logo_url: null,
+        status: "published",
+      },
+      alias: "Researcher",
+      assignment_instructions: "Research launch tasks",
+      source_type: "existing" as const,
+      template_id: null,
+      enabled: true,
+      sort_order: 3,
+      canvas_position: null,
+      created_at: null,
+      updated_at: null,
+    }
+    getWorkforceMock.mockResolvedValueOnce({ ...workforceDetail, workers: [worker] })
+    listAgentOptionsMock.mockResolvedValueOnce([])
+    updateWorkforceAgentMock.mockResolvedValueOnce({ ...worker, sort_order: 12 })
+
+    render(<WorkforceDetailPage />)
+
+    const sortInput = (await screen.findByDisplayValue("3")) as HTMLInputElement
+    fireEvent.change(sortInput, { target: { value: "" } })
+    expect(sortInput.value).toBe("")
+    fireEvent.change(sortInput, { target: { value: "12" } })
+    fireEvent.click(screen.getByText("workforces.actions.saveWorker"))
+
+    await waitFor(() => {
+      expect(updateWorkforceAgentMock).toHaveBeenCalledWith(
+        "42",
+        100,
+        expect.objectContaining({ sort_order: 12 }),
+      )
+    })
+  })
+
   it("keeps builder propose and apply controls read-only for archived workforces", async () => {
     getWorkforceMock.mockResolvedValueOnce({
       ...workforceDetail,

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -4,8 +4,19 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const getWorkforceMock = vi.hoisted(() => vi.fn())
+const getWorkforceBuilderMessagesMock = vi.hoisted(() => vi.fn())
+const listAgentOptionsMock = vi.hoisted(() => vi.fn())
 const listWorkforcesMock = vi.hoisted(() => vi.fn())
+const proposeWorkforceChangesMock = vi.hoisted(() => vi.fn())
+const applyWorkforceChangesMock = vi.hoisted(() => vi.fn())
 const runWorkforceMock = vi.hoisted(() => vi.fn())
+const addWorkforceAgentMock = vi.hoisted(() => vi.fn())
+const archiveWorkforceMock = vi.hoisted(() => vi.fn())
+const publishWorkforceMock = vi.hoisted(() => vi.fn())
+const removeWorkforceAgentMock = vi.hoisted(() => vi.fn())
+const unpublishWorkforceMock = vi.hoisted(() => vi.fn())
+const updateWorkforceMock = vi.hoisted(() => vi.fn())
+const updateWorkforceAgentMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const paramsMock = vi.hoisted(() => ({ id: "42" as string | string[] | undefined }))
 const translateMock = vi.hoisted(
@@ -44,12 +55,82 @@ vi.mock("@/contexts/i18n-context", () => ({
 }))
 
 vi.mock("@/lib/workforces-api", () => ({
+  addWorkforceAgent: addWorkforceAgentMock,
+  applyWorkforceChanges: applyWorkforceChangesMock,
+  archiveWorkforce: archiveWorkforceMock,
   getWorkforce: getWorkforceMock,
+  getWorkforceBuilderMessages: getWorkforceBuilderMessagesMock,
+  listAgentOptions: listAgentOptionsMock,
   listWorkforces: listWorkforcesMock,
+  publishWorkforce: publishWorkforceMock,
+  proposeWorkforceChanges: proposeWorkforceChangesMock,
+  removeWorkforceAgent: removeWorkforceAgentMock,
   runWorkforce: runWorkforceMock,
+  unpublishWorkforce: unpublishWorkforceMock,
+  updateWorkforce: updateWorkforceMock,
+  updateWorkforceAgent: updateWorkforceAgentMock,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    options,
+    placeholder,
+    disabled,
+  }: {
+    value?: string
+    onValueChange: (value: string) => void
+    options?: Array<{ value: string; label: string }>
+    placeholder?: string
+    disabled?: boolean
+  }) => (
+    <select
+      aria-label={placeholder}
+      value={value || ""}
+      disabled={disabled}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      <option value="">{placeholder}</option>
+      {(options || []).map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange,
+  }: {
+    checked?: boolean
+    disabled?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
+    <input
+      aria-label="switch"
+      type="checkbox"
+      checked={Boolean(checked)}
+      disabled={disabled}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
 }))
 
 import WorkforcesPage from "./page"
+import WorkforceBuilderPage from "./[id]/builder/page"
+import WorkforceDetailPage from "./[id]/page"
 import WorkforceRunPage from "./[id]/run/page"
 import { getNavigationGroupsForUser } from "@/components/layout/sidebar"
 import type { WorkforceDetail, WorkforceListResponse } from "@/types/workforce"
@@ -108,8 +189,19 @@ const listResponse: WorkforceListResponse = {
 describe("workforce route entry points", () => {
   beforeEach(() => {
     getWorkforceMock.mockReset()
+    getWorkforceBuilderMessagesMock.mockReset()
+    listAgentOptionsMock.mockReset()
     listWorkforcesMock.mockReset()
+    proposeWorkforceChangesMock.mockReset()
+    applyWorkforceChangesMock.mockReset()
     runWorkforceMock.mockReset()
+    addWorkforceAgentMock.mockReset()
+    archiveWorkforceMock.mockReset()
+    publishWorkforceMock.mockReset()
+    removeWorkforceAgentMock.mockReset()
+    unpublishWorkforceMock.mockReset()
+    updateWorkforceMock.mockReset()
+    updateWorkforceAgentMock.mockReset()
     routerPushMock.mockReset()
     paramsMock.id = "42"
   })
@@ -159,6 +251,28 @@ describe("workforce route entry points", () => {
     )
   })
 
+  it("keeps list run actions disabled for non-active workforces", async () => {
+    listWorkforcesMock.mockResolvedValueOnce({
+      ...listResponse,
+      items: [
+        {
+          ...listResponse.items[0],
+          id: 43,
+          name: "Draft Workforce",
+          status: "draft",
+          last_run: null,
+        },
+      ],
+    })
+
+    render(<WorkforcesPage />)
+
+    expect(await screen.findByText("Draft Workforce")).toBeInTheDocument()
+    expect(screen.getByText("workforces.run.inactiveDisabled")).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /workforces.actions.run/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /workforces.actions.run/ })).toBeDisabled()
+  })
+
   it("runs a workforce and redirects to the created task", async () => {
     getWorkforceMock.mockResolvedValueOnce(workforceDetail)
     runWorkforceMock.mockResolvedValueOnce({
@@ -183,5 +297,71 @@ describe("workforce route entry points", () => {
       })
     })
     expect(routerPushMock).toHaveBeenCalledWith("/task/99")
+  })
+
+  it("shows a run disabled reason for non-active workforces", async () => {
+    getWorkforceMock.mockResolvedValueOnce({
+      ...workforceDetail,
+      status: "draft",
+    })
+
+    render(<WorkforceRunPage />)
+
+    expect(await screen.findByText("Launch Workforce")).toBeInTheDocument()
+    expect(screen.getByText("workforces.run.inactiveDisabled")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("workforces.run.placeholder")).toBeDisabled()
+    expect(screen.getByText("workforces.actions.runWorkforce")).toBeDisabled()
+    fireEvent.click(screen.getByText("workforces.actions.runWorkforce"))
+    expect(runWorkforceMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps the detail run action disabled for non-active workforces", async () => {
+    getWorkforceMock.mockResolvedValueOnce({
+      ...workforceDetail,
+      status: "draft",
+    })
+    listAgentOptionsMock.mockResolvedValueOnce([])
+
+    render(<WorkforceDetailPage />)
+
+    expect(await screen.findByRole("heading", { name: "Launch Workforce" })).toBeInTheDocument()
+    expect(screen.getByText("workforces.run.inactiveDisabled")).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /workforces.actions.runWorkforce/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /workforces.actions.runWorkforce/ })).toBeDisabled()
+  })
+
+  it("keeps builder propose and apply controls read-only for archived workforces", async () => {
+    getWorkforceMock.mockResolvedValueOnce({
+      ...workforceDetail,
+      status: "archived",
+    })
+    getWorkforceBuilderMessagesMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: 12,
+          role: "assistant",
+          content: "Prepared a patch.",
+          status: "proposed",
+          proposed_patch: {
+            summary: "Rename",
+            operations: [{ op: "update_workforce", fields: { name: "Renamed" } }],
+            warnings: [],
+          },
+          created_at: null,
+        },
+      ],
+    })
+
+    render(<WorkforceBuilderPage />)
+
+    expect(await screen.findByText("Launch Workforce")).toBeInTheDocument()
+    expect(screen.getByText("workforces.builder.archivedReadOnly")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("workforces.builder.messagePlaceholder")).toBeDisabled()
+
+    const readOnlyButtons = screen.getAllByText("workforces.actions.readOnly")
+    expect(readOnlyButtons).toHaveLength(2)
+    readOnlyButtons.forEach((button) => expect(button).toBeDisabled())
+    expect(proposeWorkforceChangesMock).not.toHaveBeenCalled()
+    expect(applyWorkforceChangesMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -330,6 +330,27 @@ describe("workforce route entry points", () => {
     expect(screen.getByRole("button", { name: /workforces.actions.runWorkforce/ })).toBeDisabled()
   })
 
+  it("keeps the current manager visible when it is hidden from agent options", async () => {
+    getWorkforceMock.mockResolvedValueOnce(workforceDetail)
+    listAgentOptionsMock.mockResolvedValueOnce([
+      {
+        id: 8,
+        name: "Worker Agent",
+        description: null,
+        logo_url: null,
+        status: "published",
+      },
+    ])
+
+    render(<WorkforceDetailPage />)
+
+    expect(await screen.findByRole("heading", { name: "Launch Workforce" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Manager Agent" })).toHaveAttribute(
+      "value",
+      "7",
+    )
+  })
+
   it("allows clearing and replacing worker sort order before saving", async () => {
     const worker = {
       id: 100,

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -392,6 +392,106 @@ describe("workforce route entry points", () => {
     })
   })
 
+  it("keeps worker sort order integer-only when saving", async () => {
+    const worker = {
+      id: 100,
+      agent: {
+        id: 8,
+        name: "Worker Agent",
+        description: null,
+        logo_url: null,
+        status: "published",
+      },
+      alias: "Researcher",
+      assignment_instructions: "Research launch tasks",
+      source_type: "existing" as const,
+      template_id: null,
+      enabled: true,
+      sort_order: 3,
+      canvas_position: null,
+      created_at: null,
+      updated_at: null,
+    }
+    getWorkforceMock.mockResolvedValueOnce({ ...workforceDetail, workers: [worker] })
+    listAgentOptionsMock.mockResolvedValueOnce([])
+    updateWorkforceAgentMock.mockResolvedValueOnce(worker)
+
+    render(<WorkforceDetailPage />)
+
+    const sortInput = (await screen.findByDisplayValue("3")) as HTMLInputElement
+    fireEvent.change(sortInput, { target: { value: "1.5" } })
+    fireEvent.click(screen.getByText("workforces.actions.saveWorker"))
+
+    await waitFor(() => {
+      expect(updateWorkforceAgentMock).toHaveBeenCalledWith(
+        "42",
+        100,
+        expect.objectContaining({ sort_order: 3 }),
+      )
+    })
+  })
+
+  it("keeps the detail page visible while refreshing after adding a worker", async () => {
+    const agentOptions = [
+      {
+        id: 8,
+        name: "Worker Agent",
+        description: null,
+        logo_url: null,
+        status: "published",
+      },
+    ]
+    let resolveReload: (value: WorkforceDetail) => void
+    const reload = new Promise<WorkforceDetail>((resolve) => {
+      resolveReload = resolve
+    })
+    getWorkforceMock
+      .mockResolvedValueOnce(workforceDetail)
+      .mockReturnValueOnce(reload)
+    listAgentOptionsMock
+      .mockResolvedValueOnce(agentOptions)
+      .mockResolvedValueOnce(agentOptions)
+    addWorkforceAgentMock.mockResolvedValueOnce({ id: 101 })
+
+    const { container } = render(<WorkforceDetailPage />)
+
+    expect(await screen.findByRole("heading", { name: "Launch Workforce" })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("workforces.workers.chooseAgent"), {
+      target: { value: "8" },
+    })
+    const textareas = container.querySelectorAll("textarea")
+    fireEvent.change(textareas[textareas.length - 1], {
+      target: { value: "Research launch tasks" },
+    })
+    fireEvent.click(screen.getByText("workforces.actions.addWorker"))
+
+    await waitFor(() => {
+      expect(addWorkforceAgentMock).toHaveBeenCalled()
+    })
+    expect(screen.queryByText("workforces.loading.detail")).not.toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Launch Workforce" })).toBeInTheDocument()
+
+    resolveReload!({
+      ...workforceDetail,
+      workers: [
+        {
+          id: 100,
+          agent: agentOptions[0],
+          alias: null,
+          assignment_instructions: "Research launch tasks",
+          source_type: "existing",
+          template_id: null,
+          enabled: true,
+          sort_order: 1,
+          canvas_position: null,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+    })
+    await screen.findByText("workforces.messages.workerAdded")
+  })
+
   it("keeps builder propose and apply controls read-only for archived workforces", async () => {
     getWorkforceMock.mockResolvedValueOnce({
       ...workforceDetail,

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -456,6 +456,9 @@ describe("workforce route entry points", () => {
     const { container } = render(<WorkforceDetailPage />)
 
     expect(await screen.findByRole("heading", { name: "Launch Workforce" })).toBeInTheDocument()
+    fireEvent.change(screen.getByDisplayValue("Launch Workforce"), {
+      target: { value: "Unsaved Workforce Name" },
+    })
     fireEvent.change(screen.getByLabelText("workforces.workers.chooseAgent"), {
       target: { value: "8" },
     })
@@ -490,6 +493,7 @@ describe("workforce route entry points", () => {
       ],
     })
     await screen.findByText("workforces.messages.workerAdded")
+    expect(screen.getByDisplayValue("Unsaved Workforce Name")).toBeInTheDocument()
   })
 
   it("keeps builder propose and apply controls read-only for archived workforces", async () => {

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -1,0 +1,187 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const getWorkforceMock = vi.hoisted(() => vi.fn())
+const listWorkforcesMock = vi.hoisted(() => vi.fn())
+const runWorkforceMock = vi.hoisted(() => vi.fn())
+const routerPushMock = vi.hoisted(() => vi.fn())
+const paramsMock = vi.hoisted(() => ({ id: "42" as string | string[] | undefined }))
+const translateMock = vi.hoisted(
+  () => (key: string, vars?: Record<string, string | number>) => {
+    if (!vars) return key
+    return Object.entries(vars).reduce(
+      (value, [name, replacement]) =>
+        value.replace(`{${name}}`, String(replacement)),
+      key,
+    )
+  },
+)
+
+vi.mock("next/navigation", () => ({
+  useParams: () => paramsMock,
+  useRouter: () => ({ push: routerPushMock }),
+}))
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en-US",
+    t: translateMock,
+  }),
+}))
+
+vi.mock("@/lib/workforces-api", () => ({
+  getWorkforce: getWorkforceMock,
+  listWorkforces: listWorkforcesMock,
+  runWorkforce: runWorkforceMock,
+}))
+
+import WorkforcesPage from "./page"
+import WorkforceRunPage from "./[id]/run/page"
+import { getNavigationGroupsForUser } from "@/components/layout/sidebar"
+import type { WorkforceDetail, WorkforceListResponse } from "@/types/workforce"
+
+const workforceDetail: WorkforceDetail = {
+  id: 42,
+  name: "Launch Workforce",
+  description: null,
+  status: "active",
+  manager: {
+    id: 7,
+    name: "Manager Agent",
+    description: null,
+    logo_url: null,
+    status: "published",
+  },
+  manager_instructions: null,
+  workers: [],
+  canvas_layout: null,
+  scope_type: "user",
+  scope_id: "1",
+  owner_user_id: 1,
+  created_at: null,
+  updated_at: null,
+}
+
+const listResponse: WorkforceListResponse = {
+  items: [
+    {
+      id: 42,
+      name: "Launch Workforce",
+      description: "Coordinate launch work",
+      status: "active",
+      manager: {
+        id: 7,
+        name: "Manager Agent",
+        logo_url: null,
+      },
+      worker_count: 2,
+      last_run: {
+        id: 9,
+        task_id: 99,
+        status: "completed",
+        created_at: null,
+      },
+      created_at: null,
+      updated_at: "2026-05-27T00:00:00Z",
+    },
+  ],
+  total: 1,
+  page: 1,
+  size: 10,
+  pages: 1,
+}
+
+describe("workforce route entry points", () => {
+  beforeEach(() => {
+    getWorkforceMock.mockReset()
+    listWorkforcesMock.mockReset()
+    runWorkforceMock.mockReset()
+    routerPushMock.mockReset()
+    paramsMock.id = "42"
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("adds the visible sidebar entry for workforces", () => {
+    const agentDevelopment = getNavigationGroupsForUser(null)[0]
+
+    expect(agentDevelopment.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "/workforces",
+          nameKey: "nav.workforces",
+        }),
+      ]),
+    )
+  })
+
+  it("renders the workforce list with PR7 route links", async () => {
+    listWorkforcesMock.mockResolvedValueOnce(listResponse)
+
+    render(<WorkforcesPage />)
+
+    expect(await screen.findByText("Launch Workforce")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /workforces.actions.new/ })).toHaveAttribute(
+      "href",
+      "/workforces/new",
+    )
+    expect(screen.getByRole("link", { name: /Launch Workforce/ })).toHaveAttribute(
+      "href",
+      "/workforces/42",
+    )
+    expect(screen.getByRole("link", { name: /workforces.actions.run/ })).toHaveAttribute(
+      "href",
+      "/workforces/42/run",
+    )
+    expect(screen.getByRole("link", { name: /workforces.actions.builder/ })).toHaveAttribute(
+      "href",
+      "/workforces/42/builder",
+    )
+    expect(screen.getByRole("link", { name: /workforces.actions.canvas/ })).toHaveAttribute(
+      "href",
+      "/workforces/42/canvas",
+    )
+  })
+
+  it("runs a workforce and redirects to the created task", async () => {
+    getWorkforceMock.mockResolvedValueOnce(workforceDetail)
+    runWorkforceMock.mockResolvedValueOnce({
+      workforce_run_id: 5,
+      task_id: 99,
+      status: "running",
+      redirect_url: "/task/99",
+    })
+
+    render(<WorkforceRunPage />)
+
+    expect(await screen.findByText("Launch Workforce")).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText("workforces.run.placeholder"), {
+      target: { value: " Draft launch plan " },
+    })
+    fireEvent.click(screen.getByText("workforces.actions.runWorkforce"))
+
+    await waitFor(() => {
+      expect(runWorkforceMock).toHaveBeenCalledWith(42, {
+        message: "Draft launch plan",
+      })
+    })
+    expect(routerPushMock).toHaveBeenCalledWith("/task/99")
+  })
+})

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -327,4 +327,38 @@ describe("AgentBuilderChat", () => {
       )
     })
   })
+
+  it("handles null task completion results without crashing", async () => {
+    render(
+      <AgentBuilderChat
+        agentConfig={agentConfig}
+        onUpdateConfig={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+
+    await waitFor(() => {
+      expect(ws.sentMessages).toHaveLength(1)
+    })
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "task_completed",
+        success: true,
+        status: "completed",
+        result: null,
+      }),
+    })
+
+    await waitFor(() => {
+      const messages = screen.getAllByTestId("chat-message")
+      const latestMessage = messages[messages.length - 1]
+      expect(latestMessage).toHaveAttribute("data-process-status", "completed")
+    })
+  })
 })

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -81,15 +81,37 @@ vi.mock("@/components/chat/ChatInput", () => ({
 }))
 
 vi.mock("@/components/chat/ChatMessage", () => ({
-  ChatMessage: ({ onSendInteraction }: { onSendInteraction?: (text: string, files?: File[]) => Promise<void> | void }) => {
+  ChatMessage: ({
+    content,
+    onSendInteraction,
+    processStatus,
+    traceEvents,
+  }: {
+    content?: React.ReactNode
+    onSendInteraction?: (text: string, files?: File[]) => Promise<void> | void
+    processStatus?: string
+    traceEvents?: unknown[]
+  }) => {
     const [status, setStatus] = React.useState("idle")
 
     if (!onSendInteraction) {
-      return <div>message</div>
+      return (
+        <div
+          data-testid="chat-message"
+          data-process-status={processStatus || ""}
+          data-trace-count={traceEvents?.length ?? 0}
+        >
+          {content || "message"}
+        </div>
+      )
     }
 
     return (
-      <div>
+      <div
+        data-testid="chat-message"
+        data-process-status={processStatus || ""}
+        data-trace-count={traceEvents?.length ?? 0}
+      >
         <button
           type="button"
           onClick={async () => {
@@ -211,7 +233,7 @@ describe("AgentBuilderChat", () => {
     fireEvent.click(await screen.findByText("send-file-interaction"))
 
     await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
+      expect(toastErrorMock.mock.calls[0]?.[0]).toBe(
         "Startup file storage sync failed"
       )
     })
@@ -249,5 +271,60 @@ describe("AgentBuilderChat", () => {
       },
     ])
     expect(apiRequestMock).not.toHaveBeenCalled()
+  })
+
+  it("passes failed task completion status into the process renderer", async () => {
+    render(
+      <AgentBuilderChat
+        agentConfig={agentConfig}
+        onUpdateConfig={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+
+    await waitFor(() => {
+      expect(ws.sentMessages).toHaveLength(1)
+    })
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_id: "react-start",
+        event_type: "react_task_start",
+        step_id: "react-1",
+        timestamp: 1,
+        data: { pattern: "ReActPattern" },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_id: "llm-start",
+        event_type: "llm_call_start",
+        step_id: "react-1",
+        timestamp: 2,
+        data: { model_name: "demo-model" },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "task_completed",
+        success: false,
+        result: "All patterns failed",
+      }),
+    })
+
+    await waitFor(() => {
+      const messages = screen.getAllByTestId("chat-message")
+      expect(messages[messages.length - 1]).toHaveAttribute(
+        "data-process-status",
+        "failed"
+      )
+    })
   })
 })

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -401,7 +401,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               // The backend no longer sends config_updates in task_completed.
               // We handle it in tool_execution_end.
 
-              let finalContent = typeof taskCompletion.result === 'object' ? (taskCompletion.result as any).content : taskCompletion.result;
+              let finalContent = taskCompletion.result && typeof taskCompletion.result === 'object' ? (taskCompletion.result as any).content : taskCompletion.result;
               finalContent = finalContent || currentReply;
 
               let cleanReply = typeof finalContent === 'string' ? finalContent.replace(/```json[\s\S]*?(```|$)/gi, "").trim() : "";

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -6,6 +6,11 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { useAuth } from "@/contexts/auth-context"
 import { getApiUrl, getUploadApiUrl } from "@/lib/utils"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
+import { normalizeTaskCompletedMessage } from "@/lib/task-completion"
+import {
+  normalizeTraceProcessStatus,
+  type TraceProcessStatus,
+} from "@/lib/trace-process-status"
 import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
@@ -20,6 +25,21 @@ interface Message {
   traceEvents?: any[]
   timestamp?: number
   interactions?: Interaction[]
+  processStatus?: TraceProcessStatus
+}
+
+const updateLastAssistantMessage = (
+  messages: Message[],
+  update: (message: Message) => Message
+): Message[] => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "assistant") {
+      const updated = [...messages]
+      updated[i] = update(messages[i])
+      return updated
+    }
+  }
+  return messages
 }
 
 export interface AgentConfig {
@@ -244,15 +264,10 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
             if (data.type === "trace_event") {
               // Update the last message (assistant) with the new trace event
               setMessages(prev => {
-                const updated = [...prev]
-                const lastMsg = updated[updated.length - 1]
-                if (lastMsg && lastMsg.role === 'assistant') {
-                  updated[updated.length - 1] = {
-                    ...lastMsg,
+                return updateLastAssistantMessage(prev, lastMsg => ({
+                  ...lastMsg,
                     traceEvents: [...(lastMsg.traceEvents || []), data]
-                  }
-                }
-                return updated
+                }))
               })
 
               if (data.event_type === "ai_message") {
@@ -381,21 +396,30 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               }
             } else if (data.type === "task_completed") {
               setIsLoading(false)
+              const taskCompletion = normalizeTaskCompletedMessage(data)
 
               // The backend no longer sends config_updates in task_completed.
               // We handle it in tool_execution_end.
 
-              let finalContent = typeof data.result === 'object' ? data.result.content : data.result;
+              let finalContent = typeof taskCompletion.result === 'object' ? (taskCompletion.result as any).content : taskCompletion.result;
               finalContent = finalContent || currentReply;
 
               let cleanReply = typeof finalContent === 'string' ? finalContent.replace(/```json[\s\S]*?(```|$)/gi, "").trim() : "";
               let interactions = undefined;
+              const resultRecord = taskCompletion.result && typeof taskCompletion.result === 'object'
+                ? taskCompletion.result as any
+                : null;
 
               // Check if we have chat_response structure
-              if (typeof data.result === 'object' && data.result.chat_response) {
-                interactions = data.result.chat_response.interactions;
-                if (data.result.chat_response.message) {
-                  cleanReply = data.result.chat_response.message;
+              if (taskCompletion.chatResponse && typeof taskCompletion.chatResponse === 'object') {
+                interactions = (taskCompletion.chatResponse as any).interactions;
+                if ((taskCompletion.chatResponse as any).message) {
+                  cleanReply = (taskCompletion.chatResponse as any).message;
+                }
+              } else if (resultRecord?.chat_response) {
+                interactions = resultRecord.chat_response.interactions;
+                if (resultRecord.chat_response.message) {
+                  cleanReply = resultRecord.chat_response.message;
                 }
               }
 
@@ -426,17 +450,27 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               }
 
               setMessages(prev => {
-                const updated = [...prev]
-                updated[updated.length - 1].content = cleanReply || t("builds.configForm.chat.defaultReply") || "I have updated the configuration based on your request."
-                if (interactions) {
-                  updated[updated.length - 1].interactions = interactions;
-                }
-                return updated
+                return updateLastAssistantMessage(prev, message => ({
+                  ...message,
+                  content: cleanReply || t("builds.configForm.chat.defaultReply") || "I have updated the configuration based on your request.",
+                  interactions: interactions || message.interactions,
+                  processStatus: taskCompletion.status,
+                }))
               })
 
               currentReply = ""
             } else if (data.type === "error" || data.type === "task_error") {
               setIsLoading(false)
+              const processStatus =
+                normalizeTraceProcessStatus(data.task?.status) ||
+                normalizeTraceProcessStatus(data.status) ||
+                "failed"
+              setMessages(prev => {
+                return updateLastAssistantMessage(prev, message => ({
+                  ...message,
+                  processStatus,
+                }))
+              })
               toast.error(data.message || data.error || t("builds.configForm.chat.errorCommunicate", { appName: branding.appName }))
               ws.close()
             }
@@ -493,6 +527,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               content={msg.content}
               traceEvents={msg.traceEvents}
               showProcessView={true}
+              processStatus={msg.processStatus}
               timestamp={msg.timestamp}
               interactions={msg.interactions}
               onSendInteraction={async (text, files, meta) => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -126,4 +126,22 @@ describe("ChatInput", () => {
     })
     expect(screen.queryByText("chatPage.input.noModelAlert")).not.toBeInTheDocument()
   })
+
+  it("does not show pause for uppercase terminal task status", () => {
+    const { container } = render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue="next request"
+        isLoading
+        onInputChange={vi.fn()}
+        onPause={vi.fn()}
+        onSend={vi.fn()}
+        taskStatus="FAILED"
+      />
+    )
+
+    expect(screen.queryByTitle("agent.input.actions.pauseTask")).not.toBeInTheDocument()
+    expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
+  })
 })

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ConfigDialog } from "@/components/config-dialog";
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper";
+import { isPausableTaskStatus, isStoppedTaskStatus, normalizeTaskStatus, type TaskStatus } from "@/lib/task-status";
 import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "@/components/ui/sonner";
@@ -32,7 +33,7 @@ interface ChatInputProps {
   onModeChange?: (mode: "task" | "process") => void;
   inputValue?: string;
   onInputChange?: (value: string) => void;
-  taskStatus?: "pending" | "running" | "completed" | "failed" | "paused" | "waiting_for_user";
+  taskStatus?: TaskStatus | string;
   onPause?: () => void;
   onResume?: () => void;
   taskConfig?: {
@@ -454,8 +455,9 @@ export function ChatInput({
     setAgentConfig(config);
   };
 
-  const allowsInterruptedInput = taskStatus === 'paused' || taskStatus === 'waiting_for_user';
-  const isInputBusy = !!isLoading && !allowsInterruptedInput;
+  const normalizedTaskStatus = normalizeTaskStatus(taskStatus);
+  const allowsInterruptedInput = normalizedTaskStatus === 'paused' || normalizedTaskStatus === 'waiting_for_user';
+  const isInputBusy = !!isLoading && !allowsInterruptedInput && !isStoppedTaskStatus(normalizedTaskStatus);
 
   const canSubmit = () => {
     const hasText = message.trim().length > 0;
@@ -464,10 +466,9 @@ export function ChatInput({
     return (hasText || hasFiles) && !isInputBusy && !isUploadingFiles;
   };
   const canPauseTask =
-    taskStatus === 'running' ||
-    (isLoading &&
-      !!onPause &&
-      !['completed', 'failed', 'paused', 'waiting_for_user'].includes(taskStatus || ''));
+    !!isLoading &&
+    !!onPause &&
+    isPausableTaskStatus(normalizedTaskStatus);
 
   const handleDragEnter = (e: React.DragEvent<HTMLFormElement>) => {
     if (!isFileDragEvent(e) || isInputBusy || hideFileUpload) return;
@@ -880,6 +881,7 @@ export function ChatInput({
                     size="icon"
                     onClick={onPause}
                     className="h-8 w-8 rounded-full transition-all duration-300 bg-yellow-500 hover:bg-yellow-600 text-white"
+                    title={t('agent.input.actions.pauseTask')}
                   >
                     <Pause className="h-4 w-4" />
                   </Button>
@@ -903,7 +905,7 @@ export function ChatInput({
                         <ArrowUp className="h-4 w-4" />
                       )}
                     </Button>
-                    {taskStatus === 'paused' && onResume && (
+                    {normalizedTaskStatus === 'paused' && onResume && (
                       <Button
                         type="button"
                         size="icon"

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { normalizeTimestampMs } from "@/lib/time-utils";
 import { FileChip } from "./FileChip";
 import { ClarificationForm } from "./clarification-form";
+import { resolveTraceProcessStatus } from "@/lib/trace-process-status";
 
 interface ToolArgs {
   code?: string;
@@ -67,6 +68,7 @@ export interface ChatMessageProps {
   showProcessView?: boolean;
   isVirtual?: boolean;
   taskStatus?: string;
+  processStatus?: string;
   timestamp?: number | string;
   interactions?: any[];
   interactionsActive?: boolean;
@@ -273,6 +275,7 @@ export function ChatMessage({
   traceEvents,
   showProcessView,
   taskStatus,
+  processStatus,
   timestamp,
   interactions,
   interactionsActive = true,
@@ -340,9 +343,14 @@ export function ChatMessage({
       ? traceEvents[traceEvents.length - 1]
       : undefined
   );
+  const resolvedProcessStatus = resolveTraceProcessStatus({
+    processStatus,
+    taskStatus,
+    traceEvents,
+  });
 
   let errorMessage = "";
-  if (taskStatus === "failed" && Array.isArray(traceEvents)) {
+  if (resolvedProcessStatus === "failed" && Array.isArray(traceEvents)) {
     for (let i = traceEvents.length - 1; i >= 0; i--) {
       const event = traceEvents[i];
       if (['trace_error', 'task_failed', 'react_task_failed', 'dag_step_failed', 'agent_error'].includes(event.event_type || '')) {
@@ -360,7 +368,7 @@ export function ChatMessage({
     <div className="w-full space-y-2 animate-fade-in group">
       {shouldShowProcess && !isUser && (
         <div className={cn("pl-7")}>
-          <TraceEventRenderer events={traceEvents} />
+          <TraceEventRenderer events={traceEvents} taskStatus={resolvedProcessStatus} />
         </div>
       )}
 
@@ -392,7 +400,7 @@ export function ChatMessage({
 
             {/* Message content */}
             <div className={cn("flex-1 min-w-0")}>
-              {!isUser && taskStatus === "failed" ? (
+              {!isUser && resolvedProcessStatus === "failed" ? (
                 <div className="py-3 text-sm leading-relaxed text-red-500 break-words [overflow-wrap:anywhere]">
                   {failedMessageText}
                 </div>
@@ -412,7 +420,7 @@ export function ChatMessage({
                   <div className="text-sm leading-relaxed break-words [overflow-wrap:anywhere]">{content}</div>
                 )
               ) : (
-                !isUser && showEmptyStatus && <GeneratingIndicator latestTitle={latestTitle} taskStatus={taskStatus} errorMessage={errorMessage} />
+                !isUser && showEmptyStatus && <GeneratingIndicator latestTitle={latestTitle} taskStatus={resolvedProcessStatus || taskStatus} errorMessage={errorMessage} />
               )}
               {!isUser && interactions && interactions.length > 0 && (
                 <div className="mt-4 border-t pt-4">

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -354,7 +354,7 @@ export function ChatMessage({
     for (let i = traceEvents.length - 1; i >= 0; i--) {
       const event = traceEvents[i];
       if (['trace_error', 'task_failed', 'react_task_failed', 'dag_step_failed', 'agent_error'].includes(event.event_type || '')) {
-        errorMessage = (event.data?.error as string) || (event.data?.message as string) || "";
+        errorMessage = (event.data?.error as string) || (event.data?.message as string) || (event.data?.error_message as string) || "";
         if (errorMessage) break;
       }
     }

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import React from "react"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 
@@ -59,6 +59,10 @@ vi.mock("@/components/file/pptx-preview-renderer", () => ({
 import { TraceEventRenderer } from "./TraceEventRenderer"
 
 describe("TraceEventRenderer", () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn()
+  })
+
   afterEach(() => {
     cleanup()
     apiRequestMock.mockReset()
@@ -488,6 +492,75 @@ describe("TraceEventRenderer", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true")
     expect(screen.getByText("traceEventRenderer.hideProcess")).toBeInTheDocument()
     expect(screen.getByText(/traceEventRenderer.executeTool:web_search/)).toBeInTheDocument()
+  })
+
+  it("stops running process spinners when the parent task has failed", () => {
+    const { container } = render(
+      <TraceEventRenderer
+        taskStatus="failed"
+        events={[
+          {
+            event_id: "start",
+            event_type: "react_task_start",
+            step_id: "step-1",
+            timestamp: 1000,
+            data: {},
+          },
+          {
+            event_id: "llm-start",
+            event_type: "llm_call_start",
+            step_id: "step-1",
+            timestamp: 2000,
+            data: { model_name: "gpt-test" },
+          },
+          {
+            event_id: "llm-failed",
+            event_type: "llm_call_failed",
+            step_id: "step-1",
+            timestamp: 3000,
+            data: { error: "OpenAI bad request" },
+          },
+        ]}
+      />,
+    )
+
+    expect(container.querySelector(".animate-spin")).toBeNull()
+  })
+
+  it("infers a failed process from terminal trace errors when task status is unavailable", () => {
+    const { container } = render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "start",
+            event_type: "react_task_start",
+            step_id: "step-1",
+            timestamp: 1000,
+            data: {},
+          },
+          {
+            event_id: "llm-start",
+            event_type: "llm_call_start",
+            step_id: "step-1",
+            timestamp: 2000,
+            data: { model_name: "gpt-test" },
+          },
+          {
+            event_id: "trace-error",
+            event_type: "trace_error",
+            step_id: "step-1",
+            timestamp: 3000,
+            data: {
+              error_type: "agent_error",
+              status: "failed",
+              error_message: "All patterns failed",
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(container.querySelector(".animate-spin")).toBeNull()
   })
 
   it("renders workforce delegation trace events as a dedicated step", () => {

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     t: (key: string, vars?: Record<string, string | number>) => {
       if (vars?.tool) return `${key}:${vars.tool}`
+      if (vars?.worker) return `${key}:${vars.worker}`
       return key
     },
   }),
@@ -487,5 +488,83 @@ describe("TraceEventRenderer", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true")
     expect(screen.getByText("traceEventRenderer.hideProcess")).toBeInTheDocument()
     expect(screen.getByText(/traceEventRenderer.executeTool:web_search/)).toBeInTheDocument()
+  })
+
+  it("renders workforce delegation trace events as a dedicated step", () => {
+    render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "delegation-start",
+            event_type: "workforce_delegation_start",
+            timestamp: Date.now(),
+            data: {
+              workforce_run_id: 5,
+              worker_member_id: 7,
+              worker_task_id: 99,
+              worker_alias: "Researcher",
+              tool_name: "research_worker",
+            },
+          },
+          {
+            event_id: "delegation-end",
+            event_type: "workforce_delegation_end",
+            timestamp: Date.now(),
+            data: {
+              worker_task_id: 99,
+              output: "Research complete",
+            },
+          },
+        ]}
+      />,
+    )
+
+    const toggle = screen.getByRole("button", {
+      name: /traceEventRenderer.delegateToWorker:Researcher/,
+    })
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText(/Research complete/)).toBeInTheDocument()
+  })
+
+  it("renders workforce delegation failures as errors", () => {
+    render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "delegation-start",
+            event_type: "workforce_delegation_start",
+            timestamp: Date.now(),
+            data: {
+              worker_task_id: 99,
+              worker_alias: "Researcher",
+            },
+          },
+          {
+            event_id: "delegation-error",
+            event_type: "workforce_delegation_error",
+            timestamp: Date.now(),
+            data: {
+              worker_task_id: 99,
+              error: "Worker timed out",
+            },
+          },
+        ]}
+      />,
+    )
+
+    const stepToggle = screen.getByRole("button", {
+      name: /traceEventRenderer.delegateToWorker:Researcher/,
+    })
+    fireEvent.click(stepToggle)
+
+    const errorToggle = screen.getByRole("button", {
+      name: /traceEventRenderer.workerFailed/,
+    })
+    fireEvent.click(errorToggle)
+
+    expect(screen.getByText("Worker timed out")).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -563,6 +563,42 @@ describe("TraceEventRenderer", () => {
     expect(container.querySelector(".animate-spin")).toBeNull()
   })
 
+  it("stops spinning when a step-local trace error has no explicit status", () => {
+    const { container } = render(
+      <TraceEventRenderer
+        events={[
+          {
+            event_id: "start",
+            event_type: "react_task_start",
+            step_id: "react-step",
+            timestamp: 1000,
+            data: {},
+          },
+          {
+            event_id: "llm-start",
+            event_type: "llm_call_start",
+            step_id: "react-step",
+            timestamp: 2000,
+            data: { model_name: "gpt-test" },
+          },
+          {
+            event_id: "trace-error",
+            event_type: "trace_error",
+            step_id: "react-step",
+            timestamp: 3000,
+            data: {
+              error_type: "agent_pattern_error",
+              error_message: "OpenAI bad request",
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(container.querySelector(".animate-spin")).toBeNull()
+    expect(container).toHaveTextContent("OpenAI bad request")
+  })
+
   it("renders workforce delegation trace events as a dedicated step", () => {
     render(
       <TraceEventRenderer

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -141,6 +141,40 @@ interface TraceEventRendererProps {
   events: TraceEvent[];
 }
 
+function getTraceData(event: TraceEvent): NonNullable<TraceEvent['data']> {
+  if (event.data && typeof event.data === 'object') {
+    return event.data;
+  }
+  return event as unknown as NonNullable<TraceEvent['data']>;
+}
+
+const getWaitingQuestionFromEvents = (events: TraceEvent[]): string | null => {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.event_type === 'agent_message') {
+      const expectsResponse = event.data?.expect_response === true || event.data?.message_type === 'question';
+      if (!expectsResponse) {
+        continue;
+      }
+      const message = event.data?.message || event.data?.content;
+      if (typeof message === 'string' && message.trim()) {
+        return message;
+      }
+    }
+    if (event.event_type === 'react_task_end') {
+      const result = event.data?.result as any;
+      if (
+        result?.status === 'waiting_for_user' &&
+        typeof result.message === 'string' &&
+        result.message.trim()
+      ) {
+        return result.message;
+      }
+    }
+  }
+  return null;
+};
+
 const isAgentProgressEvent = (event: TraceEvent): boolean => (
   event.event_type === 'agent_progress' ||
   (
@@ -182,8 +216,15 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
         return;
       }
 
-      let stepId = event.step_id || (event.data?.step_id as string) || 'default';
+      const eventData = getTraceData(event);
+      let stepId = event.step_id || (eventData.step_id as string) || 'default';
       const isProgressMessage = isAgentProgressEvent(event);
+      if (event.event_type?.startsWith('workforce_delegation_')) {
+        stepId = String(
+          eventData.worker_task_id ||
+          `workforce-${eventData.workforce_run_id || 'run'}-${eventData.worker_member_id || eventData.agent_id || event.event_id || index}`
+        );
+      }
 
       if (event.event_type === 'react_task_start' || event.event_type === 'task_start_react') {
         currentReactStepId = stepId;
@@ -217,11 +258,11 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
 
       // Process different event types
       if (event.event_type === 'dag_step_start' || event.event_type === 'react_task_start') {
-        step.stepName = (event.data?.step_name as string) || (event.event_type === 'react_task_start' ? t('traceEventRenderer.taskExecution') : '');
-        step.description = (event.data?.description as string) || (event.data?.task as string) || '';
+        step.stepName = (eventData.step_name as string) || (event.event_type === 'react_task_start' ? t('traceEventRenderer.taskExecution') : '');
+        step.description = (eventData.description as string) || (eventData.task as string) || '';
         step.status = 'running';
 
-        const tools = event.data?.tool_names || event.data?.tools;
+        const tools = eventData.tool_names || eventData.tools;
         if (tools && Array.isArray(tools)) {
           step.tools = tools.map((toolItem: any) => {
             if (typeof toolItem === 'string') return { function: { name: toolItem } };
@@ -235,26 +276,26 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
         step.actions.push({
           id: eventId,
           type: 'llm',
-          title: t('traceEventRenderer.callLLM', { model: event.data?.model_name || t('traceEventRenderer.unknownModel') }),
+          title: t('traceEventRenderer.callLLM', { model: eventData.model_name || t('traceEventRenderer.unknownModel') }),
           status: 'running',
           timestamp,
-          data: { model: event.data?.model_name }
+          data: { model: eventData.model_name }
         });
       }
 
       if (event.event_type === 'llm_call_end' || event.event_type === 'llm_call_result') {
-        if (event.data?.response?.reasoning) {
-          step.reasoning = event.data.response.reasoning;
+        if (eventData.response?.reasoning) {
+          step.reasoning = eventData.response.reasoning;
         }
-        if (event.data?.tools) {
-          step.tools = event.data.tools;
+        if (eventData.tools) {
+          step.tools = eventData.tools;
         }
 
         const action = findLastRunningAction(step, 'llm');
         if (action) {
           action.status = 'completed';
-          action.data.reasoning = event.data?.response?.reasoning;
-          action.data.tool_calls = event.data?.tools;
+          action.data.reasoning = eventData.response?.reasoning;
+          action.data.tool_calls = eventData.tools;
         } else {
           // Fallback if no start event found
           step.actions.push({
@@ -264,8 +305,8 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
             status: 'completed',
             timestamp,
             data: {
-              reasoning: event.data?.response?.reasoning,
-              tool_calls: event.data?.tools
+              reasoning: eventData.response?.reasoning,
+              tool_calls: eventData.tools
             }
           });
         }
@@ -290,6 +331,74 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
               output: message.trim(),
               inline: true,
             }
+          });
+        }
+      }
+
+      if (event.event_type === 'workforce_delegation_start') {
+        const workerName = String(
+          eventData.worker_alias ||
+          eventData.agent_name ||
+          eventData.tool_name ||
+          t('traceEventRenderer.unknownWorker')
+        );
+        step.stepName = t('traceEventRenderer.workforceDelegation');
+        step.description = t('traceEventRenderer.delegateToWorker', { worker: workerName });
+        step.status = 'running';
+        step.actions.push({
+          id: eventId,
+          type: 'info',
+          title: t('traceEventRenderer.delegateToWorker', { worker: workerName }),
+          status: 'running',
+          timestamp,
+          data: {
+            tool: eventData.tool_name,
+            output: eventData,
+          }
+        });
+      }
+
+      if (event.event_type === 'workforce_delegation_end') {
+        const output = eventData.output || eventData.response || '';
+        step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
+        step.description = step.description || t('traceEventRenderer.workforceDelegation');
+        step.status = 'completed';
+        const action = step.actions.find((item) => item.type === 'info' && item.status === 'running');
+        if (action) {
+          action.status = 'completed';
+          action.data.output = output || eventData;
+        } else {
+          step.actions.push({
+            id: eventId,
+            type: 'info',
+            title: t('traceEventRenderer.workerReturned'),
+            status: 'completed',
+            timestamp,
+            data: { output: output || eventData }
+          });
+        }
+      }
+
+      if (event.event_type === 'workforce_delegation_error') {
+        const errorMessage = eventData.error || eventData.message || t('traceEventRenderer.unknownError');
+        step.stepName = step.stepName || t('traceEventRenderer.workforceDelegation');
+        step.description = step.description || t('traceEventRenderer.workforceDelegation');
+        step.status = 'failed';
+        const action = step.actions.find((item) => item.type === 'info' && item.status === 'running');
+        if (action) {
+          action.type = 'error';
+          action.title = t('traceEventRenderer.workerFailed');
+          action.status = 'failed';
+          action.data.output = undefined;
+          action.data.error = errorMessage;
+        } else {
+          step.actions.push({
+            id: eventId,
+            type: 'error',
+            title: t('traceEventRenderer.workerFailed'),
+            status: 'failed',
+            timestamp,
+            data: { error: errorMessage }
           });
         }
       }

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -550,7 +550,8 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
       }
 
       if (['dag_step_failed', 'tool_execution_failed', 'llm_call_failed', 'react_task_failed', 'agent_error', 'trace_error'].includes(event.event_type as string)) {
-        const isTerminalFailure = ['dag_step_failed', 'react_task_failed', 'agent_error'].includes(event.event_type as string);
+        const isTerminalFailure =
+          ['dag_step_failed', 'react_task_failed', 'agent_error', 'trace_error'].includes(event.event_type as string);
         if (isTerminalFailure) {
           step.status = 'failed';
         } else if (step.status === 'pending') {
@@ -561,7 +562,8 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
         const errorData = event.data || {};
         let errorMessage =
           errorData.error ||
-          errorData.message;
+          errorData.message ||
+          errorData.error_message;
 
         if (!errorMessage && errorData.result) {
           errorMessage = (errorData.result as any).error || (errorData.result as any).message;

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -23,6 +23,10 @@ import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { normalizeTimestampMs } from '@/lib/time-utils';
 import { InlineFilePreview } from '@/components/file/inline-file-preview';
+import {
+  isStoppedTraceProcessStatus,
+  resolveTraceProcessStatus,
+} from '@/lib/trace-process-status';
 
 // Types
 interface ToolArgs {
@@ -128,7 +132,7 @@ interface ProcessedStep {
   stepId: string;
   stepName: string;
   description: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'paused' | 'waiting_for_user';
   tools: Array<{ function: { name: string } }>;
   reasoning?: string;
   code: string;
@@ -139,6 +143,7 @@ interface ProcessedStep {
 
 interface TraceEventRendererProps {
   events: TraceEvent[];
+  taskStatus?: string;
 }
 
 function getTraceData(event: TraceEvent): NonNullable<TraceEvent['data']> {
@@ -185,7 +190,7 @@ const isAgentProgressEvent = (event: TraceEvent): boolean => (
 );
 
 // Process trace events into steps
-function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
+function useProcessedSteps(events: TraceEvent[], taskStatus?: string): ProcessedStep[] {
   const { t } = useI18n();
   return useMemo(() => {
     const stepsMap = new Map<string, ProcessedStep>();
@@ -598,8 +603,42 @@ function useProcessedSteps(events: TraceEvent[]): ProcessedStep[] {
       }
     });
 
-    return Array.from(stepsMap.values()).filter(step => step.stepName);
-  }, [events, t]);
+    const steps = Array.from(stepsMap.values()).filter(step => step.stepName);
+
+    if (isStoppedTraceProcessStatus(taskStatus)) {
+      steps.forEach((step) => {
+        const runningActions = step.actions.filter(action => action.status === 'running');
+        if (taskStatus === 'failed' && (step.status !== 'completed' || runningActions.length > 0)) {
+          step.status = 'failed';
+          runningActions.forEach((action) => {
+            action.status = 'failed';
+            action.data.error = action.data.error || t('traceEventRenderer.unknownError');
+          });
+          return;
+        }
+
+        if (taskStatus === 'completed' && step.status !== 'failed') {
+          step.status = 'completed';
+          runningActions.forEach((action) => {
+            action.status = 'completed';
+          });
+          return;
+        }
+
+        if (
+          (taskStatus === 'paused' || taskStatus === 'waiting_for_user') &&
+          (step.status === 'pending' || step.status === 'running')
+        ) {
+          step.status = taskStatus;
+          runningActions.forEach((action) => {
+            action.status = 'completed';
+          });
+        }
+      });
+    }
+
+    return steps;
+  }, [events, taskStatus, t]);
 }
 
 
@@ -1159,6 +1198,7 @@ function StepItem({ step, index, onOpenTerminal, onViewDetail, onFileClick, onAg
   const { t } = useI18n();
   const isCompleted = step.status === 'completed';
   const isFailed = step.status === 'failed';
+  const isPaused = step.status === 'paused' || step.status === 'waiting_for_user';
   const [isExpanded, setIsExpanded] = useState(() => !isCompleted);
   const wasCompletedRef = useRef(isCompleted);
   const rawTitle = step.description || step.stepName;
@@ -1196,6 +1236,8 @@ function StepItem({ step, index, onOpenTerminal, onViewDetail, onFileClick, onAg
           <CheckCircle2 className="w-5 h-5 text-green-500 mt-0.5" />
         ) : isFailed ? (
           <Info className="w-5 h-5 text-red-500 mt-0.5" />
+        ) : isPaused ? (
+          <Info className="w-5 h-5 text-yellow-500 mt-0.5" />
         ) : (
           <Loader2 className="w-5 h-5 text-primary animate-spin mt-0.5" />
         )}
@@ -1245,9 +1287,13 @@ function StepItem({ step, index, onOpenTerminal, onViewDetail, onFileClick, onAg
 }
 
 // Main TraceEventRenderer Component
-export function TraceEventRenderer({ events }: TraceEventRendererProps) {
+export function TraceEventRenderer({ events, taskStatus }: TraceEventRendererProps) {
   const { t } = useI18n();
-  const steps = useProcessedSteps(events);
+  const processStatus = resolveTraceProcessStatus({
+    taskStatus,
+    traceEvents: events,
+  });
+  const steps = useProcessedSteps(events, processStatus);
   const router = useRouter();
 
   const { openFilePreview, dispatch } = useApp();

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -180,6 +180,13 @@ export const getNavigationGroupsForUser = (user: any): NavigationGroup[] => [
         icon: LayoutTemplate,
         color: "text-purple-400"
       },
+      {
+        name: "Workforces",
+        nameKey: "nav.workforces",
+        href: "/workforces",
+        icon: Layers,
+        color: "text-cyan-500"
+      },
     ]
   },
   {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -66,12 +66,14 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     interactionsActive,
     traceEvents,
     taskStatus,
+    processStatus,
     showEmptyStatus,
   }: {
     content?: string | null
     interactionsActive?: boolean
     traceEvents?: unknown[]
     taskStatus?: string
+    processStatus?: string
     showEmptyStatus?: boolean
   }) => (
     <div
@@ -79,6 +81,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
       data-active={interactionsActive ? "true" : "false"}
       data-trace-count={traceEvents?.length ?? 0}
       data-task-status={taskStatus || ""}
+      data-process-status={processStatus || ""}
       data-show-empty-status={showEmptyStatus ? "true" : "false"}
     >
       {content}
@@ -259,7 +262,121 @@ describe("TaskConversationPanel", () => {
     expect(renderedMessages).toHaveLength(3)
     expect(renderedMessages[0]).toHaveTextContent("Run analysis")
     expect(renderedMessages[1]).toHaveAttribute("data-trace-count", "1")
+    expect(renderedMessages[1]).toHaveAttribute("data-process-status", "completed")
     expect(renderedMessages[2]).toHaveTextContent("Done")
+  })
+
+  it("applies current task status only to the latest trace process group", () => {
+    appState.messages = [
+      {
+        id: "msg-user-1",
+        role: "user",
+        content: "First turn",
+        timestamp: "1000",
+      },
+      {
+        id: "msg-result-1",
+        role: "assistant",
+        content: "First result",
+        timestamp: "3000",
+        isResult: true,
+      },
+      {
+        id: "msg-user-2",
+        role: "user",
+        content: "Second turn",
+        timestamp: "4000",
+      },
+    ] as any
+    appState.traceEvents = [
+      {
+        event_id: "trace-old",
+        event_type: "tool_call",
+        timestamp: 2000,
+        data: { message: "Old turn work" },
+      },
+      {
+        event_id: "trace-latest",
+        event_type: "tool_call",
+        timestamp: 5000,
+        data: { message: "Latest turn work" },
+      },
+    ] as any
+    appState.currentTask = {
+      id: "42",
+      title: "Task",
+      description: "Task",
+      status: "completed",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as any
+
+    render(<TaskConversationPanel mode="page" />)
+
+    const processMessages = screen
+      .getAllByTestId("chat-message")
+      .filter((message) => message.getAttribute("data-trace-count") === "1")
+    expect(processMessages).toHaveLength(2)
+    expect(processMessages[0]).toHaveAttribute("data-process-status", "")
+    expect(processMessages[1]).toHaveAttribute("data-process-status", "completed")
+  })
+
+  it("does not apply current task status to a previous turn when the new turn has no trace yet", () => {
+    appState.messages = [
+      {
+        id: "msg-user-1",
+        role: "user",
+        content: "First turn",
+        timestamp: "1000",
+      },
+      {
+        id: "msg-result-1",
+        role: "assistant",
+        content: "First result",
+        timestamp: "3000",
+        isResult: true,
+      },
+      {
+        id: "msg-user-2",
+        role: "user",
+        content: "Second turn",
+        timestamp: "4000",
+      },
+    ] as any
+    appState.traceEvents = [
+      {
+        event_id: "trace-old",
+        event_type: "tool_call",
+        timestamp: 2000,
+        data: { message: "Old turn work" },
+      },
+    ] as any
+    appState.currentTask = {
+      id: "42",
+      title: "Task",
+      description: "Task",
+      status: "running",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as any
+    appState.isProcessing = true
+
+    render(<TaskConversationPanel mode="page" />)
+
+    const historicalProcessMessages = screen
+      .getAllByTestId("chat-message")
+      .filter((message) => message.getAttribute("data-trace-count") === "1")
+    expect(historicalProcessMessages).toHaveLength(1)
+    expect(historicalProcessMessages[0]).toHaveAttribute("data-process-status", "")
+
+    const virtualProcessMessages = screen
+      .getAllByTestId("chat-message")
+      .filter((message) => message.getAttribute("data-trace-count") === "0")
+    expect(
+      virtualProcessMessages.some(
+        (message) => message.getAttribute("data-process-status") === "running"
+      )
+    ).toBe(true)
   })
 
   it("normalizes invalid timestamps to zero for deterministic ordering", () => {

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -43,6 +43,7 @@ type CombinedItem = {
   traceEvents?: any[]
   interactions?: any[]
   showEmptyStatus?: boolean
+  processStatus?: string
   timelineOrder?: number
 }
 
@@ -67,6 +68,13 @@ const toTimestampMs = (timestamp: unknown): number => {
 
   return time < 100000000000 ? time * 1000 : time
 }
+
+const getLastUserMessageIndex = (messages: Array<{ role?: string }>): number =>
+  messages.reduce(
+    (latestIndex, message, index) =>
+      message.role === "user" ? index : latestIndex,
+    -1
+  )
 
 const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   if (currentTask?.status !== "waiting_for_user") {
@@ -243,6 +251,7 @@ export function TaskConversationPanel({
     const groupEntries = Array.from(processGroups.entries()).sort((a, b) => a[0] - b[0])
     const latestGroupIndex =
       groupEntries.length > 0 ? groupEntries[groupEntries.length - 1][0] : -1
+    const lastUserMessageIndex = getLastUserMessageIndex(sortedMessages)
 
     groupEntries.forEach(([groupIndex, events]) => {
       if (events.length === 0) {
@@ -257,6 +266,11 @@ export function TaskConversationPanel({
         !hasFinalAssistantMessage &&
         groupIndex === latestGroupIndex &&
         groupIndex >= sortedMessages.length
+      const isCurrentTurnGroup = groupIndex > lastUserMessageIndex
+      const processStatus =
+        groupIndex === latestGroupIndex && isCurrentTurnGroup
+          ? state.currentTask?.status
+          : undefined
 
       items.push({
         id: `process-${groupIndex}-${firstEvent?.event_id || groupTimestamp}`,
@@ -266,6 +280,7 @@ export function TaskConversationPanel({
         status: shouldShowEmptyStatus ? state.currentTask?.status : undefined,
         traceEvents: events,
         showEmptyStatus: shouldShowEmptyStatus,
+        processStatus,
         timelineOrder: groupIndex * 2,
       })
     })
@@ -283,6 +298,23 @@ export function TaskConversationPanel({
     state.currentTask?.status,
     state.traceEvents,
   ])
+
+  const currentTurnTraceEvents = useMemo(() => {
+    if (!Array.isArray(state.traceEvents) || state.traceEvents.length === 0) {
+      return []
+    }
+
+    const sortedMessages = [...messageItems].sort((a, b) => a.timestamp - b.timestamp)
+    const lastUserMessageIndex = getLastUserMessageIndex(sortedMessages)
+    if (lastUserMessageIndex < 0) {
+      return state.traceEvents
+    }
+
+    return state.traceEvents.filter((event: any) => {
+      const eventTime = toTimestampMs(event?.timestamp)
+      return getProcessGroupIndex(sortedMessages, eventTime) > lastUserMessageIndex
+    })
+  }, [messageItems, state.traceEvents])
 
   const waitingPrompt = useMemo(
     () => findWaitingPrompt(state.currentTask, state.traceEvents as any[]),
@@ -559,6 +591,7 @@ export function TaskConversationPanel({
                         rawContent={item.rawContent}
                         traceEvents={item.traceEvents as any || []}
                         showProcessView={true}
+                        processStatus={item.processStatus}
                         taskStatus={
                           isFailedFinalAnswerStream
                             ? "failed"
@@ -578,9 +611,10 @@ export function TaskConversationPanel({
                     <ChatMessage
                       role="assistant"
                       content={state.currentTask?.status === "waiting_for_user" ? waitingPrompt : null}
-                      traceEvents={state.traceEvents as any || []}
+                      traceEvents={currentTurnTraceEvents as any || []}
                       showProcessView={true}
                       isVirtual
+                      processStatus={state.currentTask?.status}
                       taskStatus={state.currentTask?.status}
                       interactions={state.currentTask?.status === "waiting_for_user" ? waitingInteractions : undefined}
                       interactionsActive={state.currentTask?.status === "waiting_for_user"}

--- a/frontend/src/components/workforce/workforce-builder-chat.tsx
+++ b/frontend/src/components/workforce/workforce-builder-chat.tsx
@@ -20,6 +20,8 @@ interface WorkforceBuilderChatProps {
   messages: WorkforceBuilderMessage[]
   loading?: boolean
   submitting?: boolean
+  readOnly?: boolean
+  readOnlyReason?: string
   onSubmit: (message: string) => Promise<void> | void
 }
 
@@ -31,6 +33,8 @@ export function WorkforceBuilderChat({
   messages,
   loading = false,
   submitting = false,
+  readOnly = false,
+  readOnlyReason,
   onSubmit,
 }: WorkforceBuilderChatProps) {
   const { t } = useI18n()
@@ -38,8 +42,8 @@ export function WorkforceBuilderChat({
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   const canSubmit = useMemo(
-    () => message.trim().length > 0 && !submitting,
-    [message, submitting],
+    () => message.trim().length > 0 && !submitting && !readOnly,
+    [message, readOnly, submitting],
   )
 
   useEffect(() => {
@@ -53,7 +57,7 @@ export function WorkforceBuilderChat({
 
   const handleSubmit = async () => {
     const value = message.trim()
-    if (!value || submitting) return
+    if (!value || submitting || readOnly) return
     setMessage("")
     await onSubmit(value)
   }
@@ -144,6 +148,7 @@ export function WorkforceBuilderChat({
             value={message}
             onChange={(event) => setMessage(event.target.value)}
             rows={6}
+            disabled={readOnly}
             onKeyDown={(event) => {
               if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
                 event.preventDefault()
@@ -153,10 +158,12 @@ export function WorkforceBuilderChat({
           />
           <div className="flex items-center justify-between gap-3">
             <div className="text-xs text-muted-foreground">
-              {t("workforces.builder.sendHint")}
+              {readOnly && readOnlyReason ? readOnlyReason : t("workforces.builder.sendHint")}
             </div>
             <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
-              {submitting
+              {readOnly
+                ? t("workforces.actions.readOnly")
+                : submitting
                 ? t("workforces.loading.proposing")
                 : t("workforces.actions.proposeChanges")}
             </Button>

--- a/frontend/src/components/workforce/workforce-components.test.tsx
+++ b/frontend/src/components/workforce/workforce-components.test.tsx
@@ -172,6 +172,24 @@ describe("workforce frontend core components", () => {
     })
   })
 
+  it("keeps builder chat read-only when the route disables editing", () => {
+    const onSubmit = vi.fn()
+    render(
+      <WorkforceBuilderChat
+        messages={[]}
+        readOnly
+        readOnlyReason="workforces.builder.archivedReadOnly"
+        onSubmit={onSubmit}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText("workforces.builder.messagePlaceholder")).toBeDisabled()
+    expect(screen.getByText("workforces.builder.archivedReadOnly")).toBeInTheDocument()
+    expect(screen.getByText("workforces.actions.readOnly")).toBeDisabled()
+    fireEvent.click(screen.getByText("workforces.actions.readOnly"))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it("applies the exact stored builder patch", async () => {
     const patch: WorkforceBuilderPatch = {
       summary: "Add worker",
@@ -191,6 +209,28 @@ describe("workforce frontend core components", () => {
     fireEvent.click(screen.getByText("workforces.actions.applyChanges"))
 
     expect(onApply).toHaveBeenCalledWith(12, patch)
+  })
+
+  it("does not apply builder patches in read-only mode", () => {
+    const patch: WorkforceBuilderPatch = {
+      summary: "Add worker",
+      operations: [{ op: "add_existing_worker", agent_id: 8 }],
+      warnings: [],
+    }
+    const onApply = vi.fn()
+
+    render(
+      <ProposedPatchCard
+        patch={patch}
+        messageId={12}
+        readOnly
+        onApply={onApply}
+      />,
+    )
+
+    expect(screen.getByText("workforces.actions.readOnly")).toBeDisabled()
+    fireEvent.click(screen.getByText("workforces.actions.readOnly"))
+    expect(onApply).not.toHaveBeenCalled()
   })
 
   it("creates from prompt through callbacks instead of hardcoded routes", async () => {
@@ -240,6 +280,26 @@ describe("workforce frontend core components", () => {
       })
     })
     expect(onRunCreated).toHaveBeenCalledWith(runResult)
+  })
+
+  it("shows a disabled reason and does not run when the route disables execution", () => {
+    const onRunCreated = vi.fn()
+
+    render(
+      <WorkforceTestPanel
+        workforceId={42}
+        disabled
+        disabledReason="workforces.run.inactiveDisabled"
+        onRunCreated={onRunCreated}
+      />,
+    )
+
+    expect(screen.getByText("workforces.run.inactiveDisabled")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("workforces.run.placeholder")).toBeDisabled()
+    expect(screen.getByText("workforces.actions.runWorkforce")).toBeDisabled()
+    fireEvent.click(screen.getByText("workforces.actions.runWorkforce"))
+    expect(runWorkforceMock).not.toHaveBeenCalled()
+    expect(onRunCreated).not.toHaveBeenCalled()
   })
 
   it("does not link readonly workforce agents to the editor", () => {

--- a/frontend/src/components/workforce/workforce-test-panel.tsx
+++ b/frontend/src/components/workforce/workforce-test-panel.tsx
@@ -11,12 +11,14 @@ import type { WorkforceRunResponse } from "@/types/workforce"
 interface WorkforceTestPanelProps {
   workforceId: number
   disabled?: boolean
+  disabledReason?: string
   onRunCreated: (result: WorkforceRunResponse) => void
 }
 
 export function WorkforceTestPanel({
   workforceId,
   disabled = false,
+  disabledReason,
   onRunCreated,
 }: WorkforceTestPanelProps) {
   const { t } = useI18n()
@@ -52,6 +54,9 @@ export function WorkforceTestPanel({
           rows={8}
           disabled={disabled}
         />
+        {disabled && disabledReason ? (
+          <div className="text-sm text-muted-foreground">{disabledReason}</div>
+        ) : null}
         {error ? <div className="text-sm text-red-500">{error}</div> : null}
         <Button
           onClick={handleRun}

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -212,6 +212,47 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("normalizes uppercase task info status before syncing processing state", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        data: {
+          event_id: "task-info-1",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Test task",
+            description: "Test task",
+            status: "FAILED",
+            created_at: "2026-05-27T05:00:00Z",
+            updated_at: "2026-05-27T05:00:02Z",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      expect(screen.getByTestId("processing").textContent).toBe("false")
+    })
+  })
+
   it("shows websocket error payloads and syncs task status when provided", async () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { act, render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 type TestWebSocketMessage = {
   type: string
   timestamp: string
-  data: unknown
+  data?: unknown
 }
 
 const webSocketOptions = vi.hoisted(() => ({
@@ -81,13 +81,40 @@ function StateProbe() {
           })
         )}
       </div>
+      <div data-testid="task-status">{state.currentTask?.status || ""}</div>
+      <div data-testid="processing">{String(state.isProcessing)}</div>
     </>
   )
+}
+
+function SeedRunningTask() {
+  const { dispatch } = useApp()
+
+  React.useEffect(() => {
+    dispatch({
+      type: "SET_CURRENT_TASK",
+      payload: {
+        id: "1",
+        title: "Test task",
+        status: "running",
+        description: "Test task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:00:00Z",
+      },
+    })
+    dispatch({ type: "SET_PROCESSING", payload: true })
+  }, [dispatch])
+
+  return null
 }
 
 describe("AppProvider websocket message routing", () => {
   beforeEach(() => {
     webSocketOptions.current = null
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it("routes historical assistant transcript rows to chat and progress events to trace", async () => {
@@ -148,5 +175,192 @@ describe("AppProvider websocket message routing", () => {
       )
     })
     expect(screen.getByTestId("messages").textContent).not.toContain("Searching")
+  })
+
+  it("handles top-level failed task completion payloads", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task: {
+          id: 1,
+          status: "failed",
+        },
+        success: false,
+        result: "Task failed",
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      expect(screen.getByTestId("processing").textContent).toBe("false")
+    })
+  })
+
+  it("shows websocket error payloads and syncs task status when provided", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "error",
+        timestamp: "2026-05-27T05:00:03Z",
+        message: "No live execution found to pause",
+        task: {
+          id: 1,
+          status: "failed",
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      expect(screen.getByTestId("processing").textContent).toBe("false")
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "No live execution found to pause"
+      )
+    })
+  })
+
+  it("keeps running state for non-terminal agent errors without task status", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message:
+            "Task is currently busy; please wait for the previous turn to finish before sending another message.",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Task is currently busy"
+      )
+    })
+  })
+
+  it("syncs terminal agent errors when task status is provided", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:05Z",
+        data: {
+          type: "agent_error",
+          message: "Runtime error",
+          task: {
+            id: 1,
+            status: "failed",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+      expect(screen.getByTestId("processing").textContent).toBe("false")
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Runtime error"
+      )
+    })
+  })
+
+  it("stops processing when a task waits for user input", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+      expect(screen.getByTestId("processing").textContent).toBe("true")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:06Z",
+        data: {
+          question: "Which file should I use?",
+          interactions: [],
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe(
+        "waiting_for_user"
+      )
+      expect(screen.getByTestId("processing").textContent).toBe("false")
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Which file should I use?"
+      )
+    })
   })
 })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -41,6 +41,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { unwrapFinalAnswerContent } from "@/lib/final-answer"
 import { normalizeTaskCompletedMessage } from "@/lib/task-completion"
+import { isStoppedTaskStatus, normalizeTaskStatus, type TaskStatus } from "@/lib/task-status"
 import {
   getFinalAnswerStreamActionPayload,
   getFinalAnswerStreamMessageId,
@@ -335,7 +336,7 @@ interface Message {
 interface Task {
   id: string
   title: string
-  status: "pending" | "running" | "completed" | "failed" | "paused" | "waiting_for_user"
+  status: TaskStatus
   description: string
   createdAt: string | number
   updatedAt: string | number
@@ -388,17 +389,6 @@ const normalizeStepStatus = (status: unknown): StepExecution["status"] => {
     : "pending"
 }
 
-const normalizeTaskStatus = (status: unknown): Task["status"] | null => {
-  return status === "pending" ||
-    status === "running" ||
-    status === "completed" ||
-    status === "failed" ||
-    status === "paused" ||
-    status === "waiting_for_user"
-    ? status
-    : null
-}
-
 const getString = (value: unknown, fallback = ""): string => typeof value === "string" ? value : fallback
 const getStringArray = (value: unknown): string[] => Array.isArray(value) ? value.map(item => String(item)) : []
 
@@ -413,14 +403,11 @@ const getWebSocketTaskStatus = (message: WebSocketMessage): Task["status"] | nul
   const data = isJsonRecord(message.data) ? message.data : null
   const rootTask = isJsonRecord(root.task) ? root.task : null
   const dataTask = isJsonRecord(data?.task) ? data.task : null
-  return normalizeTaskStatus(dataTask?.status) || normalizeTaskStatus(rootTask?.status) || normalizeTaskStatus(data?.status) || normalizeTaskStatus(root.status)
+  return normalizeTaskStatus(dataTask?.status) || normalizeTaskStatus(rootTask?.status) || normalizeTaskStatus(data?.status) || normalizeTaskStatus(root.status) || null
 }
 
-const shouldStopProcessingForTaskStatus = (status: Task["status"] | null): boolean =>
-  status === "completed" ||
-  status === "failed" ||
-  status === "paused" ||
-  status === "waiting_for_user"
+const shouldStopProcessingForTaskStatus = (status: unknown): boolean =>
+  isStoppedTaskStatus(status)
 
 const stepsFromPlanData = (planData: unknown, existingSteps: StepExecution[]): StepExecution[] | null => {
   const planRecord = planData && typeof planData === "object" ? planData as Record<string, unknown> : null
@@ -591,7 +578,7 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, isHistoryLoading: action.payload }
 
     case "SYNC_PROCESSING_STATUS":
-      if (state.currentTask?.status === 'completed' || state.currentTask?.status === 'failed') {
+      if (shouldStopProcessingForTaskStatus(state.currentTask?.status)) {
         return { ...state, isProcessing: false }
       }
       return state
@@ -711,25 +698,50 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, messages: updatedMessages }
     }
 
-    case "SET_CURRENT_TASK":
+    case "SET_CURRENT_TASK": {
+      const incomingTask = action.payload
+        ? {
+          ...action.payload,
+          status:
+            normalizeTaskStatus(action.payload.status) ||
+            (state.currentTask?.id === action.payload.id
+              ? state.currentTask.status
+              : "pending"),
+        }
+        : null
+
+      const currentTask = (state.currentTask && incomingTask && state.currentTask.id === incomingTask.id)
+        ? { ...state.currentTask, ...incomingTask, agentName: incomingTask.agentName || state.currentTask.agentName, agentLogoUrl: incomingTask.agentLogoUrl || state.currentTask.agentLogoUrl }
+        : incomingTask
+
       return {
         ...state,
-        currentTask: (state.currentTask && action.payload && state.currentTask.id === action.payload.id)
-          ? { ...state.currentTask, ...action.payload, agentName: action.payload.agentName || state.currentTask.agentName, agentLogoUrl: action.payload.agentLogoUrl || state.currentTask.agentLogoUrl }
-          : action.payload
+        currentTask,
+        isProcessing: currentTask && shouldStopProcessingForTaskStatus(currentTask.status)
+          ? false
+          : state.isProcessing,
       }
+    }
 
-    case "UPDATE_TASK_STATUS":
+    case "UPDATE_TASK_STATUS": {
       if (!state.currentTask) {
         return state
       }
 
-      const isWaitingForUser = action.payload.status === "waiting_for_user"
+      const nextStatus = normalizeTaskStatus(action.payload.status)
+      if (!nextStatus) {
+        return state
+      }
+
+      const isWaitingForUser = nextStatus === "waiting_for_user"
       return {
         ...state,
+        isProcessing: shouldStopProcessingForTaskStatus(nextStatus)
+          ? false
+          : state.isProcessing,
         currentTask: {
           ...state.currentTask,
-          status: action.payload.status,
+          status: nextStatus,
           updatedAt: new Date().toISOString(),
           waitingQuestion: isWaitingForUser
             ? action.payload.waitingQuestion ?? state.currentTask.waitingQuestion
@@ -739,6 +751,7 @@ function appReducer(state: AppState, action: AppAction): AppState {
             : undefined,
         },
       }
+    }
 
     case "SET_DAG_EXECUTION":
       return { ...state, dagExecution: action.payload }
@@ -1293,6 +1306,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
           // Handle structured trace events
           if (eventType === "task_info") {
             const taskData = eventData
+            const taskStatus = normalizeTaskStatus(taskData.status) || "pending"
             console.log('📥 Received task_info event:', {
               taskData,
               status: taskData.status,
@@ -1300,13 +1314,13 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             })
 
             // Store pending task for auto-execution
-            if (taskData.status === 'pending' && taskData.description) {
+            if (taskStatus === 'pending' && taskData.description) {
               pendingTaskToExecute = { description: taskData.description }
               console.log('💾 Stored pending task for auto-execution:', taskData.description)
             }
 
             // Check if status changed and trigger update if so
-            if (currentState.currentTask?.id === taskData.id.toString() && currentState.currentTask?.status !== taskData.status) {
+            if (currentState.currentTask?.id === taskData.id.toString() && currentState.currentTask?.status !== taskStatus) {
               dispatch({ type: "TRIGGER_TASK_UPDATE" })
             }
 
@@ -1316,7 +1330,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                 id: taskData.id.toString(),
                 title: taskData.title,
                 description: taskData.description,
-                status: taskData.status,
+                status: taskStatus,
                 createdAt: taskData.created_at,
                 updatedAt: taskData.updated_at,
                 modelId: taskData.model_id,
@@ -4112,7 +4126,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
           const newTask: Task = {
             id: newTaskId.toString(),
             title: taskData.title,
-            status: taskData.status,
+            status: normalizeTaskStatus(taskData.status) || "pending",
             description: taskData.description || message,
             createdAt: taskData.created_at,
             updatedAt: taskData.updated_at,

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -12,7 +12,7 @@ import { ClarificationForm } from "@/components/chat/clarification-form"
 
 interface WebSocketMessage {
   type: string
-  data: unknown
+  data?: unknown
   timestamp: string
   task_id?: number
   step_id?: string
@@ -40,6 +40,7 @@ import { apiRequest, getApiErrorMessage, getUploadErrorMessage, isJsonRecord, pa
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { unwrapFinalAnswerContent } from "@/lib/final-answer"
+import { normalizeTaskCompletedMessage } from "@/lib/task-completion"
 import {
   getFinalAnswerStreamActionPayload,
   getFinalAnswerStreamMessageId,
@@ -387,8 +388,39 @@ const normalizeStepStatus = (status: unknown): StepExecution["status"] => {
     : "pending"
 }
 
+const normalizeTaskStatus = (status: unknown): Task["status"] | null => {
+  return status === "pending" ||
+    status === "running" ||
+    status === "completed" ||
+    status === "failed" ||
+    status === "paused" ||
+    status === "waiting_for_user"
+    ? status
+    : null
+}
+
 const getString = (value: unknown, fallback = ""): string => typeof value === "string" ? value : fallback
 const getStringArray = (value: unknown): string[] => Array.isArray(value) ? value.map(item => String(item)) : []
+
+const getWebSocketErrorMessage = (message: WebSocketMessage): string => {
+  const root = message as unknown as Record<string, unknown>
+  const data = isJsonRecord(message.data) ? message.data : null
+  return getString(data?.message) || getString(data?.error) || getString(root.message) || getString(root.error) || "Unknown error"
+}
+
+const getWebSocketTaskStatus = (message: WebSocketMessage): Task["status"] | null => {
+  const root = message as unknown as Record<string, unknown>
+  const data = isJsonRecord(message.data) ? message.data : null
+  const rootTask = isJsonRecord(root.task) ? root.task : null
+  const dataTask = isJsonRecord(data?.task) ? data.task : null
+  return normalizeTaskStatus(dataTask?.status) || normalizeTaskStatus(rootTask?.status) || normalizeTaskStatus(data?.status) || normalizeTaskStatus(root.status)
+}
+
+const shouldStopProcessingForTaskStatus = (status: Task["status"] | null): boolean =>
+  status === "completed" ||
+  status === "failed" ||
+  status === "paused" ||
+  status === "waiting_for_user"
 
 const stepsFromPlanData = (planData: unknown, existingSteps: StepExecution[]): StepExecution[] | null => {
   const planRecord = planData && typeof planData === "object" ? planData as Record<string, unknown> : null
@@ -3614,10 +3646,10 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
         break
 
       case "task_completed":
-        const taskData = message.data as { success?: boolean; result?: string | Record<string, unknown>; file_outputs?: string[] }
+        const taskData = normalizeTaskCompletedMessage(message)
         dispatch({
           type: "UPDATE_TASK_STATUS",
-          payload: { status: taskData.success ? "completed" : "failed" }
+          payload: { status: taskData.status }
         })
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
         dispatch({ type: "SET_PROCESSING", payload: false })  // Stop processing on task completion
@@ -3626,13 +3658,13 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
         if (state.dagExecution) {
           const updatedDAGExecution = {
             ...state.dagExecution,
-            phase: (taskData.success ? "completed" : "failed") as "completed" | "failed",
+            phase: taskData.status,
             updated_at: new Date().toISOString()
           }
           dispatch({ type: "SET_DAG_EXECUTION", payload: updatedDAGExecution })
         } else {
           const dagExecution: DAGExecution = {
-            phase: (taskData.success ? "completed" : "failed") as "completed" | "failed",
+            phase: taskData.status,
             current_plan: {},
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString()
@@ -3646,14 +3678,14 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
         }
 
         // Handle file outputs
-        if (taskData.file_outputs && taskData.file_outputs.length > 0) {
-          const fileCount = taskData.file_outputs.length
+        if (taskData.fileOutputs.length > 0) {
+          const fileCount = taskData.fileOutputs.length
           const fileContent = (
             <>
               <FileText className="h-4 w-4 inline mr-2 text-green-500" />
               {t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}:
               <div className="mt-2 space-y-1">
-                {taskData.file_outputs.map((file: string | any, index: number) => {
+                {taskData.fileOutputs.map((file: string | any, index: number) => {
                   let fileName, filePath
                   if (typeof file === 'object' && file !== null) {
                     fileName = file.filename || 'unknown'
@@ -3669,7 +3701,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
                       <button
                         onClick={() => {
                           // Dispatch custom event to open file preview with all files
-                          const allFiles = normalizeGeneratedPreviewFiles(taskData.file_outputs)
+                          const allFiles = normalizeGeneratedPreviewFiles(taskData.fileOutputs)
 
                           if (!filePath) {
                             return
@@ -3710,7 +3742,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             })
           }
 
-          dispatchAutoOpenPreview(taskData.file_outputs, dispatch)
+          dispatchAutoOpenPreview(taskData.fileOutputs, dispatch)
         }
 
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -3787,6 +3819,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
       case "task_paused":
         console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (task_paused)')
         dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "paused" } })
+        dispatch({ type: "SET_PROCESSING", payload: false })
         break
 
       case "task_waiting_for_user":
@@ -3802,6 +3835,7 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
             waitingInteractions: interactions.length > 0 ? interactions : undefined,
           }
         })
+        dispatch({ type: "SET_PROCESSING", payload: false })
         if (
           waitingMessage &&
           waitingMessage !== "Task waiting for user response" &&
@@ -3830,10 +3864,18 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
 
       case "agent_error":
         console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (agent_error)')
-        const errorData = message.data as { message?: string }
+        const agentErrorMessage = getWebSocketErrorMessage(message)
+        const agentErrorTaskStatus = getWebSocketTaskStatus(message)
 
-        // Update DAG execution status to failed
-        if (state.dagExecution) {
+        if (agentErrorTaskStatus) {
+          dispatch({
+            type: "UPDATE_TASK_STATUS",
+            payload: { status: agentErrorTaskStatus },
+          })
+          dispatch({ type: "TRIGGER_TASK_UPDATE" })
+        }
+
+        if (agentErrorTaskStatus === "failed" && state.dagExecution) {
           const updatedDAGExecution = {
             ...state.dagExecution,
             phase: "failed" as const,
@@ -3842,17 +3884,48 @@ export function AppProvider({ children, token }: { children: React.ReactNode; to
           dispatch({ type: "SET_DAG_EXECUTION", payload: updatedDAGExecution })
         }
 
-        dispatch({ type: "SET_PROCESSING", payload: false })
+        if (shouldStopProcessingForTaskStatus(agentErrorTaskStatus)) {
+          dispatch({ type: "SET_PROCESSING", payload: false })
+        }
+
         dispatch({
           type: "ADD_MESSAGE",
           payload: {
             id: generateMessageId("msg"),
             role: "assistant",
-            content: `${t('agent.logs.event.messages.errorPrefix')} ${errorData.message || t('common.errors.unknownError')}`,
+            content: `${t('agent.logs.event.messages.errorPrefix')} ${agentErrorMessage || t('common.errors.unknownError')}`,
             timestamp: message.timestamp,
             status: "failed",
           },
         })
+        break
+
+      case "error":
+      case "task_error":
+        console.trace('Original message:', JSON.stringify(message), 'Handler: handleMessage (error)')
+        const websocketErrorMessage = getWebSocketErrorMessage(message)
+        const websocketTaskStatus = getWebSocketTaskStatus(message)
+
+        if (websocketTaskStatus) {
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: websocketTaskStatus } })
+          dispatch({ type: "TRIGGER_TASK_UPDATE" })
+        }
+        if (shouldStopProcessingForTaskStatus(websocketTaskStatus)) {
+          dispatch({ type: "SET_PROCESSING", payload: false })
+        }
+
+        if (!isDuplicateMessage(websocketErrorMessage, "agent-error")) {
+          dispatch({
+            type: "ADD_MESSAGE",
+            payload: {
+              id: generateMessageId("msg-error"),
+              role: "assistant",
+              content: `${t('agent.logs.event.messages.errorPrefix')} ${websocketErrorMessage}`,
+              timestamp: message.timestamp,
+              status: "failed",
+            },
+          })
+        }
         break
 
       case "message_received":

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3056,11 +3056,14 @@ Build when you need.`
     },
     run: {
       testTitle: "Test Workforce",
-      placeholder: "Describe the task you want the manager to coordinate."
+      placeholder: "Describe the task you want the manager to coordinate.",
+      inactiveDisabled: "Publish this workforce before running it.",
+      archivedDisabled: "Archived workforces cannot run."
     },
     builder: {
       chatTitle: "Builder Chat",
       chatDescription: "Describe the workforce change you want. The builder will turn it into a reviewable patch.",
+      archivedReadOnly: "Archived workforces are read-only. Builder changes cannot be proposed or applied.",
       emptyPrompt: "Start with something like: add worker Research Agent to handle competitor research.",
       roleBuilder: "Builder",
       roleYou: "You",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -58,6 +58,7 @@ const en = {
     deploy: "Deploy",
     agentDev: "Agent Development",
     task: "Task",
+    workforces: "Workforces",
     history: "All Tasks",
     search: "Search Tasks",
     templates: "Templates",
@@ -2851,7 +2852,12 @@ Build when you need.`
     queryPrefix: "Query:",
     pathPrefix: "Path:",
     bashPrefix: "Bash:",
-    searchPrefix: "Search:"
+    searchPrefix: "Search:",
+    workforceDelegation: "Workforce Delegation",
+    delegateToWorker: "Delegate to {worker}",
+    workerReturned: "Worker returned result",
+    workerFailed: "Worker failed",
+    unknownWorker: "Unknown Worker"
   },
   deploy_agent: {
     title: "Deploy Agent",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -58,6 +58,7 @@ const zh = {
     deploy: "部署",
     agentDev: "Agent 构建与部署",
     task: "任务",
+    workforces: "Workforces",
     history: "全部任务",
     search: "搜索任务",
     templates: "模板",
@@ -2851,7 +2852,12 @@ Build when you need.`
     queryPrefix: "查询:",
     pathPrefix: "路径:",
     bashPrefix: "Bash命令:",
-    searchPrefix: "搜索:"
+    searchPrefix: "搜索:",
+    workforceDelegation: "Workforce 委派",
+    delegateToWorker: "委派给 {worker}",
+    workerReturned: "Worker 已返回结果",
+    workerFailed: "Worker 执行失败",
+    unknownWorker: "未知 Worker"
   },
   deploy_agent: {
     title: "部署 Agent",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3056,11 +3056,14 @@ Build when you need.`
     },
     run: {
       testTitle: "测试 Workforce",
-      placeholder: "描述你希望 manager 协调完成的任务。"
+      placeholder: "描述你希望 manager 协调完成的任务。",
+      inactiveDisabled: "请先发布这个 Workforce 再运行。",
+      archivedDisabled: "已归档的 Workforce 不能运行。"
     },
     builder: {
       chatTitle: "Builder 对话",
       chatDescription: "描述你想要的 workforce 修改，builder 会生成可检查的 patch。",
+      archivedReadOnly: "已归档的 Workforce 是只读的，不能生成或应用 Builder 修改。",
       emptyPrompt: "可以这样开始：添加 Research Agent worker 来负责竞品调研。",
       roleBuilder: "Builder",
       roleYou: "你",

--- a/frontend/src/lib/task-completion.test.ts
+++ b/frontend/src/lib/task-completion.test.ts
@@ -42,6 +42,18 @@ describe("task-completion", () => {
     expect(payload.task?.id).toBe(3)
   })
 
+  it("accepts enum-style uppercase terminal statuses", () => {
+    const payload = normalizeTaskCompletedMessage({
+      type: "task_completed",
+      task: {
+        status: "FAILED",
+      },
+    })
+
+    expect(payload.status).toBe("failed")
+    expect(payload.success).toBe(false)
+  })
+
   it("falls back to task status when success is omitted", () => {
     const payload = normalizeTaskCompletedMessage({
       type: "task_completed",

--- a/frontend/src/lib/task-completion.test.ts
+++ b/frontend/src/lib/task-completion.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeTaskCompletedMessage } from "./task-completion"
+
+describe("task-completion", () => {
+  it("normalizes legacy nested data payloads", () => {
+    const payload = normalizeTaskCompletedMessage({
+      type: "task_completed",
+      data: {
+        success: true,
+        result: "done",
+        file_outputs: [{ file_id: "file-1", filename: "out.xlsx" }],
+      },
+    })
+
+    expect(payload).toEqual({
+      success: true,
+      status: "completed",
+      task: undefined,
+      result: "done",
+      output: undefined,
+      fileOutputs: [{ file_id: "file-1", filename: "out.xlsx" }],
+      chatResponse: undefined,
+      metadata: undefined,
+    })
+  })
+
+  it("normalizes top-level websocket completion payloads", () => {
+    const payload = normalizeTaskCompletedMessage({
+      type: "task_completed",
+      task: {
+        id: 3,
+        status: "failed",
+      },
+      success: false,
+      result: "failed",
+      file_outputs: [],
+    })
+
+    expect(payload.status).toBe("failed")
+    expect(payload.success).toBe(false)
+    expect(payload.task?.id).toBe(3)
+  })
+
+  it("falls back to task status when success is omitted", () => {
+    const payload = normalizeTaskCompletedMessage({
+      type: "task_completed",
+      task: {
+        status: "completed",
+      },
+    })
+
+    expect(payload.status).toBe("completed")
+    expect(payload.success).toBe(true)
+  })
+})

--- a/frontend/src/lib/task-completion.ts
+++ b/frontend/src/lib/task-completion.ts
@@ -1,0 +1,70 @@
+export type TaskTerminalStatus = "completed" | "failed"
+
+type TaskCompletedRecord = {
+  data?: unknown
+  success?: unknown
+  status?: unknown
+  task?: {
+    status?: unknown
+    [key: string]: unknown
+  }
+  result?: unknown
+  output?: unknown
+  file_outputs?: unknown
+  chat_response?: unknown
+  metadata?: unknown
+}
+
+export type NormalizedTaskCompletion = {
+  success: boolean
+  status: TaskTerminalStatus
+  task?: TaskCompletedRecord["task"]
+  result?: unknown
+  output?: unknown
+  fileOutputs: Array<string | Record<string, unknown>>
+  chatResponse?: unknown
+  metadata?: unknown
+}
+
+const asRecord = (value: unknown): TaskCompletedRecord | null => {
+  return value && typeof value === "object" ? (value as TaskCompletedRecord) : null
+}
+
+const normalizeStatus = (value: unknown): TaskTerminalStatus | null => {
+  if (typeof value !== "string") return null
+  const normalized = value.toLowerCase()
+  if (normalized === "completed") return "completed"
+  if (normalized === "failed") return "failed"
+  return null
+}
+
+export const normalizeTaskCompletedMessage = (
+  message: unknown
+): NormalizedTaskCompletion => {
+  const root = asRecord(message) || {}
+  const payload = asRecord(root.data) || root
+  const taskStatus = normalizeStatus(payload.task?.status)
+  const payloadStatus = normalizeStatus(payload.status)
+  const explicitStatus = taskStatus || payloadStatus
+  const success =
+    explicitStatus
+      ? explicitStatus === "completed"
+      : typeof payload.success === "boolean"
+      ? payload.success
+      : false
+  const status = explicitStatus || (success ? "completed" : "failed")
+  const fileOutputs = Array.isArray(payload.file_outputs)
+    ? (payload.file_outputs as Array<string | Record<string, unknown>>)
+    : []
+
+  return {
+    success,
+    status,
+    task: payload.task,
+    result: payload.result,
+    output: payload.output,
+    fileOutputs,
+    chatResponse: payload.chat_response,
+    metadata: payload.metadata,
+  }
+}

--- a/frontend/src/lib/task-completion.ts
+++ b/frontend/src/lib/task-completion.ts
@@ -1,3 +1,5 @@
+import { normalizeTaskStatus } from "./task-status"
+
 export type TaskTerminalStatus = "completed" | "failed"
 
 type TaskCompletedRecord = {
@@ -30,9 +32,8 @@ const asRecord = (value: unknown): TaskCompletedRecord | null => {
   return value && typeof value === "object" ? (value as TaskCompletedRecord) : null
 }
 
-const normalizeStatus = (value: unknown): TaskTerminalStatus | null => {
-  if (typeof value !== "string") return null
-  const normalized = value.toLowerCase()
+const normalizeTerminalStatus = (value: unknown): TaskTerminalStatus | null => {
+  const normalized = normalizeTaskStatus(value)
   if (normalized === "completed") return "completed"
   if (normalized === "failed") return "failed"
   return null
@@ -43,8 +44,8 @@ export const normalizeTaskCompletedMessage = (
 ): NormalizedTaskCompletion => {
   const root = asRecord(message) || {}
   const payload = asRecord(root.data) || root
-  const taskStatus = normalizeStatus(payload.task?.status)
-  const payloadStatus = normalizeStatus(payload.status)
+  const taskStatus = normalizeTerminalStatus(payload.task?.status)
+  const payloadStatus = normalizeTerminalStatus(payload.status)
   const explicitStatus = taskStatus || payloadStatus
   const success =
     explicitStatus

--- a/frontend/src/lib/task-status.ts
+++ b/frontend/src/lib/task-status.ts
@@ -1,0 +1,47 @@
+export type TaskStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "paused"
+  | "waiting_for_user"
+
+const TASK_STATUSES = new Set<TaskStatus>([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "paused",
+  "waiting_for_user",
+])
+
+const STOPPED_TASK_STATUSES = new Set<TaskStatus>([
+  "completed",
+  "failed",
+  "paused",
+  "waiting_for_user",
+])
+
+const PAUSABLE_TASK_STATUSES = new Set<TaskStatus>([
+  "pending",
+  "running",
+])
+
+export const normalizeTaskStatus = (status: unknown): TaskStatus | undefined => {
+  if (typeof status !== "string") return undefined
+
+  const normalized = status.trim().toLowerCase()
+  return TASK_STATUSES.has(normalized as TaskStatus)
+    ? (normalized as TaskStatus)
+    : undefined
+}
+
+export const isStoppedTaskStatus = (status: unknown): boolean => {
+  const normalized = normalizeTaskStatus(status)
+  return normalized ? STOPPED_TASK_STATUSES.has(normalized) : false
+}
+
+export const isPausableTaskStatus = (status: unknown): boolean => {
+  const normalized = normalizeTaskStatus(status)
+  return normalized ? PAUSABLE_TASK_STATUSES.has(normalized) : false
+}

--- a/frontend/src/lib/trace-process-status.test.ts
+++ b/frontend/src/lib/trace-process-status.test.ts
@@ -36,6 +36,30 @@ describe("trace process status", () => {
     ).toBe("failed")
   })
 
+  it("infers a failed process from step-local trace errors without a status field", () => {
+    expect(
+      resolveTraceProcessStatus({
+        traceEvents: [
+          {
+            event_type: "react_task_start",
+            data: {},
+          },
+          {
+            event_type: "llm_call_start",
+            data: {},
+          },
+          {
+            event_type: "trace_error",
+            data: {
+              error_type: "agent_pattern_error",
+              error_message: "OpenAI bad request",
+            },
+          },
+        ],
+      })
+    ).toBe("failed")
+  })
+
   it("prefers explicit process status over trace inference", () => {
     expect(
       resolveTraceProcessStatus({

--- a/frontend/src/lib/trace-process-status.test.ts
+++ b/frontend/src/lib/trace-process-status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeTraceProcessStatus,
+  resolveTraceProcessStatus,
+} from "./trace-process-status"
+
+describe("trace process status", () => {
+  it("normalizes task status values", () => {
+    expect(normalizeTraceProcessStatus("FAILED")).toBe("failed")
+    expect(normalizeTraceProcessStatus("waiting_for_user")).toBe("waiting_for_user")
+    expect(normalizeTraceProcessStatus("unknown")).toBeUndefined()
+  })
+
+  it("infers a failed process from terminal trace errors", () => {
+    expect(
+      resolveTraceProcessStatus({
+        traceEvents: [
+          {
+            event_type: "react_task_start",
+            data: {},
+          },
+          {
+            event_type: "llm_call_start",
+            data: {},
+          },
+          {
+            event_type: "trace_error",
+            data: {
+              error_type: "agent_error",
+              status: "failed",
+            },
+          },
+        ],
+      })
+    ).toBe("failed")
+  })
+
+  it("prefers explicit process status over trace inference", () => {
+    expect(
+      resolveTraceProcessStatus({
+        processStatus: "completed",
+        traceEvents: [
+          {
+            event_type: "trace_error",
+            data: {
+              error_type: "agent_error",
+              status: "failed",
+            },
+          },
+        ],
+      })
+    ).toBe("completed")
+  })
+})

--- a/frontend/src/lib/trace-process-status.ts
+++ b/frontend/src/lib/trace-process-status.ts
@@ -1,0 +1,99 @@
+export type TraceProcessStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "paused"
+  | "waiting_for_user"
+
+type TraceProcessEvent = {
+  event_type?: string
+  data?: unknown
+}
+
+const TRACE_PROCESS_STATUSES = new Set<TraceProcessStatus>([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "paused",
+  "waiting_for_user",
+])
+
+const STOPPED_TRACE_PROCESS_STATUSES = new Set<TraceProcessStatus>([
+  "completed",
+  "failed",
+  "paused",
+  "waiting_for_user",
+])
+
+const TERMINAL_FAILURE_EVENTS = new Set([
+  "agent_error",
+  "react_task_failed",
+  "task_failed",
+  "task_failed_react",
+])
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : null
+
+export const normalizeTraceProcessStatus = (
+  status: unknown
+): TraceProcessStatus | undefined => {
+  if (typeof status !== "string") return undefined
+  const normalized = status.trim().toLowerCase()
+  return TRACE_PROCESS_STATUSES.has(normalized as TraceProcessStatus)
+    ? (normalized as TraceProcessStatus)
+    : undefined
+}
+
+export const isStoppedTraceProcessStatus = (status: unknown): boolean => {
+  const normalized = normalizeTraceProcessStatus(status)
+  return normalized ? STOPPED_TRACE_PROCESS_STATUSES.has(normalized) : false
+}
+
+export const getTraceProcessStatusFromEvents = (
+  events?: TraceProcessEvent[]
+): TraceProcessStatus | undefined => {
+  if (!Array.isArray(events)) return undefined
+
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    const eventType = event?.event_type || ""
+    const eventData = asRecord(event?.data)
+
+    if (eventData) {
+      const eventStatus = normalizeTraceProcessStatus(eventData.status)
+      if (eventStatus && STOPPED_TRACE_PROCESS_STATUSES.has(eventStatus)) {
+        return eventStatus
+      }
+
+      if (
+        eventType === "trace_error" &&
+        (eventData.error_type === "agent_error" ||
+          eventData.status === "failed")
+      ) {
+        return "failed"
+      }
+    }
+
+    if (TERMINAL_FAILURE_EVENTS.has(eventType)) {
+      return "failed"
+    }
+  }
+
+  return undefined
+}
+
+export const resolveTraceProcessStatus = ({
+  processStatus,
+  taskStatus,
+  traceEvents,
+}: {
+  processStatus?: unknown
+  taskStatus?: unknown
+  traceEvents?: TraceProcessEvent[]
+}): TraceProcessStatus | undefined =>
+  normalizeTraceProcessStatus(processStatus) ||
+  normalizeTraceProcessStatus(taskStatus) ||
+  getTraceProcessStatusFromEvents(traceEvents)

--- a/frontend/src/lib/trace-process-status.ts
+++ b/frontend/src/lib/trace-process-status.ts
@@ -1,31 +1,15 @@
-export type TraceProcessStatus =
-  | "pending"
-  | "running"
-  | "completed"
-  | "failed"
-  | "paused"
-  | "waiting_for_user"
+import {
+  isStoppedTaskStatus,
+  normalizeTaskStatus,
+  type TaskStatus,
+} from "./task-status"
+
+export type TraceProcessStatus = TaskStatus
 
 type TraceProcessEvent = {
   event_type?: string
   data?: unknown
 }
-
-const TRACE_PROCESS_STATUSES = new Set<TraceProcessStatus>([
-  "pending",
-  "running",
-  "completed",
-  "failed",
-  "paused",
-  "waiting_for_user",
-])
-
-const STOPPED_TRACE_PROCESS_STATUSES = new Set<TraceProcessStatus>([
-  "completed",
-  "failed",
-  "paused",
-  "waiting_for_user",
-])
 
 const TERMINAL_FAILURE_EVENTS = new Set([
   "agent_error",
@@ -37,20 +21,28 @@ const TERMINAL_FAILURE_EVENTS = new Set([
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object" ? (value as Record<string, unknown>) : null
 
-export const normalizeTraceProcessStatus = (
-  status: unknown
-): TraceProcessStatus | undefined => {
-  if (typeof status !== "string") return undefined
-  const normalized = status.trim().toLowerCase()
-  return TRACE_PROCESS_STATUSES.has(normalized as TraceProcessStatus)
-    ? (normalized as TraceProcessStatus)
-    : undefined
+const isFailureTraceError = (eventData: Record<string, unknown> | null): boolean => {
+  if (!eventData) return true
+
+  const eventStatus = normalizeTraceProcessStatus(eventData.status)
+  if (eventStatus === "failed") return true
+
+  const errorType = typeof eventData.error_type === "string" ? eventData.error_type : ""
+  if (errorType.endsWith("_error")) return true
+
+  return (
+    typeof eventData.error === "string" ||
+    typeof eventData.message === "string" ||
+    typeof eventData.error_message === "string"
+  )
 }
 
-export const isStoppedTraceProcessStatus = (status: unknown): boolean => {
-  const normalized = normalizeTraceProcessStatus(status)
-  return normalized ? STOPPED_TRACE_PROCESS_STATUSES.has(normalized) : false
-}
+export const normalizeTraceProcessStatus = (
+  status: unknown
+): TraceProcessStatus | undefined => normalizeTaskStatus(status)
+
+export const isStoppedTraceProcessStatus = (status: unknown): boolean =>
+  isStoppedTaskStatus(status)
 
 export const getTraceProcessStatusFromEvents = (
   events?: TraceProcessEvent[]
@@ -64,15 +56,11 @@ export const getTraceProcessStatusFromEvents = (
 
     if (eventData) {
       const eventStatus = normalizeTraceProcessStatus(eventData.status)
-      if (eventStatus && STOPPED_TRACE_PROCESS_STATUSES.has(eventStatus)) {
+      if (eventStatus && isStoppedTraceProcessStatus(eventStatus)) {
         return eventStatus
       }
 
-      if (
-        eventType === "trace_error" &&
-        (eventData.error_type === "agent_error" ||
-          eventData.status === "failed")
-      ) {
+      if (eventType === "trace_error" && isFailureTraceError(eventData)) {
         return "failed"
       }
     }

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -18,6 +18,7 @@ from .....web.services.model_service import (
 from ....tracing import create_agent_tracer
 from ....utils.type_check import ensure_list
 from ...core.document_search import find_missing_knowledge_bases
+from .agent_tool_names import gen_agent_tool_name
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
 logger = logging.getLogger(__name__)
@@ -750,7 +751,7 @@ class CreateAgentTool(AbstractBaseTool):
             )
 
             # Generate the tool name and markdown link
-            tool_name = gen_agent_tool_name(agent_name)
+            tool_name = gen_agent_tool_name(agent.id)
             markdown_link = f"[{agent_name}](agent://{agent.id})"
 
             rename_note = ""
@@ -945,7 +946,7 @@ class UpdateAgentTool(AbstractBaseTool):
                 return UpdateAgentToolResult(
                     agent_id=agent_id,
                     agent_name=agent.name,
-                    tool_name=gen_agent_tool_name(agent.name),
+                    tool_name=gen_agent_tool_name(agent.id),
                     markdown_link=f"[{agent.name}](agent://{agent.id})",
                     status="error",
                     message=(
@@ -1045,7 +1046,7 @@ class UpdateAgentTool(AbstractBaseTool):
                 return UpdateAgentToolResult(
                     agent_id=agent_id,
                     agent_name=agent.name,
-                    tool_name=gen_agent_tool_name(agent.name),
+                    tool_name=gen_agent_tool_name(agent.id),
                     markdown_link=f"[{agent.name}](agent://{agent.id})",
                     status="success",
                     message=f"ℹ️ No updates were made to agent '{agent.name}' (ID: {agent_id}). "
@@ -1062,7 +1063,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
             # Generate the tool name and markdown link
             agent_name = str(agent.name)
-            tool_name = gen_agent_tool_name(agent_name)
+            tool_name = gen_agent_tool_name(agent.id)
             markdown_link = f"[{agent_name}](agent://{agent.id})"
 
             logger.info(
@@ -1217,7 +1218,7 @@ class ListAgentsTool(AbstractBaseTool):
             # Build agent info list
             agent_infos = []
             for agent in agents:
-                tool_name = gen_agent_tool_name(agent.name)
+                tool_name = gen_agent_tool_name(agent.id)
                 markdown_link = f"[{agent.name}](agent://{agent.id})"
 
                 agent_info = AgentInfo(
@@ -1309,7 +1310,8 @@ class AgentTool(AbstractBaseTool):
             user_id: User ID for model access
             task_id: Task ID for workspace isolation
             workspace_base_dir: Base directory for workspace files
-            tool_name: Optional delegated tool name override
+            tool_name: Deprecated delegated tool name override. Agent tools always
+                expose the canonical agent_<id> name.
             tool_description: Optional delegated tool description override
             extra_system_prompt: Optional system prompt appended during execution
             parent_task_id: Parent task ID for delegation metadata
@@ -1360,7 +1362,7 @@ class AgentTool(AbstractBaseTool):
     @property
     def name(self) -> str:
         """Tool name."""
-        return self._tool_name or gen_agent_tool_name(self._agent_name)
+        return gen_agent_tool_name(self._agent_id)
 
     @property
     def description(self) -> str:
@@ -1829,22 +1831,6 @@ class AgentTool(AbstractBaseTool):
                 "error", execution_task_id=execution_task_id, error=error_msg
             )
             return AgentToolResult(response=error_msg).model_dump(exclude_none=True)
-
-
-def gen_agent_tool_name(agent_name: str) -> str:
-    """
-    Generate the tool name for a published agent.
-
-    This is a centralized function to ensure consistent naming across the codebase.
-    Tool name format: call_agent_{agent_name_lower_with_underscores}
-
-    Args:
-        agent_name: The name of the agent
-
-    Returns:
-        The tool name that will be used for this agent
-    """
-    return f"call_agent_{agent_name.lower().replace(' ', '_')}"
 
 
 def get_published_agents_tools(

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2058,7 +2058,7 @@ if TYPE_CHECKING:
     from xagent.web.tools.config import WebToolConfig
 
 
-@register_tool(categories={"agent"})
+@register_tool(categories={"agent"}, selection_gate="published_agent")
 async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
     """Create tools from published agents.
 

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -127,6 +127,24 @@ def _apply_agent_visibility_filters(
     if not allow_cross_user_agent_ids or normalized_allowed_agent_ids is None:
         query = query.filter(agent_model.user_id == user_id)
 
+    query = _exclude_private_workforce_manager_agents(query, agent_model)
+
+    return query
+
+
+def _exclude_private_workforce_manager_agents(query: Any, agent_model: Any) -> Any:
+    from .....web.models.agent import AgentOrigin
+
+    return query.filter(
+        agent_model.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+    )
+
+
+def _apply_owned_agent_tool_filters(
+    query: Any, agent_model: Any, *, user_id: int
+) -> Any:
+    query = query.filter(agent_model.user_id == user_id)
+    query = _exclude_private_workforce_manager_agents(query, agent_model)
     return query
 
 
@@ -926,11 +944,13 @@ class UpdateAgentTool(AbstractBaseTool):
                 ).model_dump()
 
             # Find the agent
-            agent = (
-                self._db.query(Agent)
-                .filter(Agent.id == agent_id, Agent.user_id == self._user_id)
-                .first()
+            query = self._db.query(Agent).filter(Agent.id == agent_id)
+            query = _apply_owned_agent_tool_filters(
+                query,
+                Agent,
+                user_id=self._user_id,
             )
+            agent = query.first()
 
             if not agent:
                 return UpdateAgentToolResult(
@@ -963,15 +983,14 @@ class UpdateAgentTool(AbstractBaseTool):
             new_name = args.get("name", "").strip() if args.get("name") else None
             if new_name:
                 # Check for duplicate name (exclude current agent)
-                existing = (
-                    self._db.query(Agent)
-                    .filter(
-                        Agent.user_id == self._user_id,
+                existing = _apply_owned_agent_tool_filters(
+                    self._db.query(Agent).filter(
                         Agent.name == new_name,
                         Agent.id != agent_id,
-                    )
-                    .first()
-                )
+                    ),
+                    Agent,
+                    user_id=self._user_id,
+                ).first()
                 if existing:
                     return UpdateAgentToolResult(
                         agent_id=0,
@@ -1206,7 +1225,11 @@ class ListAgentsTool(AbstractBaseTool):
                 ).model_dump()
 
             # Build query
-            query = self._db.query(Agent).filter(Agent.user_id == self._user_id)
+            query = _apply_owned_agent_tool_filters(
+                self._db.query(Agent),
+                Agent,
+                user_id=self._user_id,
+            )
 
             # Apply status filter if provided
             if status_filter:
@@ -1924,15 +1947,15 @@ def get_published_agents_tools(
         elif include_draft:
             # Include both PUBLISHED and DRAFT agents
             query = db.query(Agent).filter(
-                Agent.user_id == user_id,
                 Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
             )
+            query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
         else:
             # Only PUBLISHED agents
             query = db.query(Agent).filter(
                 Agent.status == "published",
-                Agent.user_id == user_id,
             )
+            query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
 
         # Exclude the active delegation stack to prevent recursive self-calls.
         if excluded_agent_ids:
@@ -1950,15 +1973,14 @@ def get_published_agents_tools(
                 for agent_id in (normalized_draft_agent_ids or [])
                 if agent_id not in excluded_agent_ids
             ]
-            draft_agents = (
-                db.query(Agent)
-                .filter(
+            draft_agents = _apply_owned_agent_tool_filters(
+                db.query(Agent).filter(
                     Agent.id.in_(normalized_draft_agent_ids),
-                    Agent.user_id == user_id,
                     Agent.status == "draft",
-                )
-                .all()
-            )
+                ),
+                Agent,
+                user_id=user_id,
+            ).all()
             # Merge without duplicates
             existing_ids = {agent.id for agent in agents}
             for draft_agent in draft_agents:

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1418,7 +1418,6 @@ class AgentTool(AbstractBaseTool):
         file_outputs: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
         data: dict[str, Any] = {
-            "__audit_only__": True,
             "event_type": f"workforce_delegation_{status}",
             "status": status,
             "agent_id": self._agent_id,

--- a/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
@@ -1,0 +1,39 @@
+"""Stable OpenAI-compatible names for agent delegation tools."""
+
+from typing import Any
+
+AGENT_TOOL_NAME_PREFIX = "agent_"
+LEGACY_AGENT_TOOL_NAME_PREFIX = "call_agent_"
+
+
+def gen_agent_tool_name(agent_id: Any) -> str:
+    """Return the canonical tool name for an agent id."""
+    if isinstance(agent_id, bool):
+        raise ValueError("agent_id must be an integer")
+    try:
+        normalized_agent_id = int(agent_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("agent_id must be an integer") from exc
+    if normalized_agent_id <= 0:
+        raise ValueError("agent_id must be positive")
+    return f"{AGENT_TOOL_NAME_PREFIX}{normalized_agent_id}"
+
+
+def parse_agent_tool_id(tool_name: Any) -> int | None:
+    if not isinstance(tool_name, str):
+        return None
+    if not tool_name.startswith(AGENT_TOOL_NAME_PREFIX):
+        return None
+    suffix = tool_name.removeprefix(AGENT_TOOL_NAME_PREFIX)
+    if not suffix.isdecimal():
+        return None
+    agent_id = int(suffix)
+    return agent_id if agent_id > 0 else None
+
+
+def is_agent_tool_name(tool_name: Any) -> bool:
+    if parse_agent_tool_id(tool_name) is not None:
+        return True
+    return isinstance(tool_name, str) and tool_name.startswith(
+        LEGACY_AGENT_TOOL_NAME_PREFIX
+    )

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -38,13 +38,16 @@ class ToolRegistry:
     that ``create_registered_tools`` can skip the creator entirely when
     a :class:`ToolSelectionSpec` excludes those categories. Creators that
     produce tools across multiple categories or that produce categories
-    dynamically (MCP / Custom API / Published Agent) should leave
-    ``categories`` unset and short-circuit internally based on the spec.
+    dynamically (MCP / Custom API) should leave ``categories`` unset and
+    short-circuit internally based on the spec. Published-agent
+    delegation uses a creator-specific dispatch because workforce worker
+    tools can be injected by exact name without enabling the whole
+    ``agent`` category.
     """
 
-    # (creator, declared_categories) — declared_categories is None for
-    # dynamic creators that filter internally based on the spec.
-    _tool_creators: List[Tuple[Callable, Optional[FrozenSet[str]]]] = []
+    # (creator, declared_categories, selection_gate) — declared_categories is
+    # None for dynamic creators that filter internally based on the spec.
+    _tool_creators: List[Tuple[Callable, Optional[FrozenSet[str]], Optional[str]]] = []
     _modules_imported = False
 
     @classmethod
@@ -53,6 +56,7 @@ class ToolRegistry:
         creator: Optional[Callable] = None,
         *,
         categories: Optional[set] = None,
+        selection_gate: Optional[str] = None,
     ) -> Callable:
         """
         Register a tool creator function.
@@ -70,11 +74,16 @@ class ToolRegistry:
             @register_tool(categories={"basic"})
             def create_basic_tools(config: BaseToolConfig) -> List[Tool]:
                 return [BasicTool(...)]
+
+        Usage (with a creator-specific selection gate):
+            @register_tool(categories={"agent"}, selection_gate="published_agent")
+            def create_agent_tools(config: BaseToolConfig) -> List[Tool]:
+                return get_published_agents_tools(...)
         """
         declared = frozenset(categories) if categories else None
 
         def _do_register(fn: Callable) -> Callable:
-            cls._tool_creators.append((fn, declared))
+            cls._tool_creators.append((fn, declared, selection_gate))
             return fn
 
         # Bare form: ``@register_tool`` (no parens) — ``creator`` is the
@@ -119,6 +128,23 @@ class ToolRegistry:
         except Exception as e:
             logger.warning(f"Failed to import tool modules: {e}")
 
+    @staticmethod
+    def _should_run_creator(
+        declared_cats: Optional[FrozenSet[str]],
+        spec: Optional[ToolSelectionSpec],
+        selection_gate: Optional[str],
+    ) -> bool:
+        if spec is None or declared_cats is None or spec.categories is None:
+            return True
+
+        if selection_gate == "published_agent":
+            return spec.includes_published_agent()
+
+        if declared_cats & spec.categories:
+            return True
+
+        return False
+
     @classmethod
     async def create_registered_tools(cls, config: BaseToolConfig) -> List[Tool]:
         """Create tools from all registered creators.
@@ -127,8 +153,8 @@ class ToolRegistry:
         creators whose declared categories don't intersect
         ``spec.categories`` are skipped at the registry level (no
         creator call, no I/O). Creators with no declared categories
-        (dynamic ones: MCP / Custom API / Published Agent / Image /
-        Audio) are always dispatched and are responsible for
+        (dynamic ones: MCP / Custom API / Image / Audio) are always
+        dispatched and are responsible for
         short-circuiting internally based on the spec.
         """
         # Import tool modules on first call to trigger decorator registration
@@ -140,17 +166,11 @@ class ToolRegistry:
             else None
         )
         tools: List[Tool] = []
-        for creator, declared_cats in cls._tool_creators:
+        for creator, declared_cats, selection_gate in cls._tool_creators:
             # Registry-level skip: declared categories known and no
-            # intersection with the spec's allowed categories. ``spec``
-            # absent, or ``spec.categories`` absent, means "no restriction"
-            # and the creator runs.
-            if (
-                spec is not None
-                and declared_cats is not None
-                and spec.categories is not None
-                and not (declared_cats & spec.categories)
-            ):
+            # intersection with the spec's allowed categories. The helper
+            # keeps the published-agent workforce exception in one place.
+            if not cls._should_run_creator(declared_cats, spec, selection_gate):
                 continue
             try:
                 created_tools = await creator(config)

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -169,6 +169,7 @@ class ToolSelectionSpec(ABC):
         published_agent_ids: Optional[List[int]] = None,
         workforce_extra_names: Optional[Set[str]] = None,
         explicit_none: bool = False,
+        extras_only_when_unconfigured: bool = False,
     ) -> "ToolSelectionSpec":
         """Build a spec from raw ORM / dict / SDK fields.
 
@@ -182,16 +183,31 @@ class ToolSelectionSpec(ABC):
           - ``explicit_none=True`` → ``_SpecNone`` regardless of
             ``tool_categories`` (reserved for future "zero tools"
             product UI).
+          - ``extras_only_when_unconfigured=True`` with unset / empty
+            categories → only ``workforce_extra_names`` are admitted
+            (or ``_SpecNone`` when there are no extras). Workforce
+            manager tasks use this so an unconfigured manager can only
+            delegate to its workers by default, without inheriting the
+            full ordinary tool set.
           - Otherwise → ``_SpecByCategories``.
 
-        ``workforce_extra_names`` is only meaningful in
+        By default, ``workforce_extra_names`` is only meaningful in
         BY_CATEGORIES mode (ALL already includes everything; NONE
-        rejects everything). It is silently ignored in ALL / NONE
-        to avoid forcing callers to branch.
+        rejects everything). ``extras_only_when_unconfigured`` is the
+        opt-in exception for workforce manager runtime construction.
         """
         if explicit_none:
             return _SpecNone()
         if tool_categories is None or len(tool_categories) == 0:
+            if extras_only_when_unconfigured:
+                name_extras = frozenset(workforce_extra_names or ())
+                if not name_extras:
+                    return _SpecNone()
+                return _SpecByCategories(
+                    categories=frozenset(),
+                    name_extras=name_extras,
+                    _user_picked=frozenset(),
+                )
             return _SpecAll()
 
         # Agent-builder UI representation in ``tool_categories`` mixes
@@ -378,9 +394,9 @@ class _SpecNone(ToolSelectionSpec):
 class _SpecByCategories(ToolSelectionSpec):
     """BY_CATEGORIES mode — filtered build.
 
-    ``categories`` MUST be non-empty (the ``from_raw`` normalizer
-    routes empty input to ``_SpecAll``; direct construction with
-    empty categories raises ``ValueError`` at __post_init__).
+    ``categories`` is normally non-empty. The one valid empty-category
+    state is workforce manager injection: no ordinary categories, but
+    explicit ``name_extras`` worker-agent tools.
     """
 
     categories: frozenset[str] = field(default_factory=frozenset)
@@ -402,9 +418,10 @@ class _SpecByCategories(ToolSelectionSpec):
     _user_picked: Optional[frozenset[str]] = None
 
     def __post_init__(self) -> None:
-        if not self.categories:
+        if not self.categories and not self.name_extras:
             raise ValueError(
-                "_SpecByCategories requires non-empty categories. "
+                "_SpecByCategories requires non-empty categories or "
+                "name_extras. "
                 "Use ToolSelectionSpec.from_raw() with empty / None "
                 "categories to get _SpecAll, or pass "
                 "explicit_none=True for _SpecNone."

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -472,6 +472,8 @@ class _SpecByCategories(ToolSelectionSpec):
         return True
 
     def includes_published_agent(self) -> bool:
+        if self.name_extras:
+            return True
         if "agent" not in self.categories:
             return False
         if self.published_agent_ids is not None and len(self.published_agent_ids) == 0:

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -137,6 +137,14 @@ class TaskWorkspace:
 
         # Check if file already exists in database
         resolved_db_session = db_session or self.db_session
+        cached_file_id = self._recently_registered_files.get(str(resolved_path))
+        if cached_file_id:
+            self._sync_existing_file_record(
+                cached_file_id, resolved_path, resolved_db_session
+            )
+            self._remember_file_registration(cached_file_id, resolved_path)
+            return cached_file_id
+
         existing_file_id = self._get_file_id_from_db(resolved_path, resolved_db_session)
         if existing_file_id:
             self._sync_existing_file_record(

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -142,6 +142,7 @@ class TaskWorkspace:
             self._sync_existing_file_record(
                 existing_file_id, resolved_path, resolved_db_session
             )
+            self._remember_file_registration(existing_file_id, resolved_path)
             return existing_file_id
 
         # Generate new file_id if not provided
@@ -151,8 +152,114 @@ class TaskWorkspace:
 
         # Create database record
         self._create_file_record(final_file_id, resolved_path, db_session)
+        self._remember_file_registration(final_file_id, resolved_path)
 
         return final_file_id
+
+    def _remember_file_registration(self, file_id: str, file_path: Path) -> None:
+        path_str = str(file_path)
+        resolved_str = str(file_path.resolve())
+        self._recently_registered_files[path_str] = file_id
+        self._recently_registered_files[resolved_str] = file_id
+        self._file_id_to_path[file_id] = file_path
+
+    def _is_delegated_db_task_workspace(self, task_id: int) -> bool:
+        if self.db_task_id is None:
+            return False
+        parsed_task_id = self._parse_task_id_from_workspace_id(self.id)
+        return parsed_task_id != int(task_id)
+
+    def _user_workspace_base_dir(self, user_id: int) -> Path:
+        user_segment = f"user_{user_id}"
+        if self.base_dir.name == user_segment:
+            return self.base_dir
+        return self.base_dir / user_segment
+
+    @staticmethod
+    def _storage_path_record(
+        db: Any, storage_path: Path, file_id: Optional[str] = None
+    ) -> Any:
+        from ..web.models.uploaded_file import UploadedFile
+
+        query = db.query(UploadedFile).filter(
+            UploadedFile.storage_path == str(storage_path)
+        )
+        record = query.first()
+        if record is None or file_id is None or str(record.file_id) == str(file_id):
+            return record
+        return record
+
+    @classmethod
+    def _unique_registration_path(
+        cls, target_path: Path, source_path: Path, db: Any, file_id: str
+    ) -> Path:
+        stem = target_path.stem
+        suffix = target_path.suffix
+        parent = target_path.parent
+        candidate = target_path
+        index = 1
+
+        source_resolved = source_path.resolve()
+        while True:
+            try:
+                candidate_resolved = candidate.resolve()
+            except OSError:
+                candidate_resolved = candidate.absolute()
+            record = cls._storage_path_record(db, candidate, file_id)
+            same_record = record is not None and str(record.file_id) == str(file_id)
+            record_conflicts = record is not None and str(record.file_id) != str(
+                file_id
+            )
+            path_conflicts = (
+                candidate.exists()
+                and candidate_resolved != source_resolved
+                and not same_record
+            )
+            if not record_conflicts and not path_conflicts:
+                return candidate
+            candidate = parent / f"{stem}_{index}{suffix}"
+            index += 1
+
+    def _canonicalize_delegated_output_registration(
+        self,
+        *,
+        db: Any,
+        file_id: str,
+        file_path: Path,
+        task_id: int,
+        user_id: int,
+        relative_path: str,
+        category: str,
+    ) -> tuple[Path, str, str]:
+        if category != "output" or not self._is_delegated_db_task_workspace(task_id):
+            return file_path, relative_path, category
+
+        relative_parts = Path(relative_path).parts
+        output_parts = [
+            part for part in relative_parts[1:] if part not in ("", ".", "..")
+        ]
+        if not output_parts:
+            output_parts = [file_path.name]
+
+        canonical_relative_path = Path("output", *output_parts).as_posix()
+        task_root = self._user_workspace_base_dir(user_id) / f"web_task_{task_id}"
+        output_root = (task_root / "output").resolve()
+        canonical_path = (task_root / canonical_relative_path).resolve()
+        try:
+            canonical_path.relative_to(output_root)
+        except ValueError:
+            canonical_relative_path = Path("output", file_path.name).as_posix()
+            canonical_path = (task_root / canonical_relative_path).resolve()
+
+        canonical_path = self._unique_registration_path(
+            canonical_path, file_path, db, file_id
+        )
+        canonical_relative_path = canonical_path.relative_to(task_root).as_posix()
+        if canonical_path.resolve() != file_path.resolve():
+            canonical_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file_path, canonical_path)
+
+        return canonical_path, canonical_relative_path, "output"
 
     def _create_file_record(
         self, file_id: str, file_path: Path, db_session: Any = None
@@ -209,6 +316,18 @@ class TaskWorkspace:
             except ValueError:
                 relative_path = file_path.name
             category = relative_path.split("/", 1)[0] if relative_path else "workspace"
+
+            file_path, relative_path, category = (
+                self._canonicalize_delegated_output_registration(
+                    db=db,
+                    file_id=file_id,
+                    file_path=file_path,
+                    task_id=int(task_id),
+                    user_id=int(task.user_id),
+                    relative_path=relative_path,
+                    category=category,
+                )
+            )
 
             from ..web.services.uploaded_file_store import UploadedFileStore
 
@@ -304,6 +423,17 @@ class TaskWorkspace:
                 user_id = task_user_id
 
             category = relative_path.split("/", 1)[0] if relative_path else "workspace"
+            file_path, relative_path, category = (
+                self._canonicalize_delegated_output_registration(
+                    db=db,
+                    file_id=file_id,
+                    file_path=file_path,
+                    task_id=int(task_id) if task_id is not None else 0,
+                    user_id=user_id,
+                    relative_path=relative_path,
+                    category=category,
+                )
+            )
             storage_key = _build_workspace_storage_key(
                 user_id,
                 int(task_id) if task_id is not None else 0,
@@ -313,16 +443,18 @@ class TaskWorkspace:
             if task_id is None:
                 storage_key = getattr(record, "storage_key", None) or storage_key
 
-            UploadedFileStore(db).upsert_by_storage_path(
-                user_id=user_id,
-                filename=file_path.name,
-                storage_path=file_path,
-                mime_type=mime_type,
-                file_size=file_path.stat().st_size,
+            record.user_id = user_id
+            record.task_id = int(task_id) if task_id is not None else None
+            record.filename = file_path.name
+            record.storage_path = str(file_path)
+            record.file_size = file_path.stat().st_size
+            record.mime_type = mime_type
+            record.workspace_relative_path = relative_path
+            record.workspace_category = category
+            UploadedFileStore(db).sync_existing(
+                record,
                 storage_key=storage_key,
-                task_id=int(task_id) if task_id is not None else None,
-                workspace_relative_path=relative_path,
-                workspace_category=category,
+                mime_type=mime_type,
             )
             if should_close:
                 db.commit()

--- a/src/xagent/migrations/versions/20260529_add_agent_origin.py
+++ b/src/xagent/migrations/versions/20260529_add_agent_origin.py
@@ -1,7 +1,7 @@
 """add agent origin
 
 Revision ID: 20260529_add_agent_origin
-Revises: 20260526_seed_builtin_microsoft_graph_mcp_apps
+Revises: 20260528_add_kb_ingest_targets
 Create Date: 2026-05-29 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 from sqlalchemy import inspect
 
 revision: str = "20260529_add_agent_origin"
-down_revision: Union[str, None] = "20260526_seed_builtin_microsoft_graph_mcp_apps"
+down_revision: Union[str, None] = "20260528_add_kb_ingest_targets"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260529_add_agent_origin.py
+++ b/src/xagent/migrations/versions/20260529_add_agent_origin.py
@@ -1,0 +1,56 @@
+"""add agent origin
+
+Revision ID: 20260529_add_agent_origin
+Revises: 20260526_seed_builtin_microsoft_graph_mcp_apps
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "20260529_add_agent_origin"
+down_revision: Union[str, None] = "20260526_seed_builtin_microsoft_graph_mcp_apps"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("agents")}
+    if "origin" not in existing_columns:
+        op.add_column(
+            "agents",
+            sa.Column(
+                "origin",
+                sa.String(length=50),
+                server_default="user",
+                nullable=False,
+            ),
+        )
+
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("agents")}
+    if "ix_agents_origin" not in existing_indexes:
+        op.create_index("ix_agents_origin", "agents", ["origin"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("agents")}
+    if "ix_agents_origin" in existing_indexes:
+        op.drop_index("ix_agents_origin", table_name="agents")
+
+    existing_columns = {col["name"] for col in inspector.get_columns("agents")}
+    if "origin" in existing_columns:
+        op.drop_column("agents", "origin")

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -18,7 +18,7 @@ from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...core.tracing import create_agent_tracer
 from ...core.utils.api_key import generate_api_key
 from ..auth_dependencies import get_current_user
-from ..models.agent import Agent
+from ..models.agent import Agent, AgentOrigin
 from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_db
 from ..models.model import Model as DBModel
@@ -313,7 +313,11 @@ def _get_owned_agent_or_404(agent_id: int, current_user: User, db: Session) -> A
     """
     agent = (
         db.query(Agent)
-        .filter(Agent.id == agent_id, Agent.user_id == current_user.id)
+        .filter(
+            Agent.id == agent_id,
+            Agent.user_id == current_user.id,
+            Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        )
         .first()
     )
     if not agent:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -345,6 +345,7 @@ def _build_tool_selection_spec_for_task(
         workforce_extra_names=(
             workforce_runtime.worker_tool_names if workforce_runtime else None
         ),
+        extras_only_when_unconfigured=workforce_runtime is not None,
     )
     if spec.is_all():
         logger.info(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -26,7 +26,7 @@ from ...core.model.chat.basic.zhipu import ZhipuLLM
 from ...core.model.providers import is_placeholder_api_key
 from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store
-from ..models.agent import Agent, AgentStatus
+from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.chat_message import TaskChatMessage
 from ..models.database import get_db
 from ..models.model import Model as DBModel
@@ -108,6 +108,8 @@ def _load_agent_for_task_create(
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
     if agent is None:
         return None
+    if is_workforce_generated_manager_agent(agent):
+        return None
     if int(agent.user_id) == int(user.id):
         return agent
     if not _is_published_agent(agent):
@@ -134,6 +136,13 @@ def _load_agent_for_task_runtime(
 
     agent = db.query(Agent).filter(Agent.id == task_agent_id).first()
     if agent is None:
+        return None
+    if is_workforce_generated_manager_agent(agent):
+        if (
+            workforce_runtime is not None
+            and workforce_runtime.manager_agent_id == task_agent_id
+        ):
+            return agent
         return None
     if int(agent.user_id) == int(task.user_id):
         return agent

--- a/src/xagent/web/api/public_trace_events.py
+++ b/src/xagent/web/api/public_trace_events.py
@@ -1,0 +1,80 @@
+"""Public trace event normalization for websocket stream consumers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+WORKFORCE_DELEGATION_EVENT_TYPES = frozenset(
+    {
+        "workforce_delegation_start",
+        "workforce_delegation_end",
+        "workforce_delegation_error",
+    }
+)
+WORKFORCE_DELEGATION_INTERNAL_EVENT_TYPE = "task_update_general"
+
+WORKFORCE_DELEGATION_PUBLIC_FIELDS = (
+    "status",
+    "agent_id",
+    "agent_name",
+    "tool_name",
+    "workforce_run_id",
+    "workforce_id",
+    "workforce_name",
+    "worker_member_id",
+    "worker_alias",
+    "worker_task_id",
+    "output",
+    "output_length",
+    "error",
+    "file_outputs",
+)
+
+
+def is_audit_only_trace_data(data: Any) -> bool:
+    """Return True for trace payloads that must stay server-side."""
+    return isinstance(data, dict) and data.get("__audit_only__") is True
+
+
+def is_public_workforce_delegation_summary(event_type: str, data: Any) -> bool:
+    """Return True when trace data carries a safe workforce delegation summary."""
+    if (
+        event_type != WORKFORCE_DELEGATION_INTERNAL_EVENT_TYPE
+        or not isinstance(data, dict)
+        or is_audit_only_trace_data(data)
+    ):
+        return False
+    payload_event_type = data.get("event_type")
+    return (
+        isinstance(payload_event_type, str)
+        and payload_event_type in WORKFORCE_DELEGATION_EVENT_TYPES
+    )
+
+
+def _public_workforce_delegation_data(data: dict[str, Any]) -> dict[str, Any]:
+    public_data = {
+        key: data[key] for key in WORKFORCE_DELEGATION_PUBLIC_FIELDS if key in data
+    }
+    output = public_data.get("output")
+    if isinstance(output, str):
+        public_data["output"] = output[:2000]
+        public_data.setdefault("output_length", len(output))
+    return public_data
+
+
+def normalize_public_trace_event(
+    event_type: str,
+    data: Any,
+) -> tuple[str, Any]:
+    """Map internal trace rows to the public websocket event contract.
+
+    Internal workforce delegation summaries are persisted as task updates so
+    they do not expand the core trace taxonomy. Public stream consumers should
+    still see a top-level workforce_delegation_* event with only safe summary
+    fields.
+    """
+    if not is_public_workforce_delegation_summary(event_type, data):
+        return event_type, data
+
+    public_event_type = str(data["event_type"])
+    return public_event_type, _public_workforce_delegation_data(data)

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -64,15 +64,17 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from xagent.core.tools.adapters.vibe.agent_tool_names import (
+    LEGACY_AGENT_TOOL_NAME_PREFIX,
+    is_agent_tool_name,
+)
+
 logger = logging.getLogger(__name__)
 
 
-# Tool name prefix used by the runtime when one agent invokes another
-# as a tool. Calls matching this prefix are routed to the public
-# ``agent_delegation`` type instead of ``tool_call`` so SDK consumers
-# can render them differently (e.g. nested timeline) without having
-# to pattern-match tool names client-side.
-_AGENT_DELEGATION_PREFIX = "call_agent_"
+# Agent tool names are routed to the public ``agent_delegation`` type
+# instead of ``tool_call`` so SDK consumers can render nested
+# timelines without pattern-matching tool names client-side.
 
 
 def map_trace_events_to_public_steps(
@@ -106,9 +108,9 @@ def map_trace_events_to_public_steps(
           - ``tool_call``: ``{"name", "args", "result"?, "error"?}``
             (``result`` populated on success, ``error`` on failure)
           - ``agent_delegation``: ``{"sub_agent_name", "input"?, "output"?}``
-            (``sub_agent_name`` is extracted from
-            ``call_agent_<name>``; ``input`` from ``tool_args`` if
-            available, ``output`` from end event's ``result``)
+            (``sub_agent_name`` is derived from the agent tool name;
+            ``input`` from ``tool_args`` if available, ``output`` from
+            end event's ``result``)
           - ``message``: ``{"role": "user"|"assistant", "content": str}``
 
     Notes:
@@ -206,9 +208,7 @@ def map_trace_events_to_public_steps(
             "tool_execution_failed",
         ):
             tool_name = _data_get(event, "tool_name")
-            is_delegation = isinstance(tool_name, str) and tool_name.startswith(
-                _AGENT_DELEGATION_PREFIX
-            )
+            is_delegation = is_agent_tool_name(tool_name)
             public_type = "agent_delegation" if is_delegation else "tool_call"
             # Pair on a per-invocation id (unique even when one step
             # invokes the same tool twice). v1 emits
@@ -379,9 +379,9 @@ def _build_tool_start(
 ) -> Dict[str, Any]:
     """Build the start side of a tool_call or agent_delegation step.
 
-    For ``agent_delegation`` we extract ``sub_agent_name`` from the
-    ``call_agent_<name>`` prefix so SDK consumers don't have to do
-    the string surgery themselves.
+    For legacy ``call_agent_<name>`` delegation tool names we extract
+    the suffix for backward-compatible display. Canonical ``agent_<id>``
+    names are already the stable public identifier.
 
     The args/input value lives under different keys depending on which
     runtime emitted the event: v1 uses ``tool_args``, v2 uses
@@ -398,7 +398,11 @@ def _build_tool_start(
         else None
     )
     if public_type == "agent_delegation" and isinstance(tool_name, str):
-        sub_agent_name = tool_name[len(_AGENT_DELEGATION_PREFIX) :] or tool_name
+        sub_agent_name = (
+            tool_name.removeprefix(LEGACY_AGENT_TOOL_NAME_PREFIX)
+            if tool_name.startswith(LEGACY_AGENT_TOOL_NAME_PREFIX)
+            else tool_name
+        )
         data = {
             "sub_agent_name": sub_agent_name,
             "input": args,

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -28,7 +28,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session, joinedload
 
 from ....core.utils.api_key import parse_api_key, verify_api_key, verify_dummy
-from ...models.agent import Agent
+from ...models.agent import Agent, is_workforce_generated_manager_agent
 from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_db
 from .errors import V1ApiError, V1ErrorCode
@@ -112,7 +112,7 @@ async def get_agent_from_api_key(
     # invalid_api_key rather than 404 so the client retries with a
     # fresh key instead of investigating an imaginary agent.
     agent = key_row.agent
-    if agent is None:
+    if agent is None or is_workforce_generated_manager_agent(agent):
         raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 
     return agent, key_row

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -70,6 +70,7 @@ from ..services.workforce_runtime import (
 from ..tracing import create_ephemeral_tracer
 from ..user_isolated_memory import UserContext
 from ..utils.db_timezone import safe_timestamp_to_unix
+from .public_trace_events import is_audit_only_trace_data, normalize_public_trace_event
 
 logger = logging.getLogger(__name__)
 
@@ -661,7 +662,7 @@ def _is_agent_checkpoint_data(data: Any) -> bool:
 
 def _is_audit_only_trace_data(data: Any) -> bool:
     """Return True for trace payloads that should stay server-side."""
-    return isinstance(data, dict) and data.get("__audit_only__") is True
+    return is_audit_only_trace_data(data)
 
 
 def convert_to_local_time(utc_dt: Any) -> datetime:
@@ -1949,9 +1950,17 @@ class SharedWebSocketTracer(TraceHandler):
         try:
             from .ws_trace_handlers import get_event_type_mapping
 
+            if _is_audit_only_trace_data(event.data):
+                return
+
             # Convert trace event to stream format
             event_type_str = get_event_type_mapping(event)
             serialized_data = self._serialize_data(event.data)
+            if _is_agent_checkpoint_data(serialized_data):
+                return
+            event_type_str, serialized_data = normalize_public_trace_event(
+                event_type_str, serialized_data
+            )
 
             stream_event = create_stream_event(
                 event_type_str,
@@ -3553,15 +3562,19 @@ async def send_historical_data_as_stream(
                         normalized_event_data,
                         historical_path_to_file_id,
                     )
+                public_event_type, public_event_data = normalize_public_trace_event(
+                    str(trace_event.event_type),
+                    normalized_event_data,
+                )
                 historical_events.append(
                     {
                         "type": "trace_event",
                         "data": {
                             "event_id": trace_event.event_id,
-                            "event_type": trace_event.event_type,
+                            "event_type": public_event_type,
                             "step_id": trace_event.step_id,
                             "parent_event_id": trace_event.parent_event_id,
-                            "data": normalized_event_data,
+                            "data": public_event_data,
                         },
                         "timestamp": safe_timestamp_to_unix(trace_event.timestamp)
                         if trace_event.timestamp

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -34,7 +34,7 @@ from ...core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from ...core.agent.trace import TraceEvent, TraceHandler, trace_user_message
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
 from ..auth_dependencies import get_user_from_websocket_token
-from ..models.database import get_db
+from ..models.database import get_db, get_session_local
 from ..models.task import Task, TaskStatus
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
@@ -62,6 +62,7 @@ from ..services.task_lease_service import (
 )
 from ..services.uploaded_file_store import UploadedFileStore
 from ..services.workforce_runtime import (
+    mark_workforce_task_status,
     release_current_runner_task_lease_with_workforce_sync,
     release_task_lease_with_workforce_sync,
     sync_workforce_run_status,
@@ -97,6 +98,79 @@ def _task_status_uses_live_control(
     if pause_accepted:
         return False
     return status in {TaskStatus.WAITING_FOR_USER, TaskStatus.RUNNING}
+
+
+def _task_status_payload(db: Session, task_id: int) -> dict[str, Any] | None:
+    task = db.query(Task).filter(Task.id == task_id).first()
+    if task is None:
+        return None
+    return {
+        "id": task_id,
+        "status": task.status.value,
+    }
+
+
+def _task_error_payload(
+    db: Session,
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "error",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": event_type,
+        "message": message,
+    }
+    task_payload = _task_status_payload(db, task_id)
+    if task_payload is not None:
+        payload["task"] = task_payload
+    return payload
+
+
+def _terminal_task_error_payload(
+    task_id: int,
+    message: str,
+    *,
+    event_type: str = "agent_error",
+) -> dict[str, Any]:
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    try:
+        released = release_current_runner_task_lease_with_workforce_sync(
+            db, task_id, status=TaskStatus.FAILED
+        )
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if task is not None:
+            if not released:
+                setattr(task, "runner_id", None)
+                setattr(task, "lease_expires_at", None)
+                setattr(task, "last_heartbeat_at", datetime.now(timezone.utc))
+            mark_workforce_task_status(
+                db,
+                task,
+                TaskStatus.FAILED,
+                error_message=message,
+            )
+            db.commit()
+        return _task_error_payload(
+            db,
+            task_id,
+            message,
+            event_type=event_type,
+        )
+    except Exception:
+        db.rollback()
+        logger.warning("Failed to persist terminal task error", exc_info=True)
+        return {
+            "type": event_type,
+            "message": message,
+            "task": {
+                "id": task_id,
+                "status": TaskStatus.FAILED.value,
+            },
+        }
+    finally:
+        db.close()
 
 
 def _resolve_task_llm_ids(
@@ -1523,11 +1597,16 @@ async def execute_task_background(
         logger.error(f"Background task {task_id} execution failed: {e}", exc_info=True)
         # Send error event
         try:
+            message = str(e)
             await manager.broadcast_to_task(
                 {
-                    "type": "task_error",
+                    **_terminal_task_error_payload(
+                        task_id,
+                        message,
+                        event_type="task_error",
+                    ),
                     "task_id": task_id,
-                    "error": str(e),
+                    "error": message,
                     "timestamp": datetime.now(timezone.utc).timestamp(),
                 },
                 task_id,
@@ -2245,6 +2324,7 @@ async def handle_chat_message(
         context = message_data.get("context", {})
         files = message_data.get("files", [])
         user = message_data.get("user")
+        authorized_task_id: int | None = None
 
         # Race-condition fallback: when the message arrives without `files`
         # in its payload, the frontend may still have uploaded files via the
@@ -2427,6 +2507,8 @@ async def handle_chat_message(
                         )
                         await manager.broadcast_to_task(task_event, task_id)
                         logger.info(f"task_info event sent for task {task_id}")
+
+                authorized_task_id = int(task.id)
 
                 if not files and task.status == TaskStatus.PENDING:
                     files = _selected_file_refs_from_task(task, db)
@@ -2739,10 +2821,14 @@ async def handle_chat_message(
                         }:
                             await manager.broadcast_to_task(
                                 {
-                                    "type": "agent_error",
-                                    "message": (
-                                        "Task pause is still being applied; "
-                                        "please retry shortly."
+                                    **_task_error_payload(
+                                        db,
+                                        task_id,
+                                        (
+                                            "Task pause is still being applied; "
+                                            "please retry shortly."
+                                        ),
+                                        event_type="agent_error",
                                     ),
                                     "timestamp": datetime.now(timezone.utc).timestamp(),
                                 },
@@ -2885,8 +2971,12 @@ async def handle_chat_message(
                         )
                         await manager.broadcast_to_task(
                             {
-                                "type": "agent_error",
-                                "message": ("Internal dispatch error; please retry."),
+                                **_task_error_payload(
+                                    db,
+                                    task_id,
+                                    "Internal dispatch error; please retry.",
+                                    event_type="agent_error",
+                                ),
                                 "timestamp": datetime.now(timezone.utc).timestamp(),
                             },
                             task_id,
@@ -2917,11 +3007,15 @@ async def handle_chat_message(
                         )
                         await manager.broadcast_to_task(
                             {
-                                "type": "agent_error",
-                                "message": (
-                                    "Task is currently busy; please wait for "
-                                    "the previous turn to finish before sending "
-                                    "another message."
+                                **_task_error_payload(
+                                    db,
+                                    task_id,
+                                    (
+                                        "Task is currently busy; please wait for "
+                                        "the previous turn to finish before sending "
+                                        "another message."
+                                    ),
+                                    event_type="agent_error",
                                 ),
                                 "timestamp": datetime.now(timezone.utc).timestamp(),
                             },
@@ -2933,26 +3027,48 @@ async def handle_chat_message(
 
         except (ValueError, KeyError, TypeError) as e:
             # Data validation and format error
+            message = f"Data validation error: {str(e)}"
             logger.error(f"Data validation error in agent execution: {e}")
-            await manager.broadcast_to_task(
-                {
-                    "type": "agent_error",
-                    "message": f"Data validation error: {str(e)}",
-                    "timestamp": datetime.now(timezone.utc).timestamp(),
-                },
-                task_id,
-            )
+            timestamp = datetime.now(timezone.utc).timestamp()
+            if authorized_task_id is not None:
+                await manager.broadcast_to_task(
+                    {
+                        **_terminal_task_error_payload(authorized_task_id, message),
+                        "timestamp": timestamp,
+                    },
+                    authorized_task_id,
+                )
+            else:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": message,
+                        "timestamp": timestamp,
+                    },
+                    websocket,
+                )
         except RuntimeError as e:
             # Runtime error
+            message = f"Runtime error: {str(e)}"
             logger.error(f"Runtime error in agent execution: {e}")
-            await manager.broadcast_to_task(
-                {
-                    "type": "agent_error",
-                    "message": f"Runtime error: {str(e)}",
-                    "timestamp": datetime.now(timezone.utc).timestamp(),
-                },
-                task_id,
-            )
+            timestamp = datetime.now(timezone.utc).timestamp()
+            if authorized_task_id is not None:
+                await manager.broadcast_to_task(
+                    {
+                        **_terminal_task_error_payload(authorized_task_id, message),
+                        "timestamp": timestamp,
+                    },
+                    authorized_task_id,
+                )
+            else:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": message,
+                        "timestamp": timestamp,
+                    },
+                    websocket,
+                )
         except Exception as e:
             # Other unknown errors, re-raise
             logger.error(f"Unexpected error in agent execution: {e}")
@@ -2980,6 +3096,7 @@ async def handle_execute_task(
     """Handle task execution request"""
     try:
         user = message_data.get("user")
+        authorized_task_id: int | None = None
         if not user:
             raise ValueError("User authentication required for task execution")
 
@@ -3016,6 +3133,7 @@ async def handle_execute_task(
                 )
             if not task:
                 raise Exception(f"Task {task_id} not found or access denied")
+            authorized_task_id = int(task.id)
 
             (
                 model_id,
@@ -3153,26 +3271,48 @@ async def handle_execute_task(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation and format error
+        message = f"Data validation error: {str(e)}"
         logger.error(f"Data validation error in task execution: {e}")
-        await manager.broadcast_to_task(
-            {
-                "type": "agent_error",
-                "message": f"Data validation error: {str(e)}",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            },
-            task_id,
-        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        if authorized_task_id is not None:
+            await manager.broadcast_to_task(
+                {
+                    **_terminal_task_error_payload(authorized_task_id, message),
+                    "timestamp": timestamp,
+                },
+                authorized_task_id,
+            )
+        else:
+            await manager.send_personal_message(
+                {
+                    "type": "error",
+                    "message": message,
+                    "timestamp": timestamp,
+                },
+                websocket,
+            )
     except RuntimeError as e:
         # Runtime error
+        message = f"Runtime error: {str(e)}"
         logger.error(f"Runtime error in task execution: {e}")
-        await manager.broadcast_to_task(
-            {
-                "type": "agent_error",
-                "message": f"Runtime error: {str(e)}",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            },
-            task_id,
-        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        if authorized_task_id is not None:
+            await manager.broadcast_to_task(
+                {
+                    **_terminal_task_error_payload(authorized_task_id, message),
+                    "timestamp": timestamp,
+                },
+                authorized_task_id,
+            )
+        else:
+            await manager.send_personal_message(
+                {
+                    "type": "error",
+                    "message": message,
+                    "timestamp": timestamp,
+                },
+                websocket,
+            )
     except Exception as e:
         # Other unknown errors, re-raise
         logger.error(f"Unexpected error in task execution: {e}")
@@ -3842,10 +3982,11 @@ async def handle_pause_task(
             pause_result = await agent_service.pause_execution()
             if pause_result is False:
                 await manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": "No live execution found to pause",
-                    },
+                    _task_error_payload(
+                        db,
+                        task_id,
+                        "No live execution found to pause",
+                    ),
                     websocket,
                 )
                 logger.warning(f"No live execution found to pause for task {task_id}")
@@ -3867,10 +4008,11 @@ async def handle_pause_task(
         else:
             # If pause not supported, send error message
             await manager.send_personal_message(
-                {
-                    "type": "error",
-                    "message": "Current agent does not support pause functionality",
-                },
+                _task_error_payload(
+                    db,
+                    task_id,
+                    "Current agent does not support pause functionality",
+                ),
                 websocket,
             )
             logger.warning(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -142,9 +142,10 @@ def _terminal_task_error_payload(
         task = db.query(Task).filter(Task.id == task_id).first()
         if task is not None:
             if not released:
-                setattr(task, "runner_id", None)
-                setattr(task, "lease_expires_at", None)
-                setattr(task, "last_heartbeat_at", datetime.now(timezone.utc))
+                orm_task = cast(Any, task)
+                orm_task.runner_id = None
+                orm_task.lease_expires_at = None
+                orm_task.last_heartbeat_at = datetime.now(timezone.utc)
             mark_workforce_task_status(
                 db,
                 task,

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
-from ..models.agent import Agent
+from ..models.agent import Agent, is_workforce_generated_manager_agent
 from ..models.database import get_db
 from ..models.task import Task, TaskStatus
 from ..models.user import User
@@ -100,10 +100,15 @@ async def authenticate_widget(
     agent_id = request.agent_id
     user = None
     target_channel = None
+    agent = None
 
     # Authenticate via agent_id directly (since web widget channel is deprecated)
     if agent_id:
-        agent = db.query(Agent).filter(Agent.id == agent_id).first()
+        candidate_agent = db.query(Agent).filter(Agent.id == agent_id).first()
+        if candidate_agent and not is_workforce_generated_manager_agent(
+            candidate_agent
+        ):
+            agent = candidate_agent
         if agent:
             if not agent.widget_enabled:
                 raise HTTPException(
@@ -155,11 +160,9 @@ async def authenticate_widget(
     # Get agent name if available
     agent_name = None
     agent_logo = None
-    if agent_id:
-        agent = db.query(Agent).filter(Agent.id == agent_id).first()
-        if agent:
-            agent_name = agent.name
-            agent_logo = agent.logo_url
+    if agent:
+        agent_name = agent.name
+        agent_logo = agent.logo_url
 
     channel_id = target_channel.id if target_channel else None
 

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -6,7 +6,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, selectinload
 
 from ..auth_dependencies import get_current_user
-from ..models.agent import Agent
+from ..models.agent import Agent, is_workforce_generated_manager_agent
 from ..models.database import get_db
 from ..models.user import User
 from ..models.workforce import (
@@ -146,13 +146,15 @@ def _serialize_agent(agent: Agent, user: User | None = None) -> dict[str, Any]:
         return item
 
     is_owner = int(agent.user_id) == int(user.id)
+    is_generated_manager = is_workforce_generated_manager_agent(agent)
+    can_edit = is_owner and not is_generated_manager
     item.update(
         {
             "access": "owner" if is_owner else "policy",
-            "readonly": not is_owner,
-            "can_edit": is_owner,
-            "can_publish": is_owner,
-            "can_delete": is_owner,
+            "readonly": not can_edit,
+            "can_edit": can_edit,
+            "can_publish": can_edit,
+            "can_delete": can_edit,
         }
     )
     return item

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -519,21 +519,22 @@ async def update_workforce(
     if _field_supplied(request, "manager_agent_id"):
         if request.manager_agent_id is None:
             raise HTTPException(status_code=400, detail="manager_agent_id is required")
-        manager_agent = ensure_agent_access(
-            db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
-            user,
-            db,
-            require_published=True,
-        )
-        if any(
-            int(worker.agent_id) == int(manager_agent.id)
-            for worker in workforce.workers
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="Manager agent cannot also be a worker",
+        if int(request.manager_agent_id) != int(workforce.manager_agent_id):
+            manager_agent = ensure_agent_access(
+                db.query(Agent).filter(Agent.id == request.manager_agent_id).first(),
+                user,
+                db,
+                require_published=True,
             )
-        workforce_row.manager_agent_id = int(manager_agent.id)
+            if any(
+                int(worker.agent_id) == int(manager_agent.id)
+                for worker in workforce.workers
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Manager agent cannot also be a worker",
+                )
+            workforce_row.manager_agent_id = int(manager_agent.id)
 
     try:
         _validate_if_active(db, user, workforce)

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -12,6 +12,7 @@ from ...core.agent.trace import (
     TraceHandler,
     TraceScope,
 )
+from .public_trace_events import is_audit_only_trace_data, normalize_public_trace_event
 from .websocket import create_stream_event, manager
 
 
@@ -342,7 +343,7 @@ class WebSocketTraceHandler(TraceHandler):
         """
         # Server-only audit traces: drop early so we don't waste effort
         # serializing payloads we're about to discard.
-        if isinstance(event.data, dict) and event.data.get("__audit_only__") is True:
+        if is_audit_only_trace_data(event.data):
             logger.debug(
                 f"Dropping audit-only trace event from WS broadcast: "
                 f"step_id={event.step_id} task={self.task_id}"
@@ -358,6 +359,9 @@ class WebSocketTraceHandler(TraceHandler):
         data = self._serialize_data(event.data)
         if is_agent_checkpoint_data(data):
             return None
+        if self._task_description:
+            data["task_description"] = self._task_description
+        event_type_str, data = normalize_public_trace_event(event_type_str, data)
 
         # Create the base stream event
         stream_event = create_stream_event(
@@ -371,10 +375,6 @@ class WebSocketTraceHandler(TraceHandler):
         # Add parent_id if present (for event correlation)
         if event.parent_id:
             stream_event["parent_id"] = event.parent_id
-
-        # Add task description if available
-        if self._task_description:
-            stream_event["data"]["task_description"] = self._task_description
 
         return stream_event
 

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -19,6 +19,13 @@ class AgentStatus(enum.Enum):
     ARCHIVED = "archived"
 
 
+class AgentOrigin(enum.Enum):
+    """Where an agent came from."""
+
+    USER = "user"
+    WORKFORCE_GENERATED_MANAGER = "workforce_generated_manager"
+
+
 class ExecutionMode(enum.Enum):
     """Agent execution mode enumeration"""
 
@@ -65,6 +72,12 @@ class Agent(Base):  # type: ignore
     )  # List of allowed domains for the widget
 
     # Status
+    origin = Column(
+        String(50),
+        default=AgentOrigin.USER.value,
+        nullable=False,
+        index=True,
+    )
     status: AgentStatus = Column(
         SQLEnum(AgentStatus, values_callable=lambda obj: [e.value for e in obj]),
         default=AgentStatus.DRAFT,
@@ -84,5 +97,23 @@ class Agent(Base):  # type: ignore
     # Relationships
     user = relationship("User", back_populates="agents")
 
+    @property
+    def is_workforce_generated_manager(self) -> bool:
+        origin = getattr(self.origin, "value", self.origin)
+        return bool(origin == AgentOrigin.WORKFORCE_GENERATED_MANAGER.value)
+
     def __repr__(self) -> str:
         return f"<Agent(id={self.id}, name='{self.name}', status='{self.status}')>"
+
+
+def is_workforce_generated_manager_agent(agent: object | None) -> bool:
+    if agent is None:
+        return False
+
+    marker = getattr(agent, "is_workforce_generated_manager", None)
+    if isinstance(marker, bool):
+        return marker
+
+    origin = getattr(agent, "origin", None)
+    origin = getattr(origin, "value", origin)
+    return origin == AgentOrigin.WORKFORCE_GENERATED_MANAGER.value

--- a/src/xagent/web/services/agent_access.py
+++ b/src/xagent/web/services/agent_access.py
@@ -8,9 +8,8 @@ from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
-from ..models.agent import Agent, AgentStatus
+from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.user import User
-from ..models.workforce import Workforce
 from .workforce_access import get_visible_agent_ids
 
 AgentAccessLevel = Literal["owner", "policy"]
@@ -84,9 +83,8 @@ def _is_published(agent: Agent) -> bool:
     return getattr(agent.status, "value", agent.status) == AgentStatus.PUBLISHED.value
 
 
-def _exclude_workforce_manager_agents(query: Any) -> Any:
-    manager_agent_ids = query.session.query(Workforce.manager_agent_id)
-    return query.filter(Agent.id.notin_(manager_agent_ids))
+def _exclude_private_workforce_manager_agents(query: Any) -> Any:
+    return query.filter(Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value)
 
 
 def list_accessible_agents(
@@ -95,7 +93,7 @@ def list_accessible_agents(
     *,
     purpose: str = "agent_list",
     exclude_agent_ids: Iterable[int] | None = None,
-    include_workforce_manager_agents: bool = False,
+    include_private_workforce_manager_agents: bool = False,
 ) -> list[AccessibleAgent]:
     """List agents visible to the user, including owned and policy-visible drafts."""
     excluded = _normalize_excluded_agent_ids(exclude_agent_ids)
@@ -104,8 +102,8 @@ def list_accessible_agents(
     owned_query = db.query(Agent).filter(Agent.user_id == int(user.id))
     if excluded:
         owned_query = owned_query.filter(Agent.id.notin_(excluded))
-    if not include_workforce_manager_agents:
-        owned_query = _exclude_workforce_manager_agents(owned_query)
+    if not include_private_workforce_manager_agents:
+        owned_query = _exclude_private_workforce_manager_agents(owned_query)
     for agent in owned_query.all():
         items_by_id[int(agent.id)] = _owned_accessible_agent(agent)
 
@@ -119,8 +117,8 @@ def list_accessible_agents(
 
     if excluded:
         policy_query = policy_query.filter(Agent.id.notin_(excluded))
-    if not include_workforce_manager_agents:
-        policy_query = _exclude_workforce_manager_agents(policy_query)
+    if not include_private_workforce_manager_agents:
+        policy_query = _exclude_private_workforce_manager_agents(policy_query)
 
     for agent in policy_query.all():
         agent_id = int(agent.id)
@@ -137,7 +135,7 @@ def list_accessible_published_agent_items(
     *,
     purpose: str = "workforce_select",
     exclude_agent_ids: Iterable[int] | None = None,
-    include_workforce_manager_agents: bool = False,
+    include_private_workforce_manager_agents: bool = False,
 ) -> list[AccessibleAgent]:
     return sorted(
         [
@@ -147,7 +145,7 @@ def list_accessible_published_agent_items(
                 user,
                 purpose=purpose,
                 exclude_agent_ids=exclude_agent_ids,
-                include_workforce_manager_agents=include_workforce_manager_agents,
+                include_private_workforce_manager_agents=include_private_workforce_manager_agents,
             )
             if _is_published(item.agent)
         ],
@@ -161,7 +159,7 @@ def list_accessible_published_agents(
     *,
     purpose: str = "workforce_select",
     exclude_agent_ids: Iterable[int] | None = None,
-    include_workforce_manager_agents: bool = False,
+    include_private_workforce_manager_agents: bool = False,
 ) -> list[Agent]:
     return [
         item.agent
@@ -170,6 +168,6 @@ def list_accessible_published_agents(
             user,
             purpose=purpose,
             exclude_agent_ids=exclude_agent_ids,
-            include_workforce_manager_agents=include_workforce_manager_agents,
+            include_private_workforce_manager_agents=include_private_workforce_manager_agents,
         )
     ]

--- a/src/xagent/web/services/agent_access.py
+++ b/src/xagent/web/services/agent_access.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from ..models.agent import Agent, AgentStatus
 from ..models.user import User
+from ..models.workforce import Workforce
 from .workforce_access import get_visible_agent_ids
 
 AgentAccessLevel = Literal["owner", "policy"]
@@ -83,12 +84,18 @@ def _is_published(agent: Agent) -> bool:
     return getattr(agent.status, "value", agent.status) == AgentStatus.PUBLISHED.value
 
 
+def _exclude_workforce_manager_agents(query: Any) -> Any:
+    manager_agent_ids = query.session.query(Workforce.manager_agent_id)
+    return query.filter(Agent.id.notin_(manager_agent_ids))
+
+
 def list_accessible_agents(
     db: Session,
     user: User,
     *,
     purpose: str = "agent_list",
     exclude_agent_ids: Iterable[int] | None = None,
+    include_workforce_manager_agents: bool = False,
 ) -> list[AccessibleAgent]:
     """List agents visible to the user, including owned and policy-visible drafts."""
     excluded = _normalize_excluded_agent_ids(exclude_agent_ids)
@@ -97,6 +104,8 @@ def list_accessible_agents(
     owned_query = db.query(Agent).filter(Agent.user_id == int(user.id))
     if excluded:
         owned_query = owned_query.filter(Agent.id.notin_(excluded))
+    if not include_workforce_manager_agents:
+        owned_query = _exclude_workforce_manager_agents(owned_query)
     for agent in owned_query.all():
         items_by_id[int(agent.id)] = _owned_accessible_agent(agent)
 
@@ -110,6 +119,8 @@ def list_accessible_agents(
 
     if excluded:
         policy_query = policy_query.filter(Agent.id.notin_(excluded))
+    if not include_workforce_manager_agents:
+        policy_query = _exclude_workforce_manager_agents(policy_query)
 
     for agent in policy_query.all():
         agent_id = int(agent.id)
@@ -126,6 +137,7 @@ def list_accessible_published_agent_items(
     *,
     purpose: str = "workforce_select",
     exclude_agent_ids: Iterable[int] | None = None,
+    include_workforce_manager_agents: bool = False,
 ) -> list[AccessibleAgent]:
     return sorted(
         [
@@ -135,6 +147,7 @@ def list_accessible_published_agent_items(
                 user,
                 purpose=purpose,
                 exclude_agent_ids=exclude_agent_ids,
+                include_workforce_manager_agents=include_workforce_manager_agents,
             )
             if _is_published(item.agent)
         ],
@@ -148,6 +161,7 @@ def list_accessible_published_agents(
     *,
     purpose: str = "workforce_select",
     exclude_agent_ids: Iterable[int] | None = None,
+    include_workforce_manager_agents: bool = False,
 ) -> list[Agent]:
     return [
         item.agent
@@ -156,5 +170,6 @@ def list_accessible_published_agents(
             user,
             purpose=purpose,
             exclude_agent_ids=exclude_agent_ids,
+            include_workforce_manager_agents=include_workforce_manager_agents,
         )
     ]

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -8,7 +8,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from ...core.utils.type_check import ensure_list
-from ..models.agent import Agent, AgentStatus
+from ..models.agent import Agent, AgentOrigin, AgentStatus
 from ..models.agent_api_key import AgentApiKey
 from ..models.task import Task
 from .hot_path_cache import (
@@ -90,6 +90,7 @@ class AgentStore:
         agents = (
             self.db.query(Agent)
             .filter(Agent.user_id == user_id)
+            .filter(Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value)
             .order_by(Agent.created_at.desc())
             .all()
         )
@@ -114,7 +115,11 @@ class AgentStore:
     def get_owned_agent(self, user_id: int, agent_id: int) -> Agent | None:
         return (
             self.db.query(Agent)
-            .filter(Agent.id == agent_id, Agent.user_id == user_id)
+            .filter(
+                Agent.id == agent_id,
+                Agent.user_id == user_id,
+                Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
             .first()
         )
 
@@ -122,7 +127,9 @@ class AgentStore:
         self, user_id: int, name: str, *, exclude_agent_id: int | None = None
     ) -> bool:
         query = self.db.query(Agent.id).filter(
-            Agent.user_id == user_id, Agent.name == name
+            Agent.user_id == user_id,
+            Agent.name == name,
+            Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
         )
         if exclude_agent_id is not None:
             query = query.filter(Agent.id != exclude_agent_id)
@@ -141,6 +148,7 @@ class AgentStore:
         skills: list[str] | None = None,
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
+        origin: str = AgentOrigin.USER.value,
         status: AgentStatus = AgentStatus.DRAFT,
         published_at: datetime | None = None,
         widget_enabled: bool = True,
@@ -157,6 +165,7 @@ class AgentStore:
             skills=skills,
             tool_categories=tool_categories,
             suggested_prompts=suggested_prompts,
+            origin=origin,
             status=status,
             published_at=published_at,
             widget_enabled=widget_enabled,
@@ -180,6 +189,7 @@ class AgentStore:
         skills: list[str] | None = None,
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
+        origin: str = AgentOrigin.USER.value,
         status: AgentStatus = AgentStatus.DRAFT,
         published_at: datetime | None = None,
         widget_enabled: bool = True,
@@ -198,6 +208,7 @@ class AgentStore:
             skills=skills or [],
             tool_categories=tool_categories or [],
             suggested_prompts=suggested_prompts or [],
+            origin=origin,
             status=status,
             published_at=published_at,
             widget_enabled=widget_enabled,

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -1013,7 +1013,11 @@ def _load_agent_for_task_runtime(
     task_row: Any,
     workforce: Any,
 ) -> Any | None:
-    from ..models.agent import Agent, AgentStatus
+    from ..models.agent import (
+        Agent,
+        AgentStatus,
+        is_workforce_generated_manager_agent,
+    )
     from ..models.user import User
     from .agent_access import list_accessible_published_agents
 
@@ -1023,6 +1027,10 @@ def _load_agent_for_task_runtime(
 
     agent = session.query(Agent).filter(Agent.id == task_agent_id).first()
     if agent is None:
+        return None
+    if is_workforce_generated_manager_agent(agent):
+        if workforce is not None and workforce.manager_agent_id == task_agent_id:
+            return agent
         return None
     if int(agent.user_id) == int(task_row.user_id):
         return agent

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -57,6 +57,7 @@ def has_agent_checkpoint(db: Session, task_id: int) -> bool:
         db.query(TraceEvent)
         .filter(
             TraceEvent.task_id == task_id,
+            TraceEvent.build_id.is_(None),
             TraceEvent.event_type == "system_update_general",
         )
         .order_by(TraceEvent.id.desc())

--- a/src/xagent/web/services/workforce_access.py
+++ b/src/xagent/web/services/workforce_access.py
@@ -4,7 +4,11 @@ from typing import Any
 from fastapi import HTTPException
 from sqlalchemy.orm import Query, Session
 
-from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.agent import (
+    Agent,
+    AgentStatus,
+    is_workforce_generated_manager_agent,
+)
 from xagent.web.models.user import User
 
 from ..models.workforce import Workforce
@@ -191,6 +195,8 @@ def ensure_agent_access(
     require_published: bool = False,
 ) -> Agent:
     if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if is_workforce_generated_manager_agent(agent):
         raise HTTPException(status_code=404, detail="Agent not found")
     if user.is_admin or int(agent.user_id) == int(user.id):
         if require_published and agent.status != AgentStatus.PUBLISHED:

--- a/src/xagent/web/services/workforce_creator.py
+++ b/src/xagent/web/services/workforce_creator.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import UserAwareModelStorage
 
@@ -261,8 +261,9 @@ def _create_manager_agent_from_plan(
         skills=[],
         tool_categories=[],
         suggested_prompts=[],
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
         status=AgentStatus.PUBLISHED,
-        widget_enabled=True,
+        widget_enabled=False,
         allowed_domains=[],
     )
 

--- a/src/xagent/web/services/workforce_snapshot.py
+++ b/src/xagent/web/services/workforce_snapshot.py
@@ -1,10 +1,9 @@
-import hashlib
-import re
 from typing import Any, Literal, cast, overload
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from xagent.core.tools.adapters.vibe.agent_tool_names import gen_agent_tool_name
 from xagent.web.models.agent import Agent
 from xagent.web.models.user import User
 
@@ -54,35 +53,8 @@ def normalize_text(
     return normalized or None
 
 
-def slugify_name(value: str | None, fallback: str = "worker") -> str:
-    base = (value or "").strip().lower()
-    slug = re.sub(r"[^a-z0-9]+", "_", base).strip("_")
-    return slug or fallback
-
-
-_MAX_TOOL_NAME_LENGTH = 64
-_TOOL_NAME_PREFIX = "call_workforce_worker_"
-
-
-def build_worker_tool_name(worker_id: int, alias: str) -> str:
-    slug = slugify_name(alias)
-    raw = f"{_TOOL_NAME_PREFIX}{worker_id}_{slug}"
-    if len(raw) <= _MAX_TOOL_NAME_LENGTH:
-        return raw
-
-    worker_id_str = str(worker_id)
-    hash_suffix = "_" + hashlib.sha256(slug.encode()).hexdigest()[:6]
-    available = (
-        _MAX_TOOL_NAME_LENGTH
-        - len(_TOOL_NAME_PREFIX)
-        - len(worker_id_str)
-        - len(hash_suffix)
-        - 1
-    )
-    if available < 4:
-        available = 4
-    truncated_slug = slug[:available]
-    return f"{_TOOL_NAME_PREFIX}{worker_id_str}_{truncated_slug}{hash_suffix}"
+def build_worker_tool_name(agent_id: int, alias: str | None = None) -> str:
+    return gen_agent_tool_name(agent_id)
 
 
 def _sorted_workers(workforce: Workforce) -> list[WorkforceAgent]:
@@ -191,7 +163,7 @@ def build_agent_tool_overrides(
         description_parts.append(f"Workforce role: {alias}.")
         description_parts.append(f"Assignment: {worker['assignment_instructions']}")
         overrides[int(worker["agent_id"])] = {
-            "tool_name": worker["tool_name"],
+            "tool_name": build_worker_tool_name(int(worker["agent_id"])),
             "description": " ".join(description_parts),
             "extra_system_prompt": build_worker_system_prompt(
                 workforce_name, worker["assignment_instructions"]
@@ -235,7 +207,7 @@ def build_workforce_snapshot(
                 "description": worker.agent.description,
                 "assignment_instructions": assignment_instructions,
                 "execution_mode": worker.agent.execution_mode,
-                "tool_name": build_worker_tool_name(cast(int, worker.id), alias),
+                "tool_name": build_worker_tool_name(cast(int, worker.agent_id), alias),
                 "enabled": bool(worker.enabled),
             }
         )

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -269,6 +269,68 @@ def test_agent_workspace_register_file_avoids_parent_output_name_collision(
         engine.dispose()
 
 
+def test_agent_workspace_register_file_is_idempotent_after_canonicalization(
+    monkeypatch, tmp_path, mock_workspace_db
+):
+    del mock_workspace_db
+    object_root = tmp_path / "objects"
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+    get_file_storage.cache_clear()
+
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="delegated-idempotent-user", password_hash="hash")
+        db.add(user)
+        db.flush()
+        task = Task(id=321, user_id=user.id, title="Parent task")
+        db.add(task)
+        db.commit()
+
+        workspace = TaskWorkspace(
+            id="agent_2_abcd1234",
+            base_dir=str(tmp_path / "workspaces"),
+            db_task_id=321,
+        )
+        output_path = workspace.output_dir / "report.txt"
+        output_path.write_text("first delegated output", encoding="utf-8")
+
+        file_id = workspace.register_file(str(output_path), db_session=db)
+        db.commit()
+
+        output_path.write_text("updated delegated output", encoding="utf-8")
+        second_file_id = workspace.register_file(str(output_path), db_session=db)
+        db.commit()
+
+        assert second_file_id == file_id
+        records = db.query(UploadedFile).all()
+        assert len(records) == 1
+        record = records[0]
+        canonical_path = (
+            tmp_path
+            / "workspaces"
+            / f"user_{user.id}"
+            / "web_task_321"
+            / "output"
+            / "report.txt"
+        )
+        assert record.storage_path == str(canonical_path)
+        assert record.workspace_relative_path == "output/report.txt"
+        assert record.file_size == len("updated delegated output")
+        assert canonical_path.read_text(encoding="utf-8") == "updated delegated output"
+
+        object_files = [path for path in object_root.rglob("*") if path.is_file()]
+        assert len(object_files) == 1
+        assert object_files[0].read_text(encoding="utf-8") == "updated delegated output"
+    finally:
+        db.close()
+        engine.dispose()
+
+
 def test_tool_factory_workspace_preserves_db_task_id(tmp_path):
     workspace = ToolFactory._create_workspace(
         {

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -45,6 +45,7 @@ def test_workspace_register_file_writes_durable_storage(
         db.commit()
 
         record = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        assert record.storage_path == str(output_path)
         assert record.storage_status == "available"
         assert record.storage_backend == "file"
         assert record.storage_key == (
@@ -96,10 +97,19 @@ def test_agent_workspace_register_file_uses_explicit_db_task_id(
         db.commit()
 
         record = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        canonical_path = (
+            tmp_path
+            / "workspaces"
+            / f"user_{user.id}"
+            / "web_task_321"
+            / "output"
+            / "report.txt"
+        )
         assert workspace.current_task_id == 321
         assert record.user_id == user.id
         assert record.task_id == 321
-        assert record.storage_path == str(output_path)
+        assert record.storage_path == str(canonical_path)
+        assert canonical_path.read_text(encoding="utf-8") == "delegated output"
         assert record.storage_key == (
             f"users/{user.id}/tasks/321/outputs/{file_id}/output/report.txt"
         )
@@ -162,14 +172,98 @@ def test_agent_workspace_register_file_rebinds_existing_output_to_db_task_id(
 
         assert file_id == "worker-output"
         db.refresh(record)
+        canonical_path = (
+            tmp_path
+            / "workspaces"
+            / f"user_{user.id}"
+            / "web_task_321"
+            / "output"
+            / "report.txt"
+        )
         assert record.user_id == user.id
         assert record.task_id == 321
+        assert record.storage_path == str(canonical_path)
+        assert canonical_path.read_text(encoding="utf-8") == "parent-visible output"
         assert record.storage_key == (
             f"users/{user.id}/tasks/321/outputs/worker-output/output/report.txt"
         )
         assert record.workspace_relative_path == "output/report.txt"
         assert record.workspace_category == "output"
         assert record.file_size == len("parent-visible output")
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def test_agent_workspace_register_file_avoids_parent_output_name_collision(
+    monkeypatch, tmp_path, mock_workspace_db
+):
+    del mock_workspace_db
+    object_root = tmp_path / "objects"
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+    get_file_storage.cache_clear()
+
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(username="delegated-collision-user", password_hash="hash")
+        db.add(user)
+        db.flush()
+        task = Task(id=321, user_id=user.id, title="Parent task")
+        db.add(task)
+        db.commit()
+
+        parent_output_path = (
+            tmp_path
+            / "workspaces"
+            / f"user_{user.id}"
+            / "web_task_321"
+            / "output"
+            / "report.txt"
+        )
+        parent_output_path.parent.mkdir(parents=True)
+        parent_output_path.write_text("existing parent output", encoding="utf-8")
+        db.add(
+            UploadedFile(
+                file_id="existing-parent-output",
+                user_id=user.id,
+                task_id=321,
+                filename="report.txt",
+                storage_path=str(parent_output_path),
+                mime_type="text/plain",
+                file_size=len("existing parent output"),
+                workspace_relative_path="output/report.txt",
+                workspace_category="output",
+            )
+        )
+        db.commit()
+
+        workspace = TaskWorkspace(
+            id="agent_2_abcd1234",
+            base_dir=str(tmp_path / "workspaces"),
+            db_task_id=321,
+        )
+        output_path = workspace.output_dir / "report.txt"
+        output_path.write_text("delegated output", encoding="utf-8")
+
+        file_id = workspace.register_file(str(output_path), db_session=db)
+        db.commit()
+
+        record = db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        canonical_path = parent_output_path.with_name("report_1.txt")
+        assert (
+            parent_output_path.read_text(encoding="utf-8") == "existing parent output"
+        )
+        assert canonical_path.read_text(encoding="utf-8") == "delegated output"
+        assert record.storage_path == str(canonical_path)
+        assert record.workspace_relative_path == "output/report_1.txt"
+        assert record.storage_key == (
+            f"users/{user.id}/tasks/321/outputs/{file_id}/output/report_1.txt"
+        )
     finally:
         db.close()
         engine.dispose()

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -152,6 +152,15 @@ class _FakeConfig:
     def get_workspace_config(self):  # noqa: D401
         return None
 
+    def get_max_output_length(self):  # noqa: D401
+        return None
+
+    def get_max_field_count(self):  # noqa: D401
+        return None
+
+    def get_max_recursion_depth(self):  # noqa: D401
+        return None
+
 
 async def test_registry_runs_all_creators_when_spec_none(isolated_registry):
     """Backward-compat path: ``spec=None`` (or no spec attribute) means
@@ -220,6 +229,47 @@ async def test_registry_runs_published_agent_creator_for_workforce_extras(
     assert published_agents.await_count == 1
     assert agent_management.await_count == 0
     assert [tool.name for tool in tools] == ["calc", "agent_42"]
+
+
+async def test_factory_worker_only_mode_keeps_only_injected_agent_tools(
+    isolated_registry,
+):
+    """Workforce managers with no ordinary categories should only expose
+    injected worker agent tools, not the full default tool set.
+    """
+    basic = AsyncMock(return_value=[_mock_tool("exa_web_search", "basic")])
+    basic.__name__ = "basic_creator"
+    published_agents = AsyncMock(
+        return_value=[
+            _mock_tool("agent_42", "agent"),
+            _mock_tool("agent_99", "agent"),
+        ]
+    )
+    published_agents.__name__ = "create_agent_tools"
+    agent_management = AsyncMock(return_value=[_mock_tool("create_agent", "agent")])
+    agent_management.__name__ = "create_create_agent_tool"
+    isolated_registry.register(basic, categories={"basic"})
+    isolated_registry.register(
+        published_agents,
+        categories={"agent"},
+        selection_gate="published_agent",
+    )
+    isolated_registry.register(agent_management, categories={"agent"})
+
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=[],
+        workforce_extra_names={"agent_42"},
+        extras_only_when_unconfigured=True,
+    )
+    tools = await ToolFactory.create_all_tools(
+        _FakeConfig(spec),
+        apply_user_override_filter=False,
+    )
+
+    assert basic.await_count == 0
+    assert published_agents.await_count == 1
+    assert agent_management.await_count == 0
+    assert [tool.name for tool in tools] == ["agent_42"]
 
 
 async def test_registry_always_runs_creator_without_declared_categories(
@@ -946,6 +996,47 @@ def test_from_raw_workforce_extras_ignored_in_all_mode():
     # ALL mode: no name_extras field on _SpecAll, callsite that
     # asks for extras must have categories set.
     assert isinstance(spec, _SpecAll)
+
+
+def test_from_raw_can_restrict_unconfigured_agent_to_workforce_extras_only():
+    """Workforce manager runtime can opt out of legacy ALL semantics for
+    unconfigured categories, yielding only injected worker names.
+    """
+    from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
+
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=[],
+        workforce_extra_names={"agent_42"},
+        extras_only_when_unconfigured=True,
+    )
+
+    assert isinstance(spec, _SpecByCategories)
+    assert spec.categories == frozenset()
+    assert spec.name_extras == frozenset({"agent_42"})
+    assert spec.includes_category("basic") is False
+    assert spec.includes_published_agent() is True
+    assert spec.compute_allowed_names(
+        [
+            _mock_tool("exa_web_search", "basic"),
+            _mock_tool("agent_42", "agent"),
+            _mock_tool("agent_99", "agent"),
+        ]
+    ) == frozenset({"agent_42"})
+
+
+def test_from_raw_unconfigured_extras_only_without_extras_yields_none_mode():
+    """A workforce manager with no configured categories and no worker
+    extras should get zero tools, not all ordinary tools.
+    """
+    from xagent.core.tools.adapters.vibe.selection_spec import _SpecNone
+
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=None,
+        workforce_extra_names=set(),
+        extras_only_when_unconfigured=True,
+    )
+
+    assert isinstance(spec, _SpecNone)
 
 
 def test_from_raw_workforce_extras_carried_in_by_categories():

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -188,6 +188,40 @@ async def test_registry_skips_creator_when_categories_disjoint(isolated_registry
     assert len(tools) == 1
 
 
+async def test_registry_runs_published_agent_creator_for_workforce_extras(
+    isolated_registry,
+):
+    """Workforce injects specific worker agent tools by name, without
+    selecting the whole ``agent`` category. The registry must still dispatch
+    only the published-agent creator so the final name filter can keep the
+    injected worker tool.
+    """
+    basic = AsyncMock(return_value=[_mock_tool("calc", "basic")])
+    basic.__name__ = "basic_creator"
+    published_agents = AsyncMock(return_value=[_mock_tool("agent_42", "agent")])
+    published_agents.__name__ = "create_agent_tools"
+    agent_management = AsyncMock(return_value=[_mock_tool("create_agent", "agent")])
+    agent_management.__name__ = "create_create_agent_tool"
+    isolated_registry.register(basic, categories={"basic"})
+    isolated_registry.register(
+        published_agents,
+        categories={"agent"},
+        selection_gate="published_agent",
+    )
+    isolated_registry.register(agent_management, categories={"agent"})
+
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=["basic"],
+        workforce_extra_names={"agent_42"},
+    )
+    tools = await isolated_registry.create_registered_tools(_FakeConfig(spec))
+
+    assert basic.await_count == 1
+    assert published_agents.await_count == 1
+    assert agent_management.await_count == 0
+    assert [tool.name for tool in tools] == ["calc", "agent_42"]
+
+
 async def test_registry_always_runs_creator_without_declared_categories(
     isolated_registry,
 ):
@@ -1010,6 +1044,26 @@ def test_compute_allowed_names_by_categories_filters_correctly():
         ]
     )
     assert result == frozenset({"calc", "injected_worker_tool"})
+
+
+def test_compute_allowed_names_workforce_extra_does_not_admit_agent_category():
+    """Injected workforce worker names must not broaden the user's category
+    selection to every agent-category tool.
+    """
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=["basic"],
+        workforce_extra_names={"agent_42"},
+    )
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("calc", "basic"),
+            _mock_tool("agent_42", "agent"),
+            _mock_tool("agent_99", "agent"),
+        ]
+    )
+
+    assert spec.categories == frozenset({"basic"})
+    assert result == frozenset({"calc", "agent_42"})
 
 
 # ----- Factory L252 dispatch through spec.compute_allowed_names ---------

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -926,6 +926,7 @@ def test_from_raw_workforce_extras_carried_in_by_categories():
     )
     assert isinstance(spec, _SpecByCategories)
     assert spec.name_extras == frozenset({"worker_tool_a", "worker_tool_b"})
+    assert spec.includes_published_agent() is True
 
 
 # ----- P2 fix: includes_custom_api with category restriction -------------

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -93,7 +93,7 @@ def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
         tools_for_other = get_published_agents_tools(db=db, user_id=2)
         tool_names = {tool.name for tool in tools_for_other}
 
-        assert "call_agent_owner_published_agent" not in tool_names
+        assert f"agent_{published_agent.id}" not in tool_names
     finally:
         db.close()
         try:
@@ -128,8 +128,38 @@ def test_owner_sees_only_own_published_agents_not_drafts() -> None:
         tools_for_owner = get_published_agents_tools(db=db, user_id=1)
         tool_names = {tool.name for tool in tools_for_owner}
 
-        assert "call_agent_owner_published_agent" in tool_names
-        assert "call_agent_owner_draft_agent" not in tool_names
+        assert f"agent_{published_agent.id}" in tool_names
+        assert f"agent_{draft_agent.id}" not in tool_names
+    finally:
+        db.close()
+        try:
+            import os
+
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+def test_published_agent_tool_name_is_id_based_for_non_ascii_names() -> None:
+    db, db_path = _create_session()
+    try:
+        owner = User(username="owner_non_ascii", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.commit()
+        db.refresh(owner)
+
+        published_agent = Agent(
+            user_id=owner.id,
+            name="中文整理助手",
+            status=AgentStatus.PUBLISHED,
+        )
+        db.add(published_agent)
+        db.commit()
+        db.refresh(published_agent)
+
+        tools = get_published_agents_tools(db=db, user_id=owner.id)
+
+        assert {tool.name for tool in tools} == {f"agent_{published_agent.id}"}
     finally:
         db.close()
         try:
@@ -191,10 +221,10 @@ def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None
         )
         tool_names = {tool.name for tool in tools}
 
-        assert "call_agent_selected_published_agent" in tool_names
-        assert "call_agent_selected_draft_agent" not in tool_names
-        assert "call_agent_unselected_published_agent" not in tool_names
-        assert "call_agent_other_users_agent" not in tool_names
+        assert f"agent_{selected_published.id}" in tool_names
+        assert f"agent_{selected_draft.id}" not in tool_names
+        assert f"agent_{unselected_published.id}" not in tool_names
+        assert f"agent_{other_users_agent.id}" not in tool_names
     finally:
         db.close()
         try:
@@ -230,7 +260,7 @@ def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
             allowed_agent_ids=[published_agent.id],
             enable_global_agent_tools=False,
         )
-        assert "call_agent_shared_workforce_worker" not in {
+        assert f"agent_{published_agent.id}" not in {
             tool.name for tool in blocked_tools
         }
 
@@ -241,9 +271,7 @@ def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
             enable_global_agent_tools=False,
             allow_cross_user_agent_ids=True,
         )
-        assert "call_agent_shared_workforce_worker" in {
-            tool.name for tool in allowed_tools
-        }
+        assert f"agent_{published_agent.id}" in {tool.name for tool in allowed_tools}
     finally:
         db.close()
         try:
@@ -514,8 +542,8 @@ def test_agent_call_stack_prevents_recursive_agent_tools() -> None:
         )
         tool_names = {tool.name for tool in tools}
 
-        assert "call_agent_active_agent" not in tool_names
-        assert "call_agent_other_agent" in tool_names
+        assert f"agent_{active_agent.id}" not in tool_names
+        assert f"agent_{other_agent.id}" in tool_names
     finally:
         db.close()
         try:
@@ -565,7 +593,7 @@ def test_worker_overrides_inject_selected_agent_tool_metadata() -> None:
             },
         )
 
-        assert [tool.name for tool in tools] == ["call_workforce_worker_1_writer"]
+        assert [tool.name for tool in tools] == [f"agent_{worker.id}"]
         assert tools[0].description == "Write the workforce report."
     finally:
         db.close()

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -315,11 +315,11 @@ class TestCreateAgentTool:
                 "task_update_general",
             ]
             assert parent_tracer.events[0]["task_id"] == "parent-task-2"
-            assert parent_tracer.events[0]["data"]["__audit_only__"] is True
+            assert "__audit_only__" not in parent_tracer.events[0]["data"]
             assert parent_tracer.events[0]["data"]["status"] == "start"
             assert parent_tracer.events[0]["data"]["workforce_id"] == 123
             assert parent_tracer.events[0]["data"]["worker_alias"] == "Writer"
-            assert parent_tracer.events[1]["data"]["__audit_only__"] is True
+            assert "__audit_only__" not in parent_tracer.events[1]["data"]
             assert parent_tracer.events[1]["data"]["status"] == "end"
             assert parent_tracer.events[1]["data"]["output"] == "worker response"
             assert parent_tracer.events[1]["data"]["output_length"] == len(

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -126,7 +126,7 @@ class TestCreateAgentTool:
                 assert result["status"] == "success"
                 assert result["agent_name"] == "test_agent"
                 assert result["agent_id"] > 0
-                assert result["tool_name"] == "call_agent_test_agent"
+                assert result["tool_name"] == f"agent_{result['agent_id']}"
                 assert "test_agent" in result["markdown_link"]
                 assert "agent://" in result["markdown_link"]
                 mock_invalidate_agent_cache.assert_called_once_with(
@@ -250,7 +250,7 @@ class TestCreateAgentTool:
 
                 result = await tool.run_json_async({"task": "draft report"})
 
-            assert tool.name == "call_workforce_worker_7_writer"
+            assert tool.name == f"agent_{agent.id}"
             assert tool.description == "Write the final report."
             assert result["response"] == "worker response"
             assert result["file_outputs"] == []
@@ -1445,19 +1445,19 @@ class TestAgentToolNameGeneration:
     """Test suite for agent tool name generation."""
 
     def test_gen_agent_tool_name_simple(self) -> None:
-        """Test tool name generation with simple name."""
-        result = gen_agent_tool_name("TestAgent")
-        assert result == "call_agent_testagent"  # No spaces, just lowercased
+        """Test tool name generation with an agent ID."""
+        result = gen_agent_tool_name(42)
+        assert result == "agent_42"
 
-    def test_gen_agent_tool_name_with_spaces(self) -> None:
-        """Test tool name generation with spaces."""
-        result = gen_agent_tool_name("Research Assistant")
-        assert result == "call_agent_research_assistant"
+    def test_gen_agent_tool_name_with_string_id(self) -> None:
+        """Test tool name generation with a string agent ID."""
+        result = gen_agent_tool_name("42")
+        assert result == "agent_42"
 
-    def test_gen_agent_tool_name_with_special_chars(self) -> None:
-        """Test tool name generation with special characters."""
-        result = gen_agent_tool_name("AI-Research-Agent_2024")
-        assert result == "call_agent_ai-research-agent_2024"
+    def test_gen_agent_tool_name_rejects_names(self) -> None:
+        """Test tool name generation rejects display names."""
+        with pytest.raises(ValueError):
+            gen_agent_tool_name("Research Assistant")
 
 
 class TestDraftAgentsInTools:
@@ -1490,8 +1490,8 @@ class TestDraftAgentsInTools:
             )
             tool_names = {tool.name for tool in tools}
 
-            assert "call_agent_published_agent" in tool_names
-            assert "call_agent_draft_agent" not in tool_names
+            assert f"agent_{published_agent.id}" in tool_names
+            assert f"agent_{draft_agent.id}" not in tool_names
 
         finally:
             db.close()
@@ -1529,8 +1529,8 @@ class TestDraftAgentsInTools:
             )
             tool_names = {tool.name for tool in tools}
 
-            assert "call_agent_published_agent" in tool_names
-            assert "call_agent_draft_agent" in tool_names
+            assert f"agent_{published_agent.id}" in tool_names
+            assert f"agent_{draft_agent.id}" in tool_names
 
         finally:
             db.close()
@@ -1567,7 +1567,7 @@ class TestDraftAgentsInTools:
             )
             tool_names = {tool.name for tool in tools_for_user2}
 
-            assert "call_agent_user1_draft" not in tool_names
+            assert f"agent_{draft_agent.id}" not in tool_names
 
         finally:
             db.close()
@@ -1632,7 +1632,7 @@ class TestCreateAndCallAgent:
                 )
                 tool_names = {tool.name for tool in tools}
 
-                assert "call_agent_simple_calculator" in tool_names
+                assert f"agent_{agent_id}" in tool_names
 
                 # Step 3: Verify agent can be loaded
                 agent = db.query(Agent).filter(Agent.id == agent_id).first()

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -20,7 +20,7 @@ from xagent.core.tools.adapters.vibe.agent_tool import (
 )
 from xagent.core.tracing.langfuse.handler import LangfuseTraceHandler
 from xagent.core.workspace import TaskWorkspace
-from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model
 from xagent.web.models.task import Task
@@ -144,6 +144,57 @@ class TestCreateAgentTool:
                 assert agent.status == AgentStatus.DRAFT
                 assert agent.instructions == "You are a test agent for unit testing."
 
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_agent_tool_rejects_generated_workforce_manager(self) -> None:
+        db, db_path = _create_session()
+        try:
+            user = User(
+                username="testuser_generated_manager_run",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            generated_manager = Agent(
+                user_id=user.id,
+                name="Generated Manager",
+                description="Private workforce manager",
+                instructions="Coordinate the workforce.",
+                status=AgentStatus.PUBLISHED,
+                origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            db.add(generated_manager)
+            db.commit()
+            db.refresh(generated_manager)
+
+            tool = AgentTool(
+                agent_id=generated_manager.id,
+                agent_name=generated_manager.name,
+                agent_description=generated_manager.description or "",
+                db=db,
+                user_id=user.id,
+            )
+
+            with patch(
+                "xagent.core.agent.service.AgentService"
+            ) as mock_agent_service_class:
+                result = await tool.run_json_async({"task": "run private manager"})
+
+            assert (
+                result["response"] == f"Error: Agent {generated_manager.id} not found"
+            )
+            mock_agent_service_class.assert_not_called()
         finally:
             db.close()
             try:
@@ -1089,6 +1140,106 @@ class TestUpdateAgentTool:
                 pass
 
     @pytest.mark.asyncio
+    async def test_update_agent_rejects_generated_workforce_manager(self) -> None:
+        db, db_path = _create_session()
+        try:
+            user = User(
+                username="testuser_update_generated_manager",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            generated_manager = Agent(
+                user_id=user.id,
+                name="Generated Manager",
+                description="Private manager",
+                instructions="Coordinate the workforce.",
+                status=AgentStatus.PUBLISHED,
+                origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            db.add(generated_manager)
+            db.commit()
+            db.refresh(generated_manager)
+
+            tool = UpdateAgentTool(db=db, user_id=user.id)
+
+            result = await tool.run_json_async(
+                {
+                    "agent_id": generated_manager.id,
+                    "name": "renamed_manager",
+                }
+            )
+
+            assert result["status"] == "error"
+            assert "not found" in result["message"].lower()
+            db.refresh(generated_manager)
+            assert generated_manager.name == "Generated Manager"
+
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_update_agent_name_conflict_ignores_generated_workforce_manager(
+        self,
+    ) -> None:
+        db, db_path = _create_session()
+        try:
+            user = User(
+                username="testuser_update_generated_manager_name",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            visible_agent = Agent(
+                user_id=user.id,
+                name="Visible Agent",
+                status=AgentStatus.DRAFT,
+            )
+            generated_manager = Agent(
+                user_id=user.id,
+                name="Hidden Manager Name",
+                status=AgentStatus.PUBLISHED,
+                origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            db.add_all([visible_agent, generated_manager])
+            db.commit()
+            db.refresh(visible_agent)
+
+            tool = UpdateAgentTool(db=db, user_id=user.id)
+
+            result = await tool.run_json_async(
+                {
+                    "agent_id": visible_agent.id,
+                    "name": "Hidden Manager Name",
+                }
+            )
+
+            assert result["status"] == "success"
+            db.refresh(visible_agent)
+            assert visible_agent.name == "Hidden Manager Name"
+
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
     async def test_update_agent_rejects_missing_knowledge_base(self) -> None:
         """Test that update_agent rejects knowledge bases that do not exist."""
         db, db_path = _create_session()
@@ -1347,6 +1498,53 @@ class TestListAgentsTool:
                 pass
 
     @pytest.mark.asyncio
+    async def test_list_agents_hides_generated_workforce_managers(self) -> None:
+        db, db_path = _create_session()
+        try:
+            user = User(
+                username="testuser_list_generated_manager",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            regular_agent = Agent(
+                user_id=user.id,
+                name="reusable_agent",
+                description="User reusable agent",
+                status=AgentStatus.PUBLISHED,
+            )
+            generated_manager = Agent(
+                user_id=user.id,
+                name="generated_manager",
+                description="Private workforce manager",
+                status=AgentStatus.PUBLISHED,
+                origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            db.add_all([regular_agent, generated_manager])
+            db.commit()
+
+            tool = ListAgentsTool(db=db, user_id=user.id)
+
+            result = await tool.run_json_async({})
+
+            assert result["status"] == "success"
+            assert result["total_count"] == 1
+            agent_names = {agent["name"] for agent in result["agents"]}
+            assert agent_names == {"reusable_agent"}
+
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    @pytest.mark.asyncio
     async def test_list_agents_with_status_filter(self) -> None:
         """Test listing agents with status filter."""
         db, db_path = _create_session()
@@ -1550,6 +1748,56 @@ class TestDraftAgentsInTools:
             assert f"agent_{published_agent.id}" in tool_names
             assert f"agent_{draft_agent.id}" in tool_names
 
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    def test_generated_workforce_managers_are_hidden_from_agent_tools(self) -> None:
+        db, db_path = _create_session()
+        try:
+            user = User(
+                username="testuser_generated_manager_tools",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            reusable_agent = Agent(
+                user_id=user.id,
+                name="Reusable Agent",
+                status=AgentStatus.PUBLISHED,
+            )
+            generated_manager = Agent(
+                user_id=user.id,
+                name="Generated Manager",
+                status=AgentStatus.PUBLISHED,
+                origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            db.add_all([reusable_agent, generated_manager])
+            db.commit()
+            db.refresh(reusable_agent)
+            db.refresh(generated_manager)
+
+            tools = get_published_agents_tools(db=db, user_id=user.id)
+            tool_names = {tool.name for tool in tools}
+
+            assert f"agent_{reusable_agent.id}" in tool_names
+            assert f"agent_{generated_manager.id}" not in tool_names
+
+            explicitly_allowed_tools = get_published_agents_tools(
+                db=db,
+                user_id=user.id,
+                allowed_agent_ids=[generated_manager.id],
+            )
+
+            assert explicitly_allowed_tools == []
         finally:
             db.close()
             try:

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -1,6 +1,7 @@
 """Tests for CreateAgentTool - dynamically creating agents during task execution."""
 
 import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -430,9 +431,17 @@ class TestCreateAgentTool:
                     .filter(UploadedFile.file_id == file_outputs[0]["file_id"])
                     .one()
                 )
+                canonical_path = (
+                    Path(workspace_root)
+                    / f"user_{user.id}"
+                    / "web_task_77"
+                    / "output"
+                    / "report.txt"
+                )
                 assert file_record.user_id == user.id
                 assert file_record.task_id == 77
-                assert file_record.storage_path == str(output_path)
+                assert file_record.storage_path == str(canonical_path)
+                assert canonical_path.read_text(encoding="utf-8") == "worker report"
                 assert file_record.workspace_relative_path == "output/report.txt"
                 assert file_record.workspace_category == "output"
 
@@ -535,7 +544,16 @@ class TestCreateAgentTool:
                     .filter(UploadedFile.file_id == "worker-owned-output")
                     .one()
                 )
+                canonical_path = (
+                    Path(workspace_root)
+                    / f"user_{user.id}"
+                    / "web_task_77"
+                    / "output"
+                    / "report.txt"
+                )
                 assert file_record.task_id == 77
+                assert file_record.storage_path == str(canonical_path)
+                assert canonical_path.read_text(encoding="utf-8") == "worker report"
                 assert file_record.workspace_relative_path == "output/report.txt"
                 assert file_record.workspace_category == "output"
         finally:

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -36,6 +36,7 @@ from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
 from xagent.web.api.v1 import v1_router
 from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
+from xagent.web.api.widget import widget_router
 from xagent.web.api.workforces import router as workforces_router
 from xagent.web.models.database import Base, get_db, get_engine
 
@@ -60,6 +61,7 @@ app_for_tests = FastAPI()
 app_for_tests.include_router(auth_router)
 app_for_tests.include_router(agents_router)
 app_for_tests.include_router(workforces_router)
+app_for_tests.include_router(widget_router)
 app_for_tests.include_router(v1_router)
 app_for_tests.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: ignore[arg-type]
 

--- a/tests/web/api/test_agent_api_keys.py
+++ b/tests/web/api/test_agent_api_keys.py
@@ -17,6 +17,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from xagent.web.models.agent import Agent, AgentOrigin
 from xagent.web.models.agent_api_key import AgentApiKey
 
 from .conftest import (
@@ -51,6 +52,17 @@ def _create_agent(headers: dict[str, str], name: str = "Test Agent") -> int:
     )
     assert resp.status_code == 200, resp.text
     return resp.json()["id"]
+
+
+def _mark_generated_manager(agent_id: int) -> None:
+    db = _direct_db_session()
+    try:
+        db.query(Agent).filter(Agent.id == agent_id).update(
+            {"origin": AgentOrigin.WORKFORCE_GENERATED_MANAGER.value}
+        )
+        db.commit()
+    finally:
+        db.close()
 
 
 # ===== POST /{agent_id}/api-key =====
@@ -201,6 +213,30 @@ class TestPostGenerateApiKey:
         assert resp.json()["detail"] == "Internal server error"
         assert secret_message not in resp.text
 
+    def test_generated_manager_returns_404_without_rotating_existing_key(self):
+        headers = _headers()
+        agent_id = _create_agent(headers)
+        first = client.post(f"/api/agents/{agent_id}/api-key", headers=headers).json()
+        _mark_generated_manager(agent_id)
+
+        resp = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Agent not found"
+        db = _direct_db_session()
+        try:
+            rows = (
+                db.query(AgentApiKey)
+                .filter(AgentApiKey.agent_id == agent_id)
+                .order_by(AgentApiKey.id)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].key_prefix == first["key_prefix"]
+            assert rows[0].revoked_at is None
+        finally:
+            db.close()
+
 
 # ===== GET /{agent_id}/api-key =====
 
@@ -254,6 +290,17 @@ class TestGetActiveApiKey:
         assert resp.status_code == 404
         # Same "agent not found" detail -- never reveals the existence
         # of admin's key, only that the agent itself isn't bob's.
+        assert resp.json()["detail"] == "Agent not found"
+
+    def test_generated_manager_returns_404_even_if_key_exists(self):
+        headers = _headers()
+        agent_id = _create_agent(headers)
+        client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+        _mark_generated_manager(agent_id)
+
+        resp = client.get(f"/api/agents/{agent_id}/api-key", headers=headers)
+
+        assert resp.status_code == 404
         assert resp.json()["detail"] == "Agent not found"
 
 
@@ -318,3 +365,21 @@ class TestDeleteApiKey:
             f"/api/agents/{admin_agent_id}/api-key", headers=bob_headers
         )
         assert resp.status_code == 404
+
+    def test_generated_manager_returns_404_without_revoking_existing_key(self):
+        headers = _headers()
+        agent_id = _create_agent(headers)
+        first = client.post(f"/api/agents/{agent_id}/api-key", headers=headers).json()
+        _mark_generated_manager(agent_id)
+
+        resp = client.delete(f"/api/agents/{agent_id}/api-key", headers=headers)
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Agent not found"
+        db = _direct_db_session()
+        try:
+            row = db.query(AgentApiKey).filter(AgentApiKey.agent_id == agent_id).one()
+            assert row.key_prefix == first["key_prefix"]
+            assert row.revoked_at is None
+        finally:
+            db.close()

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
@@ -48,6 +48,9 @@ def _create_agent_row(
     user_id: int,
     name: str,
     status: AgentStatus = AgentStatus.DRAFT,
+    origin: str = AgentOrigin.USER.value,
+    widget_enabled: bool = True,
+    allowed_domains: list[str] | None = None,
 ) -> int:
     db = _direct_db_session()
     try:
@@ -57,7 +60,10 @@ def _create_agent_row(
             description=f"{name} description",
             instructions=f"{name} instructions",
             execution_mode="balanced",
+            origin=origin,
             status=status,
+            widget_enabled=widget_enabled,
+            allowed_domains=allowed_domains or [],
         )
         db.add(agent)
         db.commit()
@@ -142,13 +148,19 @@ def test_list_agents_includes_owned_agents_and_policy_visible_agents() -> None:
     assert items_by_id[shared_draft_id]["readonly"] is True
 
 
-def test_list_agents_hides_workforce_manager_agents() -> None:
+def test_agent_lists_keep_reusable_managers_and_hide_generated_managers() -> None:
     headers = _admin_headers()
     owner_id = _user_id("admin")
-    manager_id = _create_agent_row(
+    reusable_manager_id = _create_agent_row(
+        user_id=owner_id,
+        name="Reusable Manager",
+        status=AgentStatus.PUBLISHED,
+    )
+    generated_manager_id = _create_agent_row(
         user_id=owner_id,
         name="Generated Manager",
         status=AgentStatus.PUBLISHED,
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
     )
     worker_id = _create_agent_row(
         user_id=owner_id,
@@ -162,8 +174,8 @@ def test_list_agents_hides_workforce_manager_agents() -> None:
             owner_user_id=owner_id,
             scope_type="user",
             scope_id=str(owner_id),
-            name="Generated Workforce",
-            manager_agent_id=manager_id,
+            name="Reusable Manager Workforce",
+            manager_agent_id=reusable_manager_id,
             status="draft",
         )
         db.add(workforce)
@@ -174,14 +186,83 @@ def test_list_agents_hides_workforce_manager_agents() -> None:
     response = client.get("/api/agents", headers=headers)
     assert response.status_code == 200, response.text
     agent_ids = {item["id"] for item in response.json()}
-    assert manager_id not in agent_ids
+    assert reusable_manager_id in agent_ids
+    assert generated_manager_id not in agent_ids
     assert worker_id in agent_ids
 
     options_response = client.get("/api/workforces/agent-options", headers=headers)
     assert options_response.status_code == 200, options_response.text
     option_ids = {item["id"] for item in options_response.json()}
-    assert manager_id not in option_ids
+    assert reusable_manager_id in option_ids
+    assert generated_manager_id not in option_ids
     assert worker_id in option_ids
+
+
+def test_agent_name_conflicts_ignore_generated_workforce_managers() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    generated_name = "Generated Manager Name"
+    generated_manager_id = _create_agent_row(
+        user_id=owner_id,
+        name=generated_name,
+        status=AgentStatus.PUBLISHED,
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+    )
+
+    create_response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": generated_name,
+            "description": "Reusable agent",
+            "instructions": "You are reusable.",
+            "execution_mode": "balanced",
+        },
+    )
+
+    assert create_response.status_code == 200, create_response.text
+    created_agent_id = create_response.json()["id"]
+    assert created_agent_id != generated_manager_id
+
+    update_target_id = _create_agent_row(user_id=owner_id, name="Update Target")
+    hidden_update_name = "Hidden Update Manager Name"
+    _create_agent_row(
+        user_id=owner_id,
+        name=hidden_update_name,
+        status=AgentStatus.PUBLISHED,
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+    )
+
+    update_response = client.put(
+        f"/api/agents/{update_target_id}",
+        headers=headers,
+        json={"name": hidden_update_name},
+    )
+
+    assert update_response.status_code == 200, update_response.text
+    assert update_response.json()["name"] == hidden_update_name
+
+
+def test_generated_workforce_manager_agents_cannot_authenticate_widget() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    generated_manager_id = _create_agent_row(
+        user_id=owner_id,
+        name="Generated Widget Manager",
+        status=AgentStatus.PUBLISHED,
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        widget_enabled=True,
+        allowed_domains=["*"],
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": generated_manager_id, "guest_id": "guest-1"},
+        headers={"origin": "https://example.com"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Widget owner not found or invalid agent_id"
 
 
 class TestDeleteAgent:

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -8,6 +8,7 @@ from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+from xagent.web.models.workforce import Workforce
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 
 from .conftest import (
@@ -139,6 +140,48 @@ def test_list_agents_includes_owned_agents_and_policy_visible_agents() -> None:
     assert items_by_id[shared_draft_id]["access"] == "policy"
     assert items_by_id[shared_draft_id]["status"] == "draft"
     assert items_by_id[shared_draft_id]["readonly"] is True
+
+
+def test_list_agents_hides_workforce_manager_agents() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    manager_id = _create_agent_row(
+        user_id=owner_id,
+        name="Generated Manager",
+        status=AgentStatus.PUBLISHED,
+    )
+    worker_id = _create_agent_row(
+        user_id=owner_id,
+        name="Reusable Worker",
+        status=AgentStatus.PUBLISHED,
+    )
+
+    db = _direct_db_session()
+    try:
+        workforce = Workforce(
+            owner_user_id=owner_id,
+            scope_type="user",
+            scope_id=str(owner_id),
+            name="Generated Workforce",
+            manager_agent_id=manager_id,
+            status="draft",
+        )
+        db.add(workforce)
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.get("/api/agents", headers=headers)
+    assert response.status_code == 200, response.text
+    agent_ids = {item["id"] for item in response.json()}
+    assert manager_id not in agent_ids
+    assert worker_id in agent_ids
+
+    options_response = client.get("/api/workforces/agent-options", headers=headers)
+    assert options_response.status_code == 200, options_response.text
+    option_ids = {item["id"] for item in options_response.json()}
+    assert manager_id not in option_ids
+    assert worker_id in option_ids
 
 
 class TestDeleteAgent:

--- a/tests/web/api/test_websocket_error_payload.py
+++ b/tests/web/api/test_websocket_error_payload.py
@@ -1,0 +1,241 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from xagent.web.api import websocket as websocket_api
+from xagent.web.api.websocket import _terminal_task_error_payload
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.task_lease_service import get_runner_id
+
+from .conftest import _direct_db_session
+
+
+def test_terminal_task_error_payload_marks_task_failed(_test_db):
+    db = _direct_db_session()
+    try:
+        user = User(username="owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+
+        task = Task(
+            user_id=user.id,
+            title="Failing task",
+            description="Failing task",
+            status=TaskStatus.RUNNING,
+            runner_id=get_runner_id(),
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = task.id
+
+        payload = _terminal_task_error_payload(task_id, "Runtime error")
+
+        assert payload["type"] == "agent_error"
+        assert payload["message"] == "Runtime error"
+        assert payload["task"]["id"] == task_id
+        assert payload["task"]["status"] == "failed"
+
+        db.expire_all()
+        persisted_task = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted_task.status == TaskStatus.FAILED
+        assert persisted_task.runner_id is None
+        assert persisted_task.lease_expires_at is None
+        assert persisted_task.error_message == "Runtime error"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_message_access_denied_does_not_fail_task(
+    _test_db, monkeypatch
+):
+    db = _direct_db_session()
+    try:
+        owner = User(username="owner", password_hash="hash")
+        intruder = User(username="intruder", password_hash="hash")
+        db.add_all([owner, intruder])
+        db.commit()
+
+        task = Task(
+            user_id=owner.id,
+            title="Private task",
+            description="Private task",
+            status=TaskStatus.RUNNING,
+            runner_id=get_runner_id(),
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = task.id
+        intruder_id = intruder.id
+    finally:
+        db.close()
+
+    sent_messages = []
+    broadcasts = []
+
+    async def fake_send_personal_message(message, websocket):
+        sent_messages.append(message)
+
+    async def fake_broadcast_to_task(message, broadcast_task_id):
+        broadcasts.append((broadcast_task_id, message))
+
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "send_personal_message",
+        fake_send_personal_message,
+    )
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "broadcast_to_task",
+        fake_broadcast_to_task,
+    )
+
+    await websocket_api.handle_chat_message(
+        object(),
+        task_id,
+        {
+            "message": "use this task",
+            "user": SimpleNamespace(id=intruder_id, is_admin=False),
+        },
+    )
+
+    assert broadcasts == []
+    assert sent_messages
+    assert sent_messages[0]["type"] == "error"
+    assert "Access denied" in sent_messages[0]["message"]
+
+    db = _direct_db_session()
+    try:
+        persisted_task = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted_task.status == TaskStatus.RUNNING
+        assert persisted_task.runner_id == get_runner_id()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_execute_task_unauthenticated_does_not_fail_task(
+    _test_db, monkeypatch
+):
+    db = _direct_db_session()
+    try:
+        user = User(username="owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+
+        task = Task(
+            user_id=user.id,
+            title="Private task",
+            description="Private task",
+            status=TaskStatus.RUNNING,
+            runner_id=get_runner_id(),
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = task.id
+    finally:
+        db.close()
+
+    sent_messages = []
+    broadcasts = []
+
+    async def fake_send_personal_message(message, websocket):
+        sent_messages.append(message)
+
+    async def fake_broadcast_to_task(message, broadcast_task_id):
+        broadcasts.append((broadcast_task_id, message))
+
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "send_personal_message",
+        fake_send_personal_message,
+    )
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "broadcast_to_task",
+        fake_broadcast_to_task,
+    )
+
+    await websocket_api.handle_execute_task(object(), task_id, {})
+
+    assert broadcasts == []
+    assert sent_messages
+    assert sent_messages[0]["type"] == "error"
+    assert "authentication required" in sent_messages[0]["message"].lower()
+
+    db = _direct_db_session()
+    try:
+        persisted_task = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted_task.status == TaskStatus.RUNNING
+        assert persisted_task.runner_id == get_runner_id()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_background_error_marks_task_failed(_test_db, monkeypatch):
+    db = _direct_db_session()
+    try:
+        user = User(username="owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+
+        task = Task(
+            user_id=user.id,
+            title="Failing background task",
+            description="Failing background task",
+            status=TaskStatus.RUNNING,
+            runner_id=get_runner_id(),
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        db.add(task)
+        db.commit()
+        task_id = task.id
+        user_id = user.id
+    finally:
+        db.close()
+
+    broadcasts = []
+
+    async def fake_broadcast_to_task(message, broadcast_task_id):
+        broadcasts.append((broadcast_task_id, message))
+
+    class FailingAgentManager:
+        async def get_agent_for_task(self, *args, **kwargs):
+            raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(
+        websocket_api.manager,
+        "broadcast_to_task",
+        fake_broadcast_to_task,
+    )
+
+    await websocket_api.execute_task_background(
+        task_id=task_id,
+        user_message="run",
+        context={},
+        agent_manager=FailingAgentManager(),
+        user_id=user_id,
+    )
+
+    assert broadcasts
+    broadcast_task_id, payload = broadcasts[-1]
+    assert broadcast_task_id == task_id
+    assert payload["type"] == "task_error"
+    assert payload["task"]["status"] == "failed"
+    assert payload["error"] == "setup failed"
+
+    db = _direct_db_session()
+    try:
+        persisted_task = db.query(Task).filter(Task.id == task_id).one()
+        assert persisted_task.status == TaskStatus.FAILED
+        assert persisted_task.runner_id is None
+        assert persisted_task.lease_expires_at is None
+        assert persisted_task.error_message == "setup failed"
+    finally:
+        db.close()

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import event
 
 from xagent.web.api import workforces as workforces_api
-from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.database import get_engine
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceBuilderMessage, WorkforceRun
@@ -42,7 +42,12 @@ def _user_id(username: str = "admin") -> int:
         db.close()
 
 
-def _create_agent(user_id: int, name: str, status: AgentStatus) -> int:
+def _create_agent(
+    user_id: int,
+    name: str,
+    status: AgentStatus,
+    origin: str = AgentOrigin.USER.value,
+) -> int:
     db = _direct_db_session()
     try:
         agent = Agent(
@@ -51,6 +56,7 @@ def _create_agent(user_id: int, name: str, status: AgentStatus) -> int:
             description=f"{name} description",
             instructions=f"{name} instructions",
             execution_mode="balanced",
+            origin=origin,
             status=status,
         )
         db.add(agent)
@@ -194,6 +200,42 @@ def test_agent_options_use_workforce_policy_and_only_published_agents() -> None:
     assert options_by_id[shared_published_id]["access"] == "policy"
     assert options_by_id[shared_published_id]["readonly"] is True
     assert options_by_id[shared_published_id]["can_edit"] is False
+
+
+def test_generated_workforce_manager_agents_are_private_to_their_workforce() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    reusable_manager_id = _create_agent(
+        owner_id,
+        "Reusable Manager",
+        AgentStatus.PUBLISHED,
+    )
+    generated_manager_id = _create_agent(
+        owner_id,
+        "Generated Manager",
+        AgentStatus.PUBLISHED,
+        AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+    )
+
+    reusable_response = client.post(
+        "/api/workforces",
+        headers=headers,
+        json={
+            "name": "Reusable Manager Workforce",
+            "manager_agent_id": reusable_manager_id,
+        },
+    )
+    assert reusable_response.status_code == 200, reusable_response.text
+
+    generated_response = client.post(
+        "/api/workforces",
+        headers=headers,
+        json={
+            "name": "Generated Manager Workforce",
+            "manager_agent_id": generated_manager_id,
+        },
+    )
+    assert generated_response.status_code == 404
 
 
 def test_workforce_detail_marks_policy_visible_agents_readonly() -> None:

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -302,6 +302,44 @@ def test_update_workforce_keeps_existing_generated_manager_but_rejects_switching
     assert switch_to_generated_response.status_code == 404
 
 
+def test_workforce_detail_marks_generated_manager_readonly() -> None:
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    generated_manager_id = _create_agent(
+        owner_id,
+        "Generated Manager",
+        AgentStatus.PUBLISHED,
+        AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+    )
+
+    db = _direct_db_session()
+    try:
+        workforce = Workforce(
+            owner_user_id=owner_id,
+            scope_type="user",
+            scope_id=str(owner_id),
+            name="Generated Manager Workforce",
+            manager_agent_id=generated_manager_id,
+            status="draft",
+        )
+        db.add(workforce)
+        db.commit()
+        db.refresh(workforce)
+        workforce_id = int(workforce.id)
+    finally:
+        db.close()
+
+    response = client.get(f"/api/workforces/{workforce_id}", headers=headers)
+    assert response.status_code == 200, response.text
+    manager = response.json()["manager"]
+    assert manager["id"] == generated_manager_id
+    assert manager["access"] == "owner"
+    assert manager["readonly"] is True
+    assert manager["can_edit"] is False
+    assert manager["can_publish"] is False
+    assert manager["can_delete"] is False
+
+
 def test_workforce_detail_marks_policy_visible_agents_readonly() -> None:
     _admin_headers()
     bob_headers = _register_second_user()

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -9,7 +9,7 @@ from xagent.web.api import workforces as workforces_api
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.database import get_engine
 from xagent.web.models.user import User
-from xagent.web.models.workforce import WorkforceBuilderMessage, WorkforceRun
+from xagent.web.models.workforce import Workforce, WorkforceBuilderMessage, WorkforceRun
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 
 from .conftest import (
@@ -236,6 +236,70 @@ def test_generated_workforce_manager_agents_are_private_to_their_workforce() -> 
         },
     )
     assert generated_response.status_code == 404
+
+
+def test_update_workforce_keeps_existing_generated_manager_but_rejects_switching_to_one() -> (
+    None
+):
+    headers = _admin_headers()
+    owner_id = _user_id("admin")
+    generated_manager_id = _create_agent(
+        owner_id,
+        "Generated Manager",
+        AgentStatus.PUBLISHED,
+        AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+    )
+    reusable_manager_id = _create_agent(
+        owner_id,
+        "Reusable Manager",
+        AgentStatus.PUBLISHED,
+    )
+
+    db = _direct_db_session()
+    try:
+        workforce = Workforce(
+            owner_user_id=owner_id,
+            scope_type="user",
+            scope_id=str(owner_id),
+            name="Generated Manager Workforce",
+            manager_agent_id=generated_manager_id,
+            status="draft",
+        )
+        db.add(workforce)
+        db.commit()
+        db.refresh(workforce)
+        workforce_id = int(workforce.id)
+    finally:
+        db.close()
+
+    keep_response = client.patch(
+        f"/api/workforces/{workforce_id}",
+        headers=headers,
+        json={
+            "name": "Renamed Generated Manager Workforce",
+            "manager_agent_id": generated_manager_id,
+        },
+    )
+    assert keep_response.status_code == 200, keep_response.text
+    assert keep_response.json()["name"] == "Renamed Generated Manager Workforce"
+    assert keep_response.json()["manager"]["id"] == generated_manager_id
+
+    switch_to_reusable_response = client.patch(
+        f"/api/workforces/{workforce_id}",
+        headers=headers,
+        json={"manager_agent_id": reusable_manager_id},
+    )
+    assert switch_to_reusable_response.status_code == 200, (
+        switch_to_reusable_response.text
+    )
+    assert switch_to_reusable_response.json()["manager"]["id"] == reusable_manager_id
+
+    switch_to_generated_response = client.patch(
+        f"/api/workforces/{workforce_id}",
+        headers=headers,
+        json={"manager_agent_id": generated_manager_id},
+    )
+    assert switch_to_generated_response.status_code == 404
 
 
 def test_workforce_detail_marks_policy_visible_agents_readonly() -> None:

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -18,8 +18,9 @@ import bcrypt
 import pytest
 
 from xagent.core.utils.api_key import BCRYPT_COST
+from xagent.web.models.agent import Agent, AgentOrigin
 
-from ..conftest import _admin_headers, client
+from ..conftest import _admin_headers, _direct_db_session, client
 
 # Opt this file into the shared conftest ``_test_db`` fixture. See the
 # note in test_agent_api_keys.py for why we use ``usefixtures`` with a
@@ -50,6 +51,17 @@ def _create_agent_and_key() -> tuple[int, str, str]:
     assert key_resp.status_code == 200, key_resp.text
     body = key_resp.json()
     return agent_id, body["full_key"], body["key_prefix"]
+
+
+def _mark_generated_manager(agent_id: int) -> None:
+    db = _direct_db_session()
+    try:
+        db.query(Agent).filter(Agent.id == agent_id).update(
+            {"origin": AgentOrigin.WORKFORCE_GENERATED_MANAGER.value}
+        )
+        db.commit()
+    finally:
+        db.close()
 
 
 # ===== happy path =====
@@ -131,6 +143,15 @@ def test_revoked_key_returns_401():
     assert revoke.json()["revoked"] is True
 
     resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
+    _assert_invalid_api_key(resp)
+
+
+def test_generated_manager_key_returns_401():
+    agent_id, full_key, _prefix = _create_agent_and_key()
+    _mark_generated_manager(agent_id)
+
+    resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
+
     _assert_invalid_api_key(resp)
 
 

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -168,14 +168,14 @@ def test_tool_execution_pair_becomes_tool_call_with_args_and_result():
     assert "output" not in s["data"]
 
 
-def test_tool_execution_call_agent_becomes_agent_delegation():
-    """A tool_name starting with ``call_agent_`` routes to agent_delegation."""
+def test_tool_execution_agent_id_tool_becomes_agent_delegation():
+    """A canonical ``agent_<id>`` tool routes to agent_delegation."""
     events = [
         _ev(
             "tool_execution_start",
             step_id="s4",
             data={
-                "tool_name": "call_agent_translator",
+                "tool_name": "agent_42",
                 "tool_args": {"text": "hello"},
                 "tool_execution_id": "tx-2",
             },
@@ -184,7 +184,7 @@ def test_tool_execution_call_agent_becomes_agent_delegation():
             "tool_execution_end",
             step_id="s4",
             data={
-                "tool_name": "call_agent_translator",
+                "tool_name": "agent_42",
                 "tool_args": {"text": "hello"},
                 "tool_execution_id": "tx-2",
                 "result": {"translated": "你好"},
@@ -197,7 +197,7 @@ def test_tool_execution_call_agent_becomes_agent_delegation():
     assert len(steps) == 1
     s = steps[0]
     assert s["type"] == "agent_delegation"
-    assert s["data"]["sub_agent_name"] == "translator"
+    assert s["data"]["sub_agent_name"] == "agent_42"
     assert s["data"]["input"] == {"text": "hello"}
     # Contract: agent_delegation uses ``output`` on the public surface
     # (mirrors ``input`` on the start side). The internal field is
@@ -206,6 +206,39 @@ def test_tool_execution_call_agent_becomes_agent_delegation():
     # ``result`` must NOT appear on agent_delegation steps.
     assert s["data"]["output"] == {"translated": "你好"}
     assert "result" not in s["data"]
+
+
+def test_tool_execution_legacy_call_agent_trace_still_maps_to_delegation():
+    """Historical traces with ``call_agent_<name>`` remain readable."""
+    events = [
+        _ev(
+            "tool_execution_start",
+            step_id="s4",
+            data={
+                "tool_name": "call_agent_translator",
+                "tool_args": {"text": "hello"},
+                "tool_execution_id": "tx-legacy",
+            },
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="s4",
+            data={
+                "tool_name": "call_agent_translator",
+                "tool_args": {"text": "hello"},
+                "tool_execution_id": "tx-legacy",
+                "result": {"translated": "你好"},
+                "success": True,
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 4, tzinfo=timezone.utc),
+        ),
+    ]
+
+    steps = map_trace_events_to_public_steps(events)
+
+    assert len(steps) == 1
+    assert steps[0]["type"] == "agent_delegation"
+    assert steps[0]["data"]["sub_agent_name"] == "translator"
 
 
 def test_tool_execution_failure_marks_failed_with_error():

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -78,6 +78,55 @@ def test_action_llm_error_maps_to_llm_call_failed() -> None:
     assert get_event_type_mapping(event) == "llm_call_failed"
 
 
+def test_workforce_delegation_summary_maps_to_public_stream_event() -> None:
+    event = TraceEvent(
+        TraceEventType(TraceScope.TASK, TraceAction.UPDATE, TraceCategory.GENERAL),
+        task_id="365",
+        data={
+            "event_type": "workforce_delegation_start",
+            "status": "start",
+            "agent_id": 12,
+            "agent_name": "Researcher",
+            "worker_alias": "Research",
+            "worker_task_id": "agent_12_abcd1234",
+            "messages": [{"role": "user", "content": "raw prompt"}],
+        },
+    )
+
+    stream_event = WebSocketTraceHandler(365)._convert_trace_event_to_stream_event(
+        event
+    )
+
+    assert stream_event is not None
+    assert stream_event["event_type"] == "workforce_delegation_start"
+    assert stream_event["data"]["worker_alias"] == "Research"
+    assert stream_event["data"]["worker_task_id"] == "agent_12_abcd1234"
+    assert "messages" not in stream_event["data"]
+    assert "event_type" not in stream_event["data"]
+
+
+def test_non_task_update_event_with_delegation_payload_is_not_promoted() -> None:
+    event = TraceEvent(
+        TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL),
+        task_id="365",
+        step_id="step-1",
+        data={
+            "event_type": "workforce_delegation_end",
+            "tool_name": "agent_12",
+            "output": "worker response",
+        },
+    )
+
+    stream_event = WebSocketTraceHandler(365)._convert_trace_event_to_stream_event(
+        event
+    )
+
+    assert stream_event is not None
+    assert stream_event["event_type"] == "tool_execution_end"
+    assert stream_event["data"]["event_type"] == "workforce_delegation_end"
+    assert stream_event["data"]["output"] == "worker response"
+
+
 def test_historical_stream_identifies_agent_checkpoint_payload() -> None:
     assert _is_agent_checkpoint_data(
         {
@@ -591,6 +640,74 @@ async def test_historical_replay_skips_audit_only_trace_events(monkeypatch) -> N
 
     assert "audit-workforce" not in trace_event_ids
     assert "visible-tool" in trace_event_ids
+
+
+@pytest.mark.asyncio
+async def test_historical_replay_promotes_workforce_delegation_summary(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _create_trace_handler_test_task("delegation-history")
+    try:
+        task_id = int(task.id)
+        user_id = int(task.user_id)
+        base_time = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        db.add(
+            DatabaseTraceEvent(
+                task_id=task_id,
+                event_id="delegation-end",
+                event_type="task_update_general",
+                timestamp=base_time + timedelta(seconds=1),
+                data={
+                    "event_type": "workforce_delegation_end",
+                    "status": "end",
+                    "worker_task_id": "agent_123_abcd1234",
+                    "worker_alias": "Writer",
+                    "output": "draft complete",
+                    "messages": [{"role": "user", "content": "raw prompt"}],
+                },
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    delegation_event = next(
+        event for event in sent_events if event.get("event_id") == "delegation-end"
+    )
+    assert delegation_event["event_type"] == "workforce_delegation_end"
+    assert delegation_event["data"]["worker_alias"] == "Writer"
+    assert delegation_event["data"]["worker_task_id"] == "agent_123_abcd1234"
+    assert delegation_event["data"]["output"] == "draft complete"
+    assert "messages" not in delegation_event["data"]
+    assert "event_type" not in delegation_event["data"]
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_agent_tools_visibility_api.py
+++ b/tests/web/test_agent_tools_visibility_api.py
@@ -101,12 +101,12 @@ def test_published_agent_is_callable_for_owner_and_hidden_from_other_users() -> 
         owner_tools = client.get("/api/tools/available", headers=admin_headers)
         assert owner_tools.status_code == 200
         owner_names = {tool["name"] for tool in owner_tools.json()["tools"]}
-        assert "call_agent_admin_published_agent" in owner_names
+        assert f"agent_{agent_id}" in owner_names
 
         other_tools = client.get("/api/tools/available", headers=regular_headers)
         assert other_tools.status_code == 200
         other_names = {tool["name"] for tool in other_tools.json()["tools"]}
-        assert "call_agent_admin_published_agent" not in other_names
+        assert f"agent_{agent_id}" not in other_names
     finally:
         Base.metadata.drop_all(bind=get_engine())
         try:
@@ -135,7 +135,7 @@ def test_unpublish_moves_agent_back_to_non_callable_state() -> None:
         names_after_publish = {
             tool["name"] for tool in tools_after_publish.json()["tools"]
         }
-        assert "call_agent_admin_toggle_agent" in names_after_publish
+        assert f"agent_{agent_id}" in names_after_publish
 
         unpublish_response = client.post(
             f"/api/agents/{agent_id}/unpublish",
@@ -150,7 +150,7 @@ def test_unpublish_moves_agent_back_to_non_callable_state() -> None:
         names_after_unpublish = {
             tool["name"] for tool in tools_after_unpublish.json()["tools"]
         }
-        assert "call_agent_admin_toggle_agent" not in names_after_unpublish
+        assert f"agent_{agent_id}" not in names_after_unpublish
     finally:
         Base.metadata.drop_all(bind=get_engine())
         try:

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -752,6 +752,60 @@ def test_task_create_rejects_agent_id_from_another_user(
         db.close()
 
 
+def test_task_create_rejects_generated_workforce_manager_agent(
+    test_db,
+    user1_headers,
+):
+    from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
+    from xagent.web.models.database import get_db
+    from xagent.web.models.task import Task, TaskStatus
+    from xagent.web.models.user import User
+
+    db = next(get_db())
+    try:
+        user1 = db.query(User).filter(User.username == "user1").first()
+        assert user1 is not None
+
+        agent = Agent(
+            user_id=user1.id,
+            name="generated-workforce-manager",
+            description="private manager",
+            status=AgentStatus.PUBLISHED,
+            origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+
+        resp = client.post(
+            "/api/chat/task/create",
+            json={
+                "title": "generated-manager-task",
+                "description": "desc",
+                "agent_id": agent.id,
+            },
+            headers=user1_headers,
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Agent not found or access denied"
+
+        task = Task(
+            user_id=user1.id,
+            title="legacy generated manager task",
+            description="legacy",
+            status=TaskStatus.PENDING,
+            agent_id=agent.id,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        assert _load_agent_for_task_runtime(db, task) is None
+    finally:
+        db.close()
+
+
 def test_task_create_allows_policy_visible_published_agent(
     test_db, user1_headers, user2_headers
 ):

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -93,6 +93,34 @@ def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:
     assert task.lease_expires_at is None
 
 
+def test_stale_running_task_ignores_child_agent_checkpoint(db_session) -> None:
+    task = _create_task(db_session, status=TaskStatus.RUNNING)
+    task.runner_id = "dead-runner"
+    task.lease_expires_at = utc_now() - timedelta(seconds=1)
+    db_session.add(
+        TraceEvent(
+            task_id=task.id,
+            build_id="agent_123_child",
+            event_id="child-checkpoint-1",
+            event_type="system_update_general",
+            timestamp=utc_now(),
+            step_id=None,
+            parent_event_id=None,
+            data={
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "snapshot": {"type": "checkpoint"},
+            },
+        )
+    )
+    db_session.commit()
+
+    assert mark_task_paused_if_stale(db_session, task) is True
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
+
+
 def test_stale_running_task_with_legacy_checkpoint_becomes_paused(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.runner_id = "dead-runner"

--- a/tests/web/test_workforce_builder_services.py
+++ b/tests/web/test_workforce_builder_services.py
@@ -15,7 +15,7 @@ from xagent.web.models import (
     WorkforceAgent,
     WorkforceBuilderMessage,
 )
-from xagent.web.models.agent import AgentStatus
+from xagent.web.models.agent import AgentOrigin, AgentStatus
 from xagent.web.services import workforce_builder as builder_module
 from xagent.web.services import workforce_creator as creator_module
 from xagent.web.services.agent_store import AgentStore
@@ -300,7 +300,11 @@ async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
     assert workforce.status == "draft"
     assert workforce.manager_agent.name == "launch manager 2"
     assert workforce.manager_agent.status == AgentStatus.PUBLISHED
+    assert (
+        workforce.manager_agent.origin == AgentOrigin.WORKFORCE_GENERATED_MANAGER.value
+    )
     assert workforce.manager_agent.published_at is not None
+    assert workforce.manager_agent.widget_enabled is False
     assert workforce.manager_agent.execution_mode == "think"
     assert len(workforce.workers) == 1
     assert workforce.workers[0].agent_id == worker_agent.id
@@ -310,7 +314,7 @@ async def test_create_workforce_from_prompt_creates_draft_and_builder_messages(
 
 
 @pytest.mark.asyncio
-async def test_create_workforce_from_prompt_invalidates_agent_list_cache(
+async def test_create_workforce_from_prompt_hides_generated_manager_from_agent_list(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -363,7 +367,7 @@ async def test_create_workforce_from_prompt_invalidates_agent_list_cache(
             item["name"] for item in store.list_agent_items(int(owner.id))
         }
         assert result.workforce.manager_agent.name == "Launch Manager"
-        assert refreshed_agent_names == {"Analyst", "Launch Manager"}
+        assert refreshed_agent_names == {"Analyst"}
     finally:
         set_cache_backend_for_testing(None)
 

--- a/tests/web/test_workforce_foundation.py
+++ b/tests/web/test_workforce_foundation.py
@@ -1,5 +1,3 @@
-import hashlib
-
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine, inspect
@@ -162,12 +160,12 @@ def test_build_workforce_snapshot_for_active_workforce(db_session: Session) -> N
             "description": "Analyst description",
             "assignment_instructions": "Collect evidence and cite sources.",
             "execution_mode": "balanced",
-            "tool_name": build_worker_tool_name(worker.id, "Research Analyst"),
+            "tool_name": build_worker_tool_name(worker_agent.id, "Research Analyst"),
             "enabled": True,
         }
     ]
     assert overrides[worker_agent.id]["workforce_run_id"] == 123
-    assert overrides[worker_agent.id]["tool_name"].startswith("call_workforce_worker_")
+    assert overrides[worker_agent.id]["tool_name"] == f"agent_{worker_agent.id}"
 
 
 def test_validate_workforce_run_requires_active_enabled_workers(
@@ -331,13 +329,7 @@ def test_workforce_status_and_tool_name_normalization() -> None:
     assert normalize_workforce_run_status(None) == "pending"
     assert normalize_workforce_run_status(" Paused ") == "paused"
     assert normalize_workforce_run_status(" Completed ") == "completed"
-    assert len(tool_name) <= 64
-    assert tool_name.startswith("call_workforce_worker_99_")
-    assert tool_name.endswith(
-        hashlib.sha256(
-            "this_worker_alias_is_long_enough_to_require_stable_truncation".encode()
-        ).hexdigest()[:6]
-    )
+    assert tool_name == "agent_99"
 
     with pytest.raises(HTTPException) as status_error:
         normalize_workforce_status("unknown")

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -631,7 +631,7 @@ async def test_create_default_tools_forwards_workforce_delegation_config(
     )
 
     user = _create_user(db_session, "owner")
-    overrides = {42: {"tool_name": "call_workforce_worker_1_research"}}
+    overrides = {42: {"tool_name": "agent_42"}}
 
     await create_default_tools(
         db_session,

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
-from xagent.web.api.chat import AgentServiceManager, create_default_tools
+from xagent.web.api.chat import (
+    AgentServiceManager,
+    _build_tool_selection_spec_for_task,
+    create_default_tools,
+)
 from xagent.web.models import Agent, Base, Task, User, Workforce, WorkforceRun
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.chat_message import TaskChatMessage
@@ -20,6 +24,7 @@ from xagent.web.services.task_lease_service import acquire_task_lease
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 from xagent.web.services.workforce_runs import create_workforce_run
 from xagent.web.services.workforce_runtime import (
+    WorkforceTaskRuntime,
     _map_task_status,
     release_current_runner_task_lease_with_workforce_sync,
     release_task_lease_with_workforce_sync,
@@ -141,6 +146,28 @@ def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     monkeypatch.setattr(task_orchestrator_module, "_schedule_bg", fake_schedule_bg)
     return scheduled
+
+
+def _mock_tool(name: str, category: str) -> Any:
+    tool = MagicMock()
+    tool.name = name
+    tool.metadata = MagicMock()
+    tool.metadata.category = MagicMock()
+    tool.metadata.category.value = category
+    return tool
+
+
+def _workforce_runtime_with_worker_tools(*tool_names: str) -> WorkforceTaskRuntime:
+    return WorkforceTaskRuntime(
+        workforce_run_id=1,
+        workforce_id=1,
+        snapshot={},
+        allowed_agent_ids=[idx + 1 for idx, _ in enumerate(tool_names)],
+        agent_tool_overrides={},
+        worker_tool_names=set(tool_names),
+        manager_system_prompt=None,
+        manager_agent_id=100,
+    )
 
 
 @pytest.mark.asyncio
@@ -653,3 +680,42 @@ async def test_create_default_tools_forwards_workforce_delegation_config(
         "parent_task_id": "123",
         "agent_call_stack": [7],
     }
+
+
+def test_workforce_manager_without_tool_categories_gets_only_worker_tools() -> None:
+    spec = _build_tool_selection_spec_for_task(
+        {"tool_categories": []},
+        _workforce_runtime_with_worker_tools("agent_1", "agent_2"),
+        task_id=123,
+    )
+
+    assert spec.is_by_categories()
+    assert spec.categories == frozenset()
+    assert spec.compute_allowed_names(
+        [
+            _mock_tool("exa_web_search", "basic"),
+            _mock_tool("write_file", "file"),
+            _mock_tool("agent_1", "agent"),
+            _mock_tool("agent_2", "agent"),
+            _mock_tool("agent_99", "agent"),
+        ]
+    ) == frozenset({"agent_1", "agent_2"})
+
+
+def test_workforce_manager_with_tool_categories_keeps_categories_and_workers() -> None:
+    spec = _build_tool_selection_spec_for_task(
+        {"tool_categories": ["browser"]},
+        _workforce_runtime_with_worker_tools("agent_1"),
+        task_id=123,
+    )
+
+    assert spec.is_by_categories()
+    assert spec.categories == frozenset({"browser"})
+    assert spec.compute_allowed_names(
+        [
+            _mock_tool("exa_web_search", "basic"),
+            _mock_tool("browser_use", "browser"),
+            _mock_tool("agent_1", "agent"),
+            _mock_tool("agent_99", "agent"),
+        ]
+    ) == frozenset({"browser_use", "agent_1"})


### PR DESCRIPTION
## Summary

- Add the user-facing workforce UI entry points and supporting frontend state handling.
- Disable invalid workforce UI actions so unavailable operations cannot be triggered from the page.
- Stabilize task trace completion state so failed/completed task traces stop rendering as active Thinking flows after refresh.

## Validation

- `pre-commit run --all-files`