### PR TITLE
perf: start task turns without blocking the event loop

### DIFF
--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -43,6 +43,7 @@ from ...services.hot_path_cache import (
 )
 from ...services.task_orchestrator import (
     TaskTurnError,
+    TaskTurnNotFoundError,
     TaskTurnOrchestrator,
     TaskTurnPayload,
     TurnKind,
@@ -151,29 +152,28 @@ async def create_chat_task(
     # A brand-new task shouldn't ever hit busy -- but we map it
     # anyway for defense.
     try:
-        await TaskTurnOrchestrator.begin_turn(
-            task=task,
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
-            user=task.user,
-            db=db,
             kind=TurnKind.CREATE,
             force_fresh=False,
         )
+    except TaskTurnNotFoundError:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
     except TaskTurnError:
         raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
 
-    # ``status=task.status.value`` (i.e. 'running'), not 'pending':
-    # ``begin_turn`` ran an atomic UPDATE that flipped the row to
-    # RUNNING and ``db.refresh(task)``'d the in-memory object before
-    # returning. Returning 'pending' would lie to the SDK client --
-    # an immediately-following GET would see 'running' and the caller
-    # would have to reconcile two contradictory values from
-    # back-to-back calls. This matches the AppendMessageResponse
-    # contract below.
+    # ``status`` comes from the orchestrator's committed-row snapshot
+    # (``started.status`` == RUNNING), NOT the caller's ``task`` object --
+    # ``begin_turn`` now commits on an isolated worker-thread session and
+    # never refreshes this request's ORM row, so ``task.status`` is still
+    # the stale PENDING. ``created_at`` is set at task creation and isn't
+    # touched by the turn, so the in-memory value is correct.
     return CreateTaskResponse(
         task_id=int(task.id),
         agent_id=int(agent.id),
-        status=task.status.value,
+        status=started.status.value,
         created_at=task.created_at,
     )
 
@@ -301,39 +301,29 @@ async def append_message_to_task(
     # 409), persists the new user message, and schedules the bg turn
     # with a single-flight guard against concurrent kickoffs.
     try:
-        await TaskTurnOrchestrator.begin_turn(
-            task=task,
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
-            user=task.user,
-            db=db,
             kind=TurnKind.APPEND,
             force_fresh=False,
         )
+    except TaskTurnNotFoundError:
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
     except TaskTurnError:
         raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
 
-    # Pick up updated_at written by the orchestrator's UPDATE.
-    db.refresh(task)
-
-    # accepted_at uses the DB row's ``updated_at`` (set by ``onupdate=
-    # func.now()`` on the atomic UPDATE) instead of a fresh
-    # ``datetime.now(...)``. That way SDK clients reading this field
-    # see a value that matches what they'd read from the DB directly
-    # via GET /v1/chat/tasks/{id}, with no clock-skew between the two.
-    #
-    # ``status=task.status.value`` (i.e. 'running'), read from the
-    # refreshed in-memory row rather than hardcoded, mirrors the
-    # CreateTaskResponse contract above: the atomic UPDATE inside
-    # ``begin_turn`` flipped the row to RUNNING in the same
-    # transaction. Returning 'pending' here would lie to the SDK
-    # client -- an immediately-following GET would see 'running' and
-    # the caller would have to reconcile two contradictory values
-    # from back-to-back calls.
+    # ``status`` / ``accepted_at`` come from the orchestrator's committed-row
+    # snapshot (``started``), not a post-call ``db.refresh(task)``. The
+    # refresh was itself a blocking SELECT on the event loop; ``begin_turn``
+    # already SELECTed ``updated_at`` (set by ``onupdate=func.now()`` on the
+    # atomic UPDATE) inside its off-loop transaction, so SDK clients still see
+    # a value matching what GET /v1/chat/tasks/{id} would return.
     return AppendMessageResponse(
         task_id=int(task.id),
         agent_id=int(agent.id),
-        status=task.status.value,
-        accepted_at=task.updated_at,
+        status=started.status.value,
+        accepted_at=started.updated_at,
     )
 
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -154,7 +154,7 @@ async def create_chat_task(
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
-            user_id=int(agent.user_id),
+            task_owner_user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
             kind=TurnKind.CREATE,
             force_fresh=False,
@@ -303,7 +303,7 @@ async def append_message_to_task(
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
-            user_id=int(agent.user_id),
+            task_owner_user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
             kind=TurnKind.APPEND,
             force_fresh=False,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2987,6 +2987,7 @@ async def handle_chat_message(
                     # lifecycle state machine.
                     from ..services.task_orchestrator import (
                         TaskTurnError,
+                        TaskTurnNotFoundError,
                         TaskTurnOrchestrator,
                         TaskTurnPayload,
                         TurnKind,
@@ -3047,15 +3048,34 @@ async def handle_chat_message(
 
                     try:
                         await TaskTurnOrchestrator.begin_turn(
-                            task=task,
+                            task_id=int(task.id),
+                            user_id=int(user.id),
                             payload=payload,
-                            user=user,
-                            db=db,
                             kind=turn_kind,
                             force_fresh=turn_force_fresh,
                             context=context,
                         )
                         logger.info(f"Task {task_id} started in background")
+                    except TaskTurnNotFoundError:
+                        # Task vanished or changed ownership between the
+                        # resolve above and the atomic claim — surface it the
+                        # same way as a busy refusal (no row was mutated).
+                        logger.warning(
+                            "begin_turn: task %s not found / not owned at claim",
+                            task_id,
+                        )
+                        await manager.broadcast_to_task(
+                            {
+                                **_task_error_payload(
+                                    db,
+                                    task_id,
+                                    "Task is no longer available.",
+                                    event_type="agent_error",
+                                ),
+                                "timestamp": datetime.now(timezone.utc).timestamp(),
+                            },
+                            task_id,
+                        )
                     except TaskTurnError as busy_err:
                         # begin_turn's atomic transaction rolls back on
                         # bg_inflight / busy — neither the status flip

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3049,7 +3049,11 @@ async def handle_chat_message(
                     try:
                         await TaskTurnOrchestrator.begin_turn(
                             task_id=int(task.id),
-                            user_id=int(user.id),
+                            # Owner, not the acting principal: ``task`` was
+                            # already authorized above (admin bypass / owner
+                            # check), and the turn must run as the task owner,
+                            # not an admin acting on someone else's task.
+                            task_owner_user_id=int(task.user_id),
                             payload=payload,
                             kind=turn_kind,
                             force_fresh=turn_force_fresh,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -272,37 +272,47 @@ class TaskTurnOrchestrator:
         # bg-inflight guard before any DB write (see note 1 in docstring).
         _refuse_if_bg_inflight(task_id)
 
-        # Off-loop atomic claim + persist + commit. Only raises pre-commit
-        # (bg-inflight already handled above; busy / not-found here), so
-        # reaching the next line means the row is committed RUNNING.
-        claimed = await asyncio.to_thread(
-            _begin_turn_atomic_sync,
-            task_id,
-            user_id,
-            payload=payload,
-            kind=kind,
-        )
-
-        # Point of no return: the row is RUNNING. ``_schedule_bg`` is
-        # synchronous (no await), so there is no suspension point between
-        # the commit and the schedule; any failure here (or a CancelledError
-        # delivered at the ``to_thread`` resume above) must force the task
-        # FAILED so it isn't left RUNNING with no worker.
-        try:
-            bg_task = _schedule_bg(
-                task_id=task_id,
-                user_id=user_id,
-                task_source=claimed.task_source,
+        # The claim and the schedule must be atomic with respect to
+        # cancellation: once the claim commits, the row is RUNNING, so the bg
+        # run MUST be scheduled (or the task forced FAILED) -- otherwise a
+        # CancelledError landing at the ``to_thread`` resume, after the commit,
+        # would strand the row as RUNNING with no worker. Running both inside
+        # ``asyncio.shield`` lets them finish even when ``begin_turn``'s caller
+        # is cancelled.
+        async def _claim_and_schedule() -> tuple[_ClaimedTurn, "asyncio.Task[None]"]:
+            # Off-loop atomic claim + persist + commit. Only raises pre-commit
+            # (busy / not-found), so a normal exception here means nothing was
+            # committed; reaching the schedule means the row is RUNNING.
+            res = await asyncio.to_thread(
+                _begin_turn_atomic_sync,
+                task_id,
+                user_id,
                 payload=payload,
-                force_fresh=force_fresh,
-                context=context,
-                before_message_id=claimed.before_message_id,
+                kind=kind,
             )
-        except BaseException:
-            _mark_task_failed_if_running(
-                task_id, "turn scheduling failed after claim commit"
-            )
-            raise
+            try:
+                handle = _schedule_bg(
+                    task_id=task_id,
+                    user_id=user_id,
+                    task_source=res.task_source,
+                    payload=payload,
+                    force_fresh=force_fresh,
+                    context=context,
+                    before_message_id=res.before_message_id,
+                )
+            except BaseException:
+                # Schedule failed after the claim committed -> force FAILED so
+                # the row isn't left RUNNING. Off-loop, so the error path also
+                # keeps the goal of no synchronous DB on the event loop.
+                await asyncio.to_thread(
+                    _mark_task_failed_if_running,
+                    task_id,
+                    "turn scheduling failed after claim commit",
+                )
+                raise
+            return res, handle
+
+        claimed, bg_task = await asyncio.shield(_claim_and_schedule())
 
         return TurnStarted(
             task_id=task_id,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -53,7 +53,6 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from ..models.task import Task, TaskStatus
-from ..models.user import User
 from .hot_path_cache import invalidate_task_cache
 from .task_lease_service import (
     acquire_task_lease_isolated,
@@ -152,6 +151,46 @@ class TaskTurnError(Exception):
         self.reason = reason
 
 
+class TaskTurnNotFoundError(Exception):
+    """Raised when the turn's atomic claim finds no row that both exists
+    and is owned by the calling principal.
+
+    Deliberately NOT a subclass of :class:`TaskTurnError`: callers map
+    ``TaskTurnError`` to 409 (busy / bg_inflight), but a missing or
+    not-owned task is a 404. Keeping it a separate type means a
+    ``except TaskTurnError`` clause never silently turns a not-found into
+    a "busy". Part of ``begin_turn``'s public error contract.
+    """
+
+    def __init__(self, task_id: int):
+        super().__init__(f"task {task_id} not found or not owned by caller")
+        self.task_id = task_id
+
+
+@dataclass(frozen=True)
+class TurnStarted:
+    """Result of a started turn.
+
+    Internal orchestration result (not a serialized public DTO): it
+    carries the committed-row snapshot the caller needs to build its
+    response WITHOUT re-reading the ORM (``begin_turn`` no longer touches
+    the caller's session), plus the live bg handle.
+
+    The snapshot fields (``status`` / ``updated_at`` / ``before_message_id``)
+    are read inside the isolated worker-thread transaction, so callers do
+    not pay an on-loop ``db.refresh`` to learn the post-claim state.
+    ``task_source`` is internal (passed to ``_schedule_bg``); ``background_task``
+    is the scheduler handle (workforce / tests await it).
+    """
+
+    task_id: int
+    status: TaskStatus
+    updated_at: Optional[datetime]
+    before_message_id: Optional[int]
+    task_source: Optional[str]
+    background_task: "asyncio.Task[None]"
+
+
 class TaskTurnOrchestrator:
     """Drive one task-turn lifecycle.
 
@@ -163,94 +202,66 @@ class TaskTurnOrchestrator:
     @staticmethod
     async def begin_turn(
         *,
-        task: Task,
+        task_id: int,
+        user_id: int,
         payload: TaskTurnPayload,
-        user: User,
-        db: Any,
         kind: TurnKind,
         force_fresh: bool = False,
         context: Optional[Dict[str, Any]] = None,
-    ) -> "asyncio.Task[None]":
+    ) -> TurnStarted:
         """Single entry for any new-turn transition (CREATE / APPEND).
 
-        The single transactional primitive that owns the full turn-start
-        contract:
+        Owns the full turn-start contract. The atomic write transaction
+        (claim + user-message persist + commit) runs on an isolated
+        worker-thread session via ``asyncio.to_thread`` so the ~5s write
+        RTT does not block the asyncio event loop (issue #427). The caller
+        passes primitives only; ``begin_turn`` never touches the caller's
+        session, and returns a :class:`TurnStarted` snapshot the caller
+        reads instead of re-fetching the ORM.
 
-          1. Refuse if a bg coroutine is still in flight for this task
-             (``TaskTurnError("bg_inflight")``). Checked before any DB
-             write so a rejected turn never mutates the row.
-          2. Atomic UPDATE in one statement on the caller's session
-             — the latest-turn snapshot invariant:
+        Sequence:
 
-             - ``status = RUNNING``
-             - ``input = payload.transcript_message``
-             - ``output = NULL``          (clear prior-turn terminal field)
-             - ``error_message = NULL``   (clear prior-turn terminal field)
+          1. ``_refuse_if_bg_inflight`` — reject if a bg coroutine is still
+             running for this task (``TaskTurnError("bg_inflight")``). Pure
+             in-memory dict check. NOTE: it now sits before the
+             ``await asyncio.to_thread`` below, so two concurrent new turns
+             can both pass it; the authoritative serializer is the DB atomic
+             claim (the status-filter rowcount), which lets exactly one win.
+          2. ``_begin_turn_atomic_sync`` (off-loop): atomic claim
+             (``id == task_id AND user_id == user_id AND <status_filter>``)
+             + persist + snapshot SELECT + single commit. By construction it
+             only raises BEFORE commit, so a successful return means the row
+             is committed RUNNING.
+          3. ``_schedule_bg`` (sync, no await) — schedule the lease-aware bg
+             coroutine. Once step 2 committed, this must succeed or the task
+             is forced FAILED (no zombie RUNNING).
 
-             with filter:
-
-             - ``kind == CREATE`` → ``status == PENDING``
-             - ``kind == APPEND`` → ``status IN APPENDABLE_STATUSES``
-
-             rowcount 0 → ``TaskTurnError("busy")``.
-          3. ``persist_user_message(payload.transcript_message)`` in the
-             same session (no commit yet).
-          4. ``db.commit()`` ONCE for steps 2 + 3 together — the
-             single-transaction turn-start contract. If any step above
-             raises, the session is rolled back and neither the status
-             flip nor the message persists, so a rejected turn never
-             leaves an orphan user message in the transcript.
-          5. Schedule the bg coroutine via ``_schedule_bg``, passing
-             the full payload so the execution side receives the
-             execution-only message channel, not just the transcript.
-
-        Preconditions (caller contract — assert on entry):
-
-          - ``db`` is a clean session: no uncommitted ``new`` /
-            ``dirty`` / ``deleted`` instances. ``begin_turn`` commits
-            the atomic UPDATE + message persist together; a dirty
-            caller session would have its pending changes committed
-            alongside, which is rarely the caller's intent. All current
-            callers (SDK ``create_chat_task``, SDK
-            ``append_message_to_task``, WS path) satisfy this; the
-            assert is defensive against future callers.
-          - ``kind == CREATE and force_fresh`` is invalid — a new task
-            has no prior execution state to discard. Raises
-            ``ValueError``.
+        ``user_id`` is the authenticated principal's id (the SDK agent's
+        owner / the WS user), NOT ``task.user_id`` — folding it into the
+        claim predicate is what makes ownership meaningful instead of the
+        row proving itself.
 
         Args:
-            task: The committed Task row. ``status`` should be PENDING
-                for ``kind=CREATE`` or terminal for ``kind=APPEND``.
-            payload: Two-channel message (transcript + execution); see
-                :class:`TaskTurnPayload`.
-            user: Task owner; passed through to the bg coroutine's
-                ``UserContext``.
-            db: Caller's request-scoped session. Used for steps 2-4
-                (atomic claim + persist + commit). The bg coroutine
-                opens its own independent session inside
-                ``_schedule_bg``.
-            kind: Which status filter the atomic claim uses; see
-                :class:`TurnKind`.
-            force_fresh: When True, the bg coroutine ignores any
-                reconstructible prior execution state and starts a
-                fresh agent run. WS terminal-task re-engage passes
-                True; SDK callers pass False.
-            context: Optional execution-context dict
-                (execution_mode / process_description / examples)
-                merged into the bg run.
+            task_id: The committed task's id.
+            user_id: Authenticated principal id; claim only succeeds if the
+                task belongs to this user.
+            payload: Two-channel message (transcript + execution).
+            kind: Which status filter the atomic claim uses.
+            force_fresh: When True, the bg coroutine starts a fresh agent
+                run (WS terminal re-engage); invalid with ``kind=CREATE``.
+            context: Optional execution-context dict.
 
         Returns:
-            The ``asyncio.Task`` wrapping the bg coroutine. Callers
-            usually fire-and-forget; the handle is returned for tests.
+            :class:`TurnStarted` — committed-row snapshot
+            (``status``/``updated_at``/``before_message_id``) plus the bg
+            ``background_task`` handle.
 
         Raises:
-            ValueError: invalid ``kind`` / ``force_fresh`` combination,
-                or caller session not clean.
-            TaskTurnError("bg_inflight"): a previous bg coroutine for
-                this task is still running.
-            TaskTurnError("busy"): atomic claim filter mismatched the
-                current row status (e.g. ``kind=APPEND`` against a
-                non-terminal row).
+            ValueError: ``kind == CREATE and force_fresh``.
+            TaskTurnError("bg_inflight"): a previous bg coroutine is running.
+            TaskTurnError("busy"): the row exists and is owned but its status
+                did not match the claim filter.
+            TaskTurnNotFoundError: no row matched id + ownership (404).
         """
         if kind == TurnKind.CREATE and force_fresh:
             raise ValueError(
@@ -258,86 +269,184 @@ class TaskTurnOrchestrator:
                 "has no prior execution state to discard"
             )
 
-        # Session-clean precondition. Catching this up-front prevents the
-        # commit at step 4 from accidentally persisting unrelated
-        # caller-staged objects.
-        if db.new or db.dirty or db.deleted:
-            raise ValueError(
-                "begin_turn requires a clean db session "
-                f"(new={len(db.new)}, dirty={len(db.dirty)}, "
-                f"deleted={len(db.deleted)}); caller must commit or "
-                "rollback its pending changes before calling begin_turn"
-            )
-
-        task_id = int(task.id)
-
-        # Step 1: bg-inflight guard before any DB write.
+        # bg-inflight guard before any DB write (see note 1 in docstring).
         _refuse_if_bg_inflight(task_id)
 
-        # Step 2 + 3 + 4: atomic claim + persist + single commit. We
-        # don't commit between 2 and 3, so a failure at step 3 rolls
-        # back step 2 cleanly — the rejected-turn-leaves-no-side-effect
-        # contract.
-        try:
-            if kind == TurnKind.CREATE:
-                status_filter = Task.status == TaskStatus.PENDING
-            else:  # APPEND
-                status_filter = Task.status.in_(_APPENDABLE_STATUSES)
-
-            claimed = (
-                db.query(Task)
-                .filter(Task.id == task_id, status_filter)
-                .update(
-                    {
-                        Task.status: TaskStatus.RUNNING,
-                        Task.input: payload.transcript_message,
-                        Task.output: None,
-                        Task.error_message: None,
-                    },
-                    synchronize_session=False,
-                )
-            )
-            if claimed == 0:
-                db.rollback()
-                raise TaskTurnError("busy")
-
-            from .chat_history_service import persist_user_message_no_commit
-
-            persisted_message = persist_user_message_no_commit(
-                db=db,
-                task_id=task_id,
-                user_id=int(user.id),
-                content=payload.transcript_message,
-                attachments=payload.attachments,
-                turn_id=payload.turn_id,
-            )
-            if persisted_message is not None:
-                db.flush()
-                before_message_id = int(persisted_message.id)
-            else:
-                before_message_id = None
-            db.commit()
-            invalidate_task_cache(task_id)
-        except TaskTurnError:
-            raise
-        except Exception:
-            db.rollback()
-            raise
-
-        db.refresh(task)
-
-        # Step 5: hand off to lease-aware scheduler.
-        return await _schedule_bg(
-            task=task,
-            user=user,
+        # Off-loop atomic claim + persist + commit. Only raises pre-commit
+        # (bg-inflight already handled above; busy / not-found here), so
+        # reaching the next line means the row is committed RUNNING.
+        claimed = await asyncio.to_thread(
+            _begin_turn_atomic_sync,
+            task_id,
+            user_id,
             payload=payload,
-            force_fresh=force_fresh,
-            context=context,
-            before_message_id=before_message_id,
+            kind=kind,
+        )
+
+        # Point of no return: the row is RUNNING. ``_schedule_bg`` is
+        # synchronous (no await), so there is no suspension point between
+        # the commit and the schedule; any failure here (or a CancelledError
+        # delivered at the ``to_thread`` resume above) must force the task
+        # FAILED so it isn't left RUNNING with no worker.
+        try:
+            bg_task = _schedule_bg(
+                task_id=task_id,
+                user_id=user_id,
+                task_source=claimed.task_source,
+                payload=payload,
+                force_fresh=force_fresh,
+                context=context,
+                before_message_id=claimed.before_message_id,
+            )
+        except BaseException:
+            _mark_task_failed_if_running(
+                task_id, "turn scheduling failed after claim commit"
+            )
+            raise
+
+        return TurnStarted(
+            task_id=task_id,
+            status=claimed.status,
+            updated_at=claimed.updated_at,
+            before_message_id=claimed.before_message_id,
+            task_source=claimed.task_source,
+            background_task=bg_task,
         )
 
 
 # ===== internal helpers =====
+
+
+@dataclass(frozen=True)
+class _ClaimedTurn:
+    """Snapshot returned by ``_begin_turn_atomic_sync`` after the claim
+    commits, so ``begin_turn`` can build :class:`TurnStarted` without the
+    caller re-reading the ORM."""
+
+    status: TaskStatus
+    updated_at: Optional[datetime]
+    before_message_id: Optional[int]
+    task_source: Optional[str]
+
+
+def _begin_turn_atomic_sync(
+    task_id: int,
+    user_id: int,
+    *,
+    payload: TaskTurnPayload,
+    kind: TurnKind,
+) -> _ClaimedTurn:
+    """Atomic claim + user-message persist + commit on its OWN session.
+
+    Designed to run under ``asyncio.to_thread`` so the synchronous write
+    transaction (~5s RTT measured in issue #427) stays off the event loop.
+    Opens / commits / closes its own ``SessionLocal`` — never touches the
+    caller's session.
+
+    Ownership is folded into the claim predicate (``id`` AND ``user_id`` AND
+    status filter) so the UPDATE is atomic w.r.t. ownership. On ``rowcount
+    0`` a diagnostic SELECT distinguishes:
+
+      - row missing or not owned by ``user_id`` → :class:`TaskTurnNotFoundError`
+      - row exists + owned but wrong status     → ``TaskTurnError("busy")``
+
+    Invariant relied on by ``begin_turn``: this function only raises BEFORE
+    ``commit``. The committed-row snapshot is SELECTed pre-commit
+    (read-your-writes within the transaction; a bulk
+    ``.update(synchronize_session=False)`` leaves no ORM object to refresh),
+    and the only post-commit work — ``invalidate_task_cache`` — is
+    best-effort. So a successful return always means the row is committed
+    RUNNING, and any exception means it is not.
+    """
+    from ..models.database import get_session_local
+    from .chat_history_service import persist_user_message_no_commit
+
+    if kind == TurnKind.CREATE:
+        status_filter = Task.status == TaskStatus.PENDING
+    else:  # APPEND
+        status_filter = Task.status.in_(_APPENDABLE_STATUSES)
+
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    try:
+        claimed = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.user_id == user_id,
+                status_filter,
+            )
+            .update(
+                {
+                    Task.status: TaskStatus.RUNNING,
+                    Task.input: payload.transcript_message,
+                    Task.output: None,
+                    Task.error_message: None,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed == 0:
+            db.rollback()
+            owned = (
+                db.query(Task.id)
+                .filter(Task.id == task_id, Task.user_id == user_id)
+                .first()
+            )
+            if owned is None:
+                raise TaskTurnNotFoundError(task_id)
+            raise TaskTurnError("busy")
+
+        persisted_message = persist_user_message_no_commit(
+            db=db,
+            task_id=task_id,
+            user_id=user_id,
+            content=payload.transcript_message,
+            attachments=payload.attachments,
+            turn_id=payload.turn_id,
+        )
+        if persisted_message is not None:
+            db.flush()
+            before_message_id: Optional[int] = int(persisted_message.id)
+        else:
+            before_message_id = None
+
+        # Snapshot the committed row's columns BEFORE commit (read-your-writes
+        # in the same transaction). Keeps commit as the last fallible DB op,
+        # so there is no post-commit window where the row is RUNNING but this
+        # helper still raises.
+        status, updated_at, source = (
+            db.query(Task.status, Task.updated_at, Task.source)
+            .filter(Task.id == task_id)
+            .one()
+        )
+
+        db.commit()
+    except (TaskTurnError, TaskTurnNotFoundError):
+        raise
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+    # Best-effort: a stale cache entry self-heals on the next write / TTL,
+    # and must never strand a committed RUNNING task by raising here.
+    try:
+        invalidate_task_cache(task_id)
+    except Exception:
+        logger.warning(
+            "invalidate_task_cache failed for task %s (non-fatal)",
+            task_id,
+            exc_info=True,
+        )
+
+    return _ClaimedTurn(
+        status=status,
+        updated_at=updated_at,
+        before_message_id=before_message_id,
+        task_source=source,
+    )
 
 
 def _refuse_if_bg_inflight(task_id: int) -> None:
@@ -564,16 +673,23 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
     # PAUSED / WAITING_FOR_USER / other: leave alone.
 
 
-async def _schedule_bg(
+def _schedule_bg(
     *,
-    task: Task,
-    user: User,
+    task_id: int,
+    user_id: int,
+    task_source: Optional[str],
     payload: TaskTurnPayload,
     force_fresh: bool,
     context: Optional[Dict[str, Any]],
     before_message_id: Optional[int] = None,
 ) -> "asyncio.Task[None]":
     """Lease-aware bg scheduler.
+
+    Synchronous: it defines ``_runner``, schedules it via
+    ``asyncio.create_task``, registers the handle and returns it — there is
+    no ``await`` at this level (every await lives inside ``_runner``, which
+    runs later as its own task). Being sync removes a misleading
+    suspension/cancellation point right after ``begin_turn``'s claim commit.
 
     Owns the full lease lifecycle for the bg run:
 
@@ -590,12 +706,12 @@ async def _schedule_bg(
         returned normally or raised. ``execute_task_background`` only
         writes ``task.status`` and never touches the lease columns;
         the scheduler is responsible for the whole lease lifecycle.
+
+    Takes primitives only (``task_id`` / ``user_id`` / ``task_source``); the
+    bg run loads its own snapshot and opens its own sessions, so no
+    caller-bound ORM object crosses into the coroutine.
     """
     from ..api.websocket import background_task_manager, execute_task_background
-
-    task_id = int(task.id)
-    task_source = getattr(task, "source", None)
-    user_id = int(user.id)
 
     async def _runner() -> None:
         # ``bg_db`` is opened lazily inside the post-run finalize block

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -203,7 +203,7 @@ class TaskTurnOrchestrator:
     async def begin_turn(
         *,
         task_id: int,
-        user_id: int,
+        task_owner_user_id: int,
         payload: TaskTurnPayload,
         kind: TurnKind,
         force_fresh: bool = False,
@@ -228,23 +228,28 @@ class TaskTurnOrchestrator:
              can both pass it; the authoritative serializer is the DB atomic
              claim (the status-filter rowcount), which lets exactly one win.
           2. ``_begin_turn_atomic_sync`` (off-loop): atomic claim
-             (``id == task_id AND user_id == user_id AND <status_filter>``)
-             + persist + snapshot SELECT + single commit. By construction it
-             only raises BEFORE commit, so a successful return means the row
-             is committed RUNNING.
+             (``id == task_id AND user_id == task_owner_user_id AND
+             <status_filter>``) + persist + snapshot SELECT + single commit.
+             By construction it only raises BEFORE commit, so a successful
+             return means the row is committed RUNNING.
           3. ``_schedule_bg`` (sync, no await) — schedule the lease-aware bg
              coroutine. Once step 2 committed, this must succeed or the task
              is forced FAILED (no zombie RUNNING).
 
-        ``user_id`` is the authenticated principal's id (the SDK agent's
-        owner / the WS user), NOT ``task.user_id`` — folding it into the
-        claim predicate is what makes ownership meaningful instead of the
-        row proving itself.
+        ``task_owner_user_id`` is the task OWNER's id — the runtime identity
+        the turn executes as. Callers derive it from the already-authorized
+        task row (``task.user_id``) or the SDK agent's owner
+        (``agent.user_id``), NOT from the acting principal. They differ when
+        an admin operates on another user's task: authorization happens at
+        the entry (e.g. the WS admin bypass), and the turn must still run as
+        the owner, not the admin. The claim predicate keeps ``Task.user_id ==
+        task_owner_user_id`` as defense-in-depth.
 
         Args:
             task_id: The committed task's id.
-            user_id: Authenticated principal id; claim only succeeds if the
-                task belongs to this user.
+            task_owner_user_id: The task owner's id (runtime identity). Used
+                for the claim predicate, the persisted user message, and the
+                whole bg execution context.
             payload: Two-channel message (transcript + execution).
             kind: Which status filter the atomic claim uses.
             force_fresh: When True, the bg coroutine starts a fresh agent
@@ -261,7 +266,7 @@ class TaskTurnOrchestrator:
             TaskTurnError("bg_inflight"): a previous bg coroutine is running.
             TaskTurnError("busy"): the row exists and is owned but its status
                 did not match the claim filter.
-            TaskTurnNotFoundError: no row matched id + ownership (404).
+            TaskTurnNotFoundError: no row matched id + owner.
         """
         if kind == TurnKind.CREATE and force_fresh:
             raise ValueError(
@@ -286,14 +291,14 @@ class TaskTurnOrchestrator:
             res = await asyncio.to_thread(
                 _begin_turn_atomic_sync,
                 task_id,
-                user_id,
+                task_owner_user_id,
                 payload=payload,
                 kind=kind,
             )
             try:
                 handle = _schedule_bg(
                     task_id=task_id,
-                    user_id=user_id,
+                    task_owner_user_id=task_owner_user_id,
                     task_source=res.task_source,
                     payload=payload,
                     force_fresh=force_fresh,
@@ -341,7 +346,7 @@ class _ClaimedTurn:
 
 def _begin_turn_atomic_sync(
     task_id: int,
-    user_id: int,
+    task_owner_user_id: int,
     *,
     payload: TaskTurnPayload,
     kind: TurnKind,
@@ -353,12 +358,13 @@ def _begin_turn_atomic_sync(
     Opens / commits / closes its own ``SessionLocal`` — never touches the
     caller's session.
 
-    Ownership is folded into the claim predicate (``id`` AND ``user_id`` AND
-    status filter) so the UPDATE is atomic w.r.t. ownership. On ``rowcount
+    Owner is folded into the claim predicate (``id`` AND ``user_id`` AND
+    status filter) so the UPDATE is atomic w.r.t. the owner. On ``rowcount
     0`` a diagnostic SELECT distinguishes:
 
-      - row missing or not owned by ``user_id`` → :class:`TaskTurnNotFoundError`
-      - row exists + owned but wrong status     → ``TaskTurnError("busy")``
+      - row missing / not owned by ``task_owner_user_id`` →
+        :class:`TaskTurnNotFoundError`
+      - row exists + owned but wrong status → ``TaskTurnError("busy")``
 
     Invariant relied on by ``begin_turn``: this function only raises BEFORE
     ``commit``. The committed-row snapshot is SELECTed pre-commit
@@ -383,7 +389,7 @@ def _begin_turn_atomic_sync(
             db.query(Task)
             .filter(
                 Task.id == task_id,
-                Task.user_id == user_id,
+                Task.user_id == task_owner_user_id,
                 status_filter,
             )
             .update(
@@ -400,7 +406,7 @@ def _begin_turn_atomic_sync(
             db.rollback()
             owned = (
                 db.query(Task.id)
-                .filter(Task.id == task_id, Task.user_id == user_id)
+                .filter(Task.id == task_id, Task.user_id == task_owner_user_id)
                 .first()
             )
             if owned is None:
@@ -410,7 +416,7 @@ def _begin_turn_atomic_sync(
         persisted_message = persist_user_message_no_commit(
             db=db,
             task_id=task_id,
-            user_id=user_id,
+            user_id=task_owner_user_id,
             content=payload.transcript_message,
             attachments=payload.attachments,
             turn_id=payload.turn_id,
@@ -686,7 +692,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
 def _schedule_bg(
     *,
     task_id: int,
-    user_id: int,
+    task_owner_user_id: int,
     task_source: Optional[str],
     payload: TaskTurnPayload,
     force_fresh: bool,
@@ -786,7 +792,7 @@ def _schedule_bg(
                     # chain of three redundant Task queries into a
                     # single off-loop read.
                     snapshot = await asyncio.to_thread(
-                        load_task_setup_snapshot_sync, task_id, user_id
+                        load_task_setup_snapshot_sync, task_id, task_owner_user_id
                     )
                     if snapshot is None:
                         logger.warning(
@@ -805,7 +811,7 @@ def _schedule_bg(
                             context, payload.turn_id
                         ),
                         agent_manager=_get_agent_manager(),
-                        user_id=user_id,
+                        user_id=task_owner_user_id,
                         before_message_id=before_message_id,
                         llm_user_message=payload.execution_message,
                         task_setup_snapshot=snapshot,

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -160,7 +160,7 @@ async def create_workforce_run(
     try:
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=task_id,
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             payload=TaskTurnPayload(transcript_message=normalized_message),
             kind=TurnKind.CREATE,
             force_fresh=False,

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -158,14 +158,14 @@ async def create_workforce_run(
     task_id = int(task.id)
 
     try:
-        background_task = await TaskTurnOrchestrator.begin_turn(
-            task=task,
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=task_id,
+            user_id=int(user.id),
             payload=TaskTurnPayload(transcript_message=normalized_message),
-            user=user,
-            db=db,
             kind=TurnKind.CREATE,
             force_fresh=False,
         )
+        background_task = started.background_task
     except Exception:
         db.rollback()
         fresh_task = db.get(Task, task_id)

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -16,7 +16,7 @@ drive the mapping.
 
 from datetime import datetime, timezone
 from typing import Tuple
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -88,7 +88,7 @@ def mock_start_task():
     # only the asyncio.create_task / agent execution is stubbed.
     with patch(
         "xagent.web.services.task_orchestrator._schedule_bg",
-        new=AsyncMock(),
+        new=MagicMock(),
     ) as mocked:
         yield mocked
 
@@ -147,9 +147,9 @@ def test_create_task_happy_path(mock_start_task):
     # Background kickoff was called exactly once for this task. The
     # scheduler receives a ``TaskTurnPayload`` carrying both transcript
     # and execution channels.
-    assert mock_start_task.await_count == 1
-    kwargs = mock_start_task.await_args.kwargs
-    assert kwargs["task"].id == task_id
+    assert mock_start_task.call_count == 1
+    kwargs = mock_start_task.call_args.kwargs
+    assert kwargs["task_id"] == task_id
     assert kwargs["payload"].transcript_message == "first user message"
 
 
@@ -168,7 +168,7 @@ def test_create_task_missing_authorization_returns_401(mock_start_task):
     body = resp.json()
     assert body["error"]["code"] == "invalid_api_key"
     # No DB side effects
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_agent_id_mismatch_returns_404(mock_start_task):
@@ -186,7 +186,7 @@ def test_create_task_agent_id_mismatch_returns_404(mock_start_task):
     assert resp.status_code == 404
     body = resp.json()
     assert body["error"]["code"] == "agent_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_empty_message_returns_422(mock_start_task):
@@ -211,7 +211,7 @@ def test_create_task_empty_message_returns_422(mock_start_task):
     body = resp.json()
     assert body["error"]["code"] == "invalid_input"
     assert "detail" not in body  # legacy FastAPI shape must not leak
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_wrong_role_returns_422(mock_start_task):
@@ -231,7 +231,7 @@ def test_create_task_wrong_role_returns_422(mock_start_task):
     body = resp.json()
     assert body["error"]["code"] == "invalid_input"
     assert "detail" not in body
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_revoked_key_returns_401(mock_start_task):
@@ -253,7 +253,7 @@ def test_create_task_revoked_key_returns_401(mock_start_task):
     )
     assert resp.status_code == 401
     assert resp.json()["error"]["code"] == "invalid_api_key"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_create_task_cross_user_agent_returns_404(mock_start_task):
@@ -297,7 +297,7 @@ def test_create_task_cross_user_agent_returns_404(mock_start_task):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "agent_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 # ===== Shared helper for E tests: create a task via POST then return its id =====
@@ -382,7 +382,7 @@ def test_append_message_happy_path(mock_start_task):
     finally:
         db.close()
 
-    assert mock_start_task.await_count == 1
+    assert mock_start_task.call_count == 1
 
 
 def test_append_message_to_running_task_returns_409(mock_start_task):
@@ -409,7 +409,7 @@ def test_append_message_to_running_task_returns_409(mock_start_task):
     assert resp.status_code == 409
     assert resp.json()["error"]["code"] == "task_busy"
     # No new background kickoff happened
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_append_message_claims_slot_atomically(mock_start_task):
@@ -456,7 +456,7 @@ def test_append_message_claims_slot_atomically(mock_start_task):
     assert r2.status_code == 409
     assert r2.json()["error"]["code"] == "task_busy"
     # Only one bg kickoff total (from the winning first append).
-    assert mock_start_task.await_count == 1
+    assert mock_start_task.call_count == 1
 
 
 def test_create_then_append_race_returns_409(mock_start_task):
@@ -488,7 +488,7 @@ def test_create_then_append_race_returns_409(mock_start_task):
     assert resp.status_code == 409
     assert resp.json()["error"]["code"] == "task_busy"
     # No second bg kickoff should have happened
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_append_message_bg_inflight_does_not_corrupt_task_state(mock_start_task):
@@ -548,7 +548,7 @@ def test_append_message_bg_inflight_does_not_corrupt_task_state(mock_start_task)
             )
             assert resp.status_code == 409
             assert resp.json()["error"]["code"] == "task_busy"
-            assert mock_start_task.await_count == 0
+            assert mock_start_task.call_count == 0
 
             # The critical assertion: DB row was NOT mutated by the
             # refused append. status stays terminal, input unchanged.
@@ -584,7 +584,7 @@ def test_append_message_to_missing_task_returns_404(mock_start_task):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "task_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_append_message_to_other_agents_task_returns_404(mock_start_task):
@@ -618,7 +618,7 @@ def test_append_message_to_other_agents_task_returns_404(mock_start_task):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "task_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_append_message_body_agent_id_mismatch_returns_404(mock_start_task):
@@ -639,7 +639,7 @@ def test_append_message_body_agent_id_mismatch_returns_404(mock_start_task):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "agent_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 # ===== GET /v1/chat/tasks/{task_id} =====
@@ -1083,7 +1083,7 @@ def test_append_message_returns_404_for_non_sdk_source(mock_start_task):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "task_not_found"
-    assert mock_start_task.await_count == 0
+    assert mock_start_task.call_count == 0
 
 
 def test_get_steps_returns_404_for_non_sdk_source(mock_start_task):
@@ -1133,7 +1133,7 @@ def test_append_message_clears_stale_output_for_sdk_caller(mock_start_task):
         json={"agent_id": agent_id, "message": {"role": "user", "content": "second"}},
     )
     assert resp.status_code == 202, resp.text
-    assert mock_start_task.await_count == 1
+    assert mock_start_task.call_count == 1
 
     # After the response returns, an immediate GET must see:
     #   - status = running (atomic transition committed)

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -151,7 +151,7 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=TaskTurnPayload("first turn"),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         kind=TurnKind.CREATE,
         force_fresh=False,
     )
@@ -185,7 +185,7 @@ async def test_begin_turn_append_clears_stale_output_and_error(
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=TaskTurnPayload("second question"),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -217,7 +217,7 @@ async def test_begin_turn_append_clears_stale_error_message(
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=TaskTurnPayload("second"),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -249,7 +249,7 @@ async def test_begin_turn_append_accepts_paused_task_as_new_turn(
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=payload,
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -290,7 +290,7 @@ async def test_begin_turn_passes_force_fresh_through_to_schedule_bg(
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
         payload=payload,
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=True,
     )
@@ -326,7 +326,7 @@ async def test_begin_turn_rejects_create_with_force_fresh(
         await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             kind=TurnKind.CREATE,
             force_fresh=True,
         )
@@ -347,7 +347,7 @@ async def test_begin_turn_rejects_task_not_owned_by_user(
     with pytest.raises(TaskTurnNotFoundError):
         await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
-            user_id=int(user.id) + 9999,
+            task_owner_user_id=int(user.id) + 9999,
             payload=TaskTurnPayload("x"),
             kind=TurnKind.CREATE,
         )
@@ -374,7 +374,7 @@ async def test_begin_turn_marks_failed_when_schedule_raises(
         with pytest.raises(RuntimeError, match="schedule boom"):
             await TaskTurnOrchestrator.begin_turn(
                 task_id=int(task.id),
-                user_id=int(user.id),
+                task_owner_user_id=int(user.id),
                 payload=TaskTurnPayload("x"),
                 kind=TurnKind.CREATE,
             )
@@ -394,7 +394,7 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
 
-    def slow_claim(task_id, user_id, *, payload, kind):
+    def slow_claim(task_id, task_owner_user_id, *, payload, kind):
         _time.sleep(0.15)  # window during which we cancel the caller
         return _ClaimedTurn(
             status=TaskStatus.RUNNING,
@@ -417,7 +417,7 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
         t = asyncio.create_task(
             TaskTurnOrchestrator.begin_turn(
                 task_id=int(task.id),
-                user_id=int(user.id),
+                task_owner_user_id=int(user.id),
                 payload=TaskTurnPayload("x"),
                 kind=TurnKind.CREATE,
             )
@@ -456,7 +456,7 @@ async def test_begin_turn_refuses_when_bg_inflight(
             await TaskTurnOrchestrator.begin_turn(
                 task_id=int(task.id),
                 payload=TaskTurnPayload("x"),
-                user_id=int(user.id),
+                task_owner_user_id=int(user.id),
                 kind=TurnKind.APPEND,
             )
         assert excinfo.value.reason == "bg_inflight"
@@ -482,7 +482,7 @@ async def test_begin_turn_refuses_create_against_terminal_task(
         await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             kind=TurnKind.CREATE,
         )
     assert excinfo.value.reason == "busy"
@@ -501,7 +501,7 @@ async def test_begin_turn_refuses_append_against_pending_task(
         await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             kind=TurnKind.APPEND,
         )
     assert excinfo.value.reason == "busy"
@@ -668,7 +668,7 @@ async def test_schedule_bg_skips_finish_turn_when_lease_acquire_fails(
         # function runs with the deeper layers patched.
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
@@ -720,7 +720,7 @@ async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
     ):
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
@@ -791,7 +791,7 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
         )
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=payload,
             force_fresh=False,
@@ -879,7 +879,7 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
     ):
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
@@ -956,7 +956,7 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
     ):
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
@@ -1037,7 +1037,7 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
     ):
         bg_task = _schedule_bg(
             task_id=int(task.id),
-            user_id=int(user.id),
+            task_owner_user_id=int(user.id),
             task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -32,6 +32,7 @@ from xagent.web.services.task_orchestrator import (
     TaskTurnOrchestrator,
     TaskTurnPayload,
     TurnKind,
+    _ClaimedTurn,
     _schedule_bg,
     finish_turn,
 )
@@ -380,6 +381,55 @@ async def test_begin_turn_marks_failed_when_schedule_raises(
 
     db_session.refresh(task)
     assert task.status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> None:
+    """Cancellation safety: if begin_turn's caller is cancelled while the
+    off-loop claim is in flight (which commits RUNNING in a worker thread),
+    ``asyncio.shield`` must still let the claim+schedule finish, so a committed
+    RUNNING task is never left with no scheduled worker."""
+    import time as _time
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+
+    def slow_claim(task_id, user_id, *, payload, kind):
+        _time.sleep(0.15)  # window during which we cancel the caller
+        return _ClaimedTurn(
+            status=TaskStatus.RUNNING,
+            updated_at=datetime.now(timezone.utc),
+            before_message_id=1,
+            task_source="sdk",
+        )
+
+    sched = MagicMock(return_value=MagicMock())
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator._begin_turn_atomic_sync",
+            new=slow_claim,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator._schedule_bg",
+            new=sched,
+        ),
+    ):
+        t = asyncio.create_task(
+            TaskTurnOrchestrator.begin_turn(
+                task_id=int(task.id),
+                user_id=int(user.id),
+                payload=TaskTurnPayload("x"),
+                kind=TurnKind.CREATE,
+            )
+        )
+        await asyncio.sleep(0.05)  # let it enter the off-loop claim
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+        # The shielded inner keeps running; give it time to finish.
+        await asyncio.sleep(0.3)
+
+    sched.assert_called_once()  # scheduled despite the cancellation
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -28,6 +28,7 @@ from xagent.web.models.user import User
 from xagent.web.services.task_lease_service import get_runner_id
 from xagent.web.services.task_orchestrator import (
     TaskTurnError,
+    TaskTurnNotFoundError,
     TaskTurnOrchestrator,
     TaskTurnPayload,
     TurnKind,
@@ -99,7 +100,7 @@ def mock_schedule_bg():
     """
     with patch(
         "xagent.web.services.task_orchestrator._schedule_bg",
-        new=AsyncMock(),
+        new=MagicMock(),
     ) as mocked:
         yield mocked
 
@@ -147,10 +148,9 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
 
     await TaskTurnOrchestrator.begin_turn(
-        task=task,
+        task_id=int(task.id),
         payload=TaskTurnPayload("first turn"),
-        user=user,
-        db=db_session,
+        user_id=int(user.id),
         kind=TurnKind.CREATE,
         force_fresh=False,
     )
@@ -182,10 +182,9 @@ async def test_begin_turn_append_clears_stale_output_and_error(
     )
 
     await TaskTurnOrchestrator.begin_turn(
-        task=task,
+        task_id=int(task.id),
         payload=TaskTurnPayload("second question"),
-        user=user,
-        db=db_session,
+        user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -215,10 +214,9 @@ async def test_begin_turn_append_clears_stale_error_message(
     )
 
     await TaskTurnOrchestrator.begin_turn(
-        task=task,
+        task_id=int(task.id),
         payload=TaskTurnPayload("second"),
-        user=user,
-        db=db_session,
+        user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -248,10 +246,9 @@ async def test_begin_turn_append_accepts_paused_task_as_new_turn(
 
     payload = TaskTurnPayload("new request after pause")
     await TaskTurnOrchestrator.begin_turn(
-        task=task,
+        task_id=int(task.id),
         payload=payload,
-        user=user,
-        db=db_session,
+        user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=False,
     )
@@ -270,7 +267,7 @@ async def test_begin_turn_append_accepts_paused_task_as_new_turn(
     assert persisted.content == "new request after pause"
     assert persisted.turn_id == payload.turn_id
 
-    mock_schedule_bg.assert_awaited_once()
+    mock_schedule_bg.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -290,16 +287,15 @@ async def test_begin_turn_passes_force_fresh_through_to_schedule_bg(
         execution_message="show me\n\n[file: foo.pdf]",
     )
     await TaskTurnOrchestrator.begin_turn(
-        task=task,
+        task_id=int(task.id),
         payload=payload,
-        user=user,
-        db=db_session,
+        user_id=int(user.id),
         kind=TurnKind.APPEND,
         force_fresh=True,
     )
 
-    mock_schedule_bg.assert_awaited_once()
-    kwargs = mock_schedule_bg.await_args.kwargs
+    mock_schedule_bg.assert_called_once()
+    kwargs = mock_schedule_bg.call_args.kwargs
     assert kwargs["payload"] is payload
     assert kwargs["force_fresh"] is True
 
@@ -327,38 +323,63 @@ async def test_begin_turn_rejects_create_with_force_fresh(
 
     with pytest.raises(ValueError, match="force_fresh has no meaning"):
         await TaskTurnOrchestrator.begin_turn(
-            task=task,
+            task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user=user,
-            db=db_session,
+            user_id=int(user.id),
             kind=TurnKind.CREATE,
             force_fresh=True,
         )
 
 
 @pytest.mark.asyncio
-async def test_begin_turn_asserts_session_clean_precondition(
+async def test_begin_turn_rejects_task_not_owned_by_user(
     db_session,
     mock_schedule_bg,
 ) -> None:
-    """Caller contract: db session must be clean of uncommitted state."""
+    """Ownership is folded into the atomic claim predicate. A ``user_id``
+    that does not own the task → ``TaskTurnNotFoundError`` (404), NOT
+    ``TaskTurnError`` (409), and no row is mutated. Passing a *different*
+    user id (not ``task.user_id``) proves the predicate actually guards."""
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
 
-    # Stage an uncommitted user without committing — simulates a caller
-    # that forgot to commit before calling begin_turn.
-    stray = User(username="stray", password_hash="hash")
-    db_session.add(stray)
-    # NOT committing on purpose
-
-    with pytest.raises(ValueError, match="clean db session"):
+    with pytest.raises(TaskTurnNotFoundError):
         await TaskTurnOrchestrator.begin_turn(
-            task=task,
+            task_id=int(task.id),
+            user_id=int(user.id) + 9999,
             payload=TaskTurnPayload("x"),
-            user=user,
-            db=db_session,
             kind=TurnKind.CREATE,
         )
+
+    db_session.refresh(task)
+    assert task.status == TaskStatus.PENDING, "rejected claim must not mutate"
+    mock_schedule_bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_marks_failed_when_schedule_raises(
+    db_session,
+) -> None:
+    """Post-commit invariant: once the claim commits (RUNNING) but
+    ``_schedule_bg`` raises, the task must be forced FAILED so it is never
+    left RUNNING with no bg worker (zombie)."""
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(side_effect=RuntimeError("schedule boom")),
+    ):
+        with pytest.raises(RuntimeError, match="schedule boom"):
+            await TaskTurnOrchestrator.begin_turn(
+                task_id=int(task.id),
+                user_id=int(user.id),
+                payload=TaskTurnPayload("x"),
+                kind=TurnKind.CREATE,
+            )
+
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
 
 
 @pytest.mark.asyncio
@@ -383,10 +404,9 @@ async def test_begin_turn_refuses_when_bg_inflight(
     try:
         with pytest.raises(TaskTurnError) as excinfo:
             await TaskTurnOrchestrator.begin_turn(
-                task=task,
+                task_id=int(task.id),
                 payload=TaskTurnPayload("x"),
-                user=user,
-                db=db_session,
+                user_id=int(user.id),
                 kind=TurnKind.APPEND,
             )
         assert excinfo.value.reason == "bg_inflight"
@@ -410,10 +430,9 @@ async def test_begin_turn_refuses_create_against_terminal_task(
 
     with pytest.raises(TaskTurnError) as excinfo:
         await TaskTurnOrchestrator.begin_turn(
-            task=task,
+            task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user=user,
-            db=db_session,
+            user_id=int(user.id),
             kind=TurnKind.CREATE,
         )
     assert excinfo.value.reason == "busy"
@@ -430,10 +449,9 @@ async def test_begin_turn_refuses_append_against_pending_task(
 
     with pytest.raises(TaskTurnError) as excinfo:
         await TaskTurnOrchestrator.begin_turn(
-            task=task,
+            task_id=int(task.id),
             payload=TaskTurnPayload("x"),
-            user=user,
-            db=db_session,
+            user_id=int(user.id),
             kind=TurnKind.APPEND,
         )
     assert excinfo.value.reason == "busy"
@@ -598,9 +616,10 @@ async def test_schedule_bg_skips_finish_turn_when_lease_acquire_fails(
         # Note: this test does NOT use the mock_schedule_bg fixture
         # because we're testing _schedule_bg itself. The real
         # function runs with the deeper layers patched.
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
             context=None,
@@ -649,9 +668,10 @@ async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
             return_value=MagicMock(),
         ),
     ):
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
             context=None,
@@ -719,9 +739,10 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
             transcript_message="summarize this",
             execution_message="summarize this\n\n[uploaded file: secret.txt]",
         )
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=payload,
             force_fresh=False,
             context={"turn_id": "caller-turn", "existing": "value"},
@@ -806,9 +827,10 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
             return_value=MagicMock(),
         ),
     ):
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
             context=None,
@@ -882,9 +904,10 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
             return_value=MagicMock(),
         ),
     ):
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
             context=None,
@@ -962,9 +985,10 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
             return_value=MagicMock(),
         ),
     ):
-        bg_task = await _schedule_bg(
-            task=task,
-            user=user,
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            user_id=int(user.id),
+            task_source=task.source,
             payload=TaskTurnPayload("x"),
             force_fresh=False,
             context=None,

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -43,11 +43,21 @@ def db_session() -> Session:
     )
     Base.metadata.create_all(bind=engine)
     session_factory = sessionmaker(bind=engine)
+    # begin_turn now runs its atomic claim on an isolated session opened via
+    # the global SessionLocal (``get_session_local``) inside ``asyncio.to_thread``.
+    # Point that global at this test's StaticPool engine (single shared
+    # connection, check_same_thread=False) so the off-loop claim hits the same
+    # in-memory DB the test reads from.
+    import xagent.web.models.database as _db_module
+
+    _prev_session_local = _db_module._SessionLocal
+    _db_module._SessionLocal = session_factory
     session = session_factory()
     try:
         yield session
     finally:
         session.close()
+        _db_module._SessionLocal = _prev_session_local
         Base.metadata.drop_all(bind=engine)
         engine.dispose()
 
@@ -136,7 +146,7 @@ def _add_worker(
 def _patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     scheduled: dict[str, Any] = {}
 
-    async def fake_schedule_bg(**kwargs: Any) -> asyncio.Task[None]:
+    def fake_schedule_bg(**kwargs: Any) -> asyncio.Task[None]:
         scheduled.update(kwargs)
 
         async def noop() -> None:
@@ -218,7 +228,7 @@ async def test_create_workforce_run_creates_task_run_and_starts_turn(
     assert workforce_run.task_id == task.id
     assert workforce_run.status == "running"
     assert uploaded_file.task_id == task.id
-    assert scheduled["task"].id == task.id
+    assert scheduled["task_id"] == task.id
     assert scheduled["payload"].transcript_message == "Coordinate a launch brief"
     assert (
         db_session.query(TaskChatMessage)
@@ -233,7 +243,7 @@ async def test_create_workforce_run_marks_task_failed_when_turn_start_fails_afte
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fail_schedule_bg(**kwargs: Any) -> asyncio.Task[None]:
+    def fail_schedule_bg(**kwargs: Any) -> asyncio.Task[None]:
         del kwargs
         raise RuntimeError("schedule failed")
 


### PR DESCRIPTION
The transaction that starts a task turn (mark the task RUNNING, persist the
user message, commit) ran synchronously on the request's event loop. While
it was in flight the loop could not serve anything else. On the production
database this commit can take seconds, blocking all concurrent requests for
that long.

This moves the transaction to a worker thread (`asyncio.to_thread`) with its
own database session. The request still awaits its own commit, so its latency
is unchanged, but the event loop stays free to serve other requests while the
write runs.

`begin_turn` now takes ids instead of ORM objects and returns the
committed-row snapshot (status, updated_at, message id) that callers need, so
they no longer do an on-loop `db.refresh` after it.

Measurement: 120 back-to-back turn-start writes against a real SQLite DB,
running the write on the loop vs. on a worker thread. Worst-case time the
event loop was unavailable to other coroutines dropped from 118 ms to 12 ms.
Per-request latency is unchanged; this helps throughput under concurrency,
not single-request speed.

Behavior:
- Responses, status codes, and persisted messages are unchanged.
- Ownership is part of the claim predicate now: a task that doesn't exist or
  isn't the caller's returns 404.
- If scheduling the background run fails after the claim has committed, the
  task is marked FAILED instead of being left RUNNING.

Tests: updated the turn-lifecycle, v1 task, and workforce tests; added
assertions for the ownership 404, the mark-FAILED-on-schedule-error
guarantee, and that responses read from the returned snapshot.

Refs #427
