### PR TITLE
ref(tools): centralize tool-selection policy and fallbacks

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1770,6 +1770,16 @@ class AgentTool(AbstractBaseTool):
                 else None,
                 allowed_skills=agent.skills,
                 tool_selection_spec=tool_selection_spec,
+                # Single-source the MCP-init decision from the spec, same as
+                # the chat path (chat.py:_spec_wants_mcp). Without this the
+                # delegated WebToolConfig falls back to include_mcp_tools=True
+                # and pays MCP server init even for agents that didn't select
+                # MCP. Unconfigured (_SpecAll) keeps include_mcp_tools=True.
+                include_mcp_tools=(
+                    tool_selection_spec.includes_mcp()
+                    if tool_selection_spec is not None
+                    else True
+                ),
                 allowed_agent_ids=self._delegation_allowed_agent_ids,
                 agent_tool_overrides=self._agent_tool_overrides,
                 enable_global_agent_tools=self._enable_global_agent_tools,

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1754,7 +1754,10 @@ class AgentTool(AbstractBaseTool):
             # "empty / None tool_categories → build every default tool"
             # invariant is preserved for legacy agents whose
             # ``tool_categories`` field defaults to ``[]``.
-            from .selection_spec import ToolSelectionSpec
+            from .selection_spec import (
+                ToolSelectionSpec,
+                should_load_mcp_server_configs,
+            )
 
             tool_selection_spec = ToolSelectionSpec.from_raw(
                 tool_categories=agent.tool_categories,
@@ -1770,16 +1773,10 @@ class AgentTool(AbstractBaseTool):
                 else None,
                 allowed_skills=agent.skills,
                 tool_selection_spec=tool_selection_spec,
-                # Single-source the MCP-init decision from the spec, same as
-                # the chat path (chat.py:_spec_wants_mcp). Without this the
-                # delegated WebToolConfig falls back to include_mcp_tools=True
-                # and pays MCP server init even for agents that didn't select
-                # MCP. Unconfigured (_SpecAll) keeps include_mcp_tools=True.
-                include_mcp_tools=(
-                    tool_selection_spec.includes_mcp()
-                    if tool_selection_spec is not None
-                    else True
-                ),
+                # Keep MCP config loading aligned with the direct chat path.
+                # _SpecAll still admits MCP at the final filter layer for
+                # compatibility, but it does not opt into MCP server init.
+                include_mcp_tools=should_load_mcp_server_configs(tool_selection_spec),
                 allowed_agent_ids=self._delegation_allowed_agent_ids,
                 agent_tool_overrides=self._agent_tool_overrides,
                 enable_global_agent_tools=self._enable_global_agent_tools,

--- a/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
@@ -93,6 +93,14 @@ class CustomApiTool(AbstractBaseTool):
         else:
             self._name = f"api_{sanitized_name}_call"
 
+        # Structured originating-server identity, normalized once through the
+        # shared SSOT. A scoped mcp:<server> selector fronts this Custom-API
+        # wrapper, so server-scoped selection matches on this field by equality
+        # instead of re-parsing ``api_<server>_call``.
+        from .selection_spec import normalize_mcp_server_name
+
+        self.source_server = normalize_mcp_server_name(name)
+
         default_info = ""
         if url:
             default_info += f"\nConfigured endpoint: {url}"

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -41,6 +41,12 @@ class ToolMetadata(BaseModel):
     allow_users: Optional[list[str]] = None  # Explicitly allowed user IDs
     has_state: bool = False
     category: ToolCategory = ToolCategory.OTHER  # Default category
+    # Normalized identity of the MCP server / Custom-API config a tool was
+    # generated from (via ``normalize_mcp_server_name``), or ``None`` for
+    # tools with no server origin. Set once at generation so server-scoped
+    # selection (``ToolSelectionSpec.compute_allowed_names``) matches by
+    # structured equality instead of re-parsing the tool name.
+    source_server: Optional[str] = None
 
 
 @runtime_checkable
@@ -86,6 +92,7 @@ class AbstractBaseTool(ABC, Tool):
             allow_users=getattr(self, "_allow_users", None),
             has_state=self.state_type() is not None,
             category=getattr(self, "category", ToolCategory.OTHER),
+            source_server=getattr(self, "source_server", None),
         )
 
     @abstractmethod

--- a/src/xagent/core/tools/adapters/vibe/custom_api_factory.py
+++ b/src/xagent/core/tools/adapters/vibe/custom_api_factory.py
@@ -19,15 +19,16 @@ logger = logging.getLogger(__name__)
 async def create_db_custom_api_tools(config: BaseToolConfig) -> Sequence[Tool]:
     """Create Custom API tools from database configurations.
 
-    Internal short-circuit via ``ToolSelectionSpec.includes_custom_api()``:
-    when the spec explicitly excludes Custom APIs (empty
-    ``custom_api_ids`` frozenset), this creator returns early WITHOUT
-    calling ``config.get_custom_api_configs()`` — that call goes
-    through the DB to enumerate the user's Custom API rows. No
-    ``categories=`` is declared on the registration because Custom
-    API tools currently surface under multiple operative categories
-    in the UI; registry-level skip therefore relies on the per-
-    creator short-circuit rather than a static category annotation.
+    Internal short-circuit via ``ToolSelectionSpec.includes_custom_api()``
+    (``"other" in categories or bool(mcp_servers)``): when the spec
+    selects neither the ``"other"`` category nor any ``mcp:<server>``
+    scope, this creator returns early WITHOUT calling
+    ``config.get_custom_api_configs()`` — that call goes through the DB
+    to enumerate the user's Custom API rows. The creator is registered
+    bare (no ``categories=``), so the registry always dispatches it;
+    selection is enforced by this per-creator short-circuit plus the
+    post-build ``compute_allowed_names`` ``source_server`` filter, not a
+    static category annotation.
 
     Args:
         config: The tool configuration containing user/workspace context.

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -140,6 +140,14 @@ class ToolRegistry:
         if selection_gate == "published_agent":
             return spec.includes_published_agent()
 
+        if selection_gate == "mcp":
+            # ``mcp:<server>`` scopes land in ``mcp_servers`` only, leaving
+            # ``categories`` without ``"mcp"``. Dispatch must read the spec's
+            # own MCP predicate (which honors both the plain ``"mcp"`` category
+            # and a server scope) rather than the category intersection below,
+            # or a server-only spec would skip the MCP creator entirely.
+            return spec.includes_mcp()
+
         if declared_cats & spec.categories:
             return True
 

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -267,7 +267,7 @@ class ToolFactory:
         #   None             — ALL mode, keep every tool from the registry
         #   frozenset()      — NONE mode, drop every tool
         #   frozenset({...}) — BY_CATEGORIES mode, keep only matching names
-        #                      (plus any workforce ``name_extras`` injection)
+        #                      (plus any workforce ``name_allowlist`` injection)
         #
         # Sealed-type dispatch — the three modes are mutually exclusive
         # and impossible to confuse, unlike the older raw list whose
@@ -279,6 +279,23 @@ class ToolFactory:
             else None
         )
         if spec is not None:
+            # Prefer the spec. If a legacy concrete ``allowed_tools`` list
+            # is ALSO present, warn rather than silently intersecting with
+            # a possibly-stale list (issue #539): the spec is the source
+            # of truth once supplied.
+            legacy_when_spec = (
+                config.get_allowed_tools()
+                if hasattr(config, "get_allowed_tools")
+                else None
+            )
+            if legacy_when_spec is not None:
+                logger.warning(
+                    "Both a ToolSelectionSpec and a legacy allowed_tools "
+                    "list are set on %s; using the spec and ignoring the "
+                    "legacy list (%d name(s)).",
+                    type(config).__name__,
+                    len(legacy_when_spec),
+                )
             allowed_names = spec.compute_allowed_names(tools)
         else:
             # Legacy contract: ``BaseToolConfig.get_allowed_tools()`` is

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -66,6 +66,7 @@ class MCPToolAdapter(AbstractBaseTool):
         name_prefix: Optional[str] = None,
         visibility: Optional[ToolVisibility] = None,
         allow_users: Optional[List[str]] = None,
+        source_server: Optional[str] = None,
     ):
         """Initialize MCP tool adapter.
 
@@ -75,12 +76,17 @@ class MCPToolAdapter(AbstractBaseTool):
             name_prefix: Optional prefix for tool name (e.g., "mcp_")
             visibility: Tool visibility setting
             allow_users: List of allowed user IDs
+            source_server: Normalized identity of the originating MCP server
+                (``normalize_mcp_server_name``), surfaced on
+                ``metadata.source_server`` so server-scoped selection matches
+                by structured equality rather than re-parsing the tool name.
         """
         self.mcp_tool = mcp_tool
         self.connection = connection
         self._name_prefix = name_prefix or ""
         self._visibility = visibility or ToolVisibility.PRIVATE
         self._allow_users = allow_users
+        self.source_server = source_server
         from .base import ToolCategory
 
         self.category = ToolCategory.MCP
@@ -481,12 +487,18 @@ def _build_mcp_tool_adapter(
     # Create tool name with server prefix
     tool_prefix = f"{name_prefix}{server_name}_" if name_prefix else f"{server_name}_"
 
+    # Carry the originating server identity as structured metadata, normalized
+    # once here through the same SSOT the selector parse / config filter use,
+    # so server-scoped selection matches by equality (no tool-name re-parse).
+    from .selection_spec import normalize_mcp_server_name
+
     return MCPToolAdapter(
         mcp_tool=mcp_tool,
         connection=connection,
         name_prefix=tool_prefix,
         visibility=visibility,
         allow_users=allow_users,
+        source_server=normalize_mcp_server_name(server_name),
     )
 
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -11,24 +11,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@register_tool(categories={"mcp"})
+@register_tool(categories={"mcp"}, selection_gate="mcp")
 async def create_mcp_tools(config: "BaseToolConfig") -> List[Any]:
     """Create MCP tools from configuration.
 
+    Registry dispatch goes through ``selection_gate="mcp"`` ->
+    ``spec.includes_mcp()`` (see ``ToolRegistry._should_run_creator``),
+    not the plain category intersection: a ``mcp:<server>`` scope lands
+    in ``mcp_servers`` only and leaves ``categories`` without ``"mcp"``,
+    so a category-only gate would skip this creator for server-only specs.
+
     Internal short-circuit via ``ToolSelectionSpec.includes_mcp()``:
-    when the spec explicitly excludes MCP (either by omitting ``"mcp"``
-    from ``categories`` or by setting ``mcp_servers`` to an empty
-    frozenset), this creator returns early WITHOUT calling
+    when the spec excludes MCP this creator returns early WITHOUT calling
     ``config.get_mcp_server_configs()`` — that call goes through the
     MCP server scan / DB lookup / per-server session-initialize path
     which dominates the 25-30s setup window for tasks that don't
