### PR TITLE
refactor(kb): add pipeline and legacy step facades

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_document.py
@@ -7,7 +7,7 @@ document chunking using various chunking strategies.
 import json
 import logging
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -32,6 +32,9 @@ from .chunk_strategies import (
     apply_recursive_strategy,
     attach_media_context,
 )
+
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +68,55 @@ def _create_spreadsheet_row_chunks(
     return chunks
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def chunk_document(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    chunk_strategy: ChunkStrategy = ChunkStrategy.RECURSIVE,
+    chunk_size: Optional[int] = 1000,
+    chunk_overlap: int = 200,
+    headers_to_split_on: Optional[List[Tuple[str, str]]] = None,
+    separators: Optional[List[str]] = None,
+    use_token_count: bool = False,
+    tiktoken_encoding: str = DEFAULT_TIKTOKEN_ENCODING,
+    enable_protected_content: bool = True,
+    protected_patterns: Optional[List[str]] = None,
+    table_context_size: int = DEFAULT_TABLE_CONTEXT_SIZE,
+    image_context_size: int = DEFAULT_IMAGE_CONTEXT_SIZE,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Chunk parsed paragraphs and write to chunks table."""
+    return _get_legacy_step_compatibility_facade().chunk_document(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        chunk_strategy=chunk_strategy,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        headers_to_split_on=headers_to_split_on,
+        separators=separators,
+        use_token_count=use_token_count,
+        tiktoken_encoding=tiktoken_encoding,
+        enable_protected_content=enable_protected_content,
+        protected_patterns=protected_patterns,
+        table_context_size=table_context_size,
+        image_context_size=image_context_size,
+        user_id=user_id,
+        is_admin=is_admin,
+        **kwargs,
+    )
+
+
+def _chunk_document_impl(
     collection: str,
     doc_id: str,
     parse_hash: str,
@@ -577,6 +628,27 @@ def chunk_recursive(
     separators: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> Dict[str, Any]:
+    """Chunk document using recursive character splitting strategy."""
+    return _get_legacy_step_compatibility_facade().chunk_recursive(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        separators=separators,
+        **kwargs,
+    )
+
+
+def _chunk_recursive_impl(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    chunk_size: Optional[int] = 1000,
+    chunk_overlap: int = 200,
+    separators: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
     """
     Chunk document using recursive character splitting strategy.
 
@@ -591,7 +663,7 @@ def chunk_recursive(
     Returns:
         Dictionary containing chunk results and statistics
     """
-    return chunk_document(
+    return _chunk_document_impl(
         collection=collection,
         doc_id=doc_id,
         parse_hash=parse_hash,
@@ -604,6 +676,29 @@ def chunk_recursive(
 
 
 def chunk_markdown(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    chunk_size: Optional[int] = 1200,
+    chunk_overlap: int = 200,
+    headers_to_split_on: Optional[List[Tuple[str, str]]] = None,
+    separators: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Chunk document using markdown header-based strategy."""
+    return _get_legacy_step_compatibility_facade().chunk_markdown(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        headers_to_split_on=headers_to_split_on,
+        separators=separators,
+        **kwargs,
+    )
+
+
+def _chunk_markdown_impl(
     collection: str,
     doc_id: str,
     parse_hash: str,
@@ -628,7 +723,7 @@ def chunk_markdown(
     Returns:
         Dictionary containing chunk results and statistics
     """
-    return chunk_document(
+    return _chunk_document_impl(
         collection=collection,
         doc_id=doc_id,
         parse_hash=parse_hash,
@@ -649,6 +744,25 @@ def chunk_fixed_size(
     chunk_overlap: int = 0,
     **kwargs: Any,
 ) -> Dict[str, Any]:
+    """Chunk document using fixed size strategy."""
+    return _get_legacy_step_compatibility_facade().chunk_fixed_size(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        **kwargs,
+    )
+
+
+def _chunk_fixed_size_impl(
+    collection: str,
+    doc_id: str,
+    parse_hash: str,
+    chunk_size: Optional[int] = 1000,
+    chunk_overlap: int = 0,
+    **kwargs: Any,
+) -> Dict[str, Any]:
     """
     Chunk document using fixed size strategy.
 
@@ -662,7 +776,7 @@ def chunk_fixed_size(
     Returns:
         Dictionary containing chunk results and statistics
     """
-    return chunk_document(
+    return _chunk_document_impl(
         collection=collection,
         doc_id=doc_id,
         parse_hash=parse_hash,

--- a/src/xagent/core/tools/core/RAG_tools/file/register_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/file/register_document.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import pandas as pd
 
@@ -29,6 +29,9 @@ from ..utils.string_utils import (
     generate_deterministic_doc_id,
 )
 
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +39,37 @@ logger = logging.getLogger(__name__)
 # Internally constructs Pydantic request and delegates to _register_document.
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def register_document(
+    collection: str,
+    source_path: str,
+    file_type: Optional[str] = None,
+    doc_id: Optional[str] = None,
+    uploaded_at: Optional[str] = None,
+    user_id: Optional[int] = None,
+    file_id: Optional[str] = None,
+    metadata_source_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Register a document into the LanceDB system."""
+    return _get_legacy_step_compatibility_facade().register_document(
+        collection=collection,
+        source_path=source_path,
+        file_type=file_type,
+        doc_id=doc_id,
+        uploaded_at=uploaded_at,
+        user_id=user_id,
+        file_id=file_id,
+        metadata_source_path=metadata_source_path,
+    )
+
+
+def _register_document_public_impl(
     collection: str,
     source_path: str,
     file_type: Optional[str] = None,
@@ -216,6 +249,13 @@ def _register_document(request: RegisterDocumentRequest) -> RegisterDocumentResp
 
 
 def get_document(db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
+    """Retrieve a document record from LanceDB using abstraction layer."""
+    return _get_legacy_step_compatibility_facade().get_document(
+        db_dir, collection, doc_id
+    )
+
+
+def _get_document_impl(db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
     """Retrieve a document record from LanceDB using abstraction layer.
 
 
@@ -254,6 +294,15 @@ def get_document(db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
 
 
 def list_documents(
+    db_dir: str, collection: str, limit: int = 100
+) -> list[Dict[str, Any]]:
+    """List documents in the collection using abstraction layer."""
+    return _get_legacy_step_compatibility_facade().list_documents(
+        db_dir, collection, limit
+    )
+
+
+def _list_documents_impl(
     db_dir: str, collection: str, limit: int = 100
 ) -> list[Dict[str, Any]]:
     """List documents in the collection using abstraction layer.

--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -7,6 +7,7 @@ from .coordinator import (
     reset_kb_coordinator_for_tests,
 )
 from .file_compatibility import KBFileCompatibilityFacade
+from .legacy_step_compatibility import KBLegacyStepCompatibilityFacade
 from .maintenance_compatibility import (
     CollectionConfigSnapshot,
     CollectionRollbackMaintenanceResult,
@@ -22,6 +23,7 @@ from .models import (
     KBUserScope,
 )
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
+from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
 from .vector_storage_compatibility import (
@@ -46,11 +48,13 @@ __all__ = [
     "KBCoreManagementCompatibilityFacade",
     "KBCoordinator",
     "KBFileCompatibilityFacade",
+    "KBLegacyStepCompatibilityFacade",
     "KBMainPointerSnapshot",
     "KBMaintenanceCompatibilityFacade",
     "KBVersionCandidateCleanupSnapshot",
     "KBVersionCandidateRollbackResult",
     "KBParseDisplayCompatibilityFacade",
+    "KBPipelineCompatibilityFacade",
     "KBRetrievalHelperCompatibilityFacade",
     "KBStorageShimCompatibilityFacade",
     "KBStorageBackend",

--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -22,6 +22,14 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .operation_compatibility import (
+    CompensationStep,
+    KBOperationCompatibilityFacade,
+    KBOperationOutcome,
+    PersistencePolicy,
+    RollbackStatus,
+    SideEffectPlane,
+)
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
@@ -49,8 +57,11 @@ __all__ = [
     "KBCoordinator",
     "KBFileCompatibilityFacade",
     "KBLegacyStepCompatibilityFacade",
+    "CompensationStep",
     "KBMainPointerSnapshot",
     "KBMaintenanceCompatibilityFacade",
+    "KBOperationCompatibilityFacade",
+    "KBOperationOutcome",
     "KBVersionCandidateCleanupSnapshot",
     "KBVersionCandidateRollbackResult",
     "KBParseDisplayCompatibilityFacade",
@@ -63,6 +74,9 @@ __all__ = [
     "KBUserScope",
     "KBVersionCompatibilityFacade",
     "LanceDBCollectionHandle",
+    "PersistencePolicy",
+    "RollbackStatus",
+    "SideEffectPlane",
     "get_kb_coordinator",
     "reset_kb_coordinator_for_tests",
 ]

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -12,6 +12,7 @@ from ..storage.factory import StorageFactory
 from ..utils.user_scope import resolve_user_scope
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .file_compatibility import KBFileCompatibilityFacade
+from .legacy_step_compatibility import KBLegacyStepCompatibilityFacade
 from .maintenance_compatibility import KBMaintenanceCompatibilityFacade
 from .management_facade import KBCoreManagementCompatibilityFacade
 from .models import (
@@ -23,6 +24,7 @@ from .models import (
     KBUserScope,
 )
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
+from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
 from .vector_storage_compatibility import KBVectorStorageCompatibilityFacade
@@ -50,6 +52,8 @@ class KBCoordinator:
             KBRetrievalHelperCompatibilityFacade | None
         ) = None,
         vector_storage_compatibility: KBVectorStorageCompatibilityFacade | None = None,
+        pipeline_compatibility: KBPipelineCompatibilityFacade | None = None,
+        legacy_step_compatibility: KBLegacyStepCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -78,6 +82,13 @@ class KBCoordinator:
         self._vector_storage_compatibility = (
             vector_storage_compatibility
             or KBVectorStorageCompatibilityFacade(coordinator=self)
+        )
+        self._pipeline_compatibility = (
+            pipeline_compatibility or KBPipelineCompatibilityFacade(coordinator=self)
+        )
+        self._legacy_step_compatibility = (
+            legacy_step_compatibility
+            or KBLegacyStepCompatibilityFacade(coordinator=self)
         )
 
     @property
@@ -149,6 +160,26 @@ class KBCoordinator:
     def vector_storage(self) -> KBVectorStorageCompatibilityFacade:
         """Backward-friendly short alias for the vector storage facade."""
         return self._vector_storage_compatibility
+
+    @property
+    def pipeline_compatibility(self) -> KBPipelineCompatibilityFacade:
+        """Return the high-level pipeline compatibility facade."""
+        return self._pipeline_compatibility
+
+    @property
+    def pipeline(self) -> KBPipelineCompatibilityFacade:
+        """Backward-friendly short alias for the pipeline facade."""
+        return self._pipeline_compatibility
+
+    @property
+    def legacy_step_compatibility(self) -> KBLegacyStepCompatibilityFacade:
+        """Return the legacy step helper compatibility facade."""
+        return self._legacy_step_compatibility
+
+    @property
+    def legacy_steps(self) -> KBLegacyStepCompatibilityFacade:
+        """Backward-friendly short alias for the legacy step facade."""
+        return self._legacy_step_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -23,6 +23,7 @@ from .models import (
     KBStorageBackend,
     KBUserScope,
 )
+from .operation_compatibility import KBOperationCompatibilityFacade
 from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
@@ -52,6 +53,7 @@ class KBCoordinator:
             KBRetrievalHelperCompatibilityFacade | None
         ) = None,
         vector_storage_compatibility: KBVectorStorageCompatibilityFacade | None = None,
+        operation_compatibility: KBOperationCompatibilityFacade | None = None,
         pipeline_compatibility: KBPipelineCompatibilityFacade | None = None,
         legacy_step_compatibility: KBLegacyStepCompatibilityFacade | None = None,
     ) -> None:
@@ -82,6 +84,9 @@ class KBCoordinator:
         self._vector_storage_compatibility = (
             vector_storage_compatibility
             or KBVectorStorageCompatibilityFacade(coordinator=self)
+        )
+        self._operation_compatibility = (
+            operation_compatibility or KBOperationCompatibilityFacade()
         )
         self._pipeline_compatibility = (
             pipeline_compatibility or KBPipelineCompatibilityFacade(coordinator=self)
@@ -160,6 +165,16 @@ class KBCoordinator:
     def vector_storage(self) -> KBVectorStorageCompatibilityFacade:
         """Backward-friendly short alias for the vector storage facade."""
         return self._vector_storage_compatibility
+
+    @property
+    def operation_compatibility(self) -> KBOperationCompatibilityFacade:
+        """Return the rollback-aware operation compatibility facade."""
+        return self._operation_compatibility
+
+    @property
+    def operations(self) -> KBOperationCompatibilityFacade:
+        """Backward-friendly short alias for the operation facade."""
+        return self._operation_compatibility
 
     @property
     def pipeline_compatibility(self) -> KBPipelineCompatibilityFacade:

--- a/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
@@ -1,0 +1,390 @@
+"""Legacy step compatibility facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from ..core.config import (
+    DEFAULT_IMAGE_CONTEXT_SIZE,
+    DEFAULT_TABLE_CONTEXT_SIZE,
+    DEFAULT_TIKTOKEN_ENCODING,
+)
+from ..core.schemas import (
+    ChunkStrategy,
+    DenseSearchResponse,
+    FusionConfig,
+    HybridSearchResponse,
+    ParseMethod,
+    SparseSearchResponse,
+)
+
+if TYPE_CHECKING:
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+
+class KBLegacyStepCompatibilityFacade:
+    """Compatibility boundary for legacy KB step helper functions.
+
+    Document registration, parse, chunk, and retrieval helper modules keep their
+    historical import paths and sync/async behavior. The facade provides one
+    coordinator-owned storage boundary while delegating to the current helper
+    implementations.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    def register_document(
+        self,
+        collection: str,
+        source_path: str,
+        file_type: Optional[str] = None,
+        doc_id: Optional[str] = None,
+        uploaded_at: Optional[str] = None,
+        user_id: Optional[int] = None,
+        file_id: Optional[str] = None,
+        metadata_source_path: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        from ..file.register_document import _register_document_public_impl
+
+        with self._storage_context():
+            return _register_document_public_impl(
+                collection=collection,
+                source_path=source_path,
+                file_type=file_type,
+                doc_id=doc_id,
+                uploaded_at=uploaded_at,
+                user_id=user_id,
+                file_id=file_id,
+                metadata_source_path=metadata_source_path,
+            )
+
+    def get_document(self, db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
+        from ..file.register_document import _get_document_impl
+
+        with self._storage_context():
+            return _get_document_impl(db_dir, collection, doc_id)
+
+    def list_documents(
+        self, db_dir: str, collection: str, limit: int = 100
+    ) -> list[Dict[str, Any]]:
+        from ..file.register_document import _list_documents_impl
+
+        with self._storage_context():
+            return _list_documents_impl(db_dir, collection, limit)
+
+    def parse_document(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_method: ParseMethod,
+        params: Optional[Dict[str, Any]] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        progress_callback: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        from ..parse.parse_document import _parse_document_impl
+
+        with self._storage_context():
+            return _parse_document_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_method=parse_method,
+                params=params,
+                user_id=user_id,
+                is_admin=is_admin,
+                progress_callback=progress_callback,
+            )
+
+    def chunk_document(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        chunk_strategy: ChunkStrategy = ChunkStrategy.RECURSIVE,
+        chunk_size: Optional[int] = 1000,
+        chunk_overlap: int = 200,
+        headers_to_split_on: Optional[List[Tuple[str, str]]] = None,
+        separators: Optional[List[str]] = None,
+        use_token_count: bool = False,
+        tiktoken_encoding: str = DEFAULT_TIKTOKEN_ENCODING,
+        enable_protected_content: bool = True,
+        protected_patterns: Optional[List[str]] = None,
+        table_context_size: int = DEFAULT_TABLE_CONTEXT_SIZE,
+        image_context_size: int = DEFAULT_IMAGE_CONTEXT_SIZE,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        from ..chunk.chunk_document import _chunk_document_impl
+
+        with self._storage_context():
+            return _chunk_document_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_strategy=chunk_strategy,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                headers_to_split_on=headers_to_split_on,
+                separators=separators,
+                use_token_count=use_token_count,
+                tiktoken_encoding=tiktoken_encoding,
+                enable_protected_content=enable_protected_content,
+                protected_patterns=protected_patterns,
+                table_context_size=table_context_size,
+                image_context_size=image_context_size,
+                user_id=user_id,
+                is_admin=is_admin,
+                **kwargs,
+            )
+
+    def chunk_recursive(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        chunk_size: Optional[int] = 1000,
+        chunk_overlap: int = 200,
+        separators: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        from ..chunk.chunk_document import _chunk_recursive_impl
+
+        with self._storage_context():
+            return _chunk_recursive_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                separators=separators,
+                **kwargs,
+            )
+
+    def chunk_markdown(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        chunk_size: Optional[int] = 1200,
+        chunk_overlap: int = 200,
+        headers_to_split_on: Optional[List[Tuple[str, str]]] = None,
+        separators: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        from ..chunk.chunk_document import _chunk_markdown_impl
+
+        with self._storage_context():
+            return _chunk_markdown_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                headers_to_split_on=headers_to_split_on,
+                separators=separators,
+                **kwargs,
+            )
+
+    def chunk_fixed_size(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        chunk_size: Optional[int] = 1000,
+        chunk_overlap: int = 0,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        from ..chunk.chunk_document import _chunk_fixed_size_impl
+
+        with self._storage_context():
+            return _chunk_fixed_size_impl(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+                **kwargs,
+            )
+
+    def search_dense(
+        self,
+        collection: str,
+        model_tag: str,
+        query_vector: List[float],
+        *,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        from ..retrieval.search_dense import _search_dense_impl
+
+        with self._storage_context():
+            return _search_dense_impl(
+                collection=collection,
+                model_tag=model_tag,
+                query_vector=query_vector,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def search_dense_async(
+        self,
+        collection: str,
+        model_tag: str,
+        query_vector: List[float],
+        *,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        from ..retrieval.search_dense import _search_dense_async_impl
+
+        with self._storage_context():
+            return await _search_dense_async_impl(
+                collection=collection,
+                model_tag=model_tag,
+                query_vector=query_vector,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def search_sparse(
+        self,
+        collection: str,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Optional[Dict[str, Any]] = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        from ..retrieval.search_sparse import _search_sparse_impl
+
+        with self._storage_context():
+            return _search_sparse_impl(
+                collection=collection,
+                model_tag=model_tag,
+                query_text=query_text,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def search_sparse_async(
+        self,
+        collection: str,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Optional[Dict[str, Any]] = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        from ..retrieval.search_sparse import _search_sparse_async_impl
+
+        with self._storage_context():
+            return await _search_sparse_async_impl(
+                collection=collection,
+                model_tag=model_tag,
+                query_text=query_text,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def search_hybrid(
+        self,
+        collection: str,
+        model_tag: str,
+        query_text: str,
+        query_vector: List[float],
+        *,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        fusion_config: Optional[FusionConfig] = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> HybridSearchResponse:
+        from ..retrieval.search_hybrid import _search_hybrid_impl
+
+        with self._storage_context():
+            return _search_hybrid_impl(
+                collection=collection,
+                model_tag=model_tag,
+                query_text=query_text,
+                query_vector=query_vector,
+                top_k=top_k,
+                filters=filters,
+                fusion_config=fusion_config,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )

--- a/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
@@ -19,6 +19,13 @@ from ..core.schemas import (
     ParseMethod,
     SparseSearchResponse,
 )
+from .operation_compatibility import (
+    KBOperation,
+    KBOperationCompatibilityFacade,
+    PersistencePolicy,
+    RollbackStatus,
+    SideEffectPlane,
+)
 
 if TYPE_CHECKING:
     from .coordinator import KBCoordinator
@@ -38,9 +45,11 @@ class KBLegacyStepCompatibilityFacade:
         self,
         coordinator: KBCoordinator | None = None,
         storage_shim: KBStorageShimCompatibilityFacade | None = None,
+        operation_compatibility: KBOperationCompatibilityFacade | None = None,
     ) -> None:
         self._coordinator = coordinator
         self._storage_shim = storage_shim
+        self._operation_compatibility = operation_compatibility
 
     def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
         if self._storage_shim is not None:
@@ -48,6 +57,34 @@ class KBLegacyStepCompatibilityFacade:
         if self._coordinator is not None:
             return self._coordinator.storage_shim
         return None
+
+    def _active_operation_facade(self) -> KBOperationCompatibilityFacade | None:
+        if self._operation_compatibility is not None:
+            return self._operation_compatibility
+        if self._coordinator is not None:
+            return self._coordinator.operation_compatibility
+        return None
+
+    @contextmanager
+    def _operation_context(
+        self, *, operation_type: str, collection: str
+    ) -> Iterator[tuple[KBOperation | None, bool]]:
+        operation_facade = self._active_operation_facade()
+        if operation_facade is None:
+            yield None, False
+            return
+
+        current_operation = operation_facade.current_operation()
+        if current_operation is not None:
+            yield current_operation, False
+            return
+
+        with operation_facade.start_operation(
+            operation_type=operation_type,
+            collection=collection,
+            persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        ) as operation:
+            yield operation, True
 
     @contextmanager
     def _storage_context(self) -> Iterator[None]:
@@ -74,17 +111,30 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..file.register_document import _register_document_public_impl
 
-        with self._storage_context():
-            return _register_document_public_impl(
+        with self._operation_context(
+            operation_type="legacy_register_document", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _register_document_public_impl(
+                    collection=collection,
+                    source_path=source_path,
+                    file_type=file_type,
+                    doc_id=doc_id,
+                    uploaded_at=uploaded_at,
+                    user_id=user_id,
+                    file_id=file_id,
+                    metadata_source_path=metadata_source_path,
+                )
+            self._record_document_side_effect(
+                operation,
                 collection=collection,
                 source_path=source_path,
-                file_type=file_type,
-                doc_id=doc_id,
-                uploaded_at=uploaded_at,
-                user_id=user_id,
                 file_id=file_id,
-                metadata_source_path=metadata_source_path,
+                user_id=user_id,
+                result=result,
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
 
     def get_document(self, db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
         from ..file.register_document import _get_document_impl
@@ -112,16 +162,24 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..parse.parse_document import _parse_document_impl
 
-        with self._storage_context():
-            return _parse_document_impl(
-                collection=collection,
-                doc_id=doc_id,
-                parse_method=parse_method,
-                params=params,
-                user_id=user_id,
-                is_admin=is_admin,
-                progress_callback=progress_callback,
+        with self._operation_context(
+            operation_type="legacy_parse_document", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _parse_document_impl(
+                    collection=collection,
+                    doc_id=doc_id,
+                    parse_method=parse_method,
+                    params=params,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    progress_callback=progress_callback,
+                )
+            self._record_parse_side_effect(
+                operation, collection=collection, doc_id=doc_id, result=result
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
 
     def chunk_document(
         self,
@@ -145,26 +203,38 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..chunk.chunk_document import _chunk_document_impl
 
-        with self._storage_context():
-            return _chunk_document_impl(
+        with self._operation_context(
+            operation_type="legacy_chunk_document", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _chunk_document_impl(
+                    collection=collection,
+                    doc_id=doc_id,
+                    parse_hash=parse_hash,
+                    chunk_strategy=chunk_strategy,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                    headers_to_split_on=headers_to_split_on,
+                    separators=separators,
+                    use_token_count=use_token_count,
+                    tiktoken_encoding=tiktoken_encoding,
+                    enable_protected_content=enable_protected_content,
+                    protected_patterns=protected_patterns,
+                    table_context_size=table_context_size,
+                    image_context_size=image_context_size,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    **kwargs,
+                )
+            self._record_chunk_side_effect(
+                operation,
                 collection=collection,
                 doc_id=doc_id,
                 parse_hash=parse_hash,
-                chunk_strategy=chunk_strategy,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-                headers_to_split_on=headers_to_split_on,
-                separators=separators,
-                use_token_count=use_token_count,
-                tiktoken_encoding=tiktoken_encoding,
-                enable_protected_content=enable_protected_content,
-                protected_patterns=protected_patterns,
-                table_context_size=table_context_size,
-                image_context_size=image_context_size,
-                user_id=user_id,
-                is_admin=is_admin,
-                **kwargs,
+                result=result,
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
 
     def chunk_recursive(
         self,
@@ -178,16 +248,28 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..chunk.chunk_document import _chunk_recursive_impl
 
-        with self._storage_context():
-            return _chunk_recursive_impl(
+        with self._operation_context(
+            operation_type="legacy_chunk_recursive", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _chunk_recursive_impl(
+                    collection=collection,
+                    doc_id=doc_id,
+                    parse_hash=parse_hash,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                    separators=separators,
+                    **kwargs,
+                )
+            self._record_chunk_side_effect(
+                operation,
                 collection=collection,
                 doc_id=doc_id,
                 parse_hash=parse_hash,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-                separators=separators,
-                **kwargs,
+                result=result,
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
 
     def chunk_markdown(
         self,
@@ -202,17 +284,29 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..chunk.chunk_document import _chunk_markdown_impl
 
-        with self._storage_context():
-            return _chunk_markdown_impl(
+        with self._operation_context(
+            operation_type="legacy_chunk_markdown", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _chunk_markdown_impl(
+                    collection=collection,
+                    doc_id=doc_id,
+                    parse_hash=parse_hash,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                    headers_to_split_on=headers_to_split_on,
+                    separators=separators,
+                    **kwargs,
+                )
+            self._record_chunk_side_effect(
+                operation,
                 collection=collection,
                 doc_id=doc_id,
                 parse_hash=parse_hash,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-                headers_to_split_on=headers_to_split_on,
-                separators=separators,
-                **kwargs,
+                result=result,
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
 
     def chunk_fixed_size(
         self,
@@ -225,15 +319,126 @@ class KBLegacyStepCompatibilityFacade:
     ) -> Dict[str, Any]:
         from ..chunk.chunk_document import _chunk_fixed_size_impl
 
-        with self._storage_context():
-            return _chunk_fixed_size_impl(
+        with self._operation_context(
+            operation_type="legacy_chunk_fixed_size", collection=collection
+        ) as (operation, owns_operation):
+            with self._storage_context():
+                result = _chunk_fixed_size_impl(
+                    collection=collection,
+                    doc_id=doc_id,
+                    parse_hash=parse_hash,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                    **kwargs,
+                )
+            self._record_chunk_side_effect(
+                operation,
                 collection=collection,
                 doc_id=doc_id,
                 parse_hash=parse_hash,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-                **kwargs,
+                result=result,
             )
+            self._finish_owned_operation(operation, owns_operation, status="success")
+            return result
+
+    def _record_document_side_effect(
+        self,
+        operation: KBOperation | None,
+        *,
+        collection: str,
+        source_path: str,
+        file_id: Optional[str],
+        user_id: Optional[int],
+        result: Dict[str, Any],
+    ) -> None:
+        if operation is None:
+            return
+        doc_id = result.get("doc_id")
+        if not doc_id:
+            return
+        operation.record_side_effect(
+            name="remove_registered_document",
+            plane=SideEffectPlane.DOCUMENT,
+            payload={
+                "collection": collection,
+                "doc_id": doc_id,
+                "created": result.get("created"),
+                "source_path": source_path,
+                "file_id": file_id,
+            },
+            idempotency_key=f"document:{collection}:{doc_id}",
+        )
+        operation.record_side_effect(
+            name="clear_ingestion_status",
+            plane=SideEffectPlane.STATUS,
+            payload={"collection": collection, "doc_id": doc_id, "user_id": user_id},
+            idempotency_key=f"status:{collection}:{doc_id}",
+        )
+
+    def _record_parse_side_effect(
+        self,
+        operation: KBOperation | None,
+        *,
+        collection: str,
+        doc_id: str,
+        result: Dict[str, Any],
+    ) -> None:
+        if operation is None or result.get("written") is False:
+            return
+        parse_hash = result.get("parse_hash")
+        if not parse_hash:
+            return
+        operation.record_side_effect(
+            name="remove_parse_record",
+            plane=SideEffectPlane.PARSE,
+            payload={
+                "collection": collection,
+                "doc_id": doc_id,
+                "parse_hash": parse_hash,
+            },
+            idempotency_key=f"parse:{collection}:{doc_id}:{parse_hash}",
+        )
+
+    def _record_chunk_side_effect(
+        self,
+        operation: KBOperation | None,
+        *,
+        collection: str,
+        doc_id: str,
+        parse_hash: str,
+        result: Dict[str, Any],
+    ) -> None:
+        if operation is None or result.get("created") is False:
+            return
+        chunk_count = int(result.get("chunk_count", 0) or 0)
+        if chunk_count <= 0:
+            return
+        operation.record_side_effect(
+            name="remove_chunk_records",
+            plane=SideEffectPlane.CHUNK,
+            payload={
+                "collection": collection,
+                "doc_id": doc_id,
+                "parse_hash": parse_hash,
+                "chunk_count": chunk_count,
+            },
+            idempotency_key=f"chunk:{collection}:{doc_id}:{parse_hash}",
+        )
+
+    @staticmethod
+    def _finish_owned_operation(
+        operation: KBOperation | None,
+        owns_operation: bool,
+        *,
+        status: str,
+    ) -> None:
+        if operation is None or not owns_operation or operation.outcome is not None:
+            return
+        operation.finish(
+            status=status,
+            rollback_status=RollbackStatus.NOT_NEEDED,
+            side_effects_may_remain=False,
+        )
 
     def search_dense(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -198,7 +198,9 @@ class KBOperation:
 
         child_statuses = {child.status for child in self.child_outcomes}
         has_successful_child = "success" in child_statuses
-        has_failed_child = any(status != "success" for status in child_statuses)
+        has_failed_child = any(
+            child_status != "success" for child_status in child_statuses
+        )
         if (
             self.persistence_policy is PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
             and has_successful_child

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -1,0 +1,311 @@
+"""Coordinator-owned KB operation outcome compatibility facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Optional
+from uuid import uuid4
+
+
+class RollbackStatus(StrEnum):
+    """Explicit rollback state for a KB compatibility operation."""
+
+    NOT_NEEDED = "not_needed"
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    SKIPPED_BY_POLICY = "skipped_by_policy"
+
+
+class PersistencePolicy(StrEnum):
+    """Batch operation policy for successful child side effects."""
+
+    PRESERVE_SUCCESSFUL_CHILDREN = "preserve_successful_children"
+    ROLLBACK_ALL_CHILDREN = "rollback_all_children"
+
+
+class SideEffectPlane(StrEnum):
+    """Storage plane touched by a compensatable KB operation step."""
+
+    COLLECTION = "collection"
+    DOCUMENT = "document"
+    PARSE = "parse"
+    CHUNK = "chunk"
+    EMBEDDING = "embedding"
+    STATUS = "status"
+    FILE = "file"
+    WEB_PAGE = "web_page"
+
+
+@dataclass(frozen=True)
+class CompensationStep:
+    """Structured description of a side effect and its compensation boundary."""
+
+    name: str
+    plane: SideEffectPlane
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    idempotency_key: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class KBOperationOutcome:
+    """Internal outcome model for rollback-aware KB compatibility operations."""
+
+    operation_id: str
+    operation_type: str
+    collection: str
+    status: str
+    rollback_status: RollbackStatus
+    persistence_policy: PersistencePolicy
+    compensation_steps: tuple[CompensationStep, ...] = ()
+    child_outcomes: tuple["KBOperationOutcome", ...] = ()
+    warnings: tuple[str, ...] = ()
+    side_effects_may_remain: bool = False
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def compensation_plan(self) -> tuple[CompensationStep, ...]:
+        """Return compensation steps in LIFO execution order."""
+        return tuple(reversed(self.compensation_steps))
+
+
+class KBOperation:
+    """Mutable operation builder stored only in the current execution context."""
+
+    def __init__(
+        self,
+        *,
+        operation_type: str,
+        collection: str,
+        persistence_policy: PersistencePolicy,
+        operation_id: Optional[str] = None,
+        parent_operation_id: Optional[str] = None,
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.operation_id = operation_id or str(uuid4())
+        self.operation_type = operation_type
+        self.collection = collection
+        self.persistence_policy = persistence_policy
+        self.parent_operation_id = parent_operation_id
+        self.details: dict[str, Any] = dict(details or {})
+        self.compensation_steps: list[CompensationStep] = []
+        self.child_outcomes: list[KBOperationOutcome] = []
+        self.warnings: list[str] = []
+        self.side_effects_may_remain = False
+        self._idempotency_keys: set[str] = set()
+        self._outcome: KBOperationOutcome | None = None
+
+    @property
+    def outcome(self) -> KBOperationOutcome | None:
+        """Return the finalized outcome when available."""
+        return self._outcome
+
+    def has_side_effects(self) -> bool:
+        """Return whether this operation or any child recorded side effects."""
+        return bool(self.compensation_steps) or any(
+            child.side_effects_may_remain or child.compensation_steps
+            for child in self.child_outcomes
+        )
+
+    def update_details(self, **details: Any) -> None:
+        """Merge operation metadata captured during execution."""
+        self.details.update(details)
+
+    def record_side_effect(
+        self,
+        *,
+        name: str,
+        plane: SideEffectPlane,
+        payload: Optional[Mapping[str, Any]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> None:
+        """Register an idempotent compensation boundary for one side effect."""
+        step_payload = dict(payload or {})
+        dedupe_key = (
+            idempotency_key or f"{plane.value}:{name}:{step_payload!r}"
+        )
+        if dedupe_key in self._idempotency_keys:
+            return
+
+        self._idempotency_keys.add(dedupe_key)
+        self.compensation_steps.append(
+            CompensationStep(
+                name=name,
+                plane=plane,
+                payload=step_payload,
+                idempotency_key=dedupe_key,
+            )
+        )
+
+    def add_child_outcome(self, outcome: KBOperationOutcome) -> None:
+        """Attach a finalized child operation outcome."""
+        self.child_outcomes.append(outcome)
+
+    def finish(
+        self,
+        *,
+        status: str,
+        rollback_status: RollbackStatus | None = None,
+        side_effects_may_remain: Optional[bool] = None,
+        warnings: Optional[tuple[str, ...]] = None,
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> KBOperationOutcome:
+        """Finalize and return the immutable operation outcome."""
+        if details:
+            self.details.update(details)
+        if warnings:
+            self.warnings.extend(warnings)
+
+        if side_effects_may_remain is None:
+            side_effects_may_remain = self._infer_side_effects_may_remain(status)
+
+        if rollback_status is None:
+            rollback_status = self._infer_rollback_status(
+                status,
+                side_effects_may_remain=side_effects_may_remain,
+            )
+
+        self.side_effects_may_remain = side_effects_may_remain
+        self._outcome = KBOperationOutcome(
+            operation_id=self.operation_id,
+            operation_type=self.operation_type,
+            collection=self.collection,
+            status=status,
+            rollback_status=rollback_status,
+            persistence_policy=self.persistence_policy,
+            compensation_steps=tuple(self.compensation_steps),
+            child_outcomes=tuple(self.child_outcomes),
+            warnings=tuple(self.warnings),
+            side_effects_may_remain=side_effects_may_remain,
+            details=dict(self.details),
+        )
+        return self._outcome
+
+    def _infer_side_effects_may_remain(self, status: str) -> bool:
+        if status == "success":
+            return False
+        return self.has_side_effects()
+
+    def _infer_rollback_status(
+        self,
+        status: str,
+        *,
+        side_effects_may_remain: bool,
+    ) -> RollbackStatus:
+        if status == "success":
+            return RollbackStatus.NOT_NEEDED
+
+        child_statuses = {child.status for child in self.child_outcomes}
+        has_successful_child = "success" in child_statuses
+        has_failed_child = any(status != "success" for status in child_statuses)
+        if (
+            self.persistence_policy
+            is PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
+            and has_successful_child
+            and has_failed_child
+        ):
+            return RollbackStatus.SKIPPED_BY_POLICY
+
+        if side_effects_may_remain:
+            return RollbackStatus.INCOMPLETE
+        return RollbackStatus.NOT_NEEDED
+
+
+_CURRENT_OPERATION: ContextVar[KBOperation | None] = ContextVar(
+    "xagent_kb_current_operation",
+    default=None,
+)
+
+
+class KBOperationCompatibilityFacade:
+    """Compatibility facade for rollback-aware coordinator operations.
+
+    The model is intentionally internal: public pipeline/API schemas stay stable
+    while compatibility facades can record operation outcomes and child side
+    effects for future handle-level compensation.
+    """
+
+    def __init__(self) -> None:
+        self._last_outcome: KBOperationOutcome | None = None
+
+    @property
+    def last_outcome(self) -> KBOperationOutcome | None:
+        """Return the most recently finalized operation outcome."""
+        return self._last_outcome
+
+    def current_operation(self) -> KBOperation | None:
+        """Return the operation active in the current context, if any."""
+        return _CURRENT_OPERATION.get()
+
+    @contextmanager
+    def start_operation(
+        self,
+        *,
+        operation_type: str,
+        collection: str,
+        persistence_policy: PersistencePolicy = (
+            PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
+        ),
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[KBOperation]:
+        """Start a root or nested operation and attach nested outcomes to parents."""
+        parent_operation = _CURRENT_OPERATION.get()
+        operation = KBOperation(
+            operation_type=operation_type,
+            collection=collection,
+            persistence_policy=persistence_policy,
+            parent_operation_id=(
+                parent_operation.operation_id if parent_operation is not None else None
+            ),
+            details=details,
+        )
+        token = _CURRENT_OPERATION.set(operation)
+
+        try:
+            yield operation
+        except Exception as exc:
+            if operation.outcome is None:
+                operation.finish(
+                    status="error",
+                    rollback_status=(
+                        RollbackStatus.INCOMPLETE
+                        if operation.has_side_effects()
+                        else RollbackStatus.NOT_NEEDED
+                    ),
+                    side_effects_may_remain=operation.has_side_effects(),
+                    warnings=(str(exc),),
+                )
+            raise
+        finally:
+            if operation.outcome is None:
+                operation.finish(status="success")
+
+            _CURRENT_OPERATION.reset(token)
+            outcome = operation.outcome
+            if outcome is not None:
+                if parent_operation is not None:
+                    parent_operation.add_child_outcome(outcome)
+                self._last_outcome = outcome
+
+    @contextmanager
+    def start_child_operation(
+        self,
+        *,
+        operation_type: str,
+        collection: str,
+        persistence_policy: PersistencePolicy = (
+            PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
+        ),
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[KBOperation]:
+        """Start an operation intended to be attached to the current parent."""
+        with self.start_operation(
+            operation_type=operation_type,
+            collection=collection,
+            persistence_policy=persistence_policy,
+            details=details,
+        ) as operation:
+            yield operation

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -124,9 +124,7 @@ class KBOperation:
     ) -> None:
         """Register an idempotent compensation boundary for one side effect."""
         step_payload = dict(payload or {})
-        dedupe_key = (
-            idempotency_key or f"{plane.value}:{name}:{step_payload!r}"
-        )
+        dedupe_key = idempotency_key or f"{plane.value}:{name}:{step_payload!r}"
         if dedupe_key in self._idempotency_keys:
             return
 
@@ -202,8 +200,7 @@ class KBOperation:
         has_successful_child = "success" in child_statuses
         has_failed_child = any(status != "success" for status in child_statuses)
         if (
-            self.persistence_policy
-            is PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
+            self.persistence_policy is PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
             and has_successful_child
             and has_failed_child
         ):

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -218,6 +218,11 @@ _CURRENT_OPERATION: ContextVar[KBOperation | None] = ContextVar(
     default=None,
 )
 
+_LAST_OUTCOME: ContextVar[KBOperationOutcome | None] = ContextVar(
+    "xagent_kb_last_outcome",
+    default=None,
+)
+
 
 class KBOperationCompatibilityFacade:
     """Compatibility facade for rollback-aware coordinator operations.
@@ -227,13 +232,10 @@ class KBOperationCompatibilityFacade:
     effects for future handle-level compensation.
     """
 
-    def __init__(self) -> None:
-        self._last_outcome: KBOperationOutcome | None = None
-
     @property
     def last_outcome(self) -> KBOperationOutcome | None:
         """Return the most recently finalized operation outcome."""
-        return self._last_outcome
+        return _LAST_OUTCOME.get()
 
     def current_operation(self) -> KBOperation | None:
         """Return the operation active in the current context, if any."""
@@ -287,7 +289,7 @@ class KBOperationCompatibilityFacade:
             if outcome is not None:
                 if parent_operation is not None:
                     parent_operation.add_child_outcome(outcome)
-                self._last_outcome = outcome
+                _LAST_OUTCOME.set(outcome)
 
     @contextmanager
     def start_child_operation(

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -263,7 +263,7 @@ class KBOperationCompatibilityFacade:
 
         try:
             yield operation
-        except Exception as exc:
+        except BaseException as exc:  # noqa: BLE001 - record outcome before propagating
             if operation.outcome is None:
                 operation.finish(
                     status="error",

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -224,6 +224,13 @@ _LAST_OUTCOME: ContextVar[KBOperationOutcome | None] = ContextVar(
 )
 
 
+def _format_exception_warning(exc: BaseException) -> str:
+    message = str(exc)
+    if message:
+        return f"{type(exc).__name__}: {message}"
+    return type(exc).__name__
+
+
 class KBOperationCompatibilityFacade:
     """Compatibility facade for rollback-aware coordinator operations.
 
@@ -277,7 +284,7 @@ class KBOperationCompatibilityFacade:
                         else RollbackStatus.NOT_NEEDED
                     ),
                     side_effects_may_remain=operation.has_side_effects(),
-                    warnings=(str(exc),),
+                    warnings=(_format_exception_warning(exc),),
                 )
             raise
         finally:

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -594,5 +594,5 @@ class KBPipelineCompatibilityFacade:
     ) -> dict[str, Any] | None:
         for step in completed_steps:
             if step.name == name:
-                return dict(step.metadata)
+                return dict(step.metadata or {})
         return None

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -1,0 +1,222 @@
+"""Pipeline compatibility facade."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
+
+from ..core.schemas import (
+    IngestionConfig,
+    IngestionResult,
+    SearchConfig,
+    SearchPipelineResult,
+    WebCrawlConfig,
+    WebIngestionResult,
+)
+from .models import KBStorageBackend
+
+if TYPE_CHECKING:
+    from ..core.schemas import CollectionInfo
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+KB_STORAGE_METADATA_KEY = "kb_storage"
+
+
+class KBPipelineCompatibilityFacade:
+    """Compatibility boundary for high-level KB pipeline entry points.
+
+    Pipeline modules keep their historical import paths and response contracts.
+    The facade centralizes coordinator-owned storage binding and collection
+    backend binding while delegating parser, chunker, embedding, crawler,
+    progress, and rerank behavior to the existing pipeline implementations.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    def ensure_collection_backend_binding(
+        self, collection: str
+    ) -> CollectionInfo | None:
+        """Ensure direct pipeline-created collections carry a backend binding."""
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            return None
+
+        from .coordinator import _run_in_separate_loop
+
+        metadata_store = storage_shim.get_metadata_store()
+        try:
+            collection_info = _run_in_separate_loop(
+                metadata_store.get_collection(collection)
+            )
+        except ValueError:
+            return None
+
+        extra_metadata = dict(collection_info.extra_metadata or {})
+        if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
+            return collection_info
+
+        extra_metadata[KB_STORAGE_METADATA_KEY] = {
+            "backend": KBStorageBackend.LANCEDB.value
+        }
+        updated_collection = collection_info.model_copy(
+            update={"extra_metadata": extra_metadata}
+        )
+        _run_in_separate_loop(metadata_store.save_collection(updated_collection))
+        return updated_collection
+
+    def process_document(
+        self,
+        collection: str,
+        source_path: str,
+        *,
+        config: Optional[IngestionConfig] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        file_id: Optional[str] = None,
+        metadata_source_path: Optional[str] = None,
+        commit_gate: Optional[Callable[[], None]] = None,
+    ) -> IngestionResult:
+        from ..pipelines.document_ingestion import _process_document_impl
+
+        with self._storage_context():
+            result = _process_document_impl(
+                collection=collection,
+                source_path=source_path,
+                config=config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_id=file_id,
+                metadata_source_path=metadata_source_path,
+                commit_gate=commit_gate,
+            )
+            self.ensure_collection_backend_binding(collection)
+            return result
+
+    def run_document_ingestion(
+        self,
+        collection: str,
+        source_path: str,
+        *,
+        ingestion_config: Optional[Any] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        file_id: Optional[str] = None,
+        metadata_source_path: Optional[str] = None,
+        commit_gate: Optional[Callable[[], None]] = None,
+    ) -> IngestionResult:
+        from ..pipelines.document_ingestion import _run_document_ingestion_impl
+
+        with self._storage_context():
+            result = _run_document_ingestion_impl(
+                collection=collection,
+                source_path=source_path,
+                ingestion_config=ingestion_config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_id=file_id,
+                metadata_source_path=metadata_source_path,
+                commit_gate=commit_gate,
+            )
+            self.ensure_collection_backend_binding(collection)
+            return result
+
+    def search_documents(
+        self,
+        collection: str,
+        query_text: str,
+        *,
+        config: Optional[SearchConfig] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+    ) -> SearchPipelineResult:
+        from ..pipelines.document_search import _search_documents_impl
+
+        with self._storage_context():
+            return _search_documents_impl(
+                collection=collection,
+                query_text=query_text,
+                config=config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def run_document_search(
+        self,
+        collection: str,
+        query_text: str,
+        *,
+        config: Optional[SearchConfig | Mapping[str, Any]] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+    ) -> SearchPipelineResult:
+        from ..pipelines.document_search import _run_document_search_impl
+
+        with self._storage_context():
+            return _run_document_search_impl(
+                collection=collection,
+                query_text=query_text,
+                config=config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def run_web_ingestion(
+        self,
+        collection: str,
+        crawl_config: WebCrawlConfig,
+        *,
+        ingestion_config: Optional[IngestionConfig] = None,
+        progress_callback: Optional[Callable[[str, int, int], None]] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        file_handler: Optional[Callable[..., Any]] = None,
+    ) -> WebIngestionResult:
+        from ..pipelines.web_ingestion import _run_web_ingestion_impl
+
+        with self._storage_context():
+            result = await _run_web_ingestion_impl(
+                collection=collection,
+                crawl_config=crawl_config,
+                ingestion_config=ingestion_config,
+                progress_callback=progress_callback,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_handler=file_handler,
+            )
+            self.ensure_collection_backend_binding(collection)
+            return result

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -119,7 +119,7 @@ class KBPipelineCompatibilityFacade:
         ) as operation:
             yield operation
 
-    def ensure_collection_backend_binding(
+    async def ensure_collection_backend_binding_async(
         self, collection: str
     ) -> CollectionInfo | None:
         """Ensure direct pipeline-created collections carry a backend binding."""
@@ -127,13 +127,9 @@ class KBPipelineCompatibilityFacade:
         if storage_shim is None:
             return None
 
-        from .coordinator import _run_in_separate_loop
-
         metadata_store = storage_shim.get_metadata_store()
         try:
-            collection_info = _run_in_separate_loop(
-                metadata_store.get_collection(collection)
-            )
+            collection_info = await metadata_store.get_collection(collection)
         except ValueError:
             return None
 
@@ -147,8 +143,18 @@ class KBPipelineCompatibilityFacade:
         updated_collection = collection_info.model_copy(
             update={"extra_metadata": extra_metadata}
         )
-        _run_in_separate_loop(metadata_store.save_collection(updated_collection))
+        await metadata_store.save_collection(updated_collection)
         return updated_collection
+
+    def ensure_collection_backend_binding(
+        self, collection: str
+    ) -> CollectionInfo | None:
+        """Ensure direct pipeline-created collections carry a backend binding."""
+        from .coordinator import _run_in_separate_loop
+
+        return _run_in_separate_loop(
+            self.ensure_collection_backend_binding_async(collection)
+        )
 
     def process_document(
         self,
@@ -317,8 +323,8 @@ class KBPipelineCompatibilityFacade:
                     file_handler=file_handler,
                     pipeline_facade=self,
                 )
+                await self.ensure_collection_backend_binding_async(collection)
                 self._record_web_ingestion_outcome(operation, result)
-                self.ensure_collection_backend_binding(collection)
                 return result
 
     @contextmanager

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -182,7 +182,7 @@ class KBPipelineCompatibilityFacade:
                     metadata_source_path=metadata_source_path,
                     commit_gate=commit_gate,
                 )
-                self._record_document_ingestion_outcome(
+                self._record_document_ingestion_side_effects(
                     operation,
                     result,
                     collection=collection,
@@ -192,6 +192,7 @@ class KBPipelineCompatibilityFacade:
                     is_admin=is_admin,
                 )
                 self.ensure_collection_backend_binding(collection)
+                self._finish_document_ingestion_outcome(operation, result)
                 return result
 
     def run_document_ingestion(
@@ -227,7 +228,7 @@ class KBPipelineCompatibilityFacade:
                     commit_gate=commit_gate,
                 )
                 if operation is not None and operation.outcome is None:
-                    self._record_document_ingestion_outcome(
+                    self._record_document_ingestion_side_effects(
                         operation,
                         result,
                         collection=collection,
@@ -236,7 +237,10 @@ class KBPipelineCompatibilityFacade:
                         user_id=user_id,
                         is_admin=is_admin,
                     )
-                self.ensure_collection_backend_binding(collection)
+                    self.ensure_collection_backend_binding(collection)
+                    self._finish_document_ingestion_outcome(operation, result)
+                elif operation is None:
+                    self.ensure_collection_backend_binding(collection)
                 return result
 
     def search_documents(
@@ -311,12 +315,94 @@ class KBPipelineCompatibilityFacade:
                     user_id=user_id,
                     is_admin=is_admin,
                     file_handler=file_handler,
+                    pipeline_facade=self,
                 )
                 self._record_web_ingestion_outcome(operation, result)
                 self.ensure_collection_backend_binding(collection)
                 return result
 
-    def _record_document_ingestion_outcome(
+    @contextmanager
+    def web_page_operation(
+        self,
+        *,
+        collection: str,
+        url: str,
+        title: Optional[str] = None,
+    ) -> Iterator[KBOperation | None]:
+        operation_facade = self._active_operation_facade()
+        if operation_facade is None:
+            yield None
+            return
+
+        current_operation = operation_facade.current_operation()
+        if current_operation is None:
+            yield None
+            return
+
+        if current_operation.operation_type == "web_ingestion":
+            with operation_facade.start_child_operation(
+                operation_type="web_page_ingestion",
+                collection=collection,
+                persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+                details={"url": url, "title": title},
+            ) as child_operation:
+                yield child_operation
+            return
+
+        yield current_operation
+
+    def record_web_page_file_side_effect(
+        self,
+        operation: KBOperation | None,
+        *,
+        collection: str,
+        url: str,
+        file_path: Optional[str],
+        file_id: Optional[str],
+        reason: str = "file_handler",
+    ) -> None:
+        if operation is None:
+            return
+        operation.record_side_effect(
+            name="cleanup_web_page_persistence",
+            plane=SideEffectPlane.FILE,
+            payload={
+                "collection": collection,
+                "url": url,
+                "file_path": file_path,
+                "file_id": file_id,
+                "reason": reason,
+            },
+            idempotency_key=f"file:{collection}:{file_id or file_path or url}",
+        )
+
+    @staticmethod
+    def finish_web_page_operation(
+        operation: KBOperation | None,
+        *,
+        status: str,
+        message: str,
+        side_effects_may_remain: Optional[bool] = None,
+    ) -> None:
+        if operation is None or operation.outcome is not None:
+            return
+        if side_effects_may_remain is None:
+            side_effects_may_remain = (
+                status != "success" and operation.has_side_effects()
+            )
+        rollback_status = (
+            RollbackStatus.NOT_NEEDED
+            if status == "success" or not side_effects_may_remain
+            else RollbackStatus.INCOMPLETE
+        )
+        operation.finish(
+            status=status,
+            rollback_status=rollback_status,
+            side_effects_may_remain=side_effects_may_remain,
+            details={"message": message},
+        )
+
+    def _record_document_ingestion_side_effects(
         self,
         operation: KBOperation | None,
         result: IngestionResult,
@@ -426,6 +512,13 @@ class KBPipelineCompatibilityFacade:
                 idempotency_key=f"embedding:{collection}:{result.doc_id}:{result.parse_hash}",
             )
 
+    @staticmethod
+    def _finish_document_ingestion_outcome(
+        operation: KBOperation | None,
+        result: IngestionResult,
+    ) -> None:
+        if operation is None or operation.outcome is not None:
+            return
         side_effects_may_remain = (
             result.status != "success" and operation.has_side_effects()
         )

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, cast
 
 from ..core.schemas import (
     IngestionConfig,
@@ -224,7 +224,7 @@ class KBPipelineCompatibilityFacade:
             details={"source_path": source_path, "file_id": file_id},
         ) as operation:
             with self._storage_context():
-                result = _run_document_ingestion_impl(
+                result: object = _run_document_ingestion_impl(
                     collection=collection,
                     source_path=source_path,
                     ingestion_config=ingestion_config,
@@ -235,6 +235,11 @@ class KBPipelineCompatibilityFacade:
                     metadata_source_path=metadata_source_path,
                     commit_gate=commit_gate,
                 )
+                # Phase-1 compatibility: _run_document_ingestion_impl() still calls
+                # the public process_document symbol, which legacy tests/callers may
+                # monkeypatch. Only structured results carry rollback metadata.
+                if not isinstance(result, IngestionResult):
+                    return cast(IngestionResult, result)
                 if operation is not None and operation.outcome is None:
                     self._record_document_ingestion_side_effects(
                         operation,

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -150,6 +150,8 @@ class KBPipelineCompatibilityFacade:
         self, collection: str
     ) -> CollectionInfo | None:
         """Ensure direct pipeline-created collections carry a backend binding."""
+        # Compatibility wrapper for sync document ingestion paths. Async
+        # callers should await ensure_collection_backend_binding_async().
         from .coordinator import _run_in_separate_loop
 
         return _run_in_separate_loop(

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -9,12 +9,20 @@ from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 from ..core.schemas import (
     IngestionConfig,
     IngestionResult,
+    IngestionStepResult,
     SearchConfig,
     SearchPipelineResult,
     WebCrawlConfig,
     WebIngestionResult,
 )
 from .models import KBStorageBackend
+from .operation_compatibility import (
+    KBOperation,
+    KBOperationCompatibilityFacade,
+    PersistencePolicy,
+    RollbackStatus,
+    SideEffectPlane,
+)
 
 if TYPE_CHECKING:
     from ..core.schemas import CollectionInfo
@@ -37,15 +45,24 @@ class KBPipelineCompatibilityFacade:
         self,
         coordinator: KBCoordinator | None = None,
         storage_shim: KBStorageShimCompatibilityFacade | None = None,
+        operation_compatibility: KBOperationCompatibilityFacade | None = None,
     ) -> None:
         self._coordinator = coordinator
         self._storage_shim = storage_shim
+        self._operation_compatibility = operation_compatibility
 
     def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
         if self._storage_shim is not None:
             return self._storage_shim
         if self._coordinator is not None:
             return self._coordinator.storage_shim
+        return None
+
+    def _active_operation_facade(self) -> KBOperationCompatibilityFacade | None:
+        if self._operation_compatibility is not None:
+            return self._operation_compatibility
+        if self._coordinator is not None:
+            return self._coordinator.operation_compatibility
         return None
 
     @contextmanager
@@ -59,6 +76,48 @@ class KBPipelineCompatibilityFacade:
 
         with bind_storage_shim_for_current_context(storage_shim):
             yield
+
+    @contextmanager
+    def _operation_context(
+        self,
+        *,
+        operation_type: str,
+        collection: str,
+        persistence_policy: PersistencePolicy = (
+            PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN
+        ),
+        details: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[KBOperation | None]:
+        operation_facade = self._active_operation_facade()
+        if operation_facade is None:
+            yield None
+            return
+
+        current_operation = operation_facade.current_operation()
+        if current_operation is not None:
+            if (
+                current_operation.operation_type == "web_ingestion"
+                and operation_type == "document_ingestion"
+            ):
+                with operation_facade.start_child_operation(
+                    operation_type="web_page_ingestion",
+                    collection=collection,
+                    persistence_policy=persistence_policy,
+                    details=details,
+                ) as child_operation:
+                    yield child_operation
+                return
+
+            yield current_operation
+            return
+
+        with operation_facade.start_operation(
+            operation_type=operation_type,
+            collection=collection,
+            persistence_policy=persistence_policy,
+            details=details,
+        ) as operation:
+            yield operation
 
     def ensure_collection_backend_binding(
         self, collection: str
@@ -106,20 +165,34 @@ class KBPipelineCompatibilityFacade:
     ) -> IngestionResult:
         from ..pipelines.document_ingestion import _process_document_impl
 
-        with self._storage_context():
-            result = _process_document_impl(
-                collection=collection,
-                source_path=source_path,
-                config=config,
-                progress_manager=progress_manager,
-                user_id=user_id,
-                is_admin=is_admin,
-                file_id=file_id,
-                metadata_source_path=metadata_source_path,
-                commit_gate=commit_gate,
-            )
-            self.ensure_collection_backend_binding(collection)
-            return result
+        with self._operation_context(
+            operation_type="document_ingestion",
+            collection=collection,
+            details={"source_path": source_path, "file_id": file_id},
+        ) as operation:
+            with self._storage_context():
+                result = _process_document_impl(
+                    collection=collection,
+                    source_path=source_path,
+                    config=config,
+                    progress_manager=progress_manager,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    file_id=file_id,
+                    metadata_source_path=metadata_source_path,
+                    commit_gate=commit_gate,
+                )
+                self._record_document_ingestion_outcome(
+                    operation,
+                    result,
+                    collection=collection,
+                    source_path=source_path,
+                    file_id=file_id,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                self.ensure_collection_backend_binding(collection)
+                return result
 
     def run_document_ingestion(
         self,
@@ -136,20 +209,35 @@ class KBPipelineCompatibilityFacade:
     ) -> IngestionResult:
         from ..pipelines.document_ingestion import _run_document_ingestion_impl
 
-        with self._storage_context():
-            result = _run_document_ingestion_impl(
-                collection=collection,
-                source_path=source_path,
-                ingestion_config=ingestion_config,
-                progress_manager=progress_manager,
-                user_id=user_id,
-                is_admin=is_admin,
-                file_id=file_id,
-                metadata_source_path=metadata_source_path,
-                commit_gate=commit_gate,
-            )
-            self.ensure_collection_backend_binding(collection)
-            return result
+        with self._operation_context(
+            operation_type="document_ingestion",
+            collection=collection,
+            details={"source_path": source_path, "file_id": file_id},
+        ) as operation:
+            with self._storage_context():
+                result = _run_document_ingestion_impl(
+                    collection=collection,
+                    source_path=source_path,
+                    ingestion_config=ingestion_config,
+                    progress_manager=progress_manager,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    file_id=file_id,
+                    metadata_source_path=metadata_source_path,
+                    commit_gate=commit_gate,
+                )
+                if operation is not None and operation.outcome is None:
+                    self._record_document_ingestion_outcome(
+                        operation,
+                        result,
+                        collection=collection,
+                        source_path=source_path,
+                        file_id=file_id,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    )
+                self.ensure_collection_backend_binding(collection)
+                return result
 
     def search_documents(
         self,
@@ -208,15 +296,204 @@ class KBPipelineCompatibilityFacade:
     ) -> WebIngestionResult:
         from ..pipelines.web_ingestion import _run_web_ingestion_impl
 
-        with self._storage_context():
-            result = await _run_web_ingestion_impl(
-                collection=collection,
-                crawl_config=crawl_config,
-                ingestion_config=ingestion_config,
-                progress_callback=progress_callback,
-                user_id=user_id,
-                is_admin=is_admin,
-                file_handler=file_handler,
+        with self._operation_context(
+            operation_type="web_ingestion",
+            collection=collection,
+            persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+            details={"start_url": crawl_config.start_url},
+        ) as operation:
+            with self._storage_context():
+                result = await _run_web_ingestion_impl(
+                    collection=collection,
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    progress_callback=progress_callback,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    file_handler=file_handler,
+                )
+                self._record_web_ingestion_outcome(operation, result)
+                self.ensure_collection_backend_binding(collection)
+                return result
+
+    def _record_document_ingestion_outcome(
+        self,
+        operation: KBOperation | None,
+        result: IngestionResult,
+        *,
+        collection: str,
+        source_path: str,
+        file_id: Optional[str],
+        user_id: Optional[int],
+        is_admin: Optional[bool],
+    ) -> None:
+        if operation is None or operation.outcome is not None:
+            return
+
+        operation.update_details(
+            source_path=source_path,
+            file_id=file_id,
+            doc_id=result.doc_id,
+            parse_hash=result.parse_hash,
+            failed_step=result.failed_step,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        initialize_step = self._step_metadata(
+            result.completed_steps, "initialize_collection"
+        )
+        if initialize_step is not None:
+            operation.record_side_effect(
+                name="restore_collection_initialization",
+                plane=SideEffectPlane.COLLECTION,
+                payload={
+                    "collection": collection,
+                    "embedding_model_id": initialize_step.get("embedding_model_id"),
+                },
+                idempotency_key=f"collection:{collection}:initialize",
             )
-            self.ensure_collection_backend_binding(collection)
-            return result
+
+        register_step = self._step_metadata(result.completed_steps, "register_document")
+        if result.doc_id and register_step is not None:
+            operation.record_side_effect(
+                name="remove_registered_document",
+                plane=SideEffectPlane.DOCUMENT,
+                payload={
+                    "collection": collection,
+                    "doc_id": result.doc_id,
+                    "created": register_step.get("created"),
+                    "source_path": source_path,
+                    "file_id": file_id,
+                },
+                idempotency_key=f"document:{collection}:{result.doc_id}",
+            )
+            operation.record_side_effect(
+                name="clear_ingestion_status",
+                plane=SideEffectPlane.STATUS,
+                payload={
+                    "collection": collection,
+                    "doc_id": result.doc_id,
+                    "user_id": user_id,
+                },
+                idempotency_key=f"status:{collection}:{result.doc_id}",
+            )
+
+        parse_step = self._step_metadata(result.completed_steps, "parse_document")
+        if result.doc_id and result.parse_hash and parse_step is not None:
+            if parse_step.get("written") is not False:
+                operation.record_side_effect(
+                    name="remove_parse_record",
+                    plane=SideEffectPlane.PARSE,
+                    payload={
+                        "collection": collection,
+                        "doc_id": result.doc_id,
+                        "parse_hash": result.parse_hash,
+                    },
+                    idempotency_key=(
+                        f"parse:{collection}:{result.doc_id}:{result.parse_hash}"
+                    ),
+                )
+
+        chunk_step = self._step_metadata(result.completed_steps, "chunk_document")
+        if result.doc_id and result.parse_hash and chunk_step is not None:
+            if result.chunk_count > 0 and chunk_step.get("created") is not False:
+                operation.record_side_effect(
+                    name="remove_chunk_records",
+                    plane=SideEffectPlane.CHUNK,
+                    payload={
+                        "collection": collection,
+                        "doc_id": result.doc_id,
+                        "parse_hash": result.parse_hash,
+                        "chunk_count": result.chunk_count,
+                    },
+                    idempotency_key=(
+                        f"chunk:{collection}:{result.doc_id}:{result.parse_hash}"
+                    ),
+                )
+
+        write_step = self._step_metadata(result.completed_steps, "write_vectors_to_db")
+        if result.doc_id and result.vector_count > 0 and write_step is not None:
+            operation.record_side_effect(
+                name="remove_embedding_vectors",
+                plane=SideEffectPlane.EMBEDDING,
+                payload={
+                    "collection": collection,
+                    "doc_id": result.doc_id,
+                    "parse_hash": result.parse_hash,
+                    "vector_count": result.vector_count,
+                },
+                idempotency_key=f"embedding:{collection}:{result.doc_id}:{result.parse_hash}",
+            )
+
+        side_effects_may_remain = (
+            result.status != "success" and operation.has_side_effects()
+        )
+        rollback_status = (
+            RollbackStatus.NOT_NEEDED
+            if result.status == "success" or not side_effects_may_remain
+            else RollbackStatus.INCOMPLETE
+        )
+        operation.finish(
+            status=result.status,
+            rollback_status=rollback_status,
+            side_effects_may_remain=side_effects_may_remain,
+            details={"message": result.message},
+        )
+
+    def _record_web_ingestion_outcome(
+        self,
+        operation: KBOperation | None,
+        result: WebIngestionResult,
+    ) -> None:
+        if operation is None or operation.outcome is not None:
+            return
+
+        child_side_effects_may_remain = any(
+            child.side_effects_may_remain for child in operation.child_outcomes
+        )
+        successful_child_count = sum(
+            1 for child in operation.child_outcomes if child.status == "success"
+        )
+        failed_child_count = sum(
+            1 for child in operation.child_outcomes if child.status != "success"
+        )
+
+        if result.status == "success":
+            rollback_status = RollbackStatus.NOT_NEEDED
+            side_effects_may_remain = False
+        elif successful_child_count > 0 and failed_child_count > 0:
+            rollback_status = RollbackStatus.SKIPPED_BY_POLICY
+            side_effects_may_remain = child_side_effects_may_remain
+        else:
+            side_effects_may_remain = (
+                child_side_effects_may_remain or operation.has_side_effects()
+            )
+            rollback_status = (
+                RollbackStatus.INCOMPLETE
+                if side_effects_may_remain
+                else RollbackStatus.NOT_NEEDED
+            )
+
+        operation.finish(
+            status=result.status,
+            rollback_status=rollback_status,
+            side_effects_may_remain=side_effects_may_remain,
+            details={
+                "documents_created": result.documents_created,
+                "pages_crawled": result.pages_crawled,
+                "pages_failed": result.pages_failed,
+                "failed_urls": dict(result.failed_urls),
+                "message": result.message,
+            },
+        )
+
+    @staticmethod
+    def _step_metadata(
+        completed_steps: list[IngestionStepResult],
+        name: str,
+    ) -> dict[str, Any] | None:
+        for step in completed_steps:
+            if step.name == name:
+                return dict(step.metadata)
+        return None

--- a/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/parse/parse_document.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pandas as pd
 
@@ -33,10 +33,41 @@ from ..core.schemas import (
 from ..storage.factory import get_vector_index_store
 from ..utils.hash_utils import compute_parse_hash, get_parse_params_whitelist
 
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
 logger = logging.getLogger(__name__)
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def parse_document(
+    collection: str,
+    doc_id: str,
+    parse_method: ParseMethod,
+    params: Optional[Dict[str, Any]] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+    progress_callback: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Parse a document using the specified method."""
+    return _get_legacy_step_compatibility_facade().parse_document(
+        collection=collection,
+        doc_id=doc_id,
+        parse_method=parse_method,
+        params=params,
+        user_id=user_id,
+        is_admin=is_admin,
+        progress_callback=progress_callback,
+    )
+
+
+def _parse_document_impl(
     collection: str,
     doc_id: str,
     parse_method: ParseMethod,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_ingestion.py
@@ -8,7 +8,7 @@ import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from xagent.core.model.embedding.base import BaseEmbedding
 from xagent.core.model.model import EmbeddingModelConfig
@@ -60,6 +60,9 @@ from ..vector_storage.vector_manager import (
     read_chunks_for_embedding,
     write_vectors_to_db,
 )
+
+if TYPE_CHECKING:
+    from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +186,40 @@ def _log_pending_chunks_text_stats(label: str, chunks: List[ChunkForEmbedding]) 
     )
 
 
+def _get_pipeline_compatibility_facade() -> "KBPipelineCompatibilityFacade":
+    """Return the coordinator-owned pipeline compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().pipeline_compatibility
+
+
 def run_document_ingestion(
+    collection: str,
+    source_path: str,
+    *,
+    ingestion_config: Optional[IngestionConfigInput] = None,
+    progress_manager: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_id: Optional[str] = None,
+    metadata_source_path: Optional[str] = None,
+    commit_gate: Optional[Callable[[], None]] = None,
+) -> IngestionResult:
+    """Public entrypoint for LangGraph-compatible ingestion tooling."""
+    return _get_pipeline_compatibility_facade().run_document_ingestion(
+        collection=collection,
+        source_path=source_path,
+        ingestion_config=ingestion_config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_id=file_id,
+        metadata_source_path=metadata_source_path,
+        commit_gate=commit_gate,
+    )
+
+
+def _run_document_ingestion_impl(
     collection: str,
     source_path: str,
     *,
@@ -486,6 +522,32 @@ def _handle_ingestion_error(
 
 
 def process_document(
+    collection: str,
+    source_path: str,
+    *,
+    config: Optional[IngestionConfig] = None,
+    progress_manager: Optional[ProgressManager] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+    file_id: Optional[str] = None,
+    metadata_source_path: Optional[str] = None,
+    commit_gate: Optional[Callable[[], None]] = None,
+) -> IngestionResult:
+    """Execute the full ingestion pipeline for a document."""
+    return _get_pipeline_compatibility_facade().process_document(
+        collection=collection,
+        source_path=source_path,
+        config=config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_id=file_id,
+        metadata_source_path=metadata_source_path,
+        commit_gate=commit_gate,
+    )
+
+
+def _process_document_impl(
     collection: str,
     source_path: str,
     *,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 import logging
 import numbers
 import os
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import requests
 
@@ -33,6 +44,9 @@ from ..retrieval.search_sparse import search_sparse
 from ..utils.config_utils import coerce_search_config
 from ..utils.model_resolver import resolve_embedding_adapter, resolve_rerank_adapter
 from ..utils.user_scope import resolve_user_scope
+
+if TYPE_CHECKING:
+    from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
 
@@ -454,6 +468,13 @@ def _execute_sparse_search(
 SearchConfigInput = Union[SearchConfig, Mapping[str, Any]]
 
 
+def _get_pipeline_compatibility_facade() -> "KBPipelineCompatibilityFacade":
+    """Return the coordinator-owned pipeline compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().pipeline_compatibility
+
+
 def _handle_search_error(
     exc: Exception,
     current_step: str,
@@ -476,6 +497,26 @@ def _handle_search_error(
 
 
 def search_documents(
+    collection: str,
+    query_text: str,
+    *,
+    config: Optional[SearchConfig] = None,
+    progress_manager: Optional[ProgressManager] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+) -> SearchPipelineResult:
+    """Execute the document search pipeline end-to-end."""
+    return _get_pipeline_compatibility_facade().search_documents(
+        collection=collection,
+        query_text=query_text,
+        config=config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _search_documents_impl(
     collection: str,
     query_text: str,
     *,
@@ -720,6 +761,26 @@ def search_documents(
 
 
 def run_document_search(
+    collection: str,
+    query_text: str,
+    *,
+    config: Optional[SearchConfigInput] = None,
+    progress_manager: Optional[ProgressManager] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+) -> SearchPipelineResult:
+    """Public entrypoint for LangGraph-compatible tooling."""
+    return _get_pipeline_compatibility_facade().run_document_search(
+        collection=collection,
+        query_text=query_text,
+        config=config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _run_document_search_impl(
     collection: str,
     query_text: str,
     *,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -108,6 +108,7 @@ async def _run_web_ingestion_impl(
     user_id: Optional[int] = None,
     is_admin: Optional[bool] = None,
     file_handler: Optional[Callable[[Path, str, str, str], FileHandlerResult]] = None,
+    pipeline_facade: Optional["KBPipelineCompatibilityFacade"] = None,
 ) -> WebIngestionResult:
     """Crawl a website and ingest all pages into the knowledge base.
 
@@ -147,6 +148,7 @@ async def _run_web_ingestion_impl(
 
     # Normalize ingestion config
     ing_cfg = coerce_ingestion_config(ingestion_config)
+    pipeline_facade = pipeline_facade or _get_pipeline_compatibility_facade()
 
     logger.info(
         "Starting web ingestion: collection=%s, start_url=%s",
@@ -204,149 +206,205 @@ async def _run_web_ingestion_impl(
         total_chunks = 0
         total_embeddings = 0
 
-        # Copy context once before the loop to avoid repeated ContextVar copying.
-        # The request-scoped user context remains constant throughout the request.
-        # NOTE: This copies ALL ContextVars (tracing IDs, request IDs, etc.).
         loop = asyncio.get_event_loop()
-        request_context = copy_context()
 
         for i, crawl_result in enumerate(crawl_results):
             if crawl_result.status != "success":
                 continue
 
-            # Progress callback
-            if progress_callback:
-                progress_callback(
-                    f"Ingesting page {i + 1}/{len(crawl_results)}: {crawl_result.url}",
-                    i + 1,
-                    len(crawl_results),
-                )
-
-            try:
-                # Save crawled content to temporary markdown file
-                filename = sanitize_for_doc_id(crawl_result.title or f"page_{i + 1}")
-                temp_file = Path(temp_dir) / f"{filename}.md"
-
-                with open(temp_file, "w", encoding="utf-8") as f:
-                    # Add metadata header
-                    f.write(f"# {crawl_result.title or 'Untitled'}\n\n")
-                    f.write(f"**Source:** {crawl_result.url}\n\n")
-                    f.write(f"**Crawled:** {crawl_result.timestamp.isoformat()}\n\n")
-                    f.write("---\n\n")
-                    f.write(crawl_result.content_markdown)
-
-                logger.debug("Saved %s to %s", crawl_result.url, temp_file)
-
-                # Call file_handler if provided (for persistent storage and UploadedFile record)
-                final_file_path = temp_file
-                final_file_id = None
-                copied_persistent_file = None
-
-                if file_handler:
-                    try:
-                        file_info = file_handler(
-                            temp_file,
-                            crawl_result.title or f"page_{i + 1}",
-                            collection,
-                            crawl_result.url,
-                        )
-                        final_file_path = Path(file_info.get("file_path", temp_file))
-                        final_file_id = file_info.get("file_id")
-
-                        # Track if we successfully copied a persistent file for cleanup
-                        if final_file_path != temp_file and final_file_path.exists():
-                            copied_persistent_file = final_file_path
-
-                        logger.debug(
-                            "File handler returned: path=%s, file_id=%s",
-                            final_file_path,
-                            final_file_id,
-                        )
-                    except Exception as e:
-                        logger.exception("File handler failed for %s", crawl_result.url)
-                        failure_message = (
-                            f"File persistence failed for {crawl_result.url}: {e}"
-                        )
-                        failed_urls[crawl_result.url] = failure_message
-                        warnings.append(failure_message)
-                        continue
+            page_title = crawl_result.title or f"page_{i + 1}"
+            with pipeline_facade.web_page_operation(
+                collection=collection,
+                url=crawl_result.url,
+                title=page_title,
+            ) as page_operation:
+                # Progress callback
+                if progress_callback:
+                    progress_callback(
+                        f"Ingesting page {i + 1}/{len(crawl_results)}: {crawl_result.url}",
+                        i + 1,
+                        len(crawl_results),
+                    )
 
                 try:
-                    # Ingest the file
-                    progress_manager = get_progress_manager()
+                    # Save crawled content to temporary markdown file
+                    filename = sanitize_for_doc_id(page_title)
+                    temp_file = Path(temp_dir) / f"{filename}.md"
 
-                    def _ingest_file() -> IngestionResult:
-                        return run_document_ingestion(
-                            collection=collection,
-                            source_path=str(final_file_path),
-                            file_id=final_file_id,
-                            ingestion_config=ing_cfg,
-                            progress_manager=progress_manager,
-                            user_id=user_id,
-                            is_admin=is_admin,
+                    with open(temp_file, "w", encoding="utf-8") as f:
+                        # Add metadata header
+                        f.write(f"# {page_title}\n\n")
+                        f.write(f"**Source:** {crawl_result.url}\n\n")
+                        f.write(
+                            f"**Crawled:** {crawl_result.timestamp.isoformat()}\n\n"
                         )
+                        f.write("---\n\n")
+                        f.write(crawl_result.content_markdown)
 
-                    # Run ingestion in thread pool while preserving ContextVar user scope
-                    # NOTE: request_context was copied before the loop to avoid repeated copying.
-                    # Modifications made in the thread pool won't propagate back to the main request context.
-                    # This is acceptable for user scope (read-only) but observability systems should
-                    # be aware that child span updates may be lost.
-                    with concurrent.futures.ThreadPoolExecutor() as executor:
-                        ingest_result: IngestionResult = await loop.run_in_executor(
-                            executor, lambda: request_context.run(_ingest_file)
-                        )
+                    logger.debug("Saved %s to %s", crawl_result.url, temp_file)
 
-                    # Track statistics
-                    if ingest_result.status == "success":
-                        documents_created += 1
-                        successful_page_ingestions += 1
-                        total_chunks += ingest_result.chunk_count
-                        total_embeddings += ingest_result.embedding_count
-                        logger.info(
-                            "Ingested %s: %s chunks, %s embeddings",
-                            crawl_result.url,
-                            ingest_result.chunk_count,
-                            ingest_result.embedding_count,
+                    # Call file_handler if provided (for persistent storage and UploadedFile record)
+                    final_file_path = temp_file
+                    final_file_id = None
+                    copied_persistent_file = None
+
+                    if file_handler:
+                        try:
+                            file_info = file_handler(
+                                temp_file,
+                                page_title,
+                                collection,
+                                crawl_result.url,
+                            )
+                            final_file_path = Path(
+                                file_info.get("file_path", temp_file)
+                            )
+                            final_file_id = file_info.get("file_id")
+
+                            if final_file_path != temp_file or final_file_id:
+                                pipeline_facade.record_web_page_file_side_effect(
+                                    page_operation,
+                                    collection=collection,
+                                    url=crawl_result.url,
+                                    file_path=str(final_file_path),
+                                    file_id=final_file_id,
+                                )
+
+                            # Track if we successfully copied a persistent file for cleanup
+                            if (
+                                final_file_path != temp_file
+                                and final_file_path.exists()
+                            ):
+                                copied_persistent_file = final_file_path
+
+                            logger.debug(
+                                "File handler returned: path=%s, file_id=%s",
+                                final_file_path,
+                                final_file_id,
+                            )
+                        except Exception as e:
+                            logger.exception(
+                                "File handler failed for %s", crawl_result.url
+                            )
+                            failure_message = (
+                                f"File persistence failed for {crawl_result.url}: {e}"
+                            )
+                            failed_urls[crawl_result.url] = failure_message
+                            warnings.append(failure_message)
+                            pipeline_facade.record_web_page_file_side_effect(
+                                page_operation,
+                                collection=collection,
+                                url=crawl_result.url,
+                                file_path=None,
+                                file_id=None,
+                                reason="file_handler_failed",
+                            )
+                            pipeline_facade.finish_web_page_operation(
+                                page_operation,
+                                status="error",
+                                message=failure_message,
+                                side_effects_may_remain=True,
+                            )
+                            continue
+
+                    try:
+                        # Ingest the file
+                        progress_manager = get_progress_manager()
+
+                        def _ingest_file() -> IngestionResult:
+                            return run_document_ingestion(
+                                collection=collection,
+                                source_path=str(final_file_path),
+                                file_id=final_file_id,
+                                ingestion_config=ing_cfg,
+                                progress_manager=progress_manager,
+                                user_id=user_id,
+                                is_admin=is_admin,
+                            )
+
+                        # Copy the current ContextVars after the page child operation is active.
+                        # This preserves user scope and lets document ingestion record into the same child.
+                        request_context = copy_context()
+                        with concurrent.futures.ThreadPoolExecutor() as executor:
+                            ingest_result: IngestionResult = await loop.run_in_executor(
+                                executor, lambda: request_context.run(_ingest_file)
+                            )
+
+                        # Track statistics
+                        if ingest_result.status == "success":
+                            documents_created += 1
+                            successful_page_ingestions += 1
+                            total_chunks += ingest_result.chunk_count
+                            total_embeddings += ingest_result.embedding_count
+                            logger.info(
+                                "Ingested %s: %s chunks, %s embeddings",
+                                crawl_result.url,
+                                ingest_result.chunk_count,
+                                ingest_result.embedding_count,
+                            )
+                            pipeline_facade.finish_web_page_operation(
+                                page_operation,
+                                status="success",
+                                message=ingest_result.message,
+                            )
+                            # Only clear temp file reference on success
+                            copied_persistent_file = None
+                        else:
+                            # Non-success ingestion (e.g., embedding failed) without exception.
+                            # Keep file and DB record for potential retry scenarios.
+                            # Note: This accumulates files on persistent failures.
+                            # TODO: Add periodic cleanup for orphaned files from persistent failures.
+                            failed_urls[crawl_result.url] = ingest_result.message
+                            msg = (
+                                f"Partial ingestion for {crawl_result.url}: "
+                                f"{ingest_result.message}"
+                            )
+                            warnings.append(msg)
+                            pipeline_facade.finish_web_page_operation(
+                                page_operation,
+                                status=ingest_result.status,
+                                message=ingest_result.message,
+                            )
+
+                    except Exception as e:
+                        logger.exception("Failed to ingest %s", crawl_result.url)
+                        failed_urls[crawl_result.url] = str(e)
+                        failure_message = (
+                            f"Failed to ingest {crawl_result.url}: {str(e)}"
                         )
-                        # Only clear temp file reference on success
+                        warnings.append(failure_message)
+
+                        # Clean up copied persistent file on ingestion failure
+                        if copied_persistent_file and copied_persistent_file.exists():
+                            try:
+                                copied_persistent_file.unlink()
+                                logger.info(
+                                    "Cleaned up persistent file due to ingestion failure: %s",
+                                    copied_persistent_file,
+                                )
+                            except Exception as cleanup_error:
+                                logger.warning(
+                                    "Failed to clean up persistent file %s: %s",
+                                    copied_persistent_file,
+                                    cleanup_error,
+                                )
                         copied_persistent_file = None
-                    else:
-                        # Non-success ingestion (e.g., embedding failed) without exception.
-                        # Keep file and DB record for potential retry scenarios.
-                        # Note: This accumulates files on persistent failures.
-                        # TODO: Add periodic cleanup for orphaned files from persistent failures.
-                        failed_urls[crawl_result.url] = ingest_result.message
-                        msg = (
-                            f"Partial ingestion for {crawl_result.url}: "
-                            f"{ingest_result.message}"
+                        pipeline_facade.finish_web_page_operation(
+                            page_operation,
+                            status="error",
+                            message=failure_message,
                         )
-                        warnings.append(msg)
 
                 except Exception as e:
                     logger.exception("Failed to ingest %s", crawl_result.url)
                     failed_urls[crawl_result.url] = str(e)
-                    warnings.append(f"Failed to ingest {crawl_result.url}: {str(e)}")
-
-                    # Clean up copied persistent file on ingestion failure
-                    if copied_persistent_file and copied_persistent_file.exists():
-                        try:
-                            copied_persistent_file.unlink()
-                            logger.info(
-                                "Cleaned up persistent file due to ingestion failure: %s",
-                                copied_persistent_file,
-                            )
-                        except Exception as cleanup_error:
-                            logger.warning(
-                                "Failed to clean up persistent file %s: %s",
-                                copied_persistent_file,
-                                cleanup_error,
-                            )
-                    copied_persistent_file = None
-
-            except Exception as e:
-                logger.exception("Failed to ingest %s", crawl_result.url)
-                failed_urls[crawl_result.url] = str(e)
-                warnings.append(f"Failed to ingest {crawl_result.url}: {str(e)}")
+                    failure_message = f"Failed to ingest {crawl_result.url}: {str(e)}"
+                    warnings.append(failure_message)
+                    pipeline_facade.finish_web_page_operation(
+                        page_operation,
+                        status="error",
+                        message=failure_message,
+                    )
 
     # Step 3: Compile results
     elapsed_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -10,7 +10,7 @@ import tempfile
 from contextvars import copy_context
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Optional, TypedDict
+from typing import TYPE_CHECKING, Callable, Optional, TypedDict
 
 from ..core.schemas import (
     CrawlResult,
@@ -25,6 +25,9 @@ from ..utils.string_utils import sanitize_for_doc_id
 from ..utils.user_scope import resolve_user_scope
 from ..web_crawler import WebCrawler
 from .document_ingestion import run_document_ingestion
+
+if TYPE_CHECKING:
+    from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +70,36 @@ def _looks_like_crawler_block(error: str) -> bool:
     return any(marker in normalized_error for marker in _CRAWLER_BLOCK_ERROR_MARKERS)
 
 
+def _get_pipeline_compatibility_facade() -> "KBPipelineCompatibilityFacade":
+    """Return the coordinator-owned pipeline compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().pipeline_compatibility
+
+
 async def run_web_ingestion(
+    collection: str,
+    crawl_config: WebCrawlConfig,
+    *,
+    ingestion_config: Optional[IngestionConfig] = None,
+    progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_handler: Optional[Callable[[Path, str, str, str], FileHandlerResult]] = None,
+) -> WebIngestionResult:
+    """Crawl a website and ingest all pages into the knowledge base."""
+    return await _get_pipeline_compatibility_facade().run_web_ingestion(
+        collection=collection,
+        crawl_config=crawl_config,
+        ingestion_config=ingestion_config,
+        progress_callback=progress_callback,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_handler=file_handler,
+    )
+
+
+async def _run_web_ingestion_impl(
     collection: str,
     crawl_config: WebCrawlConfig,
     *,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -200,6 +200,7 @@ async def _run_web_ingestion_impl(
     # Create temporary directory for markdown files
     with tempfile.TemporaryDirectory(prefix="xagent_web_ingest_") as temp_dir:
         documents_created = 0
+        successful_page_ingestions = 0
         total_chunks = 0
         total_embeddings = 0
 
@@ -298,6 +299,7 @@ async def _run_web_ingestion_impl(
                     # Track statistics
                     if ingest_result.status == "success":
                         documents_created += 1
+                        successful_page_ingestions += 1
                         total_chunks += ingest_result.chunk_count
                         total_embeddings += ingest_result.embedding_count
                         logger.info(
@@ -359,7 +361,8 @@ async def _run_web_ingestion_impl(
     # - "success": No failures (empty results are successful)
     total_failures = pages_failed
 
-    if documents_created == 0 and total_failures > 0:
+    has_successful_ingestion = successful_page_ingestions > 0
+    if not has_successful_ingestion and total_failures > 0:
         status = "error"
     elif total_failures > 0:
         status = "partial"

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -4,7 +4,6 @@ Crawls a website and imports all discovered pages into the knowledge base.
 """
 
 import asyncio
-import concurrent.futures
 import logging
 import tempfile
 from contextvars import copy_context
@@ -325,10 +324,9 @@ async def _run_web_ingestion_impl(
                         # Copy the current ContextVars after the page child operation is active.
                         # This preserves user scope and lets document ingestion record into the same child.
                         request_context = copy_context()
-                        with concurrent.futures.ThreadPoolExecutor() as executor:
-                            ingest_result: IngestionResult = await loop.run_in_executor(
-                                executor, lambda: request_context.run(_ingest_file)
-                            )
+                        ingest_result: IngestionResult = await loop.run_in_executor(
+                            None, lambda: request_context.run(_ingest_file)
+                        )
 
                         # Track statistics
                         if ingest_result.status == "success":

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -260,7 +260,7 @@ async def _run_web_ingestion_impl(
                                     "File handler returned no file information"
                                 )
                             final_file_path = Path(
-                                file_info.get("file_path", temp_file)
+                                file_info.get("file_path") or temp_file
                             )
                             final_file_id = file_info.get("file_id")
 

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -255,6 +255,10 @@ async def _run_web_ingestion_impl(
                                 collection,
                                 crawl_result.url,
                             )
+                            if not file_info:
+                                raise ValueError(
+                                    "File handler returned no file information"
+                                )
                             final_file_path = Path(
                                 file_info.get("file_path", temp_file)
                             )

--- a/src/xagent/core/tools/core/RAG_tools/retrieval/search_dense.py
+++ b/src/xagent/core/tools/core/RAG_tools/retrieval/search_dense.py
@@ -8,7 +8,7 @@ Phase 1A Option C: Provides both sync and async search functions.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..core.exceptions import DocumentValidationError
 from ..core.schemas import (
@@ -20,10 +20,48 @@ from ..core.schemas import (
 from ..vector_storage.vector_manager import validate_query_vector
 from .search_engine import search_dense_engine
 
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
 logger = logging.getLogger(__name__)
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def search_dense(
+    collection: str,
+    model_tag: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Optional[Dict[str, Any]] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DenseSearchResponse:
+    """Execute dense vector search for RAG retrieval."""
+    return _get_legacy_step_compatibility_facade().search_dense(
+        collection=collection,
+        model_tag=model_tag,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _search_dense_impl(
     collection: str,
     model_tag: str,
     query_vector: List[float],
@@ -167,6 +205,34 @@ def search_dense(
 
 
 async def search_dense_async(
+    collection: str,
+    model_tag: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Optional[Dict[str, Any]] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DenseSearchResponse:
+    """Execute dense vector search using async vector store abstraction."""
+    return await _get_legacy_step_compatibility_facade().search_dense_async(
+        collection=collection,
+        model_tag=model_tag,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _search_dense_async_impl(
     collection: str,
     model_tag: str,
     query_vector: List[float],

--- a/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
+++ b/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
@@ -5,7 +5,7 @@ full-text search results using RRF or linear weighted combination.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..core.schemas import (
     FusionConfig,
@@ -16,6 +16,9 @@ from ..core.schemas import (
 )
 from ..retrieval.search_dense import search_dense
 from ..retrieval.search_sparse import search_sparse
+
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +169,46 @@ def _linear_fusion(
     return fused_results
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def search_hybrid(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Optional[Dict[str, Any]] = None,
+    fusion_config: Optional[FusionConfig] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> HybridSearchResponse:
+    """Performs hybrid search, combining dense and sparse retrieval."""
+    return _get_legacy_step_compatibility_facade().search_hybrid(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        fusion_config=fusion_config,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _search_hybrid_impl(
     collection: str,
     model_tag: str,
     query_text: str,

--- a/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
+++ b/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
@@ -14,8 +14,8 @@ from ..core.schemas import (
     SearchResult,
     SearchWarning,
 )
-from ..retrieval.search_dense import _search_dense_impl
-from ..retrieval.search_sparse import _search_sparse_impl
+from .search_dense import _search_dense_impl
+from .search_sparse import _search_sparse_impl
 
 if TYPE_CHECKING:
     from ..kb import KBLegacyStepCompatibilityFacade

--- a/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
+++ b/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
@@ -14,8 +14,8 @@ from ..core.schemas import (
     SearchResult,
     SearchWarning,
 )
-from ..retrieval.search_dense import search_dense
-from ..retrieval.search_sparse import search_sparse
+from ..retrieval.search_dense import _search_dense_impl
+from ..retrieval.search_sparse import _search_sparse_impl
 
 if TYPE_CHECKING:
     from ..kb import KBLegacyStepCompatibilityFacade
@@ -249,7 +249,7 @@ def _search_hybrid_impl(
 
     # 1. Execute Dense Search
     logger.info("Executing dense search for model %s...", model_tag)
-    dense_response = search_dense(
+    dense_response = _search_dense_impl(
         collection=collection,
         model_tag=model_tag,
         query_vector=query_vector,
@@ -266,7 +266,7 @@ def _search_hybrid_impl(
 
     # 2. Execute Sparse Search
     logger.info("Executing sparse search for model %s...", model_tag)
-    sparse_response = search_sparse(
+    sparse_response = _search_sparse_impl(
         collection=collection,
         model_tag=model_tag,
         query_text=query_text,

--- a/src/xagent/core/tools/core/RAG_tools/retrieval/search_sparse.py
+++ b/src/xagent/core/tools/core/RAG_tools/retrieval/search_sparse.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator
-from typing import Any, Dict, Iterable, List, Optional, Set, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, cast
 
 import pandas as pd
 import pyarrow as pa  # type: ignore
@@ -22,10 +22,48 @@ from ..storage.factory import (
 from ..utils.filter_utils import parse_legacy_filters, validate_filter_depth
 from ..utils.metadata_utils import deserialize_metadata
 
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
 logger = logging.getLogger(__name__)
 
 
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
 def search_sparse(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    *,
+    top_k: int,
+    filters: Optional[Dict[str, Any]] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> SparseSearchResponse:
+    """Performs sparse (Full-Text Search) retrieval on the specified collection."""
+    return _get_legacy_step_compatibility_facade().search_sparse(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _search_sparse_impl(
     collection: str,
     model_tag: str,
     query_text: str,
@@ -345,6 +383,34 @@ def _build_sparse_response(
 
 
 async def search_sparse_async(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    *,
+    top_k: int,
+    filters: Optional[Dict[str, Any]] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> SparseSearchResponse:
+    """Perform sparse retrieval using async vector store abstraction."""
+    return await _get_legacy_step_compatibility_facade().search_sparse_async(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _search_sparse_async_impl(
     collection: str,
     model_tag: str,
     query_text: str,

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
@@ -63,6 +63,8 @@ def test_kb_public_surface_imports() -> None:
         "KBStorageBackend",
         "KBBackendCapabilities",
         "KBHandleProvider",
+        "KBPipelineCompatibilityFacade",
+        "KBLegacyStepCompatibilityFacade",
         "LanceDBCollectionHandle",
     ]
 

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator.py
@@ -65,6 +65,12 @@ def test_kb_public_surface_imports() -> None:
         "KBHandleProvider",
         "KBPipelineCompatibilityFacade",
         "KBLegacyStepCompatibilityFacade",
+        "KBOperationCompatibilityFacade",
+        "KBOperationOutcome",
+        "RollbackStatus",
+        "PersistencePolicy",
+        "SideEffectPlane",
+        "CompensationStep",
         "LanceDBCollectionHandle",
     ]
 

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextvars import Context
+
 import pytest
 
 from xagent.core.tools.core.RAG_tools.kb import (
@@ -55,6 +57,34 @@ def test_operation_compensation_steps_are_idempotent_and_lifo() -> None:
     ]
     assert outcome.rollback_status is RollbackStatus.INCOMPLETE
     assert outcome.side_effects_may_remain is True
+
+
+def test_last_outcome_is_isolated_by_execution_context() -> None:
+    facade = KBOperationCompatibilityFacade()
+    initial_current_context_outcome = facade.last_outcome
+
+    def run_operation(collection: str):
+        with facade.start_operation(
+            operation_type="document_ingestion",
+            collection=collection,
+        ):
+            pass
+
+        outcome = facade.last_outcome
+        assert outcome is not None
+        return outcome
+
+    context_a = Context()
+    context_b = Context()
+
+    outcome_a = context_a.run(run_operation, "collection-a")
+    outcome_b = context_b.run(run_operation, "collection-b")
+
+    assert outcome_a.collection == "collection-a"
+    assert outcome_b.collection == "collection-b"
+    assert context_a.run(lambda: facade.last_outcome) is outcome_a
+    assert context_b.run(lambda: facade.last_outcome) is outcome_b
+    assert facade.last_outcome is initial_current_context_outcome
 
 
 class _OperationCancelled(BaseException):

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -1,0 +1,55 @@
+"""Tests for KB operation rollback compatibility outcomes."""
+
+from __future__ import annotations
+
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBOperationCompatibilityFacade,
+    RollbackStatus,
+    SideEffectPlane,
+)
+
+
+def test_operation_compensation_steps_are_idempotent_and_lifo() -> None:
+    facade = KBOperationCompatibilityFacade()
+
+    with facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="remove_document",
+            plane=SideEffectPlane.DOCUMENT,
+            payload={"doc_id": "doc-1"},
+            idempotency_key="document:doc-1",
+        )
+        operation.record_side_effect(
+            name="remove_parse",
+            plane=SideEffectPlane.PARSE,
+            payload={"parse_hash": "parse-1"},
+            idempotency_key="parse:parse-1",
+        )
+        operation.record_side_effect(
+            name="remove_document",
+            plane=SideEffectPlane.DOCUMENT,
+            payload={"doc_id": "doc-1"},
+            idempotency_key="document:doc-1",
+        )
+        operation.finish(
+            status="partial",
+            rollback_status=RollbackStatus.INCOMPLETE,
+            side_effects_may_remain=True,
+        )
+
+    outcome = facade.last_outcome
+
+    assert outcome is not None
+    assert [step.name for step in outcome.compensation_steps] == [
+        "remove_document",
+        "remove_parse",
+    ]
+    assert [step.name for step in outcome.compensation_plan] == [
+        "remove_parse",
+        "remove_document",
+    ]
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from xagent.core.tools.core.RAG_tools.kb import (
     KBOperationCompatibilityFacade,
     RollbackStatus,
@@ -53,3 +55,31 @@ def test_operation_compensation_steps_are_idempotent_and_lifo() -> None:
     ]
     assert outcome.rollback_status is RollbackStatus.INCOMPLETE
     assert outcome.side_effects_may_remain is True
+
+
+class _OperationCancelled(BaseException):
+    pass
+
+
+def test_operation_base_exception_records_error_outcome() -> None:
+    facade = KBOperationCompatibilityFacade()
+
+    with pytest.raises(_OperationCancelled):
+        with facade.start_operation(
+            operation_type="document_ingestion",
+            collection="demo",
+        ) as operation:
+            operation.record_side_effect(
+                name="remove_document",
+                plane=SideEffectPlane.DOCUMENT,
+                payload={"doc_id": "doc-1"},
+                idempotency_key="document:doc-1",
+            )
+            raise _OperationCancelled("cancelled")
+
+    outcome = facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert outcome.warnings == ("cancelled",)

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -112,4 +112,21 @@ def test_operation_base_exception_records_error_outcome() -> None:
     assert outcome.status == "error"
     assert outcome.rollback_status is RollbackStatus.INCOMPLETE
     assert outcome.side_effects_may_remain is True
-    assert outcome.warnings == ("cancelled",)
+    assert outcome.warnings == ("_OperationCancelled: cancelled",)
+
+
+def test_operation_exception_warning_includes_exception_type() -> None:
+    facade = KBOperationCompatibilityFacade()
+
+    with pytest.raises(KeyError):
+        with facade.start_operation(
+            operation_type="document_ingestion",
+            collection="demo",
+        ):
+            raise KeyError("doc_id")
+
+    outcome = facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.NOT_NEEDED
+    assert outcome.warnings == ("KeyError: 'doc_id'",)

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -601,6 +601,44 @@ async def test_web_ingestion_empty_file_handler_result_is_explicit_failure(
 
 
 @pytest.mark.asyncio
+async def test_web_ingestion_none_file_handler_path_uses_temp_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import web_ingestion
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    captured: dict[str, object] = {}
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        return {"file_path": None, "file_id": "file-1"}
+
+    def fake_run_document_ingestion(**kwargs: object) -> IngestionResult:
+        captured.update(kwargs)
+        return _successful_ingestion_result(doc_id="doc-ok")
+
+    monkeypatch.setattr(
+        web_ingestion,
+        "run_document_ingestion",
+        fake_run_document_ingestion,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "success"
+    assert captured["file_id"] == "file-1"
+    assert "xagent_web_ingest" in str(captured["source_path"])
+    assert str(captured["source_path"]).endswith(".md")
+
+
+@pytest.mark.asyncio
 async def test_web_ingestion_file_and_document_side_effects_share_page_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -60,6 +60,22 @@ def test_ensure_collection_backend_binding_sets_lancedb_when_missing() -> None:
     assert metadata_store.saved == [updated]
 
 
+@pytest.mark.asyncio
+async def test_ensure_collection_backend_binding_async_sets_lancedb_when_missing() -> (
+    None
+):
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="demo"))
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(metadata_store)
+    )
+
+    updated = await facade.ensure_collection_backend_binding_async("demo")
+
+    assert updated is not None
+    assert updated.extra_metadata["kb_storage"] == {"backend": "lancedb"}
+    assert metadata_store.saved == [updated]
+
+
 def test_ensure_collection_backend_binding_preserves_existing_binding() -> None:
     existing_binding = {"backend": "postgresql", "dsn": "kept"}
     metadata_store = _FakeMetadataStore(

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -130,6 +130,27 @@ def _successful_ingestion_result(doc_id: str = "doc-ok") -> IngestionResult:
     )
 
 
+def test_step_metadata_preserves_present_step_with_empty_metadata() -> None:
+    empty_metadata_step = IngestionStepResult(name="initialize_collection")
+    none_metadata_step = IngestionStepResult.model_construct(
+        name="register_document", metadata=None
+    )
+
+    assert (
+        KBPipelineCompatibilityFacade._step_metadata(
+            [empty_metadata_step], "initialize_collection"
+        )
+        == {}
+    )
+    assert (
+        KBPipelineCompatibilityFacade._step_metadata(
+            [none_metadata_step], "register_document"
+        )
+        == {}
+    )
+    assert KBPipelineCompatibilityFacade._step_metadata([], "missing") is None
+
+
 def test_process_document_binds_collection_after_first_ingest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -542,6 +563,40 @@ async def test_web_ingestion_file_handler_failure_records_page_child_outcome(
     assert child.operation_type == "web_page_ingestion"
     assert child.status == "error"
     assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert {step.plane for step in child.compensation_steps} == {SideEffectPlane.FILE}
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_empty_file_handler_result_is_explicit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import web_ingestion
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+
+    def empty_file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, str]:
+        return {}
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=empty_file_handler,
+    )
+
+    assert result.status == "error"
+    assert "File handler returned no file information" in next(
+        iter(result.failed_urls.values())
+    )
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert len(outcome.child_outcomes) == 1
+    child = outcome.child_outcomes[0]
+    assert child.status == "error"
     assert {step.plane for step in child.compensation_steps} == {SideEffectPlane.FILE}
 
 

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -1,0 +1,75 @@
+"""Tests for KB pipeline compatibility facade."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.kb import KBPipelineCompatibilityFacade
+
+
+class _FakeMetadataStore:
+    def __init__(self, collection: Optional[CollectionInfo]) -> None:
+        self.collection = collection
+        self.saved: list[CollectionInfo] = []
+
+    async def get_collection(self, collection: str) -> CollectionInfo:
+        if self.collection is None or self.collection.name != collection:
+            raise ValueError(f"Collection {collection!r} not found")
+        return self.collection
+
+    async def save_collection(self, collection: CollectionInfo) -> None:
+        self.saved.append(collection)
+        self.collection = collection
+
+
+class _FakeStorageShim:
+    def __init__(self, metadata_store: _FakeMetadataStore) -> None:
+        self.metadata_store = metadata_store
+
+    def get_metadata_store(self) -> _FakeMetadataStore:
+        return self.metadata_store
+
+
+def test_ensure_collection_backend_binding_sets_lancedb_when_missing() -> None:
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="demo"))
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(metadata_store)
+    )
+
+    updated = facade.ensure_collection_backend_binding("demo")
+
+    assert updated is not None
+    assert updated.extra_metadata["kb_storage"] == {"backend": "lancedb"}
+    assert metadata_store.saved == [updated]
+
+
+def test_ensure_collection_backend_binding_preserves_existing_binding() -> None:
+    existing_binding = {"backend": "postgresql", "dsn": "kept"}
+    metadata_store = _FakeMetadataStore(
+        CollectionInfo(
+            name="demo",
+            extra_metadata={"kb_storage": existing_binding, "other": "value"},
+        )
+    )
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(metadata_store)
+    )
+
+    existing = facade.ensure_collection_backend_binding("demo")
+
+    assert existing is metadata_store.collection
+    assert existing is not None
+    assert existing.extra_metadata["kb_storage"] == existing_binding
+    assert existing.extra_metadata["other"] == "value"
+    assert metadata_store.saved == []
+
+
+def test_ensure_collection_backend_binding_ignores_missing_collection() -> None:
+    metadata_store = _FakeMetadataStore(None)
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(metadata_store)
+    )
+
+    assert facade.ensure_collection_backend_binding("missing") is None
+    assert metadata_store.saved == []

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -302,6 +302,39 @@ def test_process_document_records_failed_ingest_operation_outcome(
     ]
 
 
+def test_run_document_ingestion_preserves_legacy_non_result_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+
+    expected_result = object()
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMetadataStore(CollectionInfo(name="demo"))),
+        operation_compatibility=KBOperationCompatibilityFacade(),
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> object:
+        return expected_result
+
+    def fail_if_called(*_: object, **__: object) -> None:
+        raise AssertionError("structured ingestion hooks should not run")
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+    monkeypatch.setattr(
+        facade, "_record_document_ingestion_side_effects", fail_if_called
+    )
+    monkeypatch.setattr(facade, "ensure_collection_backend_binding", fail_if_called)
+    monkeypatch.setattr(facade, "_finish_document_ingestion_outcome", fail_if_called)
+
+    result = facade.run_document_ingestion("demo", "/tmp/doc.md")
+
+    assert result is expected_result
+
+
 @pytest.mark.asyncio
 async def test_web_ingestion_records_page_child_outcomes_and_preserve_policy(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -525,7 +525,7 @@ class _SinglePageCrawler:
                 content_markdown="body",
                 status="success",
                 depth=0,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 content_length=4,
             )
         ]

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -4,8 +4,21 @@ from __future__ import annotations
 
 from typing import Optional
 
-from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
-from xagent.core.tools.core.RAG_tools.kb import KBPipelineCompatibilityFacade
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    IngestionResult,
+    IngestionStepResult,
+    WebCrawlConfig,
+    WebIngestionResult,
+)
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBOperationCompatibilityFacade,
+    KBPipelineCompatibilityFacade,
+    RollbackStatus,
+    SideEffectPlane,
+)
 
 
 class _FakeMetadataStore:
@@ -73,3 +86,342 @@ def test_ensure_collection_backend_binding_ignores_missing_collection() -> None:
 
     assert facade.ensure_collection_backend_binding("missing") is None
     assert metadata_store.saved == []
+
+
+def _ingestion_step(name: str, **metadata: object) -> IngestionStepResult:
+    return IngestionStepResult(name=name, metadata=dict(metadata))
+
+
+def _successful_ingestion_result(doc_id: str = "doc-ok") -> IngestionResult:
+    return IngestionResult(
+        status="success",
+        doc_id=doc_id,
+        parse_hash="parse-ok",
+        chunk_count=1,
+        embedding_count=1,
+        vector_count=1,
+        completed_steps=[
+            _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+            _ingestion_step("register_document", doc_id=doc_id, created=True),
+            _ingestion_step("parse_document", parse_hash="parse-ok", written=True),
+            _ingestion_step("chunk_document", chunk_count=1, created=True),
+            _ingestion_step("write_vectors_to_db", vector_count=1),
+        ],
+        message="ok",
+    )
+
+
+def test_process_document_binds_collection_after_first_ingest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="demo"))
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(metadata_store)
+    )
+
+    def fake_process_document_impl(**_: object) -> IngestionResult:
+        return _successful_ingestion_result()
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_process_document_impl",
+        fake_process_document_impl,
+    )
+
+    result = facade.process_document("demo", "/tmp/doc.md")
+
+    assert result.status == "success"
+    assert metadata_store.collection is not None
+    assert metadata_store.collection.extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
+    assert metadata_store.saved == [metadata_store.collection]
+
+
+@pytest.mark.parametrize(
+    ("failed_step", "completed_steps", "chunk_count", "vector_count", "planes"),
+    [
+        (
+            "register_document",
+            [
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-1", created=True),
+            ],
+            0,
+            0,
+            {
+                SideEffectPlane.COLLECTION,
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.STATUS,
+            },
+        ),
+        (
+            "parse_document",
+            [
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-1", created=True),
+                _ingestion_step("parse_document", parse_hash="parse-1", written=True),
+            ],
+            0,
+            0,
+            {
+                SideEffectPlane.COLLECTION,
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.STATUS,
+                SideEffectPlane.PARSE,
+            },
+        ),
+        (
+            "chunk_document",
+            [
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-1", created=True),
+                _ingestion_step("parse_document", parse_hash="parse-1", written=True),
+                _ingestion_step("chunk_document", chunk_count=2, created=True),
+            ],
+            2,
+            0,
+            {
+                SideEffectPlane.COLLECTION,
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.STATUS,
+                SideEffectPlane.PARSE,
+                SideEffectPlane.CHUNK,
+            },
+        ),
+        (
+            "write_vectors_to_db",
+            [
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-1", created=True),
+                _ingestion_step("parse_document", parse_hash="parse-1", written=True),
+                _ingestion_step("chunk_document", chunk_count=2, created=True),
+                _ingestion_step("write_vectors_to_db", vector_count=2),
+            ],
+            2,
+            2,
+            {
+                SideEffectPlane.COLLECTION,
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.STATUS,
+                SideEffectPlane.PARSE,
+                SideEffectPlane.CHUNK,
+                SideEffectPlane.EMBEDDING,
+            },
+        ),
+    ],
+)
+def test_process_document_records_failed_ingest_operation_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_step: str,
+    completed_steps: list[IngestionStepResult],
+    chunk_count: int,
+    vector_count: int,
+    planes: set[SideEffectPlane],
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMetadataStore(CollectionInfo(name="demo"))),
+        operation_compatibility=operation_facade,
+    )
+
+    def fake_process_document_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-1",
+            parse_hash="parse-1" if failed_step != "register_document" else None,
+            chunk_count=chunk_count,
+            embedding_count=vector_count,
+            vector_count=vector_count,
+            completed_steps=completed_steps,
+            failed_step=failed_step,
+            message=f"failed at {failed_step}",
+        )
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_process_document_impl",
+        fake_process_document_impl,
+    )
+
+    result = facade.process_document("demo", "/tmp/doc.md")
+
+    assert result.failed_step == failed_step
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "partial"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert {step.plane for step in outcome.compensation_steps} == planes
+    assert [step.name for step in outcome.compensation_plan] == [
+        step.name for step in reversed(outcome.compensation_steps)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_records_page_child_outcomes_and_preserve_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMetadataStore(CollectionInfo(name="demo"))),
+        operation_compatibility=operation_facade,
+    )
+
+    def fake_run_document_ingestion_impl(
+        collection: str,
+        source_path: str,
+        **_: object,
+    ) -> IngestionResult:
+        if source_path.endswith("ok.md"):
+            return _successful_ingestion_result("doc-ok")
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-bad",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-bad", created=True),
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    async def fake_run_web_ingestion_impl(
+        collection: str,
+        crawl_config: WebCrawlConfig,
+        **_: object,
+    ) -> WebIngestionResult:
+        facade.run_document_ingestion(collection, "/tmp/ok.md")
+        facade.run_document_ingestion(collection, "/tmp/bad.md")
+        return WebIngestionResult(
+            status="partial",
+            collection=collection,
+            total_urls_found=2,
+            pages_crawled=2,
+            pages_failed=1,
+            documents_created=1,
+            chunks_created=1,
+            embeddings_created=1,
+            crawled_urls=[crawl_config.start_url, "https://example.com/bad"],
+            failed_urls={"https://example.com/bad": "parse failed"},
+            message="partial",
+            warnings=["parse failed"],
+            elapsed_time_ms=1,
+        )
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+    monkeypatch.setattr(
+        web_ingestion,
+        "_run_web_ingestion_impl",
+        fake_run_web_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=2),
+    )
+
+    assert result.status == "partial"
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.operation_type == "web_ingestion"
+    assert outcome.status == "partial"
+    assert outcome.rollback_status is RollbackStatus.SKIPPED_BY_POLICY
+    assert outcome.side_effects_may_remain is True
+    assert [child.operation_type for child in outcome.child_outcomes] == [
+        "web_page_ingestion",
+        "web_page_ingestion",
+    ]
+    assert [child.status for child in outcome.child_outcomes] == [
+        "success",
+        "partial",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_zero_success_reports_incomplete_rollback_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(_FakeMetadataStore(CollectionInfo(name="demo"))),
+        operation_compatibility=operation_facade,
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-failed", created=True),
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    async def fake_run_web_ingestion_impl(
+        collection: str,
+        crawl_config: WebCrawlConfig,
+        **_: object,
+    ) -> WebIngestionResult:
+        facade.run_document_ingestion(collection, "/tmp/failed.md")
+        return WebIngestionResult(
+            status="error",
+            collection=collection,
+            total_urls_found=1,
+            pages_crawled=1,
+            pages_failed=1,
+            documents_created=0,
+            chunks_created=0,
+            embeddings_created=0,
+            crawled_urls=[crawl_config.start_url],
+            failed_urls={crawl_config.start_url: "parse failed"},
+            message="failed",
+            warnings=["parse failed"],
+            elapsed_time_ms=1,
+        )
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+    monkeypatch.setattr(
+        web_ingestion,
+        "_run_web_ingestion_impl",
+        fake_run_web_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+    )
+
+    assert result.status == "error"
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert len(outcome.child_outcomes) == 1
+    assert outcome.child_outcomes[0].rollback_status is RollbackStatus.INCOMPLETE

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     CollectionInfo,
+    CrawlResult,
     IngestionResult,
     IngestionStepResult,
     WebCrawlConfig,
@@ -425,3 +428,162 @@ async def test_web_ingestion_zero_success_reports_incomplete_rollback_outcome(
     assert outcome.side_effects_may_remain is True
     assert len(outcome.child_outcomes) == 1
     assert outcome.child_outcomes[0].rollback_status is RollbackStatus.INCOMPLETE
+
+
+class _FailingSaveMetadataStore(_FakeMetadataStore):
+    async def save_collection(self, collection: CollectionInfo) -> None:
+        raise RuntimeError("save failed")
+
+
+def test_process_document_binding_failure_marks_operation_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(
+        storage_shim=_FakeStorageShim(
+            _FailingSaveMetadataStore(CollectionInfo(name="demo"))
+        ),
+        operation_compatibility=operation_facade,
+    )
+
+    def fake_process_document_impl(**_: object) -> IngestionResult:
+        return _successful_ingestion_result("doc-binding")
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_process_document_impl",
+        fake_process_document_impl,
+    )
+
+    with pytest.raises(RuntimeError, match="save failed"):
+        facade.process_document("demo", "/tmp/doc.md")
+
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert {step.plane for step in outcome.compensation_steps} >= {
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.PARSE,
+        SideEffectPlane.CHUNK,
+        SideEffectPlane.EMBEDDING,
+    }
+
+
+class _SinglePageCrawler:
+    def __init__(
+        self, config: WebCrawlConfig, progress_callback: object = None
+    ) -> None:
+        self.total_urls_found = 1
+        self.failed_urls: dict[str, str] = {}
+
+    async def crawl(self) -> list[CrawlResult]:
+        return [
+            CrawlResult(
+                url="https://example.com/page",
+                title="Example Page",
+                content_markdown="body",
+                status="success",
+                depth=0,
+                timestamp=datetime.utcnow(),
+                content_length=4,
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_file_handler_failure_records_page_child_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import web_ingestion
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+
+    def failing_file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, str]:
+        raise RuntimeError("file handler failed")
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=failing_file_handler,
+    )
+
+    assert result.status == "error"
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert len(outcome.child_outcomes) == 1
+    child = outcome.child_outcomes[0]
+    assert child.operation_type == "web_page_ingestion"
+    assert child.status == "error"
+    assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert {step.plane for step in child.compensation_steps} == {SideEffectPlane.FILE}
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_file_and_document_side_effects_share_page_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-failed", created=True),
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, str]:
+        return {"file_path": str(temp_file), "file_id": "file-1"}
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert len(outcome.child_outcomes) == 1
+    child = outcome.child_outcomes[0]
+    assert child.status == "partial"
+    assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert {step.plane for step in child.compensation_steps} >= {
+        SideEffectPlane.FILE,
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.STATUS,
+    }

--- a/tests/core/tools/core/RAG_tools/retrieval/test_search_hybrid.py
+++ b/tests/core/tools/core/RAG_tools/retrieval/test_search_hybrid.py
@@ -309,14 +309,14 @@ class TestSearchHybrid:
 
     @pytest.fixture
     def mock_sub_searches(self) -> Generator[Tuple[Mock, Mock], None, None]:
-        """Fixture to mock search_dense and search_sparse functions."""
+        """Fixture to mock dense and sparse implementation functions."""
         search_hybrid_module = self._patch_search_hybrid_module()
 
         mock_dense = Mock()
         mock_sparse = Mock()
         with (
-            patch.object(search_hybrid_module, "search_dense", new=mock_dense),
-            patch.object(search_hybrid_module, "search_sparse", new=mock_sparse),
+            patch.object(search_hybrid_module, "_search_dense_impl", new=mock_dense),
+            patch.object(search_hybrid_module, "_search_sparse_impl", new=mock_sparse),
         ):
             yield mock_dense, mock_sparse
 

--- a/tests/core/tools/core/RAG_tools/test_user_context_propagation.py
+++ b/tests/core/tools/core/RAG_tools/test_user_context_propagation.py
@@ -8,7 +8,11 @@ from typing import Any
 import pytest
 
 from xagent.core.tools.core.RAG_tools.core.exceptions import VectorValidationError
-from xagent.core.tools.core.RAG_tools.core.schemas import SearchConfig, SearchType
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    IngestionResult,
+    SearchConfig,
+    SearchType,
+)
 from xagent.core.tools.core.RAG_tools.pipelines import (
     document_ingestion,
     document_search,
@@ -77,9 +81,9 @@ def test_run_document_ingestion_omitted_scope_falls_back_to_context(
     """Document ingestion entrypoint should use request scope when args are omitted."""
     captured: dict[str, Any] = {}
 
-    def _fake_process_document(*args: Any, **kwargs: Any) -> object:
+    def _fake_process_document(*args: Any, **kwargs: Any) -> IngestionResult:
         captured.update(kwargs)
-        return object()
+        return IngestionResult(status="success", message="ok")
 
     monkeypatch.setattr(document_ingestion, "process_document", _fake_process_document)
 

--- a/tests/core/tools/core/RAG_tools/test_user_context_propagation.py
+++ b/tests/core/tools/core/RAG_tools/test_user_context_propagation.py
@@ -8,11 +8,7 @@ from typing import Any
 import pytest
 
 from xagent.core.tools.core.RAG_tools.core.exceptions import VectorValidationError
-from xagent.core.tools.core.RAG_tools.core.schemas import (
-    IngestionResult,
-    SearchConfig,
-    SearchType,
-)
+from xagent.core.tools.core.RAG_tools.core.schemas import SearchConfig, SearchType
 from xagent.core.tools.core.RAG_tools.pipelines import (
     document_ingestion,
     document_search,
@@ -80,19 +76,21 @@ def test_run_document_ingestion_omitted_scope_falls_back_to_context(
 ) -> None:
     """Document ingestion entrypoint should use request scope when args are omitted."""
     captured: dict[str, Any] = {}
+    expected_result = object()
 
-    def _fake_process_document(*args: Any, **kwargs: Any) -> IngestionResult:
+    def _fake_process_document(*args: Any, **kwargs: Any) -> object:
         captured.update(kwargs)
-        return IngestionResult(status="success", message="ok")
+        return expected_result
 
     monkeypatch.setattr(document_ingestion, "process_document", _fake_process_document)
 
     with user_scope_context(user_id=42, is_admin=True):
-        document_ingestion.run_document_ingestion(
+        result = document_ingestion.run_document_ingestion(
             collection="ctx_collection",
             source_path="/tmp/source.md",
         )
 
+    assert result is expected_result
     assert captured["user_id"] == 42
     assert captured["is_admin"] is True
 


### PR DESCRIPTION
Closes #504
Part of #494.

## Summary
- Add coordinator-owned pipeline and legacy step compatibility facades for KB ingestion, search, parsing, chunking, and retrieval helpers.
- Preserve existing public import paths while routing storage access through the KB coordinator facade conventions.
- Record rollback-aware operation outcomes, including first-ingest backend binding and per-page web ingestion child operations.

## Validation
- pre-commit run --all-files
- PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/pytest tests/core/tools/core/RAG_tools/vector_storage/test_vector_storage_compatibility.py tests/core/tools/core/RAG_tools/vector_storage/test_vector_manager.py tests/core/tools/core/RAG_tools/vector_storage/test_embeddings_forward_migration.py tests/core/tools/core/RAG_tools/parse/test_parse_document.py tests/core/tools/core/RAG_tools/parse/test_parse_display.py tests/core/tools/core/RAG_tools/retrieval/test_search_hybrid.py tests/core/tools/core/RAG_tools/retrieval/test_search_dense.py tests/core/tools/core/RAG_tools/retrieval/test_search_sparse.py tests/core/tools/core/RAG_tools/retrieval/test_format_context.py tests/core/tools/core/RAG_tools/retrieval/test_format_context_metadata.py tests/core/tools/core/RAG_tools/pipelines/test_model_resolver_legacy.py tests/core/tools/core/RAG_tools/pipelines/test_document_ingestion.py tests/core/tools/core/RAG_tools/pipelines/test_document_search.py tests/core/tools/core/RAG_tools/pipelines/test_real_ingestion.py tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py tests/core/tools/core/RAG_tools/kb/test_coordinator.py tests/core/tools/core/RAG_tools/kb/test_parse_display_compatibility.py tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py tests/core/tools/core/RAG_tools/kb/test_retrieval_helper_compatibility.py tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py tests/core/tools/core/RAG_tools/chunk/test_chunk_document.py tests/core/tools/core/RAG_tools/storage/test_vector_backend.py
  - 294 passed, 2 skipped