### PR TITLE
refactor(kb): add management compatibility facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -7,6 +7,7 @@ from .coordinator import (
     reset_kb_coordinator_for_tests,
 )
 from .file_compatibility import KBFileCompatibilityFacade
+from .management_facade import KBCoreManagementCompatibilityFacade
 from .models import (
     KBAccessMode,
     KBBackendCapabilities,
@@ -23,6 +24,7 @@ __all__ = [
     "KBCollectionContext",
     "KBContextRequest",
     "KBHandleProvider",
+    "KBCoreManagementCompatibilityFacade",
     "KBCoordinator",
     "KBFileCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -12,6 +12,7 @@ from ..storage.factory import StorageFactory
 from ..utils.user_scope import resolve_user_scope
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .file_compatibility import KBFileCompatibilityFacade
+from .management_facade import KBCoreManagementCompatibilityFacade
 from .models import (
     KBAccessMode,
     KBBackendCapabilities,
@@ -36,6 +37,7 @@ class KBCoordinator:
         handle_provider: KBHandleProvider | None = None,
         storage_shim: KBStorageShimCompatibilityFacade | None = None,
         file_compatibility: KBFileCompatibilityFacade | None = None,
+        management_facade: KBCoreManagementCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -43,6 +45,9 @@ class KBCoordinator:
             storage_factory=self._storage_factory
         )
         self._file_compatibility = file_compatibility or KBFileCompatibilityFacade()
+        self._management = management_facade or KBCoreManagementCompatibilityFacade(
+            coordinator=self
+        )
 
     @property
     def storage_shim(self) -> KBStorageShimCompatibilityFacade:
@@ -58,6 +63,11 @@ class KBCoordinator:
     def file_compat(self) -> KBFileCompatibilityFacade:
         """Backward-friendly short alias for the file compatibility facade."""
         return self._file_compatibility
+
+    @property
+    def management(self) -> KBCoreManagementCompatibilityFacade:
+        """Return the core management compatibility facade."""
+        return self._management
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
@@ -44,10 +44,8 @@ class KBCoreManagementCompatibilityFacade:
 
     @contextmanager
     def _storage_context(self) -> Iterator[None]:
-        from ..storage.factory import get_bound_storage_shim_for_current_context
-
         storage_shim = self._active_storage_shim()
-        if storage_shim is None or get_bound_storage_shim_for_current_context():
+        if storage_shim is None:
             yield
             return
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..core.schemas import (
     CollectionOperationResult,
@@ -11,6 +13,10 @@ from ..core.schemas import (
     DocumentStatsResult,
     ListCollectionsResult,
 )
+
+if TYPE_CHECKING:
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
 
 
 class KBCoreManagementCompatibilityFacade:
@@ -21,6 +27,35 @@ class KBCoreManagementCompatibilityFacade:
     retry/cancel, and ingestion-status operations.
     """
 
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        from ..storage.factory import get_bound_storage_shim_for_current_context
+
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None or get_bound_storage_shim_for_current_context():
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
     async def list_collections(
         self,
         user_id: Optional[int] = None,
@@ -29,11 +64,12 @@ class KBCoreManagementCompatibilityFacade:
     ) -> ListCollectionsResult:
         from ..management import collections as management_collections
 
-        return await management_collections._list_collections_impl(
-            user_id=user_id,
-            is_admin=is_admin,
-            force_realtime=force_realtime,
-        )
+        with self._storage_context():
+            return await management_collections._list_collections_impl(
+                user_id=user_id,
+                is_admin=is_admin,
+                force_realtime=force_realtime,
+            )
 
     def list_documents(
         self,
@@ -43,11 +79,12 @@ class KBCoreManagementCompatibilityFacade:
     ) -> DocumentListResult:
         from ..management import collections as management_collections
 
-        return management_collections._list_documents_impl(
-            collection=collection,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._list_documents_impl(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def get_document_stats(
         self,
@@ -59,13 +96,14 @@ class KBCoreManagementCompatibilityFacade:
     ) -> DocumentStatsResult:
         from ..management import collections as management_collections
 
-        return management_collections._get_document_stats_impl(
-            collection=collection,
-            doc_id=doc_id,
-            model_tag=model_tag,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._get_document_stats_impl(
+                collection=collection,
+                doc_id=doc_id,
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def delete_document(
         self,
@@ -76,12 +114,13 @@ class KBCoreManagementCompatibilityFacade:
     ) -> DocumentOperationResult:
         from ..management import collections as management_collections
 
-        return management_collections._delete_document_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._delete_document_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def delete_collection(
         self,
@@ -91,11 +130,12 @@ class KBCoreManagementCompatibilityFacade:
     ) -> CollectionOperationResult:
         from ..management import collections as management_collections
 
-        return management_collections._delete_collection_impl(
-            collection=collection,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._delete_collection_impl(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def retry_document(
         self,
@@ -106,12 +146,13 @@ class KBCoreManagementCompatibilityFacade:
     ) -> DocumentOperationResult:
         from ..management import collections as management_collections
 
-        return management_collections._retry_document_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._retry_document_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def cancel_document(
         self,
@@ -123,13 +164,14 @@ class KBCoreManagementCompatibilityFacade:
     ) -> DocumentOperationResult:
         from ..management import collections as management_collections
 
-        return management_collections._cancel_document_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-            reason=reason,
-        )
+        with self._storage_context():
+            return management_collections._cancel_document_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+                reason=reason,
+            )
 
     def cancel_collection(
         self,
@@ -140,20 +182,22 @@ class KBCoreManagementCompatibilityFacade:
     ) -> CollectionOperationResult:
         from ..management import collections as management_collections
 
-        return management_collections._cancel_collection_impl(
-            collection=collection,
-            reason=reason,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_collections._cancel_collection_impl(
+                collection=collection,
+                reason=reason,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def get_document_status(self, collection: str, doc_id: str) -> Dict[str, Any]:
         from ..management import collections as management_collections
 
-        return management_collections._get_document_status_impl(
-            collection=collection,
-            doc_id=doc_id,
-        )
+        with self._storage_context():
+            return management_collections._get_document_status_impl(
+                collection=collection,
+                doc_id=doc_id,
+            )
 
     def write_ingestion_status(
         self,
@@ -167,14 +211,15 @@ class KBCoreManagementCompatibilityFacade:
     ) -> None:
         from ..management import status as management_status
 
-        management_status._write_ingestion_status_impl(
-            collection=collection,
-            doc_id=doc_id,
-            status=status,
-            message=message,
-            parse_hash=parse_hash,
-            user_id=user_id,
-        )
+        with self._storage_context():
+            management_status._write_ingestion_status_impl(
+                collection=collection,
+                doc_id=doc_id,
+                status=status,
+                message=message,
+                parse_hash=parse_hash,
+                user_id=user_id,
+            )
 
     def load_ingestion_status(
         self,
@@ -185,12 +230,13 @@ class KBCoreManagementCompatibilityFacade:
     ) -> List[Dict[str, Any]]:
         from ..management import status as management_status
 
-        return management_status._load_ingestion_status_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return management_status._load_ingestion_status_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def clear_ingestion_status(
         self,
@@ -201,12 +247,13 @@ class KBCoreManagementCompatibilityFacade:
     ) -> None:
         from ..management import status as management_status
 
-        management_status._clear_ingestion_status_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            management_status._clear_ingestion_status_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     async def write_ingestion_status_async(
         self,
@@ -220,14 +267,15 @@ class KBCoreManagementCompatibilityFacade:
     ) -> None:
         from ..management import status as management_status
 
-        await management_status._write_ingestion_status_async_impl(
-            collection=collection,
-            doc_id=doc_id,
-            status=status,
-            message=message,
-            parse_hash=parse_hash,
-            user_id=user_id,
-        )
+        with self._storage_context():
+            await management_status._write_ingestion_status_async_impl(
+                collection=collection,
+                doc_id=doc_id,
+                status=status,
+                message=message,
+                parse_hash=parse_hash,
+                user_id=user_id,
+            )
 
     async def load_ingestion_status_async(
         self,
@@ -238,12 +286,13 @@ class KBCoreManagementCompatibilityFacade:
     ) -> List[Dict[str, Any]]:
         from ..management import status as management_status
 
-        return await management_status._load_ingestion_status_async_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            return await management_status._load_ingestion_status_async_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     async def clear_ingestion_status_async(
         self,
@@ -254,9 +303,10 @@ class KBCoreManagementCompatibilityFacade:
     ) -> None:
         from ..management import status as management_status
 
-        await management_status._clear_ingestion_status_async_impl(
-            collection=collection,
-            doc_id=doc_id,
-            user_id=user_id,
-            is_admin=is_admin,
-        )
+        with self._storage_context():
+            await management_status._clear_ingestion_status_async_impl(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )

--- a/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/management_facade.py
@@ -1,0 +1,262 @@
+"""Core management compatibility facade for KB operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ..core.schemas import (
+    CollectionOperationResult,
+    DocumentListResult,
+    DocumentOperationResult,
+    DocumentStatsResult,
+    ListCollectionsResult,
+)
+
+
+class KBCoreManagementCompatibilityFacade:
+    """Compatibility boundary for legacy management module functions.
+
+    Public management modules keep their historical import paths and signatures,
+    while coordinator-owned code gets one stable surface for list, delete,
+    retry/cancel, and ingestion-status operations.
+    """
+
+    async def list_collections(
+        self,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        force_realtime: bool = False,
+    ) -> ListCollectionsResult:
+        from ..management import collections as management_collections
+
+        return await management_collections._list_collections_impl(
+            user_id=user_id,
+            is_admin=is_admin,
+            force_realtime=force_realtime,
+        )
+
+    def list_documents(
+        self,
+        collection: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DocumentListResult:
+        from ..management import collections as management_collections
+
+        return management_collections._list_documents_impl(
+            collection=collection,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def get_document_stats(
+        self,
+        collection: str,
+        doc_id: str,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DocumentStatsResult:
+        from ..management import collections as management_collections
+
+        return management_collections._get_document_stats_impl(
+            collection=collection,
+            doc_id=doc_id,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def delete_document(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> DocumentOperationResult:
+        from ..management import collections as management_collections
+
+        return management_collections._delete_document_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def delete_collection(
+        self,
+        collection: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> CollectionOperationResult:
+        from ..management import collections as management_collections
+
+        return management_collections._delete_collection_impl(
+            collection=collection,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def retry_document(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> DocumentOperationResult:
+        from ..management import collections as management_collections
+
+        return management_collections._retry_document_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def cancel_document(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: int,
+        is_admin: bool = False,
+        reason: Optional[str] = None,
+    ) -> DocumentOperationResult:
+        from ..management import collections as management_collections
+
+        return management_collections._cancel_document_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+            reason=reason,
+        )
+
+    def cancel_collection(
+        self,
+        collection: str,
+        reason: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> CollectionOperationResult:
+        from ..management import collections as management_collections
+
+        return management_collections._cancel_collection_impl(
+            collection=collection,
+            reason=reason,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def get_document_status(self, collection: str, doc_id: str) -> Dict[str, Any]:
+        from ..management import collections as management_collections
+
+        return management_collections._get_document_status_impl(
+            collection=collection,
+            doc_id=doc_id,
+        )
+
+    def write_ingestion_status(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        status: str,
+        message: Optional[str] = None,
+        parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+    ) -> None:
+        from ..management import status as management_status
+
+        management_status._write_ingestion_status_impl(
+            collection=collection,
+            doc_id=doc_id,
+            status=status,
+            message=message,
+            parse_hash=parse_hash,
+            user_id=user_id,
+        )
+
+    def load_ingestion_status(
+        self,
+        collection: Optional[str] = None,
+        doc_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> List[Dict[str, Any]]:
+        from ..management import status as management_status
+
+        return management_status._load_ingestion_status_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def clear_ingestion_status(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        from ..management import status as management_status
+
+        management_status._clear_ingestion_status_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    async def write_ingestion_status_async(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        status: str,
+        message: Optional[str] = None,
+        parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+    ) -> None:
+        from ..management import status as management_status
+
+        await management_status._write_ingestion_status_async_impl(
+            collection=collection,
+            doc_id=doc_id,
+            status=status,
+            message=message,
+            parse_hash=parse_hash,
+            user_id=user_id,
+        )
+
+    async def load_ingestion_status_async(
+        self,
+        collection: Optional[str] = None,
+        doc_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> List[Dict[str, Any]]:
+        from ..management import status as management_status
+
+        return await management_status._load_ingestion_status_async_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    async def clear_ingestion_status_async(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        from ..management import status as management_status
+
+        await management_status._clear_ingestion_status_async_impl(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )

--- a/src/xagent/core/tools/core/RAG_tools/management/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/__init__.py
@@ -14,8 +14,11 @@ from .collections import (
 )
 from .status import (
     clear_ingestion_status,
+    clear_ingestion_status_async,
     load_ingestion_status,
+    load_ingestion_status_async,
     write_ingestion_status,
+    write_ingestion_status_async,
 )
 
 __all__ = [
@@ -32,4 +35,7 @@ __all__ = [
     "write_ingestion_status",
     "load_ingestion_status",
     "clear_ingestion_status",
+    "write_ingestion_status_async",
+    "load_ingestion_status_async",
+    "clear_ingestion_status_async",
 ]

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -39,9 +39,9 @@ from ..core.schemas import (
 from ..LanceDB.model_tag_utils import embeddings_table_name
 from ..LanceDB.schema_manager import _safe_close_table
 from ..management.status import (
-    clear_ingestion_status,
-    load_ingestion_status,
-    write_ingestion_status,
+    _clear_ingestion_status_impl,
+    _load_ingestion_status_impl,
+    _write_ingestion_status_impl,
 )
 from ..storage.factory import get_metadata_store, get_vector_index_store
 from ..utils.lancedb_query_utils import _safe_count_rows, list_table_names
@@ -486,7 +486,7 @@ def _collect_document_ids(
         )
         doc_ids.update(embed_docs.keys())
 
-    for status_entry in load_ingestion_status(collection=collection):
+    for status_entry in _load_ingestion_status_impl(collection=collection):
         raw_doc = status_entry.get("doc_id")
         if isinstance(raw_doc, str):
             doc_ids.add(raw_doc)
@@ -1078,7 +1078,7 @@ def _get_document_stats_impl(
 
     # Load ingestion status
     status_record = None
-    status_entries = load_ingestion_status(collection=collection, doc_id=doc_id)
+    status_entries = _load_ingestion_status_impl(collection=collection, doc_id=doc_id)
     if status_entries:
         status_record = status_entries[-1]
 
@@ -1226,7 +1226,8 @@ def _list_documents_impl(
 
     # Load status records
     status_records = {
-        entry["doc_id"]: entry for entry in load_ingestion_status(collection=collection)
+        entry["doc_id"]: entry
+        for entry in _load_ingestion_status_impl(collection=collection)
     }
 
     # Combine all doc_ids from various sources
@@ -1576,7 +1577,7 @@ def _delete_document_impl(
             user_id=user_id,
             is_admin=is_admin,
         )
-        clear_ingestion_status(
+        _clear_ingestion_status_impl(
             collection,
             doc_id,
             user_id=None if authorized_via_legacy_source_path else user_id,
@@ -1623,7 +1624,7 @@ def _retry_document_impl(
     """Mark a document for retry by resetting its status to pending."""
 
     try:
-        write_ingestion_status(
+        _write_ingestion_status_impl(
             collection,
             doc_id,
             status=DocumentProcessingStatus.PENDING.value,
@@ -1682,7 +1683,7 @@ def _cancel_document_impl(
 
     message = reason or "Cancelled by user."
     try:
-        write_ingestion_status(
+        _write_ingestion_status_impl(
             collection,
             doc_id,
             status=DocumentProcessingStatus.FAILED.value,
@@ -1767,7 +1768,7 @@ def _cancel_collection_impl(
 
     for doc_id in doc_ids:
         try:
-            write_ingestion_status(
+            _write_ingestion_status_impl(
                 collection=collection,
                 doc_id=doc_id,
                 status=DocumentProcessingStatus.FAILED.value,
@@ -1834,7 +1835,9 @@ def _get_document_status_impl(collection: str, doc_id: str) -> Dict[str, Any]:
         Dictionary with status information, or empty dict if not found.
     """
     try:
-        status_records = load_ingestion_status(collection=collection, doc_id=doc_id)
+        status_records = _load_ingestion_status_impl(
+            collection=collection, doc_id=doc_id
+        )
         if status_records:
             return status_records[0]
         return {}

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -13,7 +13,7 @@ import re
 import warnings as py_warnings
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set
 
 import pyarrow as pa  # type: ignore
 from lancedb.db import DBConnection
@@ -52,7 +52,16 @@ from .collection_manager import delete_collection_metadata_sync
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ..kb import KBCoreManagementCompatibilityFacade
+
 DEFAULT_BATCH_SIZE = DEFAULT_LANCEDB_SCAN_BATCH_SIZE
+
+
+def _get_management_facade() -> "KBCoreManagementCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().management
 
 
 def _extract_user_id_from_source_path(source_path: Optional[str]) -> Optional[int]:
@@ -566,6 +575,19 @@ async def list_collections(
     is_admin: Optional[bool] = None,
     force_realtime: bool = False,
 ) -> ListCollectionsResult:
+    """List all knowledge base collections through the coordinator facade."""
+    return await _get_management_facade().list_collections(
+        user_id=user_id,
+        is_admin=is_admin,
+        force_realtime=force_realtime,
+    )
+
+
+async def _list_collections_impl(
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    force_realtime: bool = False,
+) -> ListCollectionsResult:
     """List all knowledge base collections along with aggregated statistics.
 
     This function returns a list of all available knowledge bases (collections)
@@ -953,6 +975,23 @@ def get_document_stats(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> DocumentStatsResult:
+    """Return document statistics through the coordinator facade."""
+    return _get_management_facade().get_document_stats(
+        collection=collection,
+        doc_id=doc_id,
+        model_tag=model_tag,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _get_document_stats_impl(
+    collection: str,
+    doc_id: str,
+    model_tag: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DocumentStatsResult:
     """Return statistics for a single document within a collection.
 
     Args:
@@ -1106,6 +1145,19 @@ def list_documents(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> DocumentListResult:
+    """List documents for a collection through the coordinator facade."""
+    return _get_management_facade().list_documents(
+        collection=collection,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _list_documents_impl(
+    collection: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DocumentListResult:
     """List documents for a collection including latest processing status.
 
     Uses batch processing to minimize memory footprint.
@@ -1238,6 +1290,19 @@ def list_documents(
 
 
 def delete_collection(
+    collection: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> CollectionOperationResult:
+    """Delete a collection through the coordinator facade."""
+    return _get_management_facade().delete_collection(
+        collection=collection,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _delete_collection_impl(
     collection: str,
     user_id: Optional[int] = None,
     is_admin: bool = False,
@@ -1419,6 +1484,18 @@ def delete_collection(
 def delete_document(
     collection: str, doc_id: str, user_id: int, is_admin: bool = False
 ) -> DocumentOperationResult:
+    """Delete a document through the coordinator facade."""
+    return _get_management_facade().delete_document(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _delete_document_impl(
+    collection: str, doc_id: str, user_id: int, is_admin: bool = False
+) -> DocumentOperationResult:
     """Delete a document and all its associated data.
 
     This performs a cascade delete of the document's parses, chunks,
@@ -1531,6 +1608,18 @@ def delete_document(
 def retry_document(
     collection: str, doc_id: str, user_id: int, is_admin: bool = False
 ) -> DocumentOperationResult:
+    """Mark a document for retry through the coordinator facade."""
+    return _get_management_facade().retry_document(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _retry_document_impl(
+    collection: str, doc_id: str, user_id: int, is_admin: bool = False
+) -> DocumentOperationResult:
     """Mark a document for retry by resetting its status to pending."""
 
     try:
@@ -1572,6 +1661,23 @@ def cancel_document(
     is_admin: bool = False,
     reason: Optional[str] = None,
 ) -> DocumentOperationResult:
+    """Mark a document as cancelled through the coordinator facade."""
+    return _get_management_facade().cancel_document(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+        reason=reason,
+    )
+
+
+def _cancel_document_impl(
+    collection: str,
+    doc_id: str,
+    user_id: int,
+    is_admin: bool = False,
+    reason: Optional[str] = None,
+) -> DocumentOperationResult:
     """Mark a document ingestion process as cancelled."""
 
     message = reason or "Cancelled by user."
@@ -1606,6 +1712,21 @@ def cancel_document(
 
 
 def cancel_collection(
+    collection: str,
+    reason: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> CollectionOperationResult:
+    """Mark all documents in a collection as cancelled through the facade."""
+    return _get_management_facade().cancel_collection(
+        collection=collection,
+        reason=reason,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _cancel_collection_impl(
     collection: str,
     reason: Optional[str] = None,
     user_id: Optional[int] = None,
@@ -1695,6 +1816,14 @@ def cancel_collection(
 
 
 def get_document_status(collection: str, doc_id: str) -> Dict[str, Any]:
+    """Get document status through the coordinator facade."""
+    return _get_management_facade().get_document_status(
+        collection=collection,
+        doc_id=doc_id,
+    )
+
+
+def _get_document_status_impl(collection: str, doc_id: str) -> Dict[str, Any]:
     """Get the current ingestion status for a document.
 
     Args:

--- a/src/xagent/core/tools/core/RAG_tools/management/status.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/status.py
@@ -10,15 +10,24 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..storage.factory import get_ingestion_status_store
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ..kb import KBCoreManagementCompatibilityFacade
+
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _get_management_facade() -> "KBCoreManagementCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().management
 
 
 def write_ingestion_status(
@@ -49,6 +58,25 @@ def write_ingestion_status(
     Raises:
         DatabaseOperationError: If write operation fails.
     """
+    _get_management_facade().write_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        status=status,
+        message=message,
+        parse_hash=parse_hash,
+        user_id=user_id,
+    )
+
+
+def _write_ingestion_status_impl(
+    collection: str,
+    doc_id: str,
+    *,
+    status: str,
+    message: Optional[str] = None,
+    parse_hash: Optional[str] = None,
+    user_id: Optional[int] = None,
+) -> None:
     store = get_ingestion_status_store()
     store.write_ingestion_status(
         collection=collection,
@@ -92,6 +120,20 @@ def load_ingestion_status(
     Raises:
         DatabaseOperationError: If read operation fails.
     """
+    return _get_management_facade().load_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _load_ingestion_status_impl(
+    collection: Optional[str] = None,
+    doc_id: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> List[Dict[str, Any]]:
     store = get_ingestion_status_store()
     return store.load_ingestion_status(
         collection=collection,
@@ -121,6 +163,17 @@ def clear_ingestion_status(
     Raises:
         DatabaseOperationError: If delete operation fails.
     """
+    _get_management_facade().clear_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _clear_ingestion_status_impl(
+    collection: str, doc_id: str, user_id: Optional[int] = None, is_admin: bool = False
+) -> None:
     store = get_ingestion_status_store()
     store.clear_ingestion_status(
         collection=collection,
@@ -160,6 +213,25 @@ async def write_ingestion_status_async(
     Raises:
         DatabaseOperationError: If write operation fails.
     """
+    await _get_management_facade().write_ingestion_status_async(
+        collection=collection,
+        doc_id=doc_id,
+        status=status,
+        message=message,
+        parse_hash=parse_hash,
+        user_id=user_id,
+    )
+
+
+async def _write_ingestion_status_async_impl(
+    collection: str,
+    doc_id: str,
+    *,
+    status: str,
+    message: Optional[str] = None,
+    parse_hash: Optional[str] = None,
+    user_id: Optional[int] = None,
+) -> None:
     store = get_ingestion_status_store()
     await store.write_ingestion_status_async(
         collection=collection,
@@ -191,6 +263,20 @@ async def load_ingestion_status_async(
     Raises:
         DatabaseOperationError: If read operation fails.
     """
+    return await _get_management_facade().load_ingestion_status_async(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _load_ingestion_status_async_impl(
+    collection: Optional[str] = None,
+    doc_id: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> List[Dict[str, Any]]:
     store = get_ingestion_status_store()
     return await store.load_ingestion_status_async(
         collection=collection,
@@ -217,6 +303,17 @@ async def clear_ingestion_status_async(
     Raises:
         DatabaseOperationError: If delete operation fails.
     """
+    await _get_management_facade().clear_ingestion_status_async(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _clear_ingestion_status_async_impl(
+    collection: str, doc_id: str, user_id: Optional[int] = None, is_admin: bool = False
+) -> None:
     store = get_ingestion_status_store()
     await store.clear_ingestion_status_async(
         collection=collection,

--- a/src/xagent/core/tools/core/RAG_tools/storage/factory.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/factory.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Optional
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from .contracts import (
     IngestionStatusStore,
@@ -35,9 +38,35 @@ from .vector_backend import (
 )
 
 logger = logging.getLogger(__name__)
+_storage_shim_override: ContextVar[Any] = ContextVar(
+    "xagent_kb_storage_shim_override",
+    default=None,
+)
 
 if TYPE_CHECKING:
     from ..kb.storage_shim import KBStorageShimCompatibilityFacade
+
+
+def get_bound_storage_shim_for_current_context() -> (
+    KBStorageShimCompatibilityFacade | None
+):
+    """Return the storage shim already bound to this execution context."""
+    return cast(
+        "KBStorageShimCompatibilityFacade | None",
+        _storage_shim_override.get(),
+    )
+
+
+@contextmanager
+def bind_storage_shim_for_current_context(
+    storage_shim: KBStorageShimCompatibilityFacade,
+) -> Iterator[None]:
+    """Route legacy storage accessors through a coordinator-owned shim."""
+    token = _storage_shim_override.set(storage_shim)
+    try:
+        yield
+    finally:
+        _storage_shim_override.reset(token)
 
 
 class StorageFactory:
@@ -228,6 +257,10 @@ class StorageFactory:
 
 def _get_storage_shim() -> KBStorageShimCompatibilityFacade:
     """Return the coordinator-owned low-level storage compatibility facade."""
+    override = get_bound_storage_shim_for_current_context()
+    if override is not None:
+        return override
+
     from ..kb import get_kb_coordinator
 
     return get_kb_coordinator().storage_shim

--- a/src/xagent/web/services/kb_collection_service.py
+++ b/src/xagent/web/services/kb_collection_service.py
@@ -16,7 +16,7 @@ from ...config import get_uploads_dir
 from ..config import get_upload_path, sanitize_path_component
 from ..kb_physical_sync import collection_physical_lock, move_collection_dir_to_trash
 from ..models.uploaded_file import UploadedFile
-from .kb_file_service import delete_uploaded_file_if_orphaned
+from .kb_file_service import _delete_uploaded_file_if_orphaned_impl
 from .uploaded_file_store import UploadedFileStore
 
 if TYPE_CHECKING:
@@ -202,7 +202,7 @@ def _delete_collection_uploaded_files_impl(
     deleted_file_ids: Set[str] = set()
 
     for current_file_id in collection_file_ids:
-        if delete_uploaded_file_if_orphaned(
+        if _delete_uploaded_file_if_orphaned_impl(
             db,
             file_id=current_file_id,
             user_id=user_id,

--- a/src/xagent/web/services/kb_file_service.py
+++ b/src/xagent/web/services/kb_file_service.py
@@ -19,7 +19,9 @@ from ...core.tools.core.RAG_tools.LanceDB.schema_manager import (
     _safe_close_table,
     ensure_documents_table,
 )
-from ...core.tools.core.RAG_tools.management.status import load_ingestion_status
+from ...core.tools.core.RAG_tools.management.status import (
+    _load_ingestion_status_impl,
+)
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from ...core.tools.core.RAG_tools.utils.lancedb_query_utils import (
     list_embeddings_table_names,
@@ -737,7 +739,7 @@ def _aggregate_uploaded_file_statuses_impl(
     )
     status_by_doc: Dict[tuple[str, str], str] = {}
     for collection in collections:
-        for entry in load_ingestion_status(
+        for entry in _load_ingestion_status_impl(
             collection=collection,
             user_id=user_id,
             is_admin=is_admin,

--- a/tests/core/tools/core/RAG_tools/kb/test_file_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_file_compatibility.py
@@ -106,3 +106,125 @@ def test_public_collection_helper_delegates_through_facade(monkeypatch) -> None:
         "db",
         collection_name="kb",
     ) == {1, 2}
+
+
+def test_file_status_aggregation_impl_uses_status_private_impl(monkeypatch) -> None:
+    """File private impl should not re-enter the public management wrapper."""
+    from xagent.web.services import kb_file_service
+
+    class FakeQuery:
+        def where(self, _filter: str) -> "FakeQuery":
+            return self
+
+        def select(self, _columns: list[str]) -> "FakeQuery":
+            return self
+
+        def limit(self, _limit: int) -> "FakeQuery":
+            return self
+
+    class FakeTable:
+        def search(self) -> FakeQuery:
+            return FakeQuery()
+
+    class FakeConnection:
+        def open_table(self, table_name: str) -> FakeTable:
+            assert table_name == "documents"
+            return FakeTable()
+
+    load_calls: list[dict[str, object]] = []
+
+    def fake_load_ingestion_status_impl(**kwargs: object) -> list[dict[str, object]]:
+        load_calls.append(dict(kwargs))
+        return [{"doc_id": "doc-1", "status": "success"}]
+
+    monkeypatch.setattr(kb_file_service, "get_connection_from_env", FakeConnection)
+    monkeypatch.setattr(kb_file_service, "ensure_documents_table", lambda _conn: None)
+    monkeypatch.setattr(
+        kb_file_service,
+        "query_to_list",
+        lambda _query: [{"file_id": "file-1", "collection": "kb", "doc_id": "doc-1"}],
+    )
+    monkeypatch.setattr(
+        kb_file_service,
+        "_load_ingestion_status_impl",
+        fake_load_ingestion_status_impl,
+    )
+    monkeypatch.setattr(
+        kb_file_service, "_load_indexed_doc_refs", lambda *_, **__: set()
+    )
+
+    result = kb_file_service._aggregate_uploaded_file_statuses_impl(
+        file_ids=["file-1"],
+        user_id=7,
+        is_admin=False,
+        use_cache=False,
+    )
+
+    assert result == {"file-1": "SUCCESS"}
+    assert load_calls == [
+        {"collection": "kb", "user_id": 7, "is_admin": False},
+    ]
+
+
+def test_collection_uploaded_file_cleanup_impl_uses_file_private_impl(
+    monkeypatch,
+) -> None:
+    """Collection private impl should not re-enter the public file wrapper."""
+    from xagent.web.services import kb_collection_service
+
+    calls: list[dict[str, object]] = []
+    commit_calls: list[bool] = []
+
+    class FakeDb:
+        def commit(self) -> None:
+            commit_calls.append(True)
+
+    fake_db = FakeDb()
+
+    def fake_delete_uploaded_file_if_orphaned_impl(
+        db: object,
+        *,
+        file_id: str,
+        user_id: int,
+        remaining_file_ids: set[str],
+    ) -> bool:
+        calls.append(
+            {
+                "db": db,
+                "file_id": file_id,
+                "user_id": user_id,
+                "remaining_file_ids": set(remaining_file_ids),
+            }
+        )
+        return file_id == "file-a"
+
+    monkeypatch.setattr(
+        kb_collection_service,
+        "_delete_uploaded_file_if_orphaned_impl",
+        fake_delete_uploaded_file_if_orphaned_impl,
+    )
+
+    result = kb_collection_service._delete_collection_uploaded_files_impl(
+        fake_db,
+        user_id=5,
+        collection_file_ids={"file-a", "file-b"},
+        remaining_file_ids={"file-b"},
+        collection_dir=None,
+    )
+
+    assert result == 1
+    assert commit_calls == [True]
+    assert sorted(calls, key=lambda call: str(call["file_id"])) == [
+        {
+            "db": fake_db,
+            "file_id": "file-a",
+            "user_id": 5,
+            "remaining_file_ids": {"file-b"},
+        },
+        {
+            "db": fake_db,
+            "file_id": "file-b",
+            "user_id": 5,
+            "remaining_file_ids": {"file-b"},
+        },
+    ]

--- a/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
@@ -230,6 +230,65 @@ def test_coordinator_management_facade_uses_instance_storage() -> None:
     ]
 
 
+def test_nested_management_facade_rebinds_inner_coordinator_storage() -> None:
+    from xagent.core.tools.core.RAG_tools.kb import KBCoordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        StorageFactory,
+        bind_storage_shim_for_current_context,
+        get_ingestion_status_store,
+    )
+
+    class IngestionStatusStore:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.load_calls: list[dict[str, object]] = []
+
+        def load_ingestion_status(self, **kwargs: object) -> list[dict[str, object]]:
+            self.load_calls.append(dict(kwargs))
+            return [
+                {
+                    "collection": kwargs.get("collection"),
+                    "doc_id": self.name,
+                    "status": "success",
+                }
+            ]
+
+    class StorageFactoryStub:
+        def __init__(self, status_store: IngestionStatusStore) -> None:
+            self.status_store = status_store
+
+        def get_ingestion_status_store(self) -> IngestionStatusStore:
+            return self.status_store
+
+    outer_store = IngestionStatusStore("outer-store")
+    inner_store = IngestionStatusStore("inner-store")
+    outer = KBCoordinator(
+        storage_factory=cast(StorageFactory, StorageFactoryStub(outer_store))
+    )
+    inner = KBCoordinator(
+        storage_factory=cast(StorageFactory, StorageFactoryStub(inner_store))
+    )
+
+    with bind_storage_shim_for_current_context(outer.storage_shim):
+        assert get_ingestion_status_store() is outer_store
+        records = inner.management.load_ingestion_status(
+            collection="docs",
+            doc_id="doc-inner",
+        )
+        assert records[0]["doc_id"] == "inner-store"
+        assert get_ingestion_status_store() is outer_store
+
+    assert outer_store.load_calls == []
+    assert inner_store.load_calls == [
+        {
+            "collection": "docs",
+            "doc_id": "doc-inner",
+            "user_id": None,
+            "is_admin": False,
+        }
+    ]
+
+
 def test_facade_delegates_document_cleanup_to_existing_management_impl(
     monkeypatch,
 ) -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
@@ -1,0 +1,216 @@
+"""Tests for the KB core management compatibility facade."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Optional
+
+import pytest
+
+
+def test_kb_management_facade_public_surface_imports() -> None:
+    import xagent.core.tools.core.RAG_tools.kb as kb
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBCoreManagementCompatibilityFacade,
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+
+    assert hasattr(kb, "KBCoreManagementCompatibilityFacade")
+    reset_kb_coordinator_for_tests()
+    assert isinstance(
+        get_kb_coordinator().management,
+        KBCoreManagementCompatibilityFacade,
+    )
+
+
+def test_management_package_exports_sync_and_async_status_helpers() -> None:
+    import xagent.core.tools.core.RAG_tools.management as management
+
+    expected = {
+        "write_ingestion_status",
+        "load_ingestion_status",
+        "clear_ingestion_status",
+        "write_ingestion_status_async",
+        "load_ingestion_status_async",
+        "clear_ingestion_status_async",
+    }
+
+    assert expected.issubset(set(management.__all__))
+    for name in expected:
+        assert hasattr(management, name)
+
+    assert inspect.iscoroutinefunction(management.write_ingestion_status_async)
+    assert inspect.iscoroutinefunction(management.load_ingestion_status_async)
+    assert inspect.iscoroutinefunction(management.clear_ingestion_status_async)
+    assert not inspect.iscoroutinefunction(management.write_ingestion_status)
+    assert not inspect.iscoroutinefunction(management.load_ingestion_status)
+    assert not inspect.iscoroutinefunction(management.clear_ingestion_status)
+
+
+@pytest.mark.asyncio
+async def test_list_collections_routes_through_management_facade(
+    monkeypatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.management import collections
+
+    sentinel = object()
+    calls: list[dict[str, Any]] = []
+
+    class Facade:
+        async def list_collections(
+            self,
+            user_id: Optional[int] = None,
+            is_admin: Optional[bool] = None,
+            force_realtime: bool = False,
+        ) -> object:
+            calls.append(
+                {
+                    "user_id": user_id,
+                    "is_admin": is_admin,
+                    "force_realtime": force_realtime,
+                }
+            )
+            return sentinel
+
+    monkeypatch.setattr(collections, "_get_management_facade", lambda: Facade())
+
+    result = await collections.list_collections(
+        user_id=123,
+        is_admin=False,
+        force_realtime=True,
+    )
+
+    assert result is sentinel
+    assert calls == [
+        {"user_id": 123, "is_admin": False, "force_realtime": True},
+    ]
+
+
+def test_delete_document_remains_sync_and_routes_through_management_facade(
+    monkeypatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.management import collections
+
+    sentinel = object()
+    calls: list[tuple[str, str, int, bool]] = []
+
+    class Facade:
+        def delete_document(
+            self,
+            collection: str,
+            doc_id: str,
+            user_id: int,
+            is_admin: bool = False,
+        ) -> object:
+            calls.append((collection, doc_id, user_id, is_admin))
+            return sentinel
+
+    monkeypatch.setattr(collections, "_get_management_facade", lambda: Facade())
+
+    assert not inspect.iscoroutinefunction(collections.delete_document)
+    result = collections.delete_document("docs", "doc-1", user_id=7, is_admin=True)
+
+    assert result is sentinel
+    assert calls == [("docs", "doc-1", 7, True)]
+
+
+@pytest.mark.asyncio
+async def test_async_status_helpers_stay_awaitable_and_route_through_facade(
+    monkeypatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.management import status
+
+    calls: list[tuple[str, str, str]] = []
+
+    class Facade:
+        async def write_ingestion_status_async(
+            self,
+            collection: str,
+            doc_id: str,
+            *,
+            status: str,
+            message: Optional[str] = None,
+            parse_hash: Optional[str] = None,
+            user_id: Optional[int] = None,
+        ) -> None:
+            calls.append((collection, doc_id, status))
+
+    monkeypatch.setattr(status, "_get_management_facade", lambda: Facade())
+
+    assert inspect.iscoroutinefunction(status.write_ingestion_status_async)
+    await status.write_ingestion_status_async("docs", "doc-1", status="pending")
+
+    assert calls == [("docs", "doc-1", "pending")]
+
+
+def test_facade_delegates_document_cleanup_to_existing_management_impl(
+    monkeypatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBCoreManagementCompatibilityFacade,
+    )
+    from xagent.core.tools.core.RAG_tools.management import collections
+
+    sentinel = object()
+    calls: list[tuple[str, str, int, bool]] = []
+
+    def fake_delete_document_impl(
+        collection: str,
+        doc_id: str,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> object:
+        calls.append((collection, doc_id, user_id, is_admin))
+        return sentinel
+
+    monkeypatch.setattr(
+        collections,
+        "_delete_document_impl",
+        fake_delete_document_impl,
+    )
+
+    result = KBCoreManagementCompatibilityFacade().delete_document(
+        "docs",
+        "doc-1",
+        user_id=9,
+        is_admin=False,
+    )
+
+    assert result is sentinel
+    assert calls == [("docs", "doc-1", 9, False)]
+
+
+@pytest.mark.asyncio
+async def test_facade_delegates_status_cleanup_to_existing_async_impl(
+    monkeypatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBCoreManagementCompatibilityFacade,
+    )
+    from xagent.core.tools.core.RAG_tools.management import status
+
+    calls: list[tuple[str, str, Optional[int], bool]] = []
+
+    async def fake_clear_status_impl(
+        collection: str,
+        doc_id: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        calls.append((collection, doc_id, user_id, is_admin))
+
+    monkeypatch.setattr(
+        status,
+        "_clear_ingestion_status_async_impl",
+        fake_clear_status_impl,
+    )
+
+    await KBCoreManagementCompatibilityFacade().clear_ingestion_status_async(
+        "docs",
+        "doc-1",
+        user_id=3,
+        is_admin=True,
+    )
+
+    assert calls == [("docs", "doc-1", 3, True)]

--- a/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import pytest
 
@@ -142,6 +142,92 @@ async def test_async_status_helpers_stay_awaitable_and_route_through_facade(
     await status.write_ingestion_status_async("docs", "doc-1", status="pending")
 
     assert calls == [("docs", "doc-1", "pending")]
+
+
+def test_coordinator_management_facade_uses_instance_storage() -> None:
+    from xagent.core.tools.core.RAG_tools.kb import KBCoordinator
+    from xagent.core.tools.core.RAG_tools.management import collections
+    from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
+    from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
+
+    class VectorStore:
+        def __init__(self) -> None:
+            self.list_calls: list[dict[str, object]] = []
+
+        def list_document_records(self, **kwargs: object) -> list[DocumentRecord]:
+            self.list_calls.append(dict(kwargs))
+            return [DocumentRecord(doc_id="doc-local", source_path="/tmp/local.txt")]
+
+        def aggregate_document_counts(self, **_: object) -> dict[str, int]:
+            return {}
+
+        def list_table_names(self) -> list[str]:
+            return []
+
+    class IngestionStatusStore:
+        def __init__(self) -> None:
+            self.load_calls: list[dict[str, object]] = []
+
+        def load_ingestion_status(self, **kwargs: object) -> list[dict[str, object]]:
+            self.load_calls.append(dict(kwargs))
+            return [
+                {
+                    "collection": "docs",
+                    "doc_id": "doc-local",
+                    "status": "failed",
+                    "message": "Loaded from injected status store",
+                    "updated_at": None,
+                }
+            ]
+
+    class StorageFactoryStub:
+        def __init__(
+            self,
+            vector_store: VectorStore,
+            status_store: IngestionStatusStore,
+        ) -> None:
+            self.vector_store = vector_store
+            self.status_store = status_store
+
+        def get_vector_index_store(self) -> VectorStore:
+            return self.vector_store
+
+        def get_ingestion_status_store(self) -> IngestionStatusStore:
+            return self.status_store
+
+    vector_store = VectorStore()
+    status_store = IngestionStatusStore()
+
+    coordinator = KBCoordinator(
+        storage_factory=cast(
+            StorageFactory,
+            StorageFactoryStub(vector_store, status_store),
+        )
+    )
+    result = coordinator.management.list_documents(
+        "docs",
+        user_id=42,
+        is_admin=False,
+    )
+
+    assert [document.doc_id for document in result.documents] == ["doc-local"]
+    assert result.documents[0].message == "Loaded from injected status store"
+    assert vector_store.list_calls == [
+        {
+            "collection_name": "docs",
+            "user_id": 42,
+            "is_admin": False,
+            "max_results": collections.DEFAULT_VECTOR_STORE_EXTENDED_SCAN_LIMIT,
+        }
+    ]
+    assert status_store.load_calls == [
+        {
+            "collection": "docs",
+            "doc_id": None,
+            "user_id": None,
+            "is_admin": False,
+        }
+    ]
 
 
 def test_facade_delegates_document_cleanup_to_existing_management_impl(

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -38,7 +38,10 @@ from src.xagent.core.tools.core.RAG_tools.management import (
     list_documents,
     retry_document,
 )
-from src.xagent.core.tools.core.RAG_tools.management.status import load_ingestion_status
+from src.xagent.core.tools.core.RAG_tools.management.status import (
+    load_ingestion_status,
+    write_ingestion_status,
+)
 from src.xagent.core.tools.core.RAG_tools.storage import get_vector_index_store
 from src.xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from src.xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
@@ -1153,6 +1156,53 @@ def test_delete_document_clears_status_with_caller_scope() -> None:
         "doc-1",
         user_id=9,
         is_admin=True,
+    )
+
+
+def test_delete_document_cleans_failed_ingest_status_by_doc_id(
+    temp_lancedb_dir: str,
+) -> None:
+    """Failed ingest rollback cleanup should remove document data and status."""
+
+    collection = "failed_ingest_cleanup"
+    doc_id = "failed-doc"
+    now = datetime.now(timezone.utc)
+
+    _insert_documents(
+        [
+            {
+                "collection": collection,
+                "doc_id": doc_id,
+                "source_path": "/uploads/user_7/failed-doc.pdf",
+                "file_type": "pdf",
+                "content_hash": "failed-hash",
+                "uploaded_at": now,
+                "title": "Failed",
+                "language": "zh",
+                "user_id": 7,
+            }
+        ]
+    )
+    write_ingestion_status(
+        collection,
+        doc_id,
+        status=DocumentProcessingStatus.FAILED.value,
+        message="Failed during ingest",
+        user_id=7,
+    )
+
+    result = delete_document(collection, doc_id, user_id=7, is_admin=False)
+
+    assert result.status == "success"
+    assert result.details.get("documents") == 1
+    assert (
+        load_ingestion_status(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=7,
+            is_admin=False,
+        )
+        == []
     )
 
 

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -515,7 +515,7 @@ def test_delete_collection_invokes_cleanup_all_documents(
 
     monkeypatch.setattr(
         collections_module,
-        "clear_ingestion_status",
+        "_clear_ingestion_status_impl",
         _fake_clear,
     )
 
@@ -545,7 +545,7 @@ def test_delete_collection_preserves_partial_vector_cleanup(
         collections_module, "get_vector_index_store", lambda: mock_store
     )
     monkeypatch.setattr(
-        collections_module, "clear_ingestion_status", lambda *args, **kwargs: None
+        collections_module, "_clear_ingestion_status_impl", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(
         collections_module,
@@ -598,7 +598,7 @@ def test_delete_collection_non_admin_uses_batched_document_scoped_delete(
     monkeypatch.setattr(collections_module, "get_vector_index_store", lambda: store)
     monkeypatch.setattr(
         collections_module,
-        "clear_ingestion_status",
+        "_clear_ingestion_status_impl",
         lambda *args, **kwargs: None,
     )
 
@@ -1027,7 +1027,7 @@ def test_delete_document_authorizes_before_cascade() -> None:
             collections_module, "get_vector_index_store", return_value=vector_store
         ),
         patch.object(vector_store, "delete_document_data") as mock_delete_data,
-        patch.object(collections_module, "clear_ingestion_status") as mock_clear,
+        patch.object(collections_module, "_clear_ingestion_status_impl") as mock_clear,
     ):
         result = delete_document("demo", "doc-1", user_id=7, is_admin=False)
 
@@ -1068,7 +1068,7 @@ def test_delete_document_allows_legacy_owner_recovered_from_source_path() -> Non
             "delete_document_data",
             return_value={"documents": 1, "main_pointers": 1},
         ) as mock_delete_data,
-        patch.object(collections_module, "clear_ingestion_status") as mock_clear,
+        patch.object(collections_module, "_clear_ingestion_status_impl") as mock_clear,
     ):
         result = delete_document("demo", "doc-legacy", user_id=7, is_admin=False)
 
@@ -1116,7 +1116,7 @@ def test_delete_document_rejects_legacy_row_owned_by_another_user() -> None:
             collections_module, "get_vector_index_store", return_value=vector_store
         ),
         patch.object(vector_store, "delete_document_data") as mock_delete_data,
-        patch.object(collections_module, "clear_ingestion_status") as mock_clear,
+        patch.object(collections_module, "_clear_ingestion_status_impl") as mock_clear,
     ):
         result = delete_document("demo", "doc-foreign", user_id=7, is_admin=False)
 
@@ -1139,7 +1139,7 @@ def test_delete_document_clears_status_with_caller_scope() -> None:
             "delete_document_data",
             return_value={"documents": 1, "main_pointers": 1},
         ) as mock_delete_data,
-        patch.object(collections_module, "clear_ingestion_status") as mock_clear,
+        patch.object(collections_module, "_clear_ingestion_status_impl") as mock_clear,
     ):
         result = delete_document("demo", "doc-1", user_id=9, is_admin=True)
 

--- a/tests/core/tools/core/RAG_tools/management/test_status.py
+++ b/tests/core/tools/core/RAG_tools/management/test_status.py
@@ -82,6 +82,60 @@ def test_write_ingestion_status_overwrites_existing(temp_lancedb_dir: str) -> No
     assert records[0]["message"] == "Completed"
 
 
+def test_failed_ingest_status_can_be_restored_then_cleared(
+    temp_lancedb_dir: str,
+) -> None:
+    """Failed ingest rollback status can be restored and then cleared."""
+
+    collection = "failed_status_collection"
+    doc_id = "failed_doc"
+
+    write_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        status="failed",
+        message="Initial ingest failed",
+        user_id=7,
+    )
+    failed_records = load_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=7,
+        is_admin=False,
+    )
+    assert len(failed_records) == 1
+    assert failed_records[0]["status"] == "failed"
+
+    write_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        status="pending",
+        message="Rollback restored status",
+        user_id=7,
+    )
+    restored_records = load_ingestion_status(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=7,
+        is_admin=False,
+    )
+    assert len(restored_records) == 1
+    assert restored_records[0]["status"] == "pending"
+    assert restored_records[0]["message"] == "Rollback restored status"
+
+    clear_ingestion_status(collection, doc_id, user_id=7, is_admin=False)
+
+    assert (
+        load_ingestion_status(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=7,
+            is_admin=False,
+        )
+        == []
+    )
+
+
 def test_load_ingestion_status_by_collection(temp_lancedb_dir: str) -> None:
     """Test loading status records filtered by collection."""
 


### PR DESCRIPTION
## Summary

- Add `KBCoreManagementCompatibilityFacade` and route management/status compatibility APIs through the KB coordinator surface.
- Bind coordinator-created management facades to the current `KBCoordinator` storage path, including nested legacy status wrapper calls.
- Preserve existing management import shapes, sync/async helper behavior, and add coverage for injected coordinator storage plus failed-ingest cleanup/status rollback cases.

Closes #498.

## Validation

- `env PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/python -m pytest tests/core/tools/core/RAG_tools/kb/test_management_facade.py tests/core/tools/core/RAG_tools/management/test_status.py tests/core/tools/core/RAG_tools/management/test_collections.py`
- `env PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/pre-commit run --all-files`