-    actually want MCP tools (see issue #427).
-
-    Registry-level skip (``categories={"mcp"}``) handles the case
-    where the spec's ``categories`` set doesn't include ``"mcp"`` at
-    all; the internal check covers the finer "include MCP category
-    but no servers" case and the legacy spec=None backward-compat
-    path.
+    actually want MCP tools (see issue #427). The check is redundant with
+    the dispatch gate but kept as defense and to cover the spec=None path.
     """
     spec = (
         config.get_tool_selection_spec()
@@ -41,25 +40,30 @@ async def create_mcp_tools(config: "BaseToolConfig") -> List[Any]:
     if not mcp_configs:
         return []
 
-    # Per-server filter: when the spec restricts which MCP servers the
-    # agent wants, drop configs for any server outside that set BEFORE
-    # ``_create_mcp_tools_from_configs`` runs -- the latter performs the
-    # actual session initialization (network I/O), which is the real
-    # cost we want to avoid. Both sides go through the single
-    # ``normalize_mcp_server_name`` SSOT (strip + spaces/hyphens ->
-    # underscore + case-fold) so a "gmail" selector matches a "Gmail"
-    # config and stray whitespace doesn't silently drop the server.
-    if spec is not None and spec.mcp_servers is not None:
-        from .selection_spec import normalize_mcp_server_name
-
-        wanted = {normalize_mcp_server_name(s) for s in spec.mcp_servers}
-        mcp_configs = [
-            cfg
-            for cfg in mcp_configs
-            if normalize_mcp_server_name(cfg.get("name", "")) in wanted
-        ]
-        if not mcp_configs:
+    # Pre-build per-server restriction comes from the single policy method
+    # ``spec.scoped_mcp_servers()`` so it stays consistent with the parent/
+    # child rule ``compute_allowed_names`` applies post-build:
+    #   - frozenset(): MCP not selected -> initialize nothing.
+    #   - None: no restriction (plain "mcp" parent, or ALL) -> keep all.
+    #   - non-empty: keep only those servers.
+    # Dropping configs here matters because ``_create_mcp_tools_from_configs``
+    # performs the actual session initialization (network I/O). The config
+    # ``name`` is folded through the same ``normalize_mcp_server_name`` SSOT
+    # as the scoped keys, so case / whitespace / hyphen never drop a server.
+    if spec is not None:
+        scoped = spec.scoped_mcp_servers()
+        if scoped == frozenset():
             return []
+        if scoped is not None:
+            from .selection_spec import normalize_mcp_server_name
+
+            mcp_configs = [
+                cfg
+                for cfg in mcp_configs
+                if normalize_mcp_server_name(cfg.get("name", "")) in scoped
+            ]
+            if not mcp_configs:
+                return []
 
     try:
         from .factory import ToolFactory

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -45,16 +45,18 @@ async def create_mcp_tools(config: "BaseToolConfig") -> List[Any]:
     # agent wants, drop configs for any server outside that set BEFORE
     # ``_create_mcp_tools_from_configs`` runs -- the latter performs the
     # actual session initialization (network I/O), which is the real
-    # cost we want to avoid. Server names are normalized the same way
-    # ``chat.py._build_selection_spec_from_categories`` and
-    # ``mcp_adapter.py`` normalize them (spaces and hyphens -> underscore)
-    # so the comparison matches across both sides.
+    # cost we want to avoid. Both sides go through the single
+    # ``normalize_mcp_server_name`` SSOT (strip + spaces/hyphens ->
+    # underscore + case-fold) so a "gmail" selector matches a "Gmail"
+    # config and stray whitespace doesn't silently drop the server.
     if spec is not None and spec.mcp_servers is not None:
+        from .selection_spec import normalize_mcp_server_name
+
+        wanted = {normalize_mcp_server_name(s) for s in spec.mcp_servers}
         mcp_configs = [
             cfg
             for cfg in mcp_configs
-            if cfg.get("name", "").replace(" ", "_").replace("-", "_")
-            in spec.mcp_servers
+            if normalize_mcp_server_name(cfg.get("name", "")) in wanted
         ]
         if not mcp_configs:
             return []

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -62,7 +62,7 @@ class ToolSelectionSpec(ABC):
       - ``_SpecNone`` — explicit "zero tools"; factory returns ``[]``.
       - ``_SpecByCategories`` — filter by category, with optional
         ID-level scopes (mcp_servers / custom_api_ids /
-        published_agent_ids) and ``name_extras`` (workforce worker
+        published_agent_ids) and ``name_allowlist`` (workforce worker
         tool injection).
 
     Mode completeness is enforced by ``@abstractmethod``: each
@@ -150,7 +150,7 @@ class ToolSelectionSpec(ABC):
             ``frozenset()`` — caller returns ``[]`` (NONE mode).
             non-empty set  — caller filters ``all_tools`` to names
                              in the set (BY_CATEGORIES mode, plus
-                             :attr:`name_extras` injection).
+                             :attr:`name_allowlist` injection).
 
         The frozenset() vs None distinction is load-bearing:
         ``ToolFactory.create_all_tools`` reads this method and
@@ -168,6 +168,7 @@ class ToolSelectionSpec(ABC):
         custom_api_ids: Optional[List[int]] = None,
         published_agent_ids: Optional[List[int]] = None,
         workforce_extra_names: Optional[Set[str]] = None,
+        name_allowlist: Optional[Set[str]] = None,
         explicit_none: bool = False,
         extras_only_when_unconfigured: bool = False,
     ) -> "ToolSelectionSpec":
@@ -198,48 +199,49 @@ class ToolSelectionSpec(ABC):
         """
         if explicit_none:
             return _SpecNone()
+
+        # Two name-level allow-list sources feed the same field:
+        # workforce worker injection and the generic ``name_allowlist``.
+        # Workforce is just one source; merge them.
+        merged_names = frozenset(
+            (workforce_extra_names or set()) | (name_allowlist or set())
+        )
+
         if tool_categories is None or len(tool_categories) == 0:
             if extras_only_when_unconfigured:
-                name_extras = frozenset(workforce_extra_names or ())
-                if not name_extras:
+                if not merged_names:
                     return _SpecNone()
                 return _SpecByCategories(
                     categories=frozenset(),
-                    name_extras=name_extras,
-                    _user_picked=frozenset(),
+                    name_allowlist=merged_names,
                 )
             return _SpecAll()
 
-        # Agent-builder UI representation in ``tool_categories`` mixes
-        # two shapes:
+        # ``tool_categories`` mixes two orthogonal shapes:
         #   - plain category names (``"basic"``, ``"file"``, ``"mcp"``)
-        #   - ``"mcp:<server-name>"`` (selects a specific MCP server
-        #     OR a Custom-API tool that fronts it; both surface as
-        #     name patterns under the ``"mcp"`` / ``"other"`` categories)
+        #   - ``"mcp:<server>"`` — a specific MCP server (or the
+        #     Custom-API tool fronting it)
         #
-        # Normalize the mixed shape into the structured spec form:
-        #   - plain entries land in ``categories``
-        #   - ``mcp:<server>`` entries add ``"mcp"`` + ``"other"`` to
-        #     ``categories`` (so MCP / Custom-API creators run) and
-        #     ``<server>`` to ``mcp_servers`` (per-server filter)
+        # Keep them in separate fields, not one overloaded set:
+        #   - plain entries  -> ``categories``
+        #   - ``mcp:<server>`` -> ``mcp_servers`` ONLY
         #
-        # The ``categories`` frozenset retains the original
-        # ``mcp:<server>`` strings too — :meth:`compute_allowed_names`
-        # uses them to match tool names (``mcp_<server>_*`` /
-        # ``api_<server>_call``) at the name-filter step.
-        derived_cats: Set[str] = set()
+        # Whether the MCP / Custom-API creators run is derived from
+        # ``includes_mcp()`` / ``includes_custom_api()`` (which read
+        # ``mcp_servers`` too); ``compute_allowed_names`` reads
+        # ``mcp_servers`` directly for the per-server name match. No
+        # support categories are injected and no raw ``mcp:<server>``
+        # string leaks into ``categories``.
+        plain_cats: Set[str] = set()
         derived_mcp_servers: Set[str] = set()
         for entry in tool_categories:
             if isinstance(entry, str) and entry.startswith("mcp:"):
                 server_name = entry.split(":", 1)[1].replace(" ", "_").replace("-", "_")
-                derived_cats.add("mcp")
-                derived_cats.add("other")
-                derived_cats.add(entry)  # keep for name-filter step
                 derived_mcp_servers.add(server_name)
             else:
-                derived_cats.add(entry)
+                plain_cats.add(entry)
 
-        # Caller-supplied mcp_servers (if any) merge with the
+        # Caller-supplied mcp_servers (if any) take precedence over the
         # derived set; explicit empty stays empty.
         if mcp_servers is not None:
             final_mcp_servers: Optional[frozenset[str]] = frozenset(mcp_servers)
@@ -249,7 +251,7 @@ class ToolSelectionSpec(ABC):
             final_mcp_servers = None
 
         return _SpecByCategories(
-            categories=frozenset(derived_cats),
+            categories=frozenset(plain_cats),
             mcp_servers=final_mcp_servers,
             custom_api_ids=(
                 frozenset(custom_api_ids) if custom_api_ids is not None else None
@@ -259,12 +261,7 @@ class ToolSelectionSpec(ABC):
                 if published_agent_ids is not None
                 else None
             ),
-            name_extras=frozenset(workforce_extra_names or ()),
-            # Record the user's raw category list so
-            # ``compute_allowed_names`` can tell plain "mcp" / "other"
-            # admit-all from a derived "mcp" added solely for the
-            # registry-skip side of mcp:<server> sub-categories.
-            _user_picked=frozenset(tool_categories),
+            name_allowlist=merged_names,
         )
 
     # ── Backward-compat helper (kept from the original spec) ─────
@@ -396,7 +393,7 @@ class _SpecByCategories(ToolSelectionSpec):
 
     ``categories`` is normally non-empty. The one valid empty-category
     state is workforce manager injection: no ordinary categories, but
-    explicit ``name_extras`` worker-agent tools.
+    explicit ``name_allowlist`` worker-agent tools.
     """
 
     categories: frozenset[str] = field(default_factory=frozenset)
@@ -406,43 +403,27 @@ class _SpecByCategories(ToolSelectionSpec):
     # Workforce worker tool name injection. Only meaningful in
     # BY_CATEGORIES mode (in ALL the full set already includes
     # them; in NONE everything is rejected).
-    name_extras: frozenset[str] = field(default_factory=frozenset)
-    # The pre-derivation user input, used by ``compute_allowed_names``
-    # to tell apart "user picked plain 'mcp' (admit ALL mcp tools)"
-    # from "user picked only 'mcp:<server>' (from_raw added 'mcp' to
-    # categories for the registry skip, but the name filter should
-    # NOT broaden to every mcp tool)". Set by :meth:`from_raw`. For
-    # direct construction the default is the same as ``categories``
-    # (so direct-construction callers without sub-category derivation
-    # behave as the legacy single-dataclass spec did).
-    _user_picked: Optional[frozenset[str]] = None
+    # Extra tools admitted by exact name, unioned with the category
+    # matches in ``compute_allowed_names``. Two sources feed it via
+    # ``from_raw``: workforce worker-tool injection
+    # (``workforce_extra_names``) and the generic ``name_allowlist``.
+    # Only meaningful in BY_CATEGORIES mode (ALL already includes
+    # everything; NONE rejects everything).
+    name_allowlist: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
-        if not self.categories and not self.name_extras:
+        # A by-categories spec must select *something*: a plain category,
+        # a scoped MCP server (``mcp:<server>`` -> ``mcp_servers``), or an
+        # explicit name in the allow-list. All three empty means "select
+        # nothing", which should be expressed as _SpecNone / _SpecAll via
+        # from_raw instead.
+        if not self.categories and not self.mcp_servers and not self.name_allowlist:
             raise ValueError(
-                "_SpecByCategories requires non-empty categories or "
-                "name_extras. "
+                "_SpecByCategories requires non-empty categories, "
+                "mcp_servers, or name_allowlist. "
                 "Use ToolSelectionSpec.from_raw() with empty / None "
                 "categories to get _SpecAll, or pass "
                 "explicit_none=True for _SpecNone."
-            )
-        # Defense against direct-construction bypass: if categories
-        # carry the agent-builder ``mcp:<server>`` sub-category form,
-        # the parallel ``mcp_servers`` field must be populated for the
-        # MCP creator's per-server filter to work. ``from_raw`` derives
-        # both consistently; a caller that direct-constructs with
-        # ``mcp:<server>`` in categories but ``mcp_servers=None`` would
-        # land in an inconsistent state.
-        mcp_sub_categories = {
-            c for c in self.categories if isinstance(c, str) and c.startswith("mcp:")
-        }
-        if mcp_sub_categories and self.mcp_servers is None:
-            raise ValueError(
-                f"_SpecByCategories with mcp:<server> sub-categories "
-                f"({sorted(mcp_sub_categories)}) requires mcp_servers "
-                f"to be set (the parallel per-server filter). "
-                f"Construct via ToolSelectionSpec.from_raw(tool_categories=...) "
-                f"to derive both fields consistently."
             )
 
     def is_all(self) -> bool:
@@ -454,42 +435,25 @@ class _SpecByCategories(ToolSelectionSpec):
     def is_by_categories(self) -> bool:
         return True
 
-    def _user_categories(self) -> frozenset[str]:
-        """Return the pre-derivation user-picked category set.
-
-        ``from_raw`` records the user's original list here so the
-        name-filter step can tell "user said plain 'mcp'" (admit all
-        mcp tools) apart from "user said only 'mcp:<server>'" (admit
-        only that server's tools). For direct construction without
-        a ``_user_picked`` arg, fall back to ``categories`` — that
-        matches the legacy single-dataclass behaviour where
-        ``categories`` was the user input verbatim.
-        """
-        return self._user_picked if self._user_picked is not None else self.categories
-
     def includes_mcp(self) -> bool:
-        # Need "mcp" in categories; otherwise the registry-level
-        # skip would have caught it but creators with no static
-        # categories annotation can still consult this method.
-        if "mcp" not in self.categories:
-            return False
+        # Explicit empty server set means "no MCP" (legacy
+        # explicit-exclude shape). Otherwise the MCP creator runs when
+        # the plain "mcp" category is selected (all MCP) or a specific
+        # server was scoped via mcp:<server> (-> mcp_servers).
         if self.mcp_servers is not None and len(self.mcp_servers) == 0:
             return False
-        return True
+        return "mcp" in self.categories or bool(self.mcp_servers)
 
     def includes_custom_api(self) -> bool:
-        # P2 fix: Custom API tools live under the "other" category.
-        # If the caller restricts categories without including
-        # "other", custom API tools cannot survive the post-build
-        # name filter, so the creator's DB lookup is wasted I/O.
-        if "other" not in self.categories:
-            return False
+        # Custom API tools surface under the "other" category. A scoped
+        # mcp:<server> also fronts a Custom-API wrapper
+        # (api_<server>_call), so a server scope runs this creator too.
         if self.custom_api_ids is not None and len(self.custom_api_ids) == 0:
             return False
-        return True
+        return "other" in self.categories or bool(self.mcp_servers)
 
     def includes_published_agent(self) -> bool:
-        if self.name_extras:
+        if self.name_allowlist:
             return True
         if "agent" not in self.categories:
             return False
@@ -498,16 +462,25 @@ class _SpecByCategories(ToolSelectionSpec):
         return True
 
     def compute_allowed_names(self, all_tools: List[Any]) -> Optional[frozenset[str]]:
-        """Filter ``all_tools`` by ``categories`` + add ``name_extras``.
+        """Filter ``all_tools`` by ``categories`` + ``mcp_servers``,
+        then union ``name_allowlist``.
 
-        Folds the matching logic of the retired
-        ``select_allowed_tool_names_from_categories`` helper plus
-        the ``_merge_workforce_tool_names`` workforce-extra step
-        into a single dispatch.
+        Reads the orthogonal policy fields directly (no ``_user_picked``
+        reconstruction):
 
-        Duck-typed access to ``tool.metadata.category`` keeps this
-        module free of any Tool / AbstractBaseTool import.
+          - a tool whose category ∈ ``categories`` is admitted (plain
+            ``"mcp"`` admits all MCP tools, ``"other"`` all Custom-API
+            tools, etc.);
+          - otherwise an ``"mcp"`` tool is admitted when its name matches
+            a scoped server in ``mcp_servers`` (``mcp_<server>_*``);
+          - otherwise an ``"other"`` tool admits the scoped Custom-API
+            wrapper ``api_<server>_call``;
+          - finally ``name_allowlist`` names are unioned in.
+
+        Duck-typed access to ``tool.metadata.category`` keeps this module
+        free of any Tool / AbstractBaseTool import.
         """
+        norm_servers = {s.lower() for s in (self.mcp_servers or frozenset())}
         names: Set[str] = set()
         for tool in all_tools:
             if not (hasattr(tool, "metadata") and hasattr(tool.metadata, "category")):
@@ -517,64 +490,26 @@ class _SpecByCategories(ToolSelectionSpec):
                 continue
             category = str(tool.metadata.category.value)
 
-            # Plain category match. Note ``from_raw`` may add "mcp" /
-            # "other" to ``categories`` when the user picked a
-            # ``mcp:<server>`` sub-category — that is for the
-            # registry-level skip, not a name-level admit. The
-            # ``categories`` frozenset distinguishes the two cases by
-            # carrying the original raw strings:
-            #
-            #   from_raw(["mcp"])           -> {"mcp"}
-            #     → user explicitly asked for ALL mcp tools; admit
-            #   from_raw(["mcp:Gmail"])     -> {"mcp", "other", "mcp:Gmail"}
-            #     → user asked for one server; do NOT broaden to all mcp
-            #   from_raw(["mcp", "mcp:X"])  -> {"mcp", "other", "mcp:X"}
-            #     → "mcp" plain entry wins → admit all mcp tools
-            #
-            # So a tool whose category is "mcp" / "other" admits when
-            # the *plain* string is in ``categories``; a tool whose
-            # category is "mcp:<server>" wouldn't exist (servers don't
-            # have their own category) -- this branch only runs once
-            # per tool. ``_raw_user_categories`` is set by ``from_raw``
-            # to the pre-derivation user input; for direct construction
-            # it falls back to ``categories``.
-            user_picked = self._user_categories()
-            if category in ("mcp", "other"):
-                if category in user_picked:
-                    names.add(tool_name)
-                    continue
-                # No plain "mcp" / "other" picked; fall through to
-                # mcp:<server> sub-category matching below.
-            elif category in self.categories:
+            # Plain category admit (categories holds only plain names).
+            if category in self.categories:
                 names.add(tool_name)
                 continue
 
-            # "mcp:<server>" sub-category — match mcp_<server>_*
-            if category == "mcp":
-                for cat_spec in self.categories:
-                    if not cat_spec.startswith("mcp:"):
-                        continue
-                    server = (
-                        cat_spec.split(":", 1)[1].replace(" ", "_").replace("-", "_")
-                    )
-                    if tool_name.lower().startswith(f"mcp_{server.lower()}_"):
-                        names.add(tool_name)
-                        break
+            # Server-scoped MCP: mcp_<server>_* for a server in
+            # mcp_servers, even when plain "mcp" was not selected.
+            if category == "mcp" and norm_servers:
+                lname = tool_name.lower()
+                if any(lname.startswith(f"mcp_{server}_") for server in norm_servers):
+                    names.add(tool_name)
+                continue
 
-            # "mcp:<server>" sub-category — match api_<server>_call
-            # (Custom-API tools surface under the "other" category but
-            # the user expresses them through the same mcp:<server> tag.)
-            elif category == "other":
-                for cat_spec in self.categories:
-                    if not cat_spec.startswith("mcp:"):
-                        continue
-                    server = (
-                        cat_spec.split(":", 1)[1].replace(" ", "_").replace("-", "_")
-                    )
-                    if tool_name.lower() == f"api_{server.lower()}_call":
-                        names.add(tool_name)
-                        break
+            # Server-scoped Custom-API wrapper: api_<server>_call.
+            if category == "other" and norm_servers:
+                lname = tool_name.lower()
+                if any(lname == f"api_{server}_call" for server in norm_servers):
+                    names.add(tool_name)
+                continue
 
-        # Inject workforce worker tool names (only meaningful in
-        # this mode; ``from_raw`` zeroes out for ALL / NONE).
-        return frozenset(names | self.name_extras)
+        # Union the exact-name allow-list (workforce injection +
+        # generic name_allowlist; ``from_raw`` zeroes it for ALL / NONE).
+        return frozenset(names | self.name_allowlist)

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -33,11 +33,11 @@ Mode completeness:
 
 Backward compat:
     All three subclasses expose ``categories`` /``mcp_servers`` /
-    ``custom_api_ids`` / ``published_agent_ids`` fields (the original
-    spec shape). ``_SpecAll`` has them at None / ``_SpecNone`` at
-    None plus empty ``categories``, so existing callsites that read
-    ``spec.categories`` directly keep working. New code should
-    prefer the typed dispatch (``spec.is_by_categories()`` etc.).
+    ``published_agent_ids`` fields (the original spec shape).
+    ``_SpecAll`` has them at None / ``_SpecNone`` at None plus empty
+    ``categories``, so existing callsites that read ``spec.categories``
+    directly keep working. New code should prefer the typed dispatch
+    (``spec.is_by_categories()`` etc.).
 
 This module deliberately has no dependencies on the rest of the
 codebase so the spec can be imported by both the factory and the
@@ -61,9 +61,9 @@ class ToolSelectionSpec(ABC):
         default tool. Factory does not filter by name.
       - ``_SpecNone`` — explicit "zero tools"; factory returns ``[]``.
       - ``_SpecByCategories`` — filter by category, with optional
-        ID-level scopes (mcp_servers / custom_api_ids /
-        published_agent_ids) and ``name_allowlist`` (workforce worker
-        tool injection).
+        ID-level scopes (mcp_servers / published_agent_ids) and
+        ``name_allowlist`` (a pure name-level filter; workforce worker
+        tool injection is one source).
 
     Mode completeness is enforced by ``@abstractmethod``: each
     subclass must implement every predicate / dispatch method.
@@ -164,10 +164,7 @@ class ToolSelectionSpec(ABC):
         cls,
         *,
         tool_categories: Optional[List[str]] = None,
-        mcp_servers: Optional[List[str]] = None,
-        custom_api_ids: Optional[List[int]] = None,
         published_agent_ids: Optional[List[int]] = None,
-        workforce_extra_names: Optional[Set[str]] = None,
         name_allowlist: Optional[Set[str]] = None,
         explicit_none: bool = False,
         extras_only_when_unconfigured: bool = False,
@@ -185,48 +182,43 @@ class ToolSelectionSpec(ABC):
             ``tool_categories`` (reserved for future "zero tools"
             product UI).
           - ``extras_only_when_unconfigured=True`` with unset / empty
-            categories → only ``workforce_extra_names`` are admitted
-            (or ``_SpecNone`` when there are no extras). Workforce
-            manager tasks use this so an unconfigured manager can only
-            delegate to its workers by default, without inheriting the
-            full ordinary tool set.
+            categories → workforce manager runtime: ``published_agent_ids``
+            declares the published-agent dispatch and ``name_allowlist``
+            filters to the worker tool names (or ``_SpecNone`` when there
+            is no ``published_agent_ids``). Lets an unconfigured manager
+            delegate only to its workers without inheriting the full set.
           - Otherwise → ``_SpecByCategories``.
 
-        By default, ``workforce_extra_names`` is only meaningful in
-        BY_CATEGORIES mode (ALL already includes everything; NONE
-        rejects everything). ``extras_only_when_unconfigured`` is the
-        opt-in exception for workforce manager runtime construction.
+        ``name_allowlist`` is a pure name-level filter (only meaningful in
+        BY_CATEGORIES; ALL already includes everything, NONE rejects
+        everything). It does NOT trigger any creator -- dispatch is
+        declared by ``categories`` / ``published_agent_ids``.
         """
         if explicit_none:
             return _SpecNone()
 
-        # Two name-level allow-list sources feed the same field:
-        # workforce worker injection and the generic ``name_allowlist``.
-        # Workforce is just one source; merge them.
-        merged_names = frozenset(
-            (workforce_extra_names or set()) | (name_allowlist or set())
-        )
+        names = frozenset(name_allowlist or set())
 
         if tool_categories is None or len(tool_categories) == 0:
             if extras_only_when_unconfigured:
-                # Workforce manager runtime: declare the published_agent
-                # dispatch via ``published_agent_ids`` (the worker agent
-                # ids) and the name-level filter via ``name_allowlist``
-                # (worker tool names). The two are orthogonal -- dispatch
-                # decides the creator runs, the allow-list narrows its
-                # output. Without the ids the creator would not run and
-                # the worker tools would never be produced.
+                # Workforce manager runtime: ``published_agent_ids``
+                # declares the dispatch (run the published-agent creator,
+                # scoped to the worker agents); ``name_allowlist`` narrows
+                # its output to the worker tool names. They are orthogonal.
+                # ``name_allowlist`` alone is a pure filter -- with no
+                # dispatch there is no creator output to filter, so that
+                # collapses to NONE.
                 pids = (
                     frozenset(published_agent_ids)
                     if published_agent_ids is not None
                     else None
                 )
-                if not merged_names and not pids:
+                if not pids:
                     return _SpecNone()
                 return _SpecByCategories(
                     categories=frozenset(),
                     published_agent_ids=pids,
-                    name_allowlist=merged_names,
+                    name_allowlist=names,
                 )
             return _SpecAll()
 
@@ -254,27 +246,19 @@ class ToolSelectionSpec(ABC):
             else:
                 plain_cats.add(entry)
 
-        # Caller-supplied mcp_servers (if any) take precedence over the
-        # derived set; explicit empty stays empty.
-        if mcp_servers is not None:
-            final_mcp_servers: Optional[frozenset[str]] = frozenset(mcp_servers)
-        elif derived_mcp_servers:
-            final_mcp_servers = frozenset(derived_mcp_servers)
-        else:
-            final_mcp_servers = None
+        final_mcp_servers = (
+            frozenset(derived_mcp_servers) if derived_mcp_servers else None
+        )
 
         return _SpecByCategories(
             categories=frozenset(plain_cats),
             mcp_servers=final_mcp_servers,
-            custom_api_ids=(
-                frozenset(custom_api_ids) if custom_api_ids is not None else None
-            ),
             published_agent_ids=(
                 frozenset(published_agent_ids)
                 if published_agent_ids is not None
                 else None
             ),
-            name_allowlist=merged_names,
+            name_allowlist=names,
         )
 
     # ── Backward-compat helper (kept from the original spec) ─────
@@ -308,17 +292,16 @@ class ToolSelectionSpec(ABC):
 class _SpecAll(ToolSelectionSpec):
     """ALL mode — legacy "未配置" / no restriction.
 
-    Exposes ``categories`` / ``mcp_servers`` / ``custom_api_ids`` /
-    ``published_agent_ids`` at ``None`` for backward compat with
-    callsites that read those attributes directly (e.g. the
-    registry-level skip in ``factory.py:ToolRegistry``).
+    Exposes ``categories`` / ``mcp_servers`` / ``published_agent_ids``
+    at ``None`` for backward compat with callsites that read those
+    attributes directly (e.g. the registry-level skip in
+    ``factory.py:ToolRegistry``).
     """
 
     # Backward-compat fields (kept None to preserve existing
     # ``spec.categories is None`` truthiness in factory.py).
     categories: Optional[frozenset[str]] = None
     mcp_servers: Optional[frozenset[str]] = None
-    custom_api_ids: Optional[frozenset[int]] = None
     published_agent_ids: Optional[frozenset[int]] = None
 
     def is_all(self) -> bool:
@@ -341,10 +324,6 @@ class _SpecAll(ToolSelectionSpec):
         return True
 
     def includes_custom_api(self) -> bool:
-        # Backward-compat mirror of includes_mcp above for the
-        # explicit-exclude legacy shape.
-        if self.custom_api_ids is not None and len(self.custom_api_ids) == 0:
-            return False
         return True
 
     def includes_published_agent(self) -> bool:
@@ -372,7 +351,6 @@ class _SpecNone(ToolSelectionSpec):
 
     categories: Optional[frozenset[str]] = field(default_factory=lambda: frozenset())
     mcp_servers: Optional[frozenset[str]] = None
-    custom_api_ids: Optional[frozenset[int]] = None
     published_agent_ids: Optional[frozenset[int]] = None
 
     def is_all(self) -> bool:
@@ -411,17 +389,17 @@ class _SpecByCategories(ToolSelectionSpec):
 
     categories: frozenset[str] = field(default_factory=frozenset)
     mcp_servers: Optional[frozenset[str]] = None
-    custom_api_ids: Optional[frozenset[int]] = None
     published_agent_ids: Optional[frozenset[int]] = None
     # Workforce worker tool name injection. Only meaningful in
     # BY_CATEGORIES mode (in ALL the full set already includes
     # them; in NONE everything is rejected).
     # Extra tools admitted by exact name, unioned with the category
-    # matches in ``compute_allowed_names``. Two sources feed it via
-    # ``from_raw``: workforce worker-tool injection
-    # (``workforce_extra_names``) and the generic ``name_allowlist``.
-    # Only meaningful in BY_CATEGORIES mode (ALL already includes
-    # everything; NONE rejects everything).
+    # matches in ``compute_allowed_names``. A pure name-level filter fed
+    # via ``from_raw(name_allowlist=...)`` (workforce passes its worker
+    # tool names here). Does NOT trigger any creator -- dispatch is
+    # declared by ``categories`` / ``published_agent_ids``. Only
+    # meaningful in BY_CATEGORIES mode (ALL already includes everything;
+    # NONE rejects everything).
     name_allowlist: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
@@ -430,20 +408,23 @@ class _SpecByCategories(ToolSelectionSpec):
         # explicit name in the allow-list. All three empty means "select
         # nothing", which should be expressed as _SpecNone / _SpecAll via
         # from_raw instead.
+        # Only DISPATCH dimensions count as "selecting something":
+        # categories, mcp_servers, published_agent_ids. ``name_allowlist``
+        # is a pure filter (applied after creators run) -- a spec with only
+        # name_allowlist and no dispatch produces nothing, which is NONE,
+        # not a valid BY_CATEGORIES. So name_allowlist is excluded here.
         if (
             not self.categories
             and not self.mcp_servers
-            and not self.name_allowlist
             and not self.published_agent_ids
-            and not self.custom_api_ids
         ):
             raise ValueError(
                 "_SpecByCategories requires a non-empty selection in at "
-                "least one dimension (categories, mcp_servers, "
-                "name_allowlist, published_agent_ids, or custom_api_ids). "
-                "Use ToolSelectionSpec.from_raw() with empty / None "
-                "categories to get _SpecAll, or pass "
-                "explicit_none=True for _SpecNone."
+                "least one DISPATCH dimension (categories, mcp_servers, or "
+                "published_agent_ids). name_allowlist is a filter, not a "
+                "selection. Use ToolSelectionSpec.from_raw() with empty / "
+                "None categories to get _SpecAll, or explicit_none=True for "
+                "_SpecNone."
             )
 
     def is_all(self) -> bool:
@@ -468,8 +449,10 @@ class _SpecByCategories(ToolSelectionSpec):
         # Custom API tools surface under the "other" category. A scoped
         # mcp:<server> also fronts a Custom-API wrapper
         # (api_<server>_call), so a server scope runs this creator too.
-        if self.custom_api_ids is not None and len(self.custom_api_ids) == 0:
-            return False
+        # Filter happens in the creator via ``config.get_custom_api_configs``
+        # and ``compute_allowed_names``'s "other"/server matching -- there
+        # is no spec-level custom_api id list (ids can't be mapped to tool
+        # names in the spec layer).
         return "other" in self.categories or bool(self.mcp_servers)
 
     def includes_published_agent(self) -> bool:

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -54,22 +54,24 @@ from typing import Any, List, Optional, Set
 
 
 def normalize_mcp_server_name(name: str) -> str:
-    """SSOT for matching an MCP server selector against server-config
-    names and generated tool names.
+    """SSOT for normalizing an MCP / Custom-API server identity.
 
-    Folds the same transform used when naming MCP / Custom-API tools
-    (spaces / hyphens -> underscore), strips surrounding whitespace, and
-    case-folds so the match is case-insensitive. Every server-name MATCH
-    site must use this:
+    Strips surrounding whitespace, folds spaces / hyphens to underscore,
+    and case-folds, yielding a stable key for a server. Every site that
+    derives a server identity must use this single transform:
 
-      - :meth:`ToolSelectionSpec.from_raw` (parse ``mcp:<server>``),
-      - the per-server config filter in ``mcp_tools.create_mcp_tools``,
-      - :meth:`_SpecByCategories.compute_allowed_names`.
+      - :meth:`ToolSelectionSpec.from_raw` (parse ``mcp:<server>`` selector),
+      - the per-server config filter in ``mcp_tools.create_mcp_tools``
+        (server-config ``name``),
+      - tool GENERATION (``mcp_adapter`` / ``api_tool_adapter``), which
+        stamps the result onto ``metadata.source_server``.
 
-    so a selector like ``"mcp: Gmail"`` / ``"mcp:gmail"`` reliably matches
-    a ``"Gmail"`` server. Tool-name GENERATION (``mcp_adapter`` /
-    ``api_tool_adapter``) intentionally keeps the original case for the
-    LLM-visible name; the case-insensitive match here tolerates that.
+    Because both the selector and the tool's ``source_server`` pass through
+    here, server-scoped selection (``compute_allowed_names``) is a plain
+    equality check on normalized keys -- a ``"mcp: Gmail"`` / ``"mcp:gmail"``
+    selector reliably matches a ``"Gmail"`` server regardless of whitespace,
+    case, or hyphen/space. The LLM-visible tool ``name`` keeps its original
+    casing; only the structured ``source_server`` key is normalized.
     """
     return name.strip().replace(" ", "_").replace("-", "_").lower()
 
@@ -254,10 +256,10 @@ class ToolSelectionSpec(ABC):
         #
         # Whether the MCP / Custom-API creators run is derived from
         # ``includes_mcp()`` / ``includes_custom_api()`` (which read
-        # ``mcp_servers`` too); ``compute_allowed_names`` reads
-        # ``mcp_servers`` directly for the per-server name match. No
-        # support categories are injected and no raw ``mcp:<server>``
-        # string leaks into ``categories``.
+        # ``mcp_servers`` too); ``compute_allowed_names`` matches
+        # ``mcp_servers`` against each tool's structured
+        # ``metadata.source_server``. No support categories are injected and
+        # no raw ``mcp:<server>`` string leaks into ``categories``.
         plain_cats: Set[str] = set()
         derived_mcp_servers: Set[str] = set()
         for entry in tool_categories:
@@ -471,9 +473,9 @@ class _SpecByCategories(ToolSelectionSpec):
         # mcp:<server> also fronts a Custom-API wrapper
         # (api_<server>_call), so a server scope runs this creator too.
         # Filter happens in the creator via ``config.get_custom_api_configs``
-        # and ``compute_allowed_names``'s "other"/server matching -- there
-        # is no spec-level custom_api id list (ids can't be mapped to tool
-        # names in the spec layer).
+        # and ``compute_allowed_names``'s structured ``source_server`` match
+        # -- there is no spec-level custom_api id list (ids can't be mapped to
+        # tool names in the spec layer).
         return "other" in self.categories or bool(self.mcp_servers)
 
     def includes_published_agent(self) -> bool:
@@ -497,14 +499,19 @@ class _SpecByCategories(ToolSelectionSpec):
           - a tool whose category ∈ ``categories`` is admitted (plain
             ``"mcp"`` admits all MCP tools, ``"other"`` all Custom-API
             tools, etc.);
-          - otherwise an ``"mcp"`` tool is admitted when its name matches
-            a scoped server in ``mcp_servers`` (``mcp_<server>_*``);
-          - otherwise an ``"other"`` tool admits the scoped Custom-API
-            wrapper ``api_<server>_call``;
+          - otherwise a tool whose ``metadata.source_server`` matches a
+            scoped server in ``mcp_servers`` is admitted. ``source_server``
+            is the normalized originating-server identity set once at
+            generation (MCP adapter + Custom-API wrapper), so this is a
+            structured equality match -- the spec never re-parses the tool
+            name (``mcp_<server>_*`` / ``api_<server>_call``). A scoped
+            ``mcp:<server>`` therefore admits both the server's MCP tools
+            and its ``api_<server>_call`` wrapper, since both carry the same
+            ``source_server``;
           - finally ``name_allowlist`` names are unioned in.
 
-        Duck-typed access to ``tool.metadata.category`` keeps this module
-        free of any Tool / AbstractBaseTool import.
+        Duck-typed access to ``tool.metadata`` keeps this module free of any
+        Tool / AbstractBaseTool import.
         """
         norm_servers = {
             normalize_mcp_server_name(s) for s in (self.mcp_servers or frozenset())
@@ -523,19 +530,13 @@ class _SpecByCategories(ToolSelectionSpec):
                 names.add(tool_name)
                 continue
 
-            # Server-scoped MCP: mcp_<server>_* for a server in
-            # mcp_servers, even when plain "mcp" was not selected.
-            if category == "mcp" and norm_servers:
-                lname = tool_name.lower()
-                if any(lname.startswith(f"mcp_{server}_") for server in norm_servers):
-                    names.add(tool_name)
-                continue
-
-            # Server-scoped Custom-API wrapper: api_<server>_call.
-            if category == "other" and norm_servers:
-                lname = tool_name.lower()
-                if any(lname == f"api_{server}_call" for server in norm_servers):
-                    names.add(tool_name)
+            # Server-scoped admit: the tool's structured originating-server
+            # identity (set + normalized once at generation) equals a scoped
+            # server. Covers MCP tools and their Custom-API wrapper uniformly,
+            # with no tool-name re-parsing / case / strip / startswith-vs-==.
+            src = getattr(tool.metadata, "source_server", None)
+            if norm_servers and src is not None and src in norm_servers:
+                names.add(tool_name)
                 continue
 
         # Union the exact-name allow-list (workforce injection +

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -322,6 +322,24 @@ class ToolSelectionSpec(ABC):
         return cat in getattr(self, "categories", frozenset())
 
 
+def should_load_mcp_server_configs(
+    tool_selection_spec: Optional[ToolSelectionSpec],
+) -> bool:
+    """Whether web-task setup should load MCP server configs.
+
+    ``includes_mcp()`` is broader creator/filter compatibility semantics:
+    ALL mode returns true so legacy unrestricted factory paths keep admitting
+    MCP tools when configs are already supplied. Web task setup has a narrower
+    product meaning: pay the MCP config scan/session-init cost only when the
+    user explicitly selected the MCP domain via categories.
+    """
+    if tool_selection_spec is None:
+        return False
+    if not tool_selection_spec.is_by_categories():
+        return False
+    return bool(tool_selection_spec.includes_mcp())
+
+
 # ─────────────────────────────────────────────────────────────────
 # Concrete subclasses. Production code MUST go through ``from_raw``.
 # The leading underscore signals "internal" — direct construction is

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -161,6 +161,24 @@ class ToolSelectionSpec(ABC):
     def includes_published_agent(self) -> bool:
         """Whether the Published Agent delegation creators should run."""
 
+    @abstractmethod
+    def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
+        """Pre-build MCP server restriction for the MCP creator.
+
+        The MCP creator initializes server sessions (network I/O) before
+        any tool name exists, so it filters at the config level. This
+        method is the single source of that restriction, kept consistent
+        with the parent/child rule ``compute_allowed_names`` applies
+        post-build:
+
+          - ``frozenset()`` — MCP is not selected; do not initialize any
+            MCP server.
+          - ``None`` — MCP is selected without a server restriction
+            (the plain ``"mcp"`` parent is present, or ALL mode); initialize
+            every MCP server.
+          - non-empty — initialize only these normalized server keys.
+        """
+
     # ── Final name-level filter ───────────────────────────────────
 
     @abstractmethod
@@ -354,6 +372,12 @@ class _SpecAll(ToolSelectionSpec):
             return False
         return True
 
+    def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
+        # ALL mode: MCP selected without restriction -> initialize every
+        # server. (``includes_mcp()`` already honors the legacy
+        # explicit-empty ``mcp_servers`` exclude before the creator runs.)
+        return None
+
     def compute_allowed_names(self, all_tools: List[Any]) -> Optional[frozenset[str]]:
         # None signals "no name-level filter" -- factory keeps
         # every tool returned by the registry.
@@ -393,6 +417,10 @@ class _SpecNone(ToolSelectionSpec):
 
     def includes_published_agent(self) -> bool:
         return False
+
+    def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
+        # NONE mode: MCP not selected -> initialize no servers.
+        return frozenset()
 
     def compute_allowed_names(self, all_tools: List[Any]) -> Optional[frozenset[str]]:
         # Empty frozenset signals "filter to []" -- factory drops
@@ -488,6 +516,16 @@ class _SpecByCategories(ToolSelectionSpec):
         if self.published_agent_ids is not None and len(self.published_agent_ids) == 0:
             return False
         return "agent" in self.categories or bool(self.published_agent_ids)
+
+    def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
+        # Parent/child rule, identical to what compute_allowed_names applies
+        # post-build: the plain "mcp" parent admits every server, so it means
+        # "no restriction" (None). A server-only selection restricts to its
+        # set. No MCP selected -> empty (initialize nothing). Mirrors
+        # includes_mcp(): when that is False this returns frozenset().
+        if "mcp" in self.categories:
+            return None
+        return self.mcp_servers or frozenset()
 
     def compute_allowed_names(self, all_tools: List[Any]) -> Optional[frozenset[str]]:
         """Filter ``all_tools`` by ``categories`` + ``mcp_servers``,

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -209,10 +209,23 @@ class ToolSelectionSpec(ABC):
 
         if tool_categories is None or len(tool_categories) == 0:
             if extras_only_when_unconfigured:
-                if not merged_names:
+                # Workforce manager runtime: declare the published_agent
+                # dispatch via ``published_agent_ids`` (the worker agent
+                # ids) and the name-level filter via ``name_allowlist``
+                # (worker tool names). The two are orthogonal -- dispatch
+                # decides the creator runs, the allow-list narrows its
+                # output. Without the ids the creator would not run and
+                # the worker tools would never be produced.
+                pids = (
+                    frozenset(published_agent_ids)
+                    if published_agent_ids is not None
+                    else None
+                )
+                if not merged_names and not pids:
                     return _SpecNone()
                 return _SpecByCategories(
                     categories=frozenset(),
+                    published_agent_ids=pids,
                     name_allowlist=merged_names,
                 )
             return _SpecAll()
@@ -417,10 +430,17 @@ class _SpecByCategories(ToolSelectionSpec):
         # explicit name in the allow-list. All three empty means "select
         # nothing", which should be expressed as _SpecNone / _SpecAll via
         # from_raw instead.
-        if not self.categories and not self.mcp_servers and not self.name_allowlist:
+        if (
+            not self.categories
+            and not self.mcp_servers
+            and not self.name_allowlist
+            and not self.published_agent_ids
+            and not self.custom_api_ids
+        ):
             raise ValueError(
-                "_SpecByCategories requires non-empty categories, "
-                "mcp_servers, or name_allowlist. "
+                "_SpecByCategories requires a non-empty selection in at "
+                "least one dimension (categories, mcp_servers, "
+                "name_allowlist, published_agent_ids, or custom_api_ids). "
                 "Use ToolSelectionSpec.from_raw() with empty / None "
                 "categories to get _SpecAll, or pass "
                 "explicit_none=True for _SpecNone."
@@ -453,13 +473,15 @@ class _SpecByCategories(ToolSelectionSpec):
         return "other" in self.categories or bool(self.mcp_servers)
 
     def includes_published_agent(self) -> bool:
-        if self.name_allowlist:
-            return True
-        if "agent" not in self.categories:
-            return False
+        # Pure dispatch decision: whether the published-agent creator runs
+        # is declared by the "agent" category or by published_agent_ids --
+        # NOT by name_allowlist. name_allowlist is a name-level filter
+        # (applied after creators run), so letting it trigger this creator
+        # would conflate filter with dispatch (issue #539). An explicit
+        # empty published_agent_ids means "no delegation".
         if self.published_agent_ids is not None and len(self.published_agent_ids) == 0:
             return False
-        return True
+        return "agent" in self.categories or bool(self.published_agent_ids)
 
     def compute_allowed_names(self, all_tools: List[Any]) -> Optional[frozenset[str]]:
         """Filter ``all_tools`` by ``categories`` + ``mcp_servers``,

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -241,7 +241,12 @@ class ToolSelectionSpec(ABC):
         derived_mcp_servers: Set[str] = set()
         for entry in tool_categories:
             if isinstance(entry, str) and entry.startswith("mcp:"):
-                server_name = entry.split(":", 1)[1].replace(" ", "_").replace("-", "_")
+                # ``.strip()`` first so ``"mcp: Gmail"`` (stray space after
+                # the colon) normalizes to ``Gmail`` rather than ``_Gmail``,
+                # which would never match ``mcp_<server>_*`` downstream.
+                server_name = (
+                    entry.split(":", 1)[1].strip().replace(" ", "_").replace("-", "_")
+                )
                 derived_mcp_servers.add(server_name)
             else:
                 plain_cats.add(entry)

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -534,8 +534,10 @@ class _SpecByCategories(ToolSelectionSpec):
             # identity (set + normalized once at generation) equals a scoped
             # server. Covers MCP tools and their Custom-API wrapper uniformly,
             # with no tool-name re-parsing / case / strip / startswith-vs-==.
+            # ``src`` is truthy-checked so a tool with no origin (None) or an
+            # empty/whitespace-only server identity never matches a scope.
             src = getattr(tool.metadata, "source_server", None)
-            if norm_servers and src is not None and src in norm_servers:
+            if norm_servers and src and src in norm_servers:
                 names.add(tool_name)
                 continue
 

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -53,6 +53,27 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional, Set
 
 
+def normalize_mcp_server_name(name: str) -> str:
+    """SSOT for matching an MCP server selector against server-config
+    names and generated tool names.
+
+    Folds the same transform used when naming MCP / Custom-API tools
+    (spaces / hyphens -> underscore), strips surrounding whitespace, and
+    case-folds so the match is case-insensitive. Every server-name MATCH
+    site must use this:
+
+      - :meth:`ToolSelectionSpec.from_raw` (parse ``mcp:<server>``),
+      - the per-server config filter in ``mcp_tools.create_mcp_tools``,
+      - :meth:`_SpecByCategories.compute_allowed_names`.
+
+    so a selector like ``"mcp: Gmail"`` / ``"mcp:gmail"`` reliably matches
+    a ``"Gmail"`` server. Tool-name GENERATION (``mcp_adapter`` /
+    ``api_tool_adapter``) intentionally keeps the original case for the
+    LLM-visible name; the case-insensitive match here tolerates that.
+    """
+    return name.strip().replace(" ", "_").replace("-", "_").lower()
+
+
 class ToolSelectionSpec(ABC):
     """Sealed type for tool selection.
 
@@ -241,12 +262,7 @@ class ToolSelectionSpec(ABC):
         derived_mcp_servers: Set[str] = set()
         for entry in tool_categories:
             if isinstance(entry, str) and entry.startswith("mcp:"):
-                # ``.strip()`` first so ``"mcp: Gmail"`` (stray space after
-                # the colon) normalizes to ``Gmail`` rather than ``_Gmail``,
-                # which would never match ``mcp_<server>_*`` downstream.
-                server_name = (
-                    entry.split(":", 1)[1].strip().replace(" ", "_").replace("-", "_")
-                )
+                server_name = normalize_mcp_server_name(entry.split(":", 1)[1])
                 derived_mcp_servers.add(server_name)
             else:
                 plain_cats.add(entry)
@@ -490,7 +506,9 @@ class _SpecByCategories(ToolSelectionSpec):
         Duck-typed access to ``tool.metadata.category`` keeps this module
         free of any Tool / AbstractBaseTool import.
         """
-        norm_servers = {s.lower() for s in (self.mcp_servers or frozenset())}
+        norm_servers = {
+            normalize_mcp_server_name(s) for s in (self.mcp_servers or frozenset())
+        }
         names: Set[str] = set()
         for tool in all_tools:
             if not (hasattr(tool, "metadata") and hasattr(tool.metadata, "category")):

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -316,19 +316,16 @@ def _spec_wants_mcp(tool_selection_spec: Optional[Any]) -> bool:
 
     Returns ``False`` for ``None`` (no spec / legacy caller),
     ``_SpecAll`` (no restriction means "build registered defaults",
-    NOT "ALL including MCP"), and ``_SpecNone`` (zero tools). Returns
-    ``True`` only when ``_SpecByCategories._user_categories()`` (the
-    pre-derivation user input) carries the ``mcp`` token or any
-    ``mcp:<server>`` form.
+    NOT "ALL including MCP"), and ``_SpecNone`` (zero tools). Only a
+    ``_SpecByCategories`` whose normalized policy includes MCP (plain
+    ``"mcp"`` category or a scoped ``mcp_servers``) wants MCP loading;
+    this defers to the spec's own ``includes_mcp()`` dispatch.
     """
     if tool_selection_spec is None:
         return False
     if not tool_selection_spec.is_by_categories():
         return False
-    user_picked = tool_selection_spec._user_categories()
-    return any(
-        c == "mcp" or (isinstance(c, str) and c.startswith("mcp:")) for c in user_picked
-    )
+    return bool(tool_selection_spec.includes_mcp())
 
 
 def _build_tool_selection_spec_for_task(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -24,6 +24,7 @@ from ...core.model.chat.basic.deepseek import DeepSeekLLM
 from ...core.model.chat.basic.openai import OpenAILLM
 from ...core.model.chat.basic.zhipu import ZhipuLLM
 from ...core.model.providers import is_placeholder_api_key
+from ...core.tools.adapters.vibe.selection_spec import should_load_mcp_server_configs
 from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
@@ -321,11 +322,7 @@ def _spec_wants_mcp(tool_selection_spec: Optional[Any]) -> bool:
     ``"mcp"`` category or a scoped ``mcp_servers``) wants MCP loading;
     this defers to the spec's own ``includes_mcp()`` dispatch.
     """
-    if tool_selection_spec is None:
-        return False
-    if not tool_selection_spec.is_by_categories():
-        return False
-    return bool(tool_selection_spec.includes_mcp())
+    return should_load_mcp_server_configs(tool_selection_spec)
 
 
 def _build_tool_selection_spec_for_task(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -348,7 +348,16 @@ def _build_tool_selection_spec_for_task(
     tool_categories = agent_config.get("tool_categories") if agent_config else None
     spec = ToolSelectionSpec.from_raw(
         tool_categories=tool_categories,
-        workforce_extra_names=(
+        # Two orthogonal inputs for the workforce delegation case:
+        #   - published_agent_ids declares the published-agent creator
+        #     should run, scoped to the worker agents (dispatch);
+        #   - name_allowlist narrows its output to the worker tool names
+        #     (filter). The creator's own config.allowed_agent_ids does
+        #     the per-agent DB filtering.
+        published_agent_ids=(
+            list(workforce_runtime.allowed_agent_ids) if workforce_runtime else None
+        ),
+        name_allowlist=(
             workforce_runtime.worker_tool_names if workforce_runtime else None
         ),
         extras_only_when_unconfigured=workforce_runtime is not None,

--- a/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
@@ -19,6 +19,10 @@ def test_custom_api_tool_init():
     )
 
     assert tool.name == "api_my_test_api_call"
+    # Structured originating-server identity, normalized once via the SSOT,
+    # so a scoped mcp:<server> selector matches this wrapper by equality.
+    assert tool.source_server == "my_test_api"
+    assert tool.metadata.source_server == "my_test_api"
     assert "A test API" in tool.description
     assert "Configured endpoint: https://api.example.com/hello" in tool.description
     assert "Configured method: POST" in tool.description

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,6 +1,47 @@
 from types import SimpleNamespace
 
-from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter
+from xagent.core.tools.adapters.vibe.mcp_adapter import (
+    MCPToolAdapter,
+    _build_mcp_tool_adapter,
+)
+
+
+def test_build_mcp_tool_adapter_stamps_normalized_source_server():
+    """``_build_mcp_tool_adapter`` carries the originating server identity
+    onto ``metadata.source_server``, normalized once via the shared SSOT,
+    while the LLM-visible name keeps its original casing. Server-scoped
+    selection matches on the structured field, not the tool name."""
+    mcp_tool = SimpleNamespace(
+        name="send_message",
+        description="Send a message",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = _build_mcp_tool_adapter(
+        "Google Drive",
+        {"transport": "stdio", "command": "python", "args": []},
+        mcp_tool,
+    )
+
+    assert adapter.source_server == "google_drive"
+    assert adapter.metadata.source_server == "google_drive"
+    # LLM-visible name keeps original casing / spacing folded to underscores.
+    assert adapter.name == "mcp_Google Drive_send_message".replace(" ", "_")
+
+
+def test_mcp_tool_adapter_source_server_defaults_none():
+    """A directly constructed adapter with no server origin reports
+    ``source_server`` as ``None`` (no scoped-selection match)."""
+    mcp_tool = SimpleNamespace(
+        name="ping",
+        description="ping",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+    assert adapter.source_server is None
+    assert adapter.metadata.source_server is None
 
 
 def test_build_args_model_handles_optional_array_schema():

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -771,6 +771,23 @@ def test_select_allowed_tool_names_mcp_server_form() -> None:
     ]
 
 
+def test_mcp_server_form_tolerates_stray_whitespace() -> None:
+    """``"mcp: Gmail"`` (stray space after the colon) must normalize to
+    ``Gmail`` and still match ``mcp_gmail_*`` -- not ``_Gmail`` which
+    would silently match nothing."""
+    from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp: Gmail"])
+    assert spec.mcp_servers == frozenset({"Gmail"})
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("mcp_gmail_send_message", "mcp"),
+            _mock_tool("mcp_slack_send", "mcp"),
+        ],
+    )
+    assert sorted(result or []) == ["mcp_gmail_send_message"]
+
+
 def test_select_allowed_tool_names_unknown_mcp_server_yields_empty() -> None:
     """User selected an MCP server whose tools aren't registered (e.g.
     server config exists but no tools loaded). The result is an

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -75,14 +75,15 @@ def test_spec_includes_mcp_when_category_present():
     assert spec.includes_mcp() is True
 
 
-def test_spec_excludes_mcp_when_category_missing():
-    """Even with mcp_servers populated, omitting "mcp" from categories
-    disables the MCP creator -- the category gate runs first."""
+def test_spec_scoped_server_includes_mcp_without_plain_category():
+    """A scoped server (``mcp_servers``) drives the MCP creator even when
+    the plain ``"mcp"`` category is absent -- that is exactly the
+    ``mcp:<server>`` intent (categories and mcp_servers are orthogonal)."""
     spec = ToolSelectionSpec(
         categories=frozenset({"basic"}),
         mcp_servers=frozenset({"Gmail"}),
     )
-    assert spec.includes_mcp() is False
+    assert spec.includes_mcp() is True
 
 
 def test_spec_excludes_mcp_on_empty_server_set():
@@ -600,28 +601,27 @@ async def test_e2e_multi_category_dispatches_matching_creators(static_creators):
 
 
 async def test_e2e_mcp_server_form_extracts_servers_and_includes_mcp(static_creators):
-    """The ``mcp:<ServerName>`` form is dual-purposed: it both adds
-    ``"mcp"`` to ``spec.categories`` (so the MCP creator runs) and
-    populates ``spec.mcp_servers`` with the normalized server name
-    (so the MCP creator's per-server filter narrows the work). Mimics
-    agent 252 "Email Agent (Sales)_V2" = ['basic', 'file', 'knowledge',
-    'mcp:Gmail']."""
+    """The ``mcp:<ServerName>`` form populates ``spec.mcp_servers`` ONLY
+    (orthogonal to ``categories``): no ``"mcp"``/``"other"`` support
+    category is injected, no raw ``mcp:<server>`` string leaks into
+    ``categories``. The MCP / Custom-API creators run via
+    ``includes_mcp()`` / ``includes_custom_api()`` reading mcp_servers.
+    Mimics agent 252 "Email Agent (Sales)_V2" = ['basic', 'file',
+    'knowledge', 'mcp:Gmail']."""
     from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=["basic", "file", "knowledge", "mcp:Gmail"]
     )
 
-    # ``"mcp"`` and ``"other"`` are added implicitly by the builder so the
-    # MCP creator AND the Custom-API-via-"other" legacy match path both
-    # remain reachable; "Gmail" lands normalized in mcp_servers.
-    assert "basic" in spec.categories
-    assert "file" in spec.categories
-    assert "knowledge" in spec.categories
-    assert "mcp" in spec.categories
-    assert "other" in spec.categories
+    # Plain entries land in categories; the server scope lands in
+    # mcp_servers. categories carries NO mcp/other/mcp:Gmail.
+    assert spec.categories == frozenset({"basic", "file", "knowledge"})
+    assert "mcp" not in spec.categories
+    assert "other" not in spec.categories
     assert spec.mcp_servers == frozenset({"Gmail"})
     assert spec.includes_mcp() is True
+    assert spec.includes_custom_api() is True
 
     # Static fakes only — actually dispatching the real MCP creator is
     # covered by the per-server filter tests above.
@@ -993,7 +993,7 @@ def test_from_raw_workforce_extras_ignored_in_all_mode():
         tool_categories=None,
         workforce_extra_names={"some_worker_tool"},
     )
-    # ALL mode: no name_extras field on _SpecAll, callsite that
+    # ALL mode: no name_allowlist field on _SpecAll, callsite that
     # asks for extras must have categories set.
     assert isinstance(spec, _SpecAll)
 
@@ -1012,7 +1012,7 @@ def test_from_raw_can_restrict_unconfigured_agent_to_workforce_extras_only():
 
     assert isinstance(spec, _SpecByCategories)
     assert spec.categories == frozenset()
-    assert spec.name_extras == frozenset({"agent_42"})
+    assert spec.name_allowlist == frozenset({"agent_42"})
     assert spec.includes_category("basic") is False
     assert spec.includes_published_agent() is True
     assert spec.compute_allowed_names(
@@ -1041,7 +1041,7 @@ def test_from_raw_unconfigured_extras_only_without_extras_yields_none_mode():
 
 def test_from_raw_workforce_extras_carried_in_by_categories():
     """In BY_CATEGORIES, ``workforce_extra_names`` lands on
-    :attr:`_SpecByCategories.name_extras` for ``compute_allowed_names``
+    :attr:`_SpecByCategories.name_allowlist` for ``compute_allowed_names``
     injection."""
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
 
@@ -1050,7 +1050,7 @@ def test_from_raw_workforce_extras_carried_in_by_categories():
         workforce_extra_names={"worker_tool_a", "worker_tool_b"},
     )
     assert isinstance(spec, _SpecByCategories)
-    assert spec.name_extras == frozenset({"worker_tool_a", "worker_tool_b"})
+    assert spec.name_allowlist == frozenset({"worker_tool_a", "worker_tool_b"})
     assert spec.includes_published_agent() is True
 
 
@@ -1120,12 +1120,12 @@ def test_compute_allowed_names_none_returns_empty_frozenset():
 
 def test_compute_allowed_names_by_categories_filters_correctly():
     """BY_CATEGORIES mode: only tools whose category matches survive,
-    plus any ``name_extras`` injection."""
+    plus any ``name_allowlist`` injection."""
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
 
     spec = _SpecByCategories(
         categories=frozenset({"basic"}),
-        name_extras=frozenset({"injected_worker_tool"}),
+        name_allowlist=frozenset({"injected_worker_tool"}),
     )
     result = spec.compute_allowed_names(
         [
@@ -1415,6 +1415,52 @@ def test_factory_falls_back_to_get_allowed_tools_when_spec_none():
         ToolRegistry._modules_imported = saved_imported
 
 
+def test_factory_prefers_spec_and_warns_when_allowed_tools_also_set(caplog):
+    """When BOTH a spec and a legacy allowed_tools list are supplied, the
+    factory prefers the spec (ignores the legacy list) and logs a warning
+    rather than silently intersecting (issue #539)."""
+    import asyncio
+    import logging
+    from unittest.mock import MagicMock as _MagicMock
+
+    tool_a = _mock_tool("a", "basic")
+    tool_b = _mock_tool("b", "basic")
+
+    cfg = _MagicMock()
+    cfg.get_tool_selection_spec.return_value = ToolSelectionSpec.from_raw(
+        tool_categories=["basic"]
+    )
+    cfg.get_allowed_tools.return_value = ["a"]  # stale legacy list
+    cfg.get_sandbox.return_value = None
+    cfg.get_workspace_config.return_value = None
+    cfg.get_user_tool_overrides.return_value = {}
+    cfg.get_max_output_length.return_value = None
+    cfg.get_max_field_count.return_value = None
+    cfg.get_max_recursion_depth.return_value = None
+
+    saved_creators = list(ToolRegistry._tool_creators)
+    saved_imported = ToolRegistry._modules_imported
+    ToolRegistry._tool_creators = []
+    ToolRegistry._modules_imported = True
+    try:
+
+        async def creator(_cfg):
+            return [tool_a, tool_b]
+
+        creator.__name__ = "test_creator"
+        ToolRegistry.register(creator, categories={"basic"})
+
+        with caplog.at_level(logging.WARNING):
+            tools = asyncio.run(ToolFactory.create_all_tools(cfg))
+
+        # Spec wins: "basic" admits both; the legacy ["a"] is ignored.
+        assert {t.name for t in tools} == {"a", "b"}
+        assert any("legacy allowed_tools" in r.getMessage() for r in caplog.records)
+    finally:
+        ToolRegistry._tool_creators = saved_creators
+        ToolRegistry._modules_imported = saved_imported
+
+
 def test_compute_allowed_names_plain_mcp_admits_all_mcp_tools():
     """User picked plain ``["mcp"]`` (no server qualifier) — MUST
     admit every mcp-category tool, not 0. Previously broken because
@@ -1471,6 +1517,41 @@ def test_compute_allowed_names_mixed_plain_and_server_picks():
         ]
     )
     assert result == frozenset({"mcp_gmail_send", "api_custom_call"})
+
+
+def test_compute_allowed_names_plain_mcp_wins_over_server_scope():
+    """``["mcp", "mcp:Gmail"]`` — the plain "mcp" category admits ALL mcp
+    tools; the parallel server scope does not narrow it (plain wins)."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp", "mcp:Gmail"])
+    assert "mcp" in spec.categories
+    assert spec.mcp_servers == frozenset({"Gmail"})
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("mcp_gmail_send", "mcp"),
+            _mock_tool("mcp_slack_post", "mcp"),
+            _mock_tool("calc", "basic"),
+        ]
+    )
+    assert result == frozenset({"mcp_gmail_send", "mcp_slack_post"})
+
+
+def test_from_raw_generic_name_allowlist_unions_into_results():
+    """The generic ``name_allowlist`` param (not only workforce extras)
+    lands on the spec and is unioned into compute_allowed_names alongside
+    the category matches."""
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=["basic"],
+        name_allowlist={"foo_tool"},
+    )
+    assert spec.name_allowlist == frozenset({"foo_tool"})
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("calc", "basic"),
+            _mock_tool("img", "image"),
+            _mock_tool("foo_tool", "other"),
+        ]
+    )
+    assert result == frozenset({"calc", "foo_tool"})
 
 
 def test_spec_wants_mcp_only_for_explicit_mcp_selection():

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -609,7 +609,7 @@ async def test_e2e_mcp_server_form_extracts_servers_and_includes_mcp(static_crea
     assert spec.categories == frozenset({"basic", "file", "knowledge"})
     assert "mcp" not in spec.categories
     assert "other" not in spec.categories
-    assert spec.mcp_servers == frozenset({"Gmail"})
+    assert spec.mcp_servers == frozenset({"gmail"})
     assert spec.includes_mcp() is True
     assert spec.includes_custom_api() is True
 
@@ -641,7 +641,7 @@ async def test_e2e_mcp_server_name_normalization_matches_prod_shape(static_creat
     # All three server names normalized identically to the way
     # mcp_tools.create_mcp_tools normalizes the prod ``mcp_configs[i]["name"]``
     # field when applying the per-server filter.
-    assert spec.mcp_servers == frozenset({"Google_Calendar", "Google_Drive", "HubSpot"})
+    assert spec.mcp_servers == frozenset({"google_calendar", "google_drive", "hubspot"})
 
 
 async def test_e2e_empty_categories_yields_none_spec(static_creators):
@@ -778,7 +778,7 @@ def test_mcp_server_form_tolerates_stray_whitespace() -> None:
     from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp: Gmail"])
-    assert spec.mcp_servers == frozenset({"Gmail"})
+    assert spec.mcp_servers == frozenset({"gmail"})
     result = spec.compute_allowed_names(
         [
             _mock_tool("mcp_gmail_send_message", "mcp"),
@@ -786,6 +786,29 @@ def test_mcp_server_form_tolerates_stray_whitespace() -> None:
         ],
     )
     assert sorted(result or []) == ["mcp_gmail_send_message"]
+
+
+def test_normalize_mcp_server_name_ssot() -> None:
+    """The single normalizer: strip + spaces/hyphens->underscore + lower."""
+    from xagent.core.tools.adapters.vibe.selection_spec import (
+        normalize_mcp_server_name,
+    )
+
+    assert normalize_mcp_server_name(" Gmail ") == "gmail"
+    assert normalize_mcp_server_name("Google Drive") == "google_drive"
+    assert normalize_mcp_server_name("Hub-Spot") == "hub_spot"
+
+
+def test_mcp_server_match_is_case_insensitive_vs_real_tool_name() -> None:
+    """A lowercase ``mcp:gmail`` selector matches a tool named
+    ``mcp_Gmail_*``. ``mcp_adapter`` generates tool names preserving the
+    config-name case; server matching is case-insensitive via the SSOT,
+    so the two reconcile without forcing tool names to lowercase."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:gmail"])
+    result = spec.compute_allowed_names(
+        [_mock_tool("mcp_Gmail_send_message", "mcp")],  # mixed case (real shape)
+    )
+    assert sorted(result or []) == ["mcp_Gmail_send_message"]
 
 
 def test_select_allowed_tool_names_unknown_mcp_server_yields_empty() -> None:
@@ -1523,7 +1546,7 @@ def test_compute_allowed_names_plain_mcp_wins_over_server_scope():
     tools; the parallel server scope does not narrow it (plain wins)."""
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp", "mcp:Gmail"])
     assert "mcp" in spec.categories
-    assert spec.mcp_servers == frozenset({"Gmail"})
+    assert spec.mcp_servers == frozenset({"gmail"})
     result = spec.compute_allowed_names(
         [
             _mock_tool("mcp_gmail_send", "mcp"),

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -96,18 +96,6 @@ def test_spec_excludes_mcp_on_empty_server_set():
     assert spec.includes_mcp() is False
 
 
-def test_spec_custom_api_empty_set_excludes():
-    spec = ToolSelectionSpec(custom_api_ids=frozenset())
-    assert spec.includes_custom_api() is False
-
-
-def test_spec_custom_api_none_includes():
-    """None means "no restriction" -- the creator still runs and falls
-    back to whatever DB-level filtering it does internally."""
-    spec = ToolSelectionSpec(custom_api_ids=None)
-    assert spec.includes_custom_api() is True
-
-
 def test_spec_published_agent_empty_set_excludes():
     spec = ToolSelectionSpec(published_agent_ids=frozenset())
     assert spec.includes_published_agent() is False
@@ -223,7 +211,7 @@ async def test_registry_runs_published_agent_creator_for_workforce_extras(
     spec = ToolSelectionSpec.from_raw(
         tool_categories=["basic"],
         published_agent_ids=[42],  # dispatch: run the published-agent creator
-        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
+        name_allowlist={"agent_42"},  # filter: keep this worker tool
     )
     tools = await isolated_registry.create_registered_tools(_FakeConfig(spec))
 
@@ -261,7 +249,7 @@ async def test_factory_worker_only_mode_keeps_only_injected_agent_tools(
     spec = ToolSelectionSpec.from_raw(
         tool_categories=[],
         published_agent_ids=[42],  # dispatch: run the published-agent creator
-        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
+        name_allowlist={"agent_42"},  # filter: keep this worker tool
         extras_only_when_unconfigured=True,
     )
     tools = await ToolFactory.create_all_tools(
@@ -986,14 +974,14 @@ def test_from_raw_explicit_none_yields_none_mode():
     assert isinstance(spec, _SpecNone)
 
 
-def test_from_raw_workforce_extras_ignored_in_all_mode():
-    """``workforce_extra_names`` is only meaningful in BY_CATEGORIES;
-    silently ignored in ALL (full set already includes everything)."""
+def test_from_raw_name_allowlist_ignored_in_all_mode():
+    """``name_allowlist`` is only meaningful in BY_CATEGORIES; silently
+    ignored in ALL (full set already includes everything)."""
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecAll
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=None,
-        workforce_extra_names={"some_worker_tool"},
+        name_allowlist={"some_worker_tool"},
     )
     # ALL mode: no name_allowlist field on _SpecAll, callsite that
     # asks for extras must have categories set.
@@ -1009,7 +997,7 @@ def test_from_raw_can_restrict_unconfigured_agent_to_workforce_extras_only():
     spec = ToolSelectionSpec.from_raw(
         tool_categories=[],
         published_agent_ids=[42],  # dispatch: run the published-agent creator
-        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
+        name_allowlist={"agent_42"},  # filter: keep this worker tool
         extras_only_when_unconfigured=True,
     )
 
@@ -1036,7 +1024,7 @@ def test_from_raw_unconfigured_extras_only_without_extras_yields_none_mode():
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=None,
-        workforce_extra_names=set(),
+        name_allowlist=set(),
         extras_only_when_unconfigured=True,
     )
 
@@ -1083,19 +1071,6 @@ def test_by_categories_includes_custom_api_when_other_present():
 
     spec = _SpecByCategories(categories=frozenset({"other"}))
     assert spec.includes_custom_api() is True
-
-
-def test_by_categories_excludes_custom_api_when_other_present_but_ids_empty():
-    """Even with ``"other"`` in categories, an explicit empty
-    ``custom_api_ids=frozenset()`` skips the creator (legacy
-    'explicit exclude' shape preserved)."""
-    from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
-
-    spec = _SpecByCategories(
-        categories=frozenset({"other"}),
-        custom_api_ids=frozenset(),
-    )
-    assert spec.includes_custom_api() is False
 
 
 # ----- compute_allowed_names mode dispatch -------------------------------
@@ -1150,7 +1125,7 @@ def test_compute_allowed_names_workforce_extra_does_not_admit_agent_category():
     """
     spec = ToolSelectionSpec.from_raw(
         tool_categories=["basic"],
-        workforce_extra_names={"agent_42"},
+        name_allowlist={"agent_42"},
     )
     result = spec.compute_allowed_names(
         [

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -309,8 +309,8 @@ class _MCPConfig:
 
 
 async def test_mcp_per_server_filter_skips_non_matching_configs(monkeypatch):
-    """The MCP creator must filter ``mcp_configs`` by
-    ``spec.mcp_servers`` BEFORE handing them to
+    """A server-only selection (``mcp:Gmail``) must filter ``mcp_configs``
+    via ``spec.scoped_mcp_servers()`` BEFORE handing them to
     ``_create_mcp_tools_from_configs`` -- the latter does the network
     session-initialize work whose cost we want to avoid.
 
@@ -338,10 +338,7 @@ async def test_mcp_per_server_filter_skips_non_matching_configs(monkeypatch):
         {"name": "Google Drive"},
         {"name": "Slack"},
     ]
-    spec = ToolSelectionSpec(
-        categories=frozenset({"mcp"}),
-        mcp_servers=frozenset({"Gmail"}),
-    )
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
     cfg = _MCPConfig(servers, selection_spec=spec)
 
     await mcp_tools.create_mcp_tools(cfg)
@@ -375,12 +372,9 @@ async def test_mcp_per_server_filter_normalizes_whitespace(monkeypatch):
         {"name": "Google Drive"},
         {"name": "Slack"},
     ]
-    # Spec contains the normalized form (matches how
-    # _build_selection_spec_from_categories assembles it).
-    spec = ToolSelectionSpec(
-        categories=frozenset({"mcp"}),
-        mcp_servers=frozenset({"Google_Drive"}),
-    )
+    # from_raw normalizes "Google Drive" -> "google_drive" on the selector
+    # side; the filter normalizes the config name the same way.
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Google Drive"])
     cfg = _MCPConfig(servers, selection_spec=spec)
 
     await mcp_tools.create_mcp_tools(cfg)
@@ -411,16 +405,45 @@ async def test_mcp_per_server_filter_empty_match_short_circuits(monkeypatch):
     )
 
     servers = [{"name": "Slack"}]
-    spec = ToolSelectionSpec(
-        categories=frozenset({"mcp"}),
-        mcp_servers=frozenset({"Gmail"}),
-    )
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
     cfg = _MCPConfig(servers, selection_spec=spec)
 
     result = await mcp_tools.create_mcp_tools(cfg)
 
     assert result == []
     assert call_count == 0  # short-circuit, no factory call
+
+
+async def test_mcp_parent_category_forwards_all_servers(monkeypatch):
+    """Parent/child rule (③): when the plain ``"mcp"`` parent is present
+    alongside a ``mcp:<server>`` child, ``scoped_mcp_servers()`` returns
+    ``None`` (no restriction), so the pre-build filter forwards EVERY
+    server -- consistent with ``compute_allowed_names`` admitting all MCP
+    tools. The earlier behavior wrongly initialized only the child server."""
+    from xagent.core.tools.adapters.vibe import mcp_tools
+    from xagent.core.tools.adapters.vibe.factory import ToolFactory
+
+    received = []
+
+    async def _fake_create(mcp_configs, sandbox=None):
+        received.append(mcp_configs)
+        return []
+
+    monkeypatch.setattr(
+        ToolFactory,
+        "_create_mcp_tools_from_configs",
+        staticmethod(_fake_create),
+    )
+
+    servers = [{"name": "Gmail"}, {"name": "Slack"}]
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp", "mcp:Gmail"])
+    assert spec.scoped_mcp_servers() is None
+    cfg = _MCPConfig(servers, selection_spec=spec)
+
+    await mcp_tools.create_mcp_tools(cfg)
+
+    assert len(received) == 1
+    assert [c["name"] for c in received[0]] == ["Gmail", "Slack"]
 
 
 async def test_mcp_no_per_server_filter_when_spec_lacks_servers(monkeypatch):
@@ -450,6 +473,46 @@ async def test_mcp_no_per_server_filter_when_spec_lacks_servers(monkeypatch):
 
     assert len(received) == 1
     assert [c["name"] for c in received[0]] == ["Gmail", "Slack"]
+
+
+def test_scoped_mcp_servers_parent_child_table() -> None:
+    """``scoped_mcp_servers()`` encodes the pre-build restriction in one
+    place: frozenset()=none, None=all (parent mcp / ALL), non-empty=scoped."""
+    raw = ToolSelectionSpec.from_raw
+    # server-only -> scoped to that server (normalized key)
+    assert raw(tool_categories=["mcp:Gmail"]).scoped_mcp_servers() == frozenset(
+        {"gmail"}
+    )
+    # plain parent -> unrestricted
+    assert raw(tool_categories=["mcp"]).scoped_mcp_servers() is None
+    # parent + child -> parent wins (unrestricted)
+    assert raw(tool_categories=["mcp", "mcp:Gmail"]).scoped_mcp_servers() is None
+    # unconfigured (_SpecAll) -> unrestricted (维持现状)
+    assert raw(tool_categories=[]).scoped_mcp_servers() is None
+    # explicit none -> initialize nothing
+    assert raw(explicit_none=True).scoped_mcp_servers() == frozenset()
+    # category without mcp -> nothing
+    assert raw(tool_categories=["basic"]).scoped_mcp_servers() == frozenset()
+
+
+def test_should_run_creator_mcp_gate_dispatches_server_only() -> None:
+    """① regression pin: the MCP creator's ``selection_gate="mcp"`` must
+    dispatch on ``spec.includes_mcp()``, NOT category intersection, so a
+    server-only ``mcp:Gmail`` spec (categories=frozenset()) still runs it."""
+    from xagent.core.tools.adapters.vibe.factory import ToolRegistry
+
+    declared = frozenset({"mcp"})
+    server_only = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
+    assert server_only.categories == frozenset()  # the trap: empty categories
+    assert ToolRegistry._should_run_creator(declared, server_only, "mcp") is True
+
+    # A non-MCP selection must still skip the MCP creator.
+    basic_only = ToolSelectionSpec.from_raw(tool_categories=["basic"])
+    assert ToolRegistry._should_run_creator(declared, basic_only, "mcp") is False
+
+    # Without the gate (category intersection) the server-only spec would
+    # wrongly be skipped -- this documents why the gate is required.
+    assert ToolRegistry._should_run_creator(declared, server_only, None) is False
 
 
 # ----- factory.py:194 allowed_tools=[] semantic fix ----------------------

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -855,6 +855,22 @@ def test_server_scope_match_is_independent_of_tool_name() -> None:
     assert sorted(result or []) == ["totally_unrelated_name"]
 
 
+def test_empty_source_server_never_matches_scope() -> None:
+    """A degenerate ``mcp:`` selector (empty server) normalizes to ``""``;
+    a tool whose ``source_server`` is empty/whitespace-only also normalizes
+    to ``""``. The truthy guard prevents that accidental equality from
+    admitting an origin-less tool under a scope."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:"])
+    assert spec.mcp_servers == frozenset({""})
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("mcp_send", "mcp", source_server=""),
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+        ],
+    )
+    assert result == frozenset()
+
+
 def test_select_allowed_tool_names_unknown_mcp_server_yields_empty() -> None:
     """User selected an MCP server whose tools aren't registered (e.g.
     server config exists but no tools loaded). The result is an

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -222,7 +222,8 @@ async def test_registry_runs_published_agent_creator_for_workforce_extras(
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=["basic"],
-        workforce_extra_names={"agent_42"},
+        published_agent_ids=[42],  # dispatch: run the published-agent creator
+        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
     )
     tools = await isolated_registry.create_registered_tools(_FakeConfig(spec))
 
@@ -259,7 +260,8 @@ async def test_factory_worker_only_mode_keeps_only_injected_agent_tools(
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=[],
-        workforce_extra_names={"agent_42"},
+        published_agent_ids=[42],  # dispatch: run the published-agent creator
+        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
         extras_only_when_unconfigured=True,
     )
     tools = await ToolFactory.create_all_tools(
@@ -888,7 +890,7 @@ def test_by_categories_rejects_empty_categories():
     """
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
 
-    with pytest.raises(ValueError, match="non-empty categories"):
+    with pytest.raises(ValueError, match="non-empty selection"):
         _SpecByCategories(categories=frozenset())
 
 
@@ -1006,7 +1008,8 @@ def test_from_raw_can_restrict_unconfigured_agent_to_workforce_extras_only():
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=[],
-        workforce_extra_names={"agent_42"},
+        published_agent_ids=[42],  # dispatch: run the published-agent creator
+        workforce_extra_names={"agent_42"},  # filter: keep this worker tool
         extras_only_when_unconfigured=True,
     )
 
