### PR TITLE
fix: rollback failed kb ingest side effects

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1859,6 +1859,13 @@ class WebIngestionResult(BaseModel):
     warnings: List[str] = Field(
         default_factory=list, description="Non-critical warnings"
     )
+    side_effects_may_remain: bool = Field(
+        default=False,
+        description=(
+            "Whether rollback failed after an ingestion error and persisted "
+            "side effects may still exist"
+        ),
+    )
     elapsed_time_ms: int = Field(
         ..., ge=0, description="Total elapsed time in milliseconds"
     )

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -4,12 +4,13 @@ Crawls a website and imports all discovered pages into the knowledge base.
 """
 
 import asyncio
+import inspect
 import logging
 import tempfile
 from contextvars import copy_context
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, TypedDict
+from typing import TYPE_CHECKING, Callable, NotRequired, Optional, TypedDict, cast
 
 from ..core.schemas import (
     CrawlResult,
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
     from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
+
+FileHandlerCallback = Callable[..., None]
 
 
 _CRAWLER_BLOCK_ERROR_MARKERS: tuple[str, ...] = (
@@ -57,10 +60,58 @@ class FileHandlerResult(TypedDict):
     Attributes:
         file_path: Path to the file for ingestion (persistent or temporary)
         file_id: Optional file_id for stable doc_id generation
+        rollback_on_failure: Optional callback to compensate file persistence
+            when the subsequent document ingestion does not succeed.
+        commit_on_success: Optional callback to finalize temporary rollback
+            resources once the subsequent document ingestion succeeds.
     """
 
     file_path: str
     file_id: Optional[str]
+    rollback_on_failure: NotRequired[FileHandlerCallback]
+    commit_on_success: NotRequired[FileHandlerCallback]
+
+
+def _callback_accepts_ingestion_result(callback: FileHandlerCallback) -> bool:
+    try:
+        signature = inspect.signature(callback)
+    except (TypeError, ValueError):
+        return False
+
+    try:
+        signature.bind(object())
+    except TypeError:
+        return False
+    return True
+
+
+def _run_file_handler_callback(
+    file_info: Optional[FileHandlerResult],
+    callback_name: str,
+    *,
+    url: str,
+    warnings: list[str],
+    ingestion_result: Optional[IngestionResult] = None,
+) -> Optional[str]:
+    if not file_info:
+        return None
+
+    callback = cast(Optional[FileHandlerCallback], file_info.get(callback_name))
+    if callback is None:
+        return None
+
+    try:
+        if _callback_accepts_ingestion_result(callback):
+            callback(ingestion_result)
+        else:
+            callback()
+    except Exception as cleanup_error:  # noqa: BLE001
+        cleanup_reason = str(cleanup_error)
+        message = f"File persistence {callback_name} failed for {url}: {cleanup_reason}"
+        logger.warning(message, exc_info=True)
+        warnings.append(message)
+        return cleanup_reason
+    return None
 
 
 def _looks_like_crawler_block(error: str) -> bool:
