### PR TITLE
feat(kb): add rollback maintenance compatibility helpers

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -7,6 +7,11 @@ from .coordinator import (
     reset_kb_coordinator_for_tests,
 )
 from .file_compatibility import KBFileCompatibilityFacade
+from .maintenance_compatibility import (
+    CollectionConfigSnapshot,
+    CollectionRollbackMaintenanceResult,
+    KBMaintenanceCompatibilityFacade,
+)
 from .management_facade import KBCoreManagementCompatibilityFacade
 from .models import (
     KBAccessMode,
@@ -25,9 +30,12 @@ __all__ = [
     "KBCollectionContext",
     "KBContextRequest",
     "KBHandleProvider",
+    "CollectionConfigSnapshot",
+    "CollectionRollbackMaintenanceResult",
     "KBCoreManagementCompatibilityFacade",
     "KBCoordinator",
     "KBFileCompatibilityFacade",
+    "KBMaintenanceCompatibilityFacade",
     "KBParseDisplayCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -57,7 +57,8 @@ class KBCoordinator:
             or KBParseDisplayCompatibilityFacade(coordinator=self)
         )
         self._maintenance_compatibility = (
-            maintenance_compatibility or KBMaintenanceCompatibilityFacade()
+            maintenance_compatibility
+            or KBMaintenanceCompatibilityFacade(coordinator=self)
         )
 
     @property

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -12,6 +12,7 @@ from ..storage.factory import StorageFactory
 from ..utils.user_scope import resolve_user_scope
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .file_compatibility import KBFileCompatibilityFacade
+from .maintenance_compatibility import KBMaintenanceCompatibilityFacade
 from .management_facade import KBCoreManagementCompatibilityFacade
 from .models import (
     KBAccessMode,
@@ -40,6 +41,7 @@ class KBCoordinator:
         file_compatibility: KBFileCompatibilityFacade | None = None,
         management_facade: KBCoreManagementCompatibilityFacade | None = None,
         parse_display_compatibility: KBParseDisplayCompatibilityFacade | None = None,
+        maintenance_compatibility: KBMaintenanceCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -53,6 +55,9 @@ class KBCoordinator:
         self._parse_display_compatibility = (
             parse_display_compatibility
             or KBParseDisplayCompatibilityFacade(coordinator=self)
+        )
+        self._maintenance_compatibility = (
+            maintenance_compatibility or KBMaintenanceCompatibilityFacade()
         )
 
     @property
@@ -84,6 +89,16 @@ class KBCoordinator:
     def parse_display(self) -> KBParseDisplayCompatibilityFacade:
         """Backward-friendly short alias for the parse display facade."""
         return self._parse_display_compatibility
+
+    @property
+    def maintenance_compatibility(self) -> KBMaintenanceCompatibilityFacade:
+        """Return the collection metadata maintenance compatibility facade."""
+        return self._maintenance_compatibility
+
+    @property
+    def maintenance_compat(self) -> KBMaintenanceCompatibilityFacade:
+        """Backward-friendly short alias for the maintenance facade."""
+        return self._maintenance_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
@@ -1,0 +1,251 @@
+"""Collection metadata maintenance compatibility facade."""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ..core.schemas import CollectionInfo
+
+
+@dataclass(frozen=True)
+class CollectionConfigSnapshot:
+    """Snapshot of the tenant-scoped collection config row before mutation."""
+
+    collection_name: str
+    user_id: Optional[int]
+    config_user_id: int
+    config_json: Optional[str]
+    existed: bool
+
+
+@dataclass(frozen=True)
+class CollectionRollbackMaintenanceResult:
+    """Outcome for collection-level rollback maintenance actions."""
+
+    collection_name: str
+    status: str
+    skipped: bool = False
+    reason: Optional[str] = None
+    cleanup_counts: dict[str, int] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    side_effects_may_remain: bool = False
+
+
+class KBMaintenanceCompatibilityFacade:
+    """Compatibility boundary for legacy collection maintenance helpers.
+
+    The legacy manager and module-level helper implementations remain in
+    ``management.collection_manager``. This facade gives coordinator-owned code
+    a stable maintenance entry point while preserving public helper names,
+    signatures, and sync/async behavior.
+    """
+
+    def get_collection_sync(self, collection_name: str) -> "CollectionInfo":
+        from ..management.collection_manager import _get_collection_sync_impl
+
+        return _get_collection_sync_impl(collection_name)
+
+    def initialize_collection_embedding_sync(
+        self, collection_name: str, embedding_model_id: str
+    ) -> "CollectionInfo":
+        from ..management.collection_manager import (
+            _initialize_collection_embedding_sync_impl,
+        )
+
+        return _initialize_collection_embedding_sync_impl(
+            collection_name, embedding_model_id
+        )
+
+    def validate_document_processing_sync(
+        self,
+        collection_name: str,
+        file_path: str,
+        parsing_method: str,
+        chunking_method: str,
+    ) -> None:
+        from ..management.collection_manager import (
+            _validate_document_processing_sync_impl,
+        )
+
+        _validate_document_processing_sync_impl(
+            collection_name, file_path, parsing_method, chunking_method
+        )
+
+    def update_collection_stats_sync(
+        self,
+        collection_name: str,
+        documents_delta: int = 0,
+        processed_documents_delta: int = 0,
+        parses_delta: int = 0,
+        chunks_delta: int = 0,
+        embeddings_delta: int = 0,
+        document_name: Optional[str] = None,
+    ) -> "CollectionInfo":
+        from ..management.collection_manager import _update_collection_stats_sync_impl
+
+        return _update_collection_stats_sync_impl(
+            collection_name,
+            documents_delta,
+            processed_documents_delta,
+            parses_delta,
+            chunks_delta,
+            embeddings_delta,
+            document_name,
+        )
+
+    def mark_collection_accessed_sync(self, collection_name: str) -> None:
+        from ..management.collection_manager import _mark_collection_accessed_sync_impl
+
+        _mark_collection_accessed_sync_impl(collection_name)
+
+    def delete_collection_metadata_sync(
+        self,
+        collection_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+        delete_orphaned_metadata: bool = False,
+    ) -> dict[str, int]:
+        from ..management.collection_manager import (
+            _delete_collection_metadata_sync_impl,
+        )
+
+        return _delete_collection_metadata_sync_impl(
+            collection_name,
+            user_id,
+            is_admin,
+            delete_orphaned_metadata,
+        )
+
+    async def capture_collection_config_snapshot(
+        self, collection_name: str, user_id: Optional[int]
+    ) -> "CollectionConfigSnapshot":
+        from ..management.collection_manager import (
+            _capture_collection_config_snapshot_impl,
+        )
+
+        return await _capture_collection_config_snapshot_impl(collection_name, user_id)
+
+    def capture_collection_config_snapshot_sync(
+        self, collection_name: str, user_id: Optional[int]
+    ) -> "CollectionConfigSnapshot":
+        from ..management.collection_manager import (
+            _capture_collection_config_snapshot_sync_impl,
+        )
+
+        return _capture_collection_config_snapshot_sync_impl(collection_name, user_id)
+
+    async def restore_collection_config_snapshot(
+        self,
+        snapshot: "CollectionConfigSnapshot",
+        *,
+        rollback_complete: bool,
+        side_effects_may_remain: bool = False,
+    ) -> "CollectionRollbackMaintenanceResult":
+        from ..management.collection_manager import (
+            _restore_collection_config_snapshot_impl,
+        )
+
+        return await _restore_collection_config_snapshot_impl(
+            snapshot,
+            rollback_complete=rollback_complete,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+    def restore_collection_config_snapshot_sync(
+        self,
+        snapshot: "CollectionConfigSnapshot",
+        *,
+        rollback_complete: bool,
+        side_effects_may_remain: bool = False,
+    ) -> "CollectionRollbackMaintenanceResult":
+        from ..management.collection_manager import (
+            _restore_collection_config_snapshot_sync_impl,
+        )
+
+        return _restore_collection_config_snapshot_sync_impl(
+            snapshot,
+            rollback_complete=rollback_complete,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+    async def cleanup_collection_metadata_after_rollback(
+        self,
+        collection_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+        *,
+        rollback_complete: bool,
+        side_effects_may_remain: bool = False,
+        delete_orphaned_metadata: bool = True,
+    ) -> "CollectionRollbackMaintenanceResult":
+        from ..management.collection_manager import (
+            _cleanup_collection_metadata_after_rollback_impl,
+        )
+
+        return await _cleanup_collection_metadata_after_rollback_impl(
+            collection_name,
+            user_id,
+            is_admin,
+            rollback_complete=rollback_complete,
+            side_effects_may_remain=side_effects_may_remain,
+            delete_orphaned_metadata=delete_orphaned_metadata,
+        )
+
+    def cleanup_collection_metadata_after_rollback_sync(
+        self,
+        collection_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+        *,
+        rollback_complete: bool,
+        side_effects_may_remain: bool = False,
+        delete_orphaned_metadata: bool = True,
+    ) -> "CollectionRollbackMaintenanceResult":
+        from ..management.collection_manager import (
+            _cleanup_collection_metadata_after_rollback_sync_impl,
+        )
+
+        return _cleanup_collection_metadata_after_rollback_sync_impl(
+            collection_name,
+            user_id,
+            is_admin,
+            rollback_complete=rollback_complete,
+            side_effects_may_remain=side_effects_may_remain,
+            delete_orphaned_metadata=delete_orphaned_metadata,
+        )
+
+    async def rebuild_collection_stats(
+        self,
+        collection_name: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+    ) -> Optional["CollectionInfo"]:
+        from ..management.collection_manager import _rebuild_collection_stats_impl
+
+        return await _rebuild_collection_stats_impl(collection_name, user_id, is_admin)
+
+    def rebuild_collection_stats_sync(
+        self,
+        collection_name: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+    ) -> Optional["CollectionInfo"]:
+        from ..management.collection_manager import _rebuild_collection_stats_sync_impl
+
+        return _rebuild_collection_stats_sync_impl(collection_name, user_id, is_admin)
+
+    def resolve_effective_embedding_model_sync(
+        self, collection_name: str, config_model_id: Optional[str] = None
+    ) -> str:
+        from ..management.collection_manager import (
+            _resolve_effective_embedding_model_sync_impl,
+        )
+
+        return _resolve_effective_embedding_model_sync_impl(
+            collection_name, config_model_id
+        )
+
+    async def rebuild_collection_metadata(self) -> None:
+        from ..management.collection_manager import _rebuild_collection_metadata_impl
+
+        await _rebuild_collection_metadata_impl()

--- a/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
@@ -1,10 +1,14 @@
 """Collection metadata maintenance compatibility facade."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ..core.schemas import CollectionInfo
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
 
 
 @dataclass(frozen=True)
@@ -40,10 +44,38 @@ class KBMaintenanceCompatibilityFacade:
     signatures, and sync/async behavior.
     """
 
+    def __init__(
+        self,
+        coordinator: "KBCoordinator | None" = None,
+        storage_shim: "KBStorageShimCompatibilityFacade | None" = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> "KBStorageShimCompatibilityFacade | None":
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
     def get_collection_sync(self, collection_name: str) -> "CollectionInfo":
         from ..management.collection_manager import _get_collection_sync_impl
 
-        return _get_collection_sync_impl(collection_name)
+        with self._storage_context():
+            return _get_collection_sync_impl(collection_name)
 
     def initialize_collection_embedding_sync(
         self, collection_name: str, embedding_model_id: str
@@ -52,9 +84,10 @@ class KBMaintenanceCompatibilityFacade:
             _initialize_collection_embedding_sync_impl,
         )
 
-        return _initialize_collection_embedding_sync_impl(
-            collection_name, embedding_model_id
-        )
+        with self._storage_context():
+            return _initialize_collection_embedding_sync_impl(
+                collection_name, embedding_model_id
+            )
 
     def validate_document_processing_sync(
         self,
@@ -67,9 +100,10 @@ class KBMaintenanceCompatibilityFacade:
             _validate_document_processing_sync_impl,
         )
 
-        _validate_document_processing_sync_impl(
-            collection_name, file_path, parsing_method, chunking_method
-        )
+        with self._storage_context():
+            _validate_document_processing_sync_impl(
+                collection_name, file_path, parsing_method, chunking_method
+            )
 
     def update_collection_stats_sync(
         self,
@@ -83,20 +117,22 @@ class KBMaintenanceCompatibilityFacade:
     ) -> "CollectionInfo":
         from ..management.collection_manager import _update_collection_stats_sync_impl
 
-        return _update_collection_stats_sync_impl(
-            collection_name,
-            documents_delta,
-            processed_documents_delta,
-            parses_delta,
-            chunks_delta,
-            embeddings_delta,
-            document_name,
-        )
+        with self._storage_context():
+            return _update_collection_stats_sync_impl(
+                collection_name,
+                documents_delta,
+                processed_documents_delta,
+                parses_delta,
+                chunks_delta,
+                embeddings_delta,
+                document_name,
+            )
 
     def mark_collection_accessed_sync(self, collection_name: str) -> None:
         from ..management.collection_manager import _mark_collection_accessed_sync_impl
 
-        _mark_collection_accessed_sync_impl(collection_name)
+        with self._storage_context():
+            _mark_collection_accessed_sync_impl(collection_name)
 
     def delete_collection_metadata_sync(
         self,
@@ -109,12 +145,13 @@ class KBMaintenanceCompatibilityFacade:
             _delete_collection_metadata_sync_impl,
         )
 
-        return _delete_collection_metadata_sync_impl(
-            collection_name,
-            user_id,
-            is_admin,
-            delete_orphaned_metadata,
-        )
+        with self._storage_context():
+            return _delete_collection_metadata_sync_impl(
+                collection_name,
+                user_id,
+                is_admin,
+                delete_orphaned_metadata,
+            )
 
     async def capture_collection_config_snapshot(
         self, collection_name: str, user_id: Optional[int]
@@ -123,7 +160,10 @@ class KBMaintenanceCompatibilityFacade:
             _capture_collection_config_snapshot_impl,
         )
 
-        return await _capture_collection_config_snapshot_impl(collection_name, user_id)
+        with self._storage_context():
+            return await _capture_collection_config_snapshot_impl(
+                collection_name, user_id
+            )
 
     def capture_collection_config_snapshot_sync(
         self, collection_name: str, user_id: Optional[int]
@@ -132,7 +172,10 @@ class KBMaintenanceCompatibilityFacade:
             _capture_collection_config_snapshot_sync_impl,
         )
 
-        return _capture_collection_config_snapshot_sync_impl(collection_name, user_id)
+        with self._storage_context():
+            return _capture_collection_config_snapshot_sync_impl(
+                collection_name, user_id
+            )
 
     async def restore_collection_config_snapshot(
         self,
@@ -145,11 +188,12 @@ class KBMaintenanceCompatibilityFacade:
             _restore_collection_config_snapshot_impl,
         )
 
-        return await _restore_collection_config_snapshot_impl(
-            snapshot,
-            rollback_complete=rollback_complete,
-            side_effects_may_remain=side_effects_may_remain,
-        )
+        with self._storage_context():
+            return await _restore_collection_config_snapshot_impl(
+                snapshot,
+                rollback_complete=rollback_complete,
+                side_effects_may_remain=side_effects_may_remain,
+            )
 
     def restore_collection_config_snapshot_sync(
         self,
@@ -162,11 +206,12 @@ class KBMaintenanceCompatibilityFacade:
             _restore_collection_config_snapshot_sync_impl,
         )
 
-        return _restore_collection_config_snapshot_sync_impl(
-            snapshot,
-            rollback_complete=rollback_complete,
-            side_effects_may_remain=side_effects_may_remain,
-        )
+        with self._storage_context():
+            return _restore_collection_config_snapshot_sync_impl(
+                snapshot,
+                rollback_complete=rollback_complete,
+                side_effects_may_remain=side_effects_may_remain,
+            )
 
     async def cleanup_collection_metadata_after_rollback(
         self,
@@ -182,14 +227,15 @@ class KBMaintenanceCompatibilityFacade:
             _cleanup_collection_metadata_after_rollback_impl,
         )
 
-        return await _cleanup_collection_metadata_after_rollback_impl(
-            collection_name,
-            user_id,
-            is_admin,
-            rollback_complete=rollback_complete,
-            side_effects_may_remain=side_effects_may_remain,
-            delete_orphaned_metadata=delete_orphaned_metadata,
-        )
+        with self._storage_context():
+            return await _cleanup_collection_metadata_after_rollback_impl(
+                collection_name,
+                user_id,
+                is_admin,
+                rollback_complete=rollback_complete,
+                side_effects_may_remain=side_effects_may_remain,
+                delete_orphaned_metadata=delete_orphaned_metadata,
+            )
 
     def cleanup_collection_metadata_after_rollback_sync(
         self,
@@ -205,14 +251,15 @@ class KBMaintenanceCompatibilityFacade:
             _cleanup_collection_metadata_after_rollback_sync_impl,
         )
 
-        return _cleanup_collection_metadata_after_rollback_sync_impl(
-            collection_name,
-            user_id,
-            is_admin,
-            rollback_complete=rollback_complete,
-            side_effects_may_remain=side_effects_may_remain,
-            delete_orphaned_metadata=delete_orphaned_metadata,
-        )
+        with self._storage_context():
+            return _cleanup_collection_metadata_after_rollback_sync_impl(
+                collection_name,
+                user_id,
+                is_admin,
+                rollback_complete=rollback_complete,
+                side_effects_may_remain=side_effects_may_remain,
+                delete_orphaned_metadata=delete_orphaned_metadata,
+            )
 
     async def rebuild_collection_stats(
         self,
@@ -220,7 +267,8 @@ class KBMaintenanceCompatibilityFacade:
     ) -> Optional["CollectionInfo"]:
         from ..management.collection_manager import _rebuild_collection_stats_impl
 
-        return await _rebuild_collection_stats_impl(collection_name)
+        with self._storage_context():
+            return await _rebuild_collection_stats_impl(collection_name)
 
     def rebuild_collection_stats_sync(
         self,
@@ -228,7 +276,8 @@ class KBMaintenanceCompatibilityFacade:
     ) -> Optional["CollectionInfo"]:
         from ..management.collection_manager import _rebuild_collection_stats_sync_impl
 
-        return _rebuild_collection_stats_sync_impl(collection_name)
+        with self._storage_context():
+            return _rebuild_collection_stats_sync_impl(collection_name)
 
     def resolve_effective_embedding_model_sync(
         self, collection_name: str, config_model_id: Optional[str] = None
@@ -237,11 +286,13 @@ class KBMaintenanceCompatibilityFacade:
             _resolve_effective_embedding_model_sync_impl,
         )
 
-        return _resolve_effective_embedding_model_sync_impl(
-            collection_name, config_model_id
-        )
+        with self._storage_context():
+            return _resolve_effective_embedding_model_sync_impl(
+                collection_name, config_model_id
+            )
 
     async def rebuild_collection_metadata(self) -> None:
         from ..management.collection_manager import _rebuild_collection_metadata_impl
 
-        await _rebuild_collection_metadata_impl()
+        with self._storage_context():
+            await _rebuild_collection_metadata_impl()

--- a/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/maintenance_compatibility.py
@@ -217,22 +217,18 @@ class KBMaintenanceCompatibilityFacade:
     async def rebuild_collection_stats(
         self,
         collection_name: str,
-        user_id: Optional[int] = None,
-        is_admin: bool = True,
     ) -> Optional["CollectionInfo"]:
         from ..management.collection_manager import _rebuild_collection_stats_impl
 
-        return await _rebuild_collection_stats_impl(collection_name, user_id, is_admin)
+        return await _rebuild_collection_stats_impl(collection_name)
 
     def rebuild_collection_stats_sync(
         self,
         collection_name: str,
-        user_id: Optional[int] = None,
-        is_admin: bool = True,
     ) -> Optional["CollectionInfo"]:
         from ..management.collection_manager import _rebuild_collection_stats_sync_impl
 
-        return _rebuild_collection_stats_sync_impl(collection_name, user_id, is_admin)
+        return _rebuild_collection_stats_sync_impl(collection_name)
 
     def resolve_effective_embedding_model_sync(
         self, collection_name: str, config_model_id: Optional[str] = None

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -1114,7 +1114,7 @@ def _coerce_stat_count(stats: dict[str, Any], key: str) -> int:
 async def rebuild_collection_stats(
     collection_name: str,
 ) -> Optional["CollectionInfo"]:
-    """Rebuild collection stats from the storage backend after commit/rollback."""
+    """Rebuild global collection metadata stats after commit/rollback."""
     return await _get_maintenance_compatibility_facade().rebuild_collection_stats(
         collection_name
     )
@@ -1130,6 +1130,7 @@ async def _rebuild_collection_stats_impl(
     except Exception:
         existing_info = None
 
+    # collection_metadata is a global cache; never persist user-scoped counts here.
     stats_by_collection = get_vector_index_store().aggregate_collection_stats(
         user_id=None,
         is_admin=True,

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -10,7 +10,7 @@ import os
 import threading
 from datetime import datetime, timezone
 from functools import wraps
-from typing import Any, Awaitable, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar
 
 import pyarrow as pa  # type: ignore
 
@@ -22,6 +22,13 @@ from ..storage.factory import get_metadata_store, get_vector_index_store
 from ..utils.lancedb_query_utils import list_table_names
 from ..utils.model_resolver import resolve_embedding_adapter
 from ..utils.tag_mapping import register_tag_mapping
+
+if TYPE_CHECKING:
+    from ..kb import (
+        CollectionConfigSnapshot,
+        CollectionRollbackMaintenanceResult,
+        KBMaintenanceCompatibilityFacade,
+    )
 
 T = TypeVar("T")
 
@@ -38,6 +45,11 @@ def reset_locks_for_testing() -> None:
     """Clear in-memory collection locks for test isolation."""
     with _collection_locks_lock:
         _collection_locks.clear()
+
+
+def _normalize_collection_config_user_id(user_id: Optional[int]) -> int:
+    """Normalize legacy collection_config ownership scope."""
+    return 0 if user_id is None else int(user_id)
 
 
 def _normalize_model_id(model_id: Optional[str]) -> Optional[str]:
@@ -625,6 +637,13 @@ class CollectionManager:
 collection_manager = CollectionManager()
 
 
+def _get_maintenance_compatibility_facade() -> "KBMaintenanceCompatibilityFacade":
+    """Return the coordinator-owned collection maintenance facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().maintenance_compatibility
+
+
 # Synchronous wrapper functions using decorator
 def get_collection_sync(collection_name: str) -> "CollectionInfo":
     """Synchronous version of get_collection for non-async contexts.
@@ -638,6 +657,10 @@ def get_collection_sync(collection_name: str) -> "CollectionInfo":
     Raises:
         ValueError: If collection not found
     """
+    return _get_maintenance_compatibility_facade().get_collection_sync(collection_name)
+
+
+def _get_collection_sync_impl(collection_name: str) -> "CollectionInfo":
     return _sync_wrapper(collection_manager.get_collection)(collection_name)
 
 
@@ -656,6 +679,14 @@ def initialize_collection_embedding_sync(
     Raises:
         ValueError: If collection already initialized with different model
     """
+    return _get_maintenance_compatibility_facade().initialize_collection_embedding_sync(
+        collection_name, embedding_model_id
+    )
+
+
+def _initialize_collection_embedding_sync_impl(
+    collection_name: str, embedding_model_id: str
+) -> "CollectionInfo":
     return _sync_wrapper(collection_manager.initialize_collection_embedding)(
         collection_name, embedding_model_id
     )
@@ -675,6 +706,14 @@ def validate_document_processing_sync(
     Raises:
         ValueError: If validation fails
     """
+    _get_maintenance_compatibility_facade().validate_document_processing_sync(
+        collection_name, file_path, parsing_method, chunking_method
+    )
+
+
+def _validate_document_processing_sync_impl(
+    collection_name: str, file_path: str, parsing_method: str, chunking_method: str
+) -> None:
     _sync_wrapper(collection_manager.validate_document_processing)(
         collection_name, file_path, parsing_method, chunking_method
     )
@@ -703,6 +742,26 @@ def update_collection_stats_sync(
     Returns:
         Updated CollectionInfo
     """
+    return _get_maintenance_compatibility_facade().update_collection_stats_sync(
+        collection_name,
+        documents_delta,
+        processed_documents_delta,
+        parses_delta,
+        chunks_delta,
+        embeddings_delta,
+        document_name,
+    )
+
+
+def _update_collection_stats_sync_impl(
+    collection_name: str,
+    documents_delta: int = 0,
+    processed_documents_delta: int = 0,
+    parses_delta: int = 0,
+    chunks_delta: int = 0,
+    embeddings_delta: int = 0,
+    document_name: Optional[str] = None,
+) -> "CollectionInfo":
     return _sync_wrapper(collection_manager.update_collection_stats)(
         collection_name,
         documents_delta,
@@ -720,6 +779,12 @@ def mark_collection_accessed_sync(collection_name: str) -> None:
     Args:
         collection_name: Name of the collection to mark as accessed
     """
+    _get_maintenance_compatibility_facade().mark_collection_accessed_sync(
+        collection_name
+    )
+
+
+def _mark_collection_accessed_sync_impl(collection_name: str) -> None:
     _sync_wrapper(collection_manager.mark_collection_accessed)(collection_name)
 
 
@@ -730,11 +795,400 @@ def delete_collection_metadata_sync(
     delete_orphaned_metadata: bool = False,
 ) -> dict[str, int]:
     """Synchronous version of delete_collection_metadata."""
+    return _get_maintenance_compatibility_facade().delete_collection_metadata_sync(
+        collection_name,
+        user_id,
+        is_admin,
+        delete_orphaned_metadata,
+    )
+
+
+def _delete_collection_metadata_sync_impl(
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    delete_orphaned_metadata: bool = False,
+) -> dict[str, int]:
     return _sync_wrapper(collection_manager.delete_collection_metadata)(
         collection_name,
         user_id,
         is_admin,
         delete_orphaned_metadata,
+    )
+
+
+def _collection_rollback_guard_warning(
+    *, rollback_complete: bool, side_effects_may_remain: bool
+) -> tuple[Optional[str], tuple[str, ...]]:
+    if side_effects_may_remain:
+        return (
+            "side_effects_may_remain",
+            (
+                "Skipped collection rollback maintenance because side effects may remain.",
+            ),
+        )
+    if not rollback_complete:
+        return (
+            "rollback_not_complete",
+            (
+                "Skipped collection rollback maintenance because rollback is incomplete.",
+            ),
+        )
+    return None, ()
+
+
+def _collection_rollback_result(
+    collection_name: str,
+    *,
+    status: str,
+    skipped: bool = False,
+    reason: Optional[str] = None,
+    cleanup_counts: Optional[dict[str, int]] = None,
+    warnings: tuple[str, ...] = (),
+    side_effects_may_remain: bool = False,
+) -> "CollectionRollbackMaintenanceResult":
+    from ..kb.maintenance_compatibility import CollectionRollbackMaintenanceResult
+
+    return CollectionRollbackMaintenanceResult(
+        collection_name=collection_name,
+        status=status,
+        skipped=skipped,
+        reason=reason,
+        cleanup_counts=cleanup_counts or {},
+        warnings=warnings,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+
+
+async def capture_collection_config_snapshot(
+    collection_name: str, user_id: Optional[int]
+) -> "CollectionConfigSnapshot":
+    """Capture the exact collection_config row before rollback-sensitive mutation."""
+    return await _get_maintenance_compatibility_facade().capture_collection_config_snapshot(
+        collection_name, user_id
+    )
+
+
+async def _capture_collection_config_snapshot_impl(
+    collection_name: str, user_id: Optional[int]
+) -> "CollectionConfigSnapshot":
+    from ..kb.maintenance_compatibility import CollectionConfigSnapshot
+
+    config_user_id = _normalize_collection_config_user_id(user_id)
+    config_json = await get_metadata_store().get_collection_config(
+        collection_name,
+        config_user_id,
+        is_admin=False,
+    )
+    return CollectionConfigSnapshot(
+        collection_name=collection_name,
+        user_id=user_id,
+        config_user_id=config_user_id,
+        config_json=config_json,
+        existed=config_json is not None,
+    )
+
+
+def capture_collection_config_snapshot_sync(
+    collection_name: str, user_id: Optional[int]
+) -> "CollectionConfigSnapshot":
+    """Synchronous version of capture_collection_config_snapshot."""
+    return (
+        _get_maintenance_compatibility_facade().capture_collection_config_snapshot_sync(
+            collection_name, user_id
+        )
+    )
+
+
+def _capture_collection_config_snapshot_sync_impl(
+    collection_name: str, user_id: Optional[int]
+) -> "CollectionConfigSnapshot":
+    return _sync_wrapper(_capture_collection_config_snapshot_impl)(
+        collection_name, user_id
+    )
+
+
+async def restore_collection_config_snapshot(
+    snapshot: "CollectionConfigSnapshot",
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+) -> "CollectionRollbackMaintenanceResult":
+    """Restore or remove collection_config from a rollback snapshot."""
+    return await _get_maintenance_compatibility_facade().restore_collection_config_snapshot(
+        snapshot,
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+
+
+async def _restore_collection_config_snapshot_impl(
+    snapshot: "CollectionConfigSnapshot",
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+) -> "CollectionRollbackMaintenanceResult":
+    reason, warnings = _collection_rollback_guard_warning(
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+    if reason is not None:
+        return _collection_rollback_result(
+            snapshot.collection_name,
+            status="skipped",
+            skipped=True,
+            reason=reason,
+            warnings=warnings,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+    lock = _get_collection_lock(snapshot.collection_name)
+    async with lock:
+        if snapshot.existed:
+            if snapshot.config_json is None:
+                return _collection_rollback_result(
+                    snapshot.collection_name,
+                    status="skipped",
+                    skipped=True,
+                    reason="snapshot_missing_config",
+                    warnings=(
+                        "Skipped collection config restore because the snapshot has no config JSON.",
+                    ),
+                    side_effects_may_remain=side_effects_may_remain,
+                )
+            await get_metadata_store().save_collection_config(
+                snapshot.collection_name,
+                snapshot.config_json,
+                snapshot.config_user_id,
+            )
+            return _collection_rollback_result(
+                snapshot.collection_name,
+                status="restored",
+                side_effects_may_remain=side_effects_may_remain,
+            )
+
+        cleanup_counts = await get_metadata_store().delete_collection_metadata(
+            snapshot.collection_name,
+            user_id=snapshot.config_user_id,
+            is_admin=False,
+            delete_orphaned_metadata=False,
+        )
+        return _collection_rollback_result(
+            snapshot.collection_name,
+            status="removed",
+            cleanup_counts=cleanup_counts,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+
+def restore_collection_config_snapshot_sync(
+    snapshot: "CollectionConfigSnapshot",
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+) -> "CollectionRollbackMaintenanceResult":
+    """Synchronous version of restore_collection_config_snapshot."""
+    return (
+        _get_maintenance_compatibility_facade().restore_collection_config_snapshot_sync(
+            snapshot,
+            rollback_complete=rollback_complete,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+    )
+
+
+def _restore_collection_config_snapshot_sync_impl(
+    snapshot: "CollectionConfigSnapshot",
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+) -> "CollectionRollbackMaintenanceResult":
+    return _sync_wrapper(_restore_collection_config_snapshot_impl)(
+        snapshot,
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+
+
+async def cleanup_collection_metadata_after_rollback(
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+    delete_orphaned_metadata: bool = True,
+) -> "CollectionRollbackMaintenanceResult":
+    """Delete metadata/config rows only when rollback completed safely."""
+    return await _get_maintenance_compatibility_facade().cleanup_collection_metadata_after_rollback(
+        collection_name,
+        user_id,
+        is_admin,
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+        delete_orphaned_metadata=delete_orphaned_metadata,
+    )
+
+
+async def _cleanup_collection_metadata_after_rollback_impl(
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+    delete_orphaned_metadata: bool = True,
+) -> "CollectionRollbackMaintenanceResult":
+    reason, warnings = _collection_rollback_guard_warning(
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+    if reason is not None:
+        return _collection_rollback_result(
+            collection_name,
+            status="skipped",
+            skipped=True,
+            reason=reason,
+            warnings=warnings,
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+    cleanup_counts = await collection_manager.delete_collection_metadata(
+        collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        delete_orphaned_metadata=delete_orphaned_metadata,
+    )
+    return _collection_rollback_result(
+        collection_name,
+        status="cleaned",
+        cleanup_counts=cleanup_counts,
+        side_effects_may_remain=side_effects_may_remain,
+    )
+
+
+def cleanup_collection_metadata_after_rollback_sync(
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+    delete_orphaned_metadata: bool = True,
+) -> "CollectionRollbackMaintenanceResult":
+    """Synchronous version of cleanup_collection_metadata_after_rollback."""
+    return _get_maintenance_compatibility_facade().cleanup_collection_metadata_after_rollback_sync(
+        collection_name,
+        user_id,
+        is_admin,
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+        delete_orphaned_metadata=delete_orphaned_metadata,
+    )
+
+
+def _cleanup_collection_metadata_after_rollback_sync_impl(
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    *,
+    rollback_complete: bool,
+    side_effects_may_remain: bool = False,
+    delete_orphaned_metadata: bool = True,
+) -> "CollectionRollbackMaintenanceResult":
+    return _sync_wrapper(_cleanup_collection_metadata_after_rollback_impl)(
+        collection_name,
+        user_id,
+        is_admin,
+        rollback_complete=rollback_complete,
+        side_effects_may_remain=side_effects_may_remain,
+        delete_orphaned_metadata=delete_orphaned_metadata,
+    )
+
+
+async def rebuild_collection_stats(
+    collection_name: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+) -> Optional["CollectionInfo"]:
+    """Rebuild collection stats from the storage backend after commit/rollback."""
+    return await _get_maintenance_compatibility_facade().rebuild_collection_stats(
+        collection_name, user_id, is_admin
+    )
+
+
+async def _rebuild_collection_stats_impl(
+    collection_name: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+) -> Optional["CollectionInfo"]:
+    try:
+        existing_info: Optional[
+            CollectionInfo
+        ] = await get_metadata_store().get_collection(collection_name)
+    except Exception:
+        existing_info = None
+
+    stats_by_collection = get_vector_index_store().aggregate_collection_stats(
+        user_id=None,
+        is_admin=True,
+    )
+    rebuilt_stats = stats_by_collection.get(collection_name)
+    if existing_info is None and rebuilt_stats is None:
+        return None
+
+    if rebuilt_stats is None:
+        rebuilt_stats = {
+            "documents": 0,
+            "parses": 0,
+            "chunks": 0,
+            "embeddings": 0,
+        }
+
+    document_count = int(rebuilt_stats.get("documents", 0))
+    base_info = existing_info or CollectionInfo(name=collection_name)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    update_data: dict[str, Any] = {
+        "documents": document_count,
+        "processed_documents": int(rebuilt_stats.get("parses", 0)),
+        "parses": int(rebuilt_stats.get("parses", 0)),
+        "chunks": int(rebuilt_stats.get("chunks", 0)),
+        "embeddings": int(rebuilt_stats.get("embeddings", 0)),
+        "updated_at": now,
+        "last_accessed_at": now,
+    }
+    if document_count == 0:
+        update_data.update(
+            {
+                "document_names": [],
+                "document_metadata": [],
+                "owners": [],
+            }
+        )
+
+    rebuilt = base_info.model_copy(update=update_data)
+    await collection_manager.save_collection(rebuilt)
+    return rebuilt
+
+
+def rebuild_collection_stats_sync(
+    collection_name: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+) -> Optional["CollectionInfo"]:
+    """Synchronous version of rebuild_collection_stats."""
+    return _get_maintenance_compatibility_facade().rebuild_collection_stats_sync(
+        collection_name, user_id, is_admin
+    )
+
+
+def _rebuild_collection_stats_sync_impl(
+    collection_name: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+) -> Optional["CollectionInfo"]:
+    return _sync_wrapper(_rebuild_collection_stats_impl)(
+        collection_name, user_id, is_admin
     )
 
 
@@ -760,6 +1214,17 @@ def resolve_effective_embedding_model_sync(
     Raises:
         ValueError: If model cannot be resolved or collection not found.
     """
+    return (
+        _get_maintenance_compatibility_facade().resolve_effective_embedding_model_sync(
+            collection_name, config_model_id
+        )
+    )
+
+
+def _resolve_effective_embedding_model_sync_impl(
+    collection_name: str, config_model_id: Optional[str] = None
+) -> str:
+    """Implementation for resolve_effective_embedding_model_sync."""
 
     # Treat empty/whitespace-only IDs and the tool-layer "none" placeholder as missing.
     config_model_id = _normalize_model_id(config_model_id)
@@ -875,6 +1340,11 @@ async def rebuild_collection_metadata() -> None:
 
     Use this to migrate existing data when collection_metadata table is missing or outdated.
     """
+    await _get_maintenance_compatibility_facade().rebuild_collection_metadata()
+
+
+async def _rebuild_collection_metadata_impl() -> None:
+    """Implementation for rebuild_collection_metadata."""
     from . import collections
 
     # Get all existing collections (use is_admin=True to bypass user filtering)

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import threading
+from contextvars import copy_context
 from datetime import datetime, timezone
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar
@@ -109,19 +110,21 @@ def _run_in_separate_loop(coro: Awaitable[T]) -> T:
         Any exception raised by the coroutine
     """
     result: Optional[T] = None
-    exception: Optional[Exception] = None
+    exception: Optional[BaseException] = None
+    context = copy_context()
 
     def target() -> None:
         """Thread target function that runs the coroutine in its own event loop."""
         nonlocal result, exception
+        # Create a fresh event loop for this thread
+        loop = asyncio.new_event_loop()
         try:
-            # Create a fresh event loop for this thread
-            loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            result = loop.run_until_complete(coro)
-            loop.close()
-        except Exception as e:
+            result = context.run(lambda: loop.run_until_complete(coro))
+        except BaseException as e:
             exception = e
+        finally:
+            loop.close()
 
     try:
         # Check if we are already in a running event loop

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -1106,21 +1106,22 @@ def _cleanup_collection_metadata_after_rollback_sync_impl(
     )
 
 
+def _coerce_stat_count(stats: dict[str, Any], key: str) -> int:
+    value = stats.get(key)
+    return int(value) if value is not None else 0
+
+
 async def rebuild_collection_stats(
     collection_name: str,
-    user_id: Optional[int] = None,
-    is_admin: bool = True,
 ) -> Optional["CollectionInfo"]:
     """Rebuild collection stats from the storage backend after commit/rollback."""
     return await _get_maintenance_compatibility_facade().rebuild_collection_stats(
-        collection_name, user_id, is_admin
+        collection_name
     )
 
 
 async def _rebuild_collection_stats_impl(
     collection_name: str,
-    user_id: Optional[int] = None,
-    is_admin: bool = True,
 ) -> Optional["CollectionInfo"]:
     try:
         existing_info: Optional[
@@ -1145,15 +1146,18 @@ async def _rebuild_collection_stats_impl(
             "embeddings": 0,
         }
 
-    document_count = int(rebuilt_stats.get("documents", 0))
+    document_count = _coerce_stat_count(rebuilt_stats, "documents")
+    parse_count = _coerce_stat_count(rebuilt_stats, "parses")
+    chunk_count = _coerce_stat_count(rebuilt_stats, "chunks")
+    embedding_count = _coerce_stat_count(rebuilt_stats, "embeddings")
     base_info = existing_info or CollectionInfo(name=collection_name)
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     update_data: dict[str, Any] = {
         "documents": document_count,
-        "processed_documents": int(rebuilt_stats.get("parses", 0)),
-        "parses": int(rebuilt_stats.get("parses", 0)),
-        "chunks": int(rebuilt_stats.get("chunks", 0)),
-        "embeddings": int(rebuilt_stats.get("embeddings", 0)),
+        "processed_documents": parse_count,
+        "parses": parse_count,
+        "chunks": chunk_count,
+        "embeddings": embedding_count,
         "updated_at": now,
         "last_accessed_at": now,
     }
@@ -1173,23 +1177,17 @@ async def _rebuild_collection_stats_impl(
 
 def rebuild_collection_stats_sync(
     collection_name: str,
-    user_id: Optional[int] = None,
-    is_admin: bool = True,
 ) -> Optional["CollectionInfo"]:
     """Synchronous version of rebuild_collection_stats."""
     return _get_maintenance_compatibility_facade().rebuild_collection_stats_sync(
-        collection_name, user_id, is_admin
+        collection_name
     )
 
 
 def _rebuild_collection_stats_sync_impl(
     collection_name: str,
-    user_id: Optional[int] = None,
-    is_admin: bool = True,
 ) -> Optional["CollectionInfo"]:
-    return _sync_wrapper(_rebuild_collection_stats_impl)(
-        collection_name, user_id, is_admin
-    )
+    return _sync_wrapper(_rebuild_collection_stats_impl)(collection_name)
 
 
 def resolve_effective_embedding_model_sync(

--- a/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from inspect import signature
+from typing import cast
 
 import pytest
 
@@ -135,6 +136,97 @@ def test_reset_helpers_keep_maintenance_facade_reusable(monkeypatch) -> None:
     second_facade = get_kb_coordinator().maintenance_compatibility
     assert second_facade.get_collection_sync("after") == "collection:after"
     assert second_facade is not first_facade
+
+
+@pytest.mark.asyncio
+async def test_coordinator_maintenance_facade_uses_instance_storage_for_config_snapshot() -> (
+    None
+):
+    """Given injected storage, maintenance calls use coordinator-owned stores."""
+    from xagent.core.tools.core.RAG_tools.kb import KBCoordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
+
+    class MetadataStore:
+        def __init__(self) -> None:
+            self.config_calls: list[dict[str, object]] = []
+
+        async def get_collection_config(
+            self, collection_name: str, user_id: int | None, is_admin: bool = False
+        ) -> str | None:
+            self.config_calls.append(
+                {
+                    "collection_name": collection_name,
+                    "user_id": user_id,
+                    "is_admin": is_admin,
+                }
+            )
+            return '{"source":"injected"}'
+
+    class StorageFactoryStub:
+        def __init__(self, metadata_store: MetadataStore) -> None:
+            self.metadata_store = metadata_store
+
+        def get_metadata_store(self) -> MetadataStore:
+            return self.metadata_store
+
+    metadata_store = MetadataStore()
+    coordinator = KBCoordinator(
+        storage_factory=cast(StorageFactory, StorageFactoryStub(metadata_store))
+    )
+
+    snapshot = (
+        await coordinator.maintenance_compatibility.capture_collection_config_snapshot(
+            "docs", 7
+        )
+    )
+
+    assert snapshot.config_json == '{"source":"injected"}'
+    assert snapshot.existed
+    assert metadata_store.config_calls == [
+        {
+            "collection_name": "docs",
+            "user_id": 7,
+            "is_admin": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_maintenance_sync_helper_keeps_storage_binding_in_running_loop() -> (
+    None
+):
+    """Given an active event loop, sync maintenance helpers keep storage binding."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import KBCoordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import StorageFactory
+
+    class MetadataStore:
+        def __init__(self) -> None:
+            self.collection_calls: list[str] = []
+
+        async def get_collection(self, collection_name: str) -> CollectionInfo:
+            self.collection_calls.append(collection_name)
+            return CollectionInfo(name=collection_name, documents=12)
+
+    class StorageFactoryStub:
+        def __init__(self, metadata_store: MetadataStore) -> None:
+            self.metadata_store = metadata_store
+
+        def get_metadata_store(self) -> MetadataStore:
+            return self.metadata_store
+
+    metadata_store = MetadataStore()
+    coordinator = KBCoordinator(
+        storage_factory=cast(StorageFactory, StorageFactoryStub(metadata_store))
+    )
+
+    collection = coordinator.maintenance_compatibility.get_collection_sync(
+        "thread_bound_docs"
+    )
+
+    assert collection.name == "thread_bound_docs"
+    assert collection.documents == 12
+    assert metadata_store.collection_calls == ["thread_bound_docs"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
@@ -1,0 +1,437 @@
+"""Tests for the KB maintenance compatibility facade."""
+
+from __future__ import annotations
+
+from inspect import signature
+
+import pytest
+
+
+def test_kb_maintenance_compatibility_public_surface_imports() -> None:
+    """Given the KB package, the maintenance facade is publicly importable."""
+    import xagent.core.tools.core.RAG_tools.kb as kb
+
+    coordinator = kb.get_kb_coordinator()
+
+    assert hasattr(kb, "CollectionConfigSnapshot")
+    assert hasattr(kb, "CollectionRollbackMaintenanceResult")
+    assert hasattr(kb, "KBMaintenanceCompatibilityFacade")
+    assert hasattr(coordinator, "maintenance_compatibility")
+    assert coordinator.maintenance_compat is coordinator.maintenance_compatibility
+
+
+def test_kb_maintenance_compatibility_methods_match_public_helper_signatures() -> None:
+    """Given legacy helpers, facade methods preserve their call signatures."""
+    from xagent.core.tools.core.RAG_tools.kb import KBMaintenanceCompatibilityFacade
+    from xagent.core.tools.core.RAG_tools.management import collection_manager
+
+    facade = KBMaintenanceCompatibilityFacade()
+    pairs = [
+        (facade.get_collection_sync, collection_manager.get_collection_sync),
+        (
+            facade.initialize_collection_embedding_sync,
+            collection_manager.initialize_collection_embedding_sync,
+        ),
+        (
+            facade.validate_document_processing_sync,
+            collection_manager.validate_document_processing_sync,
+        ),
+        (
+            facade.update_collection_stats_sync,
+            collection_manager.update_collection_stats_sync,
+        ),
+        (
+            facade.mark_collection_accessed_sync,
+            collection_manager.mark_collection_accessed_sync,
+        ),
+        (
+            facade.delete_collection_metadata_sync,
+            collection_manager.delete_collection_metadata_sync,
+        ),
+        (
+            facade.capture_collection_config_snapshot,
+            collection_manager.capture_collection_config_snapshot,
+        ),
+        (
+            facade.capture_collection_config_snapshot_sync,
+            collection_manager.capture_collection_config_snapshot_sync,
+        ),
+        (
+            facade.restore_collection_config_snapshot,
+            collection_manager.restore_collection_config_snapshot,
+        ),
+        (
+            facade.restore_collection_config_snapshot_sync,
+            collection_manager.restore_collection_config_snapshot_sync,
+        ),
+        (
+            facade.cleanup_collection_metadata_after_rollback,
+            collection_manager.cleanup_collection_metadata_after_rollback,
+        ),
+        (
+            facade.cleanup_collection_metadata_after_rollback_sync,
+            collection_manager.cleanup_collection_metadata_after_rollback_sync,
+        ),
+        (
+            facade.rebuild_collection_stats,
+            collection_manager.rebuild_collection_stats,
+        ),
+        (
+            facade.rebuild_collection_stats_sync,
+            collection_manager.rebuild_collection_stats_sync,
+        ),
+        (
+            facade.resolve_effective_embedding_model_sync,
+            collection_manager.resolve_effective_embedding_model_sync,
+        ),
+        (
+            facade.rebuild_collection_metadata,
+            collection_manager.rebuild_collection_metadata,
+        ),
+    ]
+
+    for facade_method, public_helper in pairs:
+        assert signature(facade_method) == signature(public_helper)
+
+
+def test_public_maintenance_helper_delegates_through_facade(monkeypatch) -> None:
+    """Given a public maintenance helper call, it routes through the facade."""
+    from xagent.core.tools.core.RAG_tools.management import collection_manager
+
+    class _FakeFacade:
+        def get_collection_sync(self, collection_name: str) -> str:
+            assert collection_name == "kb"
+            return "facade-collection"
+
+    monkeypatch.setattr(
+        collection_manager,
+        "_get_maintenance_compatibility_facade",
+        lambda: _FakeFacade(),
+    )
+
+    assert collection_manager.get_collection_sync("kb") == "facade-collection"
+
+
+def test_reset_helpers_keep_maintenance_facade_reusable(monkeypatch) -> None:
+    """Given reset helpers, the manager/facade can be reused in one process."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+    from xagent.core.tools.core.RAG_tools.management import collection_manager
+
+    class _FakeManager:
+        async def get_collection(self, collection_name: str) -> str:
+            return f"collection:{collection_name}"
+
+    monkeypatch.setattr(collection_manager, "collection_manager", _FakeManager())
+
+    first_facade = get_kb_coordinator().maintenance_compatibility
+    assert first_facade.get_collection_sync("before") == "collection:before"
+
+    collection_manager.reset_locks_for_testing()
+    reset_kb_coordinator_for_tests()
+
+    second_facade = get_kb_coordinator().maintenance_compatibility
+    assert second_facade.get_collection_sync("after") == "collection:after"
+    assert second_facade is not first_facade
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("collection_name", "original_config", "mutated_config"),
+    [
+        (
+            "direct_restore",
+            '{"source":"direct","chunk_size":512}',
+            '{"source":"direct","chunk_size":1024}',
+        ),
+        (
+            "cloud_restore",
+            '{"source":"cloud","bucket":"old"}',
+            '{"source":"cloud","bucket":"new"}',
+        ),
+        ("web_restore", '{"source":"web","depth":1}', '{"source":"web","depth":2}'),
+    ],
+)
+async def test_collection_config_snapshot_restores_failed_ingest_configs(
+    collection_name: str, original_config: str, mutated_config: str
+) -> None:
+    """Given failed direct/cloud/web ingest, config snapshot restore reverts changes."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    user_id = 7
+
+    await metadata_store.save_collection_config(
+        collection_name, original_config, user_id
+    )
+    snapshot = await facade.capture_collection_config_snapshot(collection_name, user_id)
+    await metadata_store.save_collection_config(
+        collection_name, mutated_config, user_id
+    )
+
+    result = await facade.restore_collection_config_snapshot(
+        snapshot,
+        rollback_complete=True,
+        side_effects_may_remain=False,
+    )
+
+    assert result.status == "restored"
+    assert not result.skipped
+    assert result.warnings == ()
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        == original_config
+    )
+
+
+@pytest.mark.asyncio
+async def test_collection_config_snapshot_removes_new_config_after_complete_rollback() -> (
+    None
+):
+    """Given no previous config, complete rollback removes the newly created config."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "new_config_removed"
+    user_id = 19
+
+    snapshot = await facade.capture_collection_config_snapshot(collection_name, user_id)
+    assert not snapshot.existed
+
+    await metadata_store.save_collection_config(
+        collection_name, '{"source":"direct"}', user_id
+    )
+    result = await facade.restore_collection_config_snapshot(
+        snapshot,
+        rollback_complete=True,
+        side_effects_may_remain=False,
+    )
+
+    assert result.status == "removed"
+    assert not result.skipped
+    assert result.cleanup_counts["config_rows"] == 1
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_collection_config_restore_skips_when_side_effects_may_remain() -> None:
+    """Given residual side effects, config cleanup/restore is left visible."""
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "config_restore_guarded"
+    user_id = 23
+
+    await metadata_store.save_collection_config(
+        collection_name, '{"source":"direct","version":1}', user_id
+    )
+    snapshot = await facade.capture_collection_config_snapshot(collection_name, user_id)
+    mutated_config = '{"source":"direct","version":2}'
+    await metadata_store.save_collection_config(
+        collection_name, mutated_config, user_id
+    )
+
+    result = await facade.restore_collection_config_snapshot(
+        snapshot,
+        rollback_complete=True,
+        side_effects_may_remain=True,
+    )
+
+    assert result.status == "skipped"
+    assert result.skipped
+    assert result.reason == "side_effects_may_remain"
+    assert result.side_effects_may_remain
+    assert result.warnings
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        == mutated_config
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_cleanup_skips_when_rollback_incomplete_and_keeps_rows() -> None:
+    """Given incomplete rollback, metadata/config stay visible with warning outcome."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "cleanup_incomplete_visible"
+    user_id = 31
+
+    await metadata_store.save_collection(
+        CollectionInfo(name=collection_name, documents=1)
+    )
+    await metadata_store.save_collection_config(
+        collection_name, '{"source":"web"}', user_id
+    )
+
+    result = await facade.cleanup_collection_metadata_after_rollback(
+        collection_name,
+        user_id,
+        rollback_complete=False,
+        side_effects_may_remain=False,
+        delete_orphaned_metadata=True,
+    )
+
+    assert result.status == "skipped"
+    assert result.skipped
+    assert result.reason == "rollback_not_complete"
+    assert result.warnings
+    assert (
+        await metadata_store.get_collection(collection_name)
+    ).name == collection_name
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        == '{"source":"web"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_cleanup_skips_when_side_effects_may_remain_and_keeps_rows() -> (
+    None
+):
+    """Given possible residual artifacts, metadata/config cleanup is skipped."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "cleanup_side_effects_visible"
+    user_id = 37
+
+    await metadata_store.save_collection(
+        CollectionInfo(name=collection_name, documents=2)
+    )
+    await metadata_store.save_collection_config(
+        collection_name, '{"source":"cloud"}', user_id
+    )
+
+    result = await facade.cleanup_collection_metadata_after_rollback(
+        collection_name,
+        user_id,
+        rollback_complete=True,
+        side_effects_may_remain=True,
+        delete_orphaned_metadata=True,
+    )
+
+    assert result.status == "skipped"
+    assert result.skipped
+    assert result.reason == "side_effects_may_remain"
+    assert result.side_effects_may_remain
+    assert result.warnings
+    assert (
+        await metadata_store.get_collection(collection_name)
+    ).name == collection_name
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        == '{"source":"cloud"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_cleanup_deletes_new_rows_after_complete_rollback() -> None:
+    """Given complete rollback, newly created metadata/config can be removed."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "cleanup_complete_removed"
+    user_id = 41
+
+    await metadata_store.save_collection(
+        CollectionInfo(name=collection_name, documents=1)
+    )
+    await metadata_store.save_collection_config(
+        collection_name, '{"source":"direct"}', user_id
+    )
+
+    result = await facade.cleanup_collection_metadata_after_rollback(
+        collection_name,
+        user_id,
+        rollback_complete=True,
+        side_effects_may_remain=False,
+        delete_orphaned_metadata=True,
+    )
+
+    assert result.status == "cleaned"
+    assert not result.skipped
+    assert result.cleanup_counts == {"metadata_rows": 1, "config_rows": 1}
+    assert (
+        await metadata_store.get_collection_config(
+            collection_name, user_id, is_admin=False
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="not found"):
+        await metadata_store.get_collection(collection_name)
+
+
+@pytest.mark.asyncio
+async def test_rebuild_collection_stats_refreshes_metadata_from_storage_state() -> None:
+    """Given stale metadata, stats rebuild recomputes counts from storage state."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "stats_rebuild_after_rollback"
+    extra_metadata = {"kb_storage": {"backend": "lancedb"}}
+
+    await metadata_store.save_collection(
+        CollectionInfo(
+            name=collection_name,
+            documents=9,
+            processed_documents=8,
+            parses=7,
+            chunks=6,
+            embeddings=5,
+            document_names=["stale.pdf"],
+            extra_metadata=extra_metadata,
+        )
+    )
+
+    rebuilt = await facade.rebuild_collection_stats(collection_name)
+
+    assert rebuilt is not None
+    assert rebuilt.documents == 0
+    assert rebuilt.processed_documents == 0
+    assert rebuilt.parses == 0
+    assert rebuilt.chunks == 0
+    assert rebuilt.embeddings == 0
+    assert rebuilt.document_names == []
+    assert rebuilt.extra_metadata == extra_metadata
+
+    stored = await metadata_store.get_collection(collection_name)
+    assert stored.documents == 0
+    assert stored.processed_documents == 0
+    assert stored.parses == 0
+    assert stored.chunks == 0
+    assert stored.embeddings == 0
+    assert stored.extra_metadata == extra_metadata

--- a/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
@@ -435,3 +435,68 @@ async def test_rebuild_collection_stats_refreshes_metadata_from_storage_state() 
     assert stored.chunks == 0
     assert stored.embeddings == 0
     assert stored.extra_metadata == extra_metadata
+
+
+@pytest.mark.asyncio
+async def test_rebuild_collection_stats_treats_null_storage_counts_as_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given nullable aggregate counts, stats rebuild stores zero counts."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+    from xagent.core.tools.core.RAG_tools.kb import get_kb_coordinator
+    from xagent.core.tools.core.RAG_tools.management import collection_manager
+    from xagent.core.tools.core.RAG_tools.storage.factory import get_metadata_store
+
+    metadata_store = get_metadata_store()
+    facade = get_kb_coordinator().maintenance_compatibility
+    collection_name = "stats_rebuild_nullable_counts"
+
+    await metadata_store.save_collection(
+        CollectionInfo(
+            name=collection_name,
+            documents=9,
+            processed_documents=8,
+            parses=7,
+            chunks=6,
+            embeddings=5,
+            document_names=["stale.pdf"],
+        )
+    )
+
+    class _FakeVectorIndexStore:
+        def aggregate_collection_stats(
+            self, *, user_id: int | None, is_admin: bool
+        ) -> dict[str, dict[str, int | None]]:
+            assert user_id is None
+            assert is_admin is True
+            return {
+                collection_name: {
+                    "documents": None,
+                    "parses": None,
+                    "chunks": None,
+                    "embeddings": None,
+                }
+            }
+
+    monkeypatch.setattr(
+        collection_manager,
+        "get_vector_index_store",
+        lambda: _FakeVectorIndexStore(),
+    )
+
+    rebuilt = await facade.rebuild_collection_stats(collection_name)
+
+    assert rebuilt is not None
+    assert rebuilt.documents == 0
+    assert rebuilt.processed_documents == 0
+    assert rebuilt.parses == 0
+    assert rebuilt.chunks == 0
+    assert rebuilt.embeddings == 0
+    assert rebuilt.document_names == []
+
+    stored = await metadata_store.get_collection(collection_name)
+    assert stored.documents == 0
+    assert stored.processed_documents == 0
+    assert stored.parses == 0
+    assert stored.chunks == 0
+    assert stored.embeddings == 0


### PR DESCRIPTION
## Summary
- add a KB maintenance compatibility facade wired through the coordinator
- preserve legacy collection maintenance helper signatures while routing through the facade
- add rollback helpers for collection config snapshot/restore, guarded metadata cleanup, and stats rebuild
- add focused tests for config restore/removal, cleanup guard behavior, and stats rebuild

Closes #499

## Validation
- pre-commit run --all-files
- uv run pytest tests/core/tools/core/RAG_tools/kb/test_maintenance_compatibility.py
- uv run pytest tests/core/tools/core/RAG_tools/management/test_collections.py
- uv run pytest tests/core/tools/core/RAG_tools/kb/test_coordinator.py tests/core/tools/core/RAG_tools/storage/test_storage_shim.py