@@ -1014,6 +1017,7 @@ def test_from_raw_can_restrict_unconfigured_agent_to_workforce_extras_only():
     assert spec.categories == frozenset()
     assert spec.name_allowlist == frozenset({"agent_42"})
     assert spec.includes_category("basic") is False
+    # Dispatch comes from published_agent_ids, not from the name allow-list.
     assert spec.includes_published_agent() is True
     assert spec.compute_allowed_names(
         [
@@ -1039,19 +1043,22 @@ def test_from_raw_unconfigured_extras_only_without_extras_yields_none_mode():
     assert isinstance(spec, _SpecNone)
 
 
-def test_from_raw_workforce_extras_carried_in_by_categories():
-    """In BY_CATEGORIES, ``workforce_extra_names`` lands on
-    :attr:`_SpecByCategories.name_allowlist` for ``compute_allowed_names``
-    injection."""
+def test_name_allowlist_alone_does_not_trigger_published_dispatch():
+    """``name_allowlist`` (incl. workforce extras) lands on the spec as a
+    pure name-level filter; it MUST NOT by itself trigger the
+    published-agent creator. Dispatch is declared via ``"agent"`` category
+    or ``published_agent_ids`` (issue #539 -- filter vs dispatch are
+    orthogonal)."""
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
 
     spec = ToolSelectionSpec.from_raw(
         tool_categories=["basic"],
-        workforce_extra_names={"worker_tool_a", "worker_tool_b"},
+        name_allowlist={"worker_tool_a", "worker_tool_b"},
     )
     assert isinstance(spec, _SpecByCategories)
     assert spec.name_allowlist == frozenset({"worker_tool_a", "worker_tool_b"})
-    assert spec.includes_published_agent() is True
+    # No "agent" category and no published_agent_ids -> creator stays off.
+    assert spec.includes_published_agent() is False
 
 
 # ----- P2 fix: includes_custom_api with category restriction -------------

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -680,10 +680,14 @@ async def test_e2e_empty_categories_yields_none_spec(static_creators):
 # ---------------------------------------------------------------------------
 
 
-def _mock_tool(name: str, category: str):
-    """Build a minimal mock tool with the ``.metadata.category.value``
-    shape the helper inspects. Using ``MagicMock`` here would
-    silently match anything; explicit class keeps the contract tight.
+def _mock_tool(name: str, category: str, source_server: str | None = None):
+    """Build a minimal mock tool with the ``.metadata.category.value`` +
+    ``.metadata.source_server`` shape the helper inspects.
+
+    ``source_server`` mirrors what tool generation stamps (the normalized
+    originating server identity, or ``None`` for non-server tools). It is
+    set explicitly -- a bare ``MagicMock`` attribute would auto-spawn a
+    truthy mock and silently match every scoped server.
     """
     from unittest.mock import MagicMock
 
@@ -692,6 +696,7 @@ def _mock_tool(name: str, category: str):
     tool.metadata = MagicMock()
     tool.metadata.category = MagicMock()
     tool.metadata.category.value = category
+    tool.metadata.source_server = source_server
     return tool
 
 
@@ -750,8 +755,8 @@ def test_select_allowed_tool_names_plain_category_match() -> None:
 
 
 def test_select_allowed_tool_names_mcp_server_form() -> None:
-    """``mcp:<server>`` entry matches tools named ``mcp_<server>_*``
-    (case-insensitive, with spaces / dashes folded to underscores).
+    """``mcp:<server>`` entry matches tools whose structured
+    ``metadata.source_server`` equals the normalized server identity.
     """
     from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
@@ -759,9 +764,10 @@ def test_select_allowed_tool_names_mcp_server_form() -> None:
         tool_categories=["mcp:Gmail"]
     ).compute_allowed_names(
         [
-            _mock_tool("mcp_gmail_send_message", "mcp"),
-            _mock_tool("mcp_gmail_list_messages", "mcp"),
-            _mock_tool("mcp_slack_send", "mcp"),  # different server, excluded
+            _mock_tool("mcp_gmail_send_message", "mcp", source_server="gmail"),
+            _mock_tool("mcp_gmail_list_messages", "mcp", source_server="gmail"),
+            # different server, excluded
+            _mock_tool("mcp_slack_send", "mcp", source_server="slack"),
             _mock_tool("calculator", "basic"),  # different category, excluded
         ],
     )
@@ -773,16 +779,17 @@ def test_select_allowed_tool_names_mcp_server_form() -> None:
 
 def test_mcp_server_form_tolerates_stray_whitespace() -> None:
     """``"mcp: Gmail"`` (stray space after the colon) must normalize to
-    ``Gmail`` and still match ``mcp_gmail_*`` -- not ``_Gmail`` which
-    would silently match nothing."""
+    ``gmail`` on the selector side and still match a tool whose
+    ``source_server`` is ``gmail`` -- not ``_gmail`` which would silently
+    match nothing."""
     from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp: Gmail"])
     assert spec.mcp_servers == frozenset({"gmail"})
     result = spec.compute_allowed_names(
         [
-            _mock_tool("mcp_gmail_send_message", "mcp"),
-            _mock_tool("mcp_slack_send", "mcp"),
+            _mock_tool("mcp_gmail_send_message", "mcp", source_server="gmail"),
+            _mock_tool("mcp_slack_send", "mcp", source_server="slack"),
         ],
     )
     assert sorted(result or []) == ["mcp_gmail_send_message"]
@@ -800,15 +807,52 @@ def test_normalize_mcp_server_name_ssot() -> None:
 
 
 def test_mcp_server_match_is_case_insensitive_vs_real_tool_name() -> None:
-    """A lowercase ``mcp:gmail`` selector matches a tool named
-    ``mcp_Gmail_*``. ``mcp_adapter`` generates tool names preserving the
-    config-name case; server matching is case-insensitive via the SSOT,
-    so the two reconcile without forcing tool names to lowercase."""
+    """A lowercase ``mcp:gmail`` selector matches a mixed-case tool. The
+    LLM-visible name (``mcp_Gmail_send_message``) keeps the config-name
+    case, but matching is on the structured ``source_server`` that
+    generation normalized to ``gmail`` -- so case never affects the match
+    and the tool name is irrelevant to selection."""
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:gmail"])
     result = spec.compute_allowed_names(
-        [_mock_tool("mcp_Gmail_send_message", "mcp")],  # mixed case (real shape)
+        # mixed-case LLM name, normalized source_server (real shape)
+        [_mock_tool("mcp_Gmail_send_message", "mcp", source_server="gmail")],
     )
     assert sorted(result or []) == ["mcp_Gmail_send_message"]
+
+
+def test_mcp_server_scope_admits_custom_api_wrapper() -> None:
+    """A scoped ``mcp:<server>`` admits the server's Custom-API wrapper
+    (``other`` category) the same way as its MCP tools: both carry the same
+    structured ``source_server``. Replaces the old name-shape ``==
+    api_<server>_call`` match, so a stray space / case in the wrapper name
+    can no longer silently drop it."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+            _mock_tool("api_Gmail_call", "other", source_server="gmail"),
+            _mock_tool("api_slack_call", "other", source_server="slack"),
+        ],
+    )
+    assert sorted(result or []) == ["api_Gmail_call", "mcp_gmail_send"]
+
+
+def test_server_scope_match_is_independent_of_tool_name() -> None:
+    """The match is purely on structured ``source_server`` -- a tool whose
+    LLM name shares no prefix with the server is still admitted when its
+    generation-stamped ``source_server`` matches, and one that merely looks
+    like it belongs (by name) is not, when ``source_server`` differs. This
+    is what ends the name-transform edge-case class."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
+    result = spec.compute_allowed_names(
+        [
+            # Name unrelated to "gmail", but source_server matches -> admit.
+            _mock_tool("totally_unrelated_name", "mcp", source_server="gmail"),
+            # Name looks gmail-ish, but source_server differs -> reject.
+            _mock_tool("mcp_gmail_lookalike", "mcp", source_server="other_srv"),
+        ],
+    )
+    assert sorted(result or []) == ["totally_unrelated_name"]
 
 
 def test_select_allowed_tool_names_unknown_mcp_server_yields_empty() -> None:
@@ -830,7 +874,7 @@ def test_select_allowed_tool_names_unknown_mcp_server_yields_empty() -> None:
     ).compute_allowed_names(
         [
             _mock_tool("calculator", "basic"),
-            _mock_tool("mcp_gmail_send", "mcp"),
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
         ],
     )
     # Non-empty input with no matches: ``compute_allowed_names`` returns
@@ -1267,8 +1311,8 @@ async def test_factory_by_categories_filters_by_compute_allowed_names(
 
 
 def test_compute_allowed_names_by_categories_mcp_subcategory_match():
-    """``mcp:Gmail`` sub-category in categories matches ``mcp_gmail_*``
-    tool names (case-insensitive, spaces normalized)."""
+    """``mcp:Gmail`` scope matches tools whose ``source_server`` is
+    ``gmail`` (normalized at generation)."""
     # Use from_raw so ``mcp_servers`` is derived consistently with
     # ``categories`` -- direct ``_SpecByCategories`` construction with
     # ``mcp:<server>`` in categories but ``mcp_servers=None`` is
@@ -1276,9 +1320,10 @@ def test_compute_allowed_names_by_categories_mcp_subcategory_match():
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
     result = spec.compute_allowed_names(
         [
-            _mock_tool("mcp_gmail_send", "mcp"),
-            _mock_tool("mcp_gmail_read", "mcp"),
-            _mock_tool("mcp_slack_post", "mcp"),  # different server
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+            _mock_tool("mcp_gmail_read", "mcp", source_server="gmail"),
+            # different server
+            _mock_tool("mcp_slack_post", "mcp", source_server="slack"),
             _mock_tool("calc", "basic"),
         ]
     )
@@ -1519,8 +1564,8 @@ def test_compute_allowed_names_mcp_server_does_not_broaden_to_all_mcp():
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"])
     result = spec.compute_allowed_names(
         [
-            _mock_tool("mcp_gmail_send", "mcp"),
-            _mock_tool("mcp_slack_post", "mcp"),
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+            _mock_tool("mcp_slack_post", "mcp", source_server="slack"),
         ]
     )
     assert result == frozenset({"mcp_gmail_send"})
@@ -1532,9 +1577,9 @@ def test_compute_allowed_names_mixed_plain_and_server_picks():
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail", "other"])
     result = spec.compute_allowed_names(
         [
-            _mock_tool("mcp_gmail_send", "mcp"),
-            _mock_tool("mcp_slack_post", "mcp"),
-            _mock_tool("api_custom_call", "other"),
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+            _mock_tool("mcp_slack_post", "mcp", source_server="slack"),
+            _mock_tool("api_custom_call", "other", source_server="custom"),
             _mock_tool("calc", "basic"),
         ]
     )

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1701,28 +1701,26 @@ def test_from_raw_generic_name_allowlist_unions_into_results():
 
 
 def test_spec_wants_mcp_only_for_explicit_mcp_selection():
-    """``_spec_wants_mcp`` (chat.py) must NOT trigger MCP DB query for
-    default / no-MCP agents. Pin the contract here to keep the
-    derivation honest."""
-    from xagent.core.tools.adapters.vibe.selection_spec import _SpecAll, _SpecNone
+    """MCP config loading must only run for explicit MCP selections."""
+    from xagent.core.tools.adapters.vibe.selection_spec import (
+        _SpecAll,
+        _SpecNone,
+        should_load_mcp_server_configs,
+    )
     from xagent.web.api.chat import _spec_wants_mcp
 
-    assert _spec_wants_mcp(None) is False  # legacy / no-spec caller
-    assert _spec_wants_mcp(_SpecAll()) is False  # default agent
-    assert _spec_wants_mcp(_SpecNone()) is False  # explicit zero tools
-    assert (
-        _spec_wants_mcp(ToolSelectionSpec.from_raw(tool_categories=["basic"])) is False
-    )  # no mcp picked
-    assert (
-        _spec_wants_mcp(ToolSelectionSpec.from_raw(tool_categories=["mcp"])) is True
-    )  # plain mcp
-    assert (
-        _spec_wants_mcp(ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"]))
-        is True
-    )  # mcp:<server>
-    assert (
-        _spec_wants_mcp(
-            ToolSelectionSpec.from_raw(tool_categories=["basic", "mcp:Gmail"])
-        )
-        is True
-    )  # mixed
+    specs = [
+        (None, False),
+        (_SpecAll(), False),
+        (_SpecNone(), False),
+        (ToolSelectionSpec.from_raw(tool_categories=[]), False),
+        (ToolSelectionSpec.from_raw(tool_categories=None), False),
+        (ToolSelectionSpec.from_raw(tool_categories=["basic"]), False),
+        (ToolSelectionSpec.from_raw(tool_categories=["mcp"]), True),
+        (ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail"]), True),
+        (ToolSelectionSpec.from_raw(tool_categories=["basic", "mcp:Gmail"]), True),
+    ]
+
+    for spec, expected in specs:
+        assert should_load_mcp_server_configs(spec) is expected
+        assert _spec_wants_mcp(spec) is expected

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2086,7 +2086,10 @@ class TestCreateAndCallAgent:
             # mcp_servers only, not in categories (no raw string leak).
             assert "mcp:LinkedIn" not in spec.categories
             assert "mcp" not in spec.categories
-            assert spec.mcp_servers == frozenset({"LinkedIn"})
+            # mcp_servers holds the normalized server key (SSOT lower-cases /
+            # folds), matched at build time against each tool's
+            # metadata.source_server.
+            assert spec.mcp_servers == frozenset({"linkedin"})
         finally:
             db.close()
             try:

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2090,6 +2090,93 @@ class TestCreateAndCallAgent:
             # folds), matched at build time against each tool's
             # metadata.source_server.
             assert spec.mcp_servers == frozenset({"linkedin"})
+            # Delegated WebToolConfig single-sources the MCP-init decision
+            # from the spec (includes_mcp()), instead of falling back to the
+            # default True. An mcp:<server> selection -> include_mcp_tools True.
+            assert tool_config._include_mcp_tools is True
+        finally:
+            db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    async def test_delegated_basic_agent_disables_mcp_init(self) -> None:
+        """A delegated agent that did not select MCP (``tool_categories``
+        without ``mcp``) must build its WebToolConfig with
+        ``include_mcp_tools=False`` -- so it does not pay MCP server init.
+        Before single-sourcing this from the spec it fell back to the
+        WebToolConfig default ``True`` (divergent MCP-init decision)."""
+        db, db_path = _create_session()
+        try:
+            user = User(username="basicdeleg", password_hash="x", is_admin=False)
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            model = Model(
+                model_id="test-model-id",
+                category="llm",
+                model_provider="openai",
+                model_name="gpt-4",
+                api_key="test-api-key",
+                base_url="https://api.openai.com/v1",
+                temperature=0.7,
+                abilities=["chat"],
+            )
+            db.add(model)
+            db.commit()
+            db.refresh(model)
+
+            agent = Agent(
+                user_id=user.id,
+                name="Basic Assistant",
+                description="Nested non-MCP agent",
+                instructions="You are delegated.",
+                status=AgentStatus.PUBLISHED,
+                models={"general": model.id},
+                tool_categories=["basic"],
+            )
+            db.add(agent)
+            db.commit()
+            db.refresh(agent)
+
+            tool = AgentTool(
+                agent_id=agent.id,
+                agent_name=agent.name,
+                agent_description=agent.description or "",
+                db=db,
+                user_id=user.id,
+                task_id="parent-task-basic",
+            )
+
+            with (
+                patch(
+                    "xagent.web.services.llm_utils.UserAwareModelStorage"
+                ) as mock_storage_class,
+                patch(
+                    "xagent.core.agent.service.AgentService"
+                ) as mock_agent_service_class,
+                patch("xagent.core.memory.in_memory.InMemoryMemoryStore"),
+            ):
+                mock_storage = Mock()
+                mock_llm = Mock()
+                mock_storage.get_llm_by_name_with_access.return_value = mock_llm
+                mock_storage_class.return_value = mock_storage
+
+                mock_agent_service = mock_agent_service_class.return_value
+                mock_agent_service.execute_task = AsyncMock(
+                    return_value={"output": "nested response"}
+                )
+
+                await tool.run_json_async({"task": "do basic work"})
+
+            tool_config = mock_agent_service_class.call_args.kwargs["tool_config"]
+            spec = tool_config.get_tool_selection_spec()
+            assert spec.includes_mcp() is False
+            assert tool_config._include_mcp_tools is False
         finally:
             db.close()
             try:

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2090,9 +2090,9 @@ class TestCreateAndCallAgent:
             # folds), matched at build time against each tool's
             # metadata.source_server.
             assert spec.mcp_servers == frozenset({"linkedin"})
-            # Delegated WebToolConfig single-sources the MCP-init decision
-            # from the spec (includes_mcp()), instead of falling back to the
-            # default True. An mcp:<server> selection -> include_mcp_tools True.
+            # Delegated WebToolConfig uses the shared MCP config-loading
+            # helper instead of falling back to the default True. An
+            # mcp:<server> selection -> include_mcp_tools True.
             assert tool_config._include_mcp_tools is True
         finally:
             db.close()
@@ -2103,12 +2103,19 @@ class TestCreateAndCallAgent:
             except OSError:
                 pass
 
-    async def test_delegated_basic_agent_disables_mcp_init(self) -> None:
+    @pytest.mark.parametrize(
+        "tool_categories",
+        [["basic"], [], None],
+        ids=["basic-only", "empty-list", "null"],
+    )
+    async def test_delegated_non_mcp_agent_disables_mcp_init(
+        self, tool_categories: list[str] | None
+    ) -> None:
         """A delegated agent that did not select MCP (``tool_categories``
         without ``mcp``) must build its WebToolConfig with
         ``include_mcp_tools=False`` -- so it does not pay MCP server init.
