### PR TITLE
feat: add SDK backend management endpoints

### DIFF
--- a/src/xagent/core/utils/api_key.py
+++ b/src/xagent/core/utils/api_key.py
@@ -1,15 +1,21 @@
 """SDK API key generation, parsing, and bcrypt verification utilities.
 
-The SDK key format is ``xag_<6-char prefix>_<32-char secret>``.
+Two key kinds share this format and code path; the kind segment is what
+distinguishes them on the wire:
+
+  - agent key:    ``xag_<6-char prefix>_<32-char secret>``
+  - personal key: ``xag_personal_<6-char prefix>_<32-char secret>``
 
   - The **prefix** is a public-safe lookup handle. It is what we index in
-    ``agent_api_keys.key_prefix`` and what we allow callers (and logs) to
-    see in cleartext. It does NOT confer any auth power on its own.
+    the key table's ``key_prefix`` column (``agent_api_keys`` for agent
+    keys, ``user_api_keys`` for personal keys) and what we allow callers
+    (and logs) to see in cleartext. It does NOT confer any auth power on
+    its own.
 
   - The **secret** is the unguessable half. The server only ever stores
-    ``bcrypt(full_key, cost=12)`` in ``agent_api_keys.key_hash``; the
-    plaintext secret leaves the response of ``POST /api/agents/{id}/api-key``
-    exactly once and is never persisted server-side.
+    ``bcrypt(full_key, cost=12)`` in the key table's ``key_hash`` column;
+    the plaintext secret leaves the issuing endpoint's response exactly
+    once and is never persisted server-side.
 
 Why the alphabet excludes ``_`` (underscore):
     Parse logic splits on ``_`` to recover (prefix, secret). If either half
@@ -113,26 +119,31 @@ def generate_api_key(
 ) -> Tuple[str, str, str]:
     """Generate a new SDK API key and its bcrypt hash.
 
-    The caller is responsible for INSERTing a row into ``agent_api_keys``
-    using the returned ``key_prefix`` and ``key_hash``; this function is
-    stateless and does not write anything to the database itself. The
-    ``db`` parameter is only used to probe for prefix collisions so we
-    can re-roll before letting the INSERT hit the unique-index trap.
+    The caller is responsible for INSERTing a row into the key table for
+    this ``kind`` (``agent_api_keys`` for AGENT, ``user_api_keys`` for
+    PERSONAL) using the returned ``key_prefix`` and ``key_hash``; this
+    function is stateless and does not write anything to the database
+    itself. The ``db`` parameter is only used to probe that kind's table
+    for prefix collisions so we can re-roll before letting the INSERT hit
+    the unique-index trap.
 
     Args:
-        db: SQLAlchemy session, used to ``SELECT`` against
-            ``agent_api_keys.key_prefix``. Pass ``None`` to skip the
-            collision check (useful in unit tests where you don't have a
-            session and the keyspace makes a real collision impossible).
+        db: SQLAlchemy session, used to ``SELECT`` against the kind's
+            ``key_prefix`` column. Pass ``None`` to skip the collision
+            check (useful in unit tests where you don't have a session
+            and the keyspace makes a real collision impossible).
+        kind: which key kind to mint; selects both the wire format and
+            the table probed for collisions.
 
     Returns:
         Tuple ``(full_key, key_prefix, key_hash)`` where:
-          - ``full_key`` is the plaintext ``xag_<prefix>_<secret>``; show
-            this to the user once and never persist it.
-          - ``key_prefix`` is the 6-char lookup handle to store in
-            ``agent_api_keys.key_prefix``.
+          - ``full_key`` is the plaintext key (``xag_<prefix>_<secret>``
+            for AGENT, ``xag_personal_<prefix>_<secret>`` for PERSONAL);
+            show this to the user once and never persist it.
+          - ``key_prefix`` is the 6-char lookup handle to store in the
+            kind's ``key_prefix`` column.
           - ``key_hash`` is the bcrypt-hashed full key (utf-8 str) to
-            store in ``agent_api_keys.key_hash``.
+            store in the kind's ``key_hash`` column.
 
     Raises:
         RuntimeError: if we hit ``PREFIX_COLLISION_RETRIES`` consecutive
