### PR TITLE
refactor(kb): add parse display compatibility facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -16,6 +16,7 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
 
 __all__ = [
@@ -27,6 +28,7 @@ __all__ = [
     "KBCoreManagementCompatibilityFacade",
     "KBCoordinator",
     "KBFileCompatibilityFacade",
+    "KBParseDisplayCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",
     "KBUserScope",

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -21,6 +21,7 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
 
 T = TypeVar("T")
@@ -38,6 +39,7 @@ class KBCoordinator:
         storage_shim: KBStorageShimCompatibilityFacade | None = None,
         file_compatibility: KBFileCompatibilityFacade | None = None,
         management_facade: KBCoreManagementCompatibilityFacade | None = None,
+        parse_display_compatibility: KBParseDisplayCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -47,6 +49,10 @@ class KBCoordinator:
         self._file_compatibility = file_compatibility or KBFileCompatibilityFacade()
         self._management = management_facade or KBCoreManagementCompatibilityFacade(
             coordinator=self
+        )
+        self._parse_display_compatibility = (
+            parse_display_compatibility
+            or KBParseDisplayCompatibilityFacade(coordinator=self)
         )
 
     @property
@@ -68,6 +74,16 @@ class KBCoordinator:
     def management(self) -> KBCoreManagementCompatibilityFacade:
         """Return the core management compatibility facade."""
         return self._management
+
+    @property
+    def parse_display_compatibility(self) -> KBParseDisplayCompatibilityFacade:
+        """Return the parse display compatibility facade."""
+        return self._parse_display_compatibility
+
+    @property
+    def parse_display(self) -> KBParseDisplayCompatibilityFacade:
+        """Backward-friendly short alias for the parse display facade."""
+        return self._parse_display_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/parse_display_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/parse_display_compatibility.py
@@ -1,0 +1,93 @@
+"""Parse display compatibility facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from .models import KBAccessMode, KBContextRequest
+
+if TYPE_CHECKING:
+    from ..core.schemas import ParsedElementDisplay
+    from ..storage.contracts import VectorIndexStore
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+
+class KBParseDisplayCompatibilityFacade:
+    """Compatibility boundary for legacy parse display helpers.
+
+    Parse display helpers are synchronous read-only APIs. The facade resolves
+    coordinator-owned context and storage access while preserving the legacy
+    helper names, signatures, tuple shapes, and conversion behavior.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    def _resolve_vector_store(
+        self,
+        collection: str,
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> VectorIndexStore:
+        if self._coordinator is not None:
+            context = self._coordinator.get_context_sync(
+                KBContextRequest(
+                    collection=collection,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    access_mode=KBAccessMode.READ,
+                    hide_missing=True,
+                )
+            )
+            return context.vector_index_store
+
+        storage_shim = self._active_storage_shim()
+        if storage_shim is not None:
+            return storage_shim.get_vector_index_store()
+
+        from ..storage.factory import get_vector_index_store
+
+        return get_vector_index_store()
+
+    def reconstruct_parse_result_from_db(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        from ..parse.parse_display import _reconstruct_parse_result_from_db_impl
+
+        vector_store = self._resolve_vector_store(collection, user_id, is_admin)
+        return _reconstruct_parse_result_from_db_impl(
+            collection,
+            doc_id,
+            parse_hash=parse_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+            vector_store=vector_store,
+        )
+
+    def paginate_parse_results(
+        self,
+        elements: List[Dict[str, Any]],
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Tuple[List[ParsedElementDisplay], Dict[str, Any]]:
+        from ..parse.parse_display import _paginate_parse_results_impl
+
+        return _paginate_parse_results_impl(elements, page=page, page_size=page_size)

--- a/src/xagent/core/tools/core/RAG_tools/kb/parse_display_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/parse_display_compatibility.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
-
-from .models import KBAccessMode, KBContextRequest
 
 if TYPE_CHECKING:
     from ..core.schemas import ParsedElementDisplay
-    from ..storage.contracts import VectorIndexStore
     from .coordinator import KBCoordinator
     from .storage_shim import KBStorageShimCompatibilityFacade
 
@@ -16,9 +15,9 @@ if TYPE_CHECKING:
 class KBParseDisplayCompatibilityFacade:
     """Compatibility boundary for legacy parse display helpers.
 
-    Parse display helpers are synchronous read-only APIs. The facade resolves
-    coordinator-owned context and storage access while preserving the legacy
-    helper names, signatures, tuple shapes, and conversion behavior.
+    Parse display helpers are synchronous read-only APIs. The facade binds
+    coordinator-owned storage access while preserving the legacy helper names,
+    signatures, tuple shapes, and conversion behavior.
     """
 
     def __init__(
@@ -36,31 +35,17 @@ class KBParseDisplayCompatibilityFacade:
             return self._coordinator.storage_shim
         return None
 
-    def _resolve_vector_store(
-        self,
-        collection: str,
-        user_id: Optional[int],
-        is_admin: bool,
-    ) -> VectorIndexStore:
-        if self._coordinator is not None:
-            context = self._coordinator.get_context_sync(
-                KBContextRequest(
-                    collection=collection,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    access_mode=KBAccessMode.READ,
-                    hide_missing=True,
-                )
-            )
-            return context.vector_index_store
-
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
         storage_shim = self._active_storage_shim()
-        if storage_shim is not None:
-            return storage_shim.get_vector_index_store()
+        if storage_shim is None:
+            yield
+            return
 
-        from ..storage.factory import get_vector_index_store
+        from ..storage.factory import bind_storage_shim_for_current_context
 
-        return get_vector_index_store()
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
 
     def reconstruct_parse_result_from_db(
         self,
@@ -72,15 +57,14 @@ class KBParseDisplayCompatibilityFacade:
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         from ..parse.parse_display import _reconstruct_parse_result_from_db_impl
 
-        vector_store = self._resolve_vector_store(collection, user_id, is_admin)
-        return _reconstruct_parse_result_from_db_impl(
-            collection,
-            doc_id,
-            parse_hash=parse_hash,
-            user_id=user_id,
-            is_admin=is_admin,
-            vector_store=vector_store,
-        )
+        with self._storage_context():
+            return _reconstruct_parse_result_from_db_impl(
+                collection,
+                doc_id,
+                parse_hash=parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
 
     def paginate_parse_results(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/parse/parse_display.py
+++ b/src/xagent/core/tools/core/RAG_tools/parse/parse_display.py
@@ -6,7 +6,7 @@ from the database for display purposes.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ..core.exceptions import DatabaseOperationError, DocumentNotFoundError
 from ..core.schemas import (
@@ -15,9 +15,19 @@ from ..core.schemas import (
     ParsedTableDisplay,
     ParsedTextSegmentDisplay,
 )
-from ..storage.factory import get_vector_index_store
+
+if TYPE_CHECKING:
+    from ..kb import KBParseDisplayCompatibilityFacade
+    from ..storage.contracts import VectorIndexStore
 
 logger = logging.getLogger(__name__)
+
+
+def _get_parse_display_compatibility_facade() -> "KBParseDisplayCompatibilityFacade":
+    """Return the coordinator-owned parse display compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().parse_display_compatibility
 
 
 def reconstruct_parse_result_from_db(
@@ -42,8 +52,30 @@ def reconstruct_parse_result_from_db(
         Tuple of (elements, parse_hash)
         elements is a list of dictionaries with 'type', 'text'/'html', and 'metadata' keys.
     """
+    return _get_parse_display_compatibility_facade().reconstruct_parse_result_from_db(
+        collection,
+        doc_id,
+        parse_hash=parse_hash,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _reconstruct_parse_result_from_db_impl(
+    collection: str,
+    doc_id: str,
+    parse_hash: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+    *,
+    vector_store: Optional["VectorIndexStore"] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Implementation for reconstruct_parse_result_from_db."""
     try:
-        vector_store = get_vector_index_store()
+        if vector_store is None:
+            from ..storage.factory import get_vector_index_store
+
+            vector_store = get_vector_index_store()
 
         # Build base filter expression
         query_filters: Dict[str, Any] = {
@@ -154,6 +186,19 @@ def paginate_parse_results(
     Returns:
         Tuple of (paginated_elements, pagination_info)
     """
+    return _get_parse_display_compatibility_facade().paginate_parse_results(
+        elements,
+        page=page,
+        page_size=page_size,
+    )
+
+
+def _paginate_parse_results_impl(
+    elements: List[Dict[str, Any]],
+    page: int = 1,
+    page_size: int = 20,
+) -> Tuple[List[ParsedElementDisplay], Dict[str, Any]]:
+    """Implementation for paginate_parse_results."""
     # Validate inputs
     if page < 1:
         page = 1

--- a/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
@@ -9,7 +9,10 @@ from typing import Any, Optional
 
 import pytest
 
-from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
+from xagent.core.tools.core.RAG_tools.core.exceptions import (
+    DatabaseOperationError,
+    DocumentNotFoundError,
+)
 
 
 class _FakeRow:
@@ -292,6 +295,35 @@ def test_parse_display_facade_preserves_sync_tuple_shapes_and_latest_selection()
         "doc_id": "doc-1",
         "parse_hash": "old",
     }
+
+
+def test_parse_display_lookup_after_rolled_back_ingest_keeps_not_found_behavior() -> (
+    None
+):
+    """Rolled-back ingest leaves no parse row, so lookup stays legacy not-found."""
+    from xagent.core.tools.core.RAG_tools.kb import KBParseDisplayCompatibilityFacade
+
+    vector_store = _FakeVectorStore([])
+    facade = KBParseDisplayCompatibilityFacade(
+        storage_shim=_FakeStorageShim(vector_store)
+    )
+
+    with pytest.raises(
+        DocumentNotFoundError,
+        match="No parse results found for document: doc_id=doc-rolled-back",
+    ):
+        facade.reconstruct_parse_result_from_db(
+            "docs",
+            "doc-rolled-back",
+            user_id=1,
+            is_admin=False,
+        )
+
+    assert vector_store.count_calls[0]["filters"] == {
+        "collection": "docs",
+        "doc_id": "doc-rolled-back",
+    }
+    assert vector_store.iter_calls == []
 
 
 def test_parse_display_facade_preserves_json_corruption_mapping() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
@@ -1,0 +1,323 @@
+"""Tests for the KB parse display compatibility facade."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.exceptions import DatabaseOperationError
+
+
+class _FakeRow:
+    def __init__(self, record: dict[str, Any]) -> None:
+        self._record = record
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._record)
+
+
+class _FakeDataFrame:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self._records = records
+
+    def iterrows(self):
+        for index, record in enumerate(self._records):
+            yield index, _FakeRow(record)
+
+
+class _FakeBatch:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self._records = records
+
+    def to_pandas(self) -> _FakeDataFrame:
+        return _FakeDataFrame(self._records)
+
+
+class _FakeVectorStore:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self._records = records
+        self.count_calls: list[dict[str, Any]] = []
+        self.iter_calls: list[dict[str, Any]] = []
+
+    def _matches(
+        self,
+        record: dict[str, Any],
+        filters: dict[str, Any],
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> bool:
+        for field, value in filters.items():
+            if record.get(field) != value:
+                return False
+        if not is_admin and record.get("user_id") != user_id:
+            return False
+        return True
+
+    def _matching_records(
+        self,
+        filters: dict[str, Any],
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> list[dict[str, Any]]:
+        return [
+            record
+            for record in self._records
+            if self._matches(record, filters, user_id, is_admin)
+        ]
+
+    def count_rows_or_zero(
+        self,
+        table_name: str,
+        *,
+        filters: dict[str, Any],
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> int:
+        self.count_calls.append(
+            {
+                "table_name": table_name,
+                "filters": filters,
+                "user_id": user_id,
+                "is_admin": is_admin,
+            }
+        )
+        assert table_name == "parses"
+        return len(self._matching_records(filters, user_id, is_admin))
+
+    def iter_batches(
+        self,
+        *,
+        table_name: str,
+        filters: dict[str, Any],
+        user_id: Optional[int],
+        is_admin: bool,
+    ):
+        self.iter_calls.append(
+            {
+                "table_name": table_name,
+                "filters": filters,
+                "user_id": user_id,
+                "is_admin": is_admin,
+            }
+        )
+        assert table_name == "parses"
+        yield _FakeBatch(self._matching_records(filters, user_id, is_admin))
+
+
+class _FakeStorageShim:
+    def __init__(self, vector_store: _FakeVectorStore) -> None:
+        self.vector_store = vector_store
+
+    def get_vector_index_store(self) -> _FakeVectorStore:
+        return self.vector_store
+
+
+def _parse_record(
+    *,
+    parse_hash: str,
+    created_at: datetime,
+    text: str,
+    layout_type: str = "text",
+    user_id: int = 1,
+) -> dict[str, Any]:
+    return {
+        "collection": "docs",
+        "doc_id": "doc-1",
+        "parse_hash": parse_hash,
+        "created_at": created_at,
+        "parsed_content": json.dumps(
+            [{"text": text, "metadata": {"layout_type": layout_type}}]
+        ),
+        "user_id": user_id,
+    }
+
+
+def _signature_shape(callable_obj: Any) -> list[tuple[str, Any, Any]]:
+    return [
+        (name, parameter.kind, parameter.default)
+        for name, parameter in inspect.signature(callable_obj).parameters.items()
+    ]
+
+
+def test_kb_parse_display_facade_public_surface_imports() -> None:
+    """Given the KB package, the parse display facade is publicly importable."""
+    import xagent.core.tools.core.RAG_tools.kb as kb
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBParseDisplayCompatibilityFacade,
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+
+    assert hasattr(kb, "KBParseDisplayCompatibilityFacade")
+    reset_kb_coordinator_for_tests()
+    coordinator = get_kb_coordinator()
+    assert isinstance(
+        coordinator.parse_display_compatibility,
+        KBParseDisplayCompatibilityFacade,
+    )
+    assert coordinator.parse_display is coordinator.parse_display_compatibility
+
+
+def test_parse_display_facade_methods_match_public_helper_signatures() -> None:
+    """Given legacy helpers, facade methods preserve their call signatures."""
+    from xagent.core.tools.core.RAG_tools.kb import KBParseDisplayCompatibilityFacade
+    from xagent.core.tools.core.RAG_tools.parse import parse_display
+
+    facade = KBParseDisplayCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeVectorStore([]))
+    )
+
+    assert _signature_shape(facade.reconstruct_parse_result_from_db) == (
+        _signature_shape(parse_display.reconstruct_parse_result_from_db)
+    )
+    assert _signature_shape(facade.paginate_parse_results) == _signature_shape(
+        parse_display.paginate_parse_results
+    )
+
+
+def test_public_parse_display_helpers_remain_sync_and_route_through_facade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given a public parse display helper call, it routes through the facade."""
+    from xagent.core.tools.core.RAG_tools.parse import parse_display
+
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    class _FakeFacade:
+        def reconstruct_parse_result_from_db(self, *args: Any, **kwargs: Any):
+            calls.append(("reconstruct", args, kwargs))
+            return ([{"type": "text", "text": "ok", "metadata": {}}], "hash-1")
+
+        def paginate_parse_results(self, *args: Any, **kwargs: Any):
+            calls.append(("paginate", args, kwargs))
+            return (["page"], {"page": kwargs["page"]})
+
+    monkeypatch.setattr(
+        parse_display,
+        "_get_parse_display_compatibility_facade",
+        lambda: _FakeFacade(),
+    )
+
+    assert not inspect.iscoroutinefunction(
+        parse_display.reconstruct_parse_result_from_db
+    )
+    assert not inspect.iscoroutinefunction(parse_display.paginate_parse_results)
+    assert parse_display.reconstruct_parse_result_from_db(
+        "docs",
+        "doc-1",
+        parse_hash="hash-1",
+        user_id=7,
+        is_admin=True,
+    ) == ([{"type": "text", "text": "ok", "metadata": {}}], "hash-1")
+    assert parse_display.paginate_parse_results([], page=2, page_size=3) == (
+        ["page"],
+        {"page": 2},
+    )
+    assert calls == [
+        (
+            "reconstruct",
+            ("docs", "doc-1"),
+            {"parse_hash": "hash-1", "user_id": 7, "is_admin": True},
+        ),
+        ("paginate", ([],), {"page": 2, "page_size": 3}),
+    ]
+
+
+def test_parse_display_facade_preserves_sync_tuple_shapes_and_latest_selection() -> (
+    None
+):
+    """Given direct sync calls, latest fallback and explicit hash behavior stay stable."""
+    from xagent.core.tools.core.RAG_tools.kb import KBParseDisplayCompatibilityFacade
+
+    created_at = datetime(2026, 1, 1, 12, 0, 0)
+    vector_store = _FakeVectorStore(
+        [
+            _parse_record(parse_hash="old", created_at=created_at, text="old body"),
+            _parse_record(
+                parse_hash="new",
+                created_at=created_at + timedelta(seconds=1),
+                text="new body",
+            ),
+        ]
+    )
+    facade = KBParseDisplayCompatibilityFacade(
+        storage_shim=_FakeStorageShim(vector_store)
+    )
+
+    elements, actual_hash = facade.reconstruct_parse_result_from_db(
+        "docs",
+        "doc-1",
+        user_id=1,
+        is_admin=False,
+    )
+    assert actual_hash == "new"
+    assert elements == [
+        {"type": "text", "text": "new body", "metadata": {"layout_type": "text"}}
+    ]
+
+    explicit_elements, explicit_hash = facade.reconstruct_parse_result_from_db(
+        "docs",
+        "doc-1",
+        parse_hash="old",
+        user_id=1,
+        is_admin=False,
+    )
+    assert explicit_hash == "old"
+    assert explicit_elements[0]["text"] == "old body"
+
+    page_elements, pagination = facade.paginate_parse_results(
+        elements + explicit_elements,
+        page=1,
+        page_size=1,
+    )
+    assert len(page_elements) == 1
+    assert pagination == {
+        "page": 1,
+        "page_size": 1,
+        "total_elements": 2,
+        "total_pages": 2,
+        "has_next": True,
+        "has_previous": False,
+    }
+    assert vector_store.count_calls[0]["filters"] == {
+        "collection": "docs",
+        "doc_id": "doc-1",
+    }
+    assert vector_store.count_calls[1]["filters"] == {
+        "collection": "docs",
+        "doc_id": "doc-1",
+        "parse_hash": "old",
+    }
+
+
+def test_parse_display_facade_preserves_json_corruption_mapping() -> None:
+    """Given corrupt parse JSON, facade preserves the legacy DatabaseOperationError."""
+    from xagent.core.tools.core.RAG_tools.kb import KBParseDisplayCompatibilityFacade
+
+    vector_store = _FakeVectorStore(
+        [
+            {
+                "collection": "docs",
+                "doc_id": "doc-1",
+                "parse_hash": "bad",
+                "created_at": datetime(2026, 1, 1, 12, 0, 0),
+                "parsed_content": "{not-json",
+                "user_id": 1,
+            }
+        ]
+    )
+    facade = KBParseDisplayCompatibilityFacade(
+        storage_shim=_FakeStorageShim(vector_store)
+    )
+
+    with pytest.raises(DatabaseOperationError, match="Failed to read parse result"):
+        facade.reconstruct_parse_result_from_db(
+            "docs",
+            "doc-1",
+            user_id=1,
+            is_admin=False,
+        )

--- a/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import json
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
@@ -324,6 +325,63 @@ def test_parse_display_lookup_after_rolled_back_ingest_keeps_not_found_behavior(
         "doc_id": "doc-rolled-back",
     }
     assert vector_store.iter_calls == []
+
+
+def test_parse_display_facade_rebinds_coordinator_storage_for_legacy_impl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Facade delegation rebinds storage factory access to its coordinator shim."""
+    from xagent.core.tools.core.RAG_tools.kb import KBParseDisplayCompatibilityFacade
+    from xagent.core.tools.core.RAG_tools.parse import parse_display
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        bind_storage_shim_for_current_context,
+        get_vector_index_store,
+    )
+
+    outer_store = _FakeVectorStore([])
+    inner_store = _FakeVectorStore([])
+    outer_shim = _FakeStorageShim(outer_store)
+    inner_shim = _FakeStorageShim(inner_store)
+
+    class _FakeCoordinator:
+        @property
+        def storage_shim(self) -> _FakeStorageShim:
+            return inner_shim
+
+        def get_context_sync(self, _request: Any) -> Any:
+            return SimpleNamespace(vector_index_store=inner_store)
+
+    def fake_impl(
+        collection: str,
+        doc_id: str,
+        parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        **_kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        assert collection == "docs"
+        assert doc_id == "doc-inner"
+        assert parse_hash is None
+        assert user_id == 1
+        assert is_admin is False
+        assert get_vector_index_store() is inner_store
+        return ([{"type": "text", "text": "inner", "metadata": {}}], "inner")
+
+    monkeypatch.setattr(
+        parse_display,
+        "_reconstruct_parse_result_from_db_impl",
+        fake_impl,
+    )
+
+    facade = KBParseDisplayCompatibilityFacade(coordinator=_FakeCoordinator())
+    with bind_storage_shim_for_current_context(outer_shim):
+        elements, parse_hash = facade.reconstruct_parse_result_from_db(
+            "docs", "doc-inner", user_id=1, is_admin=False
+        )
+        assert get_vector_index_store() is outer_store
+
+    assert parse_hash == "inner"
+    assert elements[0]["text"] == "inner"
 
 
 def test_parse_display_facade_preserves_json_corruption_mapping() -> None:


### PR DESCRIPTION
## Summary
- Add KBParseDisplayCompatibilityFacade and expose it from the KB coordinator/public surface.
- Route parse display helpers through the facade while preserving sync signatures, tuple shapes, latest parse selection, parse_hash filtering, user/admin filtering, and error behavior.
- Add direct facade coverage for rollback not-found behavior, JSON corruption mapping, and coordinator storage binding.

Closes #500

## Validation
- uv run pytest tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py tests/core/tools/core/RAG_tools/parse/test_parse_display.py -q
- uv run pytest tests/web/api/test_kb_dir.py -k parse_result -q
- uv run pytest tests/core/tools/core/RAG_tools/kb/test_coordinator.py -q
- .venv/bin/pre-commit run --all-files