-        Before single-sourcing this from the spec it fell back to the
-        WebToolConfig default ``True`` (divergent MCP-init decision)."""
+        Empty and NULL categories still build an ALL-mode selection spec
+        for final filtering, but should not opt into MCP config loading."""
         db, db_path = _create_session()
         try:
             user = User(username="basicdeleg", password_hash="x", is_admin=False)
@@ -2137,7 +2144,7 @@ class TestCreateAndCallAgent:
                 instructions="You are delegated.",
                 status=AgentStatus.PUBLISHED,
                 models={"general": model.id},
-                tool_categories=["basic"],
+                tool_categories=tool_categories,
             )
             db.add(agent)
             db.commit()
@@ -2175,7 +2182,11 @@ class TestCreateAndCallAgent:
 
             tool_config = mock_agent_service_class.call_args.kwargs["tool_config"]
             spec = tool_config.get_tool_selection_spec()
-            assert spec.includes_mcp() is False
+            if tool_categories:
+                assert spec.includes_mcp() is False
+            else:
+                assert spec.is_all()
+                assert spec.includes_mcp() is True
             assert tool_config._include_mcp_tools is False
         finally:
             db.close()

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2082,7 +2082,10 @@ class TestCreateAndCallAgent:
                 "spec, not ALL/NONE -- otherwise the factory's name filter "
                 "won't restrict to LinkedIn MCP tools."
             )