@@ -191,7 +202,8 @@ def generate_api_key(
 def parse_api_key(raw: str) -> Optional[ParsedApiKey]:
     """Split a raw API key string into kind, prefix, and secret if well-formed.
 
-    A well-formed key has shape ``xag_<6 chars>_<32 chars>`` where both
+    A well-formed key is either ``xag_<6 chars>_<32 chars>`` (AGENT) or
+    ``xag_personal_<6 chars>_<32 chars>`` (PERSONAL), where both
     char-class halves draw from ``KEY_ALPHABET``. Anything else returns
     ``None``; the caller treats that as ``invalid_api_key`` (same response
     we give for a wrong secret -- never tell the attacker which check
@@ -203,7 +215,8 @@ def parse_api_key(raw: str) -> Optional[ParsedApiKey]:
             HTTP layer).
 
     Returns:
-        ``(prefix, secret)`` on success; ``None`` on any format mismatch.
+        ``ParsedApiKey(kind, prefix, secret)`` on success; ``None`` on any
+        format mismatch.
 
     Notes:
         Never include ``raw`` in log lines. If you must log the failure,

--- a/src/xagent/core/utils/api_key.py
+++ b/src/xagent/core/utils/api_key.py
@@ -33,7 +33,8 @@ Why ``verify_dummy`` exists:
 import logging
 import secrets
 import string
-from typing import Optional, Tuple
+from enum import Enum
+from typing import NamedTuple, Optional, Tuple
 
 import bcrypt
 from sqlalchemy.orm import Session
@@ -46,6 +47,22 @@ logger = logging.getLogger(__name__)
 # OpenAI's ``sk-*``, Anthropic's ``sk-ant-*`` pattern -- a stable token in
 # logs and CI scanners that says "this is an xagent credential".
 KEY_BRAND = "xag"
+
+
+class ApiKeyKind(str, Enum):
+    """Supported API key kinds and their wire-level auth responsibilities."""
+
+    AGENT = "agent"
+    PERSONAL = "personal"
+
+
+class ParsedApiKey(NamedTuple):
+    """Structured parse result for an xagent API key."""
+
+    kind: ApiKeyKind
+    prefix: str
+    secret: str
+
 
 # Length of the public-safe lookup handle. 6 chars over a 62-symbol alphabet
 # gives ~57 billion combinations; the partial unique index on
@@ -91,7 +108,9 @@ def _generate_random_string(length: int) -> str:
 _DUMMY_HASH = bcrypt.hashpw(b"dummy", bcrypt.gensalt(rounds=BCRYPT_COST))
 
 
-def generate_api_key(db: Optional[Session]) -> Tuple[str, str, str]:
+def generate_api_key(
+    db: Optional[Session], *, kind: ApiKeyKind = ApiKeyKind.AGENT
+) -> Tuple[str, str, str]:
     """Generate a new SDK API key and its bcrypt hash.
 
     The caller is responsible for INSERTing a row into ``agent_api_keys``
@@ -123,7 +142,12 @@ def generate_api_key(db: Optional[Session]) -> Tuple[str, str, str]:
     """
     # Import locally to avoid a circular dependency: core/utils/ shouldn't
     # depend on web/models/ at module-import time.
-    from xagent.web.models.agent_api_key import AgentApiKey
+    if kind == ApiKeyKind.AGENT:
+        from xagent.web.models.agent_api_key import AgentApiKey as KeyModel
+    elif kind == ApiKeyKind.PERSONAL:
+        from xagent.web.models.user_api_key import UserApiKey as KeyModel
+    else:
+        raise ValueError(f"Unsupported API key kind: {kind}")
 
     for attempt in range(PREFIX_COLLISION_RETRIES):
         prefix = _generate_random_string(KEY_PREFIX_LENGTH)
@@ -132,9 +156,7 @@ def generate_api_key(db: Optional[Session]) -> Tuple[str, str, str]:
         # authority; this just avoids the ugly path of catching
         # IntegrityError on the caller's INSERT.
         if db is not None:
-            existing = (
-                db.query(AgentApiKey).filter(AgentApiKey.key_prefix == prefix).first()
-            )
+            existing = db.query(KeyModel).filter(KeyModel.key_prefix == prefix).first()
             if existing is not None:
                 logger.warning(
                     f"API key prefix collision on attempt {attempt + 1}, "
@@ -143,7 +165,10 @@ def generate_api_key(db: Optional[Session]) -> Tuple[str, str, str]:
                 continue
 
         secret = _generate_random_string(KEY_SECRET_LENGTH)
-        full_key = f"{KEY_BRAND}_{prefix}_{secret}"
+        if kind == ApiKeyKind.PERSONAL:
+            full_key = f"{KEY_BRAND}_{kind.value}_{prefix}_{secret}"
+        else:
+            full_key = f"{KEY_BRAND}_{prefix}_{secret}"
 
         # bcrypt.hashpw expects bytes in, bytes out. We store utf-8 str
         # in the DB so callers don't have to remember to decode every
@@ -163,8 +188,8 @@ def generate_api_key(db: Optional[Session]) -> Tuple[str, str, str]:
     )
 
 
-def parse_api_key(raw: str) -> Optional[Tuple[str, str]]:
-    """Split a raw API key string into ``(prefix, secret)`` if well-formed.
+def parse_api_key(raw: str) -> Optional[ParsedApiKey]:
+    """Split a raw API key string into kind, prefix, and secret if well-formed.
 
     A well-formed key has shape ``xag_<6 chars>_<32 chars>`` where both
     char-class halves draw from ``KEY_ALPHABET``. Anything else returns
@@ -188,15 +213,21 @@ def parse_api_key(raw: str) -> Optional[Tuple[str, str]]:
     if not isinstance(raw, str) or not raw:
         return None
 
-    # ``rsplit`` with maxsplit=2 guards against any future tweak where
-    # the brand or prefix segments grow ``_`` characters; today the
-    # alphabet excludes ``_`` so an exact split into 3 parts is what we
-    # require.
     parts = raw.split("_")
-    if len(parts) != 3:
+    if len(parts) == 3:
+        brand, prefix, secret = parts
+        kind = ApiKeyKind.AGENT
+    elif len(parts) == 4:
+        brand, kind_value, prefix, secret = parts
+        try:
+            kind = ApiKeyKind(kind_value)
+        except ValueError:
+            return None
+        if kind != ApiKeyKind.PERSONAL:
+            return None
+    else:
         return None
 
-    brand, prefix, secret = parts
     if brand != KEY_BRAND:
         return None
     if len(prefix) != KEY_PREFIX_LENGTH or len(secret) != KEY_SECRET_LENGTH:
@@ -212,7 +243,7 @@ def parse_api_key(raw: str) -> Optional[Tuple[str, str]]:
     if any(c not in alphabet_set for c in secret):
         return None
 
-    return prefix, secret
+    return ParsedApiKey(kind=kind, prefix=prefix, secret=secret)
 
 
 def verify_api_key(raw: str, stored_hash: str) -> bool:

--- a/src/xagent/migrations/versions/20260529_add_user_api_keys.py
+++ b/src/xagent/migrations/versions/20260529_add_user_api_keys.py
@@ -1,0 +1,92 @@
+"""add user personal api keys
+
+Revision ID: 20260529_add_user_api_keys
+Revises: 20260528_add_kb_ingest_targets
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260529_add_user_api_keys"
+down_revision: Union[str, tuple[str, str], None] = "20260528_add_kb_ingest_targets"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _index_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "user_api_keys" not in existing_tables:
+        constraints = [sa.PrimaryKeyConstraint("id")]
+        if "users" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE")
+            )
+
+        op.create_table(
+            "user_api_keys",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("key_prefix", sa.String(length=12), nullable=False),
+            sa.Column("key_hash", sa.String(length=128), nullable=False),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            *constraints,
+        )
+
+    existing_indexes = _index_names("user_api_keys")
+    if "ix_user_api_keys_id" not in existing_indexes:
+        op.create_index(op.f("ix_user_api_keys_id"), "user_api_keys", ["id"])
+    if "ix_user_api_keys_user_id" not in existing_indexes:
+        op.create_index(op.f("ix_user_api_keys_user_id"), "user_api_keys", ["user_id"])
+    if "ix_user_api_keys_key_prefix" not in existing_indexes:
+        op.create_index(
+            op.f("ix_user_api_keys_key_prefix"),
+            "user_api_keys",
+            ["key_prefix"],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "user_api_keys" not in inspector.get_table_names():
+        return
+
+    existing_indexes = _index_names("user_api_keys")
+    if "ix_user_api_keys_key_prefix" in existing_indexes:
+        op.drop_index(op.f("ix_user_api_keys_key_prefix"), table_name="user_api_keys")
+    if "ix_user_api_keys_user_id" in existing_indexes:
+        op.drop_index(op.f("ix_user_api_keys_user_id"), table_name="user_api_keys")
+    if "ix_user_api_keys_id" in existing_indexes:
+        op.drop_index(op.f("ix_user_api_keys_id"), table_name="user_api_keys")
+    op.drop_table("user_api_keys")

--- a/src/xagent/migrations/versions/20260529_add_user_api_keys.py
+++ b/src/xagent/migrations/versions/20260529_add_user_api_keys.py
@@ -46,7 +46,6 @@ def upgrade() -> None:
             sa.Column("key_hash", sa.String(length=128), nullable=False),
             sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
-            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column(
                 "created_at",
                 sa.DateTime(timezone=True),

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -3,12 +3,10 @@
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...config import get_agent_pattern_for_execution_mode, get_uploads_dir
@@ -16,10 +14,8 @@ from ...core.agent.service import AgentService
 from ...core.memory.in_memory import InMemoryMemoryStore
 from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...core.tracing import create_agent_tracer
-from ...core.utils.api_key import generate_api_key
 from ..auth_dependencies import get_current_user
 from ..models.agent import Agent
-from ..models.agent_api_key import AgentApiKey
 from ..models.database import get_db
 from ..models.model import Model as DBModel
 from ..models.user import User
@@ -34,6 +30,7 @@ from ..services.agent_access import (
     list_accessible_agents,
 )
 from ..services.agent_store import AgentStore
+from ..services.api_keys import AgentApiKeyService, KeyRotationConflict
 from ..services.llm_utils import UserAwareModelStorage
 from ..tools.config import WebToolConfig
 from ..user_isolated_memory import UserContext
@@ -319,23 +316,6 @@ def _get_owned_agent_or_404(agent_id: int, current_user: User, db: Session) -> A
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agent
-
-
-def _mask_key(key_prefix: str) -> str:
-    """Render the display form ``xag_<prefix>_••••••••`` for read-only views.
-
-    The bullet count is fixed at eight on purpose. The actual secret is 32
-    characters; reflecting the real length in the UI would leak length
-    metadata in screenshots and screenshares. Eight bullets is short
-    enough to render compactly and long enough to read as "redacted".
-
-    Args:
-        key_prefix: The public-safe lookup handle (6 chars).
-
-    Returns:
-        Display string suitable for the web UI's "API Key" card.
-    """
-    return f"xag_{key_prefix}_••••••••"
 
 
 # ===== Endpoints =====
@@ -787,62 +767,15 @@ async def generate_agent_api_key(
         # not yours" vs "does not exist".
         _get_owned_agent_or_404(agent_id, current_user, db)
 
-        # Revoke any existing active key for this agent. We touch
-        # ``updated_at`` so audit queries can see the rotation moment on
-        # the old row as well as the new row.
-        now = datetime.now(timezone.utc)
-        existing = (
-            db.query(AgentApiKey)
-            .filter(
-                AgentApiKey.agent_id == agent_id,
-                AgentApiKey.revoked_at.is_(None),
-            )
-            .first()
-        )
-        if existing is not None:
-            existing.revoked_at = now  # type: ignore[assignment]
-            existing.updated_at = now  # type: ignore[assignment]
-
-        # Generate a fresh prefix+secret+hash. ``generate_api_key`` does
-        # its own prefix-collision probe against ``agent_api_keys`` so
-        # we don't have to.
-        full_key, key_prefix, key_hash = generate_api_key(db)
-
-        new_row = AgentApiKey(
-            agent_id=agent_id,
-            key_prefix=key_prefix,
-            key_hash=key_hash,
-        )
-        db.add(new_row)
-
-        # Single commit: revoke + insert are atomic. If a concurrent
-        # POST snuck in between our SELECT and INSERT, the partial
-        # unique index raises IntegrityError here and the outer except
-        # rolls back. The losing client sees 500, which the UI can retry.
-        db.commit()
-        db.refresh(new_row)
-
-        # ``key_prefix`` is the only safe field to log. Do NOT log
-        # full_key / secret / key_hash even in DEBUG.
-        logger.info(
-            f"Generated API key for agent {agent_id} "
-            f"(prefix={key_prefix}, rotated={existing is not None})"
-        )
-
-        return APIKeyGenerateResponse(
-            full_key=full_key,
-            key_prefix=key_prefix,
-            created_at=new_row.created_at,
-        )
+        return AgentApiKeyService(db).rotate_key(agent_id)
 
     except HTTPException:
         raise
-    except IntegrityError as e:
+    except KeyRotationConflict as e:
         # Partial unique constraint hit -- another POST won the race
         # between our SELECT and our COMMIT. Surface this as 409 rather
         # than a generic 500 so the client can retry without alarm.
         # Internal SQL message stays in the log only.
-        db.rollback()
         logger.warning(f"Concurrent API key rotation race for agent {agent_id}: {e}")
         raise HTTPException(status_code=409, detail="rotation_conflict")
     except Exception as e:
@@ -886,24 +819,13 @@ async def get_agent_api_key(
     try:
         _get_owned_agent_or_404(agent_id, current_user, db)
 
-        row = (
-            db.query(AgentApiKey)
-            .filter(
-                AgentApiKey.agent_id == agent_id,
-                AgentApiKey.revoked_at.is_(None),
-            )
-            .first()
-        )
-        if row is None:
+        metadata = AgentApiKeyService(db).get_metadata(agent_id)
+        if metadata is None:
             # "Has the owner generated a key yet?" answered with 404 so
             # the UI catches and renders the empty state.
             raise HTTPException(status_code=404, detail="no_active_key")
 
-        return APIKeyMetadataResponse(
-            key_prefix=row.key_prefix,
-            masked_key=_mask_key(row.key_prefix),  # type: ignore[arg-type]
-            created_at=row.created_at,
-        )
+        return metadata
 
     except HTTPException:
         raise
@@ -949,27 +871,7 @@ async def revoke_agent_api_key(
     try:
         _get_owned_agent_or_404(agent_id, current_user, db)
 
-        now = datetime.now(timezone.utc)
-        row = (
-            db.query(AgentApiKey)
-            .filter(
-                AgentApiKey.agent_id == agent_id,
-                AgentApiKey.revoked_at.is_(None),
-            )
-            .first()
-        )
-        if row is None:
-            # Idempotent no-op path; same HTTP shape as "yes we revoked".
-            logger.info(f"Revoke API key for agent {agent_id}: no active key (no-op)")
-            return APIKeyRevokeResponse(revoked=False, revoked_at=None)
-
-        row.revoked_at = now  # type: ignore[assignment]
-        row.updated_at = now  # type: ignore[assignment]
-        db.commit()
-        db.refresh(row)
-
-        logger.info(f"Revoked API key for agent {agent_id} (prefix={row.key_prefix})")
-        return APIKeyRevokeResponse(revoked=True, revoked_at=row.revoked_at)
+        return AgentApiKeyService(db).revoke_key(agent_id)
 
     except HTTPException:
         raise

--- a/src/xagent/web/api/me.py
+++ b/src/xagent/web/api/me.py
@@ -1,0 +1,41 @@
+"""Current-user management endpoints."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..auth_dependencies import get_current_user
+from ..models.database import get_db
+from ..models.user import User
+from ..schemas.user_api_key import (
+    PersonalAPIKeyCreateResponse,
+    PersonalAPIKeyMetadata,
+    PersonalAPIKeyRevokeResponse,
+)
+from ..services.api_keys import UserApiKeyService
+
+router = APIRouter(prefix="/api/me", tags=["me"])
+
+
+@router.post("/personal-keys", response_model=PersonalAPIKeyCreateResponse)
+async def create_personal_key(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PersonalAPIKeyCreateResponse:
+    return UserApiKeyService(db).create_key(int(current_user.id))
+
+
+@router.get("/personal-keys", response_model=list[PersonalAPIKeyMetadata])
+async def list_personal_keys(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[PersonalAPIKeyMetadata]:
+    return UserApiKeyService(db).list_keys(int(current_user.id))
+
+
+@router.delete("/personal-keys/{key_id}", response_model=PersonalAPIKeyRevokeResponse)
+async def revoke_personal_key(
+    key_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PersonalAPIKeyRevokeResponse:
+    return UserApiKeyService(db).revoke_key(int(current_user.id), key_id)

--- a/src/xagent/web/api/v1/__init__.py
+++ b/src/xagent/web/api/v1/__init__.py
@@ -19,11 +19,15 @@ Re-exports ``v1_router`` for ``web/app.py`` to mount under ``/v1``.
 
 from fastapi import APIRouter
 
+from .agents import router as _agents_router
 from .me import router as _me_router
 from .tasks import router as _tasks_router
+from .templates import router as _templates_router
 
 v1_router = APIRouter(prefix="/v1", tags=["sdk-v1"])
 v1_router.include_router(_me_router)
+v1_router.include_router(_templates_router)
+v1_router.include_router(_agents_router)
 v1_router.include_router(_tasks_router)
 
 __all__ = ["v1_router"]

--- a/src/xagent/web/api/v1/__init__.py
+++ b/src/xagent/web/api/v1/__init__.py
@@ -1,9 +1,8 @@
 """Public SDK ``/v1/*`` namespace.
 
 This subpackage holds endpoints exposed to external SDK clients
-(Python / TypeScript / JavaScript SDKs introduced in Phase 1) that
-authenticate with an ``xag_<prefix>_<secret>`` API key rather than a
-JWT session.
+(Python / TypeScript / JavaScript) that authenticate with an
+``xag_<prefix>_<secret>`` API key rather than a JWT session.
 
 The split from ``/api/*`` is deliberate (see SDK design doc §3):
 

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -5,9 +5,11 @@ from typing import Tuple
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
+from ...models.agent import Agent
 from ...models.database import get_db
 from ...models.user import User
 from ...models.user_api_key import UserApiKey
+from ...schemas.agent_api_key import APIKeyGenerateResponse
 from ...schemas.v1 import (
     RuntimeKeyResponse,
     V1AgentCreateRequest,
@@ -29,7 +31,7 @@ from .errors import V1ApiError, V1ErrorCode
 router = APIRouter(prefix="/agents")
 
 
-def _runtime_key_response(api_key) -> RuntimeKeyResponse:
+def _runtime_key_response(api_key: APIKeyGenerateResponse) -> RuntimeKeyResponse:
     return RuntimeKeyResponse(
         full_key=api_key.full_key,
         key_prefix=api_key.key_prefix,
@@ -37,7 +39,7 @@ def _runtime_key_response(api_key) -> RuntimeKeyResponse:
     )
 
 
-def _agent_response(service: AgentManagementService, agent) -> V1AgentResponse:
+def _agent_response(service: AgentManagementService, agent: Agent) -> V1AgentResponse:
     return V1AgentResponse.model_validate(service.store.agent_to_response_dict(agent))
 
 

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -65,7 +65,9 @@ async def create_agent(
     user, _key = authed
     service = AgentManagementService(db)
     try:
-        agent = service.create_agent_for_user(
+        # Atomic: agent row + optional first runtime key commit together,
+        # so a key-step failure never leaves a persisted agent behind.
+        agent, api_key = service.create_agent_with_optional_key(
             user_id=int(user.id),
             name=request.name,
             description=request.description,
@@ -76,12 +78,8 @@ async def create_agent(
             skills=request.skills,
             tool_categories=request.tool_categories,
             suggested_prompts=request.suggested_prompts,
+            generate_runtime_key=request.generate_runtime_key,
         )
-        api_key = None
-        if request.generate_runtime_key:
-            api_key = service.generate_agent_runtime_key(
-                user_id=int(user.id), agent_id=int(agent.id)
-            )
     except DuplicateAgentNameError:
         raise V1ApiError(
             V1ErrorCode.INVALID_INPUT, 400, "Agent with this name already exists."
@@ -114,7 +112,9 @@ async def create_agent_from_template(
     template_manager = getattr(fastapi_request.app.state, "template_manager", None)
     service = AgentManagementService(db, template_manager=template_manager)
     try:
-        agent = await service.create_agent_from_template(
+        # Atomic: template-derived agent + optional first runtime key
+        # commit together, same boundary as the plain create path.
+        agent, api_key = await service.create_agent_from_template(
             user_id=int(user.id),
             template_id=request.template_id,
             name=request.name,
@@ -126,12 +126,8 @@ async def create_agent_from_template(
             skills=request.skills,
             tool_categories=request.tool_categories,
             suggested_prompts=request.suggested_prompts,
+            generate_runtime_key=request.generate_runtime_key,
         )
-        api_key = None
-        if request.generate_runtime_key:
-            api_key = service.generate_agent_runtime_key(
-                user_id=int(user.id), agent_id=int(agent.id)
-            )
     except TemplateNotFoundError:
         raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)
     except DuplicateAgentNameError:

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -1,0 +1,174 @@
+"""SDK management endpoints for user-owned agents."""
+
+from typing import Tuple
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.orm import Session
+
+from ...models.database import get_db
+from ...models.user import User
+from ...models.user_api_key import UserApiKey
+from ...schemas.v1 import (
+    RuntimeKeyResponse,
+    V1AgentCreateRequest,
+    V1AgentCreateResponse,
+    V1AgentResponse,
+    V1AgentSummary,
+    V1AgentTemplateCreateRequest,
+)
+from ...services.agent_management import (
+    AgentManagementService,
+    DuplicateAgentNameError,
+    InvalidAgentModelConfigError,
+    TemplateNotFoundError,
+)
+from ...services.api_keys import KeyRotationConflict
+from .deps import get_user_from_personal_key
+from .errors import V1ApiError, V1ErrorCode
+
+router = APIRouter(prefix="/agents")
+
+
+def _runtime_key_response(api_key) -> RuntimeKeyResponse:
+    return RuntimeKeyResponse(
+        full_key=api_key.full_key,
+        key_prefix=api_key.key_prefix,
+        created_at=api_key.created_at,
+    )
+
+
+def _agent_response(service: AgentManagementService, agent) -> V1AgentResponse:
+    return V1AgentResponse.model_validate(service.store.agent_to_response_dict(agent))
+
+
+@router.get("", response_model=list[V1AgentSummary])
+async def list_agents(
+    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    db: Session = Depends(get_db),
+) -> list[V1AgentSummary]:
+    user, _key = authed
+    service = AgentManagementService(db)
+    return [
+        V1AgentSummary.model_validate(item)
+        for item in service.list_agents_for_user(int(user.id))
+    ]
+
+
+@router.post("", response_model=V1AgentCreateResponse)
+async def create_agent(
+    request: V1AgentCreateRequest,
+    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    db: Session = Depends(get_db),
+) -> V1AgentCreateResponse:
+    user, _key = authed
+    service = AgentManagementService(db)
+    try:
+        agent = service.create_agent_for_user(
+            user_id=int(user.id),
+            name=request.name,
+            description=request.description,
+            instructions=request.instructions,
+            execution_mode=request.execution_mode,
+            models=request.models,
+            knowledge_bases=request.knowledge_bases,
+            skills=request.skills,
+            tool_categories=request.tool_categories,
+            suggested_prompts=request.suggested_prompts,
+        )
+        api_key = None
+        if request.generate_runtime_key:
+            api_key = service.generate_agent_runtime_key(
+                user_id=int(user.id), agent_id=int(agent.id)
+            )
+    except DuplicateAgentNameError:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT, 400, "Agent with this name already exists."
+        )
+    except InvalidAgentModelConfigError:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            "Agent models must use integer DB model ids for known model slots.",
+        )
+    except KeyRotationConflict:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR, 409, "Runtime key rotation conflict."
+        )
+
+    return V1AgentCreateResponse(
+        agent=_agent_response(service, agent),
+        api_key=_runtime_key_response(api_key) if api_key else None,
+    )
+
+
+@router.post("/from-template", response_model=V1AgentCreateResponse)
+async def create_agent_from_template(
+    request: V1AgentTemplateCreateRequest,
+    fastapi_request: Request,
+    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    db: Session = Depends(get_db),
+) -> V1AgentCreateResponse:
+    user, _key = authed
+    template_manager = getattr(fastapi_request.app.state, "template_manager", None)
+    service = AgentManagementService(db, template_manager=template_manager)
+    try:
+        agent = await service.create_agent_from_template(
+            user_id=int(user.id),
+            template_id=request.template_id,
+            name=request.name,
+            description=request.description,
+            instructions=request.instructions,
+            execution_mode=request.execution_mode,
+            models=request.models,
+            knowledge_bases=request.knowledge_bases,
+            skills=request.skills,
+            tool_categories=request.tool_categories,
+            suggested_prompts=request.suggested_prompts,
+        )
+        api_key = None
+        if request.generate_runtime_key:
+            api_key = service.generate_agent_runtime_key(
+                user_id=int(user.id), agent_id=int(agent.id)
+            )
+    except TemplateNotFoundError:
+        raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)
+    except DuplicateAgentNameError:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT, 400, "Agent with this name already exists."
+        )
+    except InvalidAgentModelConfigError:
+        raise V1ApiError(
+            V1ErrorCode.INVALID_INPUT,
+            400,
+            "Agent models must use integer DB model ids for known model slots.",
+        )
+    except KeyRotationConflict:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR, 409, "Runtime key rotation conflict."
+        )
+
+    return V1AgentCreateResponse(
+        agent=_agent_response(service, agent),
+        api_key=_runtime_key_response(api_key) if api_key else None,
+    )
+
+
+@router.post("/{agent_id}/api-key", response_model=RuntimeKeyResponse)
+async def rotate_agent_runtime_key(
+    agent_id: int,
+    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+    db: Session = Depends(get_db),
+) -> RuntimeKeyResponse:
+    user, _key = authed
+    service = AgentManagementService(db)
+    try:
+        api_key = service.generate_agent_runtime_key(
+            user_id=int(user.id), agent_id=agent_id
+        )
+    except KeyRotationConflict:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR, 409, "Runtime key rotation conflict."
+        )
+    if api_key is None:
+        raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
+    return _runtime_key_response(api_key)

--- a/src/xagent/web/api/v1/agents.py
+++ b/src/xagent/web/api/v1/agents.py
@@ -22,6 +22,7 @@ from ...services.agent_management import (
     AgentManagementService,
     DuplicateAgentNameError,
     InvalidAgentModelConfigError,
+    InvalidKnowledgeBaseError,
     TemplateNotFoundError,
 )
 from ...services.api_keys import KeyRotationConflict
@@ -65,10 +66,11 @@ async def create_agent(
     user, _key = authed
     service = AgentManagementService(db)
     try:
-        # Atomic: agent row + optional first runtime key commit together,
-        # so a key-step failure never leaves a persisted agent behind.
-        agent, api_key = service.create_agent_with_optional_key(
+        # Atomic: KB validation + agent row + optional first runtime key,
+        # all behind the single async create entry point.
+        agent, api_key = await service.create_agent(
             user_id=int(user.id),
+            is_admin=bool(user.is_admin),
             name=request.name,
             description=request.description,
             instructions=request.instructions,
@@ -90,6 +92,8 @@ async def create_agent(
             400,
             "Agent models must use integer DB model ids for known model slots.",
         )
+    except InvalidKnowledgeBaseError as e:
+        raise V1ApiError(V1ErrorCode.INVALID_INPUT, 400, str(e))
     except KeyRotationConflict:
         raise V1ApiError(
             V1ErrorCode.INTERNAL_ERROR, 409, "Runtime key rotation conflict."
@@ -116,6 +120,7 @@ async def create_agent_from_template(
         # commit together, same boundary as the plain create path.
         agent, api_key = await service.create_agent_from_template(
             user_id=int(user.id),
+            is_admin=bool(user.is_admin),
             template_id=request.template_id,
             name=request.name,
             description=request.description,
@@ -140,6 +145,8 @@ async def create_agent_from_template(
             400,
             "Agent models must use integer DB model ids for known model slots.",
         )
+    except InvalidKnowledgeBaseError as e:
+        raise V1ApiError(V1ErrorCode.INVALID_INPUT, 400, str(e))
     except KeyRotationConflict:
         raise V1ApiError(
             V1ErrorCode.INTERNAL_ERROR, 409, "Runtime key rotation conflict."

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -21,16 +21,24 @@ miss = prefix doesn't exist). See SDK design doc §7 (key format and
 auth flow) and §10 (security considerations).
 """
 
+from datetime import datetime, timezone
 from typing import Tuple
 
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session, joinedload
 
-from ....core.utils.api_key import parse_api_key, verify_api_key, verify_dummy
+from ....core.utils.api_key import (
+    ApiKeyKind,
+    parse_api_key,
+    verify_api_key,
+    verify_dummy,
+)
 from ...models.agent import Agent
 from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_db
+from ...models.user import User
+from ...models.user_api_key import UserApiKey
 from .errors import V1ApiError, V1ErrorCode
 
 # ``auto_error=False`` so we can raise our own V1ApiError envelope
@@ -75,7 +83,11 @@ async def get_agent_from_api_key(
         verify_dummy()
         raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 
-    prefix, _secret = parsed
+    if parsed.kind != ApiKeyKind.AGENT:
+        verify_dummy()
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    prefix = parsed.prefix
 
     # Index lookup is O(1) on ix_agent_api_keys_key_prefix and excludes
     # revoked rows via the partial unique index path. ``joinedload``
@@ -116,3 +128,49 @@ async def get_agent_from_api_key(
         raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 
     return agent, key_row
+
+
+async def get_user_from_personal_key(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+    db: Session = Depends(get_db),
+) -> Tuple[User, UserApiKey]:
+    """Resolve a personal management API key to ``(User, UserApiKey)``."""
+    if credentials is None:
+        verify_dummy()
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    raw = credentials.credentials
+    parsed = parse_api_key(raw)
+    if parsed is None or parsed.kind != ApiKeyKind.PERSONAL:
+        verify_dummy()
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    key_row = (
+        db.query(UserApiKey)
+        .options(joinedload(UserApiKey.user))
+        .filter(
+            UserApiKey.key_prefix == parsed.prefix,
+            UserApiKey.revoked_at.is_(None),
+        )
+        .first()
+    )
+    if key_row is None:
+        verify_dummy()
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    now = datetime.now(timezone.utc)
+    expires_at = key_row.expires_at
+    if expires_at is not None and expires_at <= now:
+        verify_dummy()
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    if not verify_api_key(raw, key_row.key_hash):  # type: ignore[arg-type]
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    user = key_row.user
+    if user is None:
+        raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
+
+    key_row.last_used_at = now  # type: ignore[assignment]
+    db.commit()
+    return user, key_row

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -171,6 +171,4 @@ async def get_user_from_personal_key(
     if user is None:
         raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 
-    key_row.last_used_at = now  # type: ignore[assignment]
-    db.commit()
     return user, key_row

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -39,6 +39,7 @@ from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_db
 from ...models.user import User
 from ...models.user_api_key import UserApiKey
+from ...utils.db_timezone import normalize_datetime_from_db
 from .errors import V1ApiError, V1ErrorCode
 
 # ``auto_error=False`` so we can raise our own V1ApiError envelope
@@ -160,7 +161,12 @@ async def get_user_from_personal_key(
 
     now = datetime.now(timezone.utc)
     expires_at = key_row.expires_at
-    if expires_at is not None and expires_at <= now:
+    # ``DateTime(timezone=True)`` reads back naive on SQLite; normalize
+    # to aware UTC before comparing so an expired key yields 401, not a
+    # 500 from comparing naive vs aware datetimes.
+    if (
+        expires_at is not None and normalize_datetime_from_db(expires_at) <= now  # type: ignore[arg-type]
+    ):
         verify_dummy()
         raise V1ApiError(V1ErrorCode.INVALID_API_KEY, 401)
 

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -52,6 +52,9 @@ class V1ErrorCode(str, Enum):
     # Also 404 for the same leak-prevention reason.
     TASK_NOT_FOUND = "task_not_found"
 
+    # Template id is unknown or unavailable to the caller.
+    TEMPLATE_NOT_FOUND = "template_not_found"
+
     # The task is currently running and cannot accept new input.
     # 409 Conflict. Client should retry after polling task status.
     TASK_BUSY = "task_busy"
@@ -78,6 +81,7 @@ _DEFAULT_MESSAGES: dict[V1ErrorCode, str] = {
     V1ErrorCode.INVALID_API_KEY: "Invalid or revoked API key.",
     V1ErrorCode.AGENT_NOT_FOUND: "Agent not found or not accessible with this key.",
     V1ErrorCode.TASK_NOT_FOUND: "Task not found or not accessible with this key.",
+    V1ErrorCode.TEMPLATE_NOT_FOUND: "Template not found.",
     V1ErrorCode.TASK_BUSY: "Task is currently running; retry after it completes.",
     V1ErrorCode.INVALID_INPUT: "Request body failed validation.",
     V1ErrorCode.RATE_LIMITED: "Rate limit exceeded; retry later.",

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -65,8 +65,8 @@ class V1ErrorCode(str, Enum):
     # clients always switch on ``body.error.code``.
     INVALID_INPUT = "invalid_input"
 
-    # Phase 2 feature; reserved here so SDK clients can already encode
-    # the mapping. Phase 1 never emits this.
+    # Reserved for rate limiting. The server does not emit this yet, but
+    # it stays in the enum so SDK clients can encode the mapping now.
     RATE_LIMITED = "rate_limited"
 
     # Server-side bug. Detail is sanitized; the raw exception stays in

--- a/src/xagent/web/api/v1/me.py
+++ b/src/xagent/web/api/v1/me.py
@@ -17,8 +17,10 @@ class MeResponse(BaseModel):
 
     principal_type: str = Field(default="user", description="Authenticated principal.")
     user_id: int = Field(..., description="User bound to the presented personal key.")
-    email: str = Field(..., description="User email or username.")
-    name: str = Field(..., description="User display name.")
+    username: str = Field(..., description="User's unique login name.")
+    email: str | None = Field(
+        default=None, description="User's email address, or null if unset."
+    )
     key_prefix: str = Field(
         ...,
         description=(
@@ -34,11 +36,10 @@ async def get_me(
 ) -> MeResponse:
     """Probe the user identity bound to the caller's personal key."""
     user, key = authed
-    username = str(user.username)
     return MeResponse(
         principal_type="user",
         user_id=int(user.id),
-        email=username,
-        name=username,
+        username=str(user.username),
+        email=str(user.email) if user.email is not None else None,
         key_prefix=key.key_prefix,
     )

--- a/src/xagent/web/api/v1/me.py
+++ b/src/xagent/web/api/v1/me.py
@@ -1,19 +1,13 @@
-"""GET /v1/me -- SDK auth probe.
-
-Zero side-effect, read-only endpoint that returns the agent identity
-bound to the presented API key. SDK clients call this once at startup
-to verify their key is valid and to discover which agent they're
-addressing.
-"""
+"""GET /v1/me -- personal management key identity probe."""
 
 from typing import Tuple
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from ...models.agent import Agent
-from ...models.agent_api_key import AgentApiKey
-from .deps import get_agent_from_api_key
+from ...models.user import User
+from ...models.user_api_key import UserApiKey
+from .deps import get_user_from_personal_key
 
 router = APIRouter()
 
@@ -21,8 +15,10 @@ router = APIRouter()
 class MeResponse(BaseModel):
     """Response model for ``GET /v1/me``."""
 
-    agent_id: int = Field(..., description="The agent bound to the presented key.")
-    agent_name: str = Field(..., description="Display name of the bound agent.")
+    principal_type: str = Field(default="user", description="Authenticated principal.")
+    user_id: int = Field(..., description="User bound to the presented personal key.")
+    email: str = Field(..., description="User email or username.")
+    name: str = Field(..., description="User display name.")
     key_prefix: str = Field(
         ...,
         description=(
@@ -34,32 +30,15 @@ class MeResponse(BaseModel):
 
 @router.get("/me", response_model=MeResponse)
 async def get_me(
-    authed: Tuple[Agent, AgentApiKey] = Depends(get_agent_from_api_key),
+    authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
 ) -> MeResponse:
-    """Probe the agent identity bound to the caller's API key.
-
-    Zero side-effect. SDK clients typically call this once on startup
-    to confirm their key is valid and to log which agent they're
-    targeting. The response shape is intentionally minimal -- richer
-    agent metadata (description, models, etc) is the owner's view and
-    lives behind JWT on ``/api/agents/{id}``.
-
-    Args:
-        authed: Resolved by ``get_agent_from_api_key``; the auth gate
-            handles every failure path uniformly as 401.
-
-    Returns:
-        :class:`MeResponse` with ``agent_id``, ``agent_name``, and
-        ``key_prefix``.
-
-    Raises:
-        V1ApiError 401: missing / malformed / unknown / revoked key.
-            Translated to ``{"error": {"code": "invalid_api_key", ...}}``
-            by the global exception handler.
-    """
-    agent, key = authed
+    """Probe the user identity bound to the caller's personal key."""
+    user, key = authed
+    username = str(user.username)
     return MeResponse(
-        agent_id=agent.id,
-        agent_name=agent.name,
+        principal_type="user",
+        user_id=int(user.id),
+        email=username,
+        name=username,
         key_prefix=key.key_prefix,
     )

--- a/src/xagent/web/api/v1/templates.py
+++ b/src/xagent/web/api/v1/templates.py
@@ -1,0 +1,62 @@
+"""SDK management endpoints for built-in templates."""
+
+from typing import Any, Tuple
+
+from fastapi import APIRouter, Depends, Request
+
+from ...models.user import User
+from ...models.user_api_key import UserApiKey
+from ...schemas.v1 import V1TemplateDetail, V1TemplateSummary
+from .deps import get_user_from_personal_key
+from .errors import V1ApiError, V1ErrorCode
+
+router = APIRouter(prefix="/templates")
+
+
+def _localized(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.get("en") or next(iter(value.values()), None)
+    return value
+
+
+def _template_summary(template: dict[str, Any]) -> V1TemplateSummary:
+    return V1TemplateSummary(
+        id=template["id"],
+        name=template["name"],
+        category=template.get("category", ""),
+        featured=bool(template.get("featured", False)),
+        description=_localized(template.get("descriptions")) or "",
+        features=_localized(template.get("features")) or [],
+        connections=template.get("connections") or [],
+        setup_time=_localized(template.get("setup_time")) or "5 min setup",
+        tags=_localized(template.get("tags")) or [],
+        author=template.get("author", ""),
+        version=template.get("version", ""),
+    )
+
+
+@router.get("", response_model=list[V1TemplateSummary])
+async def list_templates(
+    request: Request,
+    _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+) -> list[V1TemplateSummary]:
+    template_manager = request.app.state.template_manager
+    templates = await template_manager.list_templates()
+    return [_template_summary(template) for template in templates]
+
+
+@router.get("/{template_id}", response_model=V1TemplateDetail)
+async def get_template(
+    template_id: str,
+    request: Request,
+    _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
+) -> V1TemplateDetail:
+    template_manager = request.app.state.template_manager
+    template = await template_manager.get_template(template_id)
+    if template is None:
+        raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)
+    summary = _template_summary(template)
+    return V1TemplateDetail(
+        **summary.model_dump(),
+        agent_config=template.get("agent_config") or {},
+    )

--- a/src/xagent/web/api/v1/templates.py
+++ b/src/xagent/web/api/v1/templates.py
@@ -13,6 +13,17 @@ from .errors import V1ApiError, V1ErrorCode
 router = APIRouter(prefix="/templates")
 
 
+def _get_template_manager(request: Request) -> Any:
+    template_manager = getattr(request.app.state, "template_manager", None)
+    if template_manager is None:
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            500,
+            "Template manager is not configured.",
+        )
+    return template_manager
+
+
 def _localized(value: Any) -> Any:
     if isinstance(value, dict):
         return value.get("en") or next(iter(value.values()), None)
@@ -40,7 +51,7 @@ async def list_templates(
     request: Request,
     _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
 ) -> list[V1TemplateSummary]:
-    template_manager = request.app.state.template_manager
+    template_manager = _get_template_manager(request)
     templates = await template_manager.list_templates()
     return [_template_summary(template) for template in templates]
 
@@ -51,7 +62,7 @@ async def get_template(
     request: Request,
     _authed: Tuple[User, UserApiKey] = Depends(get_user_from_personal_key),
 ) -> V1TemplateDetail:
-    template_manager = request.app.state.template_manager
+    template_manager = _get_template_manager(request)
     template = await template_manager.get_template(template_id)
     if template is None:
         raise V1ApiError(V1ErrorCode.TEMPLATE_NOT_FOUND, 404)

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -30,6 +30,7 @@ from .api.files import file_router
 from .api.jobs import jobs_router
 from .api.kb import kb_router
 from .api.mcp import mcp_router
+from .api.me import router as me_router
 from .api.memory import MemoryManagementRouter
 from .api.model import model_router
 from .api.monitor import monitor_router
@@ -442,6 +443,7 @@ app.include_router(cloud_router)
 app.include_router(file_router)
 app.include_router(jobs_router)
 app.include_router(kb_router)
+app.include_router(me_router)
 app.include_router(model_router)
 app.include_router(ws_router)
 app.include_router(monitor_router)

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -16,6 +16,7 @@ from .template_stats import TemplateStats, UserTemplateRelation
 from .tool_config import ToolConfig, ToolUsage
 from .uploaded_file import UploadedFile
 from .user import User, UserDefaultModel, UserModel
+from .user_api_key import UserApiKey
 from .user_channel import UserChannel
 from .user_oauth import UserOAuth
 from .workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage, WorkforceRun
@@ -28,6 +29,7 @@ __all__ = [
     "User",
     "UserModel",
     "UserDefaultModel",
+    "UserApiKey",
     "UserOAuth",
     "UserChannel",
     "Model",

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -58,6 +58,7 @@ def init_db(db_url: str | None = None) -> None:
         ToolUsage,
         UploadedFile,
         User,
+        UserApiKey,
         UserDefaultModel,
         UserModel,
         UserTemplateRelation,

--- a/src/xagent/web/models/user.py
+++ b/src/xagent/web/models/user.py
@@ -72,6 +72,9 @@ class User(Base):  # type: ignore
     template_relations = relationship(
         "UserTemplateRelation", back_populates="user", cascade="all, delete-orphan"
     )
+    api_keys = relationship(
+        "UserApiKey", back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, username='{self.username}', is_admin={self.is_admin})>"

--- a/src/xagent/web/models/user_api_key.py
+++ b/src/xagent/web/models/user_api_key.py
@@ -1,0 +1,43 @@
+"""Personal SDK management API keys bound to a user."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class UserApiKey(Base):  # type: ignore
+    """User-level SDK key for management endpoints under ``/v1``."""
+
+    __tablename__ = "user_api_keys"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    key_prefix = Column(String(12), nullable=False, unique=True, index=True)
+    key_hash = Column(String(128), nullable=False)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user = relationship("User", back_populates="api_keys")
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserApiKey(id={self.id}, user_id={self.user_id}, "
+            f"key_prefix='{self.key_prefix}', revoked={self.revoked_at is not None})>"
+        )

--- a/src/xagent/web/models/user_api_key.py
+++ b/src/xagent/web/models/user_api_key.py
@@ -23,7 +23,6 @@ class UserApiKey(Base):  # type: ignore
     key_hash = Column(String(128), nullable=False)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
     expires_at = Column(DateTime(timezone=True), nullable=True)
-    last_used_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/src/xagent/web/schemas/user_api_key.py
+++ b/src/xagent/web/schemas/user_api_key.py
@@ -26,7 +26,6 @@ class PersonalAPIKeyMetadata(BaseModel):
     masked_key: str
     revoked_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
-    last_used_at: Optional[datetime] = None
     created_at: datetime
 
 

--- a/src/xagent/web/schemas/user_api_key.py
+++ b/src/xagent/web/schemas/user_api_key.py
@@ -1,0 +1,35 @@
+"""Schemas for user personal SDK management keys."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PersonalAPIKeyCreateResponse(BaseModel):
+    id: int
+    full_key: str = Field(
+        ...,
+        description=(
+            "Plaintext personal key in the format "
+            "xag_personal_<6 chars>_<32 chars>. Returned exactly once."
+        ),
+    )
+    key_prefix: str
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+
+
+class PersonalAPIKeyMetadata(BaseModel):
+    id: int
+    key_prefix: str
+    masked_key: str
+    revoked_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    last_used_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class PersonalAPIKeyRevokeResponse(BaseModel):
+    revoked: bool
+    revoked_at: Optional[datetime] = None

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -15,8 +15,8 @@ Design notes:
 
   - ``metadata`` is a free-form passthrough dict the SaaS caller can
     use to round-trip its own correlation IDs (trace_id, request_id,
-    etc). We don't interpret it server-side in Phase 1 but persist
-    enough of the SDK call shape to support future debugging.
+    etc). The server does not interpret it but persists enough of the
+    SDK call shape to support future debugging.
 
   - Timestamps are tz-aware ``datetime`` so SDK clients deserialize
     into proper datetimes (``datetime.fromisoformat`` works on both
@@ -74,8 +74,7 @@ class CreateTaskRequest(BaseModel):
         default=None,
         description=(
             "Free-form correlation data the SDK caller can pass through "
-            "(trace_id, request_id, etc). Not interpreted server-side "
-            "in Phase 1."
+            "(trace_id, request_id, etc). Not interpreted server-side."
         ),
     )
 

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -80,6 +80,101 @@ class CreateTaskRequest(BaseModel):
     )
 
 
+class RuntimeKeyResponse(BaseModel):
+    """Runtime API key returned once after creation or rotation."""
+
+    full_key: str
+    key_prefix: str
+    created_at: datetime
+
+
+class V1AgentCreateRequest(BaseModel):
+    """Body for ``POST /v1/agents``."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    description: Optional[str] = None
+    instructions: Optional[str] = None
+    execution_mode: Optional[str] = "balanced"
+    models: Optional[dict[str, Any]] = None
+    knowledge_bases: list[str] = Field(default_factory=list)
+    skills: list[str] = Field(default_factory=list)
+    tool_categories: list[str] = Field(default_factory=list)
+    suggested_prompts: list[str] = Field(default_factory=list)
+    generate_runtime_key: bool = True
+
+
+class V1AgentTemplateCreateRequest(BaseModel):
+    """Body for ``POST /v1/agents/from-template``."""
+
+    template_id: str = Field(..., min_length=1)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    description: Optional[str] = None
+    instructions: Optional[str] = None
+    execution_mode: Optional[str] = None
+    models: Optional[dict[str, Any]] = None
+    knowledge_bases: Optional[list[str]] = None
+    skills: Optional[list[str]] = None
+    tool_categories: Optional[list[str]] = None
+    suggested_prompts: Optional[list[str]] = None
+    generate_runtime_key: bool = True
+
+
+class V1AgentSummary(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    logo_url: Optional[str] = None
+    status: str
+    created_at: str
+    updated_at: str
+    widget_enabled: bool
+    allowed_domains: list[str]
+
+
+class V1AgentResponse(BaseModel):
+    id: int
+    user_id: int
+    name: str
+    description: Optional[str] = None
+    instructions: Optional[str] = None
+    execution_mode: str
+    models: Optional[dict[str, Any]] = None
+    knowledge_bases: list[str]
+    skills: list[str]
+    tool_categories: list[str]
+    suggested_prompts: list[str]
+    logo_url: Optional[str] = None
+    status: str
+    published_at: Optional[str] = None
+    created_at: str
+    updated_at: str
+    widget_enabled: bool
+    allowed_domains: list[str]
+
+
+class V1AgentCreateResponse(BaseModel):
+    agent: V1AgentResponse
+    api_key: Optional[RuntimeKeyResponse] = None
+
+
+class V1TemplateSummary(BaseModel):
+    id: str
+    name: str
+    category: str = ""
+    featured: bool = False
+    description: str = ""
+    features: list[str] = Field(default_factory=list)
+    connections: list[dict[str, Any]] = Field(default_factory=list)
+    setup_time: str = "5 min setup"
+    tags: list[str] = Field(default_factory=list)
+    author: str = ""
+    version: str = ""
+
+
+class V1TemplateDetail(V1TemplateSummary):
+    agent_config: dict[str, Any]
+
+
 class CreateTaskResponse(BaseModel):
     """``POST /v1/chat/tasks`` -> 202 Accepted response.
 

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -1,0 +1,168 @@
+"""Reusable agent management operations for web, SDK, and SaaS adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ...templates.manager import TemplateManager
+from ..models.agent import Agent
+from ..models.model import Model as DBModel
+from ..services.agent_store import AgentStore
+from .api_keys import AgentApiKeyService
+
+
+class DuplicateAgentNameError(ValueError):
+    """Raised when a user already owns an agent with the requested name."""
+
+
+class TemplateNotFoundError(LookupError):
+    """Raised when a template id cannot be resolved."""
+
+
+class InvalidAgentModelConfigError(ValueError):
+    """Raised when the agent model slot payload does not match DB id shape."""
+
+
+class AgentManagementService:
+    """High-level user-owned agent management workflow boundary."""
+
+    MODEL_SLOTS = frozenset({"general", "small_fast", "visual", "compact"})
+
+    def __init__(self, db: Session, template_manager: TemplateManager | None = None):
+        self.db = db
+        self.store = AgentStore(db)
+        self.template_manager = template_manager
+        self.key_service = AgentApiKeyService(db)
+
+    def list_agents_for_user(self, user_id: int) -> list[dict[str, Any]]:
+        return self.store.list_agent_items(user_id)
+
+    def create_agent_for_user(
+        self,
+        *,
+        user_id: int,
+        name: str,
+        description: str | None,
+        instructions: str | None,
+        execution_mode: str | None = "balanced",
+        models: dict[str, Any] | None = None,
+        knowledge_bases: list[str] | None = None,
+        skills: list[str] | None = None,
+        tool_categories: list[str] | None = None,
+        suggested_prompts: list[str] | None = None,
+    ) -> Agent:
+        if self.store.agent_name_exists(user_id, name):
+            raise DuplicateAgentNameError(name)
+
+        models = self._validate_models(models, user_id=user_id)
+
+        return self.store.create_agent(
+            user_id=user_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode or "balanced",
+            models=models,
+            knowledge_bases=knowledge_bases or [],
+            skills=skills or [],
+            tool_categories=tool_categories or [],
+            suggested_prompts=suggested_prompts or [],
+        )
+
+    async def create_agent_from_template(
+        self,
+        *,
+        user_id: int,
+        template_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        instructions: str | None = None,
+        execution_mode: str | None = None,
+        models: dict[str, Any] | None = None,
+        knowledge_bases: list[str] | None = None,
+        skills: list[str] | None = None,
+        tool_categories: list[str] | None = None,
+        suggested_prompts: list[str] | None = None,
+    ) -> Agent:
+        if self.template_manager is None:
+            raise TemplateNotFoundError(template_id)
+
+        template = await self.template_manager.get_template(template_id)
+        if template is None:
+            raise TemplateNotFoundError(template_id)
+
+        agent_config = template.get("agent_config") or {}
+        final_name = name or template.get("name") or template_id
+        final_description = description
+        if final_description is None:
+            descriptions = template.get("descriptions") or {}
+            if isinstance(descriptions, dict):
+                final_description = descriptions.get("en") or ""
+            elif isinstance(descriptions, str):
+                final_description = descriptions
+
+        return self.create_agent_for_user(
+            user_id=user_id,
+            name=final_name,
+            description=final_description,
+            instructions=(
+                instructions
+                if instructions is not None
+                else agent_config.get("instructions")
+            ),
+            execution_mode=execution_mode or agent_config.get("execution_mode"),
+            models=models if models is not None else agent_config.get("models"),
+            knowledge_bases=(
+                knowledge_bases
+                if knowledge_bases is not None
+                else agent_config.get("knowledge_bases") or []
+            ),
+            skills=skills if skills is not None else agent_config.get("skills") or [],
+            tool_categories=(
+                tool_categories
+                if tool_categories is not None
+                else agent_config.get("tool_categories") or []
+            ),
+            suggested_prompts=(
+                suggested_prompts
+                if suggested_prompts is not None
+                else agent_config.get("suggested_prompts") or []
+            ),
+        )
+
+    def generate_agent_runtime_key(self, *, user_id: int, agent_id: int):
+        agent = self.store.get_owned_agent(user_id, agent_id)
+        if agent is None:
+            return None
+        return self.key_service.rotate_key(agent_id)
+
+    def _validate_models(
+        self, models: dict[str, Any] | None, *, user_id: int
+    ) -> dict[str, Any] | None:
+        if models is None:
+            return None
+
+        from .model_service import _is_model_visible_to_user
+
+        normalized: dict[str, Any] = {}
+        for slot, model_id in models.items():
+            if slot not in self.MODEL_SLOTS:
+                raise InvalidAgentModelConfigError(slot)
+            if model_id is None:
+                normalized[slot] = None
+                continue
+            if isinstance(model_id, bool) or not isinstance(model_id, int):
+                raise InvalidAgentModelConfigError(slot)
+            exists = (
+                self.db.query(DBModel.id)
+                .filter(DBModel.id == model_id, DBModel.is_active.is_(True))
+                .first()
+            )
+            if exists is None or not _is_model_visible_to_user(
+                self.db, model_id, user_id
+            ):
+                raise InvalidAgentModelConfigError(slot)
+            normalized[slot] = model_id
+        return normalized

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from ...templates.manager import TemplateManager
 from ..models.agent import Agent
 from ..models.model import Model as DBModel
+from ..schemas.agent_api_key import APIKeyGenerateResponse
 from ..services.agent_store import AgentStore
 from .api_keys import AgentApiKeyService
 
@@ -132,7 +133,9 @@ class AgentManagementService:
             ),
         )
 
-    def generate_agent_runtime_key(self, *, user_id: int, agent_id: int):
+    def generate_agent_runtime_key(
+        self, *, user_id: int, agent_id: int
+    ) -> APIKeyGenerateResponse | None:
         agent = self.store.get_owned_agent(user_id, agent_id)
         if agent is None:
             return None

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -7,12 +7,17 @@ from typing import Any
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...templates.manager import TemplateManager
 from ..models.agent import Agent
 from ..models.model import Model as DBModel
 from ..schemas.agent_api_key import APIKeyGenerateResponse
 from ..services.agent_store import AgentStore, invalidate_agent_cache
 from .api_keys import AgentApiKeyService, KeyRotationConflict
+
+# Agent-builder tool category that gates knowledge-base access. A KB
+# selection is only valid when this category is also enabled.
+KNOWLEDGE_TOOL_CATEGORY = "knowledge"
 
 
 class DuplicateAgentNameError(ValueError):
@@ -25,6 +30,10 @@ class TemplateNotFoundError(LookupError):
 
 class InvalidAgentModelConfigError(ValueError):
     """Raised when the agent model slot payload does not match DB id shape."""
+
+
+class InvalidKnowledgeBaseError(ValueError):
+    """Raised when KB selection fails the knowledge-tool or visibility rule."""
 
 
 class AgentManagementService:
@@ -41,10 +50,44 @@ class AgentManagementService:
     def list_agents_for_user(self, user_id: int) -> list[dict[str, Any]]:
         return self.store.list_agent_items(user_id)
 
-    def create_agent_for_user(
+    async def validate_knowledge_bases(
+        self,
+        *,
+        knowledge_bases: list[str] | None,
+        tool_categories: list[str] | None,
+        user_id: int,
+        is_admin: bool,
+    ) -> None:
+        """Enforce the knowledge-base invariant shared with ``/api/agents``.
+
+        A non-empty KB selection requires the ``knowledge`` tool category
+        and every named KB must be visible to the user. Raises
+        :class:`InvalidKnowledgeBaseError` on either violation. This is
+        async (KB visibility is an I/O lookup), so it lives on the async
+        :meth:`create_agent` entry point rather than the sync transaction
+        executor.
+        """
+        if not knowledge_bases:
+            return
+        if KNOWLEDGE_TOOL_CATEGORY not in (tool_categories or []):
+            raise InvalidKnowledgeBaseError(
+                "Knowledge bases are selected but the Knowledge tool "
+                "category is not enabled."
+            )
+        missing = await find_missing_knowledge_bases(
+            knowledge_bases, user_id=user_id, is_admin=is_admin
+        )
+        if missing:
+            raise InvalidKnowledgeBaseError(
+                "Knowledge base(s) not found or not visible to this user: "
+                + ", ".join(missing)
+            )
+
+    async def create_agent(
         self,
         *,
         user_id: int,
+        is_admin: bool,
         name: str,
         description: str | None,
         instructions: str | None,
@@ -54,23 +97,31 @@ class AgentManagementService:
         skills: list[str] | None = None,
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
-    ) -> Agent:
-        if self.store.agent_name_exists(user_id, name):
-            raise DuplicateAgentNameError(name)
-
-        models = self._validate_models(models, user_id=user_id)
-
-        return self.store.create_agent(
+        generate_runtime_key: bool = True,
+    ) -> tuple[Agent, APIKeyGenerateResponse | None]:
+        """Sole external create entry point: validate KBs (async) then
+        run the transactional create. Every public create path
+        (``POST /v1/agents`` and ``POST /v1/agents/from-template``) goes
+        through here, so the KB invariant has a single enforcement point.
+        """
+        await self.validate_knowledge_bases(
+            knowledge_bases=knowledge_bases,
+            tool_categories=tool_categories,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        return self.create_agent_with_optional_key(
             user_id=user_id,
             name=name,
             description=description,
             instructions=instructions,
-            execution_mode=execution_mode or "balanced",
+            execution_mode=execution_mode,
             models=models,
-            knowledge_bases=knowledge_bases or [],
-            skills=skills or [],
-            tool_categories=tool_categories or [],
-            suggested_prompts=suggested_prompts or [],
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
         )
 
     def create_agent_with_optional_key(
@@ -89,15 +140,25 @@ class AgentManagementService:
         generate_runtime_key: bool = True,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
         """Create an agent and (optionally) its first runtime key in a
-        single transaction.
+        single transaction. Internal transaction executor: assumes
+        knowledge-base inputs were already validated by the async
+        :meth:`create_agent` entry point; this method only validates
+        models and owns the commit boundary.
 
         Committing the agent and its first key separately would leave a
         persisted agent behind if the key step fails, so a client retry
         would hit duplicate-name even though the create appeared to
         fail. This method stages both writes (flush, no commit) and
         commits once at the boundary, rolling back atomically on any
-        failure. Both ``POST /v1/agents`` and
-        ``POST /v1/agents/from-template`` route their writes through here.
+        failure.
+
+        Conflict contract: the only IntegrityError this path can raise
+        comes from the runtime key's unique constraints (``key_prefix``
+        / ``uq_agent_api_keys_agent_active``); the agent table has no
+        unique constraint and therefore does not contribute one. If a
+        ``(user_id, name)`` unique constraint is ever added to agents,
+        the conflict translation here must be split by source (agent ->
+        duplicate-name 400, key -> 409).
         """
         if self.store.agent_name_exists(user_id, name):
             raise DuplicateAgentNameError(name)
@@ -117,13 +178,14 @@ class AgentManagementService:
             suggested_prompts=suggested_prompts or [],
         )
 
+        # The runtime key is the only write that can raise IntegrityError
+        # here (agent has no unique constraint), so the conflict-to-409
+        # translation wraps key staging + commit together. See the
+        # contract note in the docstring above.
         staged_key = None
-        if generate_runtime_key:
-            staged_key = self.key_service.stage_rotated_key(
-                int(agent.id)
-            )  # flush, no commit
-
         try:
+            if generate_runtime_key:
+                staged_key = self.key_service.stage_rotated_key(int(agent.id))
             self.db.commit()  # single transaction boundary for both writes
         except IntegrityError as exc:
             self.db.rollback()
@@ -147,6 +209,7 @@ class AgentManagementService:
         self,
         *,
         user_id: int,
+        is_admin: bool,
         template_id: str,
         name: str | None = None,
         description: str | None = None,
@@ -159,13 +222,9 @@ class AgentManagementService:
         suggested_prompts: list[str] | None = None,
         generate_runtime_key: bool = True,
     ) -> tuple[Agent, APIKeyGenerateResponse | None]:
-        """Resolve a template (async I/O) then create the agent and its
-        optional first runtime key in a single transaction.
-
-        Template resolution stays async; the database writes go through
-        :meth:`create_agent_with_optional_key`, so the agent row and the
-        first key share one commit boundary here too -- a key-step
-        failure rolls the agent back instead of stranding it.
+        """Resolve a template (async I/O) then create the agent through
+        :meth:`create_agent`, so KB validation and the single commit
+        boundary are shared with the plain create path.
         """
         if self.template_manager is None:
             raise TemplateNotFoundError(template_id)
@@ -184,8 +243,9 @@ class AgentManagementService:
             elif isinstance(descriptions, str):
                 final_description = descriptions
 
-        return self.create_agent_with_optional_key(
+        return await self.create_agent(
             user_id=user_id,
+            is_admin=is_admin,
             generate_runtime_key=generate_runtime_key,
             name=final_name,
             description=final_description,

--- a/src/xagent/web/services/agent_management.py
+++ b/src/xagent/web/services/agent_management.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...templates.manager import TemplateManager
 from ..models.agent import Agent
 from ..models.model import Model as DBModel
 from ..schemas.agent_api_key import APIKeyGenerateResponse
-from ..services.agent_store import AgentStore
-from .api_keys import AgentApiKeyService
+from ..services.agent_store import AgentStore, invalidate_agent_cache
+from .api_keys import AgentApiKeyService, KeyRotationConflict
 
 
 class DuplicateAgentNameError(ValueError):
@@ -72,6 +73,76 @@ class AgentManagementService:
             suggested_prompts=suggested_prompts or [],
         )
 
+    def create_agent_with_optional_key(
+        self,
+        *,
+        user_id: int,
+        name: str,
+        description: str | None,
+        instructions: str | None,
+        execution_mode: str | None = "balanced",
+        models: dict[str, Any] | None = None,
+        knowledge_bases: list[str] | None = None,
+        skills: list[str] | None = None,
+        tool_categories: list[str] | None = None,
+        suggested_prompts: list[str] | None = None,
+        generate_runtime_key: bool = True,
+    ) -> tuple[Agent, APIKeyGenerateResponse | None]:
+        """Create an agent and (optionally) its first runtime key in a
+        single transaction.
+
+        Committing the agent and its first key separately would leave a
+        persisted agent behind if the key step fails, so a client retry
+        would hit duplicate-name even though the create appeared to
+        fail. This method stages both writes (flush, no commit) and
+        commits once at the boundary, rolling back atomically on any
+        failure. Both ``POST /v1/agents`` and
+        ``POST /v1/agents/from-template`` route their writes through here.
+        """
+        if self.store.agent_name_exists(user_id, name):
+            raise DuplicateAgentNameError(name)
+
+        models = self._validate_models(models, user_id=user_id)
+
+        agent = self.store.add_agent(  # flush, no commit
+            user_id=user_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode or "balanced",
+            models=models,
+            knowledge_bases=knowledge_bases or [],
+            skills=skills or [],
+            tool_categories=tool_categories or [],
+            suggested_prompts=suggested_prompts or [],
+        )
+
+        staged_key = None
+        if generate_runtime_key:
+            staged_key = self.key_service.stage_rotated_key(
+                int(agent.id)
+            )  # flush, no commit
+
+        try:
+            self.db.commit()  # single transaction boundary for both writes
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise KeyRotationConflict(str(exc)) from exc
+
+        self.db.refresh(agent)
+        invalidate_agent_cache(user_id, int(agent.id))
+
+        key_resp: APIKeyGenerateResponse | None = None
+        if staged_key is not None:
+            new_row, full_key = staged_key
+            self.db.refresh(new_row)
+            key_resp = APIKeyGenerateResponse(
+                full_key=full_key,
+                key_prefix=new_row.key_prefix,
+                created_at=new_row.created_at,
+            )
+        return agent, key_resp
+
     async def create_agent_from_template(
         self,
         *,
@@ -86,7 +157,16 @@ class AgentManagementService:
         skills: list[str] | None = None,
         tool_categories: list[str] | None = None,
         suggested_prompts: list[str] | None = None,
-    ) -> Agent:
+        generate_runtime_key: bool = True,
+    ) -> tuple[Agent, APIKeyGenerateResponse | None]:
+        """Resolve a template (async I/O) then create the agent and its
+        optional first runtime key in a single transaction.
+
+        Template resolution stays async; the database writes go through
+        :meth:`create_agent_with_optional_key`, so the agent row and the
+        first key share one commit boundary here too -- a key-step
+        failure rolls the agent back instead of stranding it.
+        """
         if self.template_manager is None:
             raise TemplateNotFoundError(template_id)
 
@@ -104,8 +184,9 @@ class AgentManagementService:
             elif isinstance(descriptions, str):
                 final_description = descriptions
 
-        return self.create_agent_for_user(
+        return self.create_agent_with_optional_key(
             user_id=user_id,
+            generate_runtime_key=generate_runtime_key,
             name=final_name,
             description=final_description,
             instructions=(

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -193,8 +193,8 @@ class UserApiKeyService:
             )
 
         now = datetime.now(timezone.utc)
-        row.revoked_at = now  # type: ignore[assignment]
-        row.updated_at = now  # type: ignore[assignment]
+        row.revoked_at = now
+        row.updated_at = now
         try:
             self.db.commit()
         except Exception:

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -86,9 +86,13 @@ class AgentApiKeyService:
         ``/api/agents/{id}/api-key`` endpoint, which owns its own
         transaction: returns a one-shot key, commits itself, and maps a
         unique-index race to :class:`KeyRotationConflict`.
+
+        Staging and commit share one ``try`` so the
+        ``uq_agent_api_keys_agent_active`` / ``key_prefix`` conflict is
+        translated whether it surfaces at the staging flush or at commit.
         """
-        new_row, full_key = self.stage_rotated_key(agent_id)
         try:
+            new_row, full_key = self.stage_rotated_key(agent_id)
             self.db.commit()
         except IntegrityError as exc:
             self.db.rollback()

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -36,7 +36,20 @@ class AgentApiKeyService:
     def __init__(self, db: Session) -> None:
         self.db = db
 
-    def rotate_key(self, agent_id: int) -> APIKeyGenerateResponse:
+    def stage_rotated_key(self, agent_id: int) -> tuple[AgentApiKey, str]:
+        """Revoke the active key (if any) and stage a new one, then flush.
+
+        Does NOT commit -- the caller owns the transaction boundary. This
+        is the composable building block (mirror of
+        ``AgentStore.add_agent``): single-step callers go through
+        :meth:`rotate_key` which commits, while multi-step workflows
+        (create-agent-with-key) stage this plus other writes and commit
+        once at the outer boundary.
+
+        Returns the staged ORM row and the one-shot plaintext key. The
+        row's ``created_at`` is only populated after the caller commits
+        and refreshes.
+        """
         now = datetime.now(timezone.utc)
         existing = (
             self.db.query(AgentApiKey)
@@ -59,7 +72,22 @@ class AgentApiKeyService:
             key_hash=key_hash,
         )
         self.db.add(new_row)
+        self.db.flush()
+        logger.info(
+            "Staged runtime API key for agent %s (prefix=%s, rotated=%s)",
+            agent_id,
+            key_prefix,
+            existing is not None,
+        )
+        return new_row, full_key
 
+    def rotate_key(self, agent_id: int) -> APIKeyGenerateResponse:
+        """Single-step rotate: stage + commit. Used by the JWT-gated
+        ``/api/agents/{id}/api-key`` endpoint, which owns its own
+        transaction: returns a one-shot key, commits itself, and maps a
+        unique-index race to :class:`KeyRotationConflict`.
+        """
+        new_row, full_key = self.stage_rotated_key(agent_id)
         try:
             self.db.commit()
         except IntegrityError as exc:
@@ -67,15 +95,9 @@ class AgentApiKeyService:
             raise KeyRotationConflict(str(exc)) from exc
 
         self.db.refresh(new_row)
-        logger.info(
-            "Rotated runtime API key for agent %s (prefix=%s, rotated=%s)",
-            agent_id,
-            key_prefix,
-            existing is not None,
-        )
         return APIKeyGenerateResponse(
             full_key=full_key,
-            key_prefix=key_prefix,
+            key_prefix=new_row.key_prefix,
             created_at=new_row.created_at,
         )
 

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -1,0 +1,194 @@
+"""API key services for SDK runtime and management credentials."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import NamedTuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ...core.utils.api_key import ApiKeyKind, generate_api_key
+from ..models.agent_api_key import AgentApiKey
+from ..models.user_api_key import UserApiKey
+from ..schemas.agent_api_key import (
+    APIKeyGenerateResponse,
+    APIKeyMetadataResponse,
+    APIKeyRevokeResponse,
+)
+from ..schemas.user_api_key import (
+    PersonalAPIKeyCreateResponse,
+    PersonalAPIKeyMetadata,
+    PersonalAPIKeyRevokeResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KeyRotationConflict(RuntimeError):
+    """Raised when a concurrent key rotation wins the active-key race."""
+
+
+class AgentApiKeyService:
+    """Owns agent runtime API key rotation and metadata."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def rotate_key(self, agent_id: int) -> APIKeyGenerateResponse:
+        now = datetime.now(timezone.utc)
+        existing = (
+            self.db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .first()
+        )
+        if existing is not None:
+            existing.revoked_at = now  # type: ignore[assignment]
+            existing.updated_at = now  # type: ignore[assignment]
+
+        full_key, key_prefix, key_hash = generate_api_key(
+            self.db, kind=ApiKeyKind.AGENT
+        )
+        new_row = AgentApiKey(
+            agent_id=agent_id,
+            key_prefix=key_prefix,
+            key_hash=key_hash,
+        )
+        self.db.add(new_row)
+
+        try:
+            self.db.commit()
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise KeyRotationConflict(str(exc)) from exc
+
+        self.db.refresh(new_row)
+        logger.info(
+            "Rotated runtime API key for agent %s (prefix=%s, rotated=%s)",
+            agent_id,
+            key_prefix,
+            existing is not None,
+        )
+        return APIKeyGenerateResponse(
+            full_key=full_key,
+            key_prefix=key_prefix,
+            created_at=new_row.created_at,
+        )
+
+    def get_metadata(self, agent_id: int) -> APIKeyMetadataResponse | None:
+        row = (
+            self.db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .first()
+        )
+        if row is None:
+            return None
+        return APIKeyMetadataResponse(
+            key_prefix=row.key_prefix,
+            masked_key=f"xag_{row.key_prefix}_••••••••",
+            created_at=row.created_at,
+        )
+
+    def revoke_key(self, agent_id: int) -> APIKeyRevokeResponse:
+        row = (
+            self.db.query(AgentApiKey)
+            .filter(
+                AgentApiKey.agent_id == agent_id,
+                AgentApiKey.revoked_at.is_(None),
+            )
+            .first()
+        )
+        if row is None:
+            return APIKeyRevokeResponse(revoked=False, revoked_at=None)
+
+        now = datetime.now(timezone.utc)
+        row.revoked_at = now  # type: ignore[assignment]
+        row.updated_at = now  # type: ignore[assignment]
+        self.db.commit()
+        self.db.refresh(row)
+        logger.info("Revoked runtime API key for agent %s", agent_id)
+        return APIKeyRevokeResponse(revoked=True, revoked_at=row.revoked_at)
+
+
+class PersonalKeySecret(NamedTuple):
+    full_key: str
+    key_prefix: str
+    key_hash: str
+
+
+class UserApiKeyService:
+    """Owns personal management API keys."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_key(self, user_id: int) -> PersonalAPIKeyCreateResponse:
+        full_key, key_prefix, key_hash = generate_api_key(
+            self.db, kind=ApiKeyKind.PERSONAL
+        )
+        row = UserApiKey(
+            user_id=user_id,
+            key_prefix=key_prefix,
+            key_hash=key_hash,
+        )
+        self.db.add(row)
+        self.db.commit()
+        self.db.refresh(row)
+        logger.info(
+            "Created personal API key for user %s (prefix=%s)", user_id, key_prefix
+        )
+        return PersonalAPIKeyCreateResponse(
+            id=int(row.id),
+            full_key=full_key,
+            key_prefix=row.key_prefix,
+            created_at=row.created_at,
+            expires_at=row.expires_at,
+        )
+
+    def list_keys(self, user_id: int) -> list[PersonalAPIKeyMetadata]:
+        rows = (
+            self.db.query(UserApiKey)
+            .filter(UserApiKey.user_id == user_id)
+            .order_by(UserApiKey.created_at.desc())
+            .all()
+        )
+        return [
+            PersonalAPIKeyMetadata(
+                id=int(row.id),
+                key_prefix=row.key_prefix,
+                masked_key=f"xag_personal_{row.key_prefix}_••••••••",
+                revoked_at=row.revoked_at,
+                expires_at=row.expires_at,
+                last_used_at=row.last_used_at,
+                created_at=row.created_at,
+            )
+            for row in rows
+        ]
+
+    def revoke_key(self, user_id: int, key_id: int) -> PersonalAPIKeyRevokeResponse:
+        row = (
+            self.db.query(UserApiKey)
+            .filter(UserApiKey.id == key_id, UserApiKey.user_id == user_id)
+            .first()
+        )
+        if row is None:
+            return PersonalAPIKeyRevokeResponse(revoked=False, revoked_at=None)
+        if row.revoked_at is not None:
+            return PersonalAPIKeyRevokeResponse(
+                revoked=False, revoked_at=row.revoked_at
+            )
+
+        now = datetime.now(timezone.utc)
+        row.revoked_at = now  # type: ignore[assignment]
+        row.updated_at = now  # type: ignore[assignment]
+        self.db.commit()
+        self.db.refresh(row)
+        logger.info("Revoked personal API key %s for user %s", key_id, user_id)
+        return PersonalAPIKeyRevokeResponse(revoked=True, revoked_at=row.revoked_at)

--- a/src/xagent/web/services/api_keys.py
+++ b/src/xagent/web/services/api_keys.py
@@ -97,24 +97,28 @@ class AgentApiKeyService:
         )
 
     def revoke_key(self, agent_id: int) -> APIKeyRevokeResponse:
-        row = (
+        now = datetime.now(timezone.utc)
+        updated_count = (
             self.db.query(AgentApiKey)
             .filter(
                 AgentApiKey.agent_id == agent_id,
                 AgentApiKey.revoked_at.is_(None),
             )
-            .first()
+            .update(
+                {AgentApiKey.revoked_at: now, AgentApiKey.updated_at: now},
+                synchronize_session=False,
+            )
         )
-        if row is None:
+        if updated_count == 0:
             return APIKeyRevokeResponse(revoked=False, revoked_at=None)
 
-        now = datetime.now(timezone.utc)
-        row.revoked_at = now  # type: ignore[assignment]
-        row.updated_at = now  # type: ignore[assignment]
-        self.db.commit()
-        self.db.refresh(row)
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
         logger.info("Revoked runtime API key for agent %s", agent_id)
-        return APIKeyRevokeResponse(revoked=True, revoked_at=row.revoked_at)
+        return APIKeyRevokeResponse(revoked=True, revoked_at=now)
 
 
 class PersonalKeySecret(NamedTuple):
@@ -139,7 +143,11 @@ class UserApiKeyService:
             key_hash=key_hash,
         )
         self.db.add(row)
-        self.db.commit()
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
         self.db.refresh(row)
         logger.info(
             "Created personal API key for user %s (prefix=%s)", user_id, key_prefix
@@ -166,7 +174,6 @@ class UserApiKeyService:
                 masked_key=f"xag_personal_{row.key_prefix}_••••••••",
                 revoked_at=row.revoked_at,
                 expires_at=row.expires_at,
-                last_used_at=row.last_used_at,
                 created_at=row.created_at,
             )
             for row in rows
@@ -188,7 +195,11 @@ class UserApiKeyService:
         now = datetime.now(timezone.utc)
         row.revoked_at = now  # type: ignore[assignment]
         row.updated_at = now  # type: ignore[assignment]
-        self.db.commit()
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
         self.db.refresh(row)
         logger.info("Revoked personal API key %s for user %s", key_id, user_id)
         return PersonalAPIKeyRevokeResponse(revoked=True, revoked_at=row.revoked_at)

--- a/tests/core/utils/test_api_key.py
+++ b/tests/core/utils/test_api_key.py
@@ -31,6 +31,7 @@ from xagent.core.utils.api_key import (
     KEY_PREFIX_LENGTH,
     KEY_SECRET_LENGTH,
     PREFIX_COLLISION_RETRIES,
+    ApiKeyKind,
     generate_api_key,
     parse_api_key,
     verify_api_key,
@@ -116,11 +117,27 @@ def test_parse_valid() -> None:
     full, prefix, _hash = generate_api_key(db=None)
     parsed = parse_api_key(full)
     assert parsed is not None
-    parsed_prefix, parsed_secret = parsed
-    assert parsed_prefix == prefix
-    assert len(parsed_secret) == KEY_SECRET_LENGTH
+    assert parsed.kind == ApiKeyKind.AGENT
+    assert parsed.prefix == prefix
+    assert len(parsed.secret) == KEY_SECRET_LENGTH
     # Reassembly round-trip
-    assert f"{KEY_BRAND}_{parsed_prefix}_{parsed_secret}" == full
+    assert f"{KEY_BRAND}_{parsed.prefix}_{parsed.secret}" == full
+
+
+def test_generate_and_parse_personal_key() -> None:
+    """Personal keys include an explicit kind segment."""
+    full, prefix, key_hash = generate_api_key(db=None, kind=ApiKeyKind.PERSONAL)
+    assert full.startswith(f"{KEY_BRAND}_{ApiKeyKind.PERSONAL.value}_")
+    parts = full.split("_")
+    assert len(parts) == 4
+    assert parts[2] == prefix
+    assert verify_api_key(full, key_hash) is True
+
+    parsed = parse_api_key(full)
+    assert parsed is not None
+    assert parsed.kind == ApiKeyKind.PERSONAL
+    assert parsed.prefix == prefix
+    assert len(parsed.secret) == KEY_SECRET_LENGTH
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import Session
 
 from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
+from xagent.web.api.me import router as me_router
 from xagent.web.api.v1 import v1_router
 from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
 from xagent.web.api.workforces import router as workforces_router
@@ -58,6 +59,7 @@ def _override_get_db() -> Iterator[Session]:
 # is safe to reuse across tests.
 app_for_tests = FastAPI()
 app_for_tests.include_router(auth_router)
+app_for_tests.include_router(me_router)
 app_for_tests.include_router(agents_router)
 app_for_tests.include_router(workforces_router)
 app_for_tests.include_router(v1_router)

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -1,11 +1,7 @@
-"""Integration tests for the /v1/* auth dependency (get_agent_from_api_key).
+"""Integration tests for the /v1/* personal management auth dependency.
 
-Drives /v1/me (which only does auth + return identity) to verify each
-failure path returns the stable ``{"error": {"code": "invalid_api_key",
-...}}`` envelope. Also asserts timing-oracle symmetry: prefix-miss
-should not be measurably faster than secret-wrong, and that unhandled
-internal exceptions on the /v1/* surface still respond in the SDK
-envelope rather than FastAPI's default ``{"detail": ...}``.
+Drives /v1/me to verify each personal-key failure path returns the
+stable ``{"error": {"code": "invalid_api_key", ...}}`` envelope.
 
 Test plumbing (client, _test_db fixture, auth helpers) is shared via
 ``tests/web/api/conftest.py``.
@@ -52,19 +48,37 @@ def _create_agent_and_key() -> tuple[int, str, str]:
     return agent_id, body["full_key"], body["key_prefix"]
 
 
+def _create_personal_key() -> tuple[str, str]:
+    """Helper: create a personal management key for the admin user."""
+    headers = _admin_headers()
+    key_resp = client.post("/api/me/personal-keys", headers=headers)
+    assert key_resp.status_code == 200, key_resp.text
+    body = key_resp.json()
+    return body["full_key"], body["key_prefix"]
+
+
 # ===== happy path =====
 
 
-def test_valid_key_returns_me_response():
-    """A freshly generated key authenticates /v1/me and returns identity."""
-    agent_id, full_key, prefix = _create_agent_and_key()
+def test_valid_personal_key_returns_me_response():
+    """A freshly generated personal key authenticates /v1/me."""
+    full_key, prefix = _create_personal_key()
 
     resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["agent_id"] == agent_id
-    assert body["agent_name"] == "v1 auth test agent"
+    assert body["principal_type"] == "user"
+    assert body["user_id"] > 0
+    assert body["email"] == "admin"
+    assert body["name"] == "admin"
     assert body["key_prefix"] == prefix
+
+
+def test_agent_runtime_key_cannot_authenticate_me():
+    """Runtime keys are not accepted by management identity endpoints."""
+    _agent_id, full_key, _prefix = _create_agent_and_key()
+    resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
+    _assert_invalid_api_key(resp)
 
 
 # ===== failure paths -- all must return the same envelope =====
@@ -105,17 +119,17 @@ def test_wrong_brand_prefix_returns_401():
 
 def test_unknown_prefix_returns_401():
     """A well-formed key with a prefix that's never been issued."""
-    fake_key = "xag_ZZZZZZ_" + "x" * 32
+    fake_key = "xag_personal_ZZZZZZ_" + "x" * 32
     resp = client.get("/v1/me", headers={"Authorization": f"Bearer {fake_key}"})
     _assert_invalid_api_key(resp)
 
 
 def test_known_prefix_wrong_secret_returns_401():
     """Prefix is real but the secret doesn't bcrypt-match."""
-    _agent_id, full_key, prefix = _create_agent_and_key()
+    full_key, _prefix = _create_personal_key()
     # Replace just the secret half with a different (but well-formed) value
     parts = full_key.split("_")
-    parts[2] = "y" * 32
+    parts[3] = "y" * 32
     wrong_key = "_".join(parts)
     resp = client.get("/v1/me", headers={"Authorization": f"Bearer {wrong_key}"})
     _assert_invalid_api_key(resp)
@@ -123,10 +137,12 @@ def test_known_prefix_wrong_secret_returns_401():
 
 def test_revoked_key_returns_401():
     """Once DELETE rotates / revokes, the old key must stop working."""
-    agent_id, full_key, _prefix = _create_agent_and_key()
-    # Revoke via admin endpoint
+    full_key, prefix = _create_personal_key()
     admin = _admin_headers()
-    revoke = client.delete(f"/api/agents/{agent_id}/api-key", headers=admin)
+    keys = client.get("/api/me/personal-keys", headers=admin)
+    assert keys.status_code == 200
+    key_id = next(row["id"] for row in keys.json() if row["key_prefix"] == prefix)
+    revoke = client.delete(f"/api/me/personal-keys/{key_id}", headers=admin)
     assert revoke.status_code == 200
     assert revoke.json()["revoked"] is True
 
@@ -145,9 +161,9 @@ def test_unknown_prefix_takes_similar_time_to_wrong_secret():
     flake the test. The defense is to keep the order of magnitude the
     same, not to clock to the millisecond.
     """
-    _agent_id, full_key, _prefix = _create_agent_and_key()
+    full_key, _prefix = _create_personal_key()
     parts = full_key.split("_")
-    parts[2] = "z" * 32
+    parts[3] = "z" * 32
     wrong_secret_key = "_".join(parts)
 
     # Warm the bcrypt module a bit so first-call overhead doesn't skew
@@ -162,7 +178,7 @@ def test_unknown_prefix_takes_similar_time_to_wrong_secret():
     assert resp1.status_code == 401
 
     # Unknown prefix (index miss, then verify_dummy runs)
-    fake_key = "xag_ZZZZZZ_" + "x" * 32
+    fake_key = "xag_personal_ZZZZZZ_" + "x" * 32
     t0 = time.perf_counter()
     resp2 = client.get("/v1/me", headers={"Authorization": f"Bearer {fake_key}"})
     dummy_t = time.perf_counter() - t0
@@ -202,7 +218,8 @@ def test_internal_exception_returns_v1_envelope_not_fastapi_detail():
         side_effect=RuntimeError(secret_internal_msg),
     ):
         resp = client.get(
-            "/v1/me", headers={"Authorization": "Bearer xag_ABCDEF_" + "x" * 32}
+            "/v1/me",
+            headers={"Authorization": "Bearer xag_personal_ABCDEF_" + "x" * 32},
         )
 
     # Must be 500 in the V1 envelope, not 500 with FastAPI's detail key.

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -8,6 +8,7 @@ Test plumbing (client, _test_db fixture, auth helpers) is shared via
 """
 
 import time
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import bcrypt
@@ -15,6 +16,7 @@ import pytest
 
 from xagent.core.utils.api_key import BCRYPT_COST
 from xagent.web.models.agent import Agent, AgentOrigin
+from xagent.web.models.user_api_key import UserApiKey
 
 from ..conftest import _admin_headers, _direct_db_session, client
 
@@ -160,6 +162,45 @@ def test_revoked_key_returns_401():
 
     resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
     _assert_invalid_api_key(resp)
+
+
+def _set_key_expiry(prefix: str, expires_at) -> None:
+    """Force a personal key's ``expires_at`` to a fixed value via direct DB
+    write, bypassing HTTP (the create endpoint leaves it null)."""
+    db = _direct_db_session()
+    try:
+        db.query(UserApiKey).filter(UserApiKey.key_prefix == prefix).update(
+            {"expires_at": expires_at}
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_expired_key_with_naive_expiry_returns_401_not_500():
+    """An expired key must yield 401, even when ``expires_at`` reads back
+    naive (as ``DateTime(timezone=True)`` does on SQLite).
+
+    Comparing a naive ``expires_at`` against an aware ``now`` raises
+    TypeError -- which would surface as a 500. The auth dep normalizes
+    to aware UTC first, so the expiry check stays a clean 401.
+    """
+    full_key, prefix = _create_personal_key()
+    naive_past = (datetime.now(timezone.utc) - timedelta(days=1)).replace(tzinfo=None)
+    _set_key_expiry(prefix, naive_past)
+
+    resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
+    _assert_invalid_api_key(resp)
+
+
+def test_unexpired_key_with_naive_future_expiry_authenticates():
+    """A future, naive ``expires_at`` must not be misread as expired."""
+    full_key, prefix = _create_personal_key()
+    naive_future = (datetime.now(timezone.utc) + timedelta(days=1)).replace(tzinfo=None)
+    _set_key_expiry(prefix, naive_future)
+
+    resp = client.get("/v1/me", headers={"Authorization": f"Bearer {full_key}"})
+    assert resp.status_code == 200, resp.text
 
 
 def test_generated_manager_key_returns_401():

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -83,8 +83,10 @@ def test_valid_personal_key_returns_me_response():
     body = resp.json()
     assert body["principal_type"] == "user"
     assert body["user_id"] > 0
-    assert body["email"] == "admin"
-    assert body["name"] == "admin"
+    # admin fixture: username="admin", email="admin@example.com" -- the two
+    # differ, so this pins that each field carries its own value.
+    assert body["username"] == "admin"
+    assert body["email"] == "admin@example.com"
     assert body["key_prefix"] == prefix
 
 

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -104,7 +104,8 @@ def test_v1_me_uses_personal_key():
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["principal_type"] == "user"
-    assert body["email"] == "admin"
+    assert body["username"] == "admin"
+    assert body["email"] == "admin@example.com"
 
 
 def test_v1_create_agent_defaults_to_runtime_key():

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from xagent.templates.manager import TemplateManager
 from xagent.web.models.agent import Agent
@@ -44,10 +45,29 @@ agent_config:
     - retrieval
   tool_categories:
     - web_search
-  knowledge_bases:
-    - template-kb
   suggested_prompts:
     - Ask anything
+  execution_mode: balanced
+""".strip(),
+        encoding="utf-8",
+    )
+    # Pre-sets a knowledge base without the knowledge tool category, so
+    # from-template must reject it -- exercises that template-sourced KB
+    # fields go through the same validation as user input.
+    (root / "kb-no-tool.yaml").write_text(
+        """
+id: kb-no-tool
+name: KB without tool
+category: General
+descriptions:
+  en: Pre-sets a knowledge base but not the knowledge tool category.
+connections: []
+agent_config:
+  instructions: Answer.
+  tool_categories:
+    - web_search
+  knowledge_bases:
+    - template-kb
   execution_mode: balanced
 """.strip(),
         encoding="utf-8",
@@ -153,6 +173,59 @@ def test_v1_create_agent_rolls_back_agent_when_key_step_fails():
     )
     assert retry.status_code == 200, retry.text
     assert retry.json()["agent"]["name"] == name
+
+
+def test_v1_create_agent_maps_commit_conflict_to_409():
+    """A unique-constraint IntegrityError at commit is translated to a
+    409 rotation conflict, not a 500."""
+    key = _personal_key()
+    with patch(
+        "sqlalchemy.orm.Session.commit",
+        side_effect=IntegrityError(
+            "INSERT", {}, Exception("uq_agent_api_keys_agent_active")
+        ),
+    ):
+        resp = client.post(
+            "/v1/agents",
+            headers=_bearer(key),
+            json={"name": "commit conflict agent", "instructions": "x"},
+        )
+    assert resp.status_code == 409, resp.text
+
+
+def test_v1_create_agent_rejects_kb_without_knowledge_category():
+    """KB selected but the knowledge tool category is not enabled -> 400,
+    same invariant /api/agents enforces."""
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "kb no tool",
+            "instructions": "x",
+            "knowledge_bases": ["some-kb"],
+            "tool_categories": ["web_search"],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_v1_create_agent_rejects_invisible_kb():
+    """KB not visible to the user -> 400."""
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "kb invisible",
+            "instructions": "x",
+            "knowledge_bases": ["nonexistent-kb"],
+            "tool_categories": ["knowledge"],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
 
 
 def test_v1_create_agent_rejects_string_model_ids():
@@ -271,7 +344,7 @@ def test_from_template_creates_agent(template_manager):
     assert body["agent"]["instructions"] == "Answer clearly."
     assert body["agent"]["skills"] == ["retrieval"]
     assert body["agent"]["tool_categories"] == ["web_search"]
-    assert body["agent"]["knowledge_bases"] == ["template-kb"]
+    assert body["agent"]["knowledge_bases"] == []
     assert body["agent"]["suggested_prompts"] == ["Ask anything"]
     assert body["api_key"]["full_key"].startswith("xag_")
 
@@ -340,3 +413,37 @@ def test_from_template_rolls_back_agent_when_key_step_fails(template_manager):
     )
     assert retry.status_code == 200, retry.text
     assert retry.json()["agent"]["name"] == name
+
+
+def test_from_template_rejects_template_kb_without_knowledge_category(
+    template_manager,
+):
+    """Template-sourced KB fields go through the same validation as user
+    input: a template that pre-sets a KB without the knowledge category
+    is rejected, not silently persisted."""
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={"template_id": "kb-no-tool", "name": "from bad template"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_from_template_rejects_invisible_kb_override(template_manager):
+    """A KB override that is not visible to the user -> 400 on the
+    from-template path too."""
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={
+            "template_id": "qa",
+            "name": "from template invisible kb",
+            "knowledge_bases": ["nonexistent-kb"],
+            "tool_categories": ["knowledge"],
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -1,10 +1,12 @@
 """Integration tests for /v1 management endpoints."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from xagent.templates.manager import TemplateManager
+from xagent.web.models.agent import Agent
 from xagent.web.models.model import Model as DBModel
 from xagent.web.models.user import User, UserModel
 
@@ -115,6 +117,42 @@ def test_v1_create_agent_can_skip_runtime_key():
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["api_key"] is None
+
+
+def test_v1_create_agent_rolls_back_agent_when_key_step_fails():
+    """Agent + first runtime key commit atomically: if the key step
+    fails, the agent row must not persist, so a client retry with the
+    same name succeeds instead of hitting a stale duplicate-name."""
+    key = _personal_key()
+    name = "atomic-create agent"
+
+    with patch(
+        "xagent.web.services.agent_management.AgentApiKeyService.stage_rotated_key",
+        side_effect=RuntimeError("staged key write blew up"),
+    ):
+        resp = client.post(
+            "/v1/agents",
+            headers=_bearer(key),
+            json={"name": name, "instructions": "Be useful."},
+        )
+    assert resp.status_code == 500, resp.text
+
+    # The aborted create must leave no row behind.
+    db = _direct_db_session()
+    try:
+        leftover = db.query(Agent).filter(Agent.name == name).count()
+    finally:
+        db.close()
+    assert leftover == 0
+
+    # A clean retry with the same name now goes through.
+    retry = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={"name": name, "instructions": "Be useful."},
+    )
+    assert retry.status_code == 200, retry.text
+    assert retry.json()["agent"]["name"] == name
 
 
 def test_v1_create_agent_rejects_string_model_ids():
@@ -269,3 +307,36 @@ def test_unknown_template_returns_stable_error(template_manager):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "template_not_found"
+
+
+def test_from_template_rolls_back_agent_when_key_step_fails(template_manager):
+    """The from-template path shares the plain-create atomic boundary: a
+    key-step failure must not leave the template-derived agent behind."""
+    key = _personal_key()
+    name = "atomic-template agent"
+
+    with patch(
+        "xagent.web.services.agent_management.AgentApiKeyService.stage_rotated_key",
+        side_effect=RuntimeError("staged key write blew up"),
+    ):
+        resp = client.post(
+            "/v1/agents/from-template",
+            headers=_bearer(key),
+            json={"template_id": "qa", "name": name},
+        )
+    assert resp.status_code == 500, resp.text
+
+    db = _direct_db_session()
+    try:
+        leftover = db.query(Agent).filter(Agent.name == name).count()
+    finally:
+        db.close()
+    assert leftover == 0
+
+    retry = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={"template_id": "qa", "name": name},
+    )
+    assert retry.status_code == 200, retry.text
+    assert retry.json()["agent"]["name"] == name

--- a/tests/web/api/v1/test_management.py
+++ b/tests/web/api/v1/test_management.py
@@ -1,0 +1,271 @@
+"""Integration tests for /v1 management endpoints."""
+
+from pathlib import Path
+
+import pytest
+
+from xagent.templates.manager import TemplateManager
+from xagent.web.models.model import Model as DBModel
+from xagent.web.models.user import User, UserModel
+
+from ..conftest import _admin_headers, _direct_db_session, app_for_tests, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _personal_key() -> str:
+    headers = _admin_headers()
+    resp = client.post("/api/me/personal-keys", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["full_key"]
+
+
+def _bearer(full_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {full_key}"}
+
+
+def _write_template(root: Path) -> None:
+    (root / "qa.yaml").write_text(
+        """
+id: qa
+name: Q&A Assistant
+category: General
+descriptions:
+  en: Answers questions from provided context.
+features:
+  en:
+    - Ask questions
+connections: []
+agent_config:
+  instructions: Answer clearly.
+  skills:
+    - retrieval
+  tool_categories:
+    - web_search
+  knowledge_bases:
+    - template-kb
+  suggested_prompts:
+    - Ask anything
+  execution_mode: balanced
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def template_manager(tmp_path):
+    _write_template(tmp_path)
+    manager = TemplateManager(templates_root=tmp_path)
+    app_for_tests.state.template_manager = manager
+    return manager
+
+
+def test_personal_key_management_round_trip():
+    headers = _admin_headers()
+    create = client.post("/api/me/personal-keys", headers=headers)
+    assert create.status_code == 200, create.text
+    body = create.json()
+    assert body["full_key"].startswith("xag_personal_")
+
+    list_resp = client.get("/api/me/personal-keys", headers=headers)
+    assert list_resp.status_code == 200
+    assert any(row["key_prefix"] == body["key_prefix"] for row in list_resp.json())
+
+    revoke = client.delete(f"/api/me/personal-keys/{body['id']}", headers=headers)
+    assert revoke.status_code == 200
+    assert revoke.json()["revoked"] is True
+
+
+def test_v1_me_uses_personal_key():
+    key = _personal_key()
+    resp = client.get("/v1/me", headers=_bearer(key))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["principal_type"] == "user"
+    assert body["email"] == "admin"
+
+
+def test_v1_create_agent_defaults_to_runtime_key():
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "SDK-created agent",
+            "description": "created from management SDK",
+            "instructions": "Be useful.",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent"]["name"] == "SDK-created agent"
+    assert body["api_key"]["full_key"].startswith("xag_")
+
+
+def test_v1_create_agent_can_skip_runtime_key():
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "No key agent",
+            "instructions": "Be useful.",
+            "generate_runtime_key": False,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["api_key"] is None
+
+
+def test_v1_create_agent_rejects_string_model_ids():
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "Bad model shape",
+            "instructions": "Be useful.",
+            "models": {"general": "deepseek-v4-flash"},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_v1_create_agent_rejects_unknown_model_ids():
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "Unknown model",
+            "instructions": "Be useful.",
+            "models": {"general": 999999},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_v1_create_agent_rejects_inaccessible_model_ids():
+    key = _personal_key()
+    db = _direct_db_session()
+    try:
+        other = User(username="model-owner", password_hash="hash")
+        db.add(other)
+        db.flush()
+        model = DBModel(
+            model_id="other-private-model",
+            category="llm",
+            model_provider="openai",
+            model_name="gpt-4",
+            api_key="test-api-key",
+            base_url="https://api.openai.com/v1",
+            is_active=True,
+        )
+        db.add(model)
+        db.flush()
+        db.add(
+            UserModel(
+                user_id=other.id,
+                model_id=model.id,
+                is_owner=True,
+                is_shared=False,
+            )
+        )
+        db.commit()
+        model_id = model.id
+    finally:
+        db.close()
+
+    resp = client.post(
+        "/v1/agents",
+        headers=_bearer(key),
+        json={
+            "name": "Inaccessible model",
+            "instructions": "Be useful.",
+            "models": {"general": model_id},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_runtime_key_cannot_call_management_endpoint():
+    personal = _personal_key()
+    create = client.post(
+        "/v1/agents",
+        headers=_bearer(personal),
+        json={"name": "Runtime only", "instructions": "hi"},
+    )
+    assert create.status_code == 200, create.text
+    runtime_key = create.json()["api_key"]["full_key"]
+
+    resp = client.get("/v1/agents", headers=_bearer(runtime_key))
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+def test_personal_key_cannot_call_runtime_endpoint():
+    personal = _personal_key()
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(personal),
+        json={
+            "agent_id": 1,
+            "message": {"role": "user", "content": "hello"},
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+def test_from_template_creates_agent(template_manager):
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={"template_id": "qa", "name": "Template agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent"]["name"] == "Template agent"
+    assert body["agent"]["instructions"] == "Answer clearly."
+    assert body["agent"]["skills"] == ["retrieval"]
+    assert body["agent"]["tool_categories"] == ["web_search"]
+    assert body["agent"]["knowledge_bases"] == ["template-kb"]
+    assert body["agent"]["suggested_prompts"] == ["Ask anything"]
+    assert body["api_key"]["full_key"].startswith("xag_")
+
+
+def test_from_template_allows_empty_list_overrides(template_manager):
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={
+            "template_id": "qa",
+            "name": "Template agent without defaults",
+            "knowledge_bases": [],
+            "skills": [],
+            "tool_categories": [],
+            "suggested_prompts": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent"]["knowledge_bases"] == []
+    assert body["agent"]["skills"] == []
+    assert body["agent"]["tool_categories"] == []
+    assert body["agent"]["suggested_prompts"] == []
+
+
+def test_unknown_template_returns_stable_error(template_manager):
+    key = _personal_key()
+    resp = client.post(
+        "/v1/agents/from-template",
+        headers=_bearer(key),
+        json={"template_id": "missing"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "template_not_found"


### PR DESCRIPTION
## Summary

Adds the backend pieces for SDK Phase 2 P0 by separating user management credentials from agent runtime credentials.

- Introduces personal SDK API keys with create/list/revoke endpoints under `/api/me/personal-keys`.
- Changes `/v1/me` to resolve a user principal from a personal key.
- Keeps `/v1/chat/tasks*` on agent runtime keys and rejects personal keys there.
- Adds `/v1/templates*` and `/v1/agents*` management endpoints for listing templates, creating agents directly, creating agents from templates, and rotating runtime keys.
- Moves runtime key rotation/metadata/revoke logic into a shared service used by the existing web UI endpoints and the new SDK management endpoints.

## Why

SDK users need a management flow that can create or configure agents before switching to an agent-specific runtime key for task execution. The previous `/v1/me` and `/v1/chat/tasks*` surface only modeled the runtime-key side, which made management operations hard to expose without overloading the agent key.

## Validation

- `.venv/bin/python -m pytest tests/web/api/v1/test_management.py`
- `.venv/bin/python -m pytest tests/core/utils/test_api_key.py tests/web/api/v1 tests/web/api/test_agent_api_keys.py`
- `.venv/bin/python -m ruff check src/xagent/web/services/agent_management.py tests/web/api/v1/test_management.py`
- End-to-end local server smoke test against Neon covering personal key creation, `/v1/me`, template list/detail, direct agent creation, runtime task execution, key rotation, and template-based agent creation.

## Notes

- This is intended as a breaking SDK 0.2.0 backend contract: `/v1/me` now requires a personal key and returns user identity.
- Workspace/team keys, quota, billing, and natural-language REST agent creation are intentionally out of scope for this backend change.
