### PR TITLE
refactor(kb): add storage shim facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -14,6 +14,7 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .storage_shim import KBStorageShimCompatibilityFacade
 
 __all__ = [
     "KBAccessMode",
@@ -22,6 +23,7 @@ __all__ = [
     "KBContextRequest",
     "KBHandleProvider",
     "KBCoordinator",
+    "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",
     "KBUserScope",
     "LanceDBCollectionHandle",

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -20,6 +20,13 @@ class KBHandleProvider:
             "KBHandleProvider"
         )
 
+    def reset_for_tests(self) -> None:
+        """Clear provider-owned caches for test reset.
+
+        The current provider is stateless, but the hook keeps the coordinator
+        reset path ready for backend handle caches.
+        """
+
 
 @dataclass(frozen=True)
 class LanceDBCollectionHandle:

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -19,6 +19,7 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .storage_shim import KBStorageShimCompatibilityFacade
 
 T = TypeVar("T")
 
@@ -32,17 +33,26 @@ class KBCoordinator:
         self,
         storage_factory: Optional[StorageFactory] = None,
         handle_provider: Optional[KBHandleProvider] = None,
+        storage_shim: Optional[KBStorageShimCompatibilityFacade] = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
+        self._storage_shim = storage_shim or KBStorageShimCompatibilityFacade(
+            storage_factory=self._storage_factory
+        )
+
+    @property
+    def storage_shim(self) -> KBStorageShimCompatibilityFacade:
+        """Return the low-level storage compatibility facade."""
+        return self._storage_shim
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""
         collection = self._normalize_collection(request.collection)
         access_mode = self._normalize_access_mode(request.access_mode)
         user_scope = self._resolve_user_scope(request)
-        metadata_store = self._storage_factory.get_metadata_store()
-        vector_index_store = self._storage_factory.get_vector_index_store()
+        metadata_store = self._storage_shim.get_metadata_store()
+        vector_index_store = self._storage_shim.get_vector_index_store()
 
         collection_info = None
         try:
@@ -157,6 +167,11 @@ class KBCoordinator:
             return KBBackendCapabilities.lancedb()
         return KBBackendCapabilities.unsupported()
 
+    def reset_compatibility_caches(self) -> None:
+        """Clear coordinator-owned compatibility facade caches."""
+        self._storage_shim.reset_coordinator_caches()
+        self._handle_provider.reset_for_tests()
+
 
 _coordinator_lock = threading.RLock()
 _coordinator: Optional[KBCoordinator] = None
@@ -176,6 +191,8 @@ def reset_kb_coordinator_for_tests() -> None:
     """Reset process-global KB coordinator state for tests."""
     global _coordinator
     with _coordinator_lock:
+        if _coordinator is not None:
+            _coordinator.reset_compatibility_caches()
         _coordinator = None
 
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -31,9 +31,9 @@ class KBCoordinator:
 
     def __init__(
         self,
-        storage_factory: Optional[StorageFactory] = None,
-        handle_provider: Optional[KBHandleProvider] = None,
-        storage_shim: Optional[KBStorageShimCompatibilityFacade] = None,
+        storage_factory: StorageFactory | None = None,
+        handle_provider: KBHandleProvider | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()

--- a/src/xagent/core/tools/core/RAG_tools/kb/storage_shim.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/storage_shim.py
@@ -25,13 +25,11 @@ class KBStorageShimCompatibilityFacade:
     """
 
     def __init__(self, storage_factory: StorageFactory | None = None) -> None:
-        self._storage_factory = storage_factory or self._get_default_storage_factory()
+        if storage_factory is None:
+            from ..storage.factory import StorageFactory
 
-    @staticmethod
-    def _get_default_storage_factory() -> StorageFactory:
-        from ..storage.factory import StorageFactory
-
-        return StorageFactory.get_factory()
+            storage_factory = StorageFactory.get_factory()
+        self._storage_factory = storage_factory
 
     def get_kb_write_coordinator(self) -> KBWriteCoordinator:
         """Return the legacy write coordinator singleton."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/storage_shim.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/storage_shim.py
@@ -1,0 +1,100 @@
+"""Low-level KB storage compatibility facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..storage.contracts import (
+        IngestionStatusStore,
+        KBWriteCoordinator,
+        MainPointerStore,
+        MetadataStore,
+        PromptTemplateStore,
+        VectorIndexStore,
+    )
+    from ..storage.factory import StorageFactory
+
+
+class KBStorageShimCompatibilityFacade:
+    """Compatibility boundary for legacy storage singleton accessors.
+
+    The facade keeps the current storage factory and object lifecycles intact
+    while giving newer compatibility layers a stable path that is owned by the
+    semantic KB coordinator.
+    """
+
+    def __init__(self, storage_factory: StorageFactory | None = None) -> None:
+        self._storage_factory = storage_factory or self._get_default_storage_factory()
+
+    @staticmethod
+    def _get_default_storage_factory() -> StorageFactory:
+        from ..storage.factory import StorageFactory
+
+        return StorageFactory.get_factory()
+
+    def get_kb_write_coordinator(self) -> KBWriteCoordinator:
+        """Return the legacy write coordinator singleton."""
+        return self._storage_factory.get_kb_write_coordinator()
+
+    def get_metadata_store(self) -> MetadataStore:
+        """Return the legacy metadata store singleton."""
+        return self._storage_factory.get_metadata_store()
+
+    def get_vector_index_store(self) -> VectorIndexStore:
+        """Return the legacy vector index store singleton."""
+        return self._storage_factory.get_vector_index_store()
+
+    def get_vector_store_raw_connection(self) -> Any:
+        """Return the raw vector-store connection escape hatch."""
+        return self.get_vector_index_store().get_raw_connection()
+
+    def get_ingestion_status_store(self) -> IngestionStatusStore:
+        """Return the legacy ingestion status store singleton."""
+        return self._storage_factory.get_ingestion_status_store()
+
+    def get_prompt_template_store(self) -> PromptTemplateStore:
+        """Return the legacy prompt template store singleton."""
+        return self._storage_factory.get_prompt_template_store()
+
+    def get_main_pointer_store(self) -> MainPointerStore:
+        """Return the legacy main pointer store singleton."""
+        return self._storage_factory.get_main_pointer_store()
+
+    def reset_kb_write_coordinator(self) -> None:
+        """Clear legacy storage singletons and coordinator-backed shim state."""
+        self._storage_factory.reset_all()
+        self.reset_coordinator_caches()
+
+    def reset_rag_storage_for_tests(self) -> None:
+        """Reset all process-global KB/RAG storage state for tests."""
+        from ..storage.vector_backend import (
+            VectorBackend,
+            get_configured_vector_backend,
+        )
+
+        backend = get_configured_vector_backend()
+        if backend is VectorBackend.LANCEDB:
+            from xagent.providers.vector_store.lancedb import clear_connection_cache
+
+            clear_connection_cache()
+        elif backend is VectorBackend.MILVUS:
+            # Future: clear Milvus client pools / connection cache when implemented.
+            pass
+        elif backend is VectorBackend.QDRANT:
+            # Future: clear Qdrant client singleton when implemented.
+            pass
+
+        self.reset_kb_write_coordinator()
+
+        from ..management import collection_manager
+
+        collection_manager.reset_locks_for_testing()
+
+    def reset_coordinator_caches(self) -> None:
+        """Clear facade-owned caches.
+
+        The storage shim currently delegates directly to the storage factory and
+        does not cache handles itself. This hook is intentionally kept as the
+        reset point for future coordinator-side operation caches.
+        """

--- a/src/xagent/core/tools/core/RAG_tools/storage/factory.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/factory.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from .contracts import (
     IngestionStatusStore,
@@ -35,6 +35,9 @@ from .vector_backend import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..kb.storage_shim import KBStorageShimCompatibilityFacade
 
 
 class StorageFactory:
@@ -222,19 +225,12 @@ class StorageFactory:
 # Backward Compatibility Functions
 # ============================================================================
 
-# Module-level lock for backward compatibility functions
-_compat_lock = threading.Lock()
-_default_factory: Optional[StorageFactory] = None
 
+def _get_storage_shim() -> KBStorageShimCompatibilityFacade:
+    """Return the coordinator-owned low-level storage compatibility facade."""
+    from ..kb import get_kb_coordinator
 
-def _get_default_factory() -> StorageFactory:
-    """Get or create default factory instance (thread-safe)."""
-    global _default_factory
-    if _default_factory is None:
-        with _compat_lock:
-            if _default_factory is None:
-                _default_factory = StorageFactory.get_factory()
-    return _default_factory
+    return get_kb_coordinator().storage_shim
 
 
 def reset_kb_write_coordinator() -> None:
@@ -242,7 +238,7 @@ def reset_kb_write_coordinator() -> None:
 
     Deprecated: Use StorageFactory.get_factory().reset_all() instead.
     """
-    _get_default_factory().reset_all()
+    _get_storage_shim().reset_kb_write_coordinator()
 
 
 def reset_rag_storage_for_tests() -> None:
@@ -262,29 +258,7 @@ def reset_rag_storage_for_tests() -> None:
         ConfigurationError: If ``XAGENT_VECTOR_BACKEND`` is set to an unknown value
             (same as :func:`~.vector_backend.get_configured_vector_backend`).
     """
-    backend = get_configured_vector_backend()
-    if backend is VectorBackend.LANCEDB:
-        from xagent.providers.vector_store.lancedb import clear_connection_cache
-
-        clear_connection_cache()
-    elif backend is VectorBackend.MILVUS:
-        # Future: clear Milvus client pools / connection cache when implemented.
-        pass
-    elif backend is VectorBackend.QDRANT:
-        # Future: clear Qdrant client singleton when implemented.
-        pass
-    reset_kb_write_coordinator()
-
-    # Clear semantic coordinator state without introducing a storage -> kb
-    # import cycle at module import time.
-    from ..kb import reset_kb_coordinator_for_tests
-
-    reset_kb_coordinator_for_tests()
-
-    # Clear global collection locks to prevent test-to-test lock contamination
-    from xagent.core.tools.core.RAG_tools.management import collection_manager
-
-    collection_manager.reset_locks_for_testing()
+    _get_storage_shim().reset_rag_storage_for_tests()
     logger.debug("[TEST_RESET] Global collection locks reset via public helper")
 
 
@@ -293,7 +267,7 @@ def get_kb_write_coordinator() -> KBWriteCoordinator:
 
     Deprecated: Use StorageFactory.get_factory().get_kb_write_coordinator() instead.
     """
-    return _get_default_factory().get_kb_write_coordinator()
+    return _get_storage_shim().get_kb_write_coordinator()
 
 
 def get_metadata_store() -> MetadataStore:
@@ -301,7 +275,7 @@ def get_metadata_store() -> MetadataStore:
 
     Deprecated: Use StorageFactory.get_factory().get_metadata_store() instead.
     """
-    return _get_default_factory().get_metadata_store()
+    return _get_storage_shim().get_metadata_store()
 
 
 def get_vector_index_store() -> VectorIndexStore:
@@ -309,7 +283,7 @@ def get_vector_index_store() -> VectorIndexStore:
 
     Deprecated: Use StorageFactory.get_factory().get_vector_index_store() instead.
     """
-    return _get_default_factory().get_vector_index_store()
+    return _get_storage_shim().get_vector_index_store()
 
 
 def get_vector_store_raw_connection() -> Any:
@@ -322,7 +296,7 @@ def get_vector_store_raw_connection() -> Any:
     Returns:
         The object returned by :meth:`VectorIndexStore.get_raw_connection`.
     """
-    return get_vector_index_store().get_raw_connection()
+    return _get_storage_shim().get_vector_store_raw_connection()
 
 
 def get_ingestion_status_store() -> IngestionStatusStore:
@@ -331,7 +305,7 @@ def get_ingestion_status_store() -> IngestionStatusStore:
     Returns:
         LanceDBIngestionStatusStore instance.
     """
-    return _get_default_factory().get_ingestion_status_store()
+    return _get_storage_shim().get_ingestion_status_store()
 
 
 def get_prompt_template_store() -> PromptTemplateStore:
@@ -340,7 +314,7 @@ def get_prompt_template_store() -> PromptTemplateStore:
     Returns:
         LanceDBPromptTemplateStore instance.
     """
-    return _get_default_factory().get_prompt_template_store()
+    return _get_storage_shim().get_prompt_template_store()
 
 
 def get_main_pointer_store() -> MainPointerStore:
@@ -349,7 +323,7 @@ def get_main_pointer_store() -> MainPointerStore:
     Returns:
         LanceDBMainPointerStore instance.
     """
-    return _get_default_factory().get_main_pointer_store()
+    return _get_storage_shim().get_main_pointer_store()
 
 
 # ============================================================================

--- a/tests/core/tools/core/RAG_tools/storage/test_storage_shim.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_storage_shim.py
@@ -1,0 +1,197 @@
+"""Tests for the KB storage shim compatibility facade."""
+
+from __future__ import annotations
+
+from inspect import signature
+
+
+class _FakeVectorStore:
+    def __init__(self) -> None:
+        self.raw_connection = object()
+
+    def get_raw_connection(self) -> object:
+        return self.raw_connection
+
+
+class _FakeStorageFactory:
+    def __init__(self) -> None:
+        self.coordinator = object()
+        self.metadata_store = object()
+        self.vector_index_store = _FakeVectorStore()
+        self.ingestion_status_store = object()
+        self.prompt_template_store = object()
+        self.main_pointer_store = object()
+        self.reset_count = 0
+
+    def get_kb_write_coordinator(self) -> object:
+        return self.coordinator
+
+    def get_metadata_store(self) -> object:
+        return self.metadata_store
+
+    def get_vector_index_store(self) -> _FakeVectorStore:
+        return self.vector_index_store
+
+    def get_ingestion_status_store(self) -> object:
+        return self.ingestion_status_store
+
+    def get_prompt_template_store(self) -> object:
+        return self.prompt_template_store
+
+    def get_main_pointer_store(self) -> object:
+        return self.main_pointer_store
+
+    def reset_all(self) -> None:
+        self.reset_count += 1
+
+
+def test_storage_public_import_surface_retains_low_level_exports() -> None:
+    """Given legacy callers, every retained storage export remains importable."""
+    import xagent.core.tools.core.RAG_tools.storage as storage
+    from xagent.core.tools.core.RAG_tools.storage import contracts, vector_backend
+    from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
+
+    expected_symbols = [
+        "KBWriteCoordinator",
+        "MetadataStore",
+        "VectorIndexStore",
+        "IngestionStatusStore",
+        "PromptTemplateStore",
+        "MainPointerStore",
+        "StorageFactory",
+        "get_kb_write_coordinator",
+        "get_metadata_store",
+        "get_vector_index_store",
+        "get_vector_store_raw_connection",
+        "get_ingestion_status_store",
+        "get_prompt_template_store",
+        "get_main_pointer_store",
+        "reset_kb_write_coordinator",
+        "reset_rag_storage_for_tests",
+        "VectorBackend",
+        "VECTOR_BACKEND_ENV",
+        "VECTOR_BACKEND_ENV_LEGACY",
+        "get_configured_vector_backend",
+    ]
+
+    for symbol in expected_symbols:
+        assert hasattr(storage, symbol)
+
+    assert storage.KBWriteCoordinator is contracts.KBWriteCoordinator
+    assert storage.MetadataStore is contracts.MetadataStore
+    assert storage.VectorIndexStore is contracts.VectorIndexStore
+    assert storage.IngestionStatusStore is contracts.IngestionStatusStore
+    assert storage.PromptTemplateStore is contracts.PromptTemplateStore
+    assert storage.MainPointerStore is contracts.MainPointerStore
+    assert storage.StorageFactory is StorageFactory
+    assert storage.VectorBackend is vector_backend.VectorBackend
+    assert storage.VECTOR_BACKEND_ENV is vector_backend.VECTOR_BACKEND_ENV
+    assert storage.VECTOR_BACKEND_ENV_LEGACY is vector_backend.VECTOR_BACKEND_ENV_LEGACY
+    assert storage.get_configured_vector_backend is (
+        vector_backend.get_configured_vector_backend
+    )
+
+
+def test_storage_shim_public_methods_match_legacy_function_signatures() -> None:
+    """Given legacy storage functions, the facade exposes matching sync methods."""
+    from xagent.core.tools.core.RAG_tools.kb import KBStorageShimCompatibilityFacade
+    from xagent.core.tools.core.RAG_tools.storage import factory
+
+    shim = KBStorageShimCompatibilityFacade(storage_factory=_FakeStorageFactory())  # type: ignore[arg-type]
+    method_names = [
+        "get_kb_write_coordinator",
+        "get_metadata_store",
+        "get_vector_index_store",
+        "get_vector_store_raw_connection",
+        "get_ingestion_status_store",
+        "get_prompt_template_store",
+        "get_main_pointer_store",
+        "reset_kb_write_coordinator",
+        "reset_rag_storage_for_tests",
+    ]
+
+    for name in method_names:
+        assert signature(getattr(shim, name)) == signature(getattr(factory, name))
+
+
+def test_storage_shim_delegates_to_injected_factory() -> None:
+    """Given an injected factory, the shim preserves object identity."""
+    from xagent.core.tools.core.RAG_tools.kb import KBStorageShimCompatibilityFacade
+
+    fake_factory = _FakeStorageFactory()
+    shim = KBStorageShimCompatibilityFacade(storage_factory=fake_factory)  # type: ignore[arg-type]
+
+    assert shim.get_kb_write_coordinator() is fake_factory.coordinator
+    assert shim.get_metadata_store() is fake_factory.metadata_store
+    assert shim.get_vector_index_store() is fake_factory.vector_index_store
+    assert (
+        shim.get_vector_store_raw_connection()
+        is fake_factory.vector_index_store.raw_connection
+    )
+    assert shim.get_ingestion_status_store() is fake_factory.ingestion_status_store
+    assert shim.get_prompt_template_store() is fake_factory.prompt_template_store
+    assert shim.get_main_pointer_store() is fake_factory.main_pointer_store
+
+
+def test_storage_shim_reset_kb_write_coordinator_resets_factory_state() -> None:
+    """Given shim reset, the legacy factory reset path is used."""
+    from xagent.core.tools.core.RAG_tools.kb import KBStorageShimCompatibilityFacade
+
+    fake_factory = _FakeStorageFactory()
+    shim = KBStorageShimCompatibilityFacade(storage_factory=fake_factory)  # type: ignore[arg-type]
+
+    shim.reset_kb_write_coordinator()
+
+    assert fake_factory.reset_count == 1
+
+
+def test_legacy_storage_functions_delegate_through_coordinator_shim(
+    monkeypatch,
+) -> None:
+    """Given legacy module functions, calls flow through the coordinator shim."""
+    from xagent.core.tools.core.RAG_tools.storage import factory
+
+    fake_factory = _FakeStorageFactory()
+    shim = factory._get_storage_shim()
+    monkeypatch.setattr(factory, "_get_storage_shim", lambda: shim)
+    monkeypatch.setattr(shim, "_storage_factory", fake_factory)
+
+    assert factory.get_kb_write_coordinator() is fake_factory.coordinator
+    assert factory.get_metadata_store() is fake_factory.metadata_store
+    assert factory.get_vector_index_store() is fake_factory.vector_index_store
+    assert (
+        factory.get_vector_store_raw_connection()
+        is fake_factory.vector_index_store.raw_connection
+    )
+    assert factory.get_ingestion_status_store() is fake_factory.ingestion_status_store
+    assert factory.get_prompt_template_store() is fake_factory.prompt_template_store
+    assert factory.get_main_pointer_store() is fake_factory.main_pointer_store
+
+
+def test_reset_rag_storage_for_tests_resets_storage_and_coordinator_shim() -> None:
+    """Given test reset, old stores and coordinator facade state are both cleared."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage import (
+        get_metadata_store,
+        get_vector_index_store,
+        reset_rag_storage_for_tests,
+    )
+
+    first_coordinator = get_kb_coordinator()
+    first_shim = first_coordinator.storage_shim
+    first_metadata_store = get_metadata_store()
+    first_vector_index_store = get_vector_index_store()
+
+    reset_rag_storage_for_tests()
+
+    second_coordinator = get_kb_coordinator()
+    second_shim = second_coordinator.storage_shim
+    second_metadata_store = get_metadata_store()
+    second_vector_index_store = get_vector_index_store()
+
+    assert second_coordinator is not first_coordinator
+    assert second_shim is not first_shim
+    assert second_metadata_store is not first_metadata_store
+    assert second_vector_index_store is not first_vector_index_store
+    assert second_shim.get_metadata_store() is second_metadata_store
+    assert second_shim.get_vector_index_store() is second_vector_index_store


### PR DESCRIPTION
## Summary

- add `KBStorageShimCompatibilityFacade` as the low-level KB storage compatibility boundary
- route legacy storage module accessors through the coordinator-owned shim while preserving existing public exports
- keep storage reset behavior aligned across LanceDB caches, storage singletons, coordinator state, shim hooks, and collection locks
- add coverage for storage import surface compatibility, shim delegation, signatures, and reset behavior

Closes #496.

## Validation

- `uv run pytest tests/core/tools/core/RAG_tools/storage tests/core/tools/core/RAG_tools/kb/test_coordinator.py`
- `uv run ruff check src/xagent/core/tools/core/RAG_tools/kb/storage_shim.py src/xagent/core/tools/core/RAG_tools/kb/coordinator.py src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py src/xagent/core/tools/core/RAG_tools/kb/__init__.py src/xagent/core/tools/core/RAG_tools/storage/factory.py tests/core/tools/core/RAG_tools/storage/test_storage_shim.py`
- `uv run mypy src/xagent/core/tools/core/RAG_tools/kb src/xagent/core/tools/core/RAG_tools/storage/factory.py`
- `uv run pre-commit run --all-files`