### PR TITLE
refactor(kb): add vector storage compatibility facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -24,6 +24,10 @@ from .models import (
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .vector_storage_compatibility import (
+    KBVectorStorageCleanupResult,
+    KBVectorStorageCompatibilityFacade,
+)
 from .version_compatibility import (
     KBMainPointerSnapshot,
     KBVersionCandidateCleanupSnapshot,
@@ -50,6 +54,8 @@ __all__ = [
     "KBRetrievalHelperCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",
+    "KBVectorStorageCleanupResult",
+    "KBVectorStorageCompatibilityFacade",
     "KBUserScope",
     "KBVersionCompatibilityFacade",
     "LanceDBCollectionHandle",

--- a/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
@@ -1,0 +1,247 @@
+"""Shared KB cleanup scope and predicate helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..LanceDB.model_tag_utils import to_model_tag
+from ..LanceDB.schema_manager import _safe_close_table
+from ..utils.lancedb_query_utils import list_embeddings_table_names
+from ..utils.string_utils import (
+    build_lancedb_filter_expression,
+    build_user_id_filter_for_table,
+)
+from ..utils.user_permissions import UserPermissions
+from ..utils.user_scope import resolve_user_scope
+
+
+@dataclass(frozen=True)
+class KBCleanupScope:
+    """Resolved scope for destructive KB cleanup operations."""
+
+    collection: str
+    user_id: Optional[int]
+    is_admin: bool
+    doc_id: Optional[str] = None
+    parse_hash: Optional[str] = None
+    chunk_ids: tuple[str, ...] = ()
+    model_tag: Optional[str] = None
+
+
+def resolve_cleanup_scope(
+    *,
+    collection: str,
+    doc_id: Optional[str] = None,
+    parse_hash: Optional[str] = None,
+    chunk_ids: Optional[Sequence[str]] = None,
+    model_tag: Optional[str] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    require_target: bool = True,
+) -> KBCleanupScope:
+    """Normalize and validate a cleanup scope with request-context fallback."""
+    normalized_collection = collection.strip() if isinstance(collection, str) else ""
+    if not normalized_collection:
+        raise ValueError("collection must be a non-empty string")
+
+    normalized_doc_id = _normalize_optional_string(doc_id)
+    normalized_parse_hash = _normalize_optional_string(parse_hash)
+    normalized_chunk_ids = normalize_cleanup_chunk_ids(chunk_ids)
+    if normalized_chunk_ids and normalized_doc_id is None:
+        raise ValueError("doc_id is required when chunk_ids are provided")
+    if require_target and not any(
+        [normalized_doc_id, normalized_parse_hash, normalized_chunk_ids]
+    ):
+        raise ValueError("At least one of doc_id, parse_hash, or chunk_ids is required")
+
+    user_scope = resolve_user_scope(user_id=user_id, is_admin=is_admin)
+    return KBCleanupScope(
+        collection=normalized_collection,
+        doc_id=normalized_doc_id,
+        parse_hash=normalized_parse_hash,
+        chunk_ids=normalized_chunk_ids,
+        model_tag=model_tag,
+        user_id=user_scope.user_id,
+        is_admin=user_scope.is_admin,
+    )
+
+
+def normalize_cleanup_chunk_ids(
+    chunk_ids: Optional[Sequence[str]],
+) -> tuple[str, ...]:
+    """Return a stable deduplicated chunk-id tuple."""
+    if not chunk_ids:
+        return ()
+    return tuple(sorted({str(chunk_id) for chunk_id in chunk_ids if str(chunk_id)}))
+
+
+def select_embedding_tables(conn: Any, model_tag: Optional[str] = None) -> list[str]:
+    """List embeddings tables, optionally scoped to one model tag."""
+    table_names = list_embeddings_table_names(conn)
+    if model_tag is None:
+        return table_names
+
+    candidate_tags = {model_tag, to_model_tag(model_tag)}
+    candidate_tables = {f"embeddings_{tag}" for tag in candidate_tags}
+    return [table_name for table_name in table_names if table_name in candidate_tables]
+
+
+def build_embedding_cleanup_filters(
+    conn: Any,
+    scope: KBCleanupScope,
+) -> dict[str, list[str]]:
+    """Build per-embeddings-table cleanup predicates for a resolved scope."""
+    table_filters: dict[str, list[str]] = {}
+    for table_name in select_embedding_tables(conn, model_tag=scope.model_tag):
+        table = None
+        try:
+            table = conn.open_table(table_name)
+            table_filters[table_name] = _build_filters_for_table(table, scope)
+        except Exception:
+            table_filters[table_name] = _build_filters_without_schema(scope)
+        finally:
+            _safe_close_table(table)
+    return table_filters
+
+
+def build_embedding_cleanup_filters_from_base(
+    conn: Any,
+    *,
+    base_filter: str,
+    user_id: Optional[int],
+    is_admin: bool,
+    model_tag: Optional[str] = None,
+) -> dict[str, str]:
+    """Build per-embeddings-table predicates from an existing base filter."""
+    table_filters: dict[str, str] = {}
+    for table_name in select_embedding_tables(conn, model_tag=model_tag):
+        table = None
+        try:
+            table = conn.open_table(table_name)
+            table_filters[table_name] = append_user_filter_for_table(
+                table=table,
+                filter_expr=base_filter,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        except Exception:
+            table_filters[table_name] = append_user_filter_without_schema(
+                filter_expr=base_filter,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        finally:
+            _safe_close_table(table)
+    return table_filters
+
+
+def append_user_filter_for_table(
+    *,
+    table: Any,
+    filter_expr: str,
+    user_id: Optional[int],
+    is_admin: bool,
+) -> str:
+    """Append a schema-aware user filter for tenant-aware cleanup."""
+    if is_admin:
+        return filter_expr
+    if user_id is None:
+        return _and_filter(filter_expr, UserPermissions.get_no_access_filter())
+    if not table_has_column(table, "user_id"):
+        return filter_expr
+    user_filter = build_user_id_filter_for_table(table, int(user_id))
+    return _and_filter(filter_expr, user_filter)
+
+
+def append_user_filter_without_schema(
+    *,
+    filter_expr: str,
+    user_id: Optional[int],
+    is_admin: bool,
+) -> str:
+    """Append a conservative user filter when table schema is unavailable."""
+    if is_admin:
+        return filter_expr
+    if user_id is None:
+        return _and_filter(filter_expr, UserPermissions.get_no_access_filter())
+    return _and_filter(filter_expr, f"user_id == {int(user_id)}")
+
+
+def table_has_column(table: Any, column_name: str) -> bool:
+    """Return whether a backend table schema includes a column."""
+    try:
+        schema = getattr(table, "schema", None)
+        if schema is None:
+            return False
+        names = getattr(schema, "names", None)
+        if names is not None:
+            return str(column_name) in {str(name) for name in names}
+        field = schema.field(column_name)
+        return field is not None
+    except Exception:
+        return False
+
+
+def _build_filters_for_table(table: Any, scope: KBCleanupScope) -> list[str]:
+    filters: list[str] = []
+    for filter_values in _build_filter_inputs(scope):
+        base_filter = build_lancedb_filter_expression(
+            filter_values,
+            user_id=scope.user_id,
+            is_admin=scope.is_admin,
+            skip_user_filter=True,
+        )
+        filters.append(
+            append_user_filter_for_table(
+                table=table,
+                filter_expr=base_filter,
+                user_id=scope.user_id,
+                is_admin=scope.is_admin,
+            )
+        )
+    return filters
+
+
+def _build_filters_without_schema(scope: KBCleanupScope) -> list[str]:
+    filters: list[str] = []
+    for filter_values in _build_filter_inputs(scope):
+        base_filter = build_lancedb_filter_expression(
+            filter_values,
+            user_id=scope.user_id,
+            is_admin=scope.is_admin,
+            skip_user_filter=True,
+        )
+        filters.append(
+            append_user_filter_without_schema(
+                filter_expr=base_filter,
+                user_id=scope.user_id,
+                is_admin=scope.is_admin,
+            )
+        )
+    return filters
+
+
+def _and_filter(base_filter: str, extra_filter: str) -> str:
+    if not base_filter:
+        return extra_filter
+    return f"{base_filter} AND {extra_filter}"
+
+
+def _build_filter_inputs(scope: KBCleanupScope) -> list[dict[str, Any]]:
+    base: dict[str, Any] = {"collection": scope.collection}
+    if scope.doc_id is not None:
+        base["doc_id"] = scope.doc_id
+    if scope.parse_hash is not None:
+        base["parse_hash"] = scope.parse_hash
+    if not scope.chunk_ids:
+        return [base]
+    return [dict(base, chunk_id=chunk_id) for chunk_id in scope.chunk_ids]
+
+
+def _normalize_optional_string(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value)
+    return normalized if normalized else None

--- a/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
@@ -12,6 +12,7 @@ from ..utils.lancedb_query_utils import list_embeddings_table_names
 from ..utils.string_utils import (
     build_lancedb_filter_expression,
     build_user_id_filter_for_table,
+    escape_lancedb_string,
 )
 from ..utils.user_permissions import UserPermissions
 from ..utils.user_scope import resolve_user_scope
@@ -196,42 +197,28 @@ def table_has_column(table: Any, column_name: str) -> bool:
 
 
 def _build_filters_for_table(table: Any, scope: KBCleanupScope) -> list[str]:
-    filters: list[str] = []
-    for filter_values in _build_filter_inputs(scope):
-        base_filter = build_lancedb_filter_expression(
-            filter_values,
+    base_filter = _build_base_filter(scope)
+    filter_expr = _append_chunk_id_filter_if_needed(base_filter, scope.chunk_ids)
+    return [
+        append_user_filter_for_table(
+            table=table,
+            filter_expr=filter_expr,
             user_id=scope.user_id,
             is_admin=scope.is_admin,
-            skip_user_filter=True,
         )
-        filters.append(
-            append_user_filter_for_table(
-                table=table,
-                filter_expr=base_filter,
-                user_id=scope.user_id,
-                is_admin=scope.is_admin,
-            )
-        )
-    return filters
+    ]
 
 
 def _build_filters_without_schema(scope: KBCleanupScope) -> list[str]:
-    filters: list[str] = []
-    for filter_values in _build_filter_inputs(scope):
-        base_filter = build_lancedb_filter_expression(
-            filter_values,
+    base_filter = _build_base_filter(scope)
+    filter_expr = _append_chunk_id_filter_if_needed(base_filter, scope.chunk_ids)
+    return [
+        append_user_filter_without_schema(
+            filter_expr=filter_expr,
             user_id=scope.user_id,
             is_admin=scope.is_admin,
-            skip_user_filter=True,
         )
-        filters.append(
-            append_user_filter_without_schema(
-                filter_expr=base_filter,
-                user_id=scope.user_id,
-                is_admin=scope.is_admin,
-            )
-        )
-    return filters
+    ]
 
 
 def _and_filter(base_filter: str, extra_filter: str) -> str:
@@ -240,15 +227,33 @@ def _and_filter(base_filter: str, extra_filter: str) -> str:
     return f"{base_filter} AND {extra_filter}"
 
 
-def _build_filter_inputs(scope: KBCleanupScope) -> list[dict[str, Any]]:
-    base: dict[str, Any] = {"collection": scope.collection}
+def _build_base_filter(scope: KBCleanupScope) -> str:
+    filter_values: dict[str, Any] = {"collection": scope.collection}
     if scope.doc_id is not None:
-        base["doc_id"] = scope.doc_id
+        filter_values["doc_id"] = scope.doc_id
     if scope.parse_hash is not None:
-        base["parse_hash"] = scope.parse_hash
-    if not scope.chunk_ids:
-        return [base]
-    return [dict(base, chunk_id=chunk_id) for chunk_id in scope.chunk_ids]
+        filter_values["parse_hash"] = scope.parse_hash
+    return build_lancedb_filter_expression(
+        filter_values,
+        user_id=scope.user_id,
+        is_admin=scope.is_admin,
+        skip_user_filter=True,
+    )
+
+
+def _append_chunk_id_filter_if_needed(
+    base_filter: str, chunk_ids: tuple[str, ...]
+) -> str:
+    if not chunk_ids:
+        return base_filter
+    return _and_filter(base_filter, _chunk_ids_filter(chunk_ids))
+
+
+def _chunk_ids_filter(chunk_ids: tuple[str, ...]) -> str:
+    if len(chunk_ids) == 1:
+        return f"chunk_id == '{escape_lancedb_string(chunk_ids[0])}'"
+    values = ", ".join(f"'{escape_lancedb_string(chunk_id)}'" for chunk_id in chunk_ids)
+    return f"chunk_id IN ({values})"
 
 
 def _normalize_optional_string(value: Optional[str]) -> Optional[str]:

--- a/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/cleanup_filters.py
@@ -35,7 +35,7 @@ def resolve_cleanup_scope(
     collection: str,
     doc_id: Optional[str] = None,
     parse_hash: Optional[str] = None,
-    chunk_ids: Optional[Sequence[str]] = None,
+    chunk_ids: Optional[Sequence[object]] = None,
     model_tag: Optional[str] = None,
     user_id: Optional[int] = None,
     is_admin: Optional[bool] = None,
@@ -69,12 +69,19 @@ def resolve_cleanup_scope(
 
 
 def normalize_cleanup_chunk_ids(
-    chunk_ids: Optional[Sequence[str]],
+    chunk_ids: Optional[Sequence[object]],
 ) -> tuple[str, ...]:
     """Return a stable deduplicated chunk-id tuple."""
     if not chunk_ids:
         return ()
-    return tuple(sorted({str(chunk_id) for chunk_id in chunk_ids if str(chunk_id)}))
+    normalized: set[str] = set()
+    for chunk_id in chunk_ids:
+        if chunk_id is None:
+            continue
+        value = str(chunk_id)
+        if value:
+            normalized.add(value)
+    return tuple(sorted(normalized))
 
 
 def select_embedding_tables(conn: Any, model_tag: Optional[str] = None) -> list[str]:
@@ -113,25 +120,29 @@ def build_embedding_cleanup_filters_from_base(
     user_id: Optional[int],
     is_admin: bool,
     model_tag: Optional[str] = None,
-) -> dict[str, str]:
-    """Build per-embeddings-table predicates from an existing base filter."""
-    table_filters: dict[str, str] = {}
+) -> dict[str, list[str]]:
+    """Build per-embeddings-table predicate lists from an existing base filter."""
+    table_filters: dict[str, list[str]] = {}
     for table_name in select_embedding_tables(conn, model_tag=model_tag):
         table = None
         try:
             table = conn.open_table(table_name)
-            table_filters[table_name] = append_user_filter_for_table(
-                table=table,
-                filter_expr=base_filter,
-                user_id=user_id,
-                is_admin=is_admin,
-            )
+            table_filters[table_name] = [
+                append_user_filter_for_table(
+                    table=table,
+                    filter_expr=base_filter,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+            ]
         except Exception:
-            table_filters[table_name] = append_user_filter_without_schema(
-                filter_expr=base_filter,
-                user_id=user_id,
-                is_admin=is_admin,
-            )
+            table_filters[table_name] = [
+                append_user_filter_without_schema(
+                    filter_expr=base_filter,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+            ]
         finally:
             _safe_close_table(table)
     return table_filters

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -25,6 +25,7 @@ from .models import (
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .vector_storage_compatibility import KBVectorStorageCompatibilityFacade
 from .version_compatibility import KBVersionCompatibilityFacade
 
 T = TypeVar("T")
@@ -48,6 +49,7 @@ class KBCoordinator:
         retrieval_helper_compatibility: (
             KBRetrievalHelperCompatibilityFacade | None
         ) = None,
+        vector_storage_compatibility: KBVectorStorageCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -72,6 +74,10 @@ class KBCoordinator:
         self._retrieval_helper_compatibility = (
             retrieval_helper_compatibility
             or KBRetrievalHelperCompatibilityFacade(coordinator=self)
+        )
+        self._vector_storage_compatibility = (
+            vector_storage_compatibility
+            or KBVectorStorageCompatibilityFacade(coordinator=self)
         )
 
     @property
@@ -133,6 +139,16 @@ class KBCoordinator:
     def retrieval_helper(self) -> KBRetrievalHelperCompatibilityFacade:
         """Backward-friendly short alias for the retrieval helper facade."""
         return self._retrieval_helper_compatibility
+
+    @property
+    def vector_storage_compatibility(self) -> KBVectorStorageCompatibilityFacade:
+        """Return the vector storage compatibility facade."""
+        return self._vector_storage_compatibility
+
+    @property
+    def vector_storage(self) -> KBVectorStorageCompatibilityFacade:
+        """Backward-friendly short alias for the vector storage facade."""
+        return self._vector_storage_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/vector_storage_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/vector_storage_compatibility.py
@@ -1,0 +1,386 @@
+"""Vector storage compatibility facade."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from ..LanceDB.model_tag_utils import to_model_tag
+from ..LanceDB.schema_manager import _safe_close_table
+from ..utils.lancedb_query_utils import _safe_count_rows, list_embeddings_table_names
+from ..utils.string_utils import (
+    build_lancedb_filter_expression,
+    build_user_id_filter_for_table,
+)
+
+if TYPE_CHECKING:
+    from ..core.schemas import (
+        ChunkEmbeddingData,
+        EmbeddingReadResponse,
+        EmbeddingWriteResponse,
+    )
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KBVectorStorageCleanupResult:
+    """Outcome for vector-storage rollback cleanup actions."""
+
+    collection: str
+    status: str
+    deleted_count: int = 0
+    table_counts: dict[str, int] = field(default_factory=dict)
+    model_tag: Optional[str] = None
+    preview_only: bool = True
+    warnings: tuple[str, ...] = ()
+    side_effects_may_remain: bool = False
+
+
+class KBVectorStorageCompatibilityFacade:
+    """Compatibility boundary for legacy vector-storage helpers.
+
+    Public vector-storage functions keep their historical synchronous shape.
+    The facade binds coordinator-owned storage access, then delegates to the
+    current vector manager implementation so model-tag routing, dimension
+    checks, merge error mapping, and result models remain unchanged.
+    """
+
+    def __init__(
+        self,
+        coordinator: "KBCoordinator | None" = None,
+        storage_shim: "KBStorageShimCompatibilityFacade | None" = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> "KBStorageShimCompatibilityFacade | None":
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    def validate_query_vector(
+        self,
+        query_vector: List[float],
+        model_tag: Optional[str] = None,
+        conn: Any = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> None:
+        from ..vector_storage.vector_manager import _validate_query_vector_impl
+
+        with self._storage_context():
+            _validate_query_vector_impl(
+                query_vector,
+                model_tag=model_tag,
+                conn=conn,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def read_chunks_for_embedding(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        model: str,
+        filters: Optional[Dict[str, Any]] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> "EmbeddingReadResponse":
+        from ..vector_storage.vector_manager import _read_chunks_for_embedding_impl
+
+        with self._storage_context():
+            return _read_chunks_for_embedding_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                model=model,
+                filters=filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def write_vectors_to_db(
+        self,
+        collection: str,
+        embeddings: List["ChunkEmbeddingData"],
+        create_index: bool = True,
+        user_id: Optional[int] = None,
+    ) -> "EmbeddingWriteResponse":
+        from ..vector_storage.vector_manager import _write_vectors_to_db_impl
+
+        with self._storage_context():
+            return _write_vectors_to_db_impl(
+                collection=collection,
+                embeddings=embeddings,
+                create_index=create_index,
+                user_id=user_id,
+            )
+
+    def cleanup_vectors_for_document(
+        self,
+        *,
+        collection: str,
+        doc_id: str,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> KBVectorStorageCleanupResult:
+        """Delete or preview all vectors for one document."""
+        return self.cleanup_vectors_for_operation(
+            collection=collection,
+            doc_id=doc_id,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    def cleanup_vectors_for_chunks(
+        self,
+        *,
+        collection: str,
+        doc_id: str,
+        chunk_ids: Sequence[str],
+        parse_hash: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> KBVectorStorageCleanupResult:
+        """Delete or preview vectors for an explicit chunk set."""
+        return self.cleanup_vectors_for_operation(
+            collection=collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=chunk_ids,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    def cleanup_vectors_for_operation(
+        self,
+        *,
+        collection: str,
+        doc_id: Optional[str] = None,
+        parse_hash: Optional[str] = None,
+        chunk_ids: Optional[Sequence[str]] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> KBVectorStorageCleanupResult:
+        """Delete or preview vectors created by a failed compatibility operation.
+
+        Current embeddings rows do not carry an operation ID, so rollback callers
+        scope cleanup through the operation's known document, parse, chunk set,
+        and model tag. Future handle-level embedding rollback can replace this
+        adapter without changing coordinator rollback code.
+        """
+        normalized_collection = collection.strip() if isinstance(collection, str) else ""
+        if not normalized_collection:
+            raise ValueError("collection must be a non-empty string")
+        normalized_chunk_ids = _normalize_chunk_ids(chunk_ids)
+        if not any([doc_id, parse_hash, normalized_chunk_ids]):
+            raise ValueError(
+                "At least one of doc_id, parse_hash, or chunk_ids is required"
+            )
+
+        with self._storage_context():
+            return self._cleanup_vectors_for_operation_impl(
+                collection=normalized_collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_ids=normalized_chunk_ids,
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+
+    def _cleanup_vectors_for_operation_impl(
+        self,
+        *,
+        collection: str,
+        doc_id: Optional[str],
+        parse_hash: Optional[str],
+        chunk_ids: tuple[str, ...],
+        model_tag: Optional[str],
+        user_id: Optional[int],
+        is_admin: bool,
+        preview_only: bool,
+        confirm: bool,
+    ) -> KBVectorStorageCleanupResult:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is not None:
+            conn = storage_shim.get_vector_store_raw_connection()
+        else:
+            from ..storage.factory import get_vector_store_raw_connection
+
+            conn = get_vector_store_raw_connection()
+
+        table_counts: dict[str, int] = {}
+        warnings: list[str] = []
+        side_effects_may_remain = False
+        should_delete = bool(confirm and not preview_only)
+        target_tables = _target_embedding_tables(conn, model_tag=model_tag)
+
+        if not target_tables:
+            return KBVectorStorageCleanupResult(
+                collection=collection,
+                status="skipped",
+                deleted_count=0,
+                table_counts={},
+                model_tag=model_tag,
+                preview_only=preview_only,
+            )
+
+        filter_inputs = _build_filter_inputs(
+            collection=collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=chunk_ids,
+        )
+
+        for table_name in target_tables:
+            table = None
+            try:
+                table = conn.open_table(table_name)
+                count = 0
+                for filter_values in filter_inputs:
+                    filter_expr = build_lancedb_filter_expression(
+                        filter_values,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                        skip_user_filter=True,
+                    )
+                    filter_expr = _append_table_user_filter(
+                        table=table,
+                        filter_expr=filter_expr,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    )
+                    matched = _safe_count_rows(table, filter_expr, on_error="raise")
+                    if should_delete and matched > 0:
+                        table.delete(filter_expr)
+                    count += matched
+                table_counts[table_name] = count
+            except Exception as exc:  # noqa: BLE001 - report rollback cleanup state
+                side_effects_may_remain = True
+                message = f"{table_name}: {exc}"
+                warnings.append(message)
+                logger.warning("Vector cleanup failed for %s: %s", table_name, exc)
+            finally:
+                _safe_close_table(table)
+
+        deleted_count = sum(table_counts.values())
+        if warnings:
+            status = "incomplete"
+        elif should_delete:
+            status = "complete"
+        else:
+            status = "planned"
+
+        return KBVectorStorageCleanupResult(
+            collection=collection,
+            status=status,
+            deleted_count=deleted_count,
+            table_counts=table_counts,
+            model_tag=model_tag,
+            preview_only=preview_only,
+            warnings=tuple(warnings),
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+
+def _normalize_chunk_ids(chunk_ids: Optional[Sequence[str]]) -> tuple[str, ...]:
+    if not chunk_ids:
+        return ()
+    return tuple(sorted({str(chunk_id) for chunk_id in chunk_ids if str(chunk_id)}))
+
+
+def _build_filter_inputs(
+    *,
+    collection: str,
+    doc_id: Optional[str],
+    parse_hash: Optional[str],
+    chunk_ids: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    base: dict[str, Any] = {"collection": collection}
+    if doc_id is not None:
+        base["doc_id"] = doc_id
+    if parse_hash is not None:
+        base["parse_hash"] = parse_hash
+    if not chunk_ids:
+        return [base]
+    return [dict(base, chunk_id=chunk_id) for chunk_id in chunk_ids]
+
+
+def _target_embedding_tables(conn: Any, model_tag: Optional[str]) -> list[str]:
+    table_names = list_embeddings_table_names(conn)
+    if model_tag is None:
+        return table_names
+
+    candidate_tags = {model_tag, to_model_tag(model_tag)}
+    candidate_tables = {f"embeddings_{tag}" for tag in candidate_tags}
+    return [table_name for table_name in table_names if table_name in candidate_tables]
+
+
+def _append_table_user_filter(
+    *,
+    table: Any,
+    filter_expr: str,
+    user_id: Optional[int],
+    is_admin: bool,
+) -> str:
+    if is_admin or user_id is None:
+        return filter_expr
+    if not _table_has_column(table, "user_id"):
+        return filter_expr
+    user_filter = build_user_id_filter_for_table(table, int(user_id))
+    if not filter_expr:
+        return user_filter
+    return f"{filter_expr} AND {user_filter}"
+
+
+def _table_has_column(table: Any, column_name: str) -> bool:
+    try:
+        schema = getattr(table, "schema", None)
+        if schema is None:
+            return False
+        names = getattr(schema, "names", None)
+        if names is not None:
+            return str(column_name) in {str(name) for name in names}
+        field = schema.field(column_name)
+        return field is not None
+    except Exception:
+        return False

--- a/src/xagent/core/tools/core/RAG_tools/kb/vector_storage_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/vector_storage_compatibility.py
@@ -8,12 +8,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from ..LanceDB.model_tag_utils import to_model_tag
 from ..LanceDB.schema_manager import _safe_close_table
-from ..utils.lancedb_query_utils import _safe_count_rows, list_embeddings_table_names
-from ..utils.string_utils import (
-    build_lancedb_filter_expression,
-    build_user_id_filter_for_table,
+from ..utils.lancedb_query_utils import _safe_count_rows
+from .cleanup_filters import (
+    KBCleanupScope,
+    build_embedding_cleanup_filters,
+    resolve_cleanup_scope,
 )
 
 if TYPE_CHECKING:
@@ -144,7 +144,7 @@ class KBVectorStorageCompatibilityFacade:
         doc_id: str,
         model_tag: Optional[str] = None,
         user_id: Optional[int] = None,
-        is_admin: bool = False,
+        is_admin: Optional[bool] = None,
         preview_only: bool = True,
         confirm: bool = False,
     ) -> KBVectorStorageCleanupResult:
@@ -168,7 +168,7 @@ class KBVectorStorageCompatibilityFacade:
         parse_hash: Optional[str] = None,
         model_tag: Optional[str] = None,
         user_id: Optional[int] = None,
-        is_admin: bool = False,
+        is_admin: Optional[bool] = None,
         preview_only: bool = True,
         confirm: bool = False,
     ) -> KBVectorStorageCleanupResult:
@@ -194,7 +194,7 @@ class KBVectorStorageCompatibilityFacade:
         chunk_ids: Optional[Sequence[str]] = None,
         model_tag: Optional[str] = None,
         user_id: Optional[int] = None,
-        is_admin: bool = False,
+        is_admin: Optional[bool] = None,
         preview_only: bool = True,
         confirm: bool = False,
     ) -> KBVectorStorageCleanupResult:
@@ -205,24 +205,19 @@ class KBVectorStorageCompatibilityFacade:
         and model tag. Future handle-level embedding rollback can replace this
         adapter without changing coordinator rollback code.
         """
-        normalized_collection = collection.strip() if isinstance(collection, str) else ""
-        if not normalized_collection:
-            raise ValueError("collection must be a non-empty string")
-        normalized_chunk_ids = _normalize_chunk_ids(chunk_ids)
-        if not any([doc_id, parse_hash, normalized_chunk_ids]):
-            raise ValueError(
-                "At least one of doc_id, parse_hash, or chunk_ids is required"
-            )
+        scope = resolve_cleanup_scope(
+            collection=collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=chunk_ids,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
 
         with self._storage_context():
             return self._cleanup_vectors_for_operation_impl(
-                collection=normalized_collection,
-                doc_id=doc_id,
-                parse_hash=parse_hash,
-                chunk_ids=normalized_chunk_ids,
-                model_tag=model_tag,
-                user_id=user_id,
-                is_admin=is_admin,
+                scope=scope,
                 preview_only=preview_only,
                 confirm=confirm,
             )
@@ -230,13 +225,7 @@ class KBVectorStorageCompatibilityFacade:
     def _cleanup_vectors_for_operation_impl(
         self,
         *,
-        collection: str,
-        doc_id: Optional[str],
-        parse_hash: Optional[str],
-        chunk_ids: tuple[str, ...],
-        model_tag: Optional[str],
-        user_id: Optional[int],
-        is_admin: bool,
+        scope: KBCleanupScope,
         preview_only: bool,
         confirm: bool,
     ) -> KBVectorStorageCleanupResult:
@@ -252,43 +241,24 @@ class KBVectorStorageCompatibilityFacade:
         warnings: list[str] = []
         side_effects_may_remain = False
         should_delete = bool(confirm and not preview_only)
-        target_tables = _target_embedding_tables(conn, model_tag=model_tag)
+        table_filters = build_embedding_cleanup_filters(conn, scope)
 
-        if not target_tables:
+        if not table_filters:
             return KBVectorStorageCleanupResult(
-                collection=collection,
+                collection=scope.collection,
                 status="skipped",
                 deleted_count=0,
                 table_counts={},
-                model_tag=model_tag,
+                model_tag=scope.model_tag,
                 preview_only=preview_only,
             )
 
-        filter_inputs = _build_filter_inputs(
-            collection=collection,
-            doc_id=doc_id,
-            parse_hash=parse_hash,
-            chunk_ids=chunk_ids,
-        )
-
-        for table_name in target_tables:
+        for table_name, filter_exprs in table_filters.items():
             table = None
             try:
                 table = conn.open_table(table_name)
                 count = 0
-                for filter_values in filter_inputs:
-                    filter_expr = build_lancedb_filter_expression(
-                        filter_values,
-                        user_id=user_id,
-                        is_admin=is_admin,
-                        skip_user_filter=True,
-                    )
-                    filter_expr = _append_table_user_filter(
-                        table=table,
-                        filter_expr=filter_expr,
-                        user_id=user_id,
-                        is_admin=is_admin,
-                    )
+                for filter_expr in filter_exprs:
                     matched = _safe_count_rows(table, filter_expr, on_error="raise")
                     if should_delete and matched > 0:
                         table.delete(filter_expr)
@@ -311,76 +281,12 @@ class KBVectorStorageCompatibilityFacade:
             status = "planned"
 
         return KBVectorStorageCleanupResult(
-            collection=collection,
+            collection=scope.collection,
             status=status,
             deleted_count=deleted_count,
             table_counts=table_counts,
-            model_tag=model_tag,
+            model_tag=scope.model_tag,
             preview_only=preview_only,
             warnings=tuple(warnings),
             side_effects_may_remain=side_effects_may_remain,
         )
-
-
-def _normalize_chunk_ids(chunk_ids: Optional[Sequence[str]]) -> tuple[str, ...]:
-    if not chunk_ids:
-        return ()
-    return tuple(sorted({str(chunk_id) for chunk_id in chunk_ids if str(chunk_id)}))
-
-
-def _build_filter_inputs(
-    *,
-    collection: str,
-    doc_id: Optional[str],
-    parse_hash: Optional[str],
-    chunk_ids: tuple[str, ...],
-) -> list[dict[str, Any]]:
-    base: dict[str, Any] = {"collection": collection}
-    if doc_id is not None:
-        base["doc_id"] = doc_id
-    if parse_hash is not None:
-        base["parse_hash"] = parse_hash
-    if not chunk_ids:
-        return [base]
-    return [dict(base, chunk_id=chunk_id) for chunk_id in chunk_ids]
-
-
-def _target_embedding_tables(conn: Any, model_tag: Optional[str]) -> list[str]:
-    table_names = list_embeddings_table_names(conn)
-    if model_tag is None:
-        return table_names
-
-    candidate_tags = {model_tag, to_model_tag(model_tag)}
-    candidate_tables = {f"embeddings_{tag}" for tag in candidate_tags}
-    return [table_name for table_name in table_names if table_name in candidate_tables]
-
-
-def _append_table_user_filter(
-    *,
-    table: Any,
-    filter_expr: str,
-    user_id: Optional[int],
-    is_admin: bool,
-) -> str:
-    if is_admin or user_id is None:
-        return filter_expr
-    if not _table_has_column(table, "user_id"):
-        return filter_expr
-    user_filter = build_user_id_filter_for_table(table, int(user_id))
-    if not filter_expr:
-        return user_filter
-    return f"{filter_expr} AND {user_filter}"
-
-
-def _table_has_column(table: Any, column_name: str) -> bool:
-    try:
-        schema = getattr(table, "schema", None)
-        if schema is None:
-            return False
-        names = getattr(schema, "names", None)
-        if names is not None:
-            return str(column_name) in {str(name) for name in names}
-        field = schema.field(column_name)
-        return field is not None
-    except Exception:
-        return False

--- a/src/xagent/core/tools/core/RAG_tools/vector_storage/vector_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/vector_storage/vector_manager.py
@@ -15,7 +15,7 @@ import logging
 import numbers
 import os
 import time
-from typing import Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -44,6 +44,18 @@ from ..utils.lancedb_query_utils import list_table_names
 from ..utils.metadata_utils import deserialize_metadata, serialize_metadata
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..kb.vector_storage_compatibility import (
+        KBVectorStorageCompatibilityFacade,
+    )
+
+
+def _get_vector_storage_compatibility_facade() -> "KBVectorStorageCompatibilityFacade":
+    """Return the coordinator-owned vector storage compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().vector_storage_compatibility
 
 
 def _is_non_recoverable_merge_error(error: Exception) -> bool:
@@ -113,6 +125,23 @@ def _is_non_recoverable_merge_error(error: Exception) -> bool:
 
 
 def validate_query_vector(
+    query_vector: List[float],
+    model_tag: Optional[str] = None,
+    conn: Any = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> None:
+    """Validate query vector format and content through the coordinator facade."""
+    _get_vector_storage_compatibility_facade().validate_query_vector(
+        query_vector,
+        model_tag=model_tag,
+        conn=conn,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _validate_query_vector_impl(
     query_vector: List[float],
     model_tag: Optional[str] = None,
     conn: Any = None,
@@ -202,6 +231,27 @@ def _safe_str_value(value: Any) -> Optional[str]:
 
 
 def read_chunks_for_embedding(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    model: str,
+    filters: Optional[Dict[str, Any]] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> EmbeddingReadResponse:
+    """Read chunks from database for embedding computation through the facade."""
+    return _get_vector_storage_compatibility_facade().read_chunks_for_embedding(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        model=model,
+        filters=filters,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _read_chunks_for_embedding_impl(
     collection: str,
     doc_id: str,
     parse_hash: str,
@@ -761,6 +811,21 @@ def _process_model_embeddings(
 
 
 def write_vectors_to_db(
+    collection: str,
+    embeddings: List[ChunkEmbeddingData],
+    create_index: bool = True,
+    user_id: Optional[int] = None,
+) -> EmbeddingWriteResponse:
+    """Write embedding vectors to database with idempotency."""
+    return _get_vector_storage_compatibility_facade().write_vectors_to_db(
+        collection=collection,
+        embeddings=embeddings,
+        create_index=create_index,
+        user_id=user_id,
+    )
+
+
+def _write_vectors_to_db_impl(
     collection: str,
     embeddings: List[ChunkEmbeddingData],
     create_index: bool = True,

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -52,6 +52,29 @@ def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
     return get_kb_coordinator().version_compatibility
 
 
+FilterPredicateMap = Dict[str, list[str]]
+
+
+def _set_predicate(
+    predicates: FilterPredicateMap, table_name: str, filter_expr: str
+) -> None:
+    predicates[table_name] = [filter_expr]
+
+
+def _count_rows_by_filters(table: Any, filter_exprs: list[str]) -> int:
+    return sum(_safe_count_rows(table, filter_expr) for filter_expr in filter_exprs)
+
+
+def _delete_rows_by_filters(table: Any, filter_exprs: list[str]) -> int:
+    deleted_count = 0
+    for filter_expr in filter_exprs:
+        count = _safe_count_rows(table, filter_expr)
+        if count > 0:
+            table.delete(filter_expr)
+        deleted_count += count
+    return deleted_count
+
+
 def _build_collection_filter(
     *,
     conn: Any,
@@ -191,7 +214,7 @@ def _append_user_filter_if_needed(
 
 def _add_embedding_predicates(
     *,
-    predicates: Dict[str, str],
+    predicates: FilterPredicateMap,
     conn: Any,
     base_expr: str,
     user_id: Optional[int],
@@ -199,15 +222,16 @@ def _add_embedding_predicates(
     model_tag: Optional[str] = None,
 ) -> None:
     """Expand an embeddings cleanup predicate per target embeddings table."""
-    predicates.update(
-        build_embedding_cleanup_filters_from_base(
-            conn,
-            base_filter=base_expr,
-            user_id=user_id,
-            is_admin=is_admin,
-            model_tag=model_tag,
-        )
+    table_filters = build_embedding_cleanup_filters_from_base(
+        conn,
+        base_filter=base_expr,
+        user_id=user_id,
+        is_admin=is_admin,
+        model_tag=model_tag,
     )
+    for table_name, filter_exprs in table_filters.items():
+        if filter_exprs:
+            predicates[table_name] = list(filter_exprs)
 
 
 def _get_table_names(conn: Any) -> list[str]:
@@ -219,13 +243,13 @@ def _get_table_names(conn: Any) -> list[str]:
 
 
 def _plan_by_predicates(
-    conn: Any, table_to_filter: Dict[str, str], model_tag: Optional[str] = None
+    conn: Any, table_to_filter: FilterPredicateMap, model_tag: Optional[str] = None
 ) -> Dict[str, int]:
     """Count rows that match each table predicate without deleting.
 
     Args:
         conn: LanceDB connection
-        table_to_filter: Mapping of table name -> filter expression
+        table_to_filter: Mapping of table name -> filter expressions
         model_tag: Optional model tag to filter embeddings tables. If specified,
                    only the embeddings table matching this model will be counted.
 
@@ -241,11 +265,11 @@ def _plan_by_predicates(
             table = None
             try:
                 table = conn.open_table(t)
-                counts[t] = _safe_count_rows(table, table_to_filter[t])
+                counts[t] = _count_rows_by_filters(table, table_to_filter[t])
             finally:
                 _safe_close_table(table)
 
-    for table_name, filt in table_to_filter.items():
+    for table_name, filter_exprs in table_to_filter.items():
         # Special fan-out handling for embeddings preview like deleter
         if table_name == "__embeddings__":
             total = 0
@@ -254,11 +278,12 @@ def _plan_by_predicates(
                 table = None
                 try:
                     table = conn.open_table(t)
-                    count = _safe_count_rows(table, filt)
-                    total += count
+                    total += _count_rows_by_filters(table, filter_exprs)
                 finally:
                     _safe_close_table(table)
             counts[table_name] = total
+            continue
+        if table_name.startswith("embeddings_"):
             continue
 
         if table_name not in table_names:
@@ -267,7 +292,7 @@ def _plan_by_predicates(
         table = None
         try:
             table = conn.open_table(table_name)
-            count = _safe_count_rows(table, filt)
+            count = _count_rows_by_filters(table, filter_exprs)
             counts[table_name] = count
         finally:
             _safe_close_table(table)
@@ -275,7 +300,7 @@ def _plan_by_predicates(
 
 
 def _delete_by_predicates(
-    conn: Any, table_to_filter: Dict[str, str], model_tag: Optional[str] = None
+    conn: Any, table_to_filter: FilterPredicateMap, model_tag: Optional[str] = None
 ) -> Dict[str, int]:
     """Delete rows by table predicates in a fixed, safe order.
 
@@ -295,13 +320,12 @@ def _delete_by_predicates(
     for t in table_names:
         if not t.startswith("embeddings_") or t not in table_to_filter:
             continue
-        filt = table_to_filter[t]
+        filter_exprs = table_to_filter[t]
         table = None
         try:
             table = conn.open_table(t)
-            cnt = _safe_count_rows(table, filt)
+            cnt = _delete_rows_by_filters(table, filter_exprs)
             if cnt > 0:
-                table.delete(filt)
                 logger.info("Cascade cleanup: deleted %s rows from %s", cnt, t)
             deleted[t] = cnt
         finally:
@@ -319,7 +343,7 @@ def _delete_by_predicates(
 
     # First handle embeddings fan-out
     if "__embeddings__" in table_to_filter:
-        filt = table_to_filter["__embeddings__"]
+        filter_exprs = table_to_filter["__embeddings__"]
         total = 0
 
         target_tables = select_embedding_tables(conn, model_tag=model_tag)
@@ -328,10 +352,7 @@ def _delete_by_predicates(
             table = None
             try:
                 table = conn.open_table(t)
-                cnt = _safe_count_rows(table, filt)
-                if cnt > 0:
-                    table.delete(filt)
-                total += cnt
+                total += _delete_rows_by_filters(table, filter_exprs)
             finally:
                 _safe_close_table(table)
         deleted["embeddings"] = total
@@ -343,20 +364,18 @@ def _delete_by_predicates(
     # Then handle known tables
     for name in order[1:]:
         if name in table_to_filter and name in table_names:
-            filt = table_to_filter[name]
             table = None
             try:
                 table = conn.open_table(name)
-                cnt = _safe_count_rows(table, filt)
+                cnt = _delete_rows_by_filters(table, table_to_filter[name])
                 if cnt > 0:
-                    table.delete(filt)
                     logger.info("Cascade cleanup: deleted %s rows from %s", cnt, name)
                 deleted[name] = cnt
             finally:
                 _safe_close_table(table)
 
     # Finally, handle any remaining custom tables once
-    for name, filt in table_to_filter.items():
+    for name, filter_exprs in table_to_filter.items():
         if name in (
             "__embeddings__",
             "chunks",
@@ -372,9 +391,8 @@ def _delete_by_predicates(
         table = None
         try:
             table = conn.open_table(name)
-            cnt = _safe_count_rows(table, filt)
+            cnt = _delete_rows_by_filters(table, filter_exprs)
             if cnt > 0:
-                table.delete(filt)
                 logger.info("Cascade cleanup: deleted %s rows from %s", cnt, name)
             deleted[name] = cnt
         finally:
@@ -454,50 +472,50 @@ def _cascade_delete_impl(
     ensure_ingestion_runs_table(conn)
 
     table_names = _get_table_names(conn)
-    predicates: Dict[str, str] = {}
+    predicates: FilterPredicateMap = {}
 
-    # Core known tables
     core_tables = ["documents", "parses", "chunks", "main_pointers", "ingestion_runs"]
-    for t in core_tables:
-        if t not in table_names:
+    for table_name in core_tables:
+        if table_name not in table_names:
             continue
         if target == "collection":
-            predicates[t] = _build_collection_filter(
+            filter_expr = _build_collection_filter(
                 conn=conn,
-                table_name=t,
+                table_name=table_name,
                 collection=collection,
                 user_id=user_id,
                 is_admin=is_admin,
             )
         else:
-            predicates[t] = _build_document_filter(
+            filter_expr = _build_document_filter(
                 conn=conn,
-                table_name=t,
+                table_name=table_name,
                 collection=collection,
                 doc_id=str(doc_id),
                 user_id=user_id,
                 is_admin=is_admin,
             )
+        _set_predicate(predicates, table_name, filter_expr)
 
-    # Embeddings tables: expand explicitly so we can safely include user_id filter
-    for t in select_embedding_tables(conn, model_tag=model_tag):
+    for table_name in select_embedding_tables(conn, model_tag=model_tag):
         if target == "collection":
-            predicates[t] = _build_collection_filter(
+            filter_expr = _build_collection_filter(
                 conn=conn,
-                table_name=t,
+                table_name=table_name,
                 collection=collection,
                 user_id=user_id,
                 is_admin=is_admin,
             )
         else:
-            predicates[t] = _build_document_filter(
+            filter_expr = _build_document_filter(
                 conn=conn,
-                table_name=t,
+                table_name=table_name,
                 collection=collection,
                 doc_id=str(doc_id),
                 user_id=user_id,
                 is_admin=is_admin,
             )
+        _set_predicate(predicates, table_name, filter_expr)
 
     if preview_only and not confirm:
         return _plan_by_predicates(conn, predicates, model_tag=None)
@@ -540,13 +558,13 @@ def cascade_delete_documents(
     ensure_ingestion_runs_table(conn)
 
     table_names = _get_table_names(conn)
-    predicates: Dict[str, str] = {}
+    predicates: FilterPredicateMap = {}
 
     core_tables = ["documents", "parses", "chunks", "main_pointers", "ingestion_runs"]
     for table_name in core_tables:
         if table_name not in table_names:
             continue
-        predicates[table_name] = _build_documents_filter(
+        filter_expr = _build_documents_filter(
             conn=conn,
             table_name=table_name,
             collection=collection,
@@ -554,9 +572,10 @@ def cascade_delete_documents(
             user_id=user_id,
             is_admin=is_admin,
         )
+        _set_predicate(predicates, table_name, filter_expr)
 
     for table_name in select_embedding_tables(conn):
-        predicates[table_name] = _build_documents_filter(
+        filter_expr = _build_documents_filter(
             conn=conn,
             table_name=table_name,
             collection=collection,
@@ -564,6 +583,7 @@ def cascade_delete_documents(
             user_id=user_id,
             is_admin=is_admin,
         )
+        _set_predicate(predicates, table_name, filter_expr)
 
     if preview_only and not confirm:
         return _plan_by_predicates(conn, predicates, model_tag=None)
@@ -627,7 +647,6 @@ def _cleanup_cascade_impl(
     Returns:
         Deleted (or planned) counts per table scope
     """
-    # Default to admin=True for system-level version promotion operations
     if is_admin is None:
         is_admin = True
     user_scope = resolve_user_scope(user_id=user_id, is_admin=is_admin)
@@ -663,16 +682,14 @@ def _cleanup_cascade_impl(
             "ingestion_runs": int(raw.get("ingestion_runs", 0)),
         }
 
-    predicates: Dict[str, str] = {}
+    predicates: FilterPredicateMap = {}
 
     if scope == "parse":
-        # Fill old from pointer if needed
         if old_parse_hash is None:
             pointer = get_main_pointer(collection, doc_id, "parse")
             old_parse_hash = pointer["technical_id"] if pointer else None
 
         if old_parse_hash:
-            # Build safe filter expression for old parse hash
             base_filters = {
                 "collection": collection,
                 "doc_id": doc_id,
@@ -689,15 +706,18 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            predicates["chunks"] = _append_user_filter_if_needed(
-                conn=conn,
-                table_name="chunks",
-                base_expr=base,
-                user_id=user_id,
-                is_admin=is_admin,
+            _set_predicate(
+                predicates,
+                "chunks",
+                _append_user_filter_if_needed(
+                    conn=conn,
+                    table_name="chunks",
+                    base_expr=base,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ),
             )
         if new_parse_hash:
-            # Build safe filter expression for new parse hash (using != operator)
             escaped_collection = escape_lancedb_string(collection)
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_new_parse_hash = escape_lancedb_string(new_parse_hash)
@@ -710,26 +730,33 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            predicates["chunks"] = _append_user_filter_if_needed(
-                conn=conn,
-                table_name="chunks",
-                base_expr=other,
-                user_id=user_id,
-                is_admin=is_admin,
+            _set_predicate(
+                predicates,
+                "chunks",
+                _append_user_filter_if_needed(
+                    conn=conn,
+                    table_name="chunks",
+                    base_expr=other,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ),
             )
-            predicates["parses"] = _append_user_filter_if_needed(
-                conn=conn,
-                table_name="parses",
-                base_expr=other,
-                user_id=user_id,
-                is_admin=is_admin,
+            _set_predicate(
+                predicates,
+                "parses",
+                _append_user_filter_if_needed(
+                    conn=conn,
+                    table_name="parses",
+                    base_expr=other,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ),
             )
     elif scope == "chunk":
         if old_parse_hash is None:
             pointer = get_main_pointer(collection, doc_id, "chunk")
             old_parse_hash = pointer["technical_id"] if pointer else None
         if old_parse_hash:
-            # Build safe filter expression for old parse hash
             base_filters = {
                 "collection": collection,
                 "doc_id": doc_id,
@@ -747,8 +774,6 @@ def _cleanup_cascade_impl(
                 model_tag=model_tag,
             )
         if new_parse_hash:
-            # Note: For != operator, we need to manually construct the filter
-            # as build_lancedb_filter_expression only supports == operator
             escaped_collection = escape_lancedb_string(collection)
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_parse_hash = escape_lancedb_string(new_parse_hash)
@@ -761,12 +786,16 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            predicates["chunks"] = _append_user_filter_if_needed(
-                conn=conn,
-                table_name="chunks",
-                base_expr=other,
-                user_id=user_id,
-                is_admin=is_admin,
+            _set_predicate(
+                predicates,
+                "chunks",
+                _append_user_filter_if_needed(
+                    conn=conn,
+                    table_name="chunks",
+                    base_expr=other,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ),
             )
     elif scope == "embeddings":
         scope_obj = KBCleanupScope(
@@ -777,13 +806,9 @@ def _cleanup_cascade_impl(
             model_tag=model_tag,
         )
         filters_by_table = build_embedding_cleanup_filters(conn, scope_obj)
-        predicates.update(
-            {
-                table_name: filter_exprs[0]
-                for table_name, filter_exprs in filters_by_table.items()
-                if filter_exprs
-            }
-        )
+        for table_name, filter_exprs in filters_by_table.items():
+            if filter_exprs:
+                predicates[table_name] = list(filter_exprs)
     elif scope == "pointers":
         filt = _build_document_filter(
             conn=conn,
@@ -793,7 +818,7 @@ def _cleanup_cascade_impl(
             user_id=user_id,
             is_admin=is_admin,
         )
-        predicates["main_pointers"] = filt
+        _set_predicate(predicates, "main_pointers", filt)
     else:
         raise CascadeCleanupError(f"Unsupported scope: {scope}")
 

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -55,10 +55,22 @@ def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
 FilterPredicateMap = Dict[str, list[str]]
 
 
-def _set_predicate(
+def _replace_predicate(
     predicates: FilterPredicateMap, table_name: str, filter_expr: str
 ) -> None:
-    predicates[table_name] = [filter_expr]
+    _replace_predicates(predicates, table_name, [filter_expr])
+
+
+def _replace_predicates(
+    predicates: FilterPredicateMap, table_name: str, filter_exprs: list[str]
+) -> None:
+    predicates[table_name] = list(filter_exprs)
+
+
+def _append_predicates(
+    predicates: FilterPredicateMap, table_name: str, filter_exprs: list[str]
+) -> None:
+    predicates.setdefault(table_name, []).extend(filter_exprs)
 
 
 def _count_rows_by_filters(table: Any, filter_exprs: list[str]) -> int:
@@ -212,7 +224,7 @@ def _append_user_filter_if_needed(
         _safe_close_table(table)
 
 
-def _add_embedding_predicates(
+def _replace_embedding_predicates(
     *,
     predicates: FilterPredicateMap,
     conn: Any,
@@ -231,7 +243,7 @@ def _add_embedding_predicates(
     )
     for table_name, filter_exprs in table_filters.items():
         if filter_exprs:
-            predicates[table_name] = list(filter_exprs)
+            _replace_predicates(predicates, table_name, filter_exprs)
 
 
 def _get_table_names(conn: Any) -> list[str]:
@@ -495,7 +507,7 @@ def _cascade_delete_impl(
                 user_id=user_id,
                 is_admin=is_admin,
             )
-        _set_predicate(predicates, table_name, filter_expr)
+        _replace_predicate(predicates, table_name, filter_expr)
 
     for table_name in select_embedding_tables(conn, model_tag=model_tag):
         if target == "collection":
@@ -515,7 +527,7 @@ def _cascade_delete_impl(
                 user_id=user_id,
                 is_admin=is_admin,
             )
-        _set_predicate(predicates, table_name, filter_expr)
+        _replace_predicate(predicates, table_name, filter_expr)
 
     if preview_only and not confirm:
         return _plan_by_predicates(conn, predicates, model_tag=None)
@@ -572,7 +584,7 @@ def cascade_delete_documents(
             user_id=user_id,
             is_admin=is_admin,
         )
-        _set_predicate(predicates, table_name, filter_expr)
+        _replace_predicate(predicates, table_name, filter_expr)
 
     for table_name in select_embedding_tables(conn):
         filter_expr = _build_documents_filter(
@@ -583,7 +595,7 @@ def cascade_delete_documents(
             user_id=user_id,
             is_admin=is_admin,
         )
-        _set_predicate(predicates, table_name, filter_expr)
+        _replace_predicate(predicates, table_name, filter_expr)
 
     if preview_only and not confirm:
         return _plan_by_predicates(conn, predicates, model_tag=None)
@@ -698,7 +710,7 @@ def _cleanup_cascade_impl(
             base = build_lancedb_filter_expression(
                 base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
             )
-            _add_embedding_predicates(
+            _replace_embedding_predicates(
                 predicates=predicates,
                 conn=conn,
                 base_expr=base,
@@ -706,7 +718,7 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            _set_predicate(
+            _replace_predicate(
                 predicates,
                 "chunks",
                 _append_user_filter_if_needed(
@@ -722,7 +734,7 @@ def _cleanup_cascade_impl(
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_new_parse_hash = escape_lancedb_string(new_parse_hash)
             other = f"collection == '{escaped_collection}' AND doc_id == '{escaped_doc_id}' AND parse_hash != '{escaped_new_parse_hash}'"
-            _add_embedding_predicates(
+            _replace_embedding_predicates(
                 predicates=predicates,
                 conn=conn,
                 base_expr=other,
@@ -730,7 +742,7 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            _set_predicate(
+            _replace_predicate(
                 predicates,
                 "chunks",
                 _append_user_filter_if_needed(
@@ -741,7 +753,7 @@ def _cleanup_cascade_impl(
                     is_admin=is_admin,
                 ),
             )
-            _set_predicate(
+            _replace_predicate(
                 predicates,
                 "parses",
                 _append_user_filter_if_needed(
@@ -765,7 +777,7 @@ def _cleanup_cascade_impl(
             base = build_lancedb_filter_expression(
                 base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
             )
-            _add_embedding_predicates(
+            _replace_embedding_predicates(
                 predicates=predicates,
                 conn=conn,
                 base_expr=base,
@@ -778,7 +790,7 @@ def _cleanup_cascade_impl(
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_parse_hash = escape_lancedb_string(new_parse_hash)
             other = f"collection == '{escaped_collection}' AND doc_id == '{escaped_doc_id}' AND parse_hash != '{escaped_parse_hash}'"
-            _add_embedding_predicates(
+            _replace_embedding_predicates(
                 predicates=predicates,
                 conn=conn,
                 base_expr=other,
@@ -786,7 +798,7 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
                 model_tag=model_tag,
             )
-            _set_predicate(
+            _replace_predicate(
                 predicates,
                 "chunks",
                 _append_user_filter_if_needed(
@@ -808,7 +820,7 @@ def _cleanup_cascade_impl(
         filters_by_table = build_embedding_cleanup_filters(conn, scope_obj)
         for table_name, filter_exprs in filters_by_table.items():
             if filter_exprs:
-                predicates[table_name] = list(filter_exprs)
+                _append_predicates(predicates, table_name, filter_exprs)
     elif scope == "pointers":
         filt = _build_document_filter(
             conn=conn,
@@ -818,7 +830,7 @@ def _cleanup_cascade_impl(
             user_id=user_id,
             is_admin=is_admin,
         )
-        _set_predicate(predicates, "main_pointers", filt)
+        _replace_predicate(predicates, "main_pointers", filt)
     else:
         raise CascadeCleanupError(f"Unsupported scope: {scope}")
 

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -413,6 +413,25 @@ def _delete_by_predicates(
     return deleted
 
 
+def _should_execute_delete(*, preview_only: bool, confirm: bool) -> bool:
+    """Return whether a destructive cleanup should execute."""
+    return bool(confirm and not preview_only)
+
+
+def _execute_or_plan_by_predicates(
+    conn: Any,
+    predicates: FilterPredicateMap,
+    *,
+    preview_only: bool,
+    confirm: bool,
+    model_tag: Optional[str] = None,
+) -> Dict[str, int]:
+    """Plan unless deletion is explicitly confirmed outside preview mode."""
+    if not _should_execute_delete(preview_only=preview_only, confirm=confirm):
+        return _plan_by_predicates(conn, predicates, model_tag=model_tag)
+    return _delete_by_predicates(conn, predicates, model_tag=model_tag)
+
+
 def cascade_delete(
     *,
     target: Literal["collection", "document"],
@@ -529,10 +548,13 @@ def _cascade_delete_impl(
             )
         _replace_predicate(predicates, table_name, filter_expr)
 
-    if preview_only and not confirm:
-        return _plan_by_predicates(conn, predicates, model_tag=None)
-
-    return _delete_by_predicates(conn, predicates, model_tag=None)
+    return _execute_or_plan_by_predicates(
+        conn,
+        predicates,
+        preview_only=preview_only,
+        confirm=confirm,
+        model_tag=None,
+    )
 
 
 def cascade_delete_documents(
@@ -597,10 +619,13 @@ def cascade_delete_documents(
         )
         _replace_predicate(predicates, table_name, filter_expr)
 
-    if preview_only and not confirm:
-        return _plan_by_predicates(conn, predicates, model_tag=None)
-
-    return _delete_by_predicates(conn, predicates, model_tag=None)
+    return _execute_or_plan_by_predicates(
+        conn,
+        predicates,
+        preview_only=preview_only,
+        confirm=confirm,
+        model_tag=None,
+    )
 
 
 def cleanup_cascade(
@@ -834,16 +859,16 @@ def _cleanup_cascade_impl(
     else:
         raise CascadeCleanupError(f"Unsupported scope: {scope}")
 
-    if preview_only and not confirm:
-        planned = _plan_by_predicates(conn, predicates, model_tag=model_tag)
-        if scope in {"parse", "chunk", "embeddings"}:
-            return _collapse_embedding_table_counts(planned)
-        return planned
-
-    deleted = _delete_by_predicates(conn, predicates, model_tag=model_tag)
+    result = _execute_or_plan_by_predicates(
+        conn,
+        predicates,
+        preview_only=preview_only,
+        confirm=confirm,
+        model_tag=model_tag,
+    )
     if scope in {"parse", "chunk", "embeddings"}:
-        return _collapse_embedding_table_counts(deleted)
-    return deleted
+        return _collapse_embedding_table_counts(result)
+    return result
 
 
 def _collapse_embedding_table_counts(counts: Dict[str, int]) -> Dict[str, int]:

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -837,7 +837,9 @@ def _cleanup_cascade_impl(
 def _collapse_embedding_table_counts(counts: Dict[str, int]) -> Dict[str, int]:
     """Collapse concrete embeddings table counts into the legacy summary key."""
     collapsed = dict(counts)
-    embeddings_total = int(collapsed.pop("__embeddings__", 0))
+    embeddings_total = int(collapsed.pop("__embeddings__", 0)) + int(
+        collapsed.pop("embeddings", 0)
+    )
     for table_name in list(collapsed):
         if str(table_name).startswith("embeddings_"):
             embeddings_total += int(collapsed.pop(table_name, 0))

--- a/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/cascade_cleaner.py
@@ -12,6 +12,15 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from typing_extensions import Literal
 
 from ..core.exceptions import CascadeCleanupError
+from ..kb.cleanup_filters import (
+    KBCleanupScope,
+    append_user_filter_for_table,
+    append_user_filter_without_schema,
+    build_embedding_cleanup_filters,
+    build_embedding_cleanup_filters_from_base,
+    select_embedding_tables,
+)
+from ..kb.cleanup_filters import table_has_column as _table_has_column
 from ..LanceDB.schema_manager import (
     _safe_close_table,
     ensure_chunks_table,
@@ -41,19 +50,6 @@ def _get_version_compatibility_facade() -> "KBVersionCompatibilityFacade":
     from ..kb import get_kb_coordinator
 
     return get_kb_coordinator().version_compatibility
-
-
-def _table_has_column(table: Any, column: str) -> bool:
-    try:
-        schema = getattr(table, "schema", None)
-        if schema is None:
-            return False
-        names = getattr(schema, "names", None)
-        if not isinstance(names, list):
-            return False
-        return column in names
-    except Exception:
-        return False
 
 
 def _build_collection_filter(
@@ -174,49 +170,44 @@ def _append_user_filter_if_needed(
     is_admin: bool,
 ) -> str:
     """Append user_id filter when non-admin and table contains user_id."""
-    if is_admin or user_id is None:
-        return base_expr
     table = None
     try:
         table = conn.open_table(table_name)
-        if _table_has_column(table, "user_id"):
-            return (
-                f"{base_expr} AND {build_user_id_filter_for_table(table, int(user_id))}"
-            )
+        return append_user_filter_for_table(
+            table=table,
+            filter_expr=base_expr,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
     except Exception:
-        return base_expr
+        return append_user_filter_without_schema(
+            filter_expr=base_expr,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
     finally:
         _safe_close_table(table)
-    return base_expr
 
 
-def _append_user_filter_for_embeddings_if_needed(
+def _add_embedding_predicates(
     *,
+    predicates: Dict[str, str],
     conn: Any,
     base_expr: str,
     user_id: Optional[int],
     is_admin: bool,
     model_tag: Optional[str] = None,
-) -> str:
-    """Append user filter for embeddings by inspecting embeddings table schema."""
-    if is_admin or user_id is None:
-        return base_expr
-    table_names = _get_table_names(conn)
-    target_tables = [t for t in table_names if t.startswith("embeddings_")]
-    if model_tag is not None:
-        target_tables = [t for t in target_tables if t == f"embeddings_{model_tag}"]
-    if not target_tables:
-        return base_expr
-    table = None
-    try:
-        table = conn.open_table(target_tables[0])
-        if not _table_has_column(table, "user_id"):
-            return base_expr
-        return f"{base_expr} AND {build_user_id_filter_for_table(table, int(user_id))}"
-    except Exception:
-        return base_expr
-    finally:
-        _safe_close_table(table)
+) -> None:
+    """Expand an embeddings cleanup predicate per target embeddings table."""
+    predicates.update(
+        build_embedding_cleanup_filters_from_base(
+            conn,
+            base_filter=base_expr,
+            user_id=user_id,
+            is_admin=is_admin,
+            model_tag=model_tag,
+        )
+    )
 
 
 def _get_table_names(conn: Any) -> list[str]:
@@ -258,13 +249,8 @@ def _plan_by_predicates(
         # Special fan-out handling for embeddings preview like deleter
         if table_name == "__embeddings__":
             total = 0
-            all_embed_tables = [t for t in table_names if t.startswith("embeddings_")]
-            # Apply model_tag filter if specified (must match _delete_by_predicates logic)
-            if model_tag:
-                all_embed_tables = [
-                    t for t in all_embed_tables if t == f"embeddings_{model_tag}"
-                ]
-            for t in all_embed_tables:
+            target_tables = select_embedding_tables(conn, model_tag=model_tag)
+            for t in target_tables:
                 table = None
                 try:
                     table = conn.open_table(t)
@@ -336,14 +322,7 @@ def _delete_by_predicates(
         filt = table_to_filter["__embeddings__"]
         total = 0
 
-        # Filter embeddings tables based on model_tag if specified
-        all_embed_tables = [t for t in table_names if t.startswith("embeddings_")]
-        if model_tag is not None:
-            target_tables = [
-                t for t in all_embed_tables if t == f"embeddings_{model_tag}"
-            ]
-        else:
-            target_tables = all_embed_tables
+        target_tables = select_embedding_tables(conn, model_tag=model_tag)
 
         for t in target_tables:
             table = None
@@ -501,11 +480,7 @@ def _cascade_delete_impl(
             )
 
     # Embeddings tables: expand explicitly so we can safely include user_id filter
-    for t in table_names:
-        if not t.startswith("embeddings_"):
-            continue
-        if model_tag is not None and t != f"embeddings_{model_tag}":
-            continue
+    for t in select_embedding_tables(conn, model_tag=model_tag):
         if target == "collection":
             predicates[t] = _build_collection_filter(
                 conn=conn,
@@ -580,9 +555,7 @@ def cascade_delete_documents(
             is_admin=is_admin,
         )
 
-    for table_name in table_names:
-        if not table_name.startswith("embeddings_"):
-            continue
+    for table_name in select_embedding_tables(conn):
         predicates[table_name] = _build_documents_filter(
             conn=conn,
             table_name=table_name,
@@ -708,7 +681,8 @@ def _cleanup_cascade_impl(
             base = build_lancedb_filter_expression(
                 base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
             )
-            predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
+            _add_embedding_predicates(
+                predicates=predicates,
                 conn=conn,
                 base_expr=base,
                 user_id=user_id,
@@ -728,7 +702,8 @@ def _cleanup_cascade_impl(
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_new_parse_hash = escape_lancedb_string(new_parse_hash)
             other = f"collection == '{escaped_collection}' AND doc_id == '{escaped_doc_id}' AND parse_hash != '{escaped_new_parse_hash}'"
-            predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
+            _add_embedding_predicates(
+                predicates=predicates,
                 conn=conn,
                 base_expr=other,
                 user_id=user_id,
@@ -763,7 +738,8 @@ def _cleanup_cascade_impl(
             base = build_lancedb_filter_expression(
                 base_filters, user_id=user_id, is_admin=is_admin, skip_user_filter=True
             )
-            predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
+            _add_embedding_predicates(
+                predicates=predicates,
                 conn=conn,
                 base_expr=base,
                 user_id=user_id,
@@ -777,7 +753,8 @@ def _cleanup_cascade_impl(
             escaped_doc_id = escape_lancedb_string(doc_id)
             escaped_parse_hash = escape_lancedb_string(new_parse_hash)
             other = f"collection == '{escaped_collection}' AND doc_id == '{escaped_doc_id}' AND parse_hash != '{escaped_parse_hash}'"
-            predicates["__embeddings__"] = _append_user_filter_for_embeddings_if_needed(
+            _add_embedding_predicates(
+                predicates=predicates,
                 conn=conn,
                 base_expr=other,
                 user_id=user_id,
@@ -792,22 +769,21 @@ def _cleanup_cascade_impl(
                 is_admin=is_admin,
             )
     elif scope == "embeddings":
-        # Build per-embeddings-table predicates so user_id filtering is based on
-        # each embeddings table's own schema (forward/backward compatible).
-        table_names = _get_table_names(conn)
-        for t in table_names:
-            if not t.startswith("embeddings_"):
-                continue
-            if model_tag is not None and t != f"embeddings_{model_tag}":
-                continue
-            predicates[t] = _build_document_filter(
-                conn=conn,
-                table_name=t,
-                collection=collection,
-                doc_id=doc_id,
-                user_id=user_id,
-                is_admin=is_admin,
-            )
+        scope_obj = KBCleanupScope(
+            collection=collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+            model_tag=model_tag,
+        )
+        filters_by_table = build_embedding_cleanup_filters(conn, scope_obj)
+        predicates.update(
+            {
+                table_name: filter_exprs[0]
+                for table_name, filter_exprs in filters_by_table.items()
+                if filter_exprs
+            }
+        )
     elif scope == "pointers":
         filt = _build_document_filter(
             conn=conn,
@@ -823,20 +799,25 @@ def _cleanup_cascade_impl(
 
     if preview_only and not confirm:
         planned = _plan_by_predicates(conn, predicates, model_tag=model_tag)
-        if "__embeddings__" in planned:
-            planned["embeddings"] = planned.pop("__embeddings__")
-        elif scope == "embeddings":
-            planned["embeddings"] = sum(
-                int(v) for k, v in planned.items() if str(k).startswith("embeddings_")
-            )
+        if scope in {"parse", "chunk", "embeddings"}:
+            return _collapse_embedding_table_counts(planned)
         return planned
 
     deleted = _delete_by_predicates(conn, predicates, model_tag=model_tag)
-    if scope == "embeddings" and "__embeddings__" not in predicates:
-        deleted["embeddings"] = sum(
-            int(v) for k, v in deleted.items() if str(k).startswith("embeddings_")
-        )
+    if scope in {"parse", "chunk", "embeddings"}:
+        return _collapse_embedding_table_counts(deleted)
     return deleted
+
+
+def _collapse_embedding_table_counts(counts: Dict[str, int]) -> Dict[str, int]:
+    """Collapse concrete embeddings table counts into the legacy summary key."""
+    collapsed = dict(counts)
+    embeddings_total = int(collapsed.pop("__embeddings__", 0))
+    for table_name in list(collapsed):
+        if str(table_name).startswith("embeddings_"):
+            embeddings_total += int(collapsed.pop(table_name, 0))
+    collapsed["embeddings"] = embeddings_total
+    return collapsed
 
 
 def cleanup_document_cascade(

--- a/tests/core/tools/core/RAG_tools/management/test_collections.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collections.py
@@ -1162,10 +1162,11 @@ def test_delete_document_clears_status_with_caller_scope() -> None:
 def test_delete_document_cleans_failed_ingest_status_by_doc_id(
     temp_lancedb_dir: str,
 ) -> None:
-    """Failed ingest rollback cleanup should remove document data and status."""
+    """Failed ingest rollback cleanup should remove document data, vectors, and status."""
 
     collection = "failed_ingest_cleanup"
     doc_id = "failed-doc"
+    model_name = "text-embedding-v3"
     now = datetime.now(timezone.utc)
 
     _insert_documents(
@@ -1183,6 +1184,25 @@ def test_delete_document_cleans_failed_ingest_status_by_doc_id(
             }
         ]
     )
+    _insert_embeddings(
+        model_name,
+        [
+            {
+                "collection": collection,
+                "doc_id": doc_id,
+                "chunk_id": "chunk-1",
+                "parse_hash": "parse-failed",
+                "model": model_name,
+                "vector": [0.1, 0.2, 0.3],
+                "vector_dimension": 3,
+                "text": "partial vector written before ingest failed",
+                "chunk_hash": "failed-chunk-hash",
+                "created_at": now,
+                "metadata": "{}",
+                "user_id": 7,
+            }
+        ],
+    )
     write_ingestion_status(
         collection,
         doc_id,
@@ -1191,10 +1211,17 @@ def test_delete_document_cleans_failed_ingest_status_by_doc_id(
         user_id=7,
     )
 
+    conn = get_vector_index_store().get_raw_connection()
+    embedding_table = conn.open_table(embeddings_table_name(model_name))
+    assert embedding_table.count_rows() == 1
+
     result = delete_document(collection, doc_id, user_id=7, is_admin=False)
 
     assert result.status == "success"
     assert result.details.get("documents") == 1
+    assert result.details.get(embeddings_table_name(model_name)) == 1
+    embedding_table = conn.open_table(embeddings_table_name(model_name))
+    assert embedding_table.count_rows() == 0
     assert (
         load_ingestion_status(
             collection=collection,

--- a/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
@@ -13,6 +13,9 @@ from xagent.core.tools.core.RAG_tools.kb import (
     KBVectorStorageCleanupResult,
     KBVectorStorageCompatibilityFacade,
 )
+from xagent.core.tools.core.RAG_tools.kb.cleanup_filters import (
+    normalize_cleanup_chunk_ids,
+)
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from xagent.core.tools.core.RAG_tools.vector_storage import vector_manager
 
@@ -116,6 +119,12 @@ def test_coordinator_exposes_vector_storage_facade():
         KBVectorStorageCompatibilityFacade,
     )
     assert coordinator.vector_storage is coordinator.vector_storage_compatibility
+
+
+def test_normalize_cleanup_chunk_ids_skips_none_and_empty_values():
+    result = normalize_cleanup_chunk_ids(["ch2", None, "", "ch1", "ch1"])
+
+    assert result == ("ch1", "ch2")
 
 
 def test_cleanup_vectors_for_chunks_uses_model_tag_table_and_reports_counts(

--- a/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
+
+import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     EmbeddingReadResponse,
@@ -11,6 +13,7 @@ from xagent.core.tools.core.RAG_tools.kb import (
     KBVectorStorageCleanupResult,
     KBVectorStorageCompatibilityFacade,
 )
+from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from xagent.core.tools.core.RAG_tools.vector_storage import vector_manager
 
 
@@ -127,7 +130,7 @@ def test_cleanup_vectors_for_chunks_uses_model_tag_table_and_reports_counts(
     facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
 
     monkeypatch.setattr(
-        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
         "build_lancedb_filter_expression",
         lambda filters, **kwargs: " AND ".join(
             f"{key} == '{value}'" for key, value in filters.items()
@@ -153,13 +156,91 @@ def test_cleanup_vectors_for_chunks_uses_model_tag_table_and_reports_counts(
         model_tag="model_a",
         preview_only=False,
     )
-    conn.open_table.assert_called_once_with("embeddings_model_a")
+    assert conn.open_table.call_args_list == [
+        call("embeddings_model_a"),
+        call("embeddings_model_a"),
+    ]
     table.count_rows.assert_called_once_with(
         "collection == 'c' AND doc_id == 'd' AND chunk_id == 'ch1' AND user_id == 7"
     )
     table.delete.assert_called_once_with(
         "collection == 'c' AND doc_id == 'd' AND chunk_id == 'ch1' AND user_id == 7"
     )
+
+
+def test_cleanup_vectors_for_operation_uses_request_user_scope(monkeypatch):
+    table = _table_with_user_id(count=1)
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: " AND ".join(
+            f"{key} == '{value}'" for key, value in filters.items()
+        ),
+    )
+
+    with user_scope_context(user_id=42, is_admin=False):
+        result = facade.cleanup_vectors_for_document(
+            collection="c",
+            doc_id="d",
+            preview_only=True,
+            confirm=False,
+        )
+
+    assert result.status == "planned"
+    table.count_rows.assert_called_once_with(
+        "collection == 'c' AND doc_id == 'd' AND user_id == 42"
+    )
+
+
+def test_cleanup_vectors_for_operation_without_user_scope_fails_closed(monkeypatch):
+    table = _table_with_user_id(count=0)
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: " AND ".join(
+            f"{key} == '{value}'" for key, value in filters.items()
+        ),
+    )
+
+    facade.cleanup_vectors_for_document(
+        collection="c",
+        doc_id="d",
+        user_id=None,
+        is_admin=False,
+        preview_only=True,
+        confirm=False,
+    )
+
+    filter_expr = table.count_rows.call_args.args[0]
+    assert "collection == 'c'" in filter_expr
+    assert "doc_id == 'd'" in filter_expr
+    assert "user_id IS NULL" in filter_expr
+    assert "user_id IS NOT NULL" in filter_expr
+
+
+def test_cleanup_vectors_for_operation_rejects_chunk_ids_without_doc_id():
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=MagicMock())
+
+    with pytest.raises(ValueError, match="doc_id is required"):
+        facade.cleanup_vectors_for_operation(
+            collection="c",
+            chunk_ids=["ch1"],
+            model_tag="model_a",
+        )
 
 
 def test_cleanup_vectors_for_operation_preview_does_not_delete(monkeypatch):
@@ -172,7 +253,7 @@ def test_cleanup_vectors_for_operation_preview_does_not_delete(monkeypatch):
     facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
 
     monkeypatch.setattr(
-        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
         "build_lancedb_filter_expression",
         lambda filters, **kwargs: "base_filter",
     )
@@ -201,7 +282,7 @@ def test_cleanup_vectors_for_operation_reports_partial_cleanup_failure(monkeypat
     facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
 
     monkeypatch.setattr(
-        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
         "build_lancedb_filter_expression",
         lambda filters, **kwargs: "base_filter",
     )

--- a/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    EmbeddingReadResponse,
+    EmbeddingWriteResponse,
+)
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBCoordinator,
+    KBVectorStorageCleanupResult,
+    KBVectorStorageCompatibilityFacade,
+)
+from xagent.core.tools.core.RAG_tools.vector_storage import vector_manager
+
+
+def test_public_vector_storage_functions_route_through_facade(monkeypatch):
+    facade = MagicMock()
+    read_response = EmbeddingReadResponse(chunks=[], total_count=0, pending_count=0)
+    write_response = EmbeddingWriteResponse(
+        upsert_count=0,
+        deleted_stale_count=0,
+        index_status="skipped",
+    )
+    facade.read_chunks_for_embedding.return_value = read_response
+    facade.write_vectors_to_db.return_value = write_response
+
+    monkeypatch.setattr(
+        vector_manager,
+        "_get_vector_storage_compatibility_facade",
+        lambda: facade,
+    )
+
+    vector_manager.validate_query_vector([1.0])
+    assert (
+        vector_manager.read_chunks_for_embedding(
+            collection="c",
+            doc_id="d",
+            parse_hash="p",
+            model="m",
+            filters={"section": "s"},
+            user_id=7,
+            is_admin=False,
+        )
+        is read_response
+    )
+    assert (
+        vector_manager.write_vectors_to_db(
+            collection="c",
+            embeddings=[],
+            create_index=False,
+            user_id=7,
+        )
+        is write_response
+    )
+
+    facade.validate_query_vector.assert_called_once_with(
+        [1.0],
+        model_tag=None,
+        conn=None,
+        user_id=None,
+        is_admin=False,
+    )
+    facade.read_chunks_for_embedding.assert_called_once_with(
+        collection="c",
+        doc_id="d",
+        parse_hash="p",
+        model="m",
+        filters={"section": "s"},
+        user_id=7,
+        is_admin=False,
+    )
+    facade.write_vectors_to_db.assert_called_once_with(
+        collection="c",
+        embeddings=[],
+        create_index=False,
+        user_id=7,
+    )
+
+
+def test_vector_storage_facade_binds_storage_shim_for_read_chunks():
+    vector_store = MagicMock()
+    vector_store.count_rows_or_zero.return_value = 0
+    storage_shim = MagicMock()
+    storage_shim.get_vector_index_store.return_value = vector_store
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    result = facade.read_chunks_for_embedding(
+        collection="c",
+        doc_id="d",
+        parse_hash="p",
+        model="m",
+        user_id=7,
+        is_admin=False,
+    )
+
+    assert result == EmbeddingReadResponse(chunks=[], total_count=0, pending_count=0)
+    storage_shim.get_vector_index_store.assert_called_once_with()
+    vector_store.count_rows_or_zero.assert_called_once_with(
+        table_name="chunks",
+        filters={"collection": "c", "doc_id": "d", "parse_hash": "p"},
+        user_id=7,
+        is_admin=False,
+    )
+    vector_store.iter_batches.assert_not_called()
+
+
+def test_coordinator_exposes_vector_storage_facade():
+    coordinator = KBCoordinator()
+
+    assert isinstance(
+        coordinator.vector_storage_compatibility,
+        KBVectorStorageCompatibilityFacade,
+    )
+    assert coordinator.vector_storage is coordinator.vector_storage_compatibility
+
+
+def test_cleanup_vectors_for_chunks_uses_model_tag_table_and_reports_counts(
+    monkeypatch,
+):
+    table = _table_with_user_id(count=2)
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a", "embeddings_model_b"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: " AND ".join(
+            f"{key} == '{value}'" for key, value in filters.items()
+        ),
+    )
+
+    result = facade.cleanup_vectors_for_chunks(
+        collection="c",
+        doc_id="d",
+        chunk_ids=["ch1", "ch1"],
+        model_tag="model_a",
+        user_id=7,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert result == KBVectorStorageCleanupResult(
+        collection="c",
+        status="complete",
+        deleted_count=2,
+        table_counts={"embeddings_model_a": 2},
+        model_tag="model_a",
+        preview_only=False,
+    )
+    conn.open_table.assert_called_once_with("embeddings_model_a")
+    table.count_rows.assert_called_once_with(
+        "collection == 'c' AND doc_id == 'd' AND chunk_id == 'ch1' AND user_id == 7"
+    )
+    table.delete.assert_called_once_with(
+        "collection == 'c' AND doc_id == 'd' AND chunk_id == 'ch1' AND user_id == 7"
+    )
+
+
+def test_cleanup_vectors_for_operation_preview_does_not_delete(monkeypatch):
+    table = _table_with_user_id(count=3)
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: "base_filter",
+    )
+
+    result = facade.cleanup_vectors_for_operation(
+        collection="c",
+        doc_id="d",
+        preview_only=True,
+        confirm=True,
+    )
+
+    assert result.status == "planned"
+    assert result.deleted_count == 3
+    assert result.table_counts == {"embeddings_model_a": 3}
+    table.delete.assert_not_called()
+
+
+def test_cleanup_vectors_for_operation_reports_partial_cleanup_failure(monkeypatch):
+    table = _table_with_user_id(count=0)
+    table.count_rows.side_effect = RuntimeError("count failed")
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.vector_storage_compatibility."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: "base_filter",
+    )
+
+    result = facade.cleanup_vectors_for_operation(
+        collection="c",
+        doc_id="d",
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert result.status == "incomplete"
+    assert result.deleted_count == 0
+    assert result.table_counts == {}
+    assert result.side_effects_may_remain is True
+    assert result.warnings == ("embeddings_model_a: count failed",)
+
+
+def _table_with_user_id(count: int) -> MagicMock:
+    table = MagicMock()
+    schema = MagicMock()
+    schema.names = ["collection", "doc_id", "chunk_id", "user_id"]
+    user_id_field = MagicMock()
+    user_id_field.type = "int64"
+    schema.field.return_value = user_id_field
+    table.schema = schema
+    table.count_rows.return_value = count
+    return table

--- a/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py
@@ -177,6 +177,44 @@ def test_cleanup_vectors_for_chunks_uses_model_tag_table_and_reports_counts(
     )
 
 
+def test_cleanup_vectors_for_chunks_batches_chunk_ids_with_in_filter(monkeypatch):
+    table = _table_with_user_id(count=4)
+    conn = MagicMock()
+    conn.list_tables.return_value = ["embeddings_model_a"]
+    conn.open_table.return_value = table
+    storage_shim = MagicMock()
+    storage_shim.get_vector_store_raw_connection.return_value = conn
+    facade = KBVectorStorageCompatibilityFacade(storage_shim=storage_shim)
+
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.kb.cleanup_filters."
+        "build_lancedb_filter_expression",
+        lambda filters, **kwargs: " AND ".join(
+            f"{key} == '{value}'" for key, value in filters.items()
+        ),
+    )
+
+    result = facade.cleanup_vectors_for_chunks(
+        collection="c",
+        doc_id="d",
+        chunk_ids=["ch2", "ch1", "ch1"],
+        model_tag="model_a",
+        user_id=7,
+        is_admin=False,
+        preview_only=False,
+        confirm=True,
+    )
+
+    assert result.deleted_count == 4
+    assert result.table_counts == {"embeddings_model_a": 4}
+    expected_filter = (
+        "collection == 'c' AND doc_id == 'd' "
+        "AND chunk_id IN ('ch1', 'ch2') AND user_id == 7"
+    )
+    table.count_rows.assert_called_once_with(expected_filter)
+    table.delete.assert_called_once_with(expected_filter)
+
+
 def test_cleanup_vectors_for_operation_uses_request_user_scope(monkeypatch):
     table = _table_with_user_id(count=1)
     conn = MagicMock()

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -1095,6 +1095,131 @@ def test_cascade_delete_document_model_tag_probe_error_without_user_id_denied(
 @patch(
     "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
 )
+def test_cleanup_parse_cascade_probe_error_without_user_id_denied(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Parse cleanup should fail closed if table schema probing fails."""
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = ["chunks", "embeddings_m1"]
+
+    def mock_open_table(table_name: str) -> MagicMock:
+        if table_name == "chunks":
+            raise RuntimeError("chunks unavailable")
+        if table_name == "embeddings_m1":
+            raise RuntimeError("embeddings unavailable")
+        raise AssertionError(table_name)
+
+    conn.open_table.side_effect = mock_open_table
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {}
+        cleanup_parse_cascade(
+            "c_probe",
+            "d_probe",
+            new_parse_hash="new",
+            user_id=None,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert "user_id IS NULL" in predicates["chunks"]
+    assert "user_id IS NOT NULL" in predicates["chunks"]
+    assert "user_id IS NULL" in predicates["embeddings_m1"]
+    assert "user_id IS NOT NULL" in predicates["embeddings_m1"]
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cleanup_embed_without_user_scope_fails_closed(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Embeddings cleanup should not become document-wide without user scope."""
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = ["embeddings_m1"]
+    table = _create_mock_table_with_columns(["collection", "doc_id", "user_id"])
+    table.count_rows.return_value = 0
+    conn.open_table.return_value = table
+    mock_get_conn.return_value = conn
+
+    cleanup_embed_cascade(
+        "c_denied",
+        "d_denied",
+        user_id=None,
+        is_admin=False,
+        preview_only=True,
+        confirm=False,
+    )
+
+    filter_expr = table.count_rows.call_args.args[0]
+    assert "collection == 'c_denied'" in filter_expr
+    assert "doc_id == 'd_denied'" in filter_expr
+    assert "user_id IS NULL" in filter_expr
+    assert "user_id IS NOT NULL" in filter_expr
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cleanup_parse_cascade_expands_embeddings_predicates_per_table(
+    mock_get_conn: MagicMock,
+) -> None:
+    """Parse cleanup should use per-table embeddings predicates, not __embeddings__."""
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = [
+        "chunks",
+        "parses",
+        "embeddings_m1",
+        "embeddings_legacy",
+    ]
+    table_map = {
+        "chunks": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "parses": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "embeddings_m1": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "embeddings_legacy": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash"]
+        ),
+    }
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"embeddings_m1": 2, "embeddings_legacy": 3}
+        result = cleanup_parse_cascade(
+            "c_parse",
+            "d_parse",
+            new_parse_hash="new",
+            user_id=7,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert "__embeddings__" not in predicates
+    assert "embeddings_m1" in predicates
+    assert "embeddings_legacy" in predicates
+    assert "user_id == 7" in predicates["embeddings_m1"]
+    assert "user_id == 7" not in predicates["embeddings_legacy"]
+    assert result["embeddings"] == 5
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
 def test_cascade_delete_confirm_delete_error_propagates(
     mock_get_conn: MagicMock,
 ) -> None:

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -13,6 +13,7 @@ from xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner import 
     _collapse_embedding_table_counts,
     _replace_predicate,
     _replace_predicates,
+    _should_execute_delete,
     cascade_delete,
     cascade_delete_documents,
     cleanup_chunk_cascade,
@@ -78,6 +79,13 @@ def test_predicate_helpers_distinguish_replace_and_append() -> None:
 
     _replace_predicates(predicates, "table", ["final"])
     assert predicates["table"] == ["final"]
+
+
+def test_should_execute_delete_requires_confirm_and_non_preview() -> None:
+    assert _should_execute_delete(preview_only=False, confirm=True) is True
+    assert _should_execute_delete(preview_only=True, confirm=True) is False
+    assert _should_execute_delete(preview_only=False, confirm=False) is False
+    assert _should_execute_delete(preview_only=True, confirm=False) is False
 
 
 @patch(
@@ -1364,6 +1372,139 @@ def test_collapse_embedding_table_counts_preserves_existing_summary_key() -> Non
     )
 
     assert result == {"chunks": 1, "embeddings": 5}
+
+
+@pytest.mark.parametrize(
+    ("preview_only", "confirm"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_plans_unless_confirmed_outside_preview(
+    mock_get_conn: MagicMock,
+    preview_only: bool,
+    confirm: bool,
+) -> None:
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = ["documents"]
+    table = _create_mock_table_with_columns(["collection", "doc_id", "user_id"])
+    conn.open_table.return_value = table
+    mock_get_conn.return_value = conn
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+        ) as mock_plan,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._delete_by_predicates"
+        ) as mock_delete,
+    ):
+        mock_plan.return_value = {"documents": 1}
+        result = cascade_delete(
+            target="document",
+            collection="c_gate",
+            doc_id="d_gate",
+            user_id=7,
+            is_admin=False,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    assert result == {"documents": 1}
+    mock_plan.assert_called_once()
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("preview_only", "confirm"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cascade_delete_documents_plans_unless_confirmed_outside_preview(
+    mock_get_conn: MagicMock,
+    preview_only: bool,
+    confirm: bool,
+) -> None:
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = ["documents"]
+    table = _create_mock_table_with_columns(["collection", "doc_id", "user_id"])
+    conn.open_table.return_value = table
+    mock_get_conn.return_value = conn
+
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+        ) as mock_plan,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._delete_by_predicates"
+        ) as mock_delete,
+    ):
+        mock_plan.return_value = {"documents": 1}
+        result = cascade_delete_documents(
+            collection="c_gate",
+            doc_ids=["d_gate"],
+            user_id=7,
+            is_admin=False,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    assert result == {"documents": 1}
+    mock_plan.assert_called_once()
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("preview_only", "confirm"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_cleanup_cascade_plans_unless_confirmed_outside_preview(
+    preview_only: bool,
+    confirm: bool,
+) -> None:
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+        ) as mock_get_conn,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.build_embedding_cleanup_filters"
+        ) as mock_build_filters,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+        ) as mock_plan,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._delete_by_predicates"
+        ) as mock_delete,
+    ):
+        conn = MagicMock(spec=["table_names", "open_table"])
+        mock_get_conn.return_value = conn
+        mock_build_filters.return_value = {"embeddings_m1": ["collection == 'c_gate'"]}
+        mock_plan.return_value = {"embeddings_m1": 1}
+
+        result = cleanup_embed_cascade(
+            "c_gate",
+            "d_gate",
+            user_id=7,
+            is_admin=False,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    assert result == {"embeddings": 1}
+    mock_plan.assert_called_once()
+    mock_delete.assert_not_called()
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -689,7 +689,7 @@ def test_cascade_delete_collection_open_table_error_uses_tenant_safe_fallback(
         )
 
     predicates = mock_plan.call_args.args[1]
-    filt = predicates["documents"]
+    filt = predicates["documents"][0]
     assert "collection == 'c_err'" in filt
     assert "user_id == 7" in filt
 
@@ -722,7 +722,7 @@ def test_cascade_delete_document_open_table_error_uses_tenant_safe_fallback(
         )
 
     predicates = mock_plan.call_args.args[1]
-    filt = predicates["documents"]
+    filt = predicates["documents"][0]
     assert "collection == 'c_err'" in filt
     assert "doc_id == 'd_err'" in filt
     assert "user_id == 7" in filt
@@ -755,7 +755,7 @@ def test_cascade_delete_collection_open_table_error_without_user_id_denied(
         )
 
     predicates = mock_plan.call_args.args[1]
-    filt = predicates["documents"]
+    filt = predicates["documents"][0]
     assert "collection == 'c_err'" in filt
     assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
 
@@ -788,7 +788,7 @@ def test_cascade_delete_document_open_table_error_without_user_id_denied(
         )
 
     predicates = mock_plan.call_args.args[1]
-    filt = predicates["documents"]
+    filt = predicates["documents"][0]
     assert "collection == 'c_err'" in filt
     assert "doc_id == 'd_err'" in filt
     assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
@@ -828,7 +828,7 @@ def test_cascade_delete_document_schema_probe_error_keeps_legacy_compatible_filt
         )
 
     predicates = mock_plan.call_args.args[1]
-    filt = predicates["documents"]
+    filt = predicates["documents"][0]
     assert "collection == 'c_probe'" in filt
     assert "doc_id == 'd_probe'" in filt
     assert "user_id ==" not in filt
@@ -894,13 +894,13 @@ def test_cascade_delete_document_multitable_predicates_are_consistent(
         "ingestion_runs",
         "embeddings_m1",
     ):
-        filt = predicates[table_name]
+        filt = predicates[table_name][0]
         assert "collection == 'c_multi'" in filt
         assert "doc_id == 'd_multi'" in filt
         assert "user_id == 5" in filt
 
     # Legacy-compatible table without user_id should not have tenant filter appended.
-    pointers_filter = predicates["main_pointers"]
+    pointers_filter = predicates["main_pointers"][0]
     assert "collection == 'c_multi'" in pointers_filter
     assert "doc_id == 'd_multi'" in pointers_filter
     assert "user_id ==" not in pointers_filter
@@ -968,13 +968,13 @@ def test_cascade_delete_documents_builds_doc_id_batched_predicates(
         "ingestion_runs",
         "embeddings_m1",
     ):
-        filt = predicates[table_name]
+        filt = predicates[table_name][0]
         assert "collection == 'c_batch'" in filt
         assert "doc_id IN ('d1', 'd2')" in filt
         assert "user_id == 5" in filt
 
     for table_name in ("main_pointers", "embeddings_legacy"):
-        filt = predicates[table_name]
+        filt = predicates[table_name][0]
         assert "collection == 'c_batch'" in filt
         assert "doc_id IN ('d1', 'd2')" in filt
         assert "user_id ==" not in filt
@@ -1085,7 +1085,7 @@ def test_cascade_delete_document_model_tag_probe_error_without_user_id_denied(
     predicates = mock_plan.call_args.args[1]
     assert "embeddings_m1" in predicates
     assert "embeddings_m2" not in predicates
-    filt = predicates["embeddings_m1"]
+    filt = predicates["embeddings_m1"][0]
     assert "collection == 'c_model'" in filt
     assert "doc_id == 'd_model'" in filt
     assert "user_id IS NULL" in filt and "user_id IS NOT NULL" in filt
@@ -1127,10 +1127,10 @@ def test_cleanup_parse_cascade_probe_error_without_user_id_denied(
         )
 
     predicates = mock_plan.call_args.args[1]
-    assert "user_id IS NULL" in predicates["chunks"]
-    assert "user_id IS NOT NULL" in predicates["chunks"]
-    assert "user_id IS NULL" in predicates["embeddings_m1"]
-    assert "user_id IS NOT NULL" in predicates["embeddings_m1"]
+    assert "user_id IS NULL" in predicates["chunks"][0]
+    assert "user_id IS NOT NULL" in predicates["chunks"][0]
+    assert "user_id IS NULL" in predicates["embeddings_m1"][0]
+    assert "user_id IS NOT NULL" in predicates["embeddings_m1"][0]
 
 
 @patch(
@@ -1161,6 +1161,80 @@ def test_cleanup_embed_without_user_scope_fails_closed(
     assert "doc_id == 'd_denied'" in filter_expr
     assert "user_id IS NULL" in filter_expr
     assert "user_id IS NOT NULL" in filter_expr
+
+
+def test_cleanup_embed_cascade_preserves_multiple_predicates_per_table() -> None:
+    """Embeddings cleanup should pass all per-table predicates to the executor."""
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+        ) as mock_get_conn,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.build_embedding_cleanup_filters"
+        ) as mock_build_filters,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+        ) as mock_plan,
+    ):
+        conn = MagicMock(spec=["table_names", "open_table"])
+        mock_get_conn.return_value = conn
+        mock_build_filters.return_value = {
+            "embeddings_m1": ["chunk_id == 'ch1'", "chunk_id == 'ch2'"],
+        }
+        mock_plan.return_value = {"embeddings_m1": 2}
+
+        result = cleanup_embed_cascade(
+            "c_multi",
+            "d_multi",
+            user_id=7,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert predicates["embeddings_m1"] == ["chunk_id == 'ch1'", "chunk_id == 'ch2'"]
+    assert result["embeddings"] == 2
+
+
+def test_cleanup_embed_cascade_deletes_multiple_predicates_per_table() -> None:
+    """Confirm cleanup should execute every predicate in a table predicate list."""
+    with (
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+        ) as mock_get_conn,
+        patch(
+            "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.build_embedding_cleanup_filters"
+        ) as mock_build_filters,
+    ):
+        table = MagicMock()
+        table.count_rows.side_effect = [1, 1]
+        conn = MagicMock(spec=["table_names", "open_table"])
+        conn.table_names.return_value = ["embeddings_m1"]
+        conn.open_table.return_value = table
+        mock_get_conn.return_value = conn
+        mock_build_filters.return_value = {
+            "embeddings_m1": ["chunk_id == 'ch1'", "chunk_id == 'ch2'"],
+        }
+
+        result = cleanup_embed_cascade(
+            "c_multi",
+            "d_multi",
+            user_id=7,
+            is_admin=False,
+            preview_only=False,
+            confirm=True,
+        )
+
+    assert result["embeddings"] == 2
+    assert [args.args[0] for args in table.count_rows.call_args_list] == [
+        "chunk_id == 'ch1'",
+        "chunk_id == 'ch2'",
+    ]
+    assert [args.args[0] for args in table.delete.call_args_list] == [
+        "chunk_id == 'ch1'",
+        "chunk_id == 'ch2'",
+    ]
 
 
 @patch(
@@ -1212,8 +1286,8 @@ def test_cleanup_parse_cascade_expands_embeddings_predicates_per_table(
     assert "__embeddings__" not in predicates
     assert "embeddings_m1" in predicates
     assert "embeddings_legacy" in predicates
-    assert "user_id == 7" in predicates["embeddings_m1"]
-    assert "user_id == 7" not in predicates["embeddings_legacy"]
+    assert "user_id == 7" in predicates["embeddings_m1"][0]
+    assert "user_id == 7" not in predicates["embeddings_legacy"][0]
     assert result["embeddings"] == 5
 
 

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -9,6 +9,7 @@ import pytest
 
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner import (
+    _collapse_embedding_table_counts,
     cascade_delete,
     cascade_delete_documents,
     cleanup_chunk_cascade,
@@ -1289,6 +1290,18 @@ def test_cleanup_parse_cascade_expands_embeddings_predicates_per_table(
     assert "user_id == 7" in predicates["embeddings_m1"][0]
     assert "user_id == 7" not in predicates["embeddings_legacy"][0]
     assert result["embeddings"] == 5
+
+
+def test_collapse_embedding_table_counts_preserves_existing_summary_key() -> None:
+    result = _collapse_embedding_table_counts(
+        {
+            "embeddings": 2,
+            "embeddings_m1": 3,
+            "chunks": 1,
+        }
+    )
+
+    assert result == {"chunks": 1, "embeddings": 5}
 
 
 @patch(

--- a/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py
@@ -9,7 +9,10 @@ import pytest
 
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner import (
+    _append_predicates,
     _collapse_embedding_table_counts,
+    _replace_predicate,
+    _replace_predicates,
     cascade_delete,
     cascade_delete_documents,
     cleanup_chunk_cascade,
@@ -62,6 +65,19 @@ def _create_mock_table_with_columns(columns: list[str]) -> MagicMock:
     table.count_rows.return_value = 1
     table.delete = MagicMock()
     return table
+
+
+def test_predicate_helpers_distinguish_replace_and_append() -> None:
+    predicates = {"table": ["old"]}
+
+    _replace_predicate(predicates, "table", "new")
+    assert predicates["table"] == ["new"]
+
+    _append_predicates(predicates, "table", ["extra"])
+    assert predicates["table"] == ["new", "extra"]
+
+    _replace_predicates(predicates, "table", ["final"])
+    assert predicates["table"] == ["final"]
 
 
 @patch(
@@ -1290,6 +1306,52 @@ def test_cleanup_parse_cascade_expands_embeddings_predicates_per_table(
     assert "user_id == 7" in predicates["embeddings_m1"][0]
     assert "user_id == 7" not in predicates["embeddings_legacy"][0]
     assert result["embeddings"] == 5
+
+
+@patch(
+    "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner.get_vector_store_raw_connection"
+)
+def test_cleanup_parse_cascade_replaces_superseded_predicates(
+    mock_get_conn: MagicMock,
+) -> None:
+    conn = MagicMock(spec=["table_names", "open_table"])
+    conn.table_names.return_value = ["chunks", "parses", "embeddings_m1"]
+    table_map = {
+        "chunks": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "parses": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+        "embeddings_m1": _create_mock_table_with_columns(
+            ["collection", "doc_id", "parse_hash", "user_id"]
+        ),
+    }
+    conn.open_table.side_effect = lambda name: table_map[name]
+    mock_get_conn.return_value = conn
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.version_management.cascade_cleaner._plan_by_predicates"
+    ) as mock_plan:
+        mock_plan.return_value = {"embeddings_m1": 1, "chunks": 1, "parses": 1}
+        cleanup_parse_cascade(
+            "c_replace",
+            "d_replace",
+            old_parse_hash="old",
+            new_parse_hash="new",
+            user_id=7,
+            is_admin=False,
+            preview_only=True,
+            confirm=False,
+        )
+
+    predicates = mock_plan.call_args.args[1]
+    assert len(predicates["embeddings_m1"]) == 1
+    assert "parse_hash != 'new'" in predicates["embeddings_m1"][0]
+    assert "parse_hash == 'old'" not in predicates["embeddings_m1"][0]
+    assert len(predicates["chunks"]) == 1
+    assert "parse_hash != 'new'" in predicates["chunks"][0]
+    assert "parse_hash == 'old'" not in predicates["chunks"][0]
 
 
 def test_collapse_embedding_table_counts_preserves_existing_summary_key() -> None:


### PR DESCRIPTION
## Summary
- add `KBVectorStorageCompatibilityFacade` and coordinator accessors for synchronous vector storage entrypoints
- route vector cleanup through shared user-scope and model-tag predicate helpers
- cover failed ingest rollback cleanup for vectors written before failure

Closes #502

## Tests
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest tests/core/tools/core/RAG_tools/management/test_collections.py`
- `.venv/bin/pytest tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py tests/core/tools/core/RAG_tools/version_management/test_cascade_cleaner.py`
- `.venv/bin/pytest tests/core/tools/core/RAG_tools/vector_storage/test_vector_manager.py tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py tests/core/tools/core/RAG_tools/pipelines/test_document_search.py`