### PR TITLE
bug: Fix Xinference stream tool call handling

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -1001,9 +1001,10 @@ class AutoPattern(AgentPattern):
                         "answer": {
                             "type": "string",
                             "description": (
-                                "Mandatory when action is final_answer: complete "
-                                "non-empty final response to the user. Leave unset "
-                                f"for react or plan_execute. {final_answer_language_rule()}"
+                                "Required for every decision. When action is "
+                                "final_answer, provide the complete non-empty final "
+                                "response to the user. Use an empty string for react "
+                                f"or plan_execute. {final_answer_language_rule()}"
                             ),
                         },
                         "requires_current_or_external_facts": {
@@ -1046,6 +1047,7 @@ class AutoPattern(AgentPattern):
                         "action",
                         "reason",
                         "response_language",
+                        "answer",
                         "requires_current_or_external_facts",
                         "existing_context_sufficient",
                         "evidence_basis",

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -497,8 +497,23 @@ class XinferenceLLM(BaseLLM):
         if tool_calls:
             for tool_call in tool_calls:
                 call_id = tool_call.get("id")
+                index = tool_call.get("index")
+                if not call_id and isinstance(index, int):
+                    for (
+                        existing_id,
+                        existing_tool_call,
+                    ) in accumulated_tool_calls.items():
+                        if existing_tool_call.get("index") == index:
+                            call_id = existing_id
+                            break
+                if not call_id and len(accumulated_tool_calls) == 1:
+                    call_id = next(iter(accumulated_tool_calls.keys()))
+                if not call_id:
+                    continue
+
                 if call_id and call_id not in accumulated_tool_calls:
                     accumulated_tool_calls[call_id] = {
+                        "index": index if isinstance(index, int) else None,
                         "id": call_id,
                         "type": tool_call.get("type", "function"),
                         "function": {
@@ -506,17 +521,20 @@ class XinferenceLLM(BaseLLM):
                             "arguments": "",
                         },
                     }
+                elif isinstance(index, int):
+                    accumulated_tool_calls[call_id]["index"] = index
 
-                if call_id:
-                    function = tool_call.get("function", {})
-                    if function.get("name"):
-                        accumulated_tool_calls[call_id]["function"]["name"] = function[
-                            "name"
-                        ]
-                    if function.get("arguments"):
-                        accumulated_tool_calls[call_id]["function"]["arguments"] += (
-                            function["arguments"]
-                        )
+                if tool_call.get("type"):
+                    accumulated_tool_calls[call_id]["type"] = tool_call["type"]
+                function = tool_call.get("function", {})
+                if function.get("name"):
+                    accumulated_tool_calls[call_id]["function"]["name"] = function[
+                        "name"
+                    ]
+                if "arguments" in function:
+                    accumulated_tool_calls[call_id]["function"]["arguments"] += (
+                        function.get("arguments") or ""
+                    )
 
             # Return accumulated tool calls
             tool_calls_list = list(accumulated_tool_calls.values())

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -507,7 +507,14 @@ class XinferenceLLM(BaseLLM):
                             call_id = existing_id
                             break
                 if not call_id and len(accumulated_tool_calls) == 1:
-                    call_id = next(iter(accumulated_tool_calls.keys()))
+                    existing_id, existing_tool_call = next(
+                        iter(accumulated_tool_calls.items())
+                    )
+                    existing_index = existing_tool_call.get("index")
+                    if not isinstance(index, int) or (
+                        isinstance(existing_index, int) and existing_index == index
+                    ):
+                        call_id = existing_id
                 if not call_id:
                     continue
 
@@ -526,7 +533,7 @@ class XinferenceLLM(BaseLLM):
 
                 if tool_call.get("type"):
                     accumulated_tool_calls[call_id]["type"] = tool_call["type"]
-                function = tool_call.get("function", {})
+                function = tool_call.get("function") or {}
                 if function.get("name"):
                     accumulated_tool_calls[call_id]["function"]["name"] = function[
                         "name"

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -602,8 +602,12 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert "do not use generic Chinese" in response_language_schema["description"]
     assert "Output language policy" in response_language_schema["description"]
     assert "response_language" in tool_schema["parameters"]["required"]
+    assert "answer" in tool_schema["parameters"]["required"]
     answer_schema = tool_schema["parameters"]["properties"]["answer"]
-    assert "Mandatory when action is final_answer" in answer_schema["description"]
+    assert "Required for every decision" in answer_schema["description"]
+    assert (
+        "Use an empty string for react or plan_execute" in answer_schema["description"]
+    )
     assert runtime.last_checkpoint is not None
     assert runtime.last_checkpoint["pattern"] == "AutoPattern"
     assert (

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -86,6 +86,108 @@ class TestXinferenceLLM:
             }
         ]
 
+    def test_parse_stream_chunk_does_not_merge_mismatched_tool_call_index(
+        self,
+    ) -> None:
+        llm = XinferenceLLM(model_name="qwen3.5")
+        accumulated_tool_calls: dict[str, dict] = {}
+
+        llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "auto_decision",
+                                        "arguments": "{",
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+
+        chunk = llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 1,
+                                    "function": {
+                                        "arguments": '"action":"react"}',
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+
+        assert chunk is not None
+        assert chunk.tool_calls == [
+            {
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "auto_decision",
+                    "arguments": "{",
+                },
+            }
+        ]
+
+    def test_parse_stream_chunk_handles_null_tool_call_function(self) -> None:
+        llm = XinferenceLLM(model_name="qwen3.5")
+        accumulated_tool_calls: dict[str, dict] = {}
+
+        chunk = llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": None,
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+
+        assert chunk is not None
+        assert chunk.tool_calls == [
+            {
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "",
+                    "arguments": "",
+                },
+            }
+        ]
+
     @pytest.mark.asyncio
     @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
     async def test_list_available_models_handles_dict_response(

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -3,9 +3,89 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from xagent.core.model.chat.basic.xinference import XinferenceLLM
+from xagent.core.model.chat.types import ChunkType
 
 
 class TestXinferenceLLM:
+    def test_parse_stream_chunk_accumulates_tool_arguments_by_index(self) -> None:
+        llm = XinferenceLLM(model_name="qwen3.5")
+        accumulated_tool_calls: dict[str, dict] = {}
+
+        first_chunk = llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "auto_decision",
+                                        "arguments": "{",
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+        second_chunk = llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {
+                                        "arguments": '"action":"react"}',
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+        final_chunk = llm._parse_stream_chunk(
+            {
+                "choices": [
+                    {
+                        "delta": {"content": ""},
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+            accumulated_tool_calls,
+        )
+
+        assert first_chunk is not None
+        assert first_chunk.type == ChunkType.TOOL_CALL
+        assert second_chunk is not None
+        assert second_chunk.tool_calls[0]["function"]["arguments"] == (
+            '{"action":"react"}'
+        )
+        assert final_chunk is not None
+        assert final_chunk.finish_reason == "tool_calls"
+        assert final_chunk.tool_calls == [
+            {
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "auto_decision",
+                    "arguments": '{"action":"react"}',
+                },
+            }
+        ]
+
     @pytest.mark.asyncio
     @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
     async def test_list_available_models_handles_dict_response(


### PR DESCRIPTION
## Summary
- accumulate Xinference streaming tool call argument deltas by tool-call index when later chunks omit ids
- make AutoPattern decision arguments consistently include the required answer field
- add regression coverage for Xinference stream tool-call deltas and AutoPattern decision schemas

## Tests
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent/src pytest -q tests/core/model/chat/basic/test_xinference.py
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent/src pytest -q tests/core/agent/test_auto.py::test_auto_pattern_final_answer_completes_without_child_pattern tests/core/agent/test_auto.py::test_auto_pattern_empty_final_answer_falls_back_to_react tests/core/agent/test_auto.py::test_auto_pattern_retries_truncated_final_answer_arguments
- ruff check src/xagent/core/model/chat/basic/xinference.py src/xagent/core/agent/pattern/auto/auto.py tests/core/model/chat/basic/test_xinference.py tests/core/agent/test_auto.py
- git diff --check