### PR TITLE
refactor(kb): add version compatibility facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -23,6 +23,10 @@ from .models import (
 )
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .version_compatibility import (
+    KBMainPointerSnapshot,
+    KBVersionCompatibilityFacade,
+)
 
 __all__ = [
     "KBAccessMode",
@@ -35,11 +39,13 @@ __all__ = [
     "KBCoreManagementCompatibilityFacade",
     "KBCoordinator",
     "KBFileCompatibilityFacade",
+    "KBMainPointerSnapshot",
     "KBMaintenanceCompatibilityFacade",
     "KBParseDisplayCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",
     "KBUserScope",
+    "KBVersionCompatibilityFacade",
     "LanceDBCollectionHandle",
     "get_kb_coordinator",
     "reset_kb_coordinator_for_tests",

--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -25,6 +25,8 @@ from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
 from .version_compatibility import (
     KBMainPointerSnapshot,
+    KBVersionCandidateCleanupSnapshot,
+    KBVersionCandidateRollbackResult,
     KBVersionCompatibilityFacade,
 )
 
@@ -41,6 +43,8 @@ __all__ = [
     "KBFileCompatibilityFacade",
     "KBMainPointerSnapshot",
     "KBMaintenanceCompatibilityFacade",
+    "KBVersionCandidateCleanupSnapshot",
+    "KBVersionCandidateRollbackResult",
     "KBParseDisplayCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -24,6 +24,7 @@ from .models import (
 )
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .version_compatibility import KBVersionCompatibilityFacade
 
 T = TypeVar("T")
 
@@ -42,6 +43,7 @@ class KBCoordinator:
         management_facade: KBCoreManagementCompatibilityFacade | None = None,
         parse_display_compatibility: KBParseDisplayCompatibilityFacade | None = None,
         maintenance_compatibility: KBMaintenanceCompatibilityFacade | None = None,
+        version_compatibility: KBVersionCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -59,6 +61,9 @@ class KBCoordinator:
         self._maintenance_compatibility = (
             maintenance_compatibility
             or KBMaintenanceCompatibilityFacade(coordinator=self)
+        )
+        self._version_compatibility = (
+            version_compatibility or KBVersionCompatibilityFacade(coordinator=self)
         )
 
     @property
@@ -100,6 +105,16 @@ class KBCoordinator:
     def maintenance_compat(self) -> KBMaintenanceCompatibilityFacade:
         """Backward-friendly short alias for the maintenance facade."""
         return self._maintenance_compatibility
+
+    @property
+    def version_compatibility(self) -> KBVersionCompatibilityFacade:
+        """Return the version-management compatibility facade."""
+        return self._version_compatibility
+
+    @property
+    def version(self) -> KBVersionCompatibilityFacade:
+        """Backward-friendly short alias for the version facade."""
+        return self._version_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
@@ -1,0 +1,376 @@
+"""Version management compatibility facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from ..core.schemas import StepType
+from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+
+@dataclass(frozen=True)
+class KBMainPointerSnapshot:
+    """Snapshot of one main-pointer row before a version mutation."""
+
+    collection: str
+    doc_id: str
+    step_type: str
+    model_tag: Optional[str]
+    pointer: Optional[Dict[str, Any]]
+
+
+class KBVersionCompatibilityFacade:
+    """Compatibility boundary for legacy version-management helpers.
+
+    Version-management functions remain synchronous and keep their historical
+    import paths while coordinator-owned code gets one stable surface for
+    candidate listing, promotion, main-pointer operations, and cascade cleanup.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    def list_candidates(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: Union[StepType, str],
+        model_tag: Optional[str] = None,
+        state: Optional[str] = None,
+        limit: int = 50,
+        order_by: str = "created_at desc",
+    ) -> Dict[str, Any]:
+        from ..version_management.list_candidates import _list_candidates_impl
+
+        with self._storage_context():
+            return _list_candidates_impl(
+                collection=collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+                state=state,
+                limit=limit,
+                order_by=order_by,
+            )
+
+    def promote_version_main(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: Union[StepType, str],
+        selected_id: str,
+        operator: Optional[str] = None,
+        preview_only: bool = False,
+        confirm: bool = False,
+        model_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        from ..version_management.promote_version_main import _promote_version_main_impl
+
+        with self._storage_context():
+            return _promote_version_main_impl(
+                collection=collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                selected_id=selected_id,
+                operator=operator,
+                preview_only=preview_only,
+                confirm=confirm,
+                model_tag=model_tag,
+            )
+
+    def get_main_pointer(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        from ..version_management.main_pointer_manager import _get_main_pointer_impl
+
+        with self._storage_context():
+            return _get_main_pointer_impl(
+                collection=collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+            )
+
+    def set_main_pointer(
+        self,
+        lancedb_dir: str,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        semantic_id: str,
+        technical_id: str,
+        model_tag: Optional[str] = None,
+        operator: Optional[str] = None,
+    ) -> None:
+        from ..version_management.main_pointer_manager import _set_main_pointer_impl
+
+        with self._storage_context():
+            _set_main_pointer_impl(
+                lancedb_dir=lancedb_dir,
+                collection=collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                semantic_id=semantic_id,
+                technical_id=technical_id,
+                model_tag=model_tag,
+                operator=operator,
+            )
+
+    def list_main_pointers(
+        self, collection: str, doc_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        from ..version_management.main_pointer_manager import _list_main_pointers_impl
+
+        with self._storage_context():
+            return _list_main_pointers_impl(collection=collection, doc_id=doc_id)
+
+    def delete_main_pointer(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str] = None,
+    ) -> bool:
+        from ..version_management.main_pointer_manager import _delete_main_pointer_impl
+
+        with self._storage_context():
+            return _delete_main_pointer_impl(
+                collection=collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+            )
+
+    def capture_main_pointer_snapshot(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str] = None,
+    ) -> KBMainPointerSnapshot:
+        return KBMainPointerSnapshot(
+            collection=collection,
+            doc_id=doc_id,
+            step_type=step_type,
+            model_tag=model_tag,
+            pointer=self.get_main_pointer(collection, doc_id, step_type, model_tag),
+        )
+
+    def restore_main_pointer_snapshot(
+        self,
+        snapshot: KBMainPointerSnapshot,
+        *,
+        lancedb_dir: str = "",
+        operator: Optional[str] = None,
+    ) -> bool:
+        if snapshot.pointer is None:
+            return self.delete_main_pointer(
+                snapshot.collection,
+                snapshot.doc_id,
+                snapshot.step_type,
+                snapshot.model_tag,
+            )
+
+        self.set_main_pointer(
+            lancedb_dir,
+            snapshot.collection,
+            snapshot.doc_id,
+            snapshot.step_type,
+            snapshot.pointer["semantic_id"],
+            snapshot.pointer["technical_id"],
+            model_tag=snapshot.model_tag,
+            operator=operator,
+        )
+        return True
+
+    def cascade_delete(
+        self,
+        *,
+        target: Literal["collection", "document"],
+        collection: str,
+        doc_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        model_tag: Optional[str] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+        conn: Any | None = None,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cascade_delete_impl
+
+        with self._storage_context():
+            return _cascade_delete_impl(
+                target=target,
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+                model_tag=model_tag,
+                preview_only=preview_only,
+                confirm=confirm,
+                conn=conn,
+            )
+
+    def cleanup_cascade(
+        self,
+        collection: str,
+        doc_id: str,
+        scope: str,
+        new_parse_hash: Optional[str] = None,
+        old_parse_hash: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cleanup_cascade_impl
+
+        with self._storage_context():
+            return _cleanup_cascade_impl(
+                collection=collection,
+                doc_id=doc_id,
+                scope=scope,
+                new_parse_hash=new_parse_hash,
+                old_parse_hash=old_parse_hash,
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+
+    def cleanup_document_cascade(
+        self,
+        collection: str,
+        doc_id: str,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cleanup_document_cascade_impl
+
+        with self._storage_context():
+            return _cleanup_document_cascade_impl(
+                collection=collection,
+                doc_id=doc_id,
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+
+    def cleanup_parse_cascade(
+        self,
+        collection: str,
+        doc_id: str,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cleanup_parse_cascade_impl
+
+        with self._storage_context():
+            return _cleanup_parse_cascade_impl(
+                collection=collection,
+                doc_id=doc_id,
+                old_parse_hash=old_parse_hash,
+                new_parse_hash=new_parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+
+    def cleanup_chunk_cascade(
+        self,
+        collection: str,
+        doc_id: str,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cleanup_chunk_cascade_impl
+
+        with self._storage_context():
+            return _cleanup_chunk_cascade_impl(
+                collection=collection,
+                doc_id=doc_id,
+                old_parse_hash=old_parse_hash,
+                new_parse_hash=new_parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+
+    def cleanup_embed_cascade(
+        self,
+        collection: str,
+        doc_id: str,
+        model_tag: Optional[str] = None,
+        old_technical_id: Optional[str] = None,
+        new_technical_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..version_management.cascade_cleaner import _cleanup_embed_cascade_impl
+
+        with self._storage_context():
+            return _cleanup_embed_cascade_impl(
+                collection=collection,
+                doc_id=doc_id,
+                model_tag=model_tag,
+                old_technical_id=old_technical_id,
+                new_technical_id=new_technical_id,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )

--- a/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
@@ -237,13 +237,18 @@ class KBVersionCompatibilityFacade:
                 snapshot.model_tag,
             )
 
+        semantic_id = snapshot.pointer.get("semantic_id")
+        technical_id = snapshot.pointer.get("technical_id")
+        if not semantic_id or not technical_id:
+            return False
+
         self.set_main_pointer(
             lancedb_dir,
             snapshot.collection,
             snapshot.doc_id,
             snapshot.step_type,
-            snapshot.pointer["semantic_id"],
-            snapshot.pointer["technical_id"],
+            semantic_id,
+            technical_id,
             model_tag=snapshot.model_tag,
             operator=operator,
         )

--- a/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from ..core.schemas import StepType
 from typing_extensions import Literal
+
+from ..core.schemas import StepType
 
 if TYPE_CHECKING:
     from .coordinator import KBCoordinator
@@ -24,6 +25,36 @@ class KBMainPointerSnapshot:
     step_type: str
     model_tag: Optional[str]
     pointer: Optional[Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class KBVersionCandidateCleanupSnapshot:
+    """Preview snapshot for candidate cleanup before a version mutation."""
+
+    collection: str
+    doc_id: str
+    scope: str
+    cleanup_counts: Dict[str, int] = field(default_factory=dict)
+    new_parse_hash: Optional[str] = None
+    old_parse_hash: Optional[str] = None
+    model_tag: Optional[str] = None
+    user_id: Optional[int] = None
+    is_admin: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class KBVersionCandidateRollbackResult:
+    """Rollback outcome for version candidate cleanup side effects."""
+
+    collection: str
+    doc_id: str
+    status: str
+    skipped: bool = False
+    restorable: bool = False
+    reason: Optional[str] = None
+    cleanup_counts: Dict[str, int] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    side_effects_may_remain: bool = False
 
 
 class KBVersionCompatibilityFacade:
@@ -217,6 +248,75 @@ class KBVersionCompatibilityFacade:
             operator=operator,
         )
         return True
+
+    def capture_candidate_cleanup_snapshot(
+        self,
+        collection: str,
+        doc_id: str,
+        scope: str,
+        new_parse_hash: Optional[str] = None,
+        old_parse_hash: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+    ) -> KBVersionCandidateCleanupSnapshot:
+        cleanup_counts = self.cleanup_cascade(
+            collection=collection,
+            doc_id=doc_id,
+            scope=scope,
+            new_parse_hash=new_parse_hash,
+            old_parse_hash=old_parse_hash,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+            preview_only=True,
+            confirm=False,
+        )
+        return KBVersionCandidateCleanupSnapshot(
+            collection=collection,
+            doc_id=doc_id,
+            scope=scope,
+            cleanup_counts=cleanup_counts,
+            new_parse_hash=new_parse_hash,
+            old_parse_hash=old_parse_hash,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def restore_candidate_cleanup_snapshot(
+        self,
+        snapshot: KBVersionCandidateCleanupSnapshot,
+        *,
+        cleanup_executed: bool = False,
+    ) -> KBVersionCandidateRollbackResult:
+        cleanup_counts = dict(snapshot.cleanup_counts)
+        has_candidate_side_effects = any(
+            int(count) > 0 for count in cleanup_counts.values()
+        )
+        if not cleanup_executed or not has_candidate_side_effects:
+            return KBVersionCandidateRollbackResult(
+                collection=snapshot.collection,
+                doc_id=snapshot.doc_id,
+                status="not_needed",
+                restorable=True,
+                cleanup_counts=cleanup_counts,
+            )
+
+        return KBVersionCandidateRollbackResult(
+            collection=snapshot.collection,
+            doc_id=snapshot.doc_id,
+            status="incomplete",
+            skipped=True,
+            restorable=False,
+            reason="candidate_cleanup_not_restorable",
+            cleanup_counts=cleanup_counts,
+            warnings=(
+                "Version candidate cleanup cannot be restored from the compatibility facade; "
+                "preserve visible rollback state and report remaining side effects.",
+            ),
+            side_effects_may_remain=True,
+        )
 
     def cascade_delete(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
@@ -233,12 +233,13 @@ class KBVersionCompatibilityFacade:
         operator: Optional[str] = None,
     ) -> bool:
         if snapshot.pointer is None:
-            return self.delete_main_pointer(
+            self.delete_main_pointer(
                 snapshot.collection,
                 snapshot.doc_id,
                 snapshot.step_type,
                 snapshot.model_tag,
             )
+            return True
 
         semantic_id = snapshot.pointer.get("semantic_id")
         technical_id = snapshot.pointer.get("technical_id")

--- a/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/version_compatibility.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -10,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from typing_extensions import Literal
 
 from ..core.schemas import StepType
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .coordinator import KBCoordinator
@@ -240,6 +243,13 @@ class KBVersionCompatibilityFacade:
         semantic_id = snapshot.pointer.get("semantic_id")
         technical_id = snapshot.pointer.get("technical_id")
         if not semantic_id or not technical_id:
+            logger.warning(
+                "Failed to restore main pointer snapshot for %s/%s/%s: "
+                "missing semantic_id or technical_id",
+                snapshot.collection,
+                snapshot.doc_id,
+                snapshot.step_type,
+            )
             return False
 
         self.set_main_pointer(

--- a/src/xagent/core/tools/core/RAG_tools/version_management/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/__init__.py
@@ -5,6 +5,7 @@ maintaining main pointers with cascade cleanup.
 """
 
 from .cascade_cleaner import (
+    cascade_delete,
     cleanup_cascade,
     cleanup_chunk_cascade,
     cleanup_document_cascade,
@@ -28,6 +29,7 @@ __all__ = [
     "list_main_pointers",
     "delete_main_pointer",
     "cleanup_parse_cascade",
+    "cascade_delete",
     "cleanup_chunk_cascade",
     "cleanup_embed_cascade",
     "cleanup_document_cascade",

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -7,7 +7,7 @@ ensuring data consistency across processing stages.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from typing_extensions import Literal
 
@@ -29,9 +29,18 @@ from ..utils.string_utils import (
 )
 from ..utils.user_permissions import UserPermissions
 from ..utils.user_scope import resolve_user_scope
-from .main_pointer_manager import get_main_pointer
+from .main_pointer_manager import _get_main_pointer_impl as get_main_pointer
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..kb import KBVersionCompatibilityFacade
+
+
+def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().version_compatibility
 
 
 def _table_has_column(table: Any, column: str) -> bool:
@@ -407,6 +416,31 @@ def cascade_delete(
     confirm: bool = False,
     conn: Any | None = None,
 ) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cascade_delete(
+        target=target,
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+        model_tag=model_tag,
+        preview_only=preview_only,
+        confirm=confirm,
+        conn=conn,
+    )
+
+
+def _cascade_delete_impl(
+    *,
+    target: Literal["collection", "document"],
+    collection: str,
+    doc_id: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    model_tag: Optional[str] = None,
+    preview_only: bool = True,
+    confirm: bool = False,
+    conn: Any | None = None,
+) -> Dict[str, int]:
     """Unified cascade delete for collection or document targets.
 
     This is intended for user-facing destructive operations (e.g. KB delete)
@@ -576,6 +610,32 @@ def cleanup_cascade(
     preview_only: bool = True,
     confirm: bool = False,
 ) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cleanup_cascade(
+        collection=collection,
+        doc_id=doc_id,
+        scope=scope,
+        new_parse_hash=new_parse_hash,
+        old_parse_hash=old_parse_hash,
+        model_tag=model_tag,
+        user_id=user_id,
+        is_admin=is_admin,
+        preview_only=preview_only,
+        confirm=confirm,
+    )
+
+
+def _cleanup_cascade_impl(
+    collection: str,
+    doc_id: str,
+    scope: str,
+    new_parse_hash: Optional[str] = None,
+    old_parse_hash: Optional[str] = None,
+    model_tag: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    preview_only: bool = True,
+    confirm: bool = False,
+) -> Dict[str, int]:
     """Unified cascade cleanup by scope with preview/confirm semantics.
 
     Args:
@@ -608,7 +668,7 @@ def cleanup_cascade(
     ensure_main_pointers_table(conn)
 
     if scope == "document":
-        raw = cascade_delete(
+        raw = _cascade_delete_impl(
             target="document",
             collection=collection,
             doc_id=doc_id,
@@ -788,6 +848,26 @@ def cleanup_document_cascade(
     preview_only: bool = True,
     confirm: bool = False,
 ) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cleanup_document_cascade(
+        collection=collection,
+        doc_id=doc_id,
+        model_tag=model_tag,
+        user_id=user_id,
+        is_admin=is_admin,
+        preview_only=preview_only,
+        confirm=confirm,
+    )
+
+
+def _cleanup_document_cascade_impl(
+    collection: str,
+    doc_id: str,
+    model_tag: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+    preview_only: bool = True,
+    confirm: bool = False,
+) -> Dict[str, int]:
     """Cascade delete all data for a document across all stages.
 
     Order: embeddings_* -> chunks -> parses -> main_pointers -> documents
@@ -802,7 +882,7 @@ def cleanup_document_cascade(
     """
     try:
         # Delegate to unified entry
-        return cleanup_cascade(
+        return _cleanup_cascade_impl(
             collection=collection,
             doc_id=doc_id,
             scope="document",
@@ -818,6 +898,28 @@ def cleanup_document_cascade(
 
 
 def cleanup_parse_cascade(
+    collection: str,
+    doc_id: str,
+    old_parse_hash: Optional[str] = None,
+    new_parse_hash: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+    preview_only: bool = True,
+    confirm: bool = False,
+) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cleanup_parse_cascade(
+        collection=collection,
+        doc_id=doc_id,
+        old_parse_hash=old_parse_hash,
+        new_parse_hash=new_parse_hash,
+        user_id=user_id,
+        is_admin=is_admin,
+        preview_only=preview_only,
+        confirm=confirm,
+    )
+
+
+def _cleanup_parse_cascade_impl(
     collection: str,
     doc_id: str,
     old_parse_hash: Optional[str] = None,
@@ -846,7 +948,7 @@ def cleanup_parse_cascade(
         CascadeCleanupError: If cleanup fails
     """
     try:
-        return cleanup_cascade(
+        return _cleanup_cascade_impl(
             collection=collection,
             doc_id=doc_id,
             scope="parse",
@@ -863,6 +965,28 @@ def cleanup_parse_cascade(
 
 
 def cleanup_chunk_cascade(
+    collection: str,
+    doc_id: str,
+    old_parse_hash: Optional[str] = None,
+    new_parse_hash: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+    preview_only: bool = True,
+    confirm: bool = False,
+) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cleanup_chunk_cascade(
+        collection=collection,
+        doc_id=doc_id,
+        old_parse_hash=old_parse_hash,
+        new_parse_hash=new_parse_hash,
+        user_id=user_id,
+        is_admin=is_admin,
+        preview_only=preview_only,
+        confirm=confirm,
+    )
+
+
+def _cleanup_chunk_cascade_impl(
     collection: str,
     doc_id: str,
     old_parse_hash: Optional[str] = None,
@@ -891,7 +1015,7 @@ def cleanup_chunk_cascade(
         CascadeCleanupError: If cleanup fails
     """
     try:
-        return cleanup_cascade(
+        return _cleanup_cascade_impl(
             collection=collection,
             doc_id=doc_id,
             scope="chunk",
@@ -908,6 +1032,30 @@ def cleanup_chunk_cascade(
 
 
 def cleanup_embed_cascade(
+    collection: str,
+    doc_id: str,
+    model_tag: Optional[str] = None,
+    old_technical_id: Optional[str] = None,
+    new_technical_id: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = True,
+    preview_only: bool = True,
+    confirm: bool = False,
+) -> Dict[str, int]:
+    return _get_version_compatibility_facade().cleanup_embed_cascade(
+        collection=collection,
+        doc_id=doc_id,
+        model_tag=model_tag,
+        old_technical_id=old_technical_id,
+        new_technical_id=new_technical_id,
+        user_id=user_id,
+        is_admin=is_admin,
+        preview_only=preview_only,
+        confirm=confirm,
+    )
+
+
+def _cleanup_embed_cascade_impl(
     collection: str,
     doc_id: str,
     model_tag: Optional[str] = None,
@@ -938,7 +1086,7 @@ def cleanup_embed_cascade(
     """
     try:
         # Delegate to unified entry; old/new technical ids are not used in current schema
-        return cleanup_cascade(
+        return _cleanup_cascade_impl(
             collection=collection,
             doc_id=doc_id,
             scope="embeddings",

--- a/src/xagent/core/tools/core/RAG_tools/version_management/list_candidates.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/list_candidates.py
@@ -7,7 +7,7 @@ across different processing stages (parse, chunk, embed).
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..core.exceptions import DatabaseOperationError, VersionManagementError
 from ..core.schemas import StepType
@@ -15,6 +15,15 @@ from ..LanceDB.schema_manager import _safe_close_table
 from ..storage.factory import get_vector_store_raw_connection
 from ..utils.lancedb_query_utils import list_table_names, query_to_list
 from ..utils.string_utils import build_lancedb_filter_expression
+
+if TYPE_CHECKING:
+    from ..kb import KBVersionCompatibilityFacade
+
+
+def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().version_compatibility
 
 
 def _resolve_step_type(step_type_input: Union[StepType, str]) -> StepType:
@@ -320,6 +329,26 @@ def _get_candidates(
 
 
 def list_candidates(
+    collection: str,
+    doc_id: str,
+    step_type: Union[StepType, str],
+    model_tag: Optional[str] = None,
+    state: Optional[str] = None,
+    limit: int = 50,
+    order_by: str = "created_at desc",
+) -> Dict[str, Any]:
+    return _get_version_compatibility_facade().list_candidates(
+        collection=collection,
+        doc_id=doc_id,
+        step_type=step_type,
+        model_tag=model_tag,
+        state=state,
+        limit=limit,
+        order_by=order_by,
+    )
+
+
+def _list_candidates_impl(
     collection: str,
     doc_id: str,
     step_type: Union[StepType, str],

--- a/src/xagent/core/tools/core/RAG_tools/version_management/main_pointer_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/main_pointer_manager.py
@@ -9,12 +9,21 @@ Phase 1A Part 2: Refactored to use MainPointerStore abstraction layer.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..core.exceptions import MainPointerError
 from ..storage.factory import get_main_pointer_store
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..kb import KBVersionCompatibilityFacade
+
+
+def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().version_compatibility
 
 
 def _normalize_model_tag(model_tag: Optional[str]) -> str:
@@ -23,6 +32,17 @@ def _normalize_model_tag(model_tag: Optional[str]) -> str:
 
 
 def get_main_pointer(
+    collection: str, doc_id: str, step_type: str, model_tag: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    return _get_version_compatibility_facade().get_main_pointer(
+        collection=collection,
+        doc_id=doc_id,
+        step_type=step_type,
+        model_tag=model_tag,
+    )
+
+
+def _get_main_pointer_impl(
     collection: str, doc_id: str, step_type: str, model_tag: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     """Get the main pointer for a specific document and stage.
@@ -53,6 +73,28 @@ def get_main_pointer(
 
 
 def set_main_pointer(
+    lancedb_dir: str,  # Kept for backward compatibility
+    collection: str,
+    doc_id: str,
+    step_type: str,
+    semantic_id: str,
+    technical_id: str,
+    model_tag: Optional[str] = None,
+    operator: Optional[str] = None,
+) -> None:
+    _get_version_compatibility_facade().set_main_pointer(
+        lancedb_dir=lancedb_dir,
+        collection=collection,
+        doc_id=doc_id,
+        step_type=step_type,
+        semantic_id=semantic_id,
+        technical_id=technical_id,
+        model_tag=model_tag,
+        operator=operator,
+    )
+
+
+def _set_main_pointer_impl(
     lancedb_dir: str,  # Kept for backward compatibility
     collection: str,
     doc_id: str,
@@ -105,6 +147,15 @@ def set_main_pointer(
 def list_main_pointers(
     collection: str, doc_id: Optional[str] = None
 ) -> List[Dict[str, Any]]:
+    return _get_version_compatibility_facade().list_main_pointers(
+        collection=collection,
+        doc_id=doc_id,
+    )
+
+
+def _list_main_pointers_impl(
+    collection: str, doc_id: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """List main pointers for a collection and optionally a specific document.
 
     Args:
@@ -131,6 +182,17 @@ def list_main_pointers(
 
 
 def delete_main_pointer(
+    collection: str, doc_id: str, step_type: str, model_tag: Optional[str] = None
+) -> bool:
+    return _get_version_compatibility_facade().delete_main_pointer(
+        collection=collection,
+        doc_id=doc_id,
+        step_type=step_type,
+        model_tag=model_tag,
+    )
+
+
+def _delete_main_pointer_impl(
     collection: str, doc_id: str, step_type: str, model_tag: Optional[str] = None
 ) -> bool:
     """Delete a main pointer.

--- a/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
@@ -111,7 +111,7 @@ def _call_cleanup_cascade(
         return cleanup_cascade(
             collection=collection,
             doc_id=doc_id,
-            scope="embed",
+            scope="embeddings",
             model_tag=model_tag,
             preview_only=preview_only,
             confirm=confirm,

--- a/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/promote_version_main.py
@@ -8,15 +8,25 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..core.exceptions import VersionManagementError
 from ..core.schemas import StepType
-from .cascade_cleaner import cleanup_cascade
-from .list_candidates import list_candidates
-from .main_pointer_manager import get_main_pointer, set_main_pointer
+from .cascade_cleaner import _cleanup_cascade_impl as cleanup_cascade
+from .list_candidates import _list_candidates_impl as list_candidates
+from .main_pointer_manager import _get_main_pointer_impl as get_main_pointer
+from .main_pointer_manager import _set_main_pointer_impl as set_main_pointer
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..kb import KBVersionCompatibilityFacade
+
+
+def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().version_compatibility
 
 
 def _resolve_step_type(step_type_input: Union[StepType, str]) -> StepType:
@@ -233,6 +243,28 @@ def _calculate_cleanup_plan(
 
 
 def promote_version_main(
+    collection: str,
+    doc_id: str,
+    step_type: Union[StepType, str],
+    selected_id: str,
+    operator: Optional[str] = None,
+    preview_only: bool = False,
+    confirm: bool = False,
+    model_tag: Optional[str] = None,
+) -> Dict[str, Any]:
+    return _get_version_compatibility_facade().promote_version_main(
+        collection=collection,
+        doc_id=doc_id,
+        step_type=step_type,
+        selected_id=selected_id,
+        operator=operator,
+        preview_only=preview_only,
+        confirm=confirm,
+        model_tag=model_tag,
+    )
+
+
+def _promote_version_main_impl(
     collection: str,
     doc_id: str,
     step_type: Union[StepType, str],

--- a/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
@@ -1,0 +1,502 @@
+"""Tests for the KB version-management compatibility facade."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeMainPointerStore:
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str, str, Optional[str]], dict[str, Any]] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _key(
+        self,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str],
+    ) -> tuple[str, str, str, Optional[str]]:
+        return (collection, doc_id, step_type, model_tag)
+
+    def get_main_pointer(
+        self,
+        *,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str],
+        user_id: Optional[int],
+    ) -> Optional[dict[str, Any]]:
+        self.calls.append(("get", dict(locals())))
+        row = self.rows.get(self._key(collection, doc_id, step_type, model_tag))
+        return dict(row) if row is not None else None
+
+    def set_main_pointer(
+        self,
+        *,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        semantic_id: str,
+        technical_id: str,
+        model_tag: Optional[str],
+        operator: Optional[str],
+        user_id: Optional[int],
+    ) -> None:
+        self.calls.append(("set", dict(locals())))
+        self.rows[self._key(collection, doc_id, step_type, model_tag)] = {
+            "collection": collection,
+            "doc_id": doc_id,
+            "step_type": step_type,
+            "semantic_id": semantic_id,
+            "technical_id": technical_id,
+            "model_tag": model_tag,
+            "operator": operator,
+        }
+
+    def list_main_pointers(
+        self,
+        *,
+        collection: str,
+        doc_id: Optional[str],
+        user_id: Optional[int],
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        self.calls.append(("list", dict(locals())))
+        rows = [
+            dict(row)
+            for (row_collection, row_doc_id, _, _), row in self.rows.items()
+            if row_collection == collection and (doc_id is None or row_doc_id == doc_id)
+        ]
+        return rows[:limit]
+
+    def delete_main_pointer(
+        self,
+        *,
+        collection: str,
+        doc_id: str,
+        step_type: str,
+        model_tag: Optional[str],
+        user_id: Optional[int],
+    ) -> bool:
+        self.calls.append(("delete", dict(locals())))
+        return (
+            self.rows.pop(self._key(collection, doc_id, step_type, model_tag), None)
+            is not None
+        )
+
+
+class _FakeStorageShim:
+    def __init__(self, main_pointer_store: _FakeMainPointerStore) -> None:
+        self.main_pointer_store = main_pointer_store
+
+    def get_main_pointer_store(self) -> _FakeMainPointerStore:
+        return self.main_pointer_store
+
+
+def _signature_shape(callable_obj: Any) -> inspect.Signature:
+    return inspect.signature(callable_obj)
+
+
+def test_kb_version_compatibility_public_surface_imports() -> None:
+    """Given the KB package, the version facade is publicly importable."""
+    import xagent.core.tools.core.RAG_tools.kb as kb
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBMainPointerSnapshot,
+        KBVersionCompatibilityFacade,
+        get_kb_coordinator,
+        reset_kb_coordinator_for_tests,
+    )
+
+    assert hasattr(kb, "KBVersionCompatibilityFacade")
+    assert hasattr(kb, "KBMainPointerSnapshot")
+    reset_kb_coordinator_for_tests()
+    coordinator = get_kb_coordinator()
+    assert isinstance(coordinator.version_compatibility, KBVersionCompatibilityFacade)
+    assert coordinator.version is coordinator.version_compatibility
+    assert KBMainPointerSnapshot.__name__ == "KBMainPointerSnapshot"
+
+
+def test_version_facade_methods_match_public_helper_signatures() -> None:
+    """Given legacy helpers, facade methods preserve public call signatures."""
+    from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade
+
+    cascade_cleaner = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner"
+    )
+    list_candidates = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.list_candidates"
+    )
+    main_pointer_manager = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.main_pointer_manager"
+    )
+    promote_version_main = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.promote_version_main"
+    )
+
+    facade = KBVersionCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMainPointerStore())
+    )
+    pairs = [
+        (facade.list_candidates, list_candidates.list_candidates),
+        (facade.promote_version_main, promote_version_main.promote_version_main),
+        (facade.get_main_pointer, main_pointer_manager.get_main_pointer),
+        (facade.set_main_pointer, main_pointer_manager.set_main_pointer),
+        (facade.list_main_pointers, main_pointer_manager.list_main_pointers),
+        (facade.delete_main_pointer, main_pointer_manager.delete_main_pointer),
+        (facade.cascade_delete, cascade_cleaner.cascade_delete),
+        (facade.cleanup_cascade, cascade_cleaner.cleanup_cascade),
+        (facade.cleanup_document_cascade, cascade_cleaner.cleanup_document_cascade),
+        (facade.cleanup_parse_cascade, cascade_cleaner.cleanup_parse_cascade),
+        (facade.cleanup_chunk_cascade, cascade_cleaner.cleanup_chunk_cascade),
+        (facade.cleanup_embed_cascade, cascade_cleaner.cleanup_embed_cascade),
+    ]
+
+    for facade_method, public_helper in pairs:
+        assert _signature_shape(facade_method) == _signature_shape(public_helper)
+
+
+def test_version_management_package_exports_retained_functions_and_cascade_delete() -> (
+    None
+):
+    """Given package-level imports, retained version helpers remain available."""
+    import xagent.core.tools.core.RAG_tools.version_management as version_management
+
+    expected = {
+        "list_candidates",
+        "promote_version_main",
+        "get_main_pointer",
+        "set_main_pointer",
+        "list_main_pointers",
+        "delete_main_pointer",
+        "cleanup_cascade",
+        "cleanup_document_cascade",
+        "cleanup_parse_cascade",
+        "cleanup_chunk_cascade",
+        "cleanup_embed_cascade",
+        "cascade_delete",
+    }
+
+    assert expected.issubset(set(version_management.__all__))
+    for name in expected:
+        assert hasattr(version_management, name)
+        assert not inspect.iscoroutinefunction(getattr(version_management, name))
+
+
+def test_public_version_helpers_remain_sync_and_route_through_facade(
+    monkeypatch,
+) -> None:
+    """Given public version helper calls, they synchronously route through facade."""
+    cascade_cleaner = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner"
+    )
+    list_candidates = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.list_candidates"
+    )
+    main_pointer_manager = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.main_pointer_manager"
+    )
+    promote_version_main = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.promote_version_main"
+    )
+
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    class _FakeFacade:
+        def list_candidates(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            calls.append(("list_candidates", args, kwargs))
+            return {"candidates": [], "total_count": 0, "returned_count": 0}
+
+        def promote_version_main(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            calls.append(("promote_version_main", args, kwargs))
+            return {"promoted": False, "preview": True}
+
+        def get_main_pointer(self, *args: Any, **kwargs: Any) -> None:
+            calls.append(("get_main_pointer", args, kwargs))
+            return None
+
+        def cascade_delete(self, *args: Any, **kwargs: Any) -> dict[str, int]:
+            calls.append(("cascade_delete", args, kwargs))
+            return {"documents": 1}
+
+    fake_facade = _FakeFacade()
+    monkeypatch.setattr(
+        list_candidates,
+        "_get_version_compatibility_facade",
+        lambda: fake_facade,
+    )
+    monkeypatch.setattr(
+        promote_version_main,
+        "_get_version_compatibility_facade",
+        lambda: fake_facade,
+    )
+    monkeypatch.setattr(
+        main_pointer_manager,
+        "_get_version_compatibility_facade",
+        lambda: fake_facade,
+    )
+    monkeypatch.setattr(
+        cascade_cleaner,
+        "_get_version_compatibility_facade",
+        lambda: fake_facade,
+    )
+
+    assert not inspect.iscoroutinefunction(list_candidates.list_candidates)
+    assert not inspect.iscoroutinefunction(promote_version_main.promote_version_main)
+    assert not inspect.iscoroutinefunction(main_pointer_manager.get_main_pointer)
+    assert not inspect.iscoroutinefunction(cascade_cleaner.cascade_delete)
+
+    assert list_candidates.list_candidates("docs", "doc-1", "parse") == {
+        "candidates": [],
+        "total_count": 0,
+        "returned_count": 0,
+    }
+    assert promote_version_main.promote_version_main(
+        "docs", "doc-1", "parse", "parse_manual_abc", preview_only=True
+    ) == {"promoted": False, "preview": True}
+    assert main_pointer_manager.get_main_pointer("docs", "doc-1", "parse") is None
+    assert cascade_cleaner.cascade_delete(
+        target="document", collection="docs", doc_id="doc-1"
+    ) == {"documents": 1}
+
+    assert calls == [
+        (
+            "list_candidates",
+            (),
+            {
+                "collection": "docs",
+                "doc_id": "doc-1",
+                "step_type": "parse",
+                "model_tag": None,
+                "state": None,
+                "limit": 50,
+                "order_by": "created_at desc",
+            },
+        ),
+        (
+            "promote_version_main",
+            (),
+            {
+                "collection": "docs",
+                "doc_id": "doc-1",
+                "step_type": "parse",
+                "selected_id": "parse_manual_abc",
+                "operator": None,
+                "preview_only": True,
+                "confirm": False,
+                "model_tag": None,
+            },
+        ),
+        (
+            "get_main_pointer",
+            (),
+            {
+                "collection": "docs",
+                "doc_id": "doc-1",
+                "step_type": "parse",
+                "model_tag": None,
+            },
+        ),
+        (
+            "cascade_delete",
+            (),
+            {
+                "target": "document",
+                "collection": "docs",
+                "doc_id": "doc-1",
+                "user_id": None,
+                "is_admin": None,
+                "model_tag": None,
+                "preview_only": True,
+                "confirm": False,
+                "conn": None,
+            },
+        ),
+    ]
+
+
+def test_version_facade_rebinds_coordinator_storage_for_main_pointers() -> None:
+    """Facade delegation rebinds storage factory access to its coordinator shim."""
+    from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        bind_storage_shim_for_current_context,
+        get_main_pointer_store,
+    )
+
+    outer_store = _FakeMainPointerStore()
+    inner_store = _FakeMainPointerStore()
+    outer_shim = _FakeStorageShim(outer_store)
+    inner_shim = _FakeStorageShim(inner_store)
+    facade = KBVersionCompatibilityFacade(storage_shim=inner_shim)
+
+    with bind_storage_shim_for_current_context(outer_shim):
+        assert get_main_pointer_store() is outer_store
+        facade.set_main_pointer(
+            "",
+            "docs",
+            "doc-inner",
+            "parse",
+            "parse_manual_abc",
+            "parse-hash-abc",
+            operator="tester",
+        )
+        assert facade.get_main_pointer("docs", "doc-inner", "parse")[
+            "technical_id"
+        ] == ("parse-hash-abc")
+        assert get_main_pointer_store() is outer_store
+
+    assert outer_store.rows == {}
+    assert (
+        inner_store.list_main_pointers(
+            collection="docs", doc_id="doc-inner", user_id=None, limit=100
+        )[0]["semantic_id"]
+        == "parse_manual_abc"
+    )
+
+
+def test_main_pointer_snapshot_restore_reverts_mutated_pointer() -> None:
+    """Rollback-facing snapshot hooks can restore the previous main pointer."""
+    from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade
+
+    store = _FakeMainPointerStore()
+    facade = KBVersionCompatibilityFacade(storage_shim=_FakeStorageShim(store))
+    facade.set_main_pointer(
+        "",
+        "docs",
+        "doc-1",
+        "parse",
+        "parse_old",
+        "old-hash",
+        operator="setup",
+    )
+
+    snapshot = facade.capture_main_pointer_snapshot("docs", "doc-1", "parse")
+    facade.set_main_pointer(
+        "",
+        "docs",
+        "doc-1",
+        "parse",
+        "parse_new",
+        "new-hash",
+        operator="mutator",
+    )
+
+    assert (
+        facade.get_main_pointer("docs", "doc-1", "parse")["technical_id"] == "new-hash"
+    )
+    assert facade.restore_main_pointer_snapshot(snapshot, operator="rollback")
+    restored = facade.get_main_pointer("docs", "doc-1", "parse")
+    assert restored is not None
+    assert restored["semantic_id"] == "parse_old"
+    assert restored["technical_id"] == "old-hash"
+
+
+def test_cleanup_count_shape_is_preserved_through_version_facade(monkeypatch) -> None:
+    """Cleanup count keys and values pass through facade delegation unchanged."""
+    from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade
+
+    cascade_cleaner = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner"
+    )
+
+    expected = {
+        "embeddings": 3,
+        "chunks": 2,
+        "parses": 1,
+        "main_pointers": 1,
+        "documents": 1,
+        "ingestion_runs": 1,
+    }
+    calls: list[dict[str, Any]] = []
+
+    def fake_cleanup_document_cascade_impl(**kwargs: Any) -> dict[str, int]:
+        calls.append(dict(kwargs))
+        return expected
+
+    monkeypatch.setattr(
+        cascade_cleaner,
+        "_cleanup_document_cascade_impl",
+        fake_cleanup_document_cascade_impl,
+    )
+
+    result = KBVersionCompatibilityFacade().cleanup_document_cascade(
+        "docs",
+        "doc-1",
+        model_tag="text-embedding-3-small",
+        user_id=7,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert result == expected
+    assert calls == [
+        {
+            "collection": "docs",
+            "doc_id": "doc-1",
+            "model_tag": "text-embedding-3-small",
+            "user_id": 7,
+            "is_admin": False,
+            "preview_only": False,
+            "confirm": True,
+        }
+    ]
+
+
+def test_failed_promotion_does_not_advance_main_pointer(monkeypatch) -> None:
+    """Failed cleanup during promotion does not call set_main_pointer."""
+    from xagent.core.tools.core.RAG_tools.core.exceptions import VersionManagementError
+    from xagent.core.tools.core.RAG_tools.core.schemas import StepType
+
+    promote_version_main = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.promote_version_main"
+    )
+
+    mock_list_candidates = MagicMock(
+        return_value={
+            "candidates": [
+                {
+                    "technical_id": "new-hash",
+                    "semantic_id": "parse_new",
+                }
+            ]
+        }
+    )
+    mock_cleanup_plan = MagicMock(
+        return_value={
+            "deleted_counts": {"chunks": 1, "embeddings": 1},
+            "notes": [],
+            "current_pointer": {
+                "technical_id": "old-hash",
+                "semantic_id": "parse_old",
+            },
+            "new_technical_id": "new-hash",
+        }
+    )
+    mock_cleanup = MagicMock(side_effect=RuntimeError("cleanup failed"))
+    mock_set_main_pointer = MagicMock()
+
+    monkeypatch.setattr(promote_version_main, "list_candidates", mock_list_candidates)
+    monkeypatch.setattr(
+        promote_version_main, "_calculate_cleanup_plan", mock_cleanup_plan
+    )
+    monkeypatch.setattr(promote_version_main, "cleanup_cascade", mock_cleanup)
+    monkeypatch.setattr(promote_version_main, "set_main_pointer", mock_set_main_pointer)
+
+    with pytest.raises(VersionManagementError, match="cleanup failed"):
+        promote_version_main.promote_version_main(
+            "docs",
+            "doc-1",
+            StepType.PARSE,
+            "parse_new",
+            operator="tester",
+            confirm=True,
+        )
+
+    mock_set_main_pointer.assert_not_called()

--- a/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
@@ -408,6 +408,36 @@ def test_main_pointer_snapshot_restore_reverts_mutated_pointer() -> None:
     assert restored["technical_id"] == "old-hash"
 
 
+def test_main_pointer_snapshot_restore_returns_false_for_incomplete_pointer() -> None:
+    """Incomplete main-pointer snapshots report restore failure without crashing."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBMainPointerSnapshot,
+        KBVersionCompatibilityFacade,
+    )
+
+    facade = KBVersionCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMainPointerStore())
+    )
+    missing_semantic = KBMainPointerSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        step_type="parse",
+        model_tag=None,
+        pointer={"technical_id": "parse-hash"},
+    )
+    missing_technical = KBMainPointerSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        step_type="parse",
+        model_tag=None,
+        pointer={"semantic_id": "parse_manual_hash"},
+    )
+
+    assert not facade.restore_main_pointer_snapshot(missing_semantic)
+    assert not facade.restore_main_pointer_snapshot(missing_technical)
+    assert facade.list_main_pointers("docs") == []
+
+
 def test_candidate_cleanup_snapshot_records_preview_counts(monkeypatch) -> None:
     """Candidate cleanup snapshots record preview counts without deleting rows."""
     from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade

--- a/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
@@ -109,6 +109,8 @@ def test_kb_version_compatibility_public_surface_imports() -> None:
     import xagent.core.tools.core.RAG_tools.kb as kb
     from xagent.core.tools.core.RAG_tools.kb import (
         KBMainPointerSnapshot,
+        KBVersionCandidateCleanupSnapshot,
+        KBVersionCandidateRollbackResult,
         KBVersionCompatibilityFacade,
         get_kb_coordinator,
         reset_kb_coordinator_for_tests,
@@ -116,11 +118,20 @@ def test_kb_version_compatibility_public_surface_imports() -> None:
 
     assert hasattr(kb, "KBVersionCompatibilityFacade")
     assert hasattr(kb, "KBMainPointerSnapshot")
+    assert hasattr(kb, "KBVersionCandidateCleanupSnapshot")
+    assert hasattr(kb, "KBVersionCandidateRollbackResult")
     reset_kb_coordinator_for_tests()
     coordinator = get_kb_coordinator()
     assert isinstance(coordinator.version_compatibility, KBVersionCompatibilityFacade)
     assert coordinator.version is coordinator.version_compatibility
     assert KBMainPointerSnapshot.__name__ == "KBMainPointerSnapshot"
+    assert (
+        KBVersionCandidateCleanupSnapshot.__name__
+        == "KBVersionCandidateCleanupSnapshot"
+    )
+    assert (
+        KBVersionCandidateRollbackResult.__name__ == "KBVersionCandidateRollbackResult"
+    )
 
 
 def test_version_facade_methods_match_public_helper_signatures() -> None:
@@ -395,6 +406,146 @@ def test_main_pointer_snapshot_restore_reverts_mutated_pointer() -> None:
     assert restored is not None
     assert restored["semantic_id"] == "parse_old"
     assert restored["technical_id"] == "old-hash"
+
+
+def test_candidate_cleanup_snapshot_records_preview_counts(monkeypatch) -> None:
+    """Candidate cleanup snapshots record preview counts without deleting rows."""
+    from xagent.core.tools.core.RAG_tools.kb import KBVersionCompatibilityFacade
+
+    cascade_cleaner = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner"
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_cleanup_cascade_impl(**kwargs: Any) -> dict[str, int]:
+        calls.append(dict(kwargs))
+        return {"chunks": 2, "embeddings": 5}
+
+    monkeypatch.setattr(
+        cascade_cleaner,
+        "_cleanup_cascade_impl",
+        fake_cleanup_cascade_impl,
+    )
+
+    snapshot = KBVersionCompatibilityFacade().capture_candidate_cleanup_snapshot(
+        "docs",
+        "doc-1",
+        "parse",
+        new_parse_hash="new-hash",
+        old_parse_hash="old-hash",
+        model_tag="text-embedding-3-small",
+        user_id=7,
+        is_admin=False,
+    )
+
+    assert snapshot.cleanup_counts == {"chunks": 2, "embeddings": 5}
+    assert snapshot.collection == "docs"
+    assert snapshot.doc_id == "doc-1"
+    assert snapshot.scope == "parse"
+    assert calls == [
+        {
+            "collection": "docs",
+            "doc_id": "doc-1",
+            "scope": "parse",
+            "new_parse_hash": "new-hash",
+            "old_parse_hash": "old-hash",
+            "model_tag": "text-embedding-3-small",
+            "user_id": 7,
+            "is_admin": False,
+            "preview_only": True,
+            "confirm": False,
+        }
+    ]
+
+
+def test_candidate_cleanup_restore_marks_remaining_side_effects() -> None:
+    """Executed candidate cleanup is reported as incomplete, not fake-restored."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBVersionCandidateCleanupSnapshot,
+        KBVersionCompatibilityFacade,
+    )
+
+    snapshot = KBVersionCandidateCleanupSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        scope="parse",
+        cleanup_counts={"chunks": 2, "embeddings": 5},
+        new_parse_hash="new-hash",
+        old_parse_hash="old-hash",
+    )
+
+    result = KBVersionCompatibilityFacade().restore_candidate_cleanup_snapshot(
+        snapshot, cleanup_executed=True
+    )
+
+    assert result.status == "incomplete"
+    assert result.skipped
+    assert result.reason == "candidate_cleanup_not_restorable"
+    assert not result.restorable
+    assert result.side_effects_may_remain
+    assert result.cleanup_counts == {"chunks": 2, "embeddings": 5}
+    assert result.warnings
+
+
+def test_candidate_cleanup_restore_does_not_delete_active_artifacts(
+    monkeypatch,
+) -> None:
+    """Rollback-incomplete restore reports state without issuing more cleanup."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBVersionCandidateCleanupSnapshot,
+        KBVersionCompatibilityFacade,
+    )
+
+    cascade_cleaner = importlib.import_module(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner"
+    )
+    cleanup_calls: list[dict[str, Any]] = []
+
+    def fake_cleanup_cascade_impl(**kwargs: Any) -> dict[str, int]:
+        cleanup_calls.append(dict(kwargs))
+        raise AssertionError("restore must not delete active version artifacts")
+
+    monkeypatch.setattr(
+        cascade_cleaner,
+        "_cleanup_cascade_impl",
+        fake_cleanup_cascade_impl,
+    )
+
+    snapshot = KBVersionCandidateCleanupSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        scope="parse",
+        cleanup_counts={"parses": 1, "chunks": 2},
+    )
+    result = KBVersionCompatibilityFacade().restore_candidate_cleanup_snapshot(
+        snapshot, cleanup_executed=True
+    )
+
+    assert result.status == "incomplete"
+    assert result.side_effects_may_remain
+    assert cleanup_calls == []
+
+
+def test_candidate_cleanup_restore_not_needed_when_cleanup_was_not_executed() -> None:
+    """A captured plan does not imply residual side effects before cleanup runs."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBVersionCandidateCleanupSnapshot,
+        KBVersionCompatibilityFacade,
+    )
+
+    snapshot = KBVersionCandidateCleanupSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        scope="parse",
+        cleanup_counts={"chunks": 2},
+    )
+
+    result = KBVersionCompatibilityFacade().restore_candidate_cleanup_snapshot(snapshot)
+
+    assert result.status == "not_needed"
+    assert result.restorable
+    assert not result.skipped
+    assert not result.side_effects_may_remain
 
 
 def test_cleanup_count_shape_is_preserved_through_version_facade(monkeypatch) -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_version_compatibility.py
@@ -408,6 +408,28 @@ def test_main_pointer_snapshot_restore_reverts_mutated_pointer() -> None:
     assert restored["technical_id"] == "old-hash"
 
 
+def test_main_pointer_snapshot_restore_succeeds_when_pointer_already_absent() -> None:
+    """Restoring an absent pointer succeeds when the desired state is already met."""
+    from xagent.core.tools.core.RAG_tools.kb import (
+        KBMainPointerSnapshot,
+        KBVersionCompatibilityFacade,
+    )
+
+    store = _FakeMainPointerStore()
+    facade = KBVersionCompatibilityFacade(storage_shim=_FakeStorageShim(store))
+    snapshot = KBMainPointerSnapshot(
+        collection="docs",
+        doc_id="doc-1",
+        step_type="parse",
+        model_tag=None,
+        pointer=None,
+    )
+
+    assert facade.restore_main_pointer_snapshot(snapshot)
+    assert store.calls[-1][0] == "delete"
+    assert facade.list_main_pointers("docs") == []
+
+
 def test_main_pointer_snapshot_restore_returns_false_for_incomplete_pointer() -> None:
     """Incomplete main-pointer snapshots report restore failure without crashing."""
     from xagent.core.tools.core.RAG_tools.kb import (

--- a/tests/core/tools/core/RAG_tools/version_management/test_promote_version_main.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_promote_version_main.py
@@ -511,6 +511,38 @@ class TestPromoteVersionMain:
                 assert result["main_pointer"]["model_tag"] == "bge_large"
                 assert result["main_pointer"]["technical_id"] == "parse_hash1"
 
+    def test_embed_cleanup_uses_embeddings_scope(self):
+        """Embed promotion cleanup passes the cleaner-supported embeddings scope."""
+        import importlib
+
+        promote_version_main_module = importlib.import_module(
+            "xagent.core.tools.core.RAG_tools.version_management.promote_version_main"
+        )
+        mock_cleanup_cascade = MagicMock(return_value={"embeddings": 3})
+
+        with patch.object(
+            promote_version_main_module, "cleanup_cascade", mock_cleanup_cascade
+        ):
+            result = promote_version_main_module._call_cleanup_cascade(
+                collection="test_collection",
+                doc_id="test_doc",
+                step_type=StepType.EMBED,
+                technical_id="embed-hash",
+                model_tag="bge_large",
+                preview_only=False,
+                confirm=True,
+            )
+
+        assert result == {"embeddings": 3}
+        mock_cleanup_cascade.assert_called_once_with(
+            collection="test_collection",
+            doc_id="test_doc",
+            scope="embeddings",
+            model_tag="bge_large",
+            preview_only=False,
+            confirm=True,
+        )
+
     def test_wraps_unexpected_exceptions(self):
         """Test that unexpected exceptions are wrapped in VersionManagementError.
 


### PR DESCRIPTION
## Summary

- Add `KBVersionCompatibilityFacade` as the coordinator-owned boundary for version-management helpers.
- Route public sync version-management functions through the facade while preserving legacy import paths and return shapes.
- Add rollback-facing main pointer snapshot/restore hooks and candidate cleanup rollback outcome reporting.

## Issue

Closes #503.

## Validation

- `uv run pytest tests/core/tools/core/RAG_tools/kb tests/core/tools/core/RAG_tools/version_management`
- `.venv/bin/pre-commit run --all-files`