-            assert "mcp:LinkedIn" in spec.categories
+            # Orthogonal model: the mcp:<server> scope lands in
+            # mcp_servers only, not in categories (no raw string leak).
+            assert "mcp:LinkedIn" not in spec.categories
+            assert "mcp" not in spec.categories
             assert spec.mcp_servers == frozenset({"LinkedIn"})
         finally:
             db.close()


### PR DESCRIPTION
## Summary

Follow-up to PR #461: make tool selection a clean two-layer model across every dimension — **dispatch** (which creators run) vs **filter** (which tool names are admitted) — with no implicit back-derivation and no dead inputs.

Three independent commits:

1. **Orthogonalize `mcp:<server>` selection.** Split the overloaded `categories` set into plain `categories` + scoped `mcp_servers`; remove the `_user_picked` field that special-cased plain `mcp` vs `mcp:<server>` during name filtering. Generalize the workforce-only `name_extras` into a `name_allowlist`, and log a warning when both a spec and a legacy `allowed_tools` list are supplied (the spec wins).

2. **Declarative published-agent dispatch.** `includes_published_agent()` no longer triggers off `name_allowlist`; dispatch is declared by the `"agent"` category or `published_agent_ids`. The workforce path passes the worker agent ids it already holds, and narrows output via `name_allowlist`.

3. **Finish the `name_allowlist` boundary + drop dead inputs.** `name_allowlist` becomes a pure post-creator filter: `__post_init__` counts only dispatch dimensions as a selection, so a spec with only `name_allowlist` and no dispatch collapses to NONE. Remove the never-supplied `custom_api_ids` field and the `mcp_servers` override param.

Category→tool behavior is unchanged; the change removes back-derivation hacks and dead inputs and makes the dispatch/filter split consistent across all dimensions. Dispatch reads `categories` / `mcp_servers` / `published_agent_ids`; filter reads `categories` / `mcp_servers` / `name_allowlist`. Per-id filtering for published-agent / custom-api lives in the creator (config layer), since ids can't be mapped to tool names in the spec layer.

## Test
- `tests/core/tools/adapters/vibe/test_selection_spec.py` — orthogonality, `name_allowlist`-is-pure-filter pins, factory spec/allowed_tools warning, mcp plain-vs-server contracts.
- Workforce delegation (`test_workforce_run_service`, `test_workforce_builder_services`) and web entry points (chat, websocket build-preview) regression green.

Closes #539