### PR TITLE
fix: route SDK v1 requests through nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -51,6 +51,18 @@ server {
         proxy_connect_timeout 75s;
     }
 
+    # Proxy SDK API to backend
+    location /v1/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+
     # WebSocket proxy to backend
     location /ws/ {
         proxy_pass http://backend;


### PR DESCRIPTION
## Summary

- Route `/v1/` SDK API requests through the Docker nginx frontend to the backend service.
- Keep standard proxy metadata and timeout behavior for REST SDK requests.

## Why

The backend owns SDK v1 endpoints such as `/v1/me` and `/v1/chat/tasks*`. Without an explicit nginx `location /v1/`, those requests fall through to the frontend catch-all route and return frontend 404 HTML instead of backend API responses.

## Validation

- `git diff --check`
- Verified `docker/nginx.conf` now has `/v1/` before the frontend `/` catch-all route.