@@ -144,6 +195,7 @@ async def _run_web_ingestion_impl(
     start_time = datetime.now(timezone.utc)
     warnings: list[str] = []
     failed_urls: dict[str, str] = {}
+    rollback_failed_urls: dict[str, str] = {}
 
     # Normalize ingestion config
     ing_cfg = coerce_ingestion_config(ingestion_config)
@@ -246,6 +298,7 @@ async def _run_web_ingestion_impl(
                     final_file_path = temp_file
                     final_file_id = None
                     copied_persistent_file = None
+                    file_info: Optional[FileHandlerResult] = None
 
                     if file_handler:
                         try:
@@ -349,24 +402,38 @@ async def _run_web_ingestion_impl(
                                 status="success",
                                 message=ingest_result.message,
                             )
+                            _run_file_handler_callback(
+                                file_info,
+                                "commit_on_success",
+                                url=crawl_result.url,
+                                warnings=warnings,
+                                ingestion_result=ingest_result,
+                            )
                             # Only clear temp file reference on success
                             copied_persistent_file = None
                         else:
-                            # Non-success ingestion (e.g., embedding failed) without exception.
-                            # Keep file and DB record for potential retry scenarios.
-                            # Note: This accumulates files on persistent failures.
-                            # TODO: Add periodic cleanup for orphaned files from persistent failures.
                             failed_urls[crawl_result.url] = ingest_result.message
                             msg = (
                                 f"Partial ingestion for {crawl_result.url}: "
                                 f"{ingest_result.message}"
                             )
                             warnings.append(msg)
+                            rollback_error = _run_file_handler_callback(
+                                file_info,
+                                "rollback_on_failure",
+                                url=crawl_result.url,
+                                warnings=warnings,
+                                ingestion_result=ingest_result,
+                            )
+                            if rollback_error:
+                                rollback_failed_urls[crawl_result.url] = rollback_error
                             pipeline_facade.finish_web_page_operation(
                                 page_operation,
                                 status=ingest_result.status,
                                 message=ingest_result.message,
+                                side_effects_may_remain=bool(rollback_error),
                             )
+                            copied_persistent_file = None
 
                     except Exception as e:
                         logger.exception("Failed to ingest %s", crawl_result.url)
@@ -376,8 +443,21 @@ async def _run_web_ingestion_impl(
                         )
                         warnings.append(failure_message)
 
-                        # Clean up copied persistent file on ingestion failure
-                        if copied_persistent_file and copied_persistent_file.exists():
+                        rollback_error = _run_file_handler_callback(
+                            file_info,
+                            "rollback_on_failure",
+                            url=crawl_result.url,
+                            warnings=warnings,
+                        )
+                        if rollback_error:
+                            rollback_failed_urls[crawl_result.url] = rollback_error
+
+                        # Legacy cleanup for handlers that only returned a file path.
+                        if (
+                            (not file_info or "rollback_on_failure" not in file_info)
+                            and copied_persistent_file
+                            and copied_persistent_file.exists()
+                        ):
                             try:
                                 copied_persistent_file.unlink()
                                 logger.info(
@@ -395,6 +475,7 @@ async def _run_web_ingestion_impl(
                             page_operation,
                             status="error",
                             message=failure_message,
+                            side_effects_may_remain=bool(rollback_error),
                         )
 
                 except Exception as e:
@@ -428,6 +509,8 @@ async def _run_web_ingestion_impl(
         status = "partial"
     else:
         status = "success"
+    if rollback_failed_urls:
+        status = "error"
 
     crawled_urls_list = [r.url for r in crawl_results if r.status == "success"]
 
@@ -438,7 +521,10 @@ async def _run_web_ingestion_impl(
     # check all failures for anti-bot/WAF signals and otherwise surface
     # the first failing URL and its reason so the user sees something
     # actionable.
-    if (status == "error" or status == "partial") and failed_urls:
+    if rollback_failed_urls:
+        first_url, first_err = next(iter(rollback_failed_urls.items()))
+        message = f"Web ingestion rollback failed for {first_url}: {first_err}"
+    elif (status == "error" or status == "partial") and failed_urls:
         first_url, first_err = next(iter(failed_urls.items()))
         blocking_entry = next(
             (
@@ -490,6 +576,7 @@ async def _run_web_ingestion_impl(
         message=message,
         warnings=warnings,
         elapsed_time_ms=elapsed_ms,
+        side_effects_may_remain=bool(rollback_failed_urls),
     )
 
     logger.info(

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -431,8 +431,8 @@ class LanceDBMetadataStore(MetadataStore):
                     best_idx = i
             return str(result["config_json"][best_idx].as_py())
         except Exception as exc:
-            logger.debug("Error reading collection config: %s", exc)
-            return None
+            logger.debug("Error reading collection config: %s", exc, exc_info=True)
+            raise
         finally:
             _safe_close_table(table)
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3,6 +3,7 @@
 import asyncio
 import functools
 import hashlib
+import inspect
 import json
 import logging
 import mimetypes
@@ -162,7 +163,11 @@ from ..services.kb_ingest_targets import (
     tombstone_kb_ingest_target,
     tombstone_kb_ingest_targets_for_collection,
 )
-from ..services.managed_file_ref import DurableObjectMissingError, ManagedFileRef
+from ..services.managed_file_ref import (
+    DurableObjectMissingError,
+    ManagedFileRef,
+    build_upload_storage_key,
+)
 from ..services.uploaded_file_store import UploadedFileStore
 from .cloud_storage import get_google_credentials
 
@@ -354,6 +359,147 @@ def _ensure_cleanup_succeeded(operation_name: str, result_obj: Any) -> None:
     raise RuntimeError(f"{operation_name} failed: {message}")
 
 
+def _delete_web_rag_side_effects_for_file_id(
+    *,
+    collection_name: str,
+    file_id: str,
+    user_id: int,
+    is_admin: bool,
+) -> None:
+    """Best-effort RAG cleanup when document ingestion raised before returning."""
+    from ...core.tools.core.RAG_tools.utils.string_utils import (
+        generate_deterministic_doc_id,
+    )
+
+    doc_refs = [
+        (collection, doc_id)
+        for collection, doc_id in _list_document_refs_for_uploaded_file(file_id)
+        if collection == collection_name
+    ]
+
+    if doc_refs:
+        cleanup_errors: list[Exception] = []
+        for collection, doc_id in doc_refs:
+            try:
+                document_delete_result = delete_document(
+                    collection,
+                    doc_id,
+                    user_id,
+                    is_admin,
+                )
+                _ensure_cleanup_succeeded(
+                    f"delete document '{doc_id}' during web exception rollback",
+                    document_delete_result,
+                )
+            except Exception as exc:  # noqa: BLE001
+                cleanup_errors.append(exc)
+                logger.warning(
+                    "Failed to delete web RAG side effect during exception rollback: "
+                    "collection=%s, doc_id=%s, file_id=%s, error=%s",
+                    collection,
+                    doc_id,
+                    file_id,
+                    exc,
+                    exc_info=True,
+                )
+        if cleanup_errors:
+            raise RuntimeError(
+                "Best-effort RAG cleanup failed with "
+                f"{len(cleanup_errors)} errors. First error: {cleanup_errors[0]}"
+            ) from cleanup_errors[0]
+        return
+
+    doc_id = generate_deterministic_doc_id(collection_name, file_id)
+    vector_store = get_vector_index_store()
+    vector_store.delete_document_data(
+        collection_name=collection_name,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+    clear_ingestion_status(
+        collection_name,
+        doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _rollback_failed_web_document_ingestion(
+    *,
+    collection_name: str,
+    result: Optional[IngestionResult],
+    user_id: int,
+    is_admin: bool,
+    rag_snapshot: Optional["_RagDocumentSnapshot"] = None,
+    file_id: Optional[str] = None,
+) -> None:
+    """Remove RAG-side writes from a failed per-page web ingestion."""
+    if result is None:
+        if rag_snapshot is not None:
+            _restore_rag_document_snapshot(
+                rag_snapshot,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        if file_id and (rag_snapshot is None or not rag_snapshot.doc_refs):
+            _delete_web_rag_side_effects_for_file_id(
+                collection_name=collection_name,
+                file_id=file_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        return
+
+    register_metadata = _get_completed_step_metadata(result, "register_document") or {}
+    register_created = bool(register_metadata.get("created"))
+    doc_id = result.doc_id if isinstance(result.doc_id, str) and result.doc_id else None
+    if not doc_id:
+        if rag_snapshot is not None:
+            _restore_rag_document_snapshot(
+                rag_snapshot,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        elif file_id:
+            _delete_web_rag_side_effects_for_file_id(
+                collection_name=collection_name,
+                file_id=file_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        return
+
+    if register_created:
+        document_delete_result = delete_document(
+            collection_name,
+            doc_id,
+            user_id,
+            is_admin,
+        )
+        _ensure_cleanup_succeeded(
+            f"delete document '{doc_id}' during web rollback",
+            document_delete_result,
+        )
+        if rag_snapshot is None:
+            return
+
+    if rag_snapshot is not None:
+        _restore_rag_document_snapshot(
+            rag_snapshot,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        return
+
+    clear_ingestion_status(
+        collection_name,
+        doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
 def _extract_embedding_model_id_from_error(message: str) -> Optional[str]:
     match = re.search(r"Model '([^']+)' not found in hub", message)
     if match:
@@ -436,6 +582,91 @@ async def _cleanup_failed_new_collection_metadata(
         "Cleaned failed-ingest collection metadata for %s: %s",
         collection_name,
         cleanup_result,
+    )
+
+
+def _collection_or_config_existed_before(
+    collection_existed_before: bool,
+    snapshot: Optional["_CollectionConfigSnapshot"],
+) -> bool:
+    """Treat config-only collections as pre-existing for rollback decisions."""
+    return collection_existed_before or (
+        snapshot is not None and snapshot.previous_config_json is not None
+    )
+
+
+async def _restore_or_cleanup_collection_config_after_failed_ingest(
+    *,
+    snapshot: Optional["_CollectionConfigSnapshot"],
+    collection_existed_before: bool,
+    collection_name: str,
+    user: User,
+    context: str,
+    successful_documents: int = 0,
+    side_effects_may_remain: bool = False,
+) -> None:
+    """Restore previous config or clean up only truly empty new collections."""
+    if (
+        snapshot is not None
+        and not snapshot.saved
+        and not snapshot.previous_config_known
+    ):
+        logger.warning(
+            "Skipping failed-ingest collection metadata cleanup because previous "
+            "config state is unknown: %s/user_%s",
+            collection_name,
+            int(user.id),
+        )
+        return
+
+    effective_collection_existed_before = _collection_or_config_existed_before(
+        collection_existed_before,
+        snapshot,
+    )
+    config_only_existed_before = (
+        not collection_existed_before
+        and snapshot is not None
+        and snapshot.previous_config_json is not None
+    )
+    if effective_collection_existed_before:
+        await _restore_collection_config_after_failed_ingest(
+            snapshot=snapshot,
+            collection_existed_before=effective_collection_existed_before,
+            context=context,
+        )
+        if (
+            config_only_existed_before
+            and successful_documents == 0
+            and not side_effects_may_remain
+            and snapshot is not None
+        ):
+            delete_metadata = getattr(
+                snapshot.metadata_store, "delete_collection", None
+            )
+            if callable(delete_metadata):
+                await _maybe_await(delete_metadata(collection_name))
+                logger.info(
+                    "Removed collection metadata created by failed %s while "
+                    "preserving previous config: %s/user_%s",
+                    context,
+                    collection_name,
+                    int(user.id),
+                )
+        return
+
+    if successful_documents > 0 or side_effects_may_remain:
+        if side_effects_may_remain:
+            logger.warning(
+                "Skipping failed-ingest collection metadata cleanup for %s/user_%s "
+                "because rollback side effects may remain",
+                collection_name,
+                int(user.id),
+            )
+        return
+
+    await _cleanup_failed_new_collection_metadata(
+        collection_name=collection_name,
+        user=user,
     )
 
 
@@ -1030,11 +1261,791 @@ def _mark_uploaded_file_for_reindex(file_id: str) -> bool:
         return False
 
 
+_INGESTION_RUN_COLUMNS = (
+    "collection",
+    "doc_id",
+    "status",
+    "message",
+    "parse_hash",
+    "created_at",
+    "updated_at",
+    "user_id",
+)
+
+
+@dataclass
+class _IngestionRunsSnapshot:
+    doc_refs: List[tuple[str, str]]
+    rows: List[Dict[str, Any]]
+
+
+@dataclass
+class _RagDocumentSnapshot:
+    doc_refs: List[tuple[str, str]]
+    rows_by_table: Dict[str, List[Dict[str, Any]]]
+
+
+def _ingestion_run_filter(collection: str, doc_id: str) -> str:
+    from ...core.tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
+
+    safe_collection = escape_lancedb_string(collection)
+    safe_doc_id = escape_lancedb_string(doc_id)
+    return f"collection = '{safe_collection}' and doc_id = '{safe_doc_id}'"
+
+
+def _table_has_user_id_column(table: Any) -> bool:
+    schema = getattr(table, "schema", None)
+    names = getattr(schema, "names", None) or []
+    return "user_id" in names
+
+
+def _rag_document_filter(
+    table: Any,
+    *,
+    collection: str,
+    doc_id: str,
+    user_id: int,
+    is_admin: bool,
+) -> str:
+    from ...core.tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
+
+    safe_collection = escape_lancedb_string(collection)
+    safe_doc_id = escape_lancedb_string(doc_id)
+    expr = f"collection = '{safe_collection}' and doc_id = '{safe_doc_id}'"
+    if not is_admin and _table_has_user_id_column(table):
+        expr = f"{expr} and user_id = {int(user_id)}"
+    return expr
+
+
+def _combine_lancedb_filters(filters: List[str]) -> str:
+    return " or ".join(f"({filter_expr})" for filter_expr in filters)
+
+
+def _rag_document_refs_filter(
+    table: Any,
+    doc_refs: List[tuple[str, str]],
+    *,
+    user_id: int,
+    is_admin: bool,
+) -> str:
+    return _combine_lancedb_filters(
+        [
+            _rag_document_filter(
+                table,
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            for collection, doc_id in doc_refs
+        ]
+    )
+
+
+def _snapshot_rag_documents_for_uploaded_file(
+    file_id: str,
+    *,
+    user_id: int,
+    is_admin: bool,
+) -> Optional[_RagDocumentSnapshot]:
+    """Snapshot RAG rows for documents associated with an UploadedFile."""
+    try:
+        from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+            _safe_close_table,
+            ensure_chunks_table,
+            ensure_documents_table,
+            ensure_ingestion_runs_table,
+            ensure_main_pointers_table,
+            ensure_parses_table,
+        )
+        from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import (
+            list_table_names,
+            query_to_list,
+        )
+        from ...providers.vector_store.lancedb import get_connection_from_env
+
+        doc_refs = _list_document_refs_for_uploaded_file(file_id)
+        conn = get_connection_from_env()
+        ensure_documents_table(conn)
+        ensure_parses_table(conn)
+        ensure_chunks_table(conn)
+        ensure_main_pointers_table(conn)
+        ensure_ingestion_runs_table(conn)
+
+        table_names = set(list_table_names(conn))
+        target_tables = [
+            table_name
+            for table_name in (
+                "documents",
+                "parses",
+                "chunks",
+                "main_pointers",
+                "ingestion_runs",
+            )
+            if table_name in table_names
+        ]
+        target_tables.extend(
+            sorted(name for name in table_names if name.startswith("embeddings_"))
+        )
+
+        rows_by_table: Dict[str, List[Dict[str, Any]]] = {}
+        for table_name in target_tables:
+            table = None
+            try:
+                table = conn.open_table(table_name)
+                if doc_refs:
+                    rows = query_to_list(
+                        table.search()
+                        .where(
+                            _rag_document_refs_filter(
+                                table,
+                                doc_refs,
+                                user_id=user_id,
+                                is_admin=is_admin,
+                            )
+                        )
+                        .limit(-1)
+                    )
+                else:
+                    rows = []
+                rows_by_table[table_name] = rows
+            finally:
+                _safe_close_table(table)
+        return _RagDocumentSnapshot(doc_refs=doc_refs, rows_by_table=rows_by_table)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to snapshot RAG document rows before web file refresh: "
+            "file_id=%s, error=%s",
+            file_id,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+def _rag_snapshot_key_columns(table_name: str) -> Optional[tuple[str, ...]]:
+    if table_name == "documents":
+        return ("collection", "doc_id")
+    if table_name == "parses":
+        return ("collection", "doc_id", "parse_hash")
+    if table_name == "chunks":
+        return ("collection", "doc_id", "parse_hash", "chunk_id")
+    if table_name == "main_pointers":
+        return ("collection", "doc_id", "step_type", "model_tag")
+    if table_name == "ingestion_runs":
+        return ("collection", "doc_id")
+    if table_name.startswith("embeddings_"):
+        return ("collection", "doc_id", "chunk_id", "parse_hash", "model")
+    return None
+
+
+def _rag_snapshot_row_key(
+    row: Dict[str, Any], key_columns: tuple[str, ...]
+) -> tuple[Any, ...]:
+    return tuple(row.get(column) for column in key_columns)
+
+
+def _lancedb_literal(value: Any) -> str:
+    from ...core.tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return f"'{escape_lancedb_string(str(value))}'"
+
+
+def _rag_snapshot_key_filter(
+    table: Any,
+    row: Dict[str, Any],
+    key_columns: tuple[str, ...],
+    *,
+    user_id: int,
+    is_admin: bool,
+) -> str:
+    clauses = []
+    for column in key_columns:
+        value = row.get(column)
+        if value is None:
+            clauses.append(f"{column} IS NULL")
+        else:
+            clauses.append(f"{column} = {_lancedb_literal(value)}")
+    if not is_admin and _table_has_user_id_column(table):
+        clauses.append(f"user_id = {int(user_id)}")
+    return " and ".join(clauses)
+
+
+def _restore_rag_snapshot_rows(
+    table: Any,
+    *,
+    table_name: str,
+    snapshot_rows: List[Dict[str, Any]],
+    current_rows: List[Dict[str, Any]],
+    user_id: int,
+    is_admin: bool,
+) -> None:
+    """Upsert old rows before deleting stale rows introduced by a failed refresh."""
+    key_columns = _rag_snapshot_key_columns(table_name)
+    if key_columns is None:
+        delete_filters = [
+            _rag_snapshot_key_filter(
+                table,
+                row,
+                ("collection", "doc_id"),
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            for row in current_rows
+        ]
+        if delete_filters:
+            table.delete(_combine_lancedb_filters(delete_filters))
+        if snapshot_rows:
+            table.add(snapshot_rows)
+        return
+
+    if snapshot_rows:
+        (
+            table.merge_insert(list(key_columns))
+            .when_matched_update_all()
+            .when_not_matched_insert_all()
+            .execute(snapshot_rows)
+        )
+
+    snapshot_keys = {_rag_snapshot_row_key(row, key_columns) for row in snapshot_rows}
+    stale_rows = [
+        row
+        for row in current_rows
+        if _rag_snapshot_row_key(row, key_columns) not in snapshot_keys
+    ]
+    delete_filters = [
+        _rag_snapshot_key_filter(
+            table,
+            row,
+            key_columns,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        for row in stale_rows
+    ]
+    if delete_filters:
+        table.delete(_combine_lancedb_filters(delete_filters))
+
+
+def _restore_rag_document_snapshot(
+    snapshot: _RagDocumentSnapshot,
+    *,
+    user_id: int,
+    is_admin: bool,
+) -> None:
+    """Restore RAG document rows after a failed refresh of an existing web file."""
+    from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+        ensure_chunks_table,
+        ensure_documents_table,
+        ensure_ingestion_runs_table,
+        ensure_main_pointers_table,
+        ensure_parses_table,
+    )
+    from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import (
+        list_table_names,
+        query_to_list,
+    )
+    from ...providers.vector_store.lancedb import get_connection_from_env
+
+    vector_store = get_vector_index_store()
+    conn = get_connection_from_env()
+    ensure_documents_table(conn)
+    ensure_parses_table(conn)
+    ensure_chunks_table(conn)
+    ensure_main_pointers_table(conn)
+    ensure_ingestion_runs_table(conn)
+
+    current_table_names = set(list_table_names(conn))
+    restore_table_names = [
+        table_name
+        for table_name in (
+            "documents",
+            "parses",
+            "chunks",
+            "main_pointers",
+            "ingestion_runs",
+        )
+        if table_name in current_table_names or table_name in snapshot.rows_by_table
+    ]
+    for table_name in sorted(current_table_names):
+        if table_name.startswith("embeddings_"):
+            restore_table_names.append(table_name)
+    for table_name in snapshot.rows_by_table:
+        if (
+            table_name.startswith("embeddings_")
+            and table_name not in restore_table_names
+        ):
+            restore_table_names.append(table_name)
+
+    for table_name in restore_table_names:
+        snapshot_rows = snapshot.rows_by_table.get(table_name, [])
+        table = None
+        try:
+            table = conn.open_table(table_name)
+            if snapshot.doc_refs:
+                current_rows = query_to_list(
+                    table.search()
+                    .where(
+                        _rag_document_refs_filter(
+                            table,
+                            snapshot.doc_refs,
+                            user_id=user_id,
+                            is_admin=is_admin,
+                        )
+                    )
+                    .limit(-1)
+                )
+            else:
+                current_rows = []
+            _restore_rag_snapshot_rows(
+                table,
+                table_name=table_name,
+                snapshot_rows=snapshot_rows,
+                current_rows=current_rows,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        finally:
+            _safe_close_table(table)
+
+    invalidate_cache = getattr(vector_store, "invalidate_table_cache", None)
+    if callable(invalidate_cache):
+        invalidate_cache()
+
+
+def _list_document_refs_for_uploaded_file(file_id: str) -> List[tuple[str, str]]:
+    from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+        ensure_documents_table,
+    )
+    from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import query_to_list
+    from ...core.tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
+    from ...providers.vector_store.lancedb import get_connection_from_env
+
+    conn = get_connection_from_env()
+    ensure_documents_table(conn)
+    documents_table = None
+    try:
+        documents_table = conn.open_table("documents")
+        safe_file_id = escape_lancedb_string(file_id)
+        rows = query_to_list(
+            documents_table.search()
+            .where(f"file_id = '{safe_file_id}'")
+            .select(["collection", "doc_id"])
+            .limit(-1)
+        )
+        doc_refs: List[tuple[str, str]] = []
+        for row in rows:
+            collection = str(row.get("collection") or "").strip()
+            doc_id = str(row.get("doc_id") or "").strip()
+            if collection and doc_id:
+                doc_refs.append((collection, doc_id))
+        return doc_refs
+    finally:
+        _safe_close_table(documents_table)
+
+
+def _snapshot_ingestion_runs_for_uploaded_file(
+    file_id: str,
+) -> Optional[_IngestionRunsSnapshot]:
+    """Snapshot current ingestion status rows before refreshing an existing file."""
+    try:
+        from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+            _safe_close_table,
+            ensure_ingestion_runs_table,
+        )
+        from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import query_to_list
+        from ...providers.vector_store.lancedb import get_connection_from_env
+
+        doc_refs = _list_document_refs_for_uploaded_file(file_id)
+        conn = get_connection_from_env()
+        ensure_ingestion_runs_table(conn)
+        ingestion_runs_table = None
+        try:
+            ingestion_runs_table = conn.open_table("ingestion_runs")
+            if doc_refs:
+                combined_filter = _combine_lancedb_filters(
+                    [
+                        _ingestion_run_filter(collection, doc_id)
+                        for collection, doc_id in doc_refs
+                    ]
+                )
+                rows = query_to_list(
+                    ingestion_runs_table.search()
+                    .where(combined_filter)
+                    .select(list(_INGESTION_RUN_COLUMNS))
+                    .limit(-1)
+                )
+            else:
+                rows = []
+            return _IngestionRunsSnapshot(doc_refs=doc_refs, rows=rows)
+        finally:
+            _safe_close_table(ingestion_runs_table)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to snapshot ingestion runs before web file refresh: "
+            "file_id=%s, error=%s",
+            file_id,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+def _restore_ingestion_runs_snapshot(snapshot: _IngestionRunsSnapshot) -> None:
+    """Restore ingestion status rows after a failed existing-file refresh."""
+    from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+        ensure_ingestion_runs_table,
+    )
+    from ...providers.vector_store.lancedb import get_connection_from_env
+
+    conn = get_connection_from_env()
+    ensure_ingestion_runs_table(conn)
+    ingestion_runs_table = None
+    try:
+        ingestion_runs_table = conn.open_table("ingestion_runs")
+        if snapshot.doc_refs:
+            combined_filter = _combine_lancedb_filters(
+                [
+                    _ingestion_run_filter(collection, doc_id)
+                    for collection, doc_id in snapshot.doc_refs
+                ]
+            )
+            ingestion_runs_table.delete(combined_filter)
+        if snapshot.rows:
+            ingestion_runs_table.add(snapshot.rows)
+    finally:
+        _safe_close_table(ingestion_runs_table)
+
+
+_UPLOADED_FILE_ROLLBACK_FIELDS = (
+    "filename",
+    "storage_path",
+    "storage_backend",
+    "storage_key",
+    "storage_uri",
+    "checksum",
+    "etag",
+    "workspace_relative_path",
+    "workspace_category",
+    "storage_status",
+    "mime_type",
+    "file_size",
+)
+
+
+def _snapshot_uploaded_file_record(file_record: UploadedFile) -> Dict[str, Any]:
+    return {
+        field: getattr(file_record, field, None)
+        for field in _UPLOADED_FILE_ROLLBACK_FIELDS
+    }
+
+
+def _restore_uploaded_file_record_snapshot(
+    file_record: UploadedFile, snapshot: Dict[str, Any]
+) -> None:
+    for field, value in snapshot.items():
+        setattr(file_record, field, value)
+
+
+def _cleanup_failed_web_uploaded_file_setup(
+    db_session: Session,
+    *,
+    file_id: str,
+    user_id: int,
+    filename: str,
+    storage_path: Path,
+    mime_type: str,
+    storage_key: str,
+) -> None:
+    """Remove DB/durable side effects after web UploadedFile setup fails."""
+    cleanup_errors: list[Exception] = []
+    try:
+        db_session.rollback()
+    except Exception as exc:  # noqa: BLE001
+        cleanup_errors.append(exc)
+        logger.warning(
+            "Failed to rollback DB session after web UploadedFile setup failure: %s",
+            exc,
+            exc_info=True,
+        )
+
+    try:
+        persisted_record = (
+            db_session.query(UploadedFile)
+            .filter(
+                (UploadedFile.file_id == file_id)
+                | (UploadedFile.storage_path == str(storage_path))
+            )
+            .first()
+        )
+        if persisted_record is not None:
+            UploadedFileStore(db_session).delete(persisted_record, delete_local=False)
+            db_session.commit()
+        else:
+            placeholder = UploadedFile(
+                file_id=file_id,
+                user_id=user_id,
+                filename=filename,
+                storage_path=str(storage_path),
+                mime_type=mime_type,
+                file_size=storage_path.stat().st_size if storage_path.exists() else 0,
+                storage_key=storage_key,
+                storage_status="available",
+            )
+            ManagedFileRef(placeholder).delete_durable()
+    except Exception as exc:  # noqa: BLE001
+        db_session.rollback()
+        cleanup_errors.append(exc)
+        logger.warning(
+            "Failed to clean web UploadedFile setup side effects: "
+            "file_id=%s, storage_key=%s, error=%s",
+            file_id,
+            storage_key,
+            exc,
+            exc_info=True,
+        )
+
+    if cleanup_errors:
+        raise RuntimeError(
+            f"Failed to clean web UploadedFile setup side effects: {cleanup_errors[0]}"
+        ) from cleanup_errors[0]
+
+
+def _create_web_uploaded_file_record(
+    db_session: Session,
+    *,
+    user_id: int,
+    filename: str,
+    storage_path: Path,
+    mime_type: str,
+) -> UploadedFile:
+    """Create a web UploadedFile with a known durable key for compensation."""
+    file_id = str(uuid.uuid4())
+    storage_key = build_upload_storage_key(user_id, file_id, filename)
+    try:
+        file_record = UploadedFileStore(db_session).create_from_local_path(
+            local_path=storage_path,
+            user_id=user_id,
+            filename=filename,
+            file_id=file_id,
+            mime_type=mime_type,
+            storage_key=storage_key,
+        )
+        db_session.commit()
+        db_session.refresh(file_record)
+        return file_record
+    except Exception:
+        _cleanup_failed_web_uploaded_file_setup(
+            db_session,
+            file_id=file_id,
+            user_id=user_id,
+            filename=filename,
+            storage_path=storage_path,
+            mime_type=mime_type,
+            storage_key=storage_key,
+        )
+        raise
+
+
+def _existing_web_file_result_with_rollback(
+    *,
+    existing_record: Any,
+    file_path: Path,
+    collection_name: str,
+    user_id: int,
+    is_admin: bool,
+    url: str,
+    context: str,
+) -> FileHandlerResult:
+    """Return an existing web file only after preparing failure compensation."""
+    file_record_id = str(existing_record.file_id)
+    ingestion_runs_snapshot = _snapshot_ingestion_runs_for_uploaded_file(file_record_id)
+    if ingestion_runs_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot ingestion status before reusing existing web file"
+        )
+
+    rag_document_snapshot = _snapshot_rag_documents_for_uploaded_file(
+        file_record_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+    if rag_document_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot RAG document rows before reusing existing web file"
+        )
+
+    def _rollback_existing(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        rollback_error: Optional[Exception] = None
+        try:
+            _rollback_failed_web_document_ingestion(
+                collection_name=collection_name,
+                result=ingestion_result,
+                user_id=user_id,
+                is_admin=is_admin,
+                rag_snapshot=rag_document_snapshot,
+                file_id=file_record_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            rollback_error = exc
+            logger.warning(
+                "Failed to restore RAG rows during existing web file rollback: "
+                "url=%s, file_id=%s, context=%s, error=%s",
+                url,
+                file_record_id,
+                context,
+                exc,
+                exc_info=True,
+            )
+
+        try:
+            _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore ingestion runs during existing web file rollback: "
+                "url=%s, file_id=%s, context=%s, error=%s",
+                url,
+                file_record_id,
+                context,
+                exc,
+                exc_info=True,
+            )
+
+        if rollback_error is not None:
+            raise rollback_error
+
+    return FileHandlerResult(
+        file_path=str(file_path),
+        file_id=file_record_id,
+        rollback_on_failure=_rollback_existing,
+    )
+
+
+def _create_new_web_file_handler_result(
+    *,
+    temp_file_path: Path,
+    persistent_file: Path,
+    db_session: Session,
+    user_id: int,
+    is_admin: bool,
+    collection_name: str,
+    filename: str,
+    url: str,
+    url_hash: str,
+    processed_urls: Dict[str, str],
+) -> FileHandlerResult:
+    """Persist a new web-ingest file and attach failure compensation."""
+    try:
+        shutil.copy2(temp_file_path, persistent_file)
+        logger.info(
+            "Copied web ingestion file from %s to %s",
+            temp_file_path,
+            persistent_file,
+        )
+
+        file_record = _create_web_uploaded_file_record(
+            db_session,
+            user_id=user_id,
+            filename=filename,
+            storage_path=persistent_file,
+            mime_type="text/markdown",
+        )
+        logger.info(
+            "Created UploadedFile record for web ingestion: file_id=%s, filename=%s, url=%s",
+            file_record.file_id,
+            filename,
+            url,
+        )
+
+        processed_urls[url_hash] = str(file_record.file_id)
+        file_record_id = str(file_record.file_id)
+        persistent_file_path = Path(persistent_file)
+
+        def _rollback_new_web_file(
+            ingestion_result: Optional[IngestionResult] = None,
+        ) -> None:
+            rollback_error: Optional[Exception] = None
+            try:
+                _rollback_failed_web_document_ingestion(
+                    collection_name=collection_name,
+                    result=ingestion_result,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    file_id=file_record_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                rollback_error = exc
+                logger.warning(
+                    "Failed to clean RAG rows during new web file rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+            SessionLocal = get_session_local()
+            rollback_db = SessionLocal()
+            try:
+                rollback_record = (
+                    rollback_db.query(UploadedFile)
+                    .filter(UploadedFile.file_id == file_record_id)
+                    .first()
+                )
+                if rollback_record is not None:
+                    UploadedFileStore(rollback_db).delete(
+                        rollback_record,
+                        delete_local=True,
+                    )
+                else:
+                    persistent_file_path.unlink(missing_ok=True)
+                rollback_db.commit()
+            except Exception:
+                rollback_db.rollback()
+                raise
+            finally:
+                rollback_db.close()
+            if rollback_error is not None:
+                raise rollback_error
+
+        return FileHandlerResult(
+            file_path=str(persistent_file),
+            file_id=file_record_id,
+            rollback_on_failure=_rollback_new_web_file,
+        )
+    except Exception:
+        if persistent_file.exists():
+            try:
+                persistent_file.unlink()
+                logger.warning(
+                    "Cleaned up orphaned persistent file due to web file setup failure: %s",
+                    persistent_file,
+                )
+            except Exception as cleanup_error:  # noqa: BLE001
+                logger.warning(
+                    "Failed to clean up orphaned persistent file %s: %s",
+                    persistent_file,
+                    cleanup_error,
+                )
+        raise
+
+
 def _refresh_existing_file_if_changed(
     existing_record: Any,
     temp_file_path: Path,
     db_session: Session,
     user_id: int,
+    is_admin: bool,
+    collection_name: str,
     url: str,
     filename: str,
     url_hash: str,
@@ -1066,9 +2077,11 @@ def _refresh_existing_file_if_changed(
         caller should continue with normal new-file handling.
     """
     existing_path = Path(str(existing_record.storage_path))
+    record_snapshot = _snapshot_uploaded_file_record(existing_record)
     if not existing_path.exists():
         try:
             existing_path = ManagedFileRef(existing_record).ensure_local()
+            record_snapshot["storage_path"] = str(existing_path)
         except DurableObjectMissingError:
             return None
         except Exception as exc:  # noqa: BLE001
@@ -1086,31 +2099,57 @@ def _refresh_existing_file_if_changed(
     new_hash = _get_file_sha256(temp_file_path)
 
     if old_hash == new_hash:
-        # Content unchanged - return existing file
-        return FileHandlerResult(
-            file_path=str(existing_record.storage_path),
-            file_id=str(existing_record.file_id),
+        return _existing_web_file_result_with_rollback(
+            existing_record=existing_record,
+            file_path=existing_path,
+            collection_name=collection_name,
+            user_id=user_id,
+            is_admin=is_admin,
+            url=url,
+            context=context,
+        )
+
+    ingestion_runs_snapshot = _snapshot_ingestion_runs_for_uploaded_file(
+        str(existing_record.file_id)
+    )
+    if ingestion_runs_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot ingestion status before refreshing existing web file"
+        )
+
+    rag_document_snapshot = _snapshot_rag_documents_for_uploaded_file(
+        str(existing_record.file_id),
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+    if rag_document_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot RAG document rows before refreshing existing web file"
         )
 
     # Content changed - first try to mark for reindex BEFORE modifying file
     if not _mark_uploaded_file_for_reindex(str(existing_record.file_id)):
-        logger.warning(
-            "Failed to mark file for reindex, skipping file refresh to avoid inconsistent state: "
-            "url=%s, file_id=%s, context=%s",
-            url,
-            existing_record.file_id,
-            context,
-        )
-        # Return existing file without refreshing (stale embeddings but consistent state)
-        return FileHandlerResult(
-            file_path=str(existing_record.storage_path),
-            file_id=str(existing_record.file_id),
+        raise RuntimeError(
+            "Failed to mark existing web file for reindex before refresh"
         )
 
     # Mark succeeded - now atomically replace the file
     backup_path = _build_ingest_backup_path(existing_path)
-    shutil.copy2(existing_path, backup_path)
-    remove_backup = True
+    try:
+        shutil.copy2(existing_path, backup_path)
+    except Exception:
+        try:
+            _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to restore ingestion runs after web file backup failure: "
+                "file_id=%s, error=%s",
+                existing_record.file_id,
+                exc,
+                exc_info=True,
+            )
+            raise exc
+        raise
     refresh_snapshot = _capture_uploaded_file_refresh_snapshot(
         existing_record,
         backup_path=backup_path,
@@ -1127,30 +2166,31 @@ def _refresh_existing_file_if_changed(
             file_size=existing_path.stat().st_size,
         )
     except Exception as exc:
-        try:
-            db_session.rollback()
-        except Exception as rollback_exc:  # noqa: BLE001
-            logger.warning(
-                "Failed to roll back database session before restoring refreshed "
-                "web file for url=%s, file_id=%s: %s",
-                url,
-                existing_record.file_id,
-                rollback_exc,
-            )
+        restore_error: Optional[Exception] = None
         restore_result = _restore_uploaded_file_refresh_snapshot(
             db_session,
             refresh_snapshot,
         )
         if restore_result.side_effects_may_remain:
-            remove_backup = False
-            raise RollbackFailureError(
+            restore_error = RollbackFailureError(
                 "Failed to fully restore refreshed web file "
                 f"for {url}: {'; '.join(restore_result.errors) or exc}"
-            ) from exc
+            )
+        try:
+            _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+        except Exception as runs_exc:  # noqa: BLE001
+            restore_error = runs_exc
+            logger.warning(
+                "Failed to restore ingestion runs after web file refresh setup "
+                "failure: file_id=%s, error=%s",
+                existing_record.file_id,
+                runs_exc,
+                exc_info=True,
+            )
+        if restore_error is not None:
+            raise restore_error from exc
+        backup_path.unlink(missing_ok=True)
         raise
-    finally:
-        if remove_backup and backup_path.exists():
-            backup_path.unlink()
     processed_urls[url_hash] = str(file_record.file_id)
 
     logger.info(
@@ -1160,9 +2200,129 @@ def _refresh_existing_file_if_changed(
         context,
     )
 
+    file_record_id = str(file_record.file_id)
+
+    def _rollback_refresh(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        if not backup_path.exists():
+            raise FileNotFoundError(
+                f"Missing web ingest rollback backup: {backup_path}"
+            )
+
+        SessionLocal = get_session_local()
+        rollback_db = SessionLocal()
+        rollback_succeeded = False
+        try:
+            rollback_error: Optional[Exception] = None
+            try:
+                _rollback_failed_web_document_ingestion(
+                    collection_name=collection_name,
+                    result=ingestion_result,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    rag_snapshot=rag_document_snapshot,
+                    file_id=file_record_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                rollback_error = exc
+                logger.warning(
+                    "Failed to restore RAG rows during web file refresh rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            try:
+                refreshed_record = (
+                    rollback_db.query(UploadedFile)
+                    .filter(UploadedFile.file_id == file_record_id)
+                    .first()
+                )
+                if refreshed_record is None:
+                    _restore_ingest_file_backup(
+                        file_path=existing_path,
+                        backup_path=backup_path,
+                        had_existing_file=True,
+                    )
+                    rollback_db.commit()
+                else:
+                    current_storage_key = str(
+                        getattr(refreshed_record, "storage_key", "") or ""
+                    )
+                    previous_storage_key = str(record_snapshot.get("storage_key") or "")
+                    if (
+                        current_storage_key
+                        and current_storage_key != previous_storage_key
+                    ):
+                        ManagedFileRef(refreshed_record).delete_durable()
+
+                    _restore_ingest_file_backup(
+                        file_path=existing_path,
+                        backup_path=backup_path,
+                        had_existing_file=True,
+                    )
+                    _restore_uploaded_file_record_snapshot(
+                        refreshed_record, record_snapshot
+                    )
+                    if previous_storage_key:
+                        UploadedFileStore(rollback_db).sync_existing(
+                            refreshed_record,
+                            storage_key=previous_storage_key,
+                            mime_type=record_snapshot.get("mime_type"),
+                        )
+                    else:
+                        rollback_db.flush()
+                    rollback_db.commit()
+            except Exception as exc:  # noqa: BLE001
+                rollback_db.rollback()
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to restore UploadedFile/local file during web file "
+                    "refresh rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            try:
+                _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+            except Exception as exc:  # noqa: BLE001
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to restore ingestion runs during web file refresh "
+                    "rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            if rollback_error is not None:
+                raise rollback_error
+            rollback_succeeded = True
+        except Exception:
+            raise
+        finally:
+            rollback_db.close()
+            if rollback_succeeded:
+                backup_path.unlink(missing_ok=True)
+            elif backup_path.exists():
+                logger.warning(
+                    "Preserving web ingest rollback backup after failed rollback: %s",
+                    backup_path,
+                )
+
+    def _commit_refresh() -> None:
+        backup_path.unlink(missing_ok=True)
+
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
+        rollback_on_failure=_rollback_refresh,
+        commit_on_success=_commit_refresh,
     )
 
 
@@ -1172,11 +2332,32 @@ def _recreate_missing_existing_file(
     temp_file_path: Path,
     db_session: Session,
     user_id: int,
+    is_admin: bool,
+    collection_name: str,
     filename: str,
     url_hash: str,
     processed_urls: Dict[str, str],
 ) -> FileHandlerResult:
     existing_path = Path(str(existing_record.storage_path))
+    record_snapshot = _snapshot_uploaded_file_record(existing_record)
+    ingestion_runs_snapshot = _snapshot_ingestion_runs_for_uploaded_file(
+        str(existing_record.file_id)
+    )
+    if ingestion_runs_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot ingestion status before recreating existing web file"
+        )
+
+    rag_document_snapshot = _snapshot_rag_documents_for_uploaded_file(
+        str(existing_record.file_id),
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+    if rag_document_snapshot is None:
+        raise RuntimeError(
+            "Failed to snapshot RAG document rows before recreating existing web file"
+        )
+
     backup_path: Optional[Path] = None
     had_existing_file = existing_path.exists()
     if had_existing_file:
@@ -1193,22 +2374,213 @@ def _recreate_missing_existing_file(
             mime_type="text/markdown",
             file_size=existing_path.stat().st_size,
         )
-    except Exception:
-        db_session.rollback()
-        _restore_ingest_file_backup(
-            file_path=existing_path,
-            backup_path=backup_path,
-            had_existing_file=had_existing_file,
-        )
+    except Exception as setup_exc:
+        restore_error: Optional[Exception] = None
+        try:
+            db_session.rollback()
+        except Exception as exc:  # noqa: BLE001
+            restore_error = exc
+            logger.warning(
+                "Failed to rollback DB session after web file recreate setup "
+                "failure: file_id=%s, error=%s",
+                existing_record.file_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            _restore_ingest_file_backup(
+                file_path=existing_path,
+                backup_path=backup_path,
+                had_existing_file=had_existing_file,
+            )
+        except Exception as exc:  # noqa: BLE001
+            restore_error = exc
+            logger.warning(
+                "Failed to restore local file after web file recreate setup "
+                "failure: file_id=%s, path=%s, error=%s",
+                existing_record.file_id,
+                existing_path,
+                exc,
+                exc_info=True,
+            )
+        try:
+            refreshed_record = (
+                db_session.query(UploadedFile)
+                .filter(UploadedFile.file_id == str(existing_record.file_id))
+                .first()
+            )
+            if refreshed_record is not None:
+                current_storage_key = str(
+                    getattr(refreshed_record, "storage_key", "") or ""
+                )
+                previous_storage_key = str(record_snapshot.get("storage_key") or "")
+                if current_storage_key and (
+                    current_storage_key != previous_storage_key or not had_existing_file
+                ):
+                    ManagedFileRef(refreshed_record).delete_durable()
+                _restore_uploaded_file_record_snapshot(
+                    refreshed_record, record_snapshot
+                )
+                if previous_storage_key and existing_path.exists():
+                    UploadedFileStore(db_session).sync_existing(
+                        refreshed_record,
+                        storage_key=previous_storage_key,
+                        mime_type=record_snapshot.get("mime_type"),
+                    )
+                else:
+                    db_session.flush()
+                db_session.commit()
+        except Exception as exc:  # noqa: BLE001
+            db_session.rollback()
+            restore_error = exc
+            logger.warning(
+                "Failed to restore UploadedFile record after web file recreate "
+                "setup failure: file_id=%s, error=%s",
+                existing_record.file_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+        except Exception as exc:  # noqa: BLE001
+            restore_error = exc
+            logger.warning(
+                "Failed to restore ingestion runs after web file recreate setup "
+                "failure: file_id=%s, error=%s",
+                existing_record.file_id,
+                exc,
+                exc_info=True,
+            )
+        if restore_error is not None:
+            raise restore_error from setup_exc
         raise
-    finally:
-        if backup_path is not None and backup_path.exists():
-            backup_path.unlink()
 
     processed_urls[url_hash] = str(file_record.file_id)
+
+    file_record_id = str(file_record.file_id)
+    backup_for_failure = backup_path
+
+    def _rollback_recreate(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        SessionLocal = get_session_local()
+        rollback_db = SessionLocal()
+        rollback_succeeded = False
+        try:
+            rollback_error: Optional[Exception] = None
+            try:
+                _rollback_failed_web_document_ingestion(
+                    collection_name=collection_name,
+                    result=ingestion_result,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    rag_snapshot=rag_document_snapshot,
+                    file_id=file_record_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                rollback_error = exc
+                logger.warning(
+                    "Failed to clean RAG rows during recreated web file rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            try:
+                refreshed_record = (
+                    rollback_db.query(UploadedFile)
+                    .filter(UploadedFile.file_id == file_record_id)
+                    .first()
+                )
+                if refreshed_record is not None:
+                    current_storage_key = str(
+                        getattr(refreshed_record, "storage_key", "") or ""
+                    )
+                    previous_storage_key = str(record_snapshot.get("storage_key") or "")
+                    if (
+                        current_storage_key
+                        and current_storage_key != previous_storage_key
+                    ):
+                        ManagedFileRef(refreshed_record).delete_durable()
+
+                    _restore_uploaded_file_record_snapshot(
+                        refreshed_record, record_snapshot
+                    )
+                    if previous_storage_key and backup_for_failure is not None:
+                        _restore_ingest_file_backup(
+                            file_path=existing_path,
+                            backup_path=backup_for_failure,
+                            had_existing_file=True,
+                        )
+                        UploadedFileStore(rollback_db).sync_existing(
+                            refreshed_record,
+                            storage_key=previous_storage_key,
+                            mime_type=record_snapshot.get("mime_type"),
+                        )
+                    else:
+                        _restore_ingest_file_backup(
+                            file_path=existing_path,
+                            backup_path=backup_for_failure,
+                            had_existing_file=had_existing_file,
+                        )
+                        rollback_db.flush()
+                else:
+                    _restore_ingest_file_backup(
+                        file_path=existing_path,
+                        backup_path=backup_for_failure,
+                        had_existing_file=had_existing_file,
+                    )
+                rollback_db.commit()
+            except Exception as exc:  # noqa: BLE001
+                rollback_db.rollback()
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to restore UploadedFile/local file during recreated "
+                    "web file rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            try:
+                _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+            except Exception as exc:  # noqa: BLE001
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to restore ingestion runs during recreated web file "
+                    "rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+
+            if rollback_error is not None:
+                raise rollback_error
+            rollback_succeeded = True
+        except Exception:
+            raise
+        finally:
+            rollback_db.close()
+            if rollback_succeeded and backup_for_failure is not None:
+                backup_for_failure.unlink(missing_ok=True)
+            elif backup_for_failure is not None and backup_for_failure.exists():
+                logger.warning(
+                    "Preserving web ingest rollback backup after failed rollback: %s",
+                    backup_for_failure,
+                )
+
+    def _commit_recreate() -> None:
+        if backup_for_failure is not None:
+            backup_for_failure.unlink(missing_ok=True)
+
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
+        rollback_on_failure=_rollback_recreate,
+        commit_on_success=_commit_recreate,
     )
 
 
@@ -1351,6 +2723,161 @@ class CloudIngestRequest(BaseModel):
 
 class RollbackFailureError(RuntimeError):
     """Raised when best-effort ingest rollback cannot complete cleanly."""
+
+
+@dataclass
+class _CollectionConfigSnapshot:
+    metadata_store: Any
+    collection: str
+    user_id: int
+    previous_config_json: Optional[str]
+    previous_config_known: bool
+    saved: bool
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _save_collection_config_with_snapshot(
+    *,
+    collection: str,
+    config_json: str,
+    user: User,
+    context: str,
+) -> _CollectionConfigSnapshot:
+    """Save collection config while retaining the caller's previous config."""
+    from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    previous_config_json: Optional[str] = None
+    previous_config_known = False
+
+    try:
+        get_config = getattr(metadata_store, "get_collection_config", None)
+        if callable(get_config):
+            loaded = get_config(
+                collection=collection,
+                user_id=int(user.id),
+                is_admin=False,
+            )
+            loaded = await _maybe_await(loaded)
+            if isinstance(loaded, str):
+                previous_config_json = loaded
+                previous_config_known = True
+            elif loaded is None:
+                previous_config_known = True
+            else:
+                logger.warning(
+                    "Unexpected collection config snapshot type during %s: %s",
+                    context,
+                    type(loaded).__name__,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to snapshot collection config during %s: %s",
+            context,
+            exc,
+        )
+
+    if not previous_config_known:
+        logger.warning(
+            "Skipping collection config save during %s because previous config "
+            "state could not be read for %s/user_%s",
+            context,
+            collection,
+            int(user.id),
+        )
+        return _CollectionConfigSnapshot(
+            metadata_store=metadata_store,
+            collection=collection,
+            user_id=int(user.id),
+            previous_config_json=previous_config_json,
+            previous_config_known=previous_config_known,
+            saved=False,
+        )
+
+    try:
+        await metadata_store.save_collection_config(
+            collection=collection,
+            config_json=config_json,
+            user_id=int(user.id),
+        )
+        return _CollectionConfigSnapshot(
+            metadata_store=metadata_store,
+            collection=collection,
+            user_id=int(user.id),
+            previous_config_json=previous_config_json,
+            previous_config_known=previous_config_known,
+            saved=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to save collection config during %s: %s", context, exc)
+        return _CollectionConfigSnapshot(
+            metadata_store=metadata_store,
+            collection=collection,
+            user_id=int(user.id),
+            previous_config_json=previous_config_json,
+            previous_config_known=previous_config_known,
+            saved=False,
+        )
+
+
+async def _restore_collection_config_after_failed_ingest(
+    *,
+    snapshot: Optional[_CollectionConfigSnapshot],
+    collection_existed_before: bool,
+    context: str,
+) -> None:
+    """Undo the config save made before an ingest that ultimately failed."""
+    if snapshot is None or not snapshot.saved:
+        return
+
+    try:
+        if snapshot.previous_config_json is not None:
+            await snapshot.metadata_store.save_collection_config(
+                collection=snapshot.collection,
+                config_json=snapshot.previous_config_json,
+                user_id=snapshot.user_id,
+            )
+            logger.info(
+                "Restored previous collection config after failed %s: %s/user_%s",
+                context,
+                snapshot.collection,
+                snapshot.user_id,
+            )
+            return
+
+        if not snapshot.previous_config_known:
+            logger.warning(
+                "Skipping collection config deletion after failed %s because "
+                "previous config state is unknown: %s/user_%s",
+                context,
+                snapshot.collection,
+                snapshot.user_id,
+            )
+            return
+
+        delete_result = snapshot.metadata_store.delete_collection_metadata(
+            collection_name=snapshot.collection,
+            user_id=snapshot.user_id,
+            is_admin=False,
+            delete_orphaned_metadata=not collection_existed_before,
+        )
+        await _maybe_await(delete_result)
+        logger.info(
+            "Removed collection config created by failed %s: %s/user_%s",
+            context,
+            snapshot.collection,
+            snapshot.user_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RollbackFailureError(
+            "Failed to restore collection config after failed "
+            f"{context} for {snapshot.collection}/user_{snapshot.user_id}: {exc}"
+        ) from exc
 
 
 def _build_cloud_storage_filename(original_filename: str, file_id: str) -> str:
@@ -1797,17 +3324,16 @@ async def ingest(
 
     progress_manager = get_progress_manager()
 
-    try:
-        from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
-    except Exception as e:
-        logger.warning("Failed to save collection config during ingest: %s", e)
+    config_snapshot = await _save_collection_config_with_snapshot(
+        collection=safe_collection,
+        config_json=config.model_dump_json(exclude_unset=True),
+        user=_user,
+        context="ingest",
+    )
+    effective_collection_existed_before = _collection_or_config_existed_before(
+        collection_existed_before,
+        config_snapshot,
+    )
 
     try:
         file_record = _upsert_uploaded_file_record(
@@ -1845,12 +3371,20 @@ async def ingest(
                 result=result,
                 file_path=file_path,
                 file_record=file_record,
-                collection_existed_before=collection_existed_before,
+                collection_existed_before=effective_collection_existed_before,
                 uploaded_file_existed_before=uploaded_file_existed_before,
                 file_backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
+            if effective_collection_existed_before:
+                await _restore_or_cleanup_collection_config_after_failed_ingest(
+                    snapshot=config_snapshot,
+                    collection_existed_before=collection_existed_before,
+                    collection_name=collection,
+                    user=_user,
+                    context="ingest",
+                )
 
         if result.status == "error":
             return JSONResponse(
@@ -1896,27 +3430,32 @@ async def ingest(
                 result=rollback_result,
                 file_path=file_path,
                 file_record=file_record,
-                collection_existed_before=collection_existed_before,
+                collection_existed_before=effective_collection_existed_before,
                 uploaded_file_existed_before=uploaded_file_existed_before,
                 file_backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
-        elif not collection_existed_before:
-            _restore_ingest_file_backup(
-                file_path=file_path,
-                backup_path=file_backup_path,
-                had_existing_file=had_existing_file,
-            )
-            await _cleanup_failed_new_collection_metadata(
-                collection_name=collection,
-                user=_user,
-            )
+            if effective_collection_existed_before:
+                await _restore_or_cleanup_collection_config_after_failed_ingest(
+                    snapshot=config_snapshot,
+                    collection_existed_before=collection_existed_before,
+                    collection_name=collection,
+                    user=_user,
+                    context="ingest",
+                )
         else:
             _restore_ingest_file_backup(
                 file_path=file_path,
                 backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
+            )
+            await _restore_or_cleanup_collection_config_after_failed_ingest(
+                snapshot=config_snapshot,
+                collection_existed_before=collection_existed_before,
+                collection_name=collection,
+                user=_user,
+                context="ingest",
             )
         raise
 
@@ -2200,17 +3739,16 @@ async def ingest_cloud(
 
     await _ensure_collection_access(safe_collection, _user, allow_create=True)
 
-    try:
-        from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
-    except Exception as e:
-        logger.warning("Failed to save collection config during ingest_cloud: %s", e)
+    config_snapshot = await _save_collection_config_with_snapshot(
+        collection=safe_collection,
+        config_json=config.model_dump_json(exclude_unset=True),
+        user=_user,
+        context="ingest_cloud",
+    )
+    effective_collection_existed_before = _collection_or_config_existed_before(
+        collection_existed_before,
+        config_snapshot,
+    )
 
     # Concurrency limit for cloud ingestion to avoid overloading
     semaphore = asyncio.Semaphore(5)
@@ -2353,7 +3891,7 @@ async def ingest_cloud(
                                 result=result,
                                 file_path=file_path,
                                 file_record=file_record,
-                                collection_existed_before=collection_existed_before,
+                                collection_existed_before=effective_collection_existed_before,
                                 uploaded_file_existed_before=uploaded_file_existed_before,
                                 file_backup_path=file_backup_path,
                                 had_existing_file=had_existing_file,
@@ -2384,7 +3922,7 @@ async def ingest_cloud(
                             result=rollback_result,
                             file_path=file_path,
                             file_record=file_record,
-                            collection_existed_before=collection_existed_before,
+                            collection_existed_before=effective_collection_existed_before,
                             uploaded_file_existed_before=uploaded_file_existed_before,
                             file_backup_path=file_backup_path,
                             had_existing_file=had_existing_file,
@@ -2441,12 +3979,17 @@ async def ingest_cloud(
     # Run all file processings concurrently
     results = await asyncio.gather(*[process_file(f) for f in request.files])
 
-    if not collection_existed_before and not any(
-        result.status == "success" for result in results
-    ):
-        await _cleanup_failed_new_collection_metadata(
+    has_success = any(result.status == "success" for result in results)
+    has_failure = any(result.status in {"error", "partial"} for result in results)
+
+    if has_failure:
+        await _restore_or_cleanup_collection_config_after_failed_ingest(
+            snapshot=config_snapshot,
+            collection_existed_before=collection_existed_before,
             collection_name=safe_collection,
             user=_user,
+            context="ingest_cloud",
+            successful_documents=1 if has_success else 0,
         )
 
     return results
@@ -3087,18 +4630,12 @@ async def ingest_web(
         except ValueError:
             collection_existed_before = False
 
-        try:
-            from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-            metadata_store = get_metadata_store()
-            await metadata_store.save_collection_config(
-                collection=safe_collection,
-                config_json=ingestion_config.model_dump_json(exclude_unset=True),
-                user_id=int(_user.id),
-            )
-        except Exception as e:
-            logger.warning("Failed to save collection config during ingest_web: %s", e)
-
+        config_snapshot = await _save_collection_config_with_snapshot(
+            collection=safe_collection,
+            config_json=ingestion_config.model_dump_json(exclude_unset=True),
+            user=_user,
+            context="ingest_web",
+        )
         # Track processed URLs to prevent duplicate UploadedFile records
         # Key: URL hash, Value: file_id
         # Note: For large-scale web ingestion (>10000 pages), consider using
@@ -3162,6 +4699,8 @@ async def ingest_web(
                             temp_file_path=temp_file_path,
                             db_session=db_session,
                             user_id=int(_user.id),
+                            is_admin=bool(_user.is_admin),
+                            collection_name=collection_name,
                             url=url,
                             filename=filename,
                             url_hash=url_hash,
@@ -3193,6 +4732,8 @@ async def ingest_web(
                         temp_file_path=temp_file_path,
                         db_session=db_session,
                         user_id=int(_user.id),
+                        is_admin=bool(_user.is_admin),
+                        collection_name=collection_name,
                         url=url,
                         filename=filename,
                         url_hash=url_hash,
@@ -3215,6 +4756,8 @@ async def ingest_web(
                         temp_file_path=temp_file_path,
                         db_session=db_session,
                         user_id=int(_user.id),
+                        is_admin=bool(_user.is_admin),
+                        collection_name=collection_name,
                         filename=filename,
                         url_hash=url_hash,
                         processed_urls=_processed_urls,
@@ -3234,50 +4777,18 @@ async def ingest_web(
                 )
                 persistent_file.parent.mkdir(parents=True, exist_ok=True)
 
-                try:
-                    shutil.copy2(temp_file_path, persistent_file)
-                    logger.info(
-                        "Copied web ingestion file from %s to %s",
-                        temp_file_path,
-                        persistent_file,
-                    )
-
-                    file_record = _upsert_uploaded_file_record(
-                        db_session,
-                        user_id=int(_user.id),
-                        filename=filename,
-                        storage_path=persistent_file,
-                        mime_type="text/markdown",
-                        file_size=persistent_file.stat().st_size,
-                    )
-                    logger.info(
-                        "Created UploadedFile record for web ingestion: file_id=%s, filename=%s, url=%s",
-                        file_record.file_id,
-                        filename,
-                        url,
-                    )
-
-                    _processed_urls[url_hash] = str(file_record.file_id)
-                    _new_web_file_ids.add(str(file_record.file_id))
-                    return FileHandlerResult(
-                        file_path=str(persistent_file),
-                        file_id=str(file_record.file_id),
-                    )
-                except Exception:
-                    if persistent_file.exists():
-                        try:
-                            persistent_file.unlink()
-                            logger.warning(
-                                "Cleaned up orphaned persistent file due to upsert failure: %s",
-                                persistent_file,
-                            )
-                        except Exception as cleanup_error:
-                            logger.warning(
-                                "Failed to clean up orphaned persistent file %s: %s",
-                                persistent_file,
-                                cleanup_error,
-                            )
-                    raise
+                return _create_new_web_file_handler_result(
+                    temp_file_path=temp_file_path,
+                    persistent_file=persistent_file,
+                    db_session=db_session,
+                    user_id=int(_user.id),
+                    is_admin=bool(_user.is_admin),
+                    collection_name=collection_name,
+                    filename=filename,
+                    url=url,
+                    url_hash=url_hash,
+                    processed_urls=_processed_urls,
+                )
 
         # Create a wrapper that creates a dedicated DB session for the executor thread
         # This avoids sharing the request thread's session across thread boundaries,
@@ -3316,34 +4827,15 @@ async def ingest_web(
             result = result.model_copy(update={"message": web_updated_message})
 
         if result.status == "error":
-            cleanup_incomplete = False
-            cleanup_errors: list[str] = []
-            if result.documents_created == 0:
-                cleanup_incomplete, cleanup_errors = _compensate_new_web_ingest_files(
-                    db,
-                    file_ids=_new_web_file_ids,
-                    user_id=int(_user.id),
-                )
-
-            if cleanup_incomplete:
-                cleanup_message = "Web ingest rollback incomplete: " + "; ".join(
-                    cleanup_errors or ["side effects may remain"]
-                )
-                result = result.model_copy(
-                    update={"warnings": [*result.warnings, cleanup_message]}
-                )
-            if not collection_existed_before:
-                if cleanup_incomplete:
-                    logger.warning(
-                        "Skipping failed web-ingest collection metadata cleanup for %s "
-                        "because file rollback is incomplete",
-                        safe_collection,
-                    )
-                else:
-                    await _cleanup_failed_new_collection_metadata(
-                        collection_name=safe_collection,
-                        user=_user,
-                    )
+            await _restore_or_cleanup_collection_config_after_failed_ingest(
+                snapshot=config_snapshot,
+                collection_existed_before=collection_existed_before,
+                collection_name=safe_collection,
+                user=_user,
+                context="ingest_web",
+                successful_documents=result.documents_created,
+                side_effects_may_remain=result.side_effects_may_remain,
+            )
             return JSONResponse(status_code=500, content=result.model_dump())
         if result.status == "partial":
             logger.warning(
@@ -3353,13 +4845,30 @@ async def ingest_web(
                 _user.id,
                 result.message,
             )
+            await _restore_or_cleanup_collection_config_after_failed_ingest(
+                snapshot=config_snapshot,
+                collection_existed_before=collection_existed_before,
+                collection_name=safe_collection,
+                user=_user,
+                context="ingest_web",
+                successful_documents=result.documents_created,
+                side_effects_may_remain=result.side_effects_may_remain,
+            )
 
         return result
 
     except HTTPException:
         raise
     except (ValueError, KeyError, TypeError) as e:
-        if "collection_existed_before" in locals() and not collection_existed_before:
+        if "config_snapshot" in locals():
+            await _restore_or_cleanup_collection_config_after_failed_ingest(
+                snapshot=config_snapshot,
+                collection_existed_before=collection_existed_before,
+                collection_name=safe_collection,
+                user=_user,
+                context="ingest_web",
+            )
+        elif "collection_existed_before" in locals() and not collection_existed_before:
             await _cleanup_failed_new_collection_metadata(
                 collection_name=safe_collection,
                 user=_user,
@@ -3369,7 +4878,15 @@ async def ingest_web(
             status_code=400, detail=f"Data format error: {str(e)}"
         ) from e
     except Exception as e:
-        if "collection_existed_before" in locals() and not collection_existed_before:
+        if "config_snapshot" in locals():
+            await _restore_or_cleanup_collection_config_after_failed_ingest(
+                snapshot=config_snapshot,
+                collection_existed_before=collection_existed_before,
+                collection_name=safe_collection,
+                user=_user,
+                context="ingest_web",
+            )
+        elif "collection_existed_before" in locals() and not collection_existed_before:
             await _cleanup_failed_new_collection_metadata(
                 collection_name=safe_collection,
                 user=_user,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3610,18 +3610,6 @@ async def create_ingest_job(
 
     generation_id = str(uuid.uuid4())
 
-    saved_collection_config = False
-    try:
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
-        saved_collection_config = True
-    except Exception as e:
-        logger.warning("Failed to save collection config during async ingest: %s", e)
-
     job_payload = {
         "collection": safe_collection,
         "source_path": str(staged_file_path),
@@ -3663,11 +3651,6 @@ async def create_ingest_job(
     except Exception:
         db.rollback()
         _cleanup_background_ingest_staging_file(staged_file_path)
-        if saved_collection_config and not collection_existed_before:
-            await _cleanup_failed_new_collection_metadata(
-                collection_name=safe_collection,
-                user=_user,
-            )
         raise
     try:
         return await _enqueue_background_job_or_503_async(db, job)
@@ -3680,11 +3663,6 @@ async def create_ingest_job(
             generation_id=generation_id,
         )
         _cleanup_background_ingest_staging_file(staged_file_path)
-        if saved_collection_config and not collection_existed_before:
-            await _cleanup_failed_new_collection_metadata(
-                collection_name=safe_collection,
-                user=_user,
-            )
         raise
 
 
@@ -5025,20 +5003,6 @@ async def create_ingest_web_job(
     if existing_job is not None:
         return existing_job
 
-    saved_collection_config = False
-    try:
-        metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
-            collection=safe_collection,
-            config_json=ingestion_config.model_dump_json(exclude_unset=True),
-            user_id=int(_user.id),
-        )
-        saved_collection_config = True
-    except Exception as e:
-        logger.warning(
-            "Failed to save collection config during async web ingest: %s", e
-        )
-
     try:
         job = create_background_job(
             db,
@@ -5057,11 +5021,6 @@ async def create_ingest_web_job(
         )
         return await _enqueue_background_job_or_503_async(db, job)
     except Exception:
-        if saved_collection_config and not collection_existed_before:
-            await _cleanup_failed_new_collection_metadata(
-                collection_name=safe_collection,
-                user=_user,
-            )
         raise
 
 

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -41,6 +41,78 @@ class StagedDocumentIngestSuperseded(RuntimeError):
     pass
 
 
+def _get_job_user(
+    db: Session,
+    payload: dict[str, Any],
+    *,
+    context: str,
+) -> User | None:
+    user_id = int(payload["user_id"])
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        logger.warning("Cannot %s for missing user %s", context, user_id)
+    return user
+
+
+def _save_job_collection_config_with_snapshot(
+    db: Session,
+    payload: dict[str, Any],
+    ingestion_config: IngestionConfig,
+    *,
+    context: str,
+) -> Any:
+    user = _get_job_user(
+        db, payload, context=f"save collection config during {context}"
+    )
+    if user is None:
+        return None
+
+    from ..api.kb import _save_collection_config_with_snapshot
+
+    return asyncio.run(
+        _save_collection_config_with_snapshot(
+            collection=str(payload["collection"]),
+            config_json=ingestion_config.model_dump_json(exclude_unset=True),
+            user=user,
+            context=context,
+        )
+    )
+
+
+def _restore_or_cleanup_failed_job_collection_config(
+    db: Session,
+    payload: dict[str, Any],
+    *,
+    snapshot: Any,
+    context: str,
+    successful_documents: int = 0,
+    side_effects_may_remain: bool = False,
+) -> None:
+    user = _get_job_user(
+        db,
+        payload,
+        context=f"restore failed-ingest collection config during {context}",
+    )
+    if user is None:
+        return
+
+    from ..api.kb import _restore_or_cleanup_collection_config_after_failed_ingest
+
+    asyncio.run(
+        _restore_or_cleanup_collection_config_after_failed_ingest(
+            snapshot=snapshot,
+            collection_existed_before=bool(
+                payload.get("collection_existed_before", True)
+            ),
+            collection_name=str(payload["collection"]),
+            user=user,
+            context=context,
+            successful_documents=successful_documents,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+    )
+
+
 def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]:
     payload = dict(job.payload or {})
     ingestion_config = IngestionConfig.model_validate(payload["ingestion_config"])
@@ -53,6 +125,13 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
     if is_staged_input and not _is_staged_document_generation_latest(db, payload):
         update_job_progress(db, job, message="Superseded by newer upload")
         return _superseded_staged_document_result(payload)
+
+    config_snapshot = _save_job_collection_config_with_snapshot(
+        db,
+        payload,
+        ingestion_config,
+        context="background document ingest",
+    )
 
     def _assert_latest_generation() -> None:
         if is_staged_input and not _is_staged_document_generation_latest(db, payload):
@@ -74,9 +153,31 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                 metadata_source_path=str(target_path) if target_path else None,
                 commit_gate=_assert_latest_generation if is_staged_input else None,
             )
+    except StagedDocumentIngestSuperseded:
+        _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+            db,
+            payload,
+            snapshot=config_snapshot,
+            context="background staged document superseded exception",
+        )
+        return _superseded_staged_document_result(payload)
     except Exception:
-        if is_staged_input and int(job.attempts or 0) >= int(job.max_attempts or 1):
-            _cleanup_staged_document_input(payload)
+        if is_staged_input:
+            if int(job.attempts or 0) >= int(job.max_attempts or 1):
+                _cleanup_staged_document_input(payload)
+            _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background staged document ingest exception",
+            )
+        else:
+            _restore_or_cleanup_failed_job_collection_config(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background document ingest exception",
+            )
         raise
 
     result_payload = result.model_dump(mode="json")
@@ -84,14 +185,43 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
         result_payload["file_id"] = file_id
     if result.status in {"error", "partial"}:
         if is_staged_input:
-            if _is_superseded_ingestion_result(
-                result
-            ) or not _rollback_failed_staged_document_ingestion_if_current(
-                db, payload, result
-            ):
+            if _is_superseded_ingestion_result(result):
+                _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                    db,
+                    payload,
+                    snapshot=config_snapshot,
+                    context="background staged document superseded result",
+                )
                 return _superseded_staged_document_result(payload)
+            if not _rollback_failed_staged_document_ingestion_if_current(
+                db, payload, result, config_snapshot=config_snapshot
+            ):
+                _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                    db,
+                    payload,
+                    snapshot=config_snapshot,
+                    context="background stale staged document ingest",
+                )
+                return _superseded_staged_document_result(payload)
+            _restore_or_cleanup_failed_job_collection_config(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background staged document ingest",
+            )
         else:
-            _rollback_failed_document_ingestion(db, payload, result)
+            _rollback_failed_document_ingestion(
+                db,
+                payload,
+                result,
+                config_snapshot=config_snapshot,
+            )
+            _restore_or_cleanup_failed_job_collection_config(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background document ingest",
+            )
         raise BackgroundJobHandlerError(
             result.message,
             result=result_payload,
@@ -99,17 +229,41 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
         )
     if is_staged_input:
         if not _is_staged_document_generation_latest(db, payload):
+            _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background stale staged document publish",
+            )
             return _superseded_staged_document_result(payload)
         try:
             file_record = _publish_staged_document_ingestion(db, payload)
             result_payload["file_id"] = str(file_record.file_id)
         except StagedDocumentIngestSuperseded:
+            _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background staged document publish superseded",
+            )
             return _superseded_staged_document_result(payload)
         except Exception as exc:  # noqa: BLE001
             if not _rollback_failed_staged_document_ingestion_if_current(
-                db, payload, result
+                db, payload, result, config_snapshot=config_snapshot
             ):
+                _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+                    db,
+                    payload,
+                    snapshot=config_snapshot,
+                    context="background stale staged document publish rollback",
+                )
                 return _superseded_staged_document_result(payload)
+            _restore_or_cleanup_failed_job_collection_config(
+                db,
+                payload,
+                snapshot=config_snapshot,
+                context="background staged document publish",
+            )
             raise BackgroundJobHandlerError(
                 f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
                 result=result_payload,
@@ -128,6 +282,12 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
     is_admin = bool(payload.get("is_admin", False))
     collection = str(payload["collection"])
     processed_urls: dict[str, str] = {}
+    config_snapshot = _save_job_collection_config_with_snapshot(
+        db,
+        payload,
+        ingestion_config,
+        context="background web ingest",
+    )
 
     def _progress(message: str, completed: int, total: int) -> None:
         update_job_progress(
@@ -176,16 +336,23 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
                 )
             )
     except Exception:
-        _cleanup_failed_web_collection_metadata_if_new(db, payload)
-        raise
-
-    result_payload = result.model_dump(mode="json")
-    if result.status == "error":
         _cleanup_failed_web_collection_metadata_if_new(
             db,
             payload,
-            successful_documents=int(result.documents_created or 0),
+            snapshot=config_snapshot,
         )
+        raise
+
+    result_payload = result.model_dump(mode="json")
+    if result.status in {"error", "partial"}:
+        _cleanup_failed_web_collection_metadata_if_new(
+            db,
+            payload,
+            snapshot=config_snapshot,
+            successful_documents=int(result.documents_created or 0),
+            side_effects_may_remain=bool(result.side_effects_may_remain),
+        )
+    if result.status == "error":
         raise BackgroundJobHandlerError(result.message, result=result_payload)
     return result_payload
 
@@ -329,6 +496,32 @@ def _is_staged_document_generation_latest(
     )
 
 
+def _restore_or_cleanup_failed_staged_job_collection_config_if_current(
+    db: Session,
+    payload: dict[str, Any],
+    *,
+    snapshot: Any,
+    context: str,
+) -> bool:
+    if not _is_staged_document_generation_latest(db, payload):
+        logger.info(
+            "Skipping collection config restore for superseded KB ingest generation: "
+            "%s/user_%s generation=%s",
+            payload.get("collection"),
+            payload.get("user_id"),
+            payload.get("generation_id"),
+        )
+        return False
+
+    _restore_or_cleanup_failed_job_collection_config(
+        db,
+        payload,
+        snapshot=snapshot,
+        context=context,
+    )
+    return True
+
+
 def _is_superseded_ingestion_result(result: IngestionResult) -> bool:
     return str(result.message) == _SUPERSEDED_STAGED_INGEST_MESSAGE
 
@@ -349,8 +542,14 @@ def _rollback_failed_staged_document_ingestion(
     db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
+    *,
+    config_snapshot: Any = None,
 ) -> None:
-    from ..api.kb import RollbackFailureError, _rollback_failed_cloud_ingestion
+    from ..api.kb import (
+        RollbackFailureError,
+        _collection_or_config_existed_before,
+        _rollback_failed_cloud_ingestion,
+    )
 
     user_id = int(payload["user_id"])
     user = db.query(User).filter(User.id == user_id).first()
@@ -368,6 +567,10 @@ def _rollback_failed_staged_document_ingestion(
         if isinstance(ingestion_config_payload, dict)
         else None
     )
+    effective_collection_existed_before = _collection_or_config_existed_before(
+        bool(payload.get("collection_existed_before", True)),
+        config_snapshot,
+    )
 
     try:
         asyncio.run(
@@ -378,9 +581,7 @@ def _rollback_failed_staged_document_ingestion(
                 result=result,
                 file_path=Path(str(payload["source_path"])),
                 file_record=None,
-                collection_existed_before=bool(
-                    payload.get("collection_existed_before", True)
-                ),
+                collection_existed_before=effective_collection_existed_before,
                 uploaded_file_existed_before=False,
                 file_backup_path=None,
                 had_existing_file=False,
@@ -401,11 +602,18 @@ def _rollback_failed_staged_document_ingestion_if_current(
     db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
+    *,
+    config_snapshot: Any = None,
 ) -> bool:
     if not _is_staged_document_generation_latest(db, payload):
         _cleanup_staged_document_input(payload)
         return False
-    _rollback_failed_staged_document_ingestion(db, payload, result)
+    _rollback_failed_staged_document_ingestion(
+        db,
+        payload,
+        result,
+        config_snapshot=config_snapshot,
+    )
     return True
 
 
@@ -482,8 +690,14 @@ def _rollback_failed_document_ingestion(
     db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
+    *,
+    config_snapshot: Any = None,
 ) -> None:
-    from ..api.kb import RollbackFailureError, _rollback_failed_ingestion
+    from ..api.kb import (
+        RollbackFailureError,
+        _collection_or_config_existed_before,
+        _rollback_failed_ingestion,
+    )
 
     user_id = int(payload["user_id"])
     user = db.query(User).filter(User.id == user_id).first()
@@ -514,6 +728,10 @@ def _rollback_failed_document_ingestion(
         )
 
     backup_path = payload.get("file_backup_path")
+    effective_collection_existed_before = _collection_or_config_existed_before(
+        bool(payload.get("collection_existed_before", True)),
+        config_snapshot,
+    )
     try:
         asyncio.run(
             _rollback_failed_ingestion(
@@ -523,9 +741,7 @@ def _rollback_failed_document_ingestion(
                 result=result,
                 file_path=Path(str(payload["source_path"])),
                 file_record=file_record,
-                collection_existed_before=bool(
-                    payload.get("collection_existed_before", True)
-                ),
+                collection_existed_before=effective_collection_existed_before,
                 uploaded_file_existed_before=bool(
                     payload.get("uploaded_file_existed_before", True)
                 ),
@@ -558,27 +774,15 @@ def _cleanup_failed_web_collection_metadata_if_new(
     db: Session,
     payload: dict[str, Any],
     *,
+    snapshot: Any = None,
     successful_documents: int = 0,
+    side_effects_may_remain: bool = False,
 ) -> None:
-    if successful_documents > 0:
-        return
-    if bool(payload.get("collection_existed_before", True)):
-        return
-
-    user_id = int(payload["user_id"])
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
-        logger.warning(
-            "Cannot clean failed web-ingest collection metadata for missing user %s",
-            user_id,
-        )
-        return
-
-    from ..api.kb import _cleanup_failed_new_collection_metadata
-
-    asyncio.run(
-        _cleanup_failed_new_collection_metadata(
-            collection_name=str(payload["collection"]),
-            user=user,
-        )
+    _restore_or_cleanup_failed_job_collection_config(
+        db,
+        payload,
+        snapshot=snapshot,
+        context="background web ingest",
+        successful_documents=successful_documents,
+        side_effects_may_remain=side_effects_may_remain,
     )

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -155,6 +155,7 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
                 url=url,
                 db_session=db_session,
                 user_id=user_id,
+                is_admin=is_admin,
                 processed_urls=processed_urls,
             )
         finally:
@@ -180,7 +181,11 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
 
     result_payload = result.model_dump(mode="json")
     if result.status == "error":
-        _cleanup_failed_web_collection_metadata_if_new(db, payload)
+        _cleanup_failed_web_collection_metadata_if_new(
+            db,
+            payload,
+            successful_documents=int(result.documents_created or 0),
+        )
         raise BackgroundJobHandlerError(result.message, result=result_payload)
     return result_payload
 
@@ -193,13 +198,14 @@ def _handle_web_file(
     url: str,
     db_session: Session,
     user_id: int,
+    is_admin: bool,
     processed_urls: dict[str, str],
 ) -> FileHandlerResult:
     from ..api.kb import (
+        _create_new_web_file_handler_result,
         _normalize_web_title_for_filename,
         _recreate_missing_existing_file,
         _refresh_existing_file_if_changed,
-        _upsert_uploaded_file_record,
         _WebFileLock,
     )
 
@@ -222,6 +228,8 @@ def _handle_web_file(
                     temp_file_path=temp_file_path,
                     db_session=db_session,
                     user_id=user_id,
+                    is_admin=is_admin,
+                    collection_name=collection_name,
                     url=url,
                     filename=filename,
                     url_hash=url_hash,
@@ -245,6 +253,8 @@ def _handle_web_file(
                 temp_file_path=temp_file_path,
                 db_session=db_session,
                 user_id=user_id,
+                is_admin=is_admin,
+                collection_name=collection_name,
                 url=url,
                 filename=filename,
                 url_hash=url_hash,
@@ -260,6 +270,8 @@ def _handle_web_file(
                 temp_file_path=temp_file_path,
                 db_session=db_session,
                 user_id=user_id,
+                is_admin=is_admin,
+                collection_name=collection_name,
                 filename=filename,
                 url_hash=url_hash,
                 processed_urls=processed_urls,
@@ -273,31 +285,18 @@ def _handle_web_file(
             collection_is_sanitized=True,
         )
         persistent_file.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            shutil.copy2(temp_file_path, persistent_file)
-            file_record = _upsert_uploaded_file_record(
-                db_session,
-                user_id=user_id,
-                filename=filename,
-                storage_path=persistent_file,
-                mime_type="text/markdown",
-                file_size=persistent_file.stat().st_size,
-            )
-            processed_urls[url_hash] = str(file_record.file_id)
-            return FileHandlerResult(
-                file_path=str(persistent_file),
-                file_id=str(file_record.file_id),
-            )
-        except Exception:
-            if persistent_file.exists():
-                try:
-                    persistent_file.unlink()
-                except OSError:
-                    logger.warning(
-                        "Failed to clean up orphaned web-ingest file %s",
-                        persistent_file,
-                    )
-            raise
+        return _create_new_web_file_handler_result(
+            temp_file_path=temp_file_path,
+            persistent_file=persistent_file,
+            db_session=db_session,
+            user_id=user_id,
+            is_admin=is_admin,
+            collection_name=collection_name,
+            filename=filename,
+            url=url,
+            url_hash=url_hash,
+            processed_urls=processed_urls,
+        )
 
 
 def _cleanup_staged_document_input(payload: dict[str, Any]) -> None:
@@ -558,7 +557,11 @@ def _discard_ingest_backup(payload: dict[str, Any]) -> None:
 def _cleanup_failed_web_collection_metadata_if_new(
     db: Session,
     payload: dict[str, Any],
+    *,
+    successful_documents: int = 0,
 ) -> None:
+    if successful_documents > 0:
+        return
     if bool(payload.get("collection_existed_before", True)):
         return
 

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -1131,6 +1131,7 @@ class TestWebIngestionFileHandler:
 
         assert result.status == "error"
         assert result.documents_created == 1
+        assert result.side_effects_may_remain is True
         assert (
             result.message
             == "Web ingestion rollback failed for https://example.com/page2: "

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,7 +12,10 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     IngestionResult,
     WebCrawlConfig,
 )
-from xagent.core.tools.core.RAG_tools.pipelines.web_ingestion import run_web_ingestion
+from xagent.core.tools.core.RAG_tools.pipelines.web_ingestion import (
+    _callback_accepts_ingestion_result,
+    run_web_ingestion,
+)
 from xagent.core.tools.core.RAG_tools.utils.string_utils import sanitize_for_doc_id
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 
@@ -38,6 +41,36 @@ class TestWebIngestionPipeline:
             chunk_size=500,
             chunk_overlap=100,
         )
+
+    def test_callback_accepts_ingestion_result_requires_one_arg_callable(self):
+        def no_args():
+            return None
+
+        def one_required(result):
+            return result
+
+        def one_optional(result=None):
+            return result
+
+        def two_required(result, extra):
+            return result, extra
+
+        def one_required_one_optional(result, extra=None):
+            return result, extra
+
+        def varargs(*args):
+            return args
+
+        def keyword_only(*, result):
+            return result
+
+        assert not _callback_accepts_ingestion_result(no_args)
+        assert _callback_accepts_ingestion_result(one_required)
+        assert _callback_accepts_ingestion_result(one_optional)
+        assert not _callback_accepts_ingestion_result(two_required)
+        assert _callback_accepts_ingestion_result(one_required_one_optional)
+        assert _callback_accepts_ingestion_result(varargs)
+        assert not _callback_accepts_ingestion_result(keyword_only)
 
     @pytest.mark.asyncio
     async def test_successful_web_ingestion(self, crawl_config, ingestion_config):
@@ -903,3 +936,269 @@ class TestWebIngestionFileHandler:
                 assert call_kwargs["file_id"] is None
                 # source_path should be the temporary file path
                 assert "xagent_web_ingest" in call_kwargs["source_path"]
+
+    @pytest.mark.asyncio
+    async def test_file_handler_rollback_runs_on_ingestion_error_result(
+        self, crawl_config, ingestion_config
+    ):
+        """File persistence should be compensated when per-page ingestion fails."""
+        events: list[tuple[str, Optional[IngestionResult]]] = []
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title="Page 1",
+                content_markdown="# Page 1\n\nContent.",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=20,
+            )
+        ]
+        failed_ingestion = IngestionResult(
+            status="error",
+            doc_id="doc1",
+            parse_hash="hash1",
+            message="embedding failed",
+        )
+
+        def file_handler(
+            temp_file_path: Path, title: str, collection: str, url: str
+        ) -> dict[str, Any]:
+            return {
+                "file_path": str(temp_file_path),
+                "file_id": "file-1",
+                "rollback_on_failure": lambda result=None: events.append(
+                    ("rollback", result)
+                ),
+                "commit_on_success": lambda result=None: events.append(
+                    ("commit", result)
+                ),
+            }
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 1
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion."
+                "run_document_ingestion",
+                return_value=failed_ingestion,
+            ):
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    file_handler=file_handler,
+                )
+
+        assert result.status == "error"
+        assert events == [("rollback", failed_ingestion)]
+
+    @pytest.mark.asyncio
+    async def test_file_handler_rollback_runs_on_ingestion_exception(
+        self, crawl_config, ingestion_config
+    ):
+        """Raised per-page ingestion failures should also compensate persistence."""
+        events: list[tuple[str, Optional[IngestionResult]]] = []
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title="Page 1",
+                content_markdown="# Page 1\n\nContent.",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=20,
+            )
+        ]
+
+        def file_handler(
+            temp_file_path: Path, title: str, collection: str, url: str
+        ) -> dict[str, Any]:
+            return {
+                "file_path": str(temp_file_path),
+                "file_id": "file-1",
+                "rollback_on_failure": lambda result=None: events.append(
+                    ("rollback", result)
+                ),
+                "commit_on_success": lambda result=None: events.append(
+                    ("commit", result)
+                ),
+            }
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 1
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion."
+                "run_document_ingestion",
+                side_effect=RuntimeError("boom"),
+            ):
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    file_handler=file_handler,
+                )
+
+        assert result.status == "error"
+        assert events == [("rollback", None)]
+
+    @pytest.mark.asyncio
+    async def test_file_handler_rollback_failure_forces_error_status(
+        self, crawl_config, ingestion_config
+    ):
+        """A failed compensating rollback is surfaced as an overall error."""
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title="Page 1",
+                content_markdown="# Page 1\n\nContent.",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=20,
+            ),
+            MagicMock(
+                url="https://example.com/page2",
+                title="Page 2",
+                content_markdown="# Page 2\n\nContent.",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=20,
+            ),
+        ]
+        successful_ingestion = IngestionResult(
+            status="success",
+            doc_id="doc1",
+            parse_hash="hash1",
+            chunk_count=1,
+            embedding_count=1,
+            vector_count=1,
+            message="ok",
+        )
+        failed_ingestion = IngestionResult(
+            status="error",
+            doc_id="doc2",
+            parse_hash="hash2",
+            message="embedding failed",
+        )
+
+        def rollback(_result=None):
+            raise RuntimeError("rollback exploded")
+
+        def file_handler(
+            temp_file_path: Path, title: str, collection: str, url: str
+        ) -> dict[str, Any]:
+            return {
+                "file_path": str(temp_file_path),
+                "file_id": "file-1",
+                "rollback_on_failure": rollback,
+            }
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 2
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion."
+                "run_document_ingestion",
+                side_effect=[successful_ingestion, failed_ingestion],
+            ):
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    file_handler=file_handler,
+                )
+
+        assert result.status == "error"
+        assert result.documents_created == 1
+        assert (
+            result.message
+            == "Web ingestion rollback failed for https://example.com/page2: "
+            "rollback exploded"
+        )
+        assert any("rollback_on_failure failed" in item for item in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_file_handler_commit_runs_on_ingestion_success(
+        self, crawl_config, ingestion_config
+    ):
+        """Rollback resources should be finalized after successful ingestion."""
+        events: list[tuple[str, Optional[IngestionResult]]] = []
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title="Page 1",
+                content_markdown="# Page 1\n\nContent.",
+                status="success",
+                depth=0,
+                timestamp=datetime(2025, 1, 1, 12, 0, 0),
+                content_length=20,
+            )
+        ]
+        successful_ingestion = IngestionResult(
+            status="success",
+            doc_id="doc1",
+            parse_hash="hash1",
+            chunk_count=1,
+            embedding_count=1,
+            vector_count=1,
+            message="ok",
+        )
+
+        def file_handler(
+            temp_file_path: Path, title: str, collection: str, url: str
+        ) -> dict[str, Any]:
+            return {
+                "file_path": str(temp_file_path),
+                "file_id": "file-1",
+                "rollback_on_failure": lambda result=None: events.append(
+                    ("rollback", result)
+                ),
+                "commit_on_success": lambda result=None: events.append(
+                    ("commit", result)
+                ),
+            }
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 1
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion."
+                "run_document_ingestion",
+                return_value=successful_ingestion,
+            ):
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    file_handler=file_handler,
+                )
+
+        assert result.status == "success"
+        assert events == [("commit", successful_ingestion)]

--- a/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py
@@ -251,6 +251,30 @@ def test_metadata_store_get_collection_config_not_found(
 @patch(
     "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
 )
+def test_metadata_store_get_collection_config_read_error_raises(
+    mock_get_connection: Mock,
+) -> None:
+    """Read errors should not be conflated with a missing collection config."""
+    mock_conn = Mock()
+    mock_get_connection.return_value = mock_conn
+
+    mock_table = Mock()
+    mock_table.schema = Mock(names=[])
+    mock_conn.open_table.return_value = mock_table
+    mock_table.search.return_value.where.return_value.to_arrow.side_effect = (
+        RuntimeError("read failed")
+    )
+
+    store = LanceDBMetadataStore()
+    with pytest.raises(RuntimeError, match="read failed"):
+        asyncio.run(
+            store.get_collection_config(collection="test_collection", user_id=1)
+        )
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.storage.lancedb_stores.get_connection_from_env"
+)
 def test_metadata_store_get_collection_config_admin_picks_newest(
     mock_get_connection: Mock,
 ) -> None:

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2125,6 +2125,7 @@ def test_kb_ingest_setup_failure_cleans_new_collection_config(test_env, temp_upl
     app, headers, _user, _ = test_env
     client = TestClient(app, raise_server_exceptions=False)
     metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
     metadata_store.save_collection_config = AsyncMock()
     metadata_store.delete_collection_metadata = AsyncMock(
         return_value={"metadata_rows": 0, "config_rows": 1}
@@ -2154,6 +2155,174 @@ def test_kb_ingest_setup_failure_cleans_new_collection_config(test_env, temp_upl
         is_admin=False,
         delete_orphaned_metadata=True,
     )
+
+
+def test_kb_ingest_existing_collection_failure_restores_previous_config(
+    test_env, temp_uploads
+) -> None:
+    """Failed direct ingest should not replace an existing collection config."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app, raise_server_exceptions=False)
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":111}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", return_value=MagicMock()),
+        patch(
+            "xagent.web.api.kb._upsert_uploaded_file_record",
+            return_value=MagicMock(file_id="file-1"),
+        ),
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="error",
+                doc_id="doc-1",
+                parse_hash="",
+                failed_step="parse_document",
+                message="ingestion failed",
+            ),
+        ),
+        patch("xagent.web.api.kb._rollback_failed_ingestion", new_callable=AsyncMock),
+    ):
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": ("test_doc.txt", b"content", "text/plain")},
+            data={"collection": "existing_collection", "chunk_size": "2048"},
+            headers=headers,
+        )
+
+    assert response.status_code == 500
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "existing_collection",
+        "config_json": '{"chunk_size":111}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+
+
+def test_kb_ingest_config_only_collection_failure_restores_previous_config(
+    test_env, temp_uploads
+) -> None:
+    """A saved config without collection metadata is still pre-existing state."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app, raise_server_exceptions=False)
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":111}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", side_effect=ValueError("new")),
+        patch(
+            "xagent.web.api.kb._upsert_uploaded_file_record",
+            return_value=MagicMock(file_id="file-1"),
+        ),
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="error",
+                doc_id="doc-1",
+                parse_hash="",
+                failed_step="parse_document",
+                message="ingestion failed",
+            ),
+        ),
+        patch("xagent.web.api.kb._rollback_failed_ingestion", new_callable=AsyncMock),
+    ):
+        response = client.post(
+            "/api/kb/ingest",
+            files={"file": ("test_doc.txt", b"content", "text/plain")},
+            data={"collection": "config_only_collection", "chunk_size": "2048"},
+            headers=headers,
+        )
+
+    assert response.status_code == 500
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "config_only_collection",
+        "config_json": '{"chunk_size":111}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+    metadata_store.delete_collection.assert_awaited_once_with("config_only_collection")
+
+
+@pytest.mark.asyncio
+async def test_failed_ingest_config_restore_skips_delete_when_snapshot_unknown() -> (
+    None
+):
+    """Unknown prior config state should not be treated as an empty old config."""
+    from xagent.web.api.kb import (
+        _CollectionConfigSnapshot,
+        _restore_collection_config_after_failed_ingest,
+    )
+
+    metadata_store = MagicMock()
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+
+    await _restore_collection_config_after_failed_ingest(
+        snapshot=_CollectionConfigSnapshot(
+            metadata_store=metadata_store,
+            collection="existing_collection",
+            user_id=1,
+            previous_config_json=None,
+            previous_config_known=False,
+            saved=True,
+        ),
+        collection_existed_before=True,
+        context="unit-test",
+    )
+
+    metadata_store.save_collection_config.assert_not_awaited()
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_collection_config_snapshot_failure_does_not_save_new_config() -> None:
+    """If the old config cannot be read, failed ingests must not leave a new config."""
+    from xagent.web.api.kb import _save_collection_config_with_snapshot
+
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(side_effect=RuntimeError("boom"))
+    metadata_store.save_collection_config = AsyncMock()
+    user = MagicMock(id=1)
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+        return_value=metadata_store,
+    ):
+        snapshot = await _save_collection_config_with_snapshot(
+            collection="existing_collection",
+            config_json='{"chunk_size":2048}',
+            user=user,
+            context="unit-test",
+        )
+
+    assert snapshot.saved is False
+    assert snapshot.previous_config_known is False
+    metadata_store.save_collection_config.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2204,6 +2373,7 @@ def test_kb_ingest_cloud_all_failures_clean_new_collection_config(test_env) -> N
     app, headers, _user, _ = test_env
     client = TestClient(app)
     metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
     metadata_store.save_collection_config = AsyncMock()
     metadata_store.delete_collection_metadata = AsyncMock(
         return_value={"metadata_rows": 0, "config_rows": 1}
@@ -2236,6 +2406,186 @@ def test_kb_ingest_cloud_all_failures_clean_new_collection_config(test_env) -> N
         is_admin=False,
         delete_orphaned_metadata=True,
     )
+
+
+def test_kb_ingest_cloud_existing_collection_all_failures_restores_config(
+    test_env,
+) -> None:
+    """All-failed cloud ingest should restore config for existing collections."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":222}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", return_value=MagicMock()),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_existing_collection",
+                "chunk_size": 2048,
+                "files": [
+                    {
+                        "provider": "unsupported",
+                        "fileId": "file-1",
+                        "fileName": "doc.txt",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "error"
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "cloud_existing_collection",
+        "config_json": '{"chunk_size":222}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+
+
+def test_kb_ingest_cloud_config_only_collection_all_failures_restores_config(
+    test_env,
+) -> None:
+    """Cloud ingest must restore config-only collection state on failure."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":333}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", side_effect=ValueError("new")),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_config_only_collection",
+                "chunk_size": 2048,
+                "files": [
+                    {
+                        "provider": "unsupported",
+                        "fileId": "file-1",
+                        "fileName": "doc.txt",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "error"
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "cloud_config_only_collection",
+        "config_json": '{"chunk_size":333}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+    metadata_store.delete_collection.assert_awaited_once_with(
+        "cloud_config_only_collection"
+    )
+
+
+def test_kb_ingest_cloud_existing_collection_mixed_failure_restores_config(
+    test_env, temp_uploads
+) -> None:
+    """A mixed cloud ingest should not commit new config for an existing collection."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":444}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+
+    class _FakeFilesService:
+        def get_media(self, fileId: str):
+            return {"fileId": fileId}
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FakeDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"cloud-content")
+            return None, True
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", return_value=MagicMock()),
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FakeDownloader),
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="success",
+                doc_id="cloud-doc-id",
+                parse_hash="hash",
+                message="success",
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_existing_collection",
+                "chunk_size": 2048,
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-file-1",
+                        "fileName": "doc.txt",
+                    },
+                    {
+                        "provider": "unsupported",
+                        "fileId": "file-2",
+                        "fileName": "bad.txt",
+                    },
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert [item["status"] for item in response.json()] == ["success", "error"]
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "cloud_existing_collection",
+        "config_json": '{"chunk_size":444}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
 
 
 def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -934,6 +934,7 @@ def test_ingest_job_uses_staged_snapshot_in_payload(app_with_kb):
             captured_payload["file_sha256"]
             == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         )
+        metadata_store.save_collection_config.assert_not_awaited()
 
 
 def test_ingest_web_job_payload_records_new_collection_state(app_with_kb):
@@ -996,7 +997,7 @@ def test_ingest_web_job_payload_records_new_collection_state(app_with_kb):
     assert captured_payload["collection_existed_before"] is False
 
 
-def test_ingest_web_job_cleans_new_collection_metadata_when_enqueue_fails(
+def test_ingest_web_job_does_not_write_collection_config_when_enqueue_fails(
     app_with_kb,
 ):
     def fake_create_background_job(db, *, payload, **kwargs):
@@ -1057,12 +1058,8 @@ def test_ingest_web_job_cleans_new_collection_metadata_when_enqueue_fails(
         )
 
     assert response.status_code == 503
-    metadata_store.delete_collection_metadata.assert_awaited_once_with(
-        collection_name="web_jobs_enqueue_failure",
-        user_id=1,
-        is_admin=False,
-        delete_orphaned_metadata=True,
-    )
+    metadata_store.save_collection_config.assert_not_awaited()
+    metadata_store.delete_collection_metadata.assert_not_awaited()
 
 
 def test_ingest_separators_invalid_json_request_succeeds_uses_default(
@@ -1456,6 +1453,58 @@ def test_ingest_web_error_with_successful_docs_keeps_new_collection_config(
     metadata_store.delete_collection_metadata.assert_not_awaited()
     metadata_store.save_collection_config.assert_awaited_once()
     metadata_store.delete_collection.assert_not_awaited()
+
+
+def test_ingest_web_error_with_rollback_side_effects_keeps_new_collection_config(
+    app_with_kb,
+):
+    """A single-page rollback failure should not orphan rows by deleting config."""
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.web.api.kb.get_collection_sync", side_effect=ValueError("missing")
+        ),
+        patch(
+            "xagent.web.api.kb.run_web_ingestion",
+            return_value=WebIngestionResult(
+                status="error",
+                collection="web_new_collection",
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=["https://example.com/page"],
+                failed_urls={"https://example.com/page": "rollback failed"},
+                message="rollback failed",
+                warnings=[],
+                elapsed_time_ms=0,
+                side_effects_may_remain=True,
+            ),
+        ),
+    ):
+        client = TestClient(app_with_kb)
+        response = client.post(
+            "/api/kb/ingest-web",
+            data={
+                "collection": "web_new_collection",
+                "start_url": "https://example.com",
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.json()["side_effects_may_remain"] is True
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+    metadata_store.save_collection_config.assert_awaited_once()
 
 
 def test_ingest_web_existing_collection_error_restores_previous_config(app_with_kb):

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -1355,6 +1355,7 @@ def test_ingest_web_hostless_url_returns_422(app_with_kb, start_url):
 def test_ingest_web_error_cleans_new_collection_config(app_with_kb):
     """POST ingest-web should clean saved config when a new collection fails before any docs are created."""
     metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
     metadata_store.save_collection_config = AsyncMock()
     metadata_store.delete_collection_metadata = AsyncMock(
         return_value={"metadata_rows": 0, "config_rows": 1}
@@ -1405,9 +1406,234 @@ def test_ingest_web_error_cleans_new_collection_config(app_with_kb):
     )
 
 
+def test_ingest_web_error_with_successful_docs_keeps_new_collection_config(
+    app_with_kb,
+):
+    """Rollback failures surface as error without deleting config used by successful pages."""
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch(
+            "xagent.web.api.kb.get_collection_sync", side_effect=ValueError("missing")
+        ),
+        patch(
+            "xagent.web.api.kb.run_web_ingestion",
+            return_value=WebIngestionResult(
+                status="error",
+                collection="web_new_collection",
+                total_urls_found=2,
+                pages_crawled=2,
+                pages_failed=1,
+                documents_created=1,
+                chunks_created=1,
+                embeddings_created=1,
+                crawled_urls=["https://example.com/ok"],
+                failed_urls={"https://example.com/bad": "rollback failed"},
+                message="rollback failed",
+                warnings=[],
+                elapsed_time_ms=0,
+            ),
+        ),
+    ):
+        client = TestClient(app_with_kb)
+        response = client.post(
+            "/api/kb/ingest-web",
+            data={
+                "collection": "web_new_collection",
+                "start_url": "https://example.com",
+            },
+        )
+
+    assert response.status_code == 500
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+    metadata_store.save_collection_config.assert_awaited_once()
+    metadata_store.delete_collection.assert_not_awaited()
+
+
+def test_ingest_web_existing_collection_error_restores_previous_config(app_with_kb):
+    """POST ingest-web should restore old config when an existing collection fails."""
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":333}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", return_value=MagicMock()),
+        patch(
+            "xagent.web.api.kb.run_web_ingestion",
+            return_value=WebIngestionResult(
+                status="error",
+                collection="web_existing_collection",
+                total_urls_found=1,
+                pages_crawled=0,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[],
+                failed_urls={"https://example.com": "crawl failed"},
+                message="crawl failed",
+                warnings=[],
+                elapsed_time_ms=0,
+            ),
+        ),
+    ):
+        client = TestClient(app_with_kb)
+        response = client.post(
+            "/api/kb/ingest-web",
+            data={
+                "collection": "web_existing_collection",
+                "start_url": "https://example.com",
+                "chunk_size": "2048",
+            },
+        )
+
+    assert response.status_code == 500
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "web_existing_collection",
+        "config_json": '{"chunk_size":333}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+
+
+def test_ingest_web_config_only_collection_error_restores_previous_config(
+    app_with_kb,
+):
+    """A config-only web collection should restore old config on failed ingest."""
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":333}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+    metadata_store.delete_collection = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch(
+            "xagent.web.api.kb.get_collection_sync", side_effect=ValueError("missing")
+        ),
+        patch(
+            "xagent.web.api.kb.run_web_ingestion",
+            return_value=WebIngestionResult(
+                status="error",
+                collection="web_config_only_collection",
+                total_urls_found=1,
+                pages_crawled=0,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[],
+                failed_urls={"https://example.com": "crawl failed"},
+                message="crawl failed",
+                warnings=[],
+                elapsed_time_ms=0,
+            ),
+        ),
+    ):
+        client = TestClient(app_with_kb)
+        response = client.post(
+            "/api/kb/ingest-web",
+            data={
+                "collection": "web_config_only_collection",
+                "start_url": "https://example.com",
+                "chunk_size": "2048",
+            },
+        )
+
+    assert response.status_code == 500
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "web_config_only_collection",
+        "config_json": '{"chunk_size":333}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+    metadata_store.delete_collection.assert_awaited_once_with(
+        "web_config_only_collection"
+    )
+
+
+def test_ingest_web_existing_collection_partial_restores_previous_config(app_with_kb):
+    """POST ingest-web should restore old config when an existing collection is partial."""
+    metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value='{"chunk_size":555}')
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.delete_collection_metadata = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=metadata_store,
+        ),
+        patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
+        patch("xagent.web.api.kb.get_collection_sync", return_value=MagicMock()),
+        patch(
+            "xagent.web.api.kb.run_web_ingestion",
+            return_value=WebIngestionResult(
+                status="partial",
+                collection="web_existing_collection",
+                total_urls_found=2,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=1,
+                chunks_created=1,
+                embeddings_created=1,
+                crawled_urls=["https://example.com/ok"],
+                failed_urls={"https://example.com/bad": "embedding failed"},
+                message="partial failure",
+                warnings=[],
+                elapsed_time_ms=0,
+            ),
+        ),
+    ):
+        client = TestClient(app_with_kb)
+        response = client.post(
+            "/api/kb/ingest-web",
+            data={
+                "collection": "web_existing_collection",
+                "start_url": "https://example.com",
+                "chunk_size": "2048",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "partial"
+    assert metadata_store.save_collection_config.await_count == 2
+    restore_call = metadata_store.save_collection_config.await_args_list[-1]
+    assert restore_call.kwargs == {
+        "collection": "web_existing_collection",
+        "config_json": '{"chunk_size":555}',
+        "user_id": 1,
+    }
+    metadata_store.delete_collection_metadata.assert_not_awaited()
+
+
 def test_ingest_web_surfaces_embedding_configuration_fix_guidance(app_with_kb):
     """POST ingest-web should explain how to fix embedding configuration errors."""
     metadata_store = MagicMock()
+    metadata_store.get_collection_config = AsyncMock(return_value=None)
     metadata_store.save_collection_config = AsyncMock()
     metadata_store.delete_collection_metadata = AsyncMock(
         return_value={"metadata_rows": 0, "config_rows": 1}

--- a/tests/web/api/test_kb_web_ingestion_uploaded_file.py
+++ b/tests/web/api/test_kb_web_ingestion_uploaded_file.py
@@ -670,6 +670,8 @@ class TestWebIngestionUploadedFilePersistence:
                         temp_file_path=temp_file_path,
                         db_session=db_session,
                         user_id=int(mock_user.id),
+                        is_admin=False,
+                        collection_name="test_collection",
                         url="https://example.com/page",
                         filename="existing.md",
                         url_hash="hash",
@@ -1318,15 +1320,7 @@ class TestIngestWebHandleWebFile:
             from xagent.core.tools.core.RAG_tools.core.schemas import WebIngestionResult
             from xagent.web.services.managed_file_ref import build_upload_storage_key
 
-            captured["storage_key"] = build_upload_storage_key(
-                user.id,
-                captured["file_id"],
-                filename,
-            )
-            assert expected_persistent.exists()
-            assert get_file_storage().exists(captured["storage_key"])
-
-            return WebIngestionResult(
+            result = WebIngestionResult(
                 status="error",
                 collection=collection,
                 total_urls_found=1,
@@ -1341,6 +1335,16 @@ class TestIngestWebHandleWebFile:
                 warnings=[],
                 elapsed_time_ms=1,
             )
+            captured["storage_key"] = build_upload_storage_key(
+                user.id,
+                captured["file_id"],
+                filename,
+            )
+            assert expected_persistent.exists()
+            assert get_file_storage().exists(captured["storage_key"])
+
+            file_info["rollback_on_failure"](result)
+            return result
 
         with (
             patch(

--- a/tests/web/api/test_kb_web_ingestion_uploaded_file.py
+++ b/tests/web/api/test_kb_web_ingestion_uploaded_file.py
@@ -38,11 +38,16 @@ from xagent.web.api.kb import (
     _build_ingest_backup_path,
     _compensate_new_web_ingest_files,
     _copy_upload_file_to_path,
+    _create_web_uploaded_file_record,
+    _delete_web_rag_side_effects_for_file_id,
     _get_file_sha256,
     _mark_uploaded_file_for_reindex,
     _normalize_web_title_for_filename,
+    _RagDocumentSnapshot,
     _recreate_missing_existing_file,
     _refresh_existing_file_if_changed,
+    _restore_rag_snapshot_rows,
+    _rollback_failed_web_document_ingestion,
     _upsert_uploaded_file_record,
     _WebFileLock,
     kb_router,
@@ -468,34 +473,148 @@ class TestWebIngestionUploadedFilePersistence:
         )
 
         def failing_upsert(*_args, **_kwargs):
+            from xagent.web.services.uploaded_file_store import UploadedFileStore
+
+            UploadedFileStore(db_session).sync_existing(
+                existing_record,
+                storage_key=str(existing_record.storage_key),
+                mime_type="text/markdown",
+            )
+            db_session.commit()
             raise RuntimeError("durable sync failed")
 
-        with patch(
-            "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
-        ):
-            with patch(
+        ingestion_runs_snapshot = object()
+        with (
+            patch(
+                "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=ingestion_runs_snapshot,
+            ) as mock_snapshot_runs,
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+            patch(
                 "xagent.web.api.kb._atomic_replace_file",
                 wraps=_atomic_replace_file,
-            ) as atomic_replace:
-                with patch(
-                    "xagent.web.api.kb._upsert_uploaded_file_record",
-                    side_effect=failing_upsert,
-                ):
-                    with pytest.raises(RuntimeError, match="durable sync failed"):
-                        _refresh_existing_file_if_changed(
-                            existing_record=existing_record,
-                            temp_file_path=temp_file_path,
-                            db_session=db_session,
-                            user_id=int(mock_user.id),
-                            url="https://example.com/page",
-                            filename="existing.md",
-                            url_hash="hash",
-                            processed_urls={},
-                            context="cross-session",
-                        )
+            ) as atomic_replace,
+            patch(
+                "xagent.web.api.kb._upsert_uploaded_file_record",
+                side_effect=failing_upsert,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="durable sync failed"):
+                _refresh_existing_file_if_changed(
+                    existing_record=existing_record,
+                    temp_file_path=temp_file_path,
+                    db_session=db_session,
+                    user_id=int(mock_user.id),
+                    is_admin=False,
+                    collection_name="test_collection",
+                    url="https://example.com/page",
+                    filename="existing.md",
+                    url_hash="hash",
+                    processed_urls={},
+                    context="cross-session",
+                )
 
         assert atomic_replace.called
         assert existing_path.read_text(encoding="utf-8") == "old content"
+        with get_file_storage().open_read(str(existing_record.storage_key)) as handle:
+            assert handle.read() == b"old content"
+        mock_snapshot_runs.assert_called_once_with(str(existing_record.file_id))
+        mock_restore_runs.assert_called_once_with(ingestion_runs_snapshot)
+
+    def test_refresh_existing_file_restores_ingestion_runs_when_backup_fails(
+        self,
+        db_session: Session,
+        test_user: User,
+        mock_user: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        existing_path = tmp_path / "existing.md"
+        existing_path.write_text("old content", encoding="utf-8")
+        temp_file_path = tmp_path / "incoming.md"
+        temp_file_path.write_text("new content", encoding="utf-8")
+
+        existing_record = _upsert_uploaded_file_record(
+            db_session,
+            user_id=int(mock_user.id),
+            filename="existing.md",
+            storage_path=existing_path,
+            mime_type="text/markdown",
+            file_size=existing_path.stat().st_size,
+        )
+
+        ingestion_runs_snapshot = object()
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=ingestion_runs_snapshot,
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+            ),
+            patch("xagent.web.api.kb.shutil.copy2", side_effect=OSError("disk full")),
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                _refresh_existing_file_if_changed(
+                    existing_record=existing_record,
+                    temp_file_path=temp_file_path,
+                    db_session=db_session,
+                    user_id=int(mock_user.id),
+                    is_admin=False,
+                    collection_name="test_collection",
+                    url="https://example.com/page",
+                    filename="existing.md",
+                    url_hash="hash",
+                    processed_urls={},
+                    context="cross-session",
+                )
+
+        assert existing_path.read_text(encoding="utf-8") == "old content"
+        mock_restore_runs.assert_called_once_with(ingestion_runs_snapshot)
+
+    def test_create_web_uploaded_file_record_cleans_durable_when_commit_fails(
+        self,
+        db_session: Session,
+        test_user: User,
+        mock_user: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+        get_file_storage.cache_clear()
+
+        persistent_file = tmp_path / "uploads" / "web.md"
+        persistent_file.parent.mkdir(parents=True)
+        persistent_file.write_text("new content", encoding="utf-8")
+
+        with patch.object(db_session, "commit", side_effect=RuntimeError("db down")):
+            with pytest.raises(RuntimeError, match="db down"):
+                _create_web_uploaded_file_record(
+                    db_session,
+                    user_id=int(mock_user.id),
+                    filename="web.md",
+                    storage_path=persistent_file,
+                    mime_type="text/markdown",
+                )
+
+        rows = db_session.query(UploadedFile).all()
+        assert rows == []
+        assert get_file_storage().list("users") == []
 
     def test_refresh_existing_file_rolls_back_failed_upsert_before_restore(
         self,
@@ -596,20 +715,33 @@ class TestWebIngestionUploadedFilePersistence:
         existing_path.unlink()
 
         processed_urls: dict[str, str] = {}
-        result = _refresh_existing_file_if_changed(
-            existing_record=existing_record,
-            temp_file_path=temp_file_path,
-            db_session=db_session,
-            user_id=int(mock_user.id),
-            url="https://example.com/page",
-            filename="existing.md",
-            url_hash="hash",
-            processed_urls=processed_urls,
-            context="cross-session",
-        )
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+        ):
+            result = _refresh_existing_file_if_changed(
+                existing_record=existing_record,
+                temp_file_path=temp_file_path,
+                db_session=db_session,
+                user_id=int(mock_user.id),
+                is_admin=False,
+                collection_name="test_collection",
+                url="https://example.com/page",
+                filename="existing.md",
+                url_hash="hash",
+                processed_urls=processed_urls,
+                context="cross-session",
+            )
 
         assert result is not None
         assert result["file_id"] == str(existing_record.file_id)
+        assert callable(result["rollback_on_failure"])
         assert existing_path.read_text(encoding="utf-8") == "old content"
         assert processed_urls == {}
 
@@ -644,14 +776,26 @@ class TestWebIngestionUploadedFilePersistence:
         existing_path.unlink()
 
         processed_urls: dict[str, str] = {}
-        with patch(
-            "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+        with (
+            patch(
+                "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
         ):
             result = _refresh_existing_file_if_changed(
                 existing_record=existing_record,
                 temp_file_path=temp_file_path,
                 db_session=db_session,
                 user_id=int(mock_user.id),
+                is_admin=False,
+                collection_name="test_collection",
                 url="https://example.com/page",
                 filename="existing.md",
                 url_hash="hash",
@@ -687,9 +831,20 @@ class TestWebIngestionUploadedFilePersistence:
         def failing_upsert(*_args, **_kwargs):
             raise RuntimeError("durable sync failed")
 
-        with patch(
-            "xagent.web.api.kb._upsert_uploaded_file_record",
-            side_effect=failing_upsert,
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch("xagent.web.api.kb._restore_ingestion_runs_snapshot"),
+            patch(
+                "xagent.web.api.kb._upsert_uploaded_file_record",
+                side_effect=failing_upsert,
+            ),
         ):
             with pytest.raises(RuntimeError, match="durable sync failed"):
                 _recreate_missing_existing_file(
@@ -697,12 +852,114 @@ class TestWebIngestionUploadedFilePersistence:
                     temp_file_path=temp_file_path,
                     db_session=db_session,
                     user_id=int(mock_user.id),
+                    is_admin=False,
+                    collection_name="test_collection",
                     filename="existing.md",
                     url_hash="hash",
                     processed_urls={},
                 )
 
         assert not existing_path.exists()
+
+    def test_recreate_missing_existing_file_restores_after_post_commit_upsert_failure(
+        self,
+        db_session: Session,
+        test_user: User,
+        mock_user: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+        get_file_storage.cache_clear()
+
+        existing_path = tmp_path / "uploads" / "existing.md"
+        existing_path.parent.mkdir(parents=True)
+        existing_path.write_text("old content", encoding="utf-8")
+        temp_file_path = tmp_path / "incoming.md"
+        temp_file_path.write_text("new content", encoding="utf-8")
+
+        existing_record = _upsert_uploaded_file_record(
+            db_session,
+            user_id=int(mock_user.id),
+            filename="existing.md",
+            storage_path=existing_path,
+            mime_type="text/markdown",
+            file_size=existing_path.stat().st_size,
+        )
+        old_file_id = str(existing_record.file_id)
+        old_storage_key = str(existing_record.storage_key)
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+        from xagent.web.services.uploaded_file_store import UploadedFileStore
+
+        ManagedFileRef(existing_record).delete_durable()
+        existing_path.unlink()
+
+        def failing_upsert(
+            db_session_arg: Session,
+            *,
+            user_id: int,
+            filename: str,
+            storage_path: Path,
+            mime_type: str,
+            file_size: int,
+        ) -> UploadedFile:
+            refreshed_record = (
+                db_session_arg.query(UploadedFile)
+                .filter(UploadedFile.file_id == old_file_id)
+                .first()
+            )
+            assert refreshed_record is not None
+            refreshed_record.filename = filename
+            refreshed_record.file_size = file_size
+            UploadedFileStore(db_session_arg).sync_existing(
+                refreshed_record,
+                storage_key=old_storage_key,
+                mime_type=mime_type,
+            )
+            db_session_arg.commit()
+            raise RuntimeError("post-commit failure")
+
+        ingestion_runs_snapshot = object()
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=ingestion_runs_snapshot,
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+            patch(
+                "xagent.web.api.kb._upsert_uploaded_file_record",
+                side_effect=failing_upsert,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="post-commit failure"):
+                _recreate_missing_existing_file(
+                    existing_record=existing_record,
+                    temp_file_path=temp_file_path,
+                    db_session=db_session,
+                    user_id=int(mock_user.id),
+                    is_admin=False,
+                    collection_name="test_collection",
+                    filename="existing.md",
+                    url_hash="hash",
+                    processed_urls={},
+                )
+
+        assert not existing_path.exists()
+        assert get_file_storage().list("users") == []
+        row = (
+            db_session.query(UploadedFile)
+            .filter(UploadedFile.file_id == old_file_id)
+            .first()
+        )
+        assert row is not None
+        assert row.storage_key == old_storage_key
+        mock_restore_runs.assert_called_once_with(ingestion_runs_snapshot)
 
     def test_in_memory_cache_deduplication(
         self, db_session: Session, test_user: User, mock_user: MagicMock
@@ -995,7 +1252,7 @@ class TestIngestWebHandleWebFile:
                 "xagent.web.api.kb.get_session_local", return_value=TestingSessionLocal
             ),
             patch(
-                "xagent.web.api.kb._upsert_uploaded_file_record",
+                "xagent.web.api.kb._create_web_uploaded_file_record",
                 side_effect=boom_upsert,
             ),
             patch(
@@ -1119,9 +1376,605 @@ class TestIngestWebHandleWebFile:
         finally:
             session.close()
 
+    def test_ingest_web_failure_callback_removes_new_uploaded_file(
+        self, web_test_env, tmp_path: Path
+    ) -> None:
+        """The route-provided file handler should compensate new file records on failure."""
+        app, headers, user, TestingSessionLocal = web_test_env
+        client = TestClient(app)
+
+        uploads_root = tmp_path / "uploads"
+        import hashlib
+
+        url = "https://example.com/page"
+        collection = "c1"
+        title = "How to edit a completed job?"
+        url_hash = hashlib.sha256(f"{collection}:{url}".encode()).hexdigest()[:16]
+        filename = f"{url_hash}_{_normalize_web_title_for_filename(title)}.md"
+        expected_persistent = uploads_root / f"user_{user.id}" / collection / filename
+
+        def patched_get_upload_path(
+            filename_arg: str,
+            *,
+            user_id: int,
+            collection: str,
+            collection_is_sanitized: bool,
+        ) -> Path:
+            assert filename_arg == filename
+            return uploads_root / f"user_{user_id}" / collection / filename_arg
+
+        async def stub_run_web_ingestion(
+            *,
+            collection: str,
+            crawl_config,
+            ingestion_config,
+            user_id: int,
+            is_admin: bool,
+            file_handler,
+        ):
+            temp_md = tmp_path / "temp.md"
+            temp_md.write_text("# Title\n\nBody", encoding="utf-8")
+            file_info = file_handler(temp_md, title, collection, url)
+            assert callable(file_info["rollback_on_failure"])
+
+            from xagent.core.tools.core.RAG_tools.core.schemas import (
+                IngestionResult,
+                IngestionStepResult,
+                WebIngestionResult,
+            )
+
+            file_info["rollback_on_failure"](
+                IngestionResult(
+                    status="partial",
+                    doc_id="doc-1",
+                    parse_hash="hash",
+                    completed_steps=[
+                        IngestionStepResult(
+                            name="register_document",
+                            metadata={"doc_id": "doc-1", "created": True},
+                        )
+                    ],
+                    failed_step="embed_chunks",
+                    message="embedding failed",
+                )
+            )
+
+            return WebIngestionResult(
+                status="error",
+                collection=collection,
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[url],
+                failed_urls={url: "ingestion failed"},
+                message="ingestion failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        with (
+            patch(
+                "xagent.web.api.kb.get_upload_path", side_effect=patched_get_upload_path
+            ),
+            patch(
+                "xagent.web.api.kb.get_session_local", return_value=TestingSessionLocal
+            ),
+            patch(
+                "xagent.web.api.kb.run_web_ingestion",
+                side_effect=stub_run_web_ingestion,
+            ),
+            patch("xagent.web.api.kb.delete_document") as mock_delete_document,
+        ):
+            mock_delete_document.return_value = MagicMock(status="success")
+            response = client.post(
+                "/api/kb/ingest-web",
+                data={"collection": collection, "start_url": "https://example.com"},
+                headers=headers,
+            )
+
+        assert response.status_code == 500
+        assert not expected_persistent.exists()
+        mock_delete_document.assert_called_once_with(
+            collection, "doc-1", user.id, False
+        )
+
+        session = TestingSessionLocal()
+        try:
+            rows = (
+                session.query(UploadedFile)
+                .filter(UploadedFile.user_id == user.id)
+                .all()
+            )
+            assert rows == []
+        finally:
+            session.close()
+
+    def test_ingest_web_failure_callback_restores_refreshed_existing_file(
+        self, web_test_env, tmp_path: Path
+    ) -> None:
+        """A refreshed existing web file should be restored when ingestion fails."""
+        app, headers, user, TestingSessionLocal = web_test_env
+        client = TestClient(app)
+
+        uploads_root = tmp_path / "uploads"
+        import hashlib
+
+        url = "https://example.com/page"
+        collection = "c1"
+        title = "How to edit a completed job?"
+        url_hash = hashlib.sha256(f"{collection}:{url}".encode()).hexdigest()[:16]
+        filename = f"{url_hash}_{_normalize_web_title_for_filename(title)}.md"
+        persistent_file = uploads_root / f"user_{user.id}" / collection / filename
+        persistent_file.parent.mkdir(parents=True)
+        persistent_file.write_text("old content", encoding="utf-8")
+
+        session = TestingSessionLocal()
+        try:
+            existing_record = _upsert_uploaded_file_record(
+                session,
+                user_id=user.id,
+                filename=filename,
+                storage_path=persistent_file,
+                mime_type="text/markdown",
+                file_size=persistent_file.stat().st_size,
+            )
+            existing_file_id = str(existing_record.file_id)
+        finally:
+            session.close()
+
+        def patched_get_upload_path(
+            filename_arg: str,
+            *,
+            user_id: int,
+            collection: str,
+            collection_is_sanitized: bool,
+        ) -> Path:
+            assert filename_arg == filename
+            return uploads_root / f"user_{user_id}" / collection / filename_arg
+
+        async def stub_run_web_ingestion(
+            *,
+            collection: str,
+            crawl_config,
+            ingestion_config,
+            user_id: int,
+            is_admin: bool,
+            file_handler,
+        ):
+            temp_md = tmp_path / "temp.md"
+            temp_md.write_text("new content", encoding="utf-8")
+            file_info = file_handler(temp_md, title, collection, url)
+            assert file_info["file_id"] == existing_file_id
+            assert persistent_file.read_text(encoding="utf-8") == "new content"
+            assert callable(file_info["rollback_on_failure"])
+
+            from xagent.core.tools.core.RAG_tools.core.schemas import WebIngestionResult
+
+            file_info["rollback_on_failure"]()
+
+            return WebIngestionResult(
+                status="error",
+                collection=collection,
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[url],
+                failed_urls={url: "ingestion failed"},
+                message="ingestion failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        with (
+            patch(
+                "xagent.web.api.kb.get_upload_path", side_effect=patched_get_upload_path
+            ),
+            patch(
+                "xagent.web.api.kb.get_session_local", return_value=TestingSessionLocal
+            ),
+            patch(
+                "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=object(),
+            ) as mock_snapshot_runs,
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ) as mock_snapshot_rag,
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+            patch(
+                "xagent.web.api.kb._restore_rag_document_snapshot"
+            ) as mock_restore_rag,
+            patch(
+                "xagent.web.api.kb.run_web_ingestion",
+                side_effect=stub_run_web_ingestion,
+            ),
+        ):
+            response = client.post(
+                "/api/kb/ingest-web",
+                data={"collection": collection, "start_url": "https://example.com"},
+                headers=headers,
+            )
+
+        assert response.status_code == 500
+        assert persistent_file.read_text(encoding="utf-8") == "old content"
+        mock_snapshot_runs.assert_called_once_with(existing_file_id)
+        mock_snapshot_rag.assert_called_once_with(
+            existing_file_id,
+            user_id=user.id,
+            is_admin=False,
+        )
+        mock_restore_runs.assert_called_once()
+        mock_restore_rag.assert_called_once_with(
+            mock_snapshot_rag.return_value,
+            user_id=user.id,
+            is_admin=False,
+        )
+
+        session = TestingSessionLocal()
+        try:
+            rows = (
+                session.query(UploadedFile)
+                .filter(UploadedFile.user_id == user.id)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].file_id == existing_file_id
+        finally:
+            session.close()
+
+    def test_ingest_web_refresh_restores_file_when_rag_restore_fails(
+        self, web_test_env, tmp_path: Path
+    ) -> None:
+        """File and UploadedFile rollback should continue even if RAG restore fails."""
+        app, headers, user, TestingSessionLocal = web_test_env
+        client = TestClient(app)
+
+        uploads_root = tmp_path / "uploads"
+        import hashlib
+
+        url = "https://example.com/page"
+        collection = "c1"
+        title = "How to edit a completed job?"
+        url_hash = hashlib.sha256(f"{collection}:{url}".encode()).hexdigest()[:16]
+        filename = f"{url_hash}_{_normalize_web_title_for_filename(title)}.md"
+        persistent_file = uploads_root / f"user_{user.id}" / collection / filename
+        persistent_file.parent.mkdir(parents=True)
+        persistent_file.write_text("old content", encoding="utf-8")
+
+        session = TestingSessionLocal()
+        try:
+            existing_record = _upsert_uploaded_file_record(
+                session,
+                user_id=user.id,
+                filename=filename,
+                storage_path=persistent_file,
+                mime_type="text/markdown",
+                file_size=persistent_file.stat().st_size,
+            )
+            existing_file_id = str(existing_record.file_id)
+        finally:
+            session.close()
+
+        def patched_get_upload_path(
+            filename_arg: str,
+            *,
+            user_id: int,
+            collection: str,
+            collection_is_sanitized: bool,
+        ) -> Path:
+            assert filename_arg == filename
+            return uploads_root / f"user_{user_id}" / collection / filename_arg
+
+        async def stub_run_web_ingestion(
+            *,
+            collection: str,
+            crawl_config,
+            ingestion_config,
+            user_id: int,
+            is_admin: bool,
+            file_handler,
+        ):
+            temp_md = tmp_path / "temp.md"
+            temp_md.write_text("new content", encoding="utf-8")
+            file_info = file_handler(temp_md, title, collection, url)
+            assert file_info["file_id"] == existing_file_id
+            assert persistent_file.read_text(encoding="utf-8") == "new content"
+
+            file_info["rollback_on_failure"]()
+
+        with (
+            patch(
+                "xagent.web.api.kb.get_upload_path", side_effect=patched_get_upload_path
+            ),
+            patch(
+                "xagent.web.api.kb.get_session_local", return_value=TestingSessionLocal
+            ),
+            patch(
+                "xagent.web.api.kb._mark_uploaded_file_for_reindex", return_value=True
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=object(),
+            ),
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+            patch(
+                "xagent.web.api.kb._restore_rag_document_snapshot",
+                side_effect=RuntimeError("rag restore failed"),
+            ),
+            patch(
+                "xagent.web.api.kb.run_web_ingestion",
+                side_effect=stub_run_web_ingestion,
+            ),
+        ):
+            response = client.post(
+                "/api/kb/ingest-web",
+                data={"collection": collection, "start_url": "https://example.com"},
+                headers=headers,
+            )
+
+        assert response.status_code == 500
+        assert persistent_file.read_text(encoding="utf-8") == "old content"
+        mock_restore_runs.assert_called_once()
+
+        session = TestingSessionLocal()
+        try:
+            rows = (
+                session.query(UploadedFile)
+                .filter(UploadedFile.user_id == user.id)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].file_id == existing_file_id
+        finally:
+            session.close()
+
 
 class TestWebFileRefreshHelpers:
     """Test helper functions for stale content refresh."""
+
+    def test_web_rollback_exception_path_deletes_docs_for_file_id(self) -> None:
+        with (
+            patch(
+                "xagent.web.api.kb._list_document_refs_for_uploaded_file",
+                return_value=[("test_collection", "doc-1")],
+            ) as mock_list_refs,
+            patch("xagent.web.api.kb.delete_document") as mock_delete_document,
+        ):
+            mock_delete_document.return_value = MagicMock(status="success")
+
+            _rollback_failed_web_document_ingestion(
+                collection_name="test_collection",
+                result=None,
+                user_id=1,
+                is_admin=False,
+                file_id="file-1",
+            )
+
+        mock_list_refs.assert_called_once_with("file-1")
+        mock_delete_document.assert_called_once_with(
+            "test_collection",
+            "doc-1",
+            1,
+            False,
+        )
+
+    def test_web_rag_side_effect_cleanup_continues_after_delete_failure(
+        self,
+    ) -> None:
+        with (
+            patch(
+                "xagent.web.api.kb._list_document_refs_for_uploaded_file",
+                return_value=[
+                    ("test_collection", "doc-1"),
+                    ("test_collection", "doc-2"),
+                ],
+            ),
+            patch("xagent.web.api.kb.delete_document") as mock_delete_document,
+        ):
+            mock_delete_document.side_effect = [
+                MagicMock(status="error", message="delete failed"),
+                MagicMock(status="success"),
+            ]
+
+            with pytest.raises(RuntimeError, match="Best-effort RAG cleanup failed"):
+                _delete_web_rag_side_effects_for_file_id(
+                    collection_name="test_collection",
+                    file_id="file-1",
+                    user_id=1,
+                    is_admin=False,
+                )
+
+        assert mock_delete_document.call_count == 2
+        assert mock_delete_document.call_args_list[0].args == (
+            "test_collection",
+            "doc-1",
+            1,
+            False,
+        )
+        assert mock_delete_document.call_args_list[1].args == (
+            "test_collection",
+            "doc-2",
+            1,
+            False,
+        )
+
+    def test_web_rollback_exception_path_uses_file_id_after_empty_snapshot(
+        self,
+    ) -> None:
+        snapshot = _RagDocumentSnapshot(doc_refs=[], rows_by_table={})
+        with (
+            patch(
+                "xagent.web.api.kb._restore_rag_document_snapshot"
+            ) as mock_restore_snapshot,
+            patch(
+                "xagent.web.api.kb._delete_web_rag_side_effects_for_file_id"
+            ) as mock_delete_for_file,
+        ):
+            _rollback_failed_web_document_ingestion(
+                collection_name="test_collection",
+                result=None,
+                user_id=1,
+                is_admin=False,
+                rag_snapshot=snapshot,
+                file_id="file-1",
+            )
+
+        mock_restore_snapshot.assert_called_once_with(
+            snapshot,
+            user_id=1,
+            is_admin=False,
+        )
+        mock_delete_for_file.assert_called_once_with(
+            collection_name="test_collection",
+            file_id="file-1",
+            user_id=1,
+            is_admin=False,
+        )
+
+    def test_restore_rag_snapshot_rows_batches_unknown_table_delete(self) -> None:
+        table = MagicMock()
+        table.schema.names = []
+
+        _restore_rag_snapshot_rows(
+            table,
+            table_name="custom_table",
+            snapshot_rows=[{"collection": "c1", "doc_id": "doc-old"}],
+            current_rows=[
+                {"collection": "c1", "doc_id": "doc-1"},
+                {"collection": "c1", "doc_id": "doc-2"},
+            ],
+            user_id=1,
+            is_admin=False,
+        )
+
+        table.delete.assert_called_once()
+        delete_filter = table.delete.call_args.args[0]
+        assert "(collection = 'c1' and doc_id = 'doc-1')" in delete_filter
+        assert "(collection = 'c1' and doc_id = 'doc-2')" in delete_filter
+        assert " or " in delete_filter
+        table.add.assert_called_once_with([{"collection": "c1", "doc_id": "doc-old"}])
+
+    def test_restore_rag_snapshot_rows_batches_stale_row_delete(self) -> None:
+        table = MagicMock()
+        table.schema.names = []
+
+        _restore_rag_snapshot_rows(
+            table,
+            table_name="chunks",
+            snapshot_rows=[
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "parse_hash": "hash",
+                    "chunk_id": "chunk-old",
+                }
+            ],
+            current_rows=[
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "parse_hash": "hash",
+                    "chunk_id": "chunk-old",
+                },
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "parse_hash": "hash",
+                    "chunk_id": "chunk-stale",
+                },
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "parse_hash": "hash",
+                    "chunk_id": "chunk-stale-2",
+                },
+            ],
+            user_id=1,
+            is_admin=False,
+        )
+
+        table.merge_insert.assert_called_once_with(
+            ["collection", "doc_id", "parse_hash", "chunk_id"]
+        )
+        table.delete.assert_called_once()
+        delete_filter = table.delete.call_args.args[0]
+        assert "chunk_id = 'chunk-old'" not in delete_filter
+        assert "(collection = 'c1'" in delete_filter
+        assert "chunk_id = 'chunk-stale'" in delete_filter
+        assert "chunk_id = 'chunk-stale-2'" in delete_filter
+        assert " or " in delete_filter
+
+    def test_restore_rag_snapshot_rows_keys_embeddings_by_parse_and_model(
+        self,
+    ) -> None:
+        table = MagicMock()
+        table.schema.names = []
+
+        _restore_rag_snapshot_rows(
+            table,
+            table_name="embeddings_text_embedding_v4",
+            snapshot_rows=[
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "chunk_id": "chunk-1",
+                    "parse_hash": "parse-old",
+                    "model": "model-a",
+                }
+            ],
+            current_rows=[
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "chunk_id": "chunk-1",
+                    "parse_hash": "parse-old",
+                    "model": "model-a",
+                },
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "chunk_id": "chunk-1",
+                    "parse_hash": "parse-new",
+                    "model": "model-a",
+                },
+                {
+                    "collection": "c1",
+                    "doc_id": "doc-1",
+                    "chunk_id": "chunk-1",
+                    "parse_hash": "parse-old",
+                    "model": "model-b",
+                },
+            ],
+            user_id=1,
+            is_admin=False,
+        )
+
+        table.merge_insert.assert_called_once_with(
+            ["collection", "doc_id", "chunk_id", "parse_hash", "model"]
+        )
+        table.delete.assert_called_once()
+        delete_filter = table.delete.call_args.args[0]
+        assert "parse_hash = 'parse-new'" in delete_filter
+        assert "model = 'model-b'" in delete_filter
+        assert "parse_hash = 'parse-old' and model = 'model-a'" not in delete_filter
+        assert " or " in delete_filter
 
     def test_get_file_sha256_changes_with_content(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1285,3 +2138,115 @@ class TestWebFileRefreshHelpers:
         assert len(deleted_filters) == 1
         assert "collection = 'kb'" in deleted_filters[0]
         assert "doc_id = 'doc-1'" in deleted_filters[0]
+
+    def test_refresh_fails_when_ingestion_run_snapshot_fails(
+        self,
+        db_session: Session,
+        test_user: User,
+        tmp_path: Path,
+    ) -> None:
+        """Existing files should not be re-ingested without a rollback snapshot."""
+        existing_path = tmp_path / "existing.md"
+        existing_path.write_text("old content", encoding="utf-8")
+        temp_path = tmp_path / "new.md"
+        temp_path.write_text("new content", encoding="utf-8")
+
+        existing_record = _upsert_uploaded_file_record(
+            db_session,
+            user_id=test_user.id,
+            filename="existing.md",
+            storage_path=existing_path,
+            mime_type="text/markdown",
+            file_size=existing_path.stat().st_size,
+        )
+        file_id = str(existing_record.file_id)
+        processed_urls: dict[str, str] = {}
+
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=None,
+            ) as mock_snapshot_runs,
+            patch("xagent.web.api.kb._mark_uploaded_file_for_reindex") as mock_mark,
+        ):
+            with pytest.raises(RuntimeError, match="snapshot ingestion status"):
+                _refresh_existing_file_if_changed(
+                    existing_record=existing_record,
+                    temp_file_path=temp_path,
+                    db_session=db_session,
+                    user_id=test_user.id,
+                    is_admin=False,
+                    collection_name="test_collection",
+                    url="https://example.com/page",
+                    filename="existing.md",
+                    url_hash="url-hash",
+                    processed_urls=processed_urls,
+                    context="unit-test",
+                )
+
+        assert existing_path.read_text(encoding="utf-8") == "old content"
+        assert processed_urls == {}
+        mock_snapshot_runs.assert_called_once_with(file_id)
+        mock_mark.assert_not_called()
+
+    def test_unchanged_existing_file_result_has_rollback_callback(
+        self,
+        db_session: Session,
+        test_user: User,
+        tmp_path: Path,
+    ) -> None:
+        existing_path = tmp_path / "existing.md"
+        existing_path.write_text("same content", encoding="utf-8")
+        temp_path = tmp_path / "incoming.md"
+        temp_path.write_text("same content", encoding="utf-8")
+        existing_record = _upsert_uploaded_file_record(
+            db_session,
+            user_id=test_user.id,
+            filename="existing.md",
+            storage_path=existing_path,
+            mime_type="text/markdown",
+            file_size=existing_path.stat().st_size,
+        )
+        run_snapshot = object()
+        rag_snapshot = object()
+
+        with (
+            patch(
+                "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
+                return_value=run_snapshot,
+            ),
+            patch(
+                "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
+                return_value=rag_snapshot,
+            ),
+            patch(
+                "xagent.web.api.kb._rollback_failed_web_document_ingestion"
+            ) as mock_rollback_rag,
+            patch(
+                "xagent.web.api.kb._restore_ingestion_runs_snapshot"
+            ) as mock_restore_runs,
+        ):
+            result = _refresh_existing_file_if_changed(
+                existing_record=existing_record,
+                temp_file_path=temp_path,
+                db_session=db_session,
+                user_id=test_user.id,
+                is_admin=False,
+                collection_name="test_collection",
+                url="https://example.com/page",
+                filename="existing.md",
+                url_hash="url-hash",
+                processed_urls={},
+                context="unit-test",
+            )
+            result["rollback_on_failure"](None)
+
+        mock_rollback_rag.assert_called_once_with(
+            collection_name="test_collection",
+            result=None,
+            user_id=test_user.id,
+            is_admin=False,
+            rag_snapshot=rag_snapshot,
+            file_id=str(existing_record.file_id),
+        )
+        mock_restore_runs.assert_called_once_with(run_snapshot)

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -241,6 +242,11 @@ def test_kb_document_job_reads_staged_file_and_publishes_canonical(
 
     from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
 
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
+
     SessionLocal = _init_test_db(tmp_path / "kb-staged-ingest.db")
     db = SessionLocal()
     try:
@@ -314,6 +320,11 @@ def test_kb_document_job_supersedes_older_generation_for_same_target(
 
     from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
     from xagent.web.services.kb_ingest_targets import admit_kb_ingest_target
+
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
 
     SessionLocal = _init_test_db(tmp_path / "kb-target-generation.db")
     db = SessionLocal()
@@ -473,6 +484,12 @@ def test_kb_document_job_skips_canonical_rollback_when_generation_turns_stale(
             job_id=str(job.id),
             file_sha256=generation_a,
         )
+        metadata_store = MagicMock()
+        metadata_store.get_collection_config = AsyncMock(
+            return_value='{"chunk_size":111}'
+        )
+        metadata_store.save_collection_config = AsyncMock()
+        metadata_store.delete_collection_metadata = AsyncMock()
 
         def fake_run_document_ingestion(**kwargs):
             admit_kb_ingest_target(
@@ -502,6 +519,10 @@ def test_kb_document_job_skips_canonical_rollback_when_generation_turns_stale(
             fake_run_document_ingestion,
         )
         monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            lambda: metadata_store,
+        )
+        monkeypatch.setattr(
             kb_tasks,
             "_rollback_failed_staged_document_ingestion",
             fail_rollback,
@@ -512,6 +533,160 @@ def test_kb_document_job_skips_canonical_rollback_when_generation_turns_stale(
         assert result["status"] == "superseded"
         assert result["published"] is False
         assert not staged_file.exists()
+        assert metadata_store.save_collection_config.await_count == 1
+        metadata_store.delete_collection_metadata.assert_not_awaited()
+    finally:
+        db.close()
+
+
+def test_kb_document_job_existing_collection_failure_restores_previous_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.exceptions import BackgroundJobHandlerError
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
+
+    SessionLocal = _init_test_db(tmp_path / "kb-config-restore.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="kb-config-restore-test")
+        staged_file = tmp_path / "stage" / "doc.txt"
+        target_file = tmp_path / "canonical" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("staged content", encoding="utf-8")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_DOCUMENT,
+            payload={
+                "collection": "existing-kb",
+                "source_path": str(staged_file),
+                "target_path": str(target_file),
+                "file_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                "filename": "doc.txt",
+                "mime_type": "text/plain",
+                "file_size": staged_file.stat().st_size,
+                "user_id": int(user.id),
+                "is_admin": False,
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "collection_existed_before": True,
+            },
+        )
+
+        metadata_store = MagicMock()
+        metadata_store.get_collection_config = AsyncMock(
+            return_value='{"chunk_size":111}'
+        )
+        metadata_store.save_collection_config = AsyncMock()
+        metadata_store.delete_collection_metadata = AsyncMock()
+
+        def fake_run_document_ingestion(**_kwargs):
+            return IngestionResult(
+                status="error",
+                doc_id="doc-1",
+                message="ingestion failed",
+            )
+
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            lambda: metadata_store,
+        )
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_document_ingestion",
+            fake_run_document_ingestion,
+        )
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks._rollback_failed_staged_document_ingestion",
+            lambda *args, **kwargs: None,
+        )
+
+        with pytest.raises(BackgroundJobHandlerError):
+            handle_kb_ingest_document(db, job)
+
+        assert metadata_store.save_collection_config.await_count == 2
+        restore_call = metadata_store.save_collection_config.await_args_list[-1]
+        assert restore_call.kwargs == {
+            "collection": "existing-kb",
+            "config_json": '{"chunk_size":111}',
+            "user_id": int(user.id),
+        }
+        metadata_store.delete_collection_metadata.assert_not_awaited()
+    finally:
+        db.close()
+
+
+def test_kb_document_job_exception_restores_previous_config_before_retry(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
+
+    SessionLocal = _init_test_db(tmp_path / "kb-config-exception-restore.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="kb-config-exception-restore-test")
+        staged_file = tmp_path / "stage" / "doc.txt"
+        target_file = tmp_path / "canonical" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("staged content", encoding="utf-8")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_DOCUMENT,
+            payload={
+                "collection": "existing-kb",
+                "source_path": str(staged_file),
+                "target_path": str(target_file),
+                "file_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                "filename": "doc.txt",
+                "mime_type": "text/plain",
+                "file_size": staged_file.stat().st_size,
+                "user_id": int(user.id),
+                "is_admin": False,
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "collection_existed_before": True,
+            },
+        )
+        job.attempts = 1
+        job.max_attempts = 3
+
+        metadata_store = MagicMock()
+        metadata_store.get_collection_config = AsyncMock(
+            return_value='{"chunk_size":111}'
+        )
+        metadata_store.save_collection_config = AsyncMock()
+        metadata_store.delete_collection_metadata = AsyncMock()
+
+        def fake_run_document_ingestion(**_kwargs):
+            raise RuntimeError("transient failure")
+
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            lambda: metadata_store,
+        )
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_document_ingestion",
+            fake_run_document_ingestion,
+        )
+
+        with pytest.raises(RuntimeError, match="transient failure"):
+            handle_kb_ingest_document(db, job)
+
+        assert staged_file.exists()
+        assert metadata_store.save_collection_config.await_count == 2
+        restore_call = metadata_store.save_collection_config.await_args_list[-1]
+        assert restore_call.kwargs == {
+            "collection": "existing-kb",
+            "config_json": '{"chunk_size":111}',
+            "user_id": int(user.id),
+        }
+        metadata_store.delete_collection_metadata.assert_not_awaited()
     finally:
         db.close()
 
@@ -591,6 +766,11 @@ def test_kb_web_job_cleans_new_collection_metadata_on_ingest_error(
     from xagent.web.jobs.exceptions import BackgroundJobHandlerError
     from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
 
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
+
     SessionLocal = _init_test_db(tmp_path / "web-ingest-cleanup.db")
     db = SessionLocal()
     try:
@@ -659,6 +839,11 @@ def test_kb_web_job_keeps_new_collection_metadata_when_error_has_successful_docs
     from xagent.web.jobs.exceptions import BackgroundJobHandlerError
     from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
 
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
+
     SessionLocal = _init_test_db(tmp_path / "web-ingest-partial-error.db")
     db = SessionLocal()
     try:
@@ -714,6 +899,235 @@ def test_kb_web_job_keeps_new_collection_metadata_when_error_has_successful_docs
             handle_kb_ingest_web(db, job)
 
         assert cleaned == []
+    finally:
+        db.close()
+
+
+def test_kb_web_job_keeps_new_collection_metadata_when_side_effects_may_remain(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.exceptions import BackgroundJobHandlerError
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
+
+    monkeypatch.setattr(
+        "xagent.web.jobs.kb_tasks._save_job_collection_config_with_snapshot",
+        lambda *args, **kwargs: None,
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "web-ingest-rollback-side-effects.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-ingest-side-effects-test")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={
+                "collection": "web-kb",
+                "crawl_config": WebCrawlConfig(
+                    start_url="https://example.com"
+                ).model_dump(mode="json"),
+                "ingestion_config": IngestionConfig().model_dump(mode="json"),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "collection_existed_before": False,
+            },
+        )
+
+        async def fake_run_web_ingestion(**kwargs):
+            return WebIngestionResult(
+                status="error",
+                collection="web-kb",
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=["https://example.com"],
+                failed_urls={"https://example.com": "rollback failed"},
+                message="rollback failed",
+                warnings=[],
+                elapsed_time_ms=1,
+                side_effects_may_remain=True,
+            )
+
+        cleaned: list[tuple[str, int]] = []
+
+        async def fake_cleanup(*, collection_name, user):
+            cleaned.append((collection_name, int(user.id)))
+
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_web_ingestion",
+            fake_run_web_ingestion,
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.kb._cleanup_failed_new_collection_metadata",
+            fake_cleanup,
+        )
+
+        with pytest.raises(BackgroundJobHandlerError):
+            handle_kb_ingest_web(db, job)
+
+        assert cleaned == []
+    finally:
+        db.close()
+
+
+def test_kb_web_job_existing_collection_failure_restores_previous_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.exceptions import BackgroundJobHandlerError
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
+
+    SessionLocal = _init_test_db(tmp_path / "web-ingest-config-restore.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-ingest-config-restore-test")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={
+                "collection": "existing-web-kb",
+                "crawl_config": WebCrawlConfig(
+                    start_url="https://example.com"
+                ).model_dump(mode="json"),
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "collection_existed_before": True,
+            },
+        )
+
+        metadata_store = MagicMock()
+        metadata_store.get_collection_config = AsyncMock(
+            return_value='{"chunk_size":111}'
+        )
+        metadata_store.save_collection_config = AsyncMock()
+        metadata_store.delete_collection_metadata = AsyncMock()
+
+        async def fake_run_web_ingestion(**kwargs):
+            return WebIngestionResult(
+                status="error",
+                collection="existing-web-kb",
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=["https://example.com"],
+                failed_urls={"https://example.com": "ingestion failed"},
+                message="ingestion failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            lambda: metadata_store,
+        )
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_web_ingestion",
+            fake_run_web_ingestion,
+        )
+
+        with pytest.raises(BackgroundJobHandlerError):
+            handle_kb_ingest_web(db, job)
+
+        assert metadata_store.save_collection_config.await_count == 2
+        restore_call = metadata_store.save_collection_config.await_args_list[-1]
+        assert restore_call.kwargs == {
+            "collection": "existing-web-kb",
+            "config_json": '{"chunk_size":111}',
+            "user_id": int(user.id),
+        }
+        metadata_store.delete_collection_metadata.assert_not_awaited()
+    finally:
+        db.close()
+
+
+def test_kb_web_job_existing_collection_partial_restores_previous_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
+
+    SessionLocal = _init_test_db(tmp_path / "web-ingest-partial-config-restore.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-ingest-partial-config-restore-test")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={
+                "collection": "existing-web-kb",
+                "crawl_config": WebCrawlConfig(
+                    start_url="https://example.com"
+                ).model_dump(mode="json"),
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "collection_existed_before": True,
+            },
+        )
+
+        metadata_store = MagicMock()
+        metadata_store.get_collection_config = AsyncMock(
+            return_value='{"chunk_size":111}'
+        )
+        metadata_store.save_collection_config = AsyncMock()
+        metadata_store.delete_collection_metadata = AsyncMock()
+
+        async def fake_run_web_ingestion(**kwargs):
+            return WebIngestionResult(
+                status="partial",
+                collection="existing-web-kb",
+                total_urls_found=2,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=1,
+                chunks_created=1,
+                embeddings_created=1,
+                crawled_urls=["https://example.com/ok"],
+                failed_urls={"https://example.com/bad": "ingestion failed"},
+                message="partial failure",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        monkeypatch.setattr(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            lambda: metadata_store,
+        )
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_web_ingestion",
+            fake_run_web_ingestion,
+        )
+
+        result = handle_kb_ingest_web(db, job)
+
+        assert result["status"] == "partial"
+        assert metadata_store.save_collection_config.await_count == 2
+        restore_call = metadata_store.save_collection_config.await_args_list[-1]
+        assert restore_call.kwargs == {
+            "collection": "existing-web-kb",
+            "config_json": '{"chunk_size":111}',
+            "user_id": int(user.id),
+        }
+        metadata_store.delete_collection_metadata.assert_not_awaited()
     finally:
         db.close()
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -13,6 +13,7 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     IngestionConfig,
     IngestionResult,
     WebCrawlConfig,
+    WebIngestionResult,
 )
 from xagent.web.models.background_job import BackgroundJobStatus, BackgroundJobType
 from xagent.web.models.database import get_session_local, init_db
@@ -611,7 +612,21 @@ def test_kb_web_job_cleans_new_collection_metadata_on_ingest_error(
         )
 
         async def fake_run_web_ingestion(**kwargs):
-            return IngestionResult(status="error", message="crawl failed")
+            return WebIngestionResult(
+                status="error",
+                collection="web-kb",
+                total_urls_found=1,
+                pages_crawled=0,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[],
+                failed_urls={"https://example.com": "crawl failed"},
+                message="crawl failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
 
         cleaned: list[tuple[str, int]] = []
 
@@ -633,6 +648,142 @@ def test_kb_web_job_cleans_new_collection_metadata_on_ingest_error(
         assert cleaned == [("web-kb", int(user.id))]
     finally:
         db.close()
+
+
+def test_kb_web_job_keeps_new_collection_metadata_when_error_has_successful_docs(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.jobs.exceptions import BackgroundJobHandlerError
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
+
+    SessionLocal = _init_test_db(tmp_path / "web-ingest-partial-error.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-ingest-partial-error-test")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={
+                "collection": "web-kb",
+                "crawl_config": WebCrawlConfig(
+                    start_url="https://example.com"
+                ).model_dump(mode="json"),
+                "ingestion_config": IngestionConfig().model_dump(mode="json"),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "collection_existed_before": False,
+            },
+        )
+
+        async def fake_run_web_ingestion(**kwargs):
+            return WebIngestionResult(
+                status="error",
+                collection="web-kb",
+                total_urls_found=2,
+                pages_crawled=2,
+                pages_failed=1,
+                documents_created=1,
+                chunks_created=1,
+                embeddings_created=1,
+                crawled_urls=["https://example.com/a", "https://example.com/b"],
+                failed_urls={"https://example.com/b": "rollback failed"},
+                message="rollback failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        cleaned: list[tuple[str, int]] = []
+
+        async def fake_cleanup(*, collection_name, user):
+            cleaned.append((collection_name, int(user.id)))
+
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_web_ingestion",
+            fake_run_web_ingestion,
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.kb._cleanup_failed_new_collection_metadata",
+            fake_cleanup,
+        )
+
+        with pytest.raises(BackgroundJobHandlerError):
+            handle_kb_ingest_web(db, job)
+
+        assert cleaned == []
+    finally:
+        db.close()
+
+
+def test_background_web_file_new_branch_returns_rollback_callback(
+    tmp_path, monkeypatch
+):
+    from xagent.core.file_storage.factory import get_file_storage
+    from xagent.web.jobs.kb_tasks import _handle_web_file
+
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    get_file_storage.cache_clear()
+
+    SessionLocal = _init_test_db(tmp_path / "web-file-handler.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-file-handler-test")
+        temp_file = tmp_path / "temp.md"
+        temp_file.write_text("# Title\n\nBody", encoding="utf-8")
+        persistent_root = tmp_path / "uploads"
+
+        def fake_get_upload_path(
+            filename: str,
+            *,
+            user_id: int,
+            collection: str,
+            collection_is_sanitized: bool,
+        ) -> Path:
+            assert collection_is_sanitized is True
+            return persistent_root / f"user_{user_id}" / collection / filename
+
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.get_upload_path",
+            fake_get_upload_path,
+        )
+        monkeypatch.setattr(
+            "xagent.web.api.kb.get_session_local",
+            lambda: SessionLocal,
+        )
+        from unittest.mock import patch
+
+        with patch(
+            "xagent.web.api.kb._rollback_failed_web_document_ingestion"
+        ) as mock_rollback_rag:
+            result = _handle_web_file(
+                temp_file_path=temp_file,
+                title="Title",
+                collection_name="web-kb",
+                url="https://example.com/page",
+                db_session=db,
+                user_id=int(user.id),
+                is_admin=False,
+                processed_urls={},
+            )
+            assert callable(result["rollback_on_failure"])
+
+            result["rollback_on_failure"](None)
+
+        verify_db = SessionLocal()
+        try:
+            rows = verify_db.query(UploadedFile).all()
+            assert rows == []
+        finally:
+            verify_db.close()
+
+        assert not Path(result["file_path"]).exists()
+        mock_rollback_rag.assert_called_once()
+    finally:
+        db.close()
+        get_file_storage.cache_clear()
 
 
 def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes xorbitsai/xagent#517.

This PR makes KB ingestion failures rollback durable side effects instead of leaving partial collection/file/RAG state behind.

Key changes:

- Add rollback/commit callbacks to web ingestion file handling so failed or partial page ingestion can compensate per-page file side effects.
- Snapshot and restore collection ingestion config/metadata around direct, cloud, and web ingestion failures.
- Clean up newly created collection metadata when a failed ingest only created config/metadata state.
- Restore uploaded-file records, durable objects, local files, ingestion runs, and RAG rows when web ingestion refresh/recreate paths fail.
- Surface rollback callback failures as final ingestion errors instead of hiding them as warnings.
- Make RAG document restore safer by restoring old rows before removing stale failed rows.
- Add cleanup for new web uploaded-file setup failures, including known `file_id`/`storage_key` durable-object cleanup.

## Tests

- `git diff --check`
- `.venv/bin/ruff check src/xagent/web/api/kb.py tests/web/api/test_kb_web_ingestion_uploaded_file.py`
- `.venv/bin/ruff format --check src/xagent/web/api/kb.py tests/web/api/test_kb_web_ingestion_uploaded_file.py`
- `.venv/bin/pytest tests/web/api/test_kb_web_ingestion_uploaded_file.py tests/web/api/test_kb_ingest_separators.py tests/web/api/test_kb_dir.py tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py tests/core/tools/core/RAG_tools/storage/test_lancedb_stores.py -q`

Notes:

- The test run passed.