### PR TITLE
refactor(task): run task turns as the task owner, not the acting principal

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -61,6 +61,7 @@ from ..services.task_lease_service import (
     stop_task_lease_heartbeat,
 )
 from ..services.task_setup_snapshot import (
+    TaskOwnerMismatchError,
     TaskSetupSnapshot,
     load_task_setup_snapshot_sync,
 )
@@ -579,6 +580,10 @@ class AgentServiceManager:
 
     def __init__(self, request: Optional[Any] = None) -> None:
         self._agents: Dict[int, AgentService] = {}
+        # Owner (runtime identity) each cached AgentService was built for. A
+        # task_id-keyed cache must not silently hand back an instance built
+        # under a different user (e.g. once built with the wrong identity).
+        self._agent_owner_ids: Dict[int, Optional[int]] = {}
         self._sandboxes: Dict[str, Any] = {}  # lifecycle scope -> Sandbox instance
         self._default_llm = create_default_llm()
         self.request = request
@@ -1042,6 +1047,7 @@ class AgentServiceManager:
         db: Optional[Session] = None,
         user: Optional[User] = None,
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
+        task_owner_user_id: Optional[int] = None,
     ) -> AgentService:
         """Get or create AgentService instance for specific task.
 
@@ -1052,7 +1058,76 @@ class AgentServiceManager:
         callers and any caller that hasn't adopted the snapshot
         plumbing pass ``None`` and the Step-3 in-method thread call
         runs as before.
+
+        ``task_owner_user_id`` is the task OWNER's id — the runtime identity
+        the agent runs as (models, tools, OAuth, UserContext). It differs from
+        the acting principal (``user``) when an admin operates on another
+        user's task; callers that loaded/authorized the task should pass it.
+        When omitted it falls back to the snapshot owner, then the task row's
+        owner, then ``user.id``.
         """
+        # Resolve the runtime identity (OWNER). Everything below — snapshot
+        # load, model resolution, tool config, UserContext — runs as this
+        # identity, never the acting principal. Precedence: explicit owner →
+        # snapshot owner → the task row's owner (authoritative) → the acting
+        # ``user`` as a last resort. Deriving the owner from the task row means
+        # callers that pass only the acting ``user`` (e.g. WS resume / execute
+        # / pause handlers, which authorize the task separately) still run as
+        # the owner, not an admin acting on someone else's task.
+        runtime_user_id: Optional[int] = task_owner_user_id
+        if runtime_user_id is None and task_setup_snapshot is not None:
+            runtime_user_id = int(task_setup_snapshot.task.user_id)
+        if runtime_user_id is None and db is not None:
+            try:
+                owner_row = db.query(Task.user_id).filter(Task.id == task_id).first()
+                if owner_row is not None and owner_row[0] is not None:
+                    runtime_user_id = int(owner_row[0])
+            except Exception:
+                runtime_user_id = None
+        if runtime_user_id is None and user is not None and user.id is not None:
+            runtime_user_id = int(user.id)
+        # The User object the runtime needs (tool overrides / tracer). Reuse the
+        # passed ``user`` when it already IS the owner; otherwise load the owner.
+        runtime_user: Optional[User] = user
+        if (
+            runtime_user_id is not None
+            and db is not None
+            and (user is None or user.id is None or int(user.id) != runtime_user_id)
+        ):
+            runtime_user = db.query(User).filter(User.id == runtime_user_id).first()
+
+        # Owner invariant: evict a cached AgentService built for a different
+        # owner so we rebuild it under the correct runtime identity instead of
+        # silently reusing the wrong one.
+        if (
+            task_id in self._agents
+            and self._agent_owner_ids.get(task_id) != runtime_user_id
+        ):
+            logger.warning(
+                "Evicting cached AgentService for task %s: built for owner %s, "
+                "requested %s",
+                task_id,
+                self._agent_owner_ids.get(task_id),
+                runtime_user_id,
+            )
+            # The evicted instance was built for the wrong owner; its workspace
+            # lives under that owner's user-scoped path
+            # (``user_{owner}/web_task_{task_id}``), a different directory from
+            # the correct owner's. Clean it up so no wrong-owner workspace
+            # residue is left behind -- this cannot touch the rebuilt owner's
+            # workspace. Eviction itself must proceed even if cleanup fails.
+            try:
+                self._agents[task_id].cleanup_workspace()
+            except Exception as e:
+                logger.warning(
+                    "Failed to clean up workspace while evicting wrong-owner "
+                    "AgentService for task %s: %s",
+                    task_id,
+                    e,
+                )
+            del self._agents[task_id]
+            self._agent_owner_ids.pop(task_id, None)
+
         if task_id not in self._agents:
             # Check if task exists in database
             task_exists = False
@@ -1128,6 +1203,7 @@ class AgentServiceManager:
                         await self._reconstruct_agent_from_history(task_id, db)
                         self._load_persisted_conversation_history(task_id, db)
                         await self._load_persisted_execution_context(task_id, db)
+                        self._agent_owner_ids[task_id] = runtime_user_id
                         return self._agents[task_id]
                     except HTTPException:
                         raise
@@ -1141,10 +1217,11 @@ class AgentServiceManager:
                                 f"Cleaning up partially reconstructed agent for task {task_id}"
                             )
                             del self._agents[task_id]
+                            self._agent_owner_ids.pop(task_id, None)
                         # Continue with normal agent creation
 
             # Create tracer with all necessary handlers
-            tracer = create_task_tracer(task_id, user)
+            tracer = create_task_tracer(task_id, runtime_user)
 
             # Load the contiguous synchronous DB block (Task row,
             # per-task LLM resolution, optional Agent Builder lookup
@@ -1166,16 +1243,26 @@ class AgentServiceManager:
                 if task_setup_snapshot is not None:
                     # Caller already loaded the snapshot off-loop
                     # (typically ``_schedule_bg._runner``). Reuse it
-                    # instead of re-spinning a worker thread.
+                    # instead of re-spinning a worker thread. The loader's
+                    # owner guard is bypassed on this branch, so re-assert it
+                    # here: the snapshot's owner must match the runtime owner,
+                    # or tools / model / UserContext would split from the
+                    # workspace owner.
+                    if (
+                        runtime_user_id is not None
+                        and int(task_setup_snapshot.task.user_id) != runtime_user_id
+                    ):
+                        raise TaskOwnerMismatchError(
+                            task_id,
+                            runtime_user_id,
+                            int(task_setup_snapshot.task.user_id),
+                        )
                     snapshot = task_setup_snapshot
                 else:
-                    user_id_for_snapshot: Optional[int] = (
-                        int(user.id) if user and user.id is not None else None
-                    )
                     snapshot = await asyncio.to_thread(
                         load_task_setup_snapshot_sync,
                         task_id,
-                        user_id_for_snapshot,
+                        runtime_user_id,
                     )
 
                 if snapshot is not None:
@@ -1232,8 +1319,8 @@ class AgentServiceManager:
                         #    breaking those callers.
                         if snapshot.agent is not None:
                             user_id_for_fallback: Optional[int] = (
-                                int(user.id)
-                                if user and user.id is not None
+                                runtime_user_id
+                                if runtime_user_id is not None
                                 else task.user_id
                             )
                             task_llm = self._pick_default_llm_with_warning(
@@ -1270,7 +1357,11 @@ class AgentServiceManager:
                     task_fast_llm = None
                     task_vision_llm = None
                     task_compact_llm = None
-            except HTTPException:
+            except (HTTPException, TaskOwnerMismatchError):
+                # Owner mismatch is an identity/authorization fault, not a
+                # recoverable "LLM config failed to load" -- it must not fall
+                # through to the default-LLM path, which would build the
+                # runtime as the wrong user. Propagate it.
                 raise
             except Exception as e:
                 logger.error(
@@ -1283,9 +1374,12 @@ class AgentServiceManager:
             llm_info = "database LLM configuration"
 
             try:
-                # Set user context for memory operations during agent creation
-                if user is None:
-                    raise ValueError("User context is required for agent creation")
+                # Runtime creation depends on the OWNER identity, not the
+                # acting principal -- guard on the resolved runtime user.
+                if runtime_user is None:
+                    raise ValueError(
+                        "Task owner / runtime user is required for agent creation"
+                    )
 
                 if not db:
                     raise ValueError(
@@ -1347,7 +1441,7 @@ class AgentServiceManager:
                 workspace_owner_id = (
                     int(task.user_id)
                     if task and task.user_id is not None
-                    else int(user.id)
+                    else int(runtime_user.id)
                 )
                 sandbox_workspace_config = {
                     "base_dir": str(get_uploads_dir() / f"user_{workspace_owner_id}"),
@@ -1387,7 +1481,11 @@ class AgentServiceManager:
                 tools = await create_default_tools(
                     db,
                     request=self.request,
-                    user=user,
+                    # Owner, not the acting principal: tool config (models,
+                    # OAuth, KB/MCP/SQL visibility, is_admin scope) must be the
+                    # task owner's. The is_admin tri-state in WebToolConfig keeps
+                    # ``request``'s admin from widening this back.
+                    user=runtime_user,
                     task_id=f"web_task_{task_id}",
                     workspace_owner_id=workspace_owner_id,
                     allowed_collections=agent_config["knowledge_bases"]
@@ -1418,7 +1516,7 @@ class AgentServiceManager:
                     else None,
                 )
 
-                with UserContext(int(user.id)):
+                with UserContext(runtime_user_id):
                     # Unpack tools and tool_config from create_default_tools
                     tools_list, tool_config = tools
 
@@ -1495,7 +1593,9 @@ class AgentServiceManager:
                         from ..models.uploaded_file import UploadedFile
 
                         for selected_file_id in selected_file_ids:
-                            task_owner_id = int(task.user_id) if task else int(user.id)
+                            task_owner_id = (
+                                int(task.user_id) if task else int(runtime_user.id)
+                            )
                             uploaded_file = (
                                 db.query(UploadedFile)
                                 .filter(
@@ -1545,6 +1645,7 @@ class AgentServiceManager:
                 # Re-raise the exception - no fallback logic allowed
                 raise
 
+        self._agent_owner_ids[task_id] = runtime_user_id
         return self._agents[task_id]
 
     def remove_agent(self, task_id: int, user_id: Optional[int] = None) -> None:
@@ -1566,6 +1667,7 @@ class AgentServiceManager:
             logger.info(f"Cleaned up workspace for task {task_id}")
 
             del self._agents[task_id]
+            self._agent_owner_ids.pop(task_id, None)
             logger.info(f"Removed AgentService for task {task_id}")
         else:
             # If agent is not in memory, clean up workspace directory directly

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -155,6 +155,8 @@ async def create_chat_task(
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
             task_owner_user_id=int(agent.user_id),
+            # SDK key resolves to the agent owner; actor == owner here.
+            actor_user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
             kind=TurnKind.CREATE,
             force_fresh=False,
@@ -304,6 +306,8 @@ async def append_message_to_task(
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=int(task.id),
             task_owner_user_id=int(agent.user_id),
+            # SDK key resolves to the agent owner; actor == owner here.
+            actor_user_id=int(agent.user_id),
             payload=TaskTurnPayload(transcript_message=request.message.content),
             kind=TurnKind.APPEND,
             force_fresh=False,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1258,7 +1258,7 @@ async def execute_task_background(
     user_message: str,
     context: Dict[str, Any],
     agent_manager: Any,
-    user_id: int | None,
+    task_owner_user_id: int | None,
     before_message_id: int | None = None,
     llm_user_message: Optional[str] = None,
     task_setup_snapshot: Optional["TaskSetupSnapshot"] = None,
@@ -1309,7 +1309,25 @@ async def execute_task_background(
                 raise ValueError(f"Task {task_id} not found")
             task_user_id = _task_user_id(task)
 
-        effective_user_id = user_id if user_id is not None else task_user_id
+        # The task OWNER (from snapshot / DB) is the runtime identity. A passed
+        # ``task_owner_user_id`` must equal it -- it may never override the
+        # owner, or the task would run as the wrong user (e.g. an admin acting
+        # on someone else's task would get the admin's models / tools / OAuth).
+        # All callers pass the owner; a mismatch is a programming error, so
+        # reject it rather than silently continue.
+        if (
+            task_owner_user_id is not None
+            and task_user_id is not None
+            and task_owner_user_id != task_user_id
+        ):
+            raise ValueError(
+                f"execute_task_background: passed task_owner_user_id "
+                f"{task_owner_user_id} does not match task {task_id} owner "
+                f"{task_user_id}; refusing to run as the wrong user"
+            )
+        effective_user_id = (
+            task_user_id if task_user_id is not None else task_owner_user_id
+        )
         user = (
             db.query(User).filter(User.id == effective_user_id).first()
             if effective_user_id is not None
@@ -1317,12 +1335,15 @@ async def execute_task_background(
         )
 
         with UserContext(effective_user_id):
-            # Get agent service
+            # Get agent service. ``effective_user_id`` is the task owner
+            # (authoritative above); pass it as the runtime identity so the
+            # agent's models / tools resolve as the owner, not any acting admin.
             agent_service = await agent_manager.get_agent_for_task(
                 task_id,
                 db,
                 user=user,
                 task_setup_snapshot=task_setup_snapshot,
+                task_owner_user_id=effective_user_id,
             )
             if hasattr(agent_service, "set_outbound_message_handler"):
                 agent_service.set_outbound_message_handler(
@@ -1683,10 +1704,14 @@ async def execute_task_background(
 async def execute_resume_background(
     task_id: int,
     agent_service: Any,
-    user_id: int | None,
+    task_owner_user_id: int | None,
     previous_task: Optional[asyncio.Task] = None,
 ) -> None:
-    """Resume an agent execution after an interrupt/user-message checkpoint."""
+    """Resume an agent execution after an interrupt/user-message checkpoint.
+
+    ``task_owner_user_id`` is the task OWNER's id -- the runtime identity the
+    resume executes as (``UserContext``), not the acting principal.
+    """
     from ..models.agent import Agent
     from ..models.database import get_db
     from ..models.task import Task, TaskStatus
@@ -1721,6 +1746,23 @@ async def execute_resume_background(
             lease = acquire_task_lease(db_lease, task_id)
             if lease is not None:
                 task_for_sync = db_lease.query(Task).filter(Task.id == task_id).first()
+                # Same owner guard as ``execute_task_background``: the resume
+                # runs under ``UserContext(task_owner_user_id)`` below, so a
+                # passed owner that disagrees with the task row would resume as
+                # the wrong user. All callers pass the owner; a mismatch is a
+                # programming error -- fail loudly rather than run as the wrong
+                # identity.
+                if (
+                    task_for_sync is not None
+                    and task_owner_user_id is not None
+                    and int(task_for_sync.user_id) != task_owner_user_id
+                ):
+                    raise ValueError(
+                        f"execute_resume_background: passed task_owner_user_id "
+                        f"{task_owner_user_id} does not match task {task_id} "
+                        f"owner {int(task_for_sync.user_id)}; refusing to resume "
+                        "as the wrong user"
+                    )
                 if task_for_sync is not None and sync_workforce_run_status(
                     db_lease, task_for_sync, TaskStatus.RUNNING
                 ):
@@ -1737,7 +1779,7 @@ async def execute_resume_background(
             run_task_lease_heartbeat(lease, lease_stop_event)
         )
 
-        with UserContext(user_id):
+        with UserContext(task_owner_user_id):
             result = await agent_service.resume_execution_by_id(str(task_id))
 
         if result is None:
@@ -1748,7 +1790,7 @@ async def execute_resume_background(
         success = bool(result.get("success", False))
         output = str(result.get("output") or result.get("error") or "")
 
-        if user_id is not None:
+        if task_owner_user_id is not None:
             db_gen = get_db()
             db_normalize = next(db_gen)
             try:
@@ -2697,7 +2739,10 @@ async def handle_chat_message(
                 has_continuation = False
                 if task_uses_live_control:
                     agent_service = await get_agent_manager().get_agent_for_task(
-                        task_id, db, user=user
+                        task_id,
+                        db,
+                        user=user,
+                        task_owner_user_id=int(task.user_id),
                     )
                     if hasattr(agent_service, "set_outbound_message_handler"):
                         agent_service.set_outbound_message_handler(
@@ -2843,7 +2888,7 @@ async def handle_chat_message(
                         execute_resume_background(
                             task_id=task_id,
                             agent_service=agent_service,
-                            user_id=int(user.id),
+                            task_owner_user_id=int(task.user_id),
                             previous_task=previous_task,
                         )
                     )
@@ -3054,6 +3099,9 @@ async def handle_chat_message(
                             # check), and the turn must run as the task owner,
                             # not an admin acting on someone else's task.
                             task_owner_user_id=int(task.user_id),
+                            # The acting principal (the admin when acting on
+                            # another user's task) -- audit/logging only.
+                            actor_user_id=int(user.id),
                             payload=payload,
                             kind=turn_kind,
                             force_fresh=turn_force_fresh,
@@ -3269,7 +3317,7 @@ async def handle_execute_task(
 
             agent_manager = get_agent_manager()
             agent_service = await agent_manager.get_agent_for_task(
-                task_id, db, user=user
+                task_id, db, user=user, task_owner_user_id=int(task.user_id)
             )
             if hasattr(agent_service, "set_outbound_message_handler"):
                 agent_service.set_outbound_message_handler(
@@ -3283,8 +3331,11 @@ async def handle_execute_task(
                 recovery_state.get("skill_context")
             )
 
-            # Set up user context
-            with UserContext(user.id):
+            # Set up user context as the task OWNER (runtime identity), not the
+            # acting principal -- an admin executing another user's task must
+            # run with the owner's identity. ``task`` is already loaded and
+            # authorized above.
+            with UserContext(int(task.user_id)):
                 # Build context with vibe mode information if available
                 task_context = {}
                 if hasattr(task, "execution_mode") and task.execution_mode:
@@ -4057,12 +4108,32 @@ async def handle_pause_task(
         db_gen = get_db()
         db = next(db_gen)
 
-        # Get agent service
+        # Authorize the task BEFORE building any runtime: an admin may pause any
+        # task; a non-admin only their own. Loading the task here also gives us
+        # the OWNER, so the agent runtime runs as the owner, not the actor.
+        from ..models.task import Task as _PauseTask
+
+        if user.is_admin:
+            task = db.query(_PauseTask).filter(_PauseTask.id == task_id).first()
+        else:
+            task = (
+                db.query(_PauseTask)
+                .filter(_PauseTask.id == task_id, _PauseTask.user_id == int(user.id))
+                .first()
+            )
+        if task is None:
+            logger.warning(
+                "pause: task %s not found or not owned by user %s", task_id, user.id
+            )
+            raise ValueError(f"Access denied: task {task_id} is not available")
+        task_owner_user_id = int(task.user_id)
+
+        # Get agent service (as the task owner)
         from .chat import get_agent_manager
 
         logger.info(f"Getting agent service for task {task_id}")
         agent_service = await get_agent_manager().get_agent_for_task(
-            task_id, db, user=user
+            task_id, db, user=user, task_owner_user_id=task_owner_user_id
         )
         logger.info(f"Agent service obtained: {type(agent_service).__name__}")
 
@@ -4142,36 +4213,38 @@ async def handle_resume_task(
         db_gen = get_db()
         db = next(db_gen)
 
-        # Get agent service
-        from .chat import get_agent_manager
-
-        try:
-            agent_service = await get_agent_manager().get_agent_for_task(
-                task_id, db, user=user
-            )
-        finally:
-            db.close()
-
         from ..models.task import Task
 
         task: Any | None = None
-        db_update_gen = get_db()
-        db_update = next(db_update_gen)
+        agent_service: Any = None
         try:
+            # Authorize BEFORE building any runtime: an admin may resume any
+            # task, a non-admin only their own. Loading the task here also
+            # yields the OWNER, so the agent runs as the owner (not the actor)
+            # and nothing is built / cached for an unauthorized request.
             if user.is_admin:
-                task = db_update.query(Task).filter(Task.id == task_id).first()
+                task = db.query(Task).filter(Task.id == task_id).first()
             else:
                 task = (
-                    db_update.query(Task)
-                    .filter(Task.id == task_id, Task.user_id == user.id)
+                    db.query(Task)
+                    .filter(Task.id == task_id, Task.user_id == int(user.id))
                     .first()
                 )
-            if not task:
+            if task is None:
                 logger.warning(
                     f"Task {task_id} not found or access denied for user {user.id}"
                 )
+            else:
+                from .chat import get_agent_manager
+
+                agent_service = await get_agent_manager().get_agent_for_task(
+                    task_id,
+                    db,
+                    user=user,
+                    task_owner_user_id=int(task.user_id),
+                )
         finally:
-            db_update.close()
+            db.close()
 
         if task is None:
             await manager.send_personal_message(
@@ -4195,7 +4268,7 @@ async def handle_resume_task(
                 execute_resume_background(
                     task_id=task_id,
                     agent_service=agent_service,
-                    user_id=int(user.id),
+                    task_owner_user_id=int(task.user_id),
                     previous_task=previous_task,
                 )
             )

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -153,7 +153,7 @@ class TaskTurnError(Exception):
 
 class TaskTurnNotFoundError(Exception):
     """Raised when the turn's atomic claim finds no row that both exists
-    and is owned by the calling principal.
+    and is owned by ``task_owner_user_id``.
 
     Deliberately NOT a subclass of :class:`TaskTurnError`: callers map
     ``TaskTurnError`` to 409 (busy / bg_inflight), but a missing or
@@ -163,7 +163,7 @@ class TaskTurnNotFoundError(Exception):
     """
 
     def __init__(self, task_id: int):
-        super().__init__(f"task {task_id} not found or not owned by caller")
+        super().__init__(f"task {task_id} not found or not owned by the task owner")
         self.task_id = task_id
 
 
@@ -208,6 +208,7 @@ class TaskTurnOrchestrator:
         kind: TurnKind,
         force_fresh: bool = False,
         context: Optional[Dict[str, Any]] = None,
+        actor_user_id: Optional[int] = None,
     ) -> TurnStarted:
         """Single entry for any new-turn transition (CREATE / APPEND).
 
@@ -244,6 +245,13 @@ class TaskTurnOrchestrator:
         the entry (e.g. the WS admin bypass), and the turn must still run as
         the owner, not the admin. The claim predicate keeps ``Task.user_id ==
         task_owner_user_id`` as defense-in-depth.
+
+        ``actor_user_id`` is the acting principal that initiated the turn —
+        the same as the owner for normal / SDK / workforce flows, but the
+        admin's id when an admin acts on another user's task. It is recorded
+        for audit/logging only and deliberately does NOT enter the claim,
+        snapshot resolution, ``UserContext``, or tool config; the runtime
+        always runs as ``task_owner_user_id``.
 
         Args:
             task_id: The committed task's id.
@@ -318,6 +326,18 @@ class TaskTurnOrchestrator:
             return res, handle
 
         claimed, bg_task = await asyncio.shield(_claim_and_schedule())
+
+        # Audit who initiated the committed turn. The runtime always runs as
+        # the owner; this only records the acting principal (an admin when
+        # acting on another user's task) and is intentionally not used for any
+        # runtime resolution.
+        logger.info(
+            "turn started: task=%s kind=%s owner=%s actor=%s",
+            task_id,
+            kind,
+            task_owner_user_id,
+            actor_user_id if actor_user_id is not None else task_owner_user_id,
+        )
 
         return TurnStarted(
             task_id=task_id,
@@ -723,7 +743,8 @@ def _schedule_bg(
         writes ``task.status`` and never touches the lease columns;
         the scheduler is responsible for the whole lease lifecycle.
 
-    Takes primitives only (``task_id`` / ``user_id`` / ``task_source``); the
+    Takes primitives only (``task_id`` / ``task_owner_user_id`` /
+    ``task_source``); the
     bg run loads its own snapshot and opens its own sessions, so no
     caller-bound ORM object crosses into the coroutine.
     """
@@ -811,7 +832,7 @@ def _schedule_bg(
                             context, payload.turn_id
                         ),
                         agent_manager=_get_agent_manager(),
-                        user_id=task_owner_user_id,
+                        task_owner_user_id=task_owner_user_id,
                         before_message_id=before_message_id,
                         llm_user_message=payload.execution_message,
                         task_setup_snapshot=snapshot,

--- a/src/xagent/web/services/task_setup_snapshot.py
+++ b/src/xagent/web/services/task_setup_snapshot.py
@@ -106,9 +106,25 @@ class TaskSetupSnapshot:
 # primitive wrapping and runs inside the request session's lifetime.
 
 
+class TaskOwnerMismatchError(Exception):
+    """The task row's owner does not match the expected ``task_owner_user_id``.
+
+    Distinct from "task missing" (which returns ``None``): a missing task is a
+    benign race (deleted before the bg run), whereas an owner mismatch is an
+    identity/authorization inconsistency. Raising keeps the runtime from
+    silently resolving models / tools as the wrong user.
+    """
+
+    def __init__(self, task_id: int, expected: int, actual: int):
+        super().__init__(f"task {task_id} owner {actual} != expected {expected}")
+        self.task_id = task_id
+        self.expected = expected
+        self.actual = actual
+
+
 def load_task_setup_snapshot_sync(
     task_id: int,
-    user_id: Optional[int],
+    task_owner_user_id: Optional[int],
 ) -> Optional[TaskSetupSnapshot]:
     """Open a dedicated ``SessionLocal``, read every synchronous field
     ``get_agent_for_task`` needs for normal (non-reconstruct) creation,
@@ -117,6 +133,12 @@ def load_task_setup_snapshot_sync(
     Designed to be called from the event loop via
     ``await asyncio.to_thread(load_task_setup_snapshot_sync, ...)`` so
     the main loop stays responsive during the read (issue #427).
+
+    ``task_owner_user_id`` is the runtime identity the task runs as. When
+    provided it MUST match the row's ``user_id``; a mismatch raises
+    :class:`TaskOwnerMismatchError` (never silently splits "snapshot owner"
+    from "resolution user"). Model / runtime resolution always uses the
+    row's owner, not the passed value.
 
     Returns ``None`` when the task row is missing -- callers fall back
     to whatever behaviour the legacy in-line code already implements
@@ -130,6 +152,10 @@ def load_task_setup_snapshot_sync(
         task_row = session.query(Task).filter(Task.id == task_id).first()
         if task_row is None:
             return None
+
+        owner_user_id = int(task_row.user_id)
+        if task_owner_user_id is not None and owner_user_id != task_owner_user_id:
+            raise TaskOwnerMismatchError(task_id, task_owner_user_id, owner_user_id)
 
         task_fields = _TaskFields(
             id=int(task_row.id),
@@ -155,7 +181,11 @@ def load_task_setup_snapshot_sync(
             ),
         )
 
-        core = resolve_task_runtime_config_core(task_row, session, user_id=user_id)
+        # Runtime resolution always uses the row's OWNER, never the passed
+        # value (which is validated to match above when provided).
+        core = resolve_task_runtime_config_core(
+            task_row, session, user_id=owner_user_id
+        )
         task_llm, task_fast_llm, task_vision_llm, task_compact_llm = core.llms
 
         # ``core.agent_fields`` is already an ``AgentRuntimeFields``

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -161,6 +161,8 @@ async def create_workforce_run(
         started = await TaskTurnOrchestrator.begin_turn(
             task_id=task_id,
             task_owner_user_id=int(user.id),
+            # Workforce runs as the requesting user; actor == owner here.
+            actor_user_id=int(user.id),
             payload=TaskTurnPayload(transcript_message=normalized_message),
             kind=TurnKind.CREATE,
             force_fresh=False,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -125,7 +125,7 @@ class WebToolConfig(BaseToolConfig):
         db: Any,
         request: Any,
         user_id: Optional[int] = None,
-        is_admin: bool = False,
+        is_admin: Optional[bool] = None,
         user: Optional[Any] = None,
         workspace_config: Optional[Dict[str, Any]] = None,
         vision_model: Optional[Any] = None,
@@ -157,7 +157,18 @@ class WebToolConfig(BaseToolConfig):
         self._user_id = (
             user_id if user_id is not None else self._get_user_id_from_request(request)
         )
-        self._is_admin_value = is_admin or self._get_is_admin_from_request(request)
+        # Tri-state: an explicit ``is_admin`` (including ``False``) is
+        # authoritative and is NOT OR-ed with the request's admin flag. This
+        # is the privilege-isolation boundary: when the runtime builds a tool
+        # config for a task owner (passing ``is_admin=bool(owner.is_admin)``),
+        # an admin *actor* on the request must not silently widen the config
+        # to admin scope. Only when ``is_admin`` is unset do we fall back to
+        # the request.
+        self._is_admin_value = (
+            bool(is_admin)
+            if is_admin is not None
+            else self._get_is_admin_from_request(request)
+        )
         # Initialize workspace_config with base_dir and task_id if provided
         if workspace_config is None:
             workspace_config = {}
@@ -262,18 +273,13 @@ class WebToolConfig(BaseToolConfig):
             return 1
 
     def _get_is_admin_from_request(self, request: Any) -> bool:
-        """Extract is_admin flag from request."""
-        try:
-            # If request has a user attribute directly, check is_admin
-            if hasattr(request, "user") and request.user:
-                return bool(request.user.is_admin)
+        """Extract is_admin flag from the request user, defaulting to False.
 
-            return False
-
-        except Exception as e:
-            logger = logging.getLogger(__name__)
-            logger.warning(f"Failed to get is_admin from request: {e}")
-            return False
+        Uses ``getattr`` so a minimal request object (e.g. one carrying only a
+        user id) doesn't trip the broad ``except`` and log a spurious warning.
+        """
+        user = getattr(request, "user", None)
+        return bool(getattr(user, "is_admin", False)) if user is not None else False
 
     def get_workspace_config(self) -> Optional[Dict[str, Any]]:
         """Get workspace configuration."""

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -218,7 +218,7 @@ async def test_snapshot_path_skips_task_query_keeps_user_query() -> None:
                 user_message="hi",
                 context={},
                 agent_manager=agent_manager,
-                user_id=1,
+                task_owner_user_id=1,
                 task_setup_snapshot=snapshot,
             )
         except Exception:
@@ -251,7 +251,7 @@ async def test_legacy_path_runs_task_and_user_queries() -> None:
                 user_message="hi",
                 context={},
                 agent_manager=agent_manager,
-                user_id=1,
+                task_owner_user_id=1,
                 task_setup_snapshot=None,
             )
         except Exception:

--- a/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
@@ -37,6 +37,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
 from xagent.web.services.task_setup_snapshot import (
+    TaskOwnerMismatchError,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -196,3 +197,84 @@ async def test_no_snapshot_falls_back_to_internal_to_thread() -> None:
         "means either the in-method fallback was removed (breaking WS / "
         "non-passthrough callers) or the snapshot is being loaded twice."
     )
+
+
+@pytest.mark.asyncio
+async def test_wrong_owner_eviction_cleans_up_workspace() -> None:
+    """Evicting a cached AgentService built for a different owner must clean
+    up that wrong-owner workspace before dropping the instance -- otherwise a
+    workspace created under the wrong owner is left on disk. The correct
+    owner's workspace lives at a different user-scoped path and is untouched.
+    """
+    manager = AgentServiceManager()
+    snapshot = _build_snapshot()  # owner == 1
+
+    task_row = Task(
+        id=42,
+        user_id=1,
+        title="snap-pt task",
+        description="snap-pt",
+        status=TaskStatus.PENDING,
+        agent_id=7,
+        agent_type="standard",
+    )
+    db = _build_db_mock(task_row)
+
+    # Seed a cached instance owned by a DIFFERENT user (2).
+    stale_agent = MagicMock()
+    manager._agents[42] = stale_agent
+    manager._agent_owner_ids[42] = 2
+
+    with ExitStack() as stack:
+        for p in _common_patches(manager):
+            stack.enter_context(p)
+        try:
+            # Requesting owner 1 != cached owner 2 -> eviction path.
+            await manager.get_agent_for_task(
+                task_id=42, db=db, task_setup_snapshot=snapshot, task_owner_user_id=1
+            )
+        except Exception:
+            # Downstream stubs may raise after eviction; the eviction
+            # cleanup assertion below is what this test pins.
+            pass
+
+    stale_agent.cleanup_workspace.assert_called_once()
+    # The wrong-owner instance is gone (rebuilt or dropped), not silently kept.
+    assert manager._agents.get(42) is not stale_agent
+
+
+@pytest.mark.asyncio
+async def test_passthrough_snapshot_owner_mismatch_raises() -> None:
+    """A caller-supplied snapshot whose owner disagrees with the
+    requested ``task_owner_user_id`` is an identity fault. The loader's
+    owner guard is bypassed on the passthrough branch, so
+    ``get_agent_for_task`` must re-assert it and raise
+    ``TaskOwnerMismatchError`` -- never swallow it into the default-LLM
+    fallback and build the runtime as the wrong user.
+    """
+    manager = AgentServiceManager()
+    user = _make_user()  # id=1
+    snapshot = _build_snapshot()  # snapshot.task.user_id == 1
+
+    task_row = Task(
+        id=42,
+        user_id=1,
+        title="snap-pt task",
+        description="snap-pt",
+        status=TaskStatus.PENDING,
+        agent_id=7,
+        agent_type="standard",
+    )
+    db = _build_db_mock(task_row)
+
+    with ExitStack() as stack:
+        for p in _common_patches(manager):
+            stack.enter_context(p)
+        with pytest.raises(TaskOwnerMismatchError):
+            await manager.get_agent_for_task(
+                task_id=42,
+                db=db,
+                user=user,
+                task_setup_snapshot=snapshot,
+                task_owner_user_id=999,  # != snapshot owner (1)
+            )

--- a/tests/web/api/test_websocket_error_payload.py
+++ b/tests/web/api/test_websocket_error_payload.py
@@ -220,7 +220,7 @@ async def test_execute_task_background_error_marks_task_failed(_test_db, monkeyp
         user_message="run",
         context={},
         agent_manager=FailingAgentManager(),
-        user_id=user_id,
+        task_owner_user_id=user_id,
     )
 
     assert broadcasts

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1,0 +1,256 @@
+"""Owner/actor regression pins for the WebSocket control handlers.
+
+An admin may operate on another user's task (admin bypass), but the agent
+runtime must run as the task OWNER, not the admin. A non-admin who is not the
+owner must be refused before any runtime is built. These pin the pause / resume
+handlers directly (the focused unit tests cover get_agent_for_task in
+isolation; here we exercise the handlers end to end).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.web.api.websocket import (
+    execute_resume_background,
+    handle_chat_message,
+    handle_pause_task,
+    handle_resume_task,
+)
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'owner_actor.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _user(db, username, *, is_admin=False) -> User:
+    u = User(username=username, password_hash="x", is_admin=is_admin)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
+    t = Task(
+        user_id=owner_id,
+        title="t",
+        description="d",
+        status=status,
+        execution_mode="balanced",
+        source="sdk",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _patched_manager_and_agent():
+    """Return (patches contextmanagers, captured) wiring get_agent_manager +
+    the module ``manager`` so the handler can run without real IO."""
+    captured: dict = {}
+    agent_service = MagicMock()
+    agent_service.pause_execution = AsyncMock(return_value={"status": "paused"})
+    agent_service.resume_execution = AsyncMock()
+    agent_service.supports_live_control = MagicMock(return_value=False)
+
+    async def _get_agent_for_task(task_id, db, *, user=None, task_owner_user_id=None):
+        captured["task_owner_user_id"] = task_owner_user_id
+        return agent_service
+
+    mgr = MagicMock()
+    mgr.get_agent_for_task = AsyncMock(side_effect=_get_agent_for_task)
+
+    ws_manager = MagicMock()
+    ws_manager.send_personal_message = AsyncMock()
+    ws_manager.broadcast_to_task = AsyncMock()
+    return captured, agent_service, mgr, ws_manager
+
+
+@pytest.mark.asyncio
+async def test_chat_admin_append_to_other_users_task_claims_as_owner(
+    db_session,
+) -> None:
+    """The original #587 regression: an admin appending through
+    ``handle_chat_message`` to a task owned by another user. The bug was the
+    atomic claim using the actor id, so the owner's appendable task failed with
+    ``TaskTurnNotFoundError``. Pin that ``begin_turn`` is invoked with
+    ``task_owner_user_id == task.user_id`` (the owner), not the admin actor.
+    """
+    owner = _user(db_session, "owner")
+    admin = _user(db_session, "admin", is_admin=True)
+    # COMPLETED -> the WS path treats the follow-up as an APPEND turn.
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+
+    ws_manager = MagicMock()
+    ws_manager.broadcast_to_task = AsyncMock()
+    ws_manager.send_personal_message = AsyncMock()
+    begin_turn = AsyncMock()
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {"message": "follow-up", "user": admin, "files": []},
+        )
+
+    begin_turn.assert_awaited_once()
+    assert begin_turn.await_args.kwargs["task_owner_user_id"] == int(owner.id)
+
+
+@pytest.mark.asyncio
+async def test_pause_admin_on_other_users_task_runs_as_owner(db_session) -> None:
+    owner = _user(db_session, "owner")
+    admin = _user(db_session, "admin", is_admin=True)
+    task = _task(db_session, owner.id)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await handle_pause_task(MagicMock(), int(task.id), {"user": admin})
+
+    # Built and paused as the OWNER, not the admin actor.
+    assert captured["task_owner_user_id"] == int(owner.id)
+    agent.pause_execution.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pause_non_owner_non_admin_is_refused(db_session) -> None:
+    owner = _user(db_session, "owner")
+    stranger = _user(db_session, "stranger")  # not admin, not owner
+    task = _task(db_session, owner.id)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        # The handler authorizes the task away and handles the denial
+        # internally; the point is that no owner runtime is built / paused.
+        await handle_pause_task(MagicMock(), int(task.id), {"user": stranger})
+
+    assert "task_owner_user_id" not in captured
+    agent.pause_execution.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_admin_on_other_users_task_runs_as_owner(db_session) -> None:
+    owner = _user(db_session, "owner")
+    admin = _user(db_session, "admin", is_admin=True)
+    task = _task(db_session, owner.id)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await handle_resume_task(MagicMock(), int(task.id), {"user": admin})
+
+    assert captured["task_owner_user_id"] == int(owner.id)
+
+
+@pytest.mark.asyncio
+async def test_resume_live_control_admin_runs_background_as_owner(db_session) -> None:
+    """Live-control resume schedules ``execute_resume_background``; when an
+    admin resumes another user's task it must run with the OWNER's
+    UserContext, i.e. ``task_owner_user_id`` is the owner, not the admin."""
+    owner = _user(db_session, "owner")
+    admin = _user(db_session, "admin", is_admin=True)
+    task = _task(db_session, owner.id)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+    agent.supports_live_control = MagicMock(return_value=True)
+
+    resume_bg = AsyncMock()
+    bg_mgr = MagicMock()
+    bg_mgr.running_tasks.get = MagicMock(return_value=None)
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_resume_task(MagicMock(), int(task.id), {"user": admin})
+
+    # Agent built as owner, and the background resume runs as owner.
+    assert captured["task_owner_user_id"] == int(owner.id)
+    resume_bg.assert_called_once()
+    assert resume_bg.call_args.kwargs["task_owner_user_id"] == int(owner.id)
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_background_rejects_owner_mismatch(db_session) -> None:
+    """``execute_resume_background`` runs the resume under
+    ``UserContext(task_owner_user_id)``. If a caller passes an owner id that
+    disagrees with the task row, the symmetric guard (same as
+    ``execute_task_background``) must fire before the agent resumes, so the
+    runtime never executes as the wrong user."""
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id)
+
+    agent = MagicMock()
+    agent.resume_execution_by_id = AsyncMock()
+    ws_manager = MagicMock()
+    ws_manager.broadcast_to_task = AsyncMock()
+
+    with (
+        patch("xagent.web.api.websocket.acquire_task_lease", return_value=object()),
+        patch("xagent.web.api.websocket.release_task_lease_with_workforce_sync"),
+        patch("xagent.web.api.websocket.stop_task_lease_heartbeat", new=AsyncMock()),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id) + 999,  # != task owner
+        )
+
+    # Guard fired before the resume ran -- nothing executed as the wrong user.
+    agent.resume_execution_by_id.assert_not_awaited()
+    error_types = {
+        msg.get("type")
+        for (msg, _tid) in (
+            call.args for call in ws_manager.broadcast_to_task.call_args_list
+        )
+        if isinstance(msg, dict)
+    }
+    assert "task_error" in error_types
+
+
+@pytest.mark.asyncio
+async def test_resume_non_owner_non_admin_is_refused(db_session) -> None:
+    owner = _user(db_session, "owner")
+    stranger = _user(db_session, "stranger")
+    task = _task(db_session, owner.id)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await handle_resume_task(MagicMock(), int(task.id), {"user": stranger})
+
+    # Authorized away before any runtime is built; an error is sent back.
+    assert "task_owner_user_id" not in captured
+    ws_manager.send_personal_message.assert_awaited()

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -15,6 +15,7 @@ require an actual agent runtime (``execute_task_background``).
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -306,6 +307,48 @@ async def test_begin_turn_passes_force_fresh_through_to_schedule_bg(
         .one()
     )
     assert persisted.turn_id == payload.turn_id
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_actor_is_audit_only_not_runtime(
+    db_session,
+    mock_schedule_bg,
+    caplog,
+) -> None:
+    """``actor_user_id`` records who initiated the turn (an admin acting on
+    another user's task) for audit/logging only. It must never reach the
+    claim or the bg schedule -- those run as the OWNER -- and it must appear
+    in the audit log line."""
+    owner = _create_user(db_session)
+    task = _create_task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    actor_id = int(owner.id) + 999  # a different principal (e.g. an admin)
+
+    with caplog.at_level(logging.INFO, logger="xagent.web.services.task_orchestrator"):
+        await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            payload=TaskTurnPayload("follow-up"),
+            task_owner_user_id=int(owner.id),
+            actor_user_id=actor_id,
+            kind=TurnKind.APPEND,
+        )
+
+    # The bg schedule runs as the owner; the actor never leaks into it.
+    kwargs = mock_schedule_bg.call_args.kwargs
+    assert kwargs["task_owner_user_id"] == int(owner.id)
+    assert actor_id not in kwargs.values()
+
+    # The persisted user message is attributed to the owner, not the actor.
+    persisted = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.task_id == int(task.id), TaskChatMessage.role == "user")
+        .one()
+    )
+    assert persisted.user_id == int(owner.id)
+
+    # The actor is captured in the audit log.
+    assert "turn started" in caplog.text
+    assert f"owner={int(owner.id)}" in caplog.text
+    assert f"actor={actor_id}" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_setup_snapshot.py
+++ b/tests/web/services/test_task_setup_snapshot.py
@@ -99,8 +99,31 @@ def _create_agent(db, user_id: int, **overrides) -> Agent:
 def test_returns_none_when_task_missing(db_session) -> None:
     """A task_id with no matching row must yield ``None``, mirroring
     the legacy ``else`` branch's "Task not found" fallback."""
-    snapshot = load_task_setup_snapshot_sync(task_id=99999, user_id=1)
+    snapshot = load_task_setup_snapshot_sync(task_id=99999, task_owner_user_id=1)
     assert snapshot is None
+
+
+def test_owner_mismatch_raises_distinct_from_missing(db_session) -> None:
+    """Identity guard: a task that exists but is owned by a different user
+    must raise ``TaskOwnerMismatchError`` -- NOT return ``None`` (which means
+    "task missing"). Keeps runtime model/tool resolution from running as the
+    wrong user, and lets callers tell a vanished task apart from an identity
+    inconsistency."""
+    from xagent.web.services.task_setup_snapshot import TaskOwnerMismatchError
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user_id=int(user.id))
+
+    with pytest.raises(TaskOwnerMismatchError):
+        load_task_setup_snapshot_sync(
+            task_id=int(task.id), task_owner_user_id=int(user.id) + 9999
+        )
+
+    # None owner skips the check (backward compat for callers without an owner).
+    assert (
+        load_task_setup_snapshot_sync(task_id=int(task.id), task_owner_user_id=None)
+        is not None
+    )
 
 
 def test_basic_task_no_agent_builder(db_session) -> None:
@@ -110,7 +133,9 @@ def test_basic_task_no_agent_builder(db_session) -> None:
     user = _create_user(db_session)
     task = _create_task(db_session, user_id=int(user.id))
 
-    snapshot = load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
 
     assert snapshot is not None
     assert isinstance(snapshot, TaskSetupSnapshot)
@@ -151,7 +176,9 @@ def test_agent_builder_published_sets_excluded_agent_id(db_session) -> None:
         execution_mode=None,  # let agent-builder execution_mode take over downstream
     )
 
-    snapshot = load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
 
     assert snapshot is not None
     assert snapshot.agent is not None
@@ -182,7 +209,9 @@ def test_agent_builder_draft_no_excluded_agent_id(db_session) -> None:
     )
     task = _create_task(db_session, user_id=int(user.id), agent_id=int(agent.id))
 
-    snapshot = load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
 
     assert snapshot is not None
     assert snapshot.agent is not None
@@ -205,7 +234,7 @@ def test_task_pattern_derived_from_execution_mode(db_session) -> None:
     for mode, expected_pattern in cases:
         task = _create_task(db_session, user_id=int(user.id), execution_mode=mode)
         snapshot = load_task_setup_snapshot_sync(
-            task_id=int(task.id), user_id=int(user.id)
+            task_id=int(task.id), task_owner_user_id=int(user.id)
         )
         assert snapshot is not None
         assert snapshot.task_pattern == expected_pattern, (
@@ -230,7 +259,9 @@ def test_no_orm_leak_in_returned_fields(db_session) -> None:
     agent = _create_agent(db_session, user_id=int(user.id))
     task = _create_task(db_session, user_id=int(user.id), agent_id=int(agent.id))
 
-    snapshot = load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
     assert snapshot is not None
 
     # The frozen container.
@@ -291,7 +322,9 @@ def test_snapshot_frozen_dataclass(db_session) -> None:
 
     user = _create_user(db_session)
     task = _create_task(db_session, user_id=int(user.id))
-    snapshot = load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
     assert snapshot is not None
 
     with pytest.raises(FrozenInstanceError):
@@ -325,7 +358,9 @@ def test_session_closes_even_when_loader_raises(db_session) -> None:
         side_effect=boom,
     ):
         with pytest.raises(RuntimeError, match="simulated llm-resolve failure"):
-            load_task_setup_snapshot_sync(task_id=int(task.id), user_id=int(user.id))
+            load_task_setup_snapshot_sync(
+                task_id=int(task.id), task_owner_user_id=int(user.id)
+            )
 
     # If the session leaked, this fresh query would block / fail on
     # SQLite (single-writer) or exhaust the pool elsewhere. A clean

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -877,7 +877,7 @@ def test_task_create_allows_policy_visible_published_agent(
 
         snapshot = load_task_setup_snapshot_sync(
             int(task.id),
-            user_id=int(task.user_id),
+            task_owner_user_id=int(task.user_id),
         )
         assert snapshot is not None
         assert snapshot.agent is not None

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -144,7 +144,7 @@ async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
 
     class AgentManager:
         async def get_agent_for_task(
-            self, task_id, db, user=None, task_setup_snapshot=None
+            self, task_id, db, user=None, task_setup_snapshot=None, **kwargs
         ):
             captured["agent_db"] = db
             return AgentService()
@@ -194,7 +194,7 @@ async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
         user_message="重试",
         context={},
         agent_manager=AgentManager(),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         llm_user_message="重试",
     )
 
@@ -302,7 +302,7 @@ async def test_completion_broadcast_failure_keeps_task_completed(
         user_message="hi",
         context={},
         agent_manager=AgentManager(),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         llm_user_message="hi",
     )
 
@@ -352,7 +352,7 @@ async def test_execution_failure_routes_real_error_to_terminal_payload(
         user_message="hi",
         context={},
         agent_manager=AgentManager(),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         llm_user_message="hi",
     )
 
@@ -405,7 +405,7 @@ async def test_assistant_persist_failure_surfaces_as_task_failure(
         user_message="hi",
         context={},
         agent_manager=AgentManager(),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         llm_user_message="hi",
     )
 
@@ -455,7 +455,7 @@ async def test_empty_reply_turn_still_completes(db_session, monkeypatch):
         user_message="hi",
         context={},
         agent_manager=AgentManager(),
-        user_id=int(user.id),
+        task_owner_user_id=int(user.id),
         llm_user_message="hi",
     )
 

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -1,0 +1,47 @@
+"""Privilege-isolation pins for WebToolConfig identity.
+
+When the runtime builds a tool config for a task OWNER while an admin is the
+acting principal on the request, the config must reflect the owner -- not get
+silently widened to admin scope by the request.
+"""
+
+from types import SimpleNamespace
+
+from xagent.web.tools.config import WebToolConfig
+
+
+def _admin_request(actor_user_id: int = 999):
+    """A request whose authenticated user is an admin (the acting principal)."""
+    return SimpleNamespace(user=SimpleNamespace(id=actor_user_id, is_admin=True))
+
+
+def test_explicit_is_admin_false_wins_over_admin_request() -> None:
+    """Tri-state: an explicit ``is_admin=False`` (the owner's status) is
+    authoritative and is NOT OR-ed with the admin request. Otherwise an admin
+    acting on another user's task would get admin-scoped tools/visibility."""
+    cfg = WebToolConfig(
+        db=None,
+        request=_admin_request(actor_user_id=999),
+        user_id=42,  # the task owner
+        is_admin=False,  # owner is not an admin
+    )
+    assert cfg.get_user_id() == 42
+    assert cfg.is_admin() is False
+
+
+def test_unset_is_admin_falls_back_to_request() -> None:
+    """When ``is_admin`` is unset (None), fall back to the request's user --
+    preserves behavior for callers that don't pass an explicit value."""
+    cfg = WebToolConfig(
+        db=None,
+        request=_admin_request(actor_user_id=7),
+        user_id=7,
+    )
+    assert cfg.is_admin() is True
+
+
+def test_minimal_request_without_user_is_not_admin() -> None:
+    """A minimal request carrying only an id (no ``user``) must resolve to
+    non-admin without raising / logging a spurious warning."""
+    cfg = WebToolConfig(db=None, request=SimpleNamespace(), user_id=5)
+    assert cfg.is_admin() is False


### PR DESCRIPTION
## Background

A task has two identities that used to be collapsed into one `user_id`:

- the task **owner** — whose models, tools, OAuth accounts, knowledge bases
  and files a run should use
- the **actor** — the authenticated principal performing the action

They are the same for normal users, SDK, and workforce, but differ when an
admin operates on another user's task. Passing the actor where the owner was
expected both rejected admins appending to another user's task and could run
the task with the admin's models / tools / visibility.

## What this changes

The runtime resolves the task owner and uses it everywhere a run needs an
identity; the actor stays at the entry points for authorization.

- The turn-start path takes `task_owner_user_id` (the owner), derived from the
  already-authorized task/agent, used for the claim, the persisted message and
  the background run.
- `execute_task_background` treats the task's owner (snapshot/DB) as the runtime
  identity and rejects a passed id that disagrees.
- `load_task_setup_snapshot_sync` validates the owner and resolves models as the
  owner; an owner mismatch raises, distinct from a missing task.
- `get_agent_for_task` takes an explicit owner and resolves the runtime identity
  as the owner (explicit -> snapshot -> task row -> acting user); its tracer,
  snapshot load, default-model fallback, tool creation and `UserContext` all use
  the owner. `create_default_tools`' user is the owner.
- `WebToolConfig.is_admin` is tri-state: an explicit value (including `False`)
  is authoritative and is no longer OR-ed with the request's admin flag, so an
  admin actor cannot widen an owner's tool config to admin scope.
- `AgentServiceManager` keys an owner alongside the `task_id` cache and evicts
  an instance built for a different owner.
- The WebSocket pause / resume / execute handlers authorize the task first, then
  build and run as the owner; `execute_resume_background` runs `UserContext` as
  the owner.

Authorization is unchanged and stays at the entry points (WebSocket admin
bypass / ownership check, SDK key to agent, workforce).

## Tests

Pins for an admin acting on another user's task running as the owner, the
snapshot owner-mismatch raising distinct from a missing task, and
`WebToolConfig` resolving the owner's id and non-admin status even with an admin
request. Turn-lifecycle, snapshot, SDK and workforce tests updated.

Closes #587
