### PR TITLE
Feat/python sdk skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,57 @@ jobs:
           set -e
           python3 -m uv run python -m pytest tests/e2e --run-special -q
 
+  sdk-python:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ensure uv is available
+        shell: bash
+        run: |
+          set -e
+          if ! command -v uv >/dev/null 2>&1; then
+            echo "uv not found, installing..."
+            python3 -m pip install --user uv
+            echo "$HOME/.local/bin" >> $GITHUB_PATH
+          fi
+          python3 -m uv --version || uv --version
+
+      - name: Create virtual environment
+        shell: bash
+        run: |
+          set -e
+          _UV="python3 -m uv"
+          $_UV --version
+          $_UV venv --python 3.12
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -e
+          python3 -m uv sync
+
+      - name: Install SDK (editable)
+        shell: bash
+        run: |
+          set -e
+          python3 -m uv pip install -e ./sdks/python
+
+      - name: Run SDK tests
+        shell: bash
+        # cd into the SDK package so pytest discovers sdks/python/pyproject.toml
+        # (testpaths=tests, no asyncio_mode) rather than the repo-root config
+        # which is tuned for the main test suite. Use ../../.venv directly --
+        # `uv run` would walk upward and re-resolve against the root project.
+        working-directory: ./sdks/python
+        run: |
+          set -e
+          ../../.venv/bin/python -m pytest -v
+
   frontend-build:
     runs-on: ubuntu-latest
     needs: pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,8 @@ examples/*.html
 # But keep skills markdown files and test markdown files
 !src/xagent/skills/**/*.md
 !tests/resources/test_files/*.md
+# And SDK documentation under sdks/<lang>/
+!sdks/**/*.md
 
 .DS_Store
 uploads/

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,173 @@
+# Xagent Python SDK
+
+Official Python client for the Xagent public `/v1/*` HTTP API.
+
+> Status: **Alpha**. Tracks roadmap [issue #82](https://github.com/xorbitsai/xagent/issues/82) → *Python SDK (P2)*. Surface area is intentionally limited to the v1 contract documented in `src/xagent/web/api/v1/`.
+
+## Documentation
+
+Full user guide lives under [`docs/`](./docs/index.md):
+
+| | |
+| --- | --- |
+| [Quickstart](./docs/quickstart.md) | Install → key → first task in five minutes. |
+| [Authentication](./docs/authentication.md) | Personal vs agent runtime keys, rotation, revocation. |
+| [Agents API](./docs/agents.md) | `client.agents.*` — manage agents. |
+| [Tasks API](./docs/tasks.md) | `client.tasks.*` — drive task lifecycle. |
+| [Error Handling](./docs/errors.md) | Typed exceptions and retry recipes. |
+| [Examples](./docs/examples.md) | Multi-turn, async pipeline, polling, metadata. |
+| [API Reference](./docs/api-reference.md) | Method signatures, models, exception hierarchy. |
+
+The README below is a condensed overview; the docs are authoritative.
+
+## Install
+
+> ⚠️ **Not yet published to PyPI.** The `xagent-sdk` name is reserved
+> for this package but no release has been cut while the surface is
+> still in review against [issue #82](https://github.com/xorbitsai/xagent/issues/82).
+> Install from a checkout of the repo for now:
+
+```bash
+# From the repo root
+pip install -e sdks/python
+```
+
+Once a release ships, install will be:
+
+```bash
+pip install xagent-sdk    # not available yet
+```
+
+## Authentication
+
+The SDK uses bearer tokens. Two kinds exist on the server side, both
+shaped like `xag_<6-char prefix>_<32-char secret>`:
+
+| Kind         | Bound to     | Used for                                                                 |
+| ------------ | ------------ | ------------------------------------------------------------------------ |
+| **Personal** | A user       | Manage agents under the calling user (`client.agents.*`, `client.me()`)  |
+| **Agent**    | One agent    | Drive a specific agent's task lifecycle (`client.tasks.*`)               |
+
+Pass whichever key matches the surface you intend to call as `api_key=...`.
+The two kinds look identical on the wire — the server picks the right
+auth path from the key prefix — so callers usually hold one of each and
+instantiate two clients.
+
+> The server returns each `full_key` **only once** (at create / rotate
+> time) and stores a bcrypt hash thereafter. Persist it as soon as you
+> see it; lost keys must be rotated.
+
+### Getting a Personal key
+
+Personal keys are created against the logged-in web session (JWT
+cookie), not via the SDK itself. From the Xagent web UI, open
+**Settings → Personal API Keys → Create**, or call the underlying
+endpoint directly:
+
+```bash
+# Authenticated with the web session (JWT cookie / Authorization header)
+curl -X POST https://<your-host>/api/me/personal-keys
+# -> {"full_key": "xag_abc123_...", "key_prefix": "abc123", "created_at": "..."}
+```
+
+Companion endpoints:
+
+- `GET    /api/me/personal-keys`             — list (metadata only)
+- `DELETE /api/me/personal-keys/{key_id}`    — revoke
+
+### Getting an Agent runtime key
+
+You can get an agent runtime key in two ways.
+
+**(a) Create the agent through the SDK** with `generate_runtime_key=True`
+(the default) and read it from the response:
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url="http://localhost:8000",
+                  api_key="xag_<personal key>") as client:
+    result = client.agents.create(
+        name="my-agent",
+        instructions="You are a helpful assistant.",
+    )
+    runtime_key = result.api_key.full_key   # <-- persist this now
+    agent_id = result.agent.id
+```
+
+**(b) Rotate / create against an existing agent** via the SDK:
+
+```python
+new_key = client.agents.rotate_runtime_key(agent_id).full_key
+```
+
+Or with the raw endpoints (web session auth):
+
+```bash
+curl -X POST   https://<your-host>/api/agents/<agent_id>/api-key   # create / rotate
+curl -X GET    https://<your-host>/api/agents/<agent_id>/api-key   # metadata
+curl -X DELETE https://<your-host>/api/agents/<agent_id>/api-key   # revoke
+```
+
+## Sync example
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(
+    base_url="http://localhost:8000",
+    api_key="xag_<agent runtime key>",
+) as client:
+    task = client.tasks.create(agent_id=42, message="Summarise today's news.")
+    info = client.tasks.wait_for_completion(task.task_id)
+    print(info.status, info.output)
+```
+
+## Async example
+
+```python
+import asyncio
+from xagent_sdk import AsyncXagentClient
+
+async def main():
+    async with AsyncXagentClient(
+        base_url="http://localhost:8000",
+        api_key="xag_<agent runtime key>",
+    ) as client:
+        task = await client.tasks.create(agent_id=42, message="hi")
+        info = await client.tasks.wait_for_completion(task.task_id)
+        print(info.output)
+
+asyncio.run(main())
+```
+
+## Error handling
+
+All non-2xx responses are translated into typed exceptions whose names
+mirror the server-side `V1ErrorCode` enum:
+
+```python
+from xagent_sdk import TaskBusyError, InvalidApiKeyError
+
+try:
+    client.tasks.append_message(task_id, agent_id=42, message="next turn")
+except TaskBusyError:
+    ...  # poll get() until the task leaves the running state
+except InvalidApiKeyError:
+    ...  # refresh / rotate the key
+```
+
+Unknown error codes (added later on the server) fall back to the
+`XagentApiError` base class so the SDK stays forward compatible.
+
+## Testing
+
+```bash
+cd sdks/python
+pip install -e ".[dev]"
+pytest
+```
+
+Tests use [`httpx.MockTransport`](https://www.python-httpx.org/advanced/transports/#mock-transports)
+to stub responses so no server is required and `pytest` is the only
+test dependency.

--- a/sdks/python/docs/agents.md
+++ b/sdks/python/docs/agents.md
@@ -1,0 +1,151 @@
+# Agents API
+
+`client.agents.*` is the **control plane** namespace — manage agents
+under the calling user. All methods here require a **personal API key**.
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key="xag_personal_...") as client:
+    ...
+```
+
+The async counterpart is `AsyncXagentClient.agents.*`; every method
+below has an awaitable mirror with identical arguments.
+
+## `client.me()` / `client.agents.me()`
+
+Identity probe — confirm a personal key works and see who it belongs to.
+
+```python
+me = client.agents.me()
+# Me(principal_type='user', user_id=7, username='alice',
+#    email='alice@example.com', key_prefix='abc123')
+```
+
+| Returns | `Me` |
+| --- | --- |
+
+## `client.agents.list()`
+
+List every agent the calling user owns (summary only — no instructions
+or model config).
+
+```python
+agents = client.agents.list()
+for a in agents:
+    print(a.id, a.name, a.status)
+```
+
+| Returns | `list[AgentSummary]` |
+| --- | --- |
+
+## `client.agents.create(...)`
+
+Create a new agent. Optionally returns a fresh runtime key in the same
+response (see [Authentication](./authentication.md#a-generated-at-agent-creation)).
+
+```python
+result = client.agents.create(
+    name="support-bot",
+    description="Triages support tickets.",
+    instructions="You are a calm, accurate support agent.",
+    execution_mode="balanced",          # "flash" | "balanced" | "think" | "auto"
+    models={...},                       # optional model overrides
+    knowledge_bases=["kb_support"],     # optional KB ids
+    skills=[],                          # optional skill ids
+    tool_categories=["web"],            # optional tool category names
+    suggested_prompts=["Reset my password"],
+    generate_runtime_key=True,          # default: mint a runtime key too
+)
+
+agent_id = result.agent.id
+runtime_key = result.api_key.full_key   # None if generate_runtime_key=False
+```
+
+| Required | `name: str` |
+| --- | --- |
+| Returns | `CreateAgentResult(agent: Agent, api_key: RuntimeKey \| None)` |
+| Raises | `InvalidInputError` (duplicate name, bad models config, unknown KB), `XagentApiError` |
+
+## `client.agents.create_from_template(...)`
+
+Same as `create`, but inherits defaults from a server-side template.
+Only `template_id` is required; everything else, when omitted, comes
+from the template.
+
+```python
+result = client.agents.create_from_template(
+    template_id="template-customer-support",
+    name="my-custom-support-bot",        # optional override
+)
+```
+
+| Required | `template_id: str` |
+| --- | --- |
+| Returns | `CreateAgentResult` |
+| Raises | `TemplateNotFoundError`, `InvalidInputError`, `XagentApiError` |
+
+## `client.agents.rotate_runtime_key(agent_id)`
+
+Mint a new runtime key for an existing agent. The old key (if any)
+remains valid until you separately revoke it via the web management
+endpoint — this gives you a window for hot-swap deploys.
+
+```python
+new_key = client.agents.rotate_runtime_key(agent_id)
+# RuntimeKey(full_key='xag_agent_xyz...', key_prefix='xyz...', created_at=...)
+```
+
+| Returns | `RuntimeKey` |
+| --- | --- |
+| Raises | `AgentNotFoundError`, `XagentApiError` |
+
+> Like all key responses, `full_key` is returned **only this once**.
+> Persist it before the function returns to your caller.
+
+## Return models — at a glance
+
+```python
+class Me:
+    principal_type: str       # always "user"
+    user_id: int
+    username: str
+    email: str | None
+    key_prefix: str           # public-safe lookup handle of the presented key
+
+class AgentSummary:
+    id: int
+    name: str
+    description: str | None
+    logo_url: str | None
+    status: str
+    created_at: str
+    updated_at: str
+    widget_enabled: bool
+    allowed_domains: list[str]
+
+class Agent(AgentSummary):
+    # ...plus full config:
+    user_id: int
+    instructions: str | None
+    execution_mode: str
+    models: dict | None
+    knowledge_bases: list[str]
+    skills: list[str]
+    tool_categories: list[str]
+    suggested_prompts: list[str]
+    published_at: str | None
+
+class RuntimeKey:
+    full_key: str
+    key_prefix: str
+    created_at: datetime
+
+class CreateAgentResult:
+    agent: Agent
+    api_key: RuntimeKey | None
+```
+
+All models tolerate unknown fields (`model_config = ConfigDict(extra="ignore")`),
+so a newer server can add response fields without breaking the SDK.

--- a/sdks/python/docs/api-reference.md
+++ b/sdks/python/docs/api-reference.md
@@ -1,0 +1,242 @@
+# API Reference
+
+Quick lookup for every public symbol exported from `xagent_sdk`.
+
+Conceptual guides live in [Agents](./agents.md), [Tasks](./tasks.md),
+[Authentication](./authentication.md), and [Error Handling](./errors.md).
+
+## Top-level exports
+
+```python
+from xagent_sdk import (
+    # Clients
+    XagentClient, AsyncXagentClient,
+
+    # Errors
+    XagentError, XagentApiError,
+    InvalidApiKeyError, AgentNotFoundError, TaskNotFoundError,
+    TemplateNotFoundError, TaskBusyError, InvalidInputError,
+    RateLimitedError, InternalServerError,
+
+    # Models
+    Me, RuntimeKey, Agent, AgentSummary, CreateAgentResult,
+    CreateTaskResponse, AppendMessageResponse,
+    TaskInfo, PublicStep, StepsResponse,
+)
+```
+
+`__version__` is exposed on the package: `xagent_sdk.__version__`.
+
+---
+
+## Clients
+
+### `XagentClient(*, base_url, api_key, timeout=30.0, httpx_client=None)`
+
+Synchronous client.
+
+| Argument | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `base_url` | `str` | — | Server root, e.g. `"http://localhost:8000"`. Trailing slash is normalised. |
+| `api_key` | `str` | — | Bearer token (`xag_<kind>_<prefix>_<secret>`). |
+| `timeout` | `float` | `30.0` | Per-request timeout, in seconds. |
+| `httpx_client` | `httpx.Client \| None` | `None` | Inject your own. When provided, **you** own its lifecycle. |
+
+Attributes / methods:
+
+| | |
+| --- | --- |
+| `.agents: AgentsAPI` | Personal-key control plane. |
+| `.tasks: TasksAPI` | Agent runtime-key data plane. |
+| `.me() -> Me` | Shortcut for `.agents.me()`. |
+| `.close() -> None` | Close the underlying `httpx.Client` (only if owned). |
+| `__enter__` / `__exit__` | Context-manager closes on exit. |
+
+### `AsyncXagentClient(...)`
+
+Same constructor signature as `XagentClient`. Differences:
+
+| | |
+| --- | --- |
+| `.agents: AsyncAgentsAPI` | All methods are awaitable. |
+| `.tasks: AsyncTasksAPI` | All methods are awaitable. |
+| `await .me() -> Me` | Awaitable shortcut. |
+| `await .aclose()` | Async close. |
+| `__aenter__` / `__aexit__` | `async with` support. |
+
+---
+
+## `client.agents` (sync) / `client.agents` on `AsyncXagentClient` (async)
+
+| Method | Returns | Raises (typed) |
+| --- | --- | --- |
+| `me()` | `Me` | `InvalidApiKeyError` |
+| `list()` | `list[AgentSummary]` | `InvalidApiKeyError` |
+| `create(*, name, description=None, instructions=None, execution_mode="balanced", models=None, knowledge_bases=None, skills=None, tool_categories=None, suggested_prompts=None, generate_runtime_key=True)` | `CreateAgentResult` | `InvalidInputError`, `InvalidApiKeyError` |
+| `create_from_template(*, template_id, name=None, description=None, instructions=None, execution_mode=None, models=None, knowledge_bases=None, skills=None, tool_categories=None, suggested_prompts=None, generate_runtime_key=True)` | `CreateAgentResult` | `TemplateNotFoundError`, `InvalidInputError`, `InvalidApiKeyError` |
+| `rotate_runtime_key(agent_id: int)` | `RuntimeKey` | `AgentNotFoundError`, `InvalidApiKeyError` |
+
+All methods may additionally raise `InternalServerError`, the generic
+`XagentApiError` (unknown future code), or an `httpx.HTTPError` for
+network failures.
+
+---
+
+## `client.tasks` (sync) / `client.tasks` on `AsyncXagentClient` (async)
+
+| Method | Returns | Raises (typed) |
+| --- | --- | --- |
+| `create(*, agent_id: int, message: str, metadata: dict \| None = None)` | `CreateTaskResponse` | `AgentNotFoundError`, `InvalidInputError`, `InvalidApiKeyError` |
+| `append_message(task_id: int, *, agent_id: int, message: str, metadata: dict \| None = None)` | `AppendMessageResponse` | `TaskNotFoundError`, `AgentNotFoundError`, `TaskBusyError`, `InvalidInputError`, `InvalidApiKeyError` |
+| `get(task_id: int)` | `TaskInfo` | `TaskNotFoundError`, `InvalidApiKeyError` |
+| `get_steps(task_id: int)` | `StepsResponse` | `TaskNotFoundError`, `InvalidApiKeyError` |
+| `wait_for_completion(task_id: int, *, poll_interval: float = 1.0, timeout: float \| None = 300.0)` | terminal `TaskInfo` | `TaskTimeoutError`, plus anything `get` would raise |
+
+`TaskTimeoutError` is importable from `xagent_sdk.tasks`. It subclasses
+`XagentError`, **not** `XagentApiError`, because no HTTP failure
+occurred.
+
+---
+
+## Models
+
+All models are Pydantic v2, with `model_config = ConfigDict(extra="ignore")` —
+unknown server fields are silently dropped so the SDK survives
+forward-compatible server changes.
+
+### `Me`
+```python
+principal_type: str       # always "user"
+user_id: int
+username: str
+email: str | None
+key_prefix: str           # public-safe handle of the presented key
+```
+
+### `RuntimeKey`
+```python
+full_key: str             # returned ONCE, persist it now
+key_prefix: str
+created_at: datetime
+```
+
+### `AgentSummary`
+```python
+id: int
+name: str
+description: str | None
+logo_url: str | None
+status: str
+created_at: str
+updated_at: str
+widget_enabled: bool
+allowed_domains: list[str]
+```
+
+### `Agent`
+Superset of `AgentSummary`. Additional fields:
+```python
+user_id: int
+instructions: str | None
+execution_mode: str
+models: dict | None
+knowledge_bases: list[str]
+skills: list[str]
+tool_categories: list[str]
+suggested_prompts: list[str]
+published_at: str | None
+```
+
+### `CreateAgentResult`
+```python
+agent: Agent
+api_key: RuntimeKey | None    # None if generate_runtime_key=False
+```
+
+### `CreateTaskResponse`
+```python
+task_id: int
+agent_id: int
+status: str                   # "running" on 202 Accepted
+created_at: datetime
+```
+
+### `AppendMessageResponse`
+```python
+task_id: int
+agent_id: int
+status: str
+accepted_at: datetime
+```
+
+### `TaskInfo`
+```python
+task_id: int
+agent_id: int
+status: str                   # pending | running | paused | completed | failed
+input: str | None             # latest-turn user message
+output: str | None            # latest-turn assistant reply (when completed)
+error: str | None             # set when status == "failed"
+created_at: datetime
+completed_at: datetime | None
+# Convenience:
+is_terminal: bool             # property: status in {"completed", "failed"}
+```
+
+### `PublicStep`
+```python
+id: str                       # "tool_call:abc123" -- stable across re-polls
+type: Literal["thinking", "tool_call", "agent_delegation", "message"]
+status: Literal["running", "completed", "failed"]
+started_at: datetime
+completed_at: datetime | None
+data: dict[str, Any]
+```
+
+`data` keys depend on `type`:
+
+| `type` | `data` shape |
+| --- | --- |
+| `thinking` | `{"phase": "planning" \| "step" \| "action"}` |
+| `tool_call` | `{"name": str, "args": Any, "result"?: Any, "error"?: str}` |
+| `agent_delegation` | `{"sub_agent_name": str, "input"?: Any, "output"?: Any}` |
+| `message` | `{"role": "user" \| "assistant", "content": str}` |
+
+Treat unknown keys as forward-compat extensions; ignore them.
+
+### `StepsResponse`
+```python
+task_id: int
+agent_id: int
+steps: list[PublicStep]       # started_at ascending
+```
+
+---
+
+## Exception hierarchy
+
+```
+XagentError                                # base
+├── XagentApiError                         # HTTP error envelope
+│   ├── InvalidApiKeyError                 # 401
+│   ├── AgentNotFoundError                 # 404
+│   ├── TaskNotFoundError                  # 404
+│   ├── TemplateNotFoundError              # 404
+│   ├── TaskBusyError                      # 409
+│   ├── InvalidInputError                  # 400 / 422
+│   ├── RateLimitedError                   # 429 (reserved)
+│   └── InternalServerError                # 5xx
+└── TaskTimeoutError                       # wait_for_completion timed out
+```
+
+Common attributes on every `XagentApiError`:
+
+```python
+status_code: int
+code: str            # stable V1ErrorCode, or "unknown"
+message: str | None
+response_body: Any   # parsed body, for debugging
+```
+
+Network and JSON-decode failures propagate as their underlying
+`httpx.HTTPError` / `ValueError` types — not wrapped.

--- a/sdks/python/docs/authentication.md
+++ b/sdks/python/docs/authentication.md
@@ -1,0 +1,114 @@
+# Authentication
+
+The SDK uses bearer tokens. Two kinds exist on the server side, both
+shaped like `xag_<kind>_<prefix>_<secret>`:
+
+| Kind         | Bound to     | Used for                                                                 |
+| ------------ | ------------ | ------------------------------------------------------------------------ |
+| **Personal** | A user       | Manage agents under the calling user (`client.agents.*`, `client.me()`)  |
+| **Agent**    | One agent    | Drive a specific agent's task lifecycle (`client.tasks.*`)               |
+
+Pass whichever key matches the surface you intend to call as `api_key=...`.
+The two kinds look identical on the wire — the server picks the right
+auth path from the `kind` segment in the key — so callers usually hold
+one of each and instantiate two clients.
+
+## Security model
+
+- Each `full_key` is returned **once**, at create or rotate time. The
+  server only stores a bcrypt hash thereafter. **Persist immediately;
+  lost keys must be rotated.**
+- Both kinds support revocation. Revoked keys 401 with
+  `invalid_api_key` (indistinguishable from "bad secret" by design —
+  attackers cannot enumerate live prefixes by error code or timing).
+- Personal keys belong to a user; agent runtime keys belong to one
+  agent. Compromising an agent key only grants access to that agent's
+  task surface, not to other agents or to agent management.
+
+## Personal keys
+
+Created against a logged-in web session (JWT). From the web UI, open
+**Settings → Personal API Keys → Create**, or call the underlying
+endpoint directly:
+
+```bash
+# Authenticated with the web session (JWT cookie / Authorization header)
+curl -X POST https://<your-host>/api/me/personal-keys
+# -> {"full_key": "xag_personal_abc123_...", "key_prefix": "abc123", "created_at": "..."}
+```
+
+Companion endpoints:
+
+| Method | Path                                       | Purpose            |
+| ------ | ------------------------------------------ | ------------------ |
+| GET    | `/api/me/personal-keys`                    | List (metadata only — `key_prefix`, `created_at`, never `full_key`). |
+| DELETE | `/api/me/personal-keys/{key_id}`           | Revoke.            |
+
+### Identity probe
+
+To confirm a personal key works:
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key="xag_personal_...") as client:
+    me = client.agents.me()
+    print(me.user_id, me.username, me.key_prefix)
+```
+
+## Agent runtime keys
+
+You have two ways to obtain one.
+
+### (a) Generated at agent creation
+
+`client.agents.create(..., generate_runtime_key=True)` (the default)
+returns the agent **and** a runtime key in a single response:
+
+```python
+with XagentClient(base_url=BASE_URL, api_key="xag_personal_...") as ctrl:
+    result = ctrl.agents.create(name="my-agent", instructions="...")
+    runtime_key = result.api_key.full_key       # persist this now
+    agent_id = result.agent.id
+```
+
+Set `generate_runtime_key=False` if you want to create the agent now
+and mint the key separately later.
+
+### (b) Rotate / mint an existing agent's key
+
+```python
+new_key = ctrl.agents.rotate_runtime_key(agent_id).full_key
+```
+
+Or via the raw endpoints (web session auth):
+
+```bash
+curl -X POST   https://<your-host>/api/agents/<agent_id>/api-key   # create / rotate
+curl -X GET    https://<your-host>/api/agents/<agent_id>/api-key   # metadata
+curl -X DELETE https://<your-host>/api/agents/<agent_id>/api-key   # revoke
+```
+
+## Recommended deployment pattern
+
+For a server-side service that talks to Xagent:
+
+1. **Create the personal key once**, store in your secret manager.
+2. On first deploy, use the personal key to `client.agents.create(...)`
+   for each agent you need and capture `result.api_key.full_key`.
+3. Store the runtime keys in your secret manager keyed by `agent_id`.
+4. Production code reads only the runtime key matching the agent it
+   wants to drive — the personal key never has to be online in the
+   request path.
+
+## Rotation playbook
+
+- **Routine rotation** (e.g. every 90 days): call
+  `client.agents.rotate_runtime_key(agent_id)` to mint a new key.
+  Push it into your secret manager, then revoke the old `key_id` via
+  `DELETE /api/agents/{agent_id}/api-key`.
+- **Compromise**: revoke first (DELETE), then mint a new one. The
+  revoked key starts returning `InvalidApiKeyError` immediately.
+
+See [Error Handling](./errors.md) for how `InvalidApiKeyError` is
+surfaced and how to wire automatic key reload on detection.

--- a/sdks/python/docs/errors.md
+++ b/sdks/python/docs/errors.md
@@ -1,0 +1,178 @@
+# Error Handling
+
+Every non-2xx response from `/v1/*` follows a stable envelope:
+
+```json
+{"error": {"code": "<V1ErrorCode>", "message": "<text>"}}
+```
+
+The SDK translates each `code` into a typed exception so callers can
+`except TaskBusyError:` instead of string-matching. The full hierarchy:
+
+```
+XagentError                       # base for everything the SDK raises
+├── XagentApiError                # any non-2xx HTTP response (fallback)
+│   ├── InvalidApiKeyError        # 401  invalid_api_key
+│   ├── AgentNotFoundError        # 404  agent_not_found
+│   ├── TaskNotFoundError         # 404  task_not_found
+│   ├── TemplateNotFoundError     # 404  template_not_found
+│   ├── TaskBusyError             # 409  task_busy
+│   ├── InvalidInputError         # 400/422  invalid_input
+│   ├── RateLimitedError          # 429  rate_limited (reserved)
+│   └── InternalServerError       # 5xx  internal_error
+└── (network errors, JSON decode errors -> XagentError)
+```
+
+Each exception carries:
+
+| Attribute | Type | Meaning |
+| --- | --- | --- |
+| `status_code` | `int` | HTTP status returned by the server. |
+| `code` | `str` | Stable `V1ErrorCode` value. `"unknown"` if the body didn't match the envelope. |
+| `message` | `str \| None` | Human-readable text. May change without notice. |
+| `response_body` | `Any` | Raw decoded body for debugging. |
+
+## Forward compatibility
+
+If the server adds a new error code, old SDK versions surface it as
+`XagentApiError` (the base class) — your `except` for known codes
+still fires correctly, and unknown ones don't crash:
+
+```python
+try:
+    client.tasks.create(agent_id=42, message="hi")
+except TaskBusyError:
+    ...      # handle 409
+except XagentApiError as e:
+    # New code from a future server release, or one you don't handle.
+    log.warning("api error %s: %s", e.code, e.message)
+```
+
+## Recipes
+
+### `InvalidApiKeyError` — refresh & retry
+
+Triggers when the key is missing, malformed, **or revoked**. The right
+response is almost never "retry the same call":
+
+```python
+from xagent_sdk import InvalidApiKeyError, XagentClient
+
+def call_with_key_reload():
+    api_key = secret_manager.get("xagent_runtime_key")
+    try:
+        with XagentClient(base_url=BASE, api_key=api_key) as c:
+            return c.tasks.get(task_id)
+    except InvalidApiKeyError:
+        # Refresh from secret manager in case ops rotated.
+        api_key = secret_manager.reload("xagent_runtime_key")
+        with XagentClient(base_url=BASE, api_key=api_key) as c:
+            return c.tasks.get(task_id)
+```
+
+### `TaskBusyError`
+
+Returned when you call `append_message` while the previous turn is
+still running. The fix is to poll the snapshot until the task leaves
+`running`:
+
+```python
+import time
+from xagent_sdk import TaskBusyError
+
+def append_when_ready(client, task_id, agent_id, message, *, max_wait=120):
+    deadline = time.monotonic() + max_wait
+    while True:
+        try:
+            return client.tasks.append_message(
+                task_id, agent_id=agent_id, message=message
+            )
+        except TaskBusyError:
+            if time.monotonic() >= deadline:
+                raise
+            # Give the previous turn time to finish.
+            info = client.tasks.get(task_id)
+            if info.is_terminal:
+                continue            # retry immediately
+            time.sleep(1.0)
+```
+
+Or simpler — just `wait_for_completion` first:
+
+```python
+client.tasks.wait_for_completion(task_id)
+client.tasks.append_message(task_id, agent_id=agent_id, message=message)
+```
+
+### `RateLimitedError` — exponential backoff
+
+Reserved for future use; the server doesn't emit it yet, but you can
+already wire the handler:
+
+```python
+import time
+from xagent_sdk import RateLimitedError
+
+def with_backoff(fn, *, attempts=5):
+    delay = 1.0
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except RateLimitedError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay)
+            delay *= 2
+```
+
+### `AgentNotFoundError` / `TaskNotFoundError`
+
+Both are returned as **404** intentionally (never 403) so the existence
+of other tenants' resources isn't leaked. If you're sure the id is
+correct, the most likely cause is "this key isn't bound to that agent" —
+i.e. you're using the wrong runtime key.
+
+### `InternalServerError`
+
+The server has a bug or an upstream dependency failed. The exception
+message is sanitized — to debug, check the server's logs (the raw
+exception stays on the server side, never in the response).
+
+Retry sparingly; in the worst case treat it as terminal for the task
+and surface the failure to the end user.
+
+### Network / timeout errors
+
+These come from `httpx` and propagate as their original type
+(`httpx.ConnectError`, `httpx.ReadTimeout`, …). They subclass
+`httpx.HTTPError`, not `XagentError`. If you want to catch both:
+
+```python
+import httpx
+from xagent_sdk import XagentError
+
+try:
+    client.tasks.get(task_id)
+except (XagentError, httpx.HTTPError) as e:
+    ...
+```
+
+## Customising timeouts
+
+`XagentClient` accepts a `timeout=` (seconds) or a pre-configured
+`httpx_client=` for fine control:
+
+```python
+import httpx
+from xagent_sdk import XagentClient
+
+httpx_client = httpx.Client(
+    base_url=BASE,
+    timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0),
+    transport=httpx.HTTPTransport(retries=2),
+)
+client = XagentClient(base_url=BASE, api_key="...", httpx_client=httpx_client)
+```
+
+When you pass an `httpx_client`, the SDK does **not** close it — you
+remain responsible for `httpx_client.close()` / `aclose()`.

--- a/sdks/python/docs/examples.md
+++ b/sdks/python/docs/examples.md
@@ -1,0 +1,190 @@
+# Examples
+
+Recipes for common usage patterns. Every snippet assumes:
+
+```python
+BASE_URL = "http://localhost:8000"
+PERSONAL_KEY = "xag_personal_..."     # control plane
+RUNTIME_KEY  = "xag_agent_..."        # data plane (one specific agent)
+```
+
+## Multi-turn conversation
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key=RUNTIME_KEY) as data:
+    task = data.tasks.create(
+        agent_id=AGENT_ID,
+        message="I'd like to plan a trip to Tokyo.",
+    )
+    print(data.tasks.wait_for_completion(task.task_id).output)
+
+    data.tasks.append_message(
+        task.task_id, agent_id=AGENT_ID,
+        message="Make it a 5-day itinerary.",
+    )
+    print(data.tasks.wait_for_completion(task.task_id).output)
+
+    data.tasks.append_message(
+        task.task_id, agent_id=AGENT_ID,
+        message="What's the budget range?",
+    )
+    print(data.tasks.wait_for_completion(task.task_id).output)
+```
+
+`append_message` extends the same `task_id` — there is no "conversation
+id" separate from the task. See [Tasks API → lifecycle](./tasks.md#task-lifecycle)
+for the state machine.
+
+## Async pipeline
+
+```python
+import asyncio
+from xagent_sdk import AsyncXagentClient
+
+async def run(prompts: list[str]) -> list[str]:
+    async with AsyncXagentClient(base_url=BASE_URL, api_key=RUNTIME_KEY) as data:
+        # Fire all tasks concurrently...
+        creates = await asyncio.gather(*[
+            data.tasks.create(agent_id=AGENT_ID, message=p)
+            for p in prompts
+        ])
+        # ...then wait for each to terminate.
+        results = await asyncio.gather(*[
+            data.tasks.wait_for_completion(c.task_id) for c in creates
+        ])
+        return [r.output or "" for r in results]
+
+asyncio.run(run(["Summarise X", "Translate Y", "Explain Z"]))
+```
+
+## Polling vs `wait_for_completion`
+
+`wait_for_completion` is a thin polling loop. If you need progress
+updates between polls (status, latest step), poll yourself:
+
+```python
+import time
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key=RUNTIME_KEY) as data:
+    task = data.tasks.create(agent_id=AGENT_ID, message="long-running query")
+
+    while True:
+        info = data.tasks.get(task.task_id)
+        steps = data.tasks.get_steps(task.task_id).steps
+        print(info.status, f"({len(steps)} steps)")
+        if info.is_terminal:
+            break
+        time.sleep(1.0)
+
+    print("final output:", info.output)
+```
+
+## Tool & step inspection
+
+Iterate over the public timeline to see what tools the agent invoked:
+
+```python
+steps = data.tasks.get_steps(task_id).steps
+for s in steps:
+    if s.type == "tool_call":
+        print(f"  → {s.data['name']}({s.data.get('args')!r})")
+        if s.status == "completed":
+            print(f"     ← {s.data.get('result')!r}")
+        elif s.status == "failed":
+            print(f"     ✗ {s.data.get('error')!r}")
+```
+
+## Round-trip your own correlation ids
+
+`metadata` is a free-form dict the server stores but does not interpret
+— ideal for trace ids, request ids, or any client-side bookkeeping you
+want to find later in logs:
+
+```python
+task = data.tasks.create(
+    agent_id=AGENT_ID,
+    message="reset my password",
+    metadata={
+        "trace_id": "trace-abc-123",
+        "incoming_request_id": "req-987",
+        "user_segment": "premium",
+    },
+)
+```
+
+> `metadata` does not appear in any of the SDK response models today —
+> the value is opaque to the SDK. To inspect it, use the server's web
+> UI or query the database directly.
+
+## Use one shared `httpx.Client` across SDK clients
+
+If you instantiate two SDK clients (one with the personal key, one with
+the runtime key), they each open their own `httpx.Client` by default.
+For a hot path with connection pooling concerns, share one:
+
+```python
+import httpx
+from xagent_sdk import XagentClient
+
+shared = httpx.Client(base_url=BASE_URL, timeout=30.0)
+
+ctrl = XagentClient(base_url=BASE_URL, api_key=PERSONAL_KEY, httpx_client=shared)
+data = XagentClient(base_url=BASE_URL, api_key=RUNTIME_KEY, httpx_client=shared)
+
+try:
+    ctrl.agents.me()
+    data.tasks.get(some_task_id)
+finally:
+    # The SDK does NOT close httpx clients you passed in.
+    shared.close()
+```
+
+The auth header is set per-request, so two SDK clients sharing one
+underlying `httpx.Client` don't bleed credentials across calls.
+
+## Hot-swap a rotated runtime key
+
+```python
+import time
+from xagent_sdk import InvalidApiKeyError, XagentClient
+
+def with_auto_reload(call):
+    """Retry once if the cached key was revoked under us."""
+    api_key = secrets.get("xagent_runtime_key")
+    while True:
+        with XagentClient(base_url=BASE_URL, api_key=api_key) as c:
+            try:
+                return call(c)
+            except InvalidApiKeyError:
+                fresh = secrets.reload("xagent_runtime_key")
+                if fresh == api_key:
+                    raise           # really revoked, not just stale cache
+                api_key = fresh
+                time.sleep(0.1)
+
+with_auto_reload(lambda c: c.tasks.create(agent_id=AGENT_ID, message="hi"))
+```
+
+## Create-then-run, in one script
+
+End-to-end from "nothing" to "task result":
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key=PERSONAL_KEY) as ctrl:
+    created = ctrl.agents.create(
+        name="example-agent",
+        instructions="You answer concisely.",
+    )
+    agent_id = created.agent.id
+    runtime_key = created.api_key.full_key  # persist this in real code
+
+with XagentClient(base_url=BASE_URL, api_key=runtime_key) as data:
+    task = data.tasks.create(agent_id=agent_id, message="Why is the sky blue?")
+    result = data.tasks.wait_for_completion(task.task_id)
+    print(result.output)
+```

--- a/sdks/python/docs/index.md
+++ b/sdks/python/docs/index.md
@@ -1,0 +1,34 @@
+# Xagent Python SDK — Documentation
+
+A typed Python client for the Xagent public `/v1/*` HTTP API.
+
+If you've never used Xagent or the SDK before, start with the
+**[Quickstart](./quickstart.md)** — five minutes from `pip install` to a
+running task.
+
+## Contents
+
+| Guide | What it covers |
+| --- | --- |
+| **[Quickstart](./quickstart.md)** | Install, get a key, create an agent, run a task. |
+| **[Authentication](./authentication.md)** | The two key kinds (`personal` / `agent`), how to get them, how to rotate. |
+| **[Agents API](./agents.md)** | `client.agents.*` — manage agents under your account. |
+| **[Tasks API](./tasks.md)** | `client.tasks.*` — drive an agent's task lifecycle. |
+| **[Error Handling](./errors.md)** | Typed exceptions and recommended retry patterns. |
+| **[Examples](./examples.md)** | Multi-turn chat, async usage, polling, metadata round-trip. |
+| **[API Reference](./api-reference.md)** | Method signatures, parameters, return types. |
+
+## Versioning & compatibility
+
+| | |
+| --- | --- |
+| SDK package | `xagent-sdk` (name reserved; **not yet released to PyPI** — install from repo, see [Quickstart](./quickstart.md#1-install)) |
+| Tracks server API | `/v1/*` (stable contract, see [`web/api/v1/`](../../../src/xagent/web/api/v1/)) |
+| Forward compatibility | Unknown response fields → ignored. Unknown error codes → fall back to `XagentApiError`. |
+| Python | 3.10+ |
+| Runtime dependencies | `httpx`, `pydantic` |
+
+## Getting help
+
+- Bugs & feature requests: open an issue on [github.com/xorbitsai/xagent](https://github.com/xorbitsai/xagent/issues).
+- Roadmap item this SDK tracks: [issue #82 — Python SDK (P2)](https://github.com/xorbitsai/xagent/issues/82).

--- a/sdks/python/docs/quickstart.md
+++ b/sdks/python/docs/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart
+
+From zero to a running task in five minutes.
+
+## 1. Install
+
+> ⚠️ **Not yet on PyPI.** While roadmap [issue #82](https://github.com/xorbitsai/xagent/issues/82)
+> is still in review, install from a checkout of the repo:
+
+```bash
+# From the repo root
+pip install -e sdks/python
+```
+
+Once a release ships the install will be `pip install xagent-sdk` — but
+that name returns 404 on PyPI today, so don't try it yet.
+
+The SDK pulls in only `httpx` and `pydantic` — it does **not** drag in
+the server runtime.
+
+## 2. Get your API keys
+
+You need **two** bearer tokens (both shaped like `xag_<kind>_<prefix>_<secret>`):
+
+| Key | Used for | How to get it |
+| --- | --- | --- |
+| Personal | `client.agents.*`, `client.me()` | Web UI → **Settings → Personal API Keys → Create**, or `POST /api/me/personal-keys` with a JWT session. |
+| Agent runtime | `client.tasks.*` | Created automatically when you `client.agents.create(...)` (default `generate_runtime_key=True`); or rotate with `client.agents.rotate_runtime_key(agent_id)`. |
+
+Full details, including rotation and revocation: [Authentication](./authentication.md).
+
+> Each `full_key` is returned **only once** at create/rotate time. Persist it
+> immediately; lost keys must be rotated.
+
+## 3. Create an agent and grab its runtime key
+
+```python
+from xagent_sdk import XagentClient
+
+PERSONAL_KEY = "xag_personal_..."   # from step 2
+BASE_URL = "http://localhost:8000"  # your Xagent server
+
+with XagentClient(base_url=BASE_URL, api_key=PERSONAL_KEY) as ctrl:
+    result = ctrl.agents.create(
+        name="quickstart-agent",
+        instructions="You are a helpful assistant.",
+    )
+
+agent_id = result.agent.id
+runtime_key = result.api_key.full_key     # <-- persist this now
+print(f"agent_id={agent_id}, runtime_key={runtime_key}")
+```
+
+## 4. Run a task and wait for the result
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key=runtime_key) as data:
+    task = data.tasks.create(agent_id=agent_id, message="Say hi in three languages.")
+    info = data.tasks.wait_for_completion(task.task_id)
+    print(info.status, "\n", info.output)
+```
+
+`wait_for_completion` polls `GET /v1/chat/tasks/{id}` (default every 1 s,
+timeout 300 s). Tune with `poll_interval=` / `timeout=`.
+
+## 5. Async variant
+
+Every method has an async counterpart on `AsyncXagentClient`:
+
+```python
+import asyncio
+from xagent_sdk import AsyncXagentClient
+
+async def main():
+    async with AsyncXagentClient(base_url=BASE_URL, api_key=runtime_key) as data:
+        task = await data.tasks.create(agent_id=agent_id, message="hi")
+        info = await data.tasks.wait_for_completion(task.task_id)
+        print(info.output)
+
+asyncio.run(main())
+```
+
+## Next steps
+
+- [Agents API](./agents.md) — list, create, rotate keys.
+- [Tasks API](./tasks.md) — create, append turns, inspect steps.
+- [Error Handling](./errors.md) — typed exceptions and retry recipes.
+- [Examples](./examples.md) — multi-turn chat, metadata, custom httpx clients.

--- a/sdks/python/docs/tasks.md
+++ b/sdks/python/docs/tasks.md
@@ -1,0 +1,185 @@
+# Tasks API
+
+`client.tasks.*` is the **data plane** namespace — drive a single
+agent's task lifecycle. All methods here require an **agent runtime
+key** bound to the target agent.
+
+```python
+from xagent_sdk import XagentClient
+
+with XagentClient(base_url=BASE_URL, api_key="xag_agent_...") as data:
+    ...
+```
+
+The async counterpart is `AsyncXagentClient.tasks.*`; every method
+below has an awaitable mirror with identical arguments.
+
+## Task lifecycle
+
+```
+┌────────────┐  create   ┌────────────┐  bg turn ends  ┌────────────────────┐
+│  (no row)  │ ────────▶ │  running   │ ─────────────▶ │ completed / failed │
+└────────────┘           └────────────┘                └────────────────────┘
+                            ▲    │
+                  append    │    │  poll (snapshot / steps)
+                            │    ▼
+                       (another turn)
+```
+
+- `POST /v1/chat/tasks` returns **202 Accepted** with `status="running"` —
+  the server has atomically claimed the row before responding.
+- The task stays `running` while the background turn executes.
+- `append_message` is only valid when the task is **not** running
+  (otherwise 409 `task_busy`).
+- Reaching `completed` or `failed` is terminal — `wait_for_completion`
+  resolves at that point.
+
+## `client.tasks.create(agent_id=..., message=..., metadata=...)`
+
+Kick off a brand-new task and its first turn.
+
+```python
+task = client.tasks.create(
+    agent_id=agent_id,
+    message="Summarise yesterday's news.",
+    metadata={"trace_id": "abc-123"},   # optional, free-form pass-through
+)
+# CreateTaskResponse(task_id=42, agent_id=..., status='running',
+#                    created_at=datetime(..., tzinfo=utc))
+```
+
+| Required | `agent_id: int`, `message: str` |
+| --- | --- |
+| Optional | `metadata: dict \| None` — round-tripped, not interpreted server-side |
+| Returns | `CreateTaskResponse` |
+| Raises | `AgentNotFoundError`, `InvalidInputError`, `InvalidApiKeyError` |
+
+> `agent_id` must match the agent bound to your runtime key. Server
+> returns 404 `agent_not_found` (not 403) on mismatch — by design, so
+> the existence of other agents isn't leaked.
+
+## `client.tasks.append_message(task_id, agent_id=..., message=..., metadata=...)`
+
+Continue an existing task with the next user message. Only valid after
+the previous turn has terminated (`completed` / `failed`).
+
+```python
+turn = client.tasks.append_message(
+    task_id=task.task_id,
+    agent_id=agent_id,
+    message="Translate that into Spanish.",
+)
+# AppendMessageResponse(task_id=..., agent_id=..., status='running',
+#                       accepted_at=datetime(...))
+```
+
+| Returns | `AppendMessageResponse` |
+| --- | --- |
+| Raises | `TaskNotFoundError`, `AgentNotFoundError` (body `agent_id` mismatch), `TaskBusyError` (previous turn still running), `InvalidApiKeyError` |
+
+See [Error Handling — task_busy retry pattern](./errors.md#taskbusyerror)
+for a robust polling loop.
+
+## `client.tasks.get(task_id)`
+
+Snapshot of the task's current state. The fields reflect the **latest
+turn**: `input` is its user message, `output` is the assistant reply
+(set when status reaches `completed`), `error` is set when `failed`.
+
+```python
+info = client.tasks.get(task.task_id)
+# TaskInfo(task_id=42, agent_id=..., status='completed',
+#          input='Summarise yesterday\'s news.',
+#          output='Here are the top three stories...',
+#          error=None,
+#          created_at=..., completed_at=...)
+
+if info.is_terminal:
+    print(info.output if info.status == "completed" else info.error)
+```
+
+| Returns | `TaskInfo` (has convenience `.is_terminal` property) |
+| --- | --- |
+| Raises | `TaskNotFoundError`, `InvalidApiKeyError` |
+
+## `client.tasks.get_steps(task_id)`
+
+The public-timeline view of what the agent did. Four stable step types:
+
+| Type | `data` keys |
+| --- | --- |
+| `thinking` | `phase: "planning" \| "step" \| "action"` |
+| `tool_call` | `name`, `args`, `result?`, `error?` |
+| `agent_delegation` | `sub_agent_name`, `input?`, `output?` |
+| `message` | `role: "user" \| "assistant"`, `content` |
+
+```python
+steps = client.tasks.get_steps(task.task_id)
+for s in steps.steps:
+    print(s.started_at, s.type, s.status, s.data)
+```
+
+Steps appear in `started_at` ascending order. In-flight steps have
+`status="running"` and `completed_at=None`, so this endpoint is safe to
+poll while the task is still running.
+
+| Returns | `StepsResponse` |
+| --- | --- |
+| Raises | `TaskNotFoundError`, `InvalidApiKeyError` |
+
+## `client.tasks.wait_for_completion(task_id, *, poll_interval=1.0, timeout=300.0)`
+
+Convenience helper: polls `get(task_id)` until status is terminal.
+
+```python
+info = client.tasks.wait_for_completion(task.task_id, poll_interval=0.5, timeout=60)
+```
+
+| Returns | terminal `TaskInfo` |
+| --- | --- |
+| Raises | `TaskTimeoutError` (deadline reached), plus anything `get()` would raise |
+
+`timeout=None` waits indefinitely.
+
+Async version: `await async_client.tasks.wait_for_completion(...)`. It
+uses `asyncio.sleep` between polls, so other coroutines keep running.
+
+## Return models — at a glance
+
+```python
+class CreateTaskResponse:
+    task_id: int
+    agent_id: int
+    status: str            # "running" on the 202 response
+    created_at: datetime
+
+class AppendMessageResponse:
+    task_id: int
+    agent_id: int
+    status: str
+    accepted_at: datetime
+
+class TaskInfo:
+    task_id: int
+    agent_id: int
+    status: str            # pending | running | paused | completed | failed
+    input: str | None
+    output: str | None
+    error: str | None
+    created_at: datetime
+    completed_at: datetime | None
+    is_terminal: bool      # property: status in {"completed", "failed"}
+
+class PublicStep:
+    id: str                # "tool_call:abc123" — type-prefixed, stable across re-polls
+    type: Literal["thinking", "tool_call", "agent_delegation", "message"]
+    status: Literal["running", "completed", "failed"]
+    started_at: datetime
+    completed_at: datetime | None
+    data: dict[str, Any]
+
+class StepsResponse:
+    task_id: int
+    agent_id: int
+    steps: list[PublicStep]
+```

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "xagent-sdk"
+version = "0.1.0"
+description = "Official Python SDK for the Xagent /v1/* HTTP API."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Xagent Contributors" },
+]
+keywords = ["xagent", "agent", "sdk", "ai"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Typing :: Typed",
+]
+dependencies = [
+  "httpx>=0.27.0",
+  "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+  "mypy>=1.10.0",
+  "ruff>=0.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/xorbitsai/xagent"
+Issues = "https://github.com/xorbitsai/xagent/issues"
+Source = "https://github.com/xorbitsai/xagent/tree/main/sdks/python"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/xagent_sdk"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sdks/python/src/xagent_sdk/__init__.py
+++ b/sdks/python/src/xagent_sdk/__init__.py
@@ -1,0 +1,111 @@
+"""Xagent Python SDK.
+
+A thin, typed Python client for the Xagent public ``/v1/*`` HTTP API
+(see ``src/xagent/web/api/v1`` in the main repo). The SDK ships two
+parallel client trees that share request shaping, auth, and error
+translation:
+
+  - :class:`XagentClient` -- synchronous, backed by ``httpx.Client``
+  - :class:`AsyncXagentClient` -- asyncio, backed by ``httpx.AsyncClient``
+
+Both clients expose the same surface area split into two namespaces
+that mirror the two server-side auth schemes:
+
+  - ``client.agents`` -- personal management key (``xag_<...>``,
+    ``PERSONAL`` kind). Lists / creates / rotates agents under the
+    calling user, plus ``client.me()`` for the identity probe.
+  - ``client.tasks`` -- agent runtime key (``xag_<...>``, ``AGENT``
+    kind). Creates / appends / polls SDK-owned tasks against the
+    bound agent.
+
+Both auth kinds are bearer tokens, so SDK callers usually instantiate
+two clients side by side -- one with their personal key for control
+plane work, one with an agent runtime key for the data plane.
+
+Error envelope (``{"error": {"code": ..., "message": ...}}``) is
+translated into the typed exceptions exported below so callers can
+``except AgentNotFoundError:`` instead of string-matching.
+
+Example (sync):
+
+    from xagent_sdk import XagentClient
+
+    with XagentClient(base_url="http://localhost:8000",
+                      api_key="xag_abc123_...") as client:
+        task = client.tasks.create(agent_id=42, message="Hello")
+        info = client.tasks.wait_for_completion(task.task_id)
+        print(info.output)
+
+Example (async):
+
+    import asyncio
+    from xagent_sdk import AsyncXagentClient
+
+    async def main():
+        async with AsyncXagentClient(
+            base_url="http://localhost:8000",
+            api_key="xag_abc123_...",
+        ) as client:
+            task = await client.tasks.create(agent_id=42, message="Hi")
+            info = await client.tasks.wait_for_completion(task.task_id)
+            print(info.output)
+
+    asyncio.run(main())
+"""
+
+from .client import AsyncXagentClient, XagentClient
+from .errors import (
+    AgentNotFoundError,
+    InternalServerError,
+    InvalidApiKeyError,
+    InvalidInputError,
+    RateLimitedError,
+    TaskBusyError,
+    TaskNotFoundError,
+    TemplateNotFoundError,
+    XagentApiError,
+    XagentError,
+)
+from .models import (
+    Agent,
+    AgentSummary,
+    AppendMessageResponse,
+    CreateAgentResult,
+    CreateTaskResponse,
+    Me,
+    PublicStep,
+    RuntimeKey,
+    StepsResponse,
+    TaskInfo,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    # Clients
+    "XagentClient",
+    "AsyncXagentClient",
+    # Errors
+    "XagentError",
+    "XagentApiError",
+    "InvalidApiKeyError",
+    "AgentNotFoundError",
+    "TaskNotFoundError",
+    "TemplateNotFoundError",
+    "TaskBusyError",
+    "InvalidInputError",
+    "RateLimitedError",
+    "InternalServerError",
+    # Models
+    "Me",
+    "RuntimeKey",
+    "Agent",
+    "AgentSummary",
+    "CreateAgentResult",
+    "CreateTaskResponse",
+    "AppendMessageResponse",
+    "TaskInfo",
+    "PublicStep",
+    "StepsResponse",
+]

--- a/sdks/python/src/xagent_sdk/_http.py
+++ b/sdks/python/src/xagent_sdk/_http.py
@@ -10,6 +10,13 @@ wrap ``httpx.Client`` / ``httpx.AsyncClient`` respectively. They both
 return parsed JSON for 2xx responses and raise the appropriate
 :class:`XagentApiError` subclass for non-2xx, so the public client
 modules can stay focused on shaping requests and parsing models.
+
+URL composition: the transport stores its own normalised ``base_url``
+and joins request paths against it explicitly, **not** via
+``httpx.Client(base_url=...)``. That way the caller can inject a
+pre-configured ``httpx.Client`` with an unrelated ``base_url`` (e.g.
+pointing at a proxy or pinned to a different host) and we still send
+the request to the right endpoint on the Xagent server.
 """
 
 from __future__ import annotations
@@ -57,6 +64,20 @@ def _handle(response: httpx.Response) -> Any:
     raise XagentError("unreachable")
 
 
+def _join(base_url: str, path: str) -> str:
+    """Compose an absolute URL from the SDK ``base_url`` and a path.
+
+    ``base_url`` is the value the caller passed into ``XagentClient``,
+    normalised once at transport construction (no trailing slash).
+    ``path`` is the route the SDK code writes (always starts with
+    ``/``). We concatenate explicitly instead of relying on
+    ``httpx.Client(base_url=...)`` so callers that inject their own
+    ``httpx_client`` with a different ``base_url`` (proxy, sidecar,
+    test transport, …) still see requests land on the Xagent server.
+    """
+    return f"{base_url}{path}"
+
+
 class _SyncTransport:
     """Thin wrapper around ``httpx.Client``.
 
@@ -74,11 +95,9 @@ class _SyncTransport:
         httpx_client: Optional[httpx.Client] = None,
     ) -> None:
         self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
         self._owns_client = httpx_client is None
-        self._client = httpx_client or httpx.Client(
-            base_url=base_url.rstrip("/"),
-            timeout=timeout,
-        )
+        self._client = httpx_client or httpx.Client(timeout=timeout)
 
     def request(
         self,
@@ -90,7 +109,7 @@ class _SyncTransport:
     ) -> Any:
         response = self._client.request(
             method,
-            path,
+            _join(self._base_url, path),
             json=json,
             params=params,
             headers=_build_headers(self._api_key),
@@ -114,11 +133,9 @@ class _AsyncTransport:
         httpx_client: Optional[httpx.AsyncClient] = None,
     ) -> None:
         self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
         self._owns_client = httpx_client is None
-        self._client = httpx_client or httpx.AsyncClient(
-            base_url=base_url.rstrip("/"),
-            timeout=timeout,
-        )
+        self._client = httpx_client or httpx.AsyncClient(timeout=timeout)
 
     async def request(
         self,
@@ -130,7 +147,7 @@ class _AsyncTransport:
     ) -> Any:
         response = await self._client.request(
             method,
-            path,
+            _join(self._base_url, path),
             json=json,
             params=params,
             headers=_build_headers(self._api_key),

--- a/sdks/python/src/xagent_sdk/_http.py
+++ b/sdks/python/src/xagent_sdk/_http.py
@@ -1,0 +1,142 @@
+"""Internal HTTP plumbing shared by sync and async clients.
+
+Centralises:
+  - URL composition (base_url + path, no accidental ``//``)
+  - Bearer auth header injection
+  - Response decoding + error envelope translation
+
+The two transport classes (``_SyncTransport`` and ``_AsyncTransport``)
+wrap ``httpx.Client`` / ``httpx.AsyncClient`` respectively. They both
+return parsed JSON for 2xx responses and raise the appropriate
+:class:`XagentApiError` subclass for non-2xx, so the public client
+modules can stay focused on shaping requests and parsing models.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import httpx
+
+from .errors import XagentError, raise_for_error
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+USER_AGENT = "xagent-python-sdk"
+
+
+def _build_headers(api_key: str, extra: Optional[Mapping[str, str]] = None) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _decode(response: httpx.Response) -> Any:
+    """Parse the response body, treating empty / non-JSON as ``None``."""
+    if not response.content:
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        # Non-JSON body on an error response is still useful to surface.
+        return response.text
+
+
+def _handle(response: httpx.Response) -> Any:
+    """Return parsed body on 2xx, raise typed exception otherwise."""
+    body = _decode(response)
+    if 200 <= response.status_code < 300:
+        return body
+    raise_for_error(response.status_code, body)
+    # ``raise_for_error`` always raises; this is unreachable but keeps
+    # the type checker happy.
+    raise XagentError("unreachable")
+
+
+class _SyncTransport:
+    """Thin wrapper around ``httpx.Client``.
+
+    Owns the underlying client when ``close()`` is called via the
+    context manager; if the caller passes a pre-built ``httpx.Client``
+    they remain responsible for closing it.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        httpx_client: Optional[httpx.Client] = None,
+    ) -> None:
+        self._api_key = api_key
+        self._owns_client = httpx_client is None
+        self._client = httpx_client or httpx.Client(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout,
+        )
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        response = self._client.request(
+            method,
+            path,
+            json=json,
+            params=params,
+            headers=_build_headers(self._api_key),
+        )
+        return _handle(response)
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+class _AsyncTransport:
+    """Async counterpart of :class:`_SyncTransport`."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        httpx_client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self._api_key = api_key
+        self._owns_client = httpx_client is None
+        self._client = httpx_client or httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            timeout=timeout,
+        )
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        response = await self._client.request(
+            method,
+            path,
+            json=json,
+            params=params,
+            headers=_build_headers(self._api_key),
+        )
+        return _handle(response)
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()

--- a/sdks/python/src/xagent_sdk/agents.py
+++ b/sdks/python/src/xagent_sdk/agents.py
@@ -1,0 +1,272 @@
+"""``client.agents`` namespace -- personal-key control plane.
+
+Endpoints covered (all require a ``PERSONAL`` API key):
+
+  - ``GET  /v1/me``
+  - ``GET  /v1/agents``
+  - ``POST /v1/agents``
+  - ``POST /v1/agents/from-template``
+  - ``POST /v1/agents/{id}/api-key``  (rotate runtime key)
+
+Templates and other personal-key surfaces can be added later without
+changing the existing method signatures.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from ._http import _AsyncTransport, _SyncTransport
+from .models import AgentSummary, CreateAgentResult, Me, RuntimeKey
+
+
+def _create_payload(
+    *,
+    name: str,
+    description: Optional[str],
+    instructions: Optional[str],
+    execution_mode: Optional[str],
+    models: Optional[dict[str, Any]],
+    knowledge_bases: Optional[List[str]],
+    skills: Optional[List[str]],
+    tool_categories: Optional[List[str]],
+    suggested_prompts: Optional[List[str]],
+    generate_runtime_key: bool,
+) -> dict[str, Any]:
+    """Build the JSON body for ``POST /v1/agents``.
+
+    Optional list fields default to empty lists on the server, so we
+    omit them client-side rather than sending ``None`` (the server
+    would reject ``None`` for a ``list[str]`` field).
+    """
+    payload: dict[str, Any] = {
+        "name": name,
+        "generate_runtime_key": generate_runtime_key,
+    }
+    if description is not None:
+        payload["description"] = description
+    if instructions is not None:
+        payload["instructions"] = instructions
+    if execution_mode is not None:
+        payload["execution_mode"] = execution_mode
+    if models is not None:
+        payload["models"] = models
+    if knowledge_bases is not None:
+        payload["knowledge_bases"] = knowledge_bases
+    if skills is not None:
+        payload["skills"] = skills
+    if tool_categories is not None:
+        payload["tool_categories"] = tool_categories
+    if suggested_prompts is not None:
+        payload["suggested_prompts"] = suggested_prompts
+    return payload
+
+
+def _from_template_payload(
+    *,
+    template_id: str,
+    name: Optional[str],
+    description: Optional[str],
+    instructions: Optional[str],
+    execution_mode: Optional[str],
+    models: Optional[dict[str, Any]],
+    knowledge_bases: Optional[List[str]],
+    skills: Optional[List[str]],
+    tool_categories: Optional[List[str]],
+    suggested_prompts: Optional[List[str]],
+    generate_runtime_key: bool,
+) -> dict[str, Any]:
+    """Build the JSON body for ``POST /v1/agents/from-template``.
+
+    Only ``template_id`` is required; every other field is optional
+    and inherited from the template when omitted.
+    """
+    payload: dict[str, Any] = {
+        "template_id": template_id,
+        "generate_runtime_key": generate_runtime_key,
+    }
+    for key, value in (
+        ("name", name),
+        ("description", description),
+        ("instructions", instructions),
+        ("execution_mode", execution_mode),
+        ("models", models),
+        ("knowledge_bases", knowledge_bases),
+        ("skills", skills),
+        ("tool_categories", tool_categories),
+        ("suggested_prompts", suggested_prompts),
+    ):
+        if value is not None:
+            payload[key] = value
+    return payload
+
+
+class AgentsAPI:
+    """Synchronous agents namespace exposed as ``client.agents``."""
+
+    def __init__(self, transport: _SyncTransport) -> None:
+        self._t = transport
+
+    def me(self) -> Me:
+        """Identity probe -- returns user info bound to the personal key."""
+        return Me.model_validate(self._t.request("GET", "/v1/me"))
+
+    def list(self) -> List[AgentSummary]:
+        """List agents owned by the calling user."""
+        data = self._t.request("GET", "/v1/agents")
+        return [AgentSummary.model_validate(item) for item in data or []]
+
+    def create(
+        self,
+        *,
+        name: str,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        execution_mode: Optional[str] = "balanced",
+        models: Optional[dict[str, Any]] = None,
+        knowledge_bases: Optional[List[str]] = None,
+        skills: Optional[List[str]] = None,
+        tool_categories: Optional[List[str]] = None,
+        suggested_prompts: Optional[List[str]] = None,
+        generate_runtime_key: bool = True,
+    ) -> CreateAgentResult:
+        """Create a new agent."""
+        payload = _create_payload(
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
+        return CreateAgentResult.model_validate(
+            self._t.request("POST", "/v1/agents", json=payload)
+        )
+
+    def create_from_template(
+        self,
+        *,
+        template_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        execution_mode: Optional[str] = None,
+        models: Optional[dict[str, Any]] = None,
+        knowledge_bases: Optional[List[str]] = None,
+        skills: Optional[List[str]] = None,
+        tool_categories: Optional[List[str]] = None,
+        suggested_prompts: Optional[List[str]] = None,
+        generate_runtime_key: bool = True,
+    ) -> CreateAgentResult:
+        """Create a new agent from a template id."""
+        payload = _from_template_payload(
+            template_id=template_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
+        return CreateAgentResult.model_validate(
+            self._t.request("POST", "/v1/agents/from-template", json=payload)
+        )
+
+    def rotate_runtime_key(self, agent_id: int) -> RuntimeKey:
+        """Generate a new runtime API key for ``agent_id``.
+
+        The previous key (if any) remains valid; the server returns
+        the new full key only this once -- callers must persist it.
+        """
+        return RuntimeKey.model_validate(
+            self._t.request("POST", f"/v1/agents/{agent_id}/api-key")
+        )
+
+
+class AsyncAgentsAPI:
+    """Async counterpart of :class:`AgentsAPI`."""
+
+    def __init__(self, transport: _AsyncTransport) -> None:
+        self._t = transport
+
+    async def me(self) -> Me:
+        return Me.model_validate(await self._t.request("GET", "/v1/me"))
+
+    async def list(self) -> List[AgentSummary]:
+        data = await self._t.request("GET", "/v1/agents")
+        return [AgentSummary.model_validate(item) for item in data or []]
+
+    async def create(
+        self,
+        *,
+        name: str,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        execution_mode: Optional[str] = "balanced",
+        models: Optional[dict[str, Any]] = None,
+        knowledge_bases: Optional[List[str]] = None,
+        skills: Optional[List[str]] = None,
+        tool_categories: Optional[List[str]] = None,
+        suggested_prompts: Optional[List[str]] = None,
+        generate_runtime_key: bool = True,
+    ) -> CreateAgentResult:
+        payload = _create_payload(
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
+        return CreateAgentResult.model_validate(
+            await self._t.request("POST", "/v1/agents", json=payload)
+        )
+
+    async def create_from_template(
+        self,
+        *,
+        template_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        execution_mode: Optional[str] = None,
+        models: Optional[dict[str, Any]] = None,
+        knowledge_bases: Optional[List[str]] = None,
+        skills: Optional[List[str]] = None,
+        tool_categories: Optional[List[str]] = None,
+        suggested_prompts: Optional[List[str]] = None,
+        generate_runtime_key: bool = True,
+    ) -> CreateAgentResult:
+        payload = _from_template_payload(
+            template_id=template_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            execution_mode=execution_mode,
+            models=models,
+            knowledge_bases=knowledge_bases,
+            skills=skills,
+            tool_categories=tool_categories,
+            suggested_prompts=suggested_prompts,
+            generate_runtime_key=generate_runtime_key,
+        )
+        return CreateAgentResult.model_validate(
+            await self._t.request("POST", "/v1/agents/from-template", json=payload)
+        )
+
+    async def rotate_runtime_key(self, agent_id: int) -> RuntimeKey:
+        return RuntimeKey.model_validate(
+            await self._t.request("POST", f"/v1/agents/{agent_id}/api-key")
+        )

--- a/sdks/python/src/xagent_sdk/client.py
+++ b/sdks/python/src/xagent_sdk/client.py
@@ -18,6 +18,7 @@ import httpx
 
 from ._http import DEFAULT_TIMEOUT_SECONDS, _AsyncTransport, _SyncTransport
 from .agents import AgentsAPI, AsyncAgentsAPI
+from .models import Me
 from .tasks import AsyncTasksAPI, TasksAPI
 
 
@@ -57,7 +58,7 @@ class XagentClient:
         self.agents = AgentsAPI(self._transport)
         self.tasks = TasksAPI(self._transport)
 
-    def me(self) -> "object":
+    def me(self) -> Me:
         """Shortcut for :meth:`AgentsAPI.me`."""
         return self.agents.me()
 
@@ -102,7 +103,8 @@ class AsyncXagentClient:
         self.agents = AsyncAgentsAPI(self._transport)
         self.tasks = AsyncTasksAPI(self._transport)
 
-    async def me(self) -> "object":
+    async def me(self) -> Me:
+        """Shortcut for :meth:`AsyncAgentsAPI.me`."""
         return await self.agents.me()
 
     async def aclose(self) -> None:

--- a/sdks/python/src/xagent_sdk/client.py
+++ b/sdks/python/src/xagent_sdk/client.py
@@ -1,0 +1,120 @@
+"""Top-level client classes -- sync and async.
+
+A single ``api_key`` is used for both the agents namespace and the
+tasks namespace because the server-side auth dependency picks the
+correct branch based on the key's prefix kind (``personal`` vs
+``agent``). In practice a caller will hold two keys and instantiate
+two clients -- one per kind -- but the SDK doesn't enforce that
+because there's no client-side way to tell the kinds apart without
+calling the server.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Optional
+
+import httpx
+
+from ._http import DEFAULT_TIMEOUT_SECONDS, _AsyncTransport, _SyncTransport
+from .agents import AgentsAPI, AsyncAgentsAPI
+from .tasks import AsyncTasksAPI, TasksAPI
+
+
+class XagentClient:
+    """Synchronous client.
+
+    Args:
+        base_url: Server root, e.g. ``"http://localhost:8000"``.
+        api_key: Bearer token (``xag_...``). Personal key for
+            ``.agents`` calls, agent runtime key for ``.tasks`` calls.
+        timeout: Per-request timeout in seconds.
+        httpx_client: Optional pre-configured ``httpx.Client``. When
+            provided, the SDK will NOT close it on ``__exit__`` --
+            ownership stays with the caller.
+
+    Usage:
+
+        with XagentClient(base_url="...", api_key="xag_...") as client:
+            client.agents.me()
+            client.tasks.create(agent_id=1, message="hi")
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        httpx_client: Optional[httpx.Client] = None,
+    ) -> None:
+        self._transport = _SyncTransport(
+            base_url=base_url,
+            api_key=api_key,
+            timeout=timeout,
+            httpx_client=httpx_client,
+        )
+        self.agents = AgentsAPI(self._transport)
+        self.tasks = TasksAPI(self._transport)
+
+    def me(self) -> "object":
+        """Shortcut for :meth:`AgentsAPI.me`."""
+        return self.agents.me()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client (if owned)."""
+        self._transport.close()
+
+    def __enter__(self) -> "XagentClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+
+class AsyncXagentClient:
+    """Asynchronous client.
+
+    Mirrors :class:`XagentClient` but every method on ``.agents`` /
+    ``.tasks`` is awaitable. Use ``async with`` to ensure the
+    underlying ``httpx.AsyncClient`` is closed.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        httpx_client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self._transport = _AsyncTransport(
+            base_url=base_url,
+            api_key=api_key,
+            timeout=timeout,
+            httpx_client=httpx_client,
+        )
+        self.agents = AsyncAgentsAPI(self._transport)
+        self.tasks = AsyncTasksAPI(self._transport)
+
+    async def me(self) -> "object":
+        return await self.agents.me()
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+    async def __aenter__(self) -> "AsyncXagentClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()

--- a/sdks/python/src/xagent_sdk/errors.py
+++ b/sdks/python/src/xagent_sdk/errors.py
@@ -1,0 +1,135 @@
+"""Typed exceptions for the Python SDK.
+
+The server returns a stable error envelope on every ``/v1/*`` failure
+(see ``src/xagent/web/api/v1/errors.py`` in the main repo):
+
+    {"error": {"code": "<V1ErrorCode>", "message": "<text>"}}
+
+The SDK translates each ``code`` value into a dedicated exception
+subclass so callers can ``except TaskBusyError:`` and retry, instead of
+string-matching against the message. Unknown codes fall back to
+:class:`XagentApiError` so adding new codes server-side is forward
+compatible.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class XagentError(Exception):
+    """Base class for every SDK-raised exception.
+
+    Network errors, JSON decode failures, and timeouts come through as
+    this base class; API-level errors come through as
+    :class:`XagentApiError` or one of its subclasses.
+    """
+
+
+class XagentApiError(XagentError):
+    """Raised on any HTTP error response from the server.
+
+    Attributes:
+        status_code: HTTP status returned by the server.
+        code: Stable ``V1ErrorCode`` enum value (string) from the
+            envelope. ``"unknown"`` if the response did not match the
+            envelope shape.
+        message: Human-readable text from the envelope. May be
+            ``None`` if the body could not be parsed.
+        response_body: Raw decoded body for debugging.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str | None,
+        response_body: Any = None,
+    ) -> None:
+        super().__init__(f"[{status_code} {code}] {message or ''}".rstrip())
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.response_body = response_body
+
+
+class InvalidApiKeyError(XagentApiError):
+    """``invalid_api_key`` (401) -- missing / malformed / revoked key."""
+
+
+class AgentNotFoundError(XagentApiError):
+    """``agent_not_found`` (404) -- agent missing or not bound to the key."""
+
+
+class TaskNotFoundError(XagentApiError):
+    """``task_not_found`` (404) -- task missing or not owned by the agent."""
+
+
+class TemplateNotFoundError(XagentApiError):
+    """``template_not_found`` (404)."""
+
+
+class TaskBusyError(XagentApiError):
+    """``task_busy`` (409) -- task is running, retry after polling."""
+
+
+class InvalidInputError(XagentApiError):
+    """``invalid_input`` (400/422) -- request body failed validation."""
+
+
+class RateLimitedError(XagentApiError):
+    """``rate_limited`` (429) -- reserved; server may emit later."""
+
+
+class InternalServerError(XagentApiError):
+    """``internal_error`` (5xx) -- server-side bug."""
+
+
+# Maps stable error codes to the corresponding exception class. Keep
+# in lockstep with V1ErrorCode in the main repo. Unknown codes fall
+# back to :class:`XagentApiError` in :func:`raise_for_error` so adding
+# a code server-side does not break old SDK versions.
+_CODE_TO_EXC: Mapping[str, type[XagentApiError]] = {
+    "invalid_api_key": InvalidApiKeyError,
+    "agent_not_found": AgentNotFoundError,
+    "task_not_found": TaskNotFoundError,
+    "template_not_found": TemplateNotFoundError,
+    "task_busy": TaskBusyError,
+    "invalid_input": InvalidInputError,
+    "rate_limited": RateLimitedError,
+    "internal_error": InternalServerError,
+}
+
+
+def raise_for_error(status_code: int, body: Any) -> None:
+    """Translate a non-2xx response body into the right typed exception.
+
+    Args:
+        status_code: HTTP status from the response.
+        body: Parsed JSON body, or ``None`` if the body was not JSON.
+            The expected envelope is ``{"error": {"code": ..., "message": ...}}``
+            but anything else is tolerated and surfaced as
+            :class:`XagentApiError` with ``code="unknown"``.
+
+    Raises:
+        XagentApiError or one of its subclasses. Never returns.
+    """
+    code = "unknown"
+    message: str | None = None
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict):
+            raw_code = err.get("code")
+            if isinstance(raw_code, str):
+                code = raw_code
+            raw_msg = err.get("message")
+            if isinstance(raw_msg, str):
+                message = raw_msg
+
+    exc_cls = _CODE_TO_EXC.get(code, XagentApiError)
+    raise exc_cls(
+        status_code=status_code,
+        code=code,
+        message=message,
+        response_body=body,
+    )

--- a/sdks/python/src/xagent_sdk/models.py
+++ b/sdks/python/src/xagent_sdk/models.py
@@ -1,0 +1,158 @@
+"""Response models for the SDK.
+
+These mirror the server-side Pydantic schemas in
+``src/xagent/web/schemas/v1.py`` but are re-declared here so the SDK
+stays independent of the heavyweight web package import chain
+(SQLAlchemy, FastAPI, etc.) -- importing the SDK should not pull in
+the full server runtime.
+
+We keep the shapes deliberately small and aligned 1:1 with the server
+contract; new fields the server adds will simply be ignored on the
+client side (``model_config = ConfigDict(extra="ignore")``) so old
+SDKs keep working against newer servers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Mirrors ``PublicStepType`` and ``PublicStepStatus`` in
+# ``schemas/v1.py``. Kept in sync manually -- they have not changed
+# since the v1 surface was introduced and any new value would be a
+# breaking change server-side too.
+PublicStepType = Literal["thinking", "tool_call", "agent_delegation", "message"]
+PublicStepStatus = Literal["running", "completed", "failed"]
+
+
+class _SDKModel(BaseModel):
+    """Base for SDK response models.
+
+    ``extra="ignore"`` lets the server add fields without breaking
+    existing SDK installs.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class Me(_SDKModel):
+    """``GET /v1/me`` -- identity probe response."""
+
+    principal_type: str
+    user_id: int
+    username: str
+    email: Optional[str] = None
+    key_prefix: str
+
+
+class RuntimeKey(_SDKModel):
+    """One-time runtime key payload (created or rotated).
+
+    ``full_key`` is only returned by the server on creation / rotation
+    and is never retrievable again -- callers must persist it now.
+    """
+
+    full_key: str
+    key_prefix: str
+    created_at: datetime
+
+
+class AgentSummary(_SDKModel):
+    """Compact agent record returned by list endpoints."""
+
+    id: int
+    name: str
+    description: Optional[str] = None
+    logo_url: Optional[str] = None
+    status: str
+    created_at: str
+    updated_at: str
+    widget_enabled: bool = False
+    allowed_domains: List[str] = Field(default_factory=list)
+
+
+class Agent(_SDKModel):
+    """Full agent detail returned by create / get."""
+
+    id: int
+    user_id: int
+    name: str
+    description: Optional[str] = None
+    instructions: Optional[str] = None
+    execution_mode: str
+    models: Optional[dict[str, Any]] = None
+    knowledge_bases: List[str] = Field(default_factory=list)
+    skills: List[str] = Field(default_factory=list)
+    tool_categories: List[str] = Field(default_factory=list)
+    suggested_prompts: List[str] = Field(default_factory=list)
+    logo_url: Optional[str] = None
+    status: str
+    published_at: Optional[str] = None
+    created_at: str
+    updated_at: str
+    widget_enabled: bool = False
+    allowed_domains: List[str] = Field(default_factory=list)
+
+
+class CreateAgentResult(_SDKModel):
+    """``POST /v1/agents`` / ``POST /v1/agents/from-template`` response."""
+
+    agent: Agent
+    api_key: Optional[RuntimeKey] = None
+
+
+class CreateTaskResponse(_SDKModel):
+    """``POST /v1/chat/tasks`` -- 202 Accepted body."""
+
+    task_id: int
+    agent_id: int
+    status: str
+    created_at: datetime
+
+
+class AppendMessageResponse(_SDKModel):
+    """``POST /v1/chat/tasks/{id}/messages`` -- 202 Accepted body."""
+
+    task_id: int
+    agent_id: int
+    status: str
+    accepted_at: datetime
+
+
+class TaskInfo(_SDKModel):
+    """``GET /v1/chat/tasks/{id}`` -- snapshot of one task's state."""
+
+    task_id: int
+    agent_id: int
+    status: str
+    input: Optional[str] = None
+    output: Optional[str] = None
+    error: Optional[str] = None
+    created_at: datetime
+    completed_at: Optional[datetime] = None
+
+    @property
+    def is_terminal(self) -> bool:
+        """True when the task is no longer running."""
+        return self.status in ("completed", "failed")
+
+
+class PublicStep(_SDKModel):
+    """One step on the public task timeline."""
+
+    id: str
+    type: PublicStepType
+    status: PublicStepStatus
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class StepsResponse(_SDKModel):
+    """``GET /v1/chat/tasks/{id}/steps`` response body."""
+
+    task_id: int
+    agent_id: int
+    steps: List[PublicStep] = Field(default_factory=list)

--- a/sdks/python/src/xagent_sdk/tasks.py
+++ b/sdks/python/src/xagent_sdk/tasks.py
@@ -1,0 +1,210 @@
+"""``client.tasks`` namespace -- agent runtime-key data plane.
+
+Endpoints covered (all require an ``AGENT`` API key bound to the
+target agent):
+
+  - ``POST /v1/chat/tasks``                  (create)
+  - ``POST /v1/chat/tasks/{id}/messages``    (append)
+  - ``GET  /v1/chat/tasks/{id}``             (snapshot)
+  - ``GET  /v1/chat/tasks/{id}/steps``       (timeline)
+
+Convenience helper :meth:`TasksAPI.wait_for_completion` polls the
+snapshot endpoint until the task reaches a terminal state -- there is
+no WebSocket transport in this initial SDK cut, so polling is the
+documented way to wait for a result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+from ._http import _AsyncTransport, _SyncTransport
+from .errors import XagentError
+from .models import (
+    AppendMessageResponse,
+    CreateTaskResponse,
+    StepsResponse,
+    TaskInfo,
+)
+
+DEFAULT_POLL_INTERVAL = 1.0
+DEFAULT_POLL_TIMEOUT = 300.0
+
+
+class TaskTimeoutError(XagentError):
+    """Raised when :meth:`wait_for_completion` exceeds its timeout.
+
+    Distinct from :class:`xagent_sdk.errors.XagentApiError` because no
+    HTTP error occurred -- the task was simply slower than the
+    caller's deadline. The latest snapshot is attached so callers can
+    keep polling out-of-band or report progress.
+    """
+
+    def __init__(self, task_id: int, last_snapshot: Optional[TaskInfo]) -> None:
+        super().__init__(
+            f"Task {task_id} did not reach a terminal state in time."
+        )
+        self.task_id = task_id
+        self.last_snapshot = last_snapshot
+
+
+def _create_body(agent_id: int, message: str, metadata: Optional[dict[str, Any]]) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "agent_id": agent_id,
+        "message": {"role": "user", "content": message},
+    }
+    if metadata is not None:
+        body["metadata"] = metadata
+    return body
+
+
+class TasksAPI:
+    """Synchronous tasks namespace exposed as ``client.tasks``."""
+
+    def __init__(self, transport: _SyncTransport) -> None:
+        self._t = transport
+
+    def create(
+        self,
+        *,
+        agent_id: int,
+        message: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> CreateTaskResponse:
+        """Create a new SDK task and queue its first turn."""
+        return CreateTaskResponse.model_validate(
+            self._t.request(
+                "POST",
+                "/v1/chat/tasks",
+                json=_create_body(agent_id, message, metadata),
+            )
+        )
+
+    def append_message(
+        self,
+        task_id: int,
+        *,
+        agent_id: int,
+        message: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> AppendMessageResponse:
+        """Append the next user message to an existing task."""
+        return AppendMessageResponse.model_validate(
+            self._t.request(
+                "POST",
+                f"/v1/chat/tasks/{task_id}/messages",
+                json=_create_body(agent_id, message, metadata),
+            )
+        )
+
+    def get(self, task_id: int) -> TaskInfo:
+        """Return the current snapshot of a task."""
+        return TaskInfo.model_validate(
+            self._t.request("GET", f"/v1/chat/tasks/{task_id}")
+        )
+
+    def get_steps(self, task_id: int) -> StepsResponse:
+        """Return the public-timeline steps for a task."""
+        return StepsResponse.model_validate(
+            self._t.request("GET", f"/v1/chat/tasks/{task_id}/steps")
+        )
+
+    def wait_for_completion(
+        self,
+        task_id: int,
+        *,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        timeout: Optional[float] = DEFAULT_POLL_TIMEOUT,
+    ) -> TaskInfo:
+        """Block until the task reaches a terminal status.
+
+        Args:
+            task_id: Target task primary key.
+            poll_interval: Seconds between snapshot polls.
+            timeout: Maximum seconds to wait before raising
+                :class:`TaskTimeoutError`. ``None`` means wait forever.
+
+        Returns:
+            The terminal :class:`TaskInfo` snapshot.
+
+        Raises:
+            TaskTimeoutError: If the task did not terminate in time.
+            XagentApiError: Propagated from the underlying snapshot call.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        info: Optional[TaskInfo] = None
+        while True:
+            info = self.get(task_id)
+            if info.is_terminal:
+                return info
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TaskTimeoutError(task_id, info)
+            time.sleep(poll_interval)
+
+
+class AsyncTasksAPI:
+    """Async counterpart of :class:`TasksAPI`."""
+
+    def __init__(self, transport: _AsyncTransport) -> None:
+        self._t = transport
+
+    async def create(
+        self,
+        *,
+        agent_id: int,
+        message: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> CreateTaskResponse:
+        return CreateTaskResponse.model_validate(
+            await self._t.request(
+                "POST",
+                "/v1/chat/tasks",
+                json=_create_body(agent_id, message, metadata),
+            )
+        )
+
+    async def append_message(
+        self,
+        task_id: int,
+        *,
+        agent_id: int,
+        message: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> AppendMessageResponse:
+        return AppendMessageResponse.model_validate(
+            await self._t.request(
+                "POST",
+                f"/v1/chat/tasks/{task_id}/messages",
+                json=_create_body(agent_id, message, metadata),
+            )
+        )
+
+    async def get(self, task_id: int) -> TaskInfo:
+        return TaskInfo.model_validate(
+            await self._t.request("GET", f"/v1/chat/tasks/{task_id}")
+        )
+
+    async def get_steps(self, task_id: int) -> StepsResponse:
+        return StepsResponse.model_validate(
+            await self._t.request("GET", f"/v1/chat/tasks/{task_id}/steps")
+        )
+
+    async def wait_for_completion(
+        self,
+        task_id: int,
+        *,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        timeout: Optional[float] = DEFAULT_POLL_TIMEOUT,
+    ) -> TaskInfo:
+        """Async version of :meth:`TasksAPI.wait_for_completion`."""
+        deadline = None if timeout is None else asyncio.get_event_loop().time() + timeout
+        info: Optional[TaskInfo] = None
+        while True:
+            info = await self.get(task_id)
+            if info.is_terminal:
+                return info
+            if deadline is not None and asyncio.get_event_loop().time() >= deadline:
+                raise TaskTimeoutError(task_id, info)
+            await asyncio.sleep(poll_interval)

--- a/sdks/python/src/xagent_sdk/tasks.py
+++ b/sdks/python/src/xagent_sdk/tasks.py
@@ -198,13 +198,22 @@ class AsyncTasksAPI:
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         timeout: Optional[float] = DEFAULT_POLL_TIMEOUT,
     ) -> TaskInfo:
-        """Async version of :meth:`TasksAPI.wait_for_completion`."""
-        deadline = None if timeout is None else asyncio.get_event_loop().time() + timeout
+        """Async version of :meth:`TasksAPI.wait_for_completion`.
+
+        Uses :func:`time.monotonic` for the deadline (not
+        ``asyncio.get_event_loop().time()``) so the timeout doesn't
+        depend on which event loop is running and doesn't emit the
+        Python 3.12 ``DeprecationWarning`` that ``get_event_loop()``
+        triggers when there's no current loop. ``asyncio.sleep`` still
+        yields back to the loop, so cooperative scheduling is
+        unaffected.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
         info: Optional[TaskInfo] = None
         while True:
             info = await self.get(task_id)
             if info.is_terminal:
                 return info
-            if deadline is not None and asyncio.get_event_loop().time() >= deadline:
+            if deadline is not None and time.monotonic() >= deadline:
                 raise TaskTimeoutError(task_id, info)
             await asyncio.sleep(poll_interval)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,0 +1,299 @@
+"""HTTP-level tests for the SDK client.
+
+We use ``httpx.MockTransport`` (a built-in ``httpx`` feature, no extra
+dependency) to stub responses so the tests exercise the real request
+shaping (URL, headers, JSON body) without needing a live server.
+
+The goal is to pin:
+
+  - Auth header is always ``Bearer <api_key>``.
+  - URLs are composed against the configured ``base_url`` without
+    accidental double slashes.
+  - Request bodies match the documented v1 contract.
+  - 2xx bodies hydrate the right Pydantic model.
+  - Non-2xx bodies surface the right typed exception.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Callable, List, Tuple
+
+import httpx
+import pytest
+
+from xagent_sdk import (
+    AsyncXagentClient,
+    InvalidApiKeyError,
+    TaskBusyError,
+    XagentClient,
+)
+
+BASE_URL = "https://xagent.example.com"
+API_KEY = "xag_testpfx_secrettokenhere"
+
+
+# ===== helpers =====
+
+
+def _make_sync_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    base_url: str = BASE_URL,
+) -> Tuple[XagentClient, List[httpx.Request]]:
+    """Build a sync client whose transport records every request."""
+    captured: List[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    httpx_client = httpx.Client(base_url=base_url.rstrip("/"), transport=transport)
+    return (
+        XagentClient(base_url=base_url, api_key=API_KEY, httpx_client=httpx_client),
+        captured,
+    )
+
+
+def _make_async_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    base_url: str = BASE_URL,
+) -> Tuple[AsyncXagentClient, List[httpx.Request]]:
+    """Build an async client whose transport records every request."""
+    captured: List[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    httpx_client = httpx.AsyncClient(base_url=base_url.rstrip("/"), transport=transport)
+    return (
+        AsyncXagentClient(
+            base_url=base_url, api_key=API_KEY, httpx_client=httpx_client
+        ),
+        captured,
+    )
+
+
+def _ok(payload: dict | list, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=payload)
+
+
+def _err(status: int, code: str, message: str) -> httpx.Response:
+    return httpx.Response(status, json={"error": {"code": code, "message": message}})
+
+
+# ===== sync =====
+
+
+def test_sync_me_sends_bearer_and_parses_response() -> None:
+    payload = {
+        "principal_type": "user",
+        "user_id": 7,
+        "username": "alice",
+        "email": "alice@example.com",
+        "key_prefix": "testpfx",
+    }
+    client, captured = _make_sync_client(lambda req: _ok(payload))
+
+    with client:
+        me = client.agents.me()
+
+    assert me.user_id == 7
+    assert me.username == "alice"
+
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.method == "GET"
+    assert req.url.path == "/v1/me"
+    assert req.headers["authorization"] == f"Bearer {API_KEY}"
+    assert req.headers["accept"] == "application/json"
+
+
+def test_sync_create_task_posts_expected_body() -> None:
+    payload = {
+        "task_id": 100,
+        "agent_id": 42,
+        "status": "running",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    client, captured = _make_sync_client(lambda req: _ok(payload, status=202))
+
+    with client:
+        result = client.tasks.create(agent_id=42, message="hello")
+
+    assert result.task_id == 100
+    assert result.agent_id == 42
+    assert result.status == "running"
+
+    req = captured[0]
+    assert req.method == "POST"
+    assert req.url.path == "/v1/chat/tasks"
+    body = json.loads(req.content.decode())
+    assert body == {
+        "agent_id": 42,
+        "message": {"role": "user", "content": "hello"},
+    }
+
+
+def test_sync_create_task_includes_metadata_when_provided() -> None:
+    payload = {
+        "task_id": 1,
+        "agent_id": 1,
+        "status": "running",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+    client, captured = _make_sync_client(lambda req: _ok(payload, status=202))
+
+    with client:
+        client.tasks.create(
+            agent_id=1, message="hi", metadata={"trace_id": "abc"}
+        )
+
+    body = json.loads(captured[0].content.decode())
+    assert body["metadata"] == {"trace_id": "abc"}
+
+
+def test_sync_invalid_api_key_raises_typed_exception() -> None:
+    client, _ = _make_sync_client(
+        lambda req: _err(401, "invalid_api_key", "Invalid or revoked API key.")
+    )
+
+    with client:
+        with pytest.raises(InvalidApiKeyError) as excinfo:
+            client.agents.me()
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.code == "invalid_api_key"
+
+
+def test_sync_append_message_task_busy_raises_typed_exception() -> None:
+    client, captured = _make_sync_client(
+        lambda req: _err(409, "task_busy", "Task is currently running.")
+    )
+
+    with client:
+        with pytest.raises(TaskBusyError):
+            client.tasks.append_message(9, agent_id=1, message="next")
+
+    # Verify the URL still went where we expected even on failure.
+    assert captured[0].url.path == "/v1/chat/tasks/9/messages"
+
+
+def test_sync_get_task_is_terminal_flag() -> None:
+    payload = {
+        "task_id": 5,
+        "agent_id": 1,
+        "status": "completed",
+        "input": "hi",
+        "output": "hello!",
+        "error": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "completed_at": "2026-01-01T00:00:05+00:00",
+    }
+    client, _ = _make_sync_client(lambda req: _ok(payload))
+
+    with client:
+        info = client.tasks.get(5)
+
+    assert info.is_terminal is True
+    assert info.output == "hello!"
+
+
+def test_sync_base_url_trailing_slash_does_not_double_slash() -> None:
+    payload = {
+        "principal_type": "user",
+        "user_id": 1,
+        "username": "bob",
+        "email": None,
+        "key_prefix": "abcdef",
+    }
+    client, captured = _make_sync_client(
+        lambda req: _ok(payload), base_url=f"{BASE_URL}/"
+    )
+
+    with client:
+        client.agents.me()
+
+    assert str(captured[0].url) == f"{BASE_URL}/v1/me"
+
+
+def test_sync_list_agents_returns_typed_summaries() -> None:
+    payload = [
+        {
+            "id": 1,
+            "name": "agent-a",
+            "description": None,
+            "logo_url": None,
+            "status": "draft",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+            "widget_enabled": False,
+            "allowed_domains": [],
+        }
+    ]
+    client, captured = _make_sync_client(lambda req: _ok(payload))
+
+    with client:
+        agents = client.agents.list()
+
+    assert len(agents) == 1
+    assert agents[0].name == "agent-a"
+    assert captured[0].url.path == "/v1/agents"
+
+
+# ===== async =====
+#
+# We avoid a hard pytest-asyncio dependency by driving the coroutine
+# from the sync test body via ``asyncio.run``. This keeps the test
+# matrix simple (just pytest itself), and the goal here is to pin the
+# wire shape, not to exercise the event loop integration -- the
+# AsyncXagentClient logic is a thin mirror of the sync one and shares
+# all the request shaping through ``_AsyncTransport``.
+
+
+def test_async_me_round_trip() -> None:
+    import asyncio
+
+    payload = {
+        "principal_type": "user",
+        "user_id": 11,
+        "username": "carol",
+        "email": None,
+        "key_prefix": "asyncpfx",
+    }
+    client, captured = _make_async_client(lambda req: _ok(payload))
+
+    async def _run() -> None:
+        async with client:
+            me = await client.agents.me()
+        assert me.user_id == 11
+        assert me.username == "carol"
+        assert captured[0].headers["authorization"] == f"Bearer {API_KEY}"
+
+    asyncio.run(_run())
+
+
+def test_async_create_task_round_trip() -> None:
+    import asyncio
+
+    payload = {
+        "task_id": 77,
+        "agent_id": 3,
+        "status": "running",
+        "created_at": "2026-02-02T00:00:00+00:00",
+    }
+    client, captured = _make_async_client(lambda req: _ok(payload, status=202))
+
+    async def _run() -> None:
+        async with client:
+            result = await client.tasks.create(agent_id=3, message="hi")
+        assert result.task_id == 77
+        body = json.loads(captured[0].content.decode())
+        assert body["agent_id"] == 3
+
+    asyncio.run(_run())

--- a/sdks/python/tests/test_e2e.py
+++ b/sdks/python/tests/test_e2e.py
@@ -1,0 +1,375 @@
+"""End-to-end test: SDK against a real uvicorn server.
+
+Unlike ``test_client.py`` (which stubs ``httpx.MockTransport``), this
+module spins up a **real** uvicorn server in a subprocess, waits for it
+to accept connections, and points the SDK at the live ``http://`` URL.
+The full network path is exercised:
+
+    SDK -> httpx -> TCP -> uvicorn -> FastAPI -> auth dep -> SQLite
+
+No LLM key is required: the background turn scheduler is monkey-patched
+out in the child process via an env var so ``POST /v1/chat/tasks`` still
+returns 202 and the row is committed, but no LLM call is attempted.
+
+The whole module is skipped if:
+
+  - The main ``xagent`` package is not importable (SDK installed
+    standalone in a fresh venv without ``pip install -e .`` of the
+    parent project), OR
+  - ``uvicorn`` is not installed.
+
+That keeps the SDK's own CI lane independent while still letting
+contributors run the full end-to-end check from a repo checkout that
+has the server installed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+from typing import Iterator
+
+import httpx
+import pytest
+
+# Skip the entire file if the main project or uvicorn isn't available.
+xagent = pytest.importorskip(
+    "xagent.web",
+    reason=(
+        "Main xagent package not importable; install with "
+        "`pip install -e .` from the repo root to run the SDK e2e tests."
+    ),
+)
+pytest.importorskip("uvicorn", reason="uvicorn required for SDK e2e tests")
+
+from xagent_sdk import (  # noqa: E402
+    AgentNotFoundError,
+    InvalidApiKeyError,
+    TaskBusyError,
+    XagentClient,
+)
+
+
+# ===== server boot helpers =====
+
+
+def _free_port() -> int:
+    """Ask the OS for a free TCP port and immediately release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_http(url: str, timeout: float = 120.0) -> None:
+    """Poll ``url`` until it returns any HTTP response or timeout fires.
+
+    The first server boot pulls in the full xagent stack (langchain,
+    lancedb, etc.) which can take 30-60s on a cold cache; the timeout
+    is set generously and only matters when the subprocess truly
+    failed to start (then we fall back to surfacing its stderr).
+    """
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with httpx.Client(timeout=1.0) as c:
+                c.get(url)
+            return
+        except Exception as e:
+            last_err = e
+            time.sleep(0.5)
+    raise RuntimeError(f"Server at {url} never came up: {last_err}")
+
+
+# Bootstrap script run inside the uvicorn subprocess. It:
+#
+#   1. Installs a per-process SQLite DB (path from env) and initialises
+#      the schema before any request handler runs.
+#   2. Patches the background-turn scheduler to a no-op so tasks don't
+#      require an LLM key. The orchestrator's atomic claim still runs,
+#      so DB state and HTTP responses match production.
+#   3. Builds the minimum FastAPI surface the SDK touches (auth + me +
+#      agents + v1) and serves it via uvicorn.
+#
+# Inlined here as a string rather than a separate file so the SDK
+# package stays self-contained — `python -c "..."` keeps the test
+# zero-config from the contributor's side.
+_SERVER_BOOTSTRAP = textwrap.dedent(
+    '''
+    import os
+    from unittest.mock import MagicMock
+    import uvicorn
+    from fastapi import FastAPI, Request
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse
+
+    os.environ["DATABASE_URL"] = os.environ["SDK_E2E_DB_URL"]
+
+    # Patch BEFORE importing anything that imports the orchestrator so the
+    # no-op binding is in place when the route module captures the symbol.
+    import xagent.web.services.task_orchestrator as _orch
+    _orch._schedule_bg = MagicMock()
+
+    from xagent.web.api.agents import router as agents_router
+    from xagent.web.api.auth import auth_router
+    from xagent.web.api.me import router as me_router
+    from xagent.web.api.v1 import v1_router
+    from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
+    from xagent.web.models.database import get_db, init_db
+
+    init_db(db_url=os.environ["SDK_E2E_DB_URL"])
+
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.include_router(me_router)
+    app.include_router(agents_router)
+    app.include_router(v1_router)
+    app.add_exception_handler(V1ApiError, v1_api_error_handler)
+
+    @app.exception_handler(Exception)
+    async def _err(request: Request, exc: Exception):
+        if request.url.path.startswith("/v1/"):
+            return JSONResponse(
+                status_code=500,
+                content={"error": {"code": "internal_error",
+                                    "message": "Internal server error."}},
+            )
+        raise exc
+
+    @app.exception_handler(RequestValidationError)
+    async def _val(request: Request, exc: RequestValidationError):
+        if request.url.path.startswith("/v1/"):
+            errors = exc.errors()
+            first = errors[0] if errors else {}
+            msg = first.get("msg") or "Invalid request body"
+            return JSONResponse(
+                status_code=422,
+                content={"error": {"code": "invalid_input", "message": msg}},
+            )
+        return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
+    def _get_db():
+        db = None
+        try:
+            db = next(get_db())
+            yield db
+        finally:
+            if db is not None:
+                db.close()
+
+    app.dependency_overrides[get_db] = _get_db
+
+    uvicorn.run(
+        app,
+        host="127.0.0.1",
+        port=int(os.environ["SDK_E2E_PORT"]),
+        log_level="warning",
+    )
+    '''
+)
+
+
+@pytest.fixture(scope="module")
+def live_server() -> Iterator[str]:
+    """Start uvicorn in a subprocess, yield its base URL, kill on teardown.
+
+    Module-scoped so the ~5s server boot only happens once for the whole
+    test file. Each test still gets a clean DB via the per-function
+    ``clean_db`` fixture below.
+    """
+    port = _free_port()
+    tmp_dir = tempfile.mkdtemp()
+    db_path = Path(tmp_dir) / "sdk_e2e.db"
+    db_url = f"sqlite:///{db_path}"
+
+    env = {
+        **os.environ,
+        "SDK_E2E_PORT": str(port),
+        "SDK_E2E_DB_URL": db_url,
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SERVER_BOOTSTRAP],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        try:
+            _wait_for_http(f"{base_url}/api/auth/setup-status")
+        except Exception:
+            # Surface the server's stderr so failures aren't opaque.
+            proc.terminate()
+            out, _ = proc.communicate(timeout=5)
+            raise RuntimeError(
+                "uvicorn failed to start. Subprocess output:\n"
+                + (out.decode(errors="replace") if out else "<no output>")
+            )
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ===== per-test setup =====
+
+
+def _reset_db(base_url: str) -> None:
+    """Tear down + re-init the server's DB between tests.
+
+    Implemented by talking to the live server, not by reaching into its
+    process, because the DB lives in a separate process. We hit
+    /api/auth/setup-status to confirm reachability, then rely on each
+    test's own bootstrap flow to create the admin user it needs.
+
+    For now tests are written to be idempotent against an already-set-up
+    admin, so we don't need a true reset — but the helper exists for
+    future tests that need a pristine state.
+    """
+    with httpx.Client(base_url=base_url, timeout=5.0) as c:
+        c.get("/api/auth/setup-status").raise_for_status()
+
+
+# ===== auth helpers =====
+
+
+def _bootstrap_admin(base_url: str) -> str:
+    """Ensure admin exists, log in, return JWT access token."""
+    with httpx.Client(base_url=base_url, timeout=10.0) as c:
+        status = c.get("/api/auth/setup-status").json()
+        if status.get("needs_setup", True):
+            resp = c.post(
+                "/api/auth/setup-admin",
+                json={
+                    "username": "admin",
+                    "email": "admin@example.com",
+                    "password": "admin12345",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+        resp = c.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "admin12345"},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["access_token"]
+
+
+def _create_personal_key(base_url: str, jwt_token: str) -> str:
+    """Mint a personal SDK key for the admin user."""
+    with httpx.Client(base_url=base_url, timeout=10.0) as c:
+        resp = c.post(
+            "/api/me/personal-keys",
+            headers={"Authorization": f"Bearer {jwt_token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["full_key"]
+
+
+@pytest.fixture
+def personal_key(live_server: str) -> str:
+    """Bootstrap admin (once per test file) and mint a fresh personal key."""
+    _reset_db(live_server)
+    token = _bootstrap_admin(live_server)
+    return _create_personal_key(live_server, token)
+
+
+# ===== tests =====
+
+
+def test_e2e_me_returns_admin_identity(live_server: str, personal_key: str) -> None:
+    """``client.agents.me()`` against a real running uvicorn."""
+    with XagentClient(base_url=live_server, api_key=personal_key) as sdk:
+        me = sdk.agents.me()
+
+    assert me.username == "admin"
+    assert me.principal_type == "user"
+    # Key format is ``xag_<kind>_<prefix>_<secret>`` -- index 2 is the
+    # public-safe lookup prefix the server exposes via /v1/me.
+    assert me.key_prefix == personal_key.split("_")[2]
+
+
+def test_e2e_invalid_personal_key_raises_typed_exception(live_server: str) -> None:
+    """Bad bearer should surface as :class:`InvalidApiKeyError`."""
+    with XagentClient(base_url=live_server, api_key="xag_nopfx0_" + "x" * 32) as sdk:
+        with pytest.raises(InvalidApiKeyError) as excinfo:
+            sdk.agents.me()
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.code == "invalid_api_key"
+
+
+def test_e2e_create_agent_returns_runtime_key(
+    live_server: str, personal_key: str
+) -> None:
+    """SDK create_agent mints both the agent row and a runtime key."""
+    name = f"sdk-e2e-agent-{int(time.time() * 1000)}"
+    with XagentClient(base_url=live_server, api_key=personal_key) as sdk:
+        result = sdk.agents.create(
+            name=name,
+            description="created from the SDK e2e test",
+            instructions="You are a test agent.",
+            execution_mode="balanced",
+        )
+
+        assert result.agent.id > 0
+        assert result.agent.name == name
+        assert result.api_key is not None
+        assert result.api_key.full_key.startswith("xag_")
+
+        agents = sdk.agents.list()
+    assert any(a.id == result.agent.id for a in agents)
+
+
+def test_e2e_create_and_get_task(live_server: str, personal_key: str) -> None:
+    """Full happy path: agent runtime key -> create task -> GET task."""
+    name = f"task-e2e-agent-{int(time.time() * 1000)}"
+    with XagentClient(base_url=live_server, api_key=personal_key) as ctrl:
+        created = ctrl.agents.create(
+            name=name,
+            instructions="You are a test agent.",
+        )
+    assert created.api_key is not None
+    runtime_key = created.api_key.full_key
+    agent_id = created.agent.id
+
+    with XagentClient(base_url=live_server, api_key=runtime_key) as data:
+        create_resp = data.tasks.create(agent_id=agent_id, message="hello sdk")
+        assert create_resp.agent_id == agent_id
+        assert create_resp.status in ("running", "pending")
+
+        info = data.tasks.get(create_resp.task_id)
+        assert info.task_id == create_resp.task_id
+        assert info.input == "hello sdk"
+
+        # Append while the orchestrator's row is still RUNNING -> 409.
+        with pytest.raises(TaskBusyError):
+            data.tasks.append_message(
+                create_resp.task_id, agent_id=agent_id, message="next"
+            )
+
+
+def test_e2e_task_with_mismatched_agent_id_returns_typed_exception(
+    live_server: str, personal_key: str
+) -> None:
+    """``body.agent_id`` mismatch is 404 ``agent_not_found`` per v1 contract."""
+    name = f"mismatch-agent-{int(time.time() * 1000)}"
+    with XagentClient(base_url=live_server, api_key=personal_key) as ctrl:
+        created = ctrl.agents.create(name=name, instructions="x")
+    assert created.api_key is not None
+
+    with XagentClient(base_url=live_server, api_key=created.api_key.full_key) as data:
+        with pytest.raises(AgentNotFoundError):
+            data.tasks.create(agent_id=created.agent.id + 9999, message="hi")

--- a/sdks/python/tests/test_errors.py
+++ b/sdks/python/tests/test_errors.py
@@ -1,0 +1,69 @@
+"""Unit tests for the SDK error-envelope translator."""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent_sdk.errors import (
+    AgentNotFoundError,
+    InternalServerError,
+    InvalidApiKeyError,
+    InvalidInputError,
+    RateLimitedError,
+    TaskBusyError,
+    TaskNotFoundError,
+    TemplateNotFoundError,
+    XagentApiError,
+    raise_for_error,
+)
+
+
+@pytest.mark.parametrize(
+    "code, exc_cls",
+    [
+        ("invalid_api_key", InvalidApiKeyError),
+        ("agent_not_found", AgentNotFoundError),
+        ("task_not_found", TaskNotFoundError),
+        ("template_not_found", TemplateNotFoundError),
+        ("task_busy", TaskBusyError),
+        ("invalid_input", InvalidInputError),
+        ("rate_limited", RateLimitedError),
+        ("internal_error", InternalServerError),
+    ],
+)
+def test_known_codes_map_to_typed_exceptions(code: str, exc_cls: type) -> None:
+    """Every documented V1ErrorCode should map to a dedicated subclass."""
+    body = {"error": {"code": code, "message": "boom"}}
+    with pytest.raises(exc_cls) as excinfo:
+        raise_for_error(418, body)
+    err = excinfo.value
+    assert err.status_code == 418
+    assert err.code == code
+    assert err.message == "boom"
+    assert err.response_body == body
+
+
+def test_unknown_code_falls_back_to_base_class() -> None:
+    """Forward-compat: unknown codes still surface as XagentApiError."""
+    body = {"error": {"code": "future_code", "message": "soon"}}
+    with pytest.raises(XagentApiError) as excinfo:
+        raise_for_error(500, body)
+    assert type(excinfo.value) is XagentApiError
+    assert excinfo.value.code == "future_code"
+
+
+def test_missing_envelope_yields_unknown_code() -> None:
+    """Non-envelope bodies still raise, with code='unknown'."""
+    with pytest.raises(XagentApiError) as excinfo:
+        raise_for_error(502, "Bad Gateway")
+    assert excinfo.value.code == "unknown"
+    assert excinfo.value.message is None
+
+
+def test_envelope_with_non_string_fields_is_tolerated() -> None:
+    """Malformed envelope shouldn't crash the parser."""
+    body = {"error": {"code": 123, "message": ["nope"]}}
+    with pytest.raises(XagentApiError) as excinfo:
+        raise_for_error(400, body)
+    assert excinfo.value.code == "unknown"
+    assert excinfo.value.message is None


### PR DESCRIPTION
Tracks roadmap [issue #82](https://github.com/xorbitsai/xagent/issues/82) → *SDKs & Developer Access → Python SDK (P2)*.

## What this adds

A new top-level `sdks/python/` package layered over the existing `/v1/*` HTTP contract (`src/xagent/web/api/v1/`):

- **SDK code** ([`src/xagent_sdk/`](sdks/python/src/xagent_sdk/)) — sync + async clients (`XagentClient`, `AsyncXagentClient`), typed exceptions per `V1ErrorCode`, Pydantic response models, polling helper. Runtime deps: `httpx` + `pydantic` only — does **not** import the server package.
- **Tests** ([`tests/`](sdks/python/tests/)) — 26 total: 11 error-envelope unit tests, 10 `httpx.MockTransport` request-shape tests, 5 end-to-end tests that spin up a real uvicorn subprocess against SQLite. Background turn scheduler is monkey-patched so no LLM key is required.
- **Docs** ([`docs/`](sdks/python/docs/)) — 8 Markdown files: quickstart, authentication, agents/tasks guides, error handling, examples, full API reference.
- **CI** — new `sdk-python` job in `.github/workflows/ci.yml`, parallel to existing jobs, gated on `pre-commit`. Runs `uv sync` + `uv pip install -e ./sdks/python` + the SDK test suite. No `--all-extras` / deepdoc download, keeps the lane fast (~1 min).

## Surface (phase 1)

| Endpoint | SDK call |
| --- | --- |
| `GET /v1/me` | `client.agents.me()` |
| `GET /v1/agents` | `client.agents.list()` |
| `POST /v1/agents` | `client.agents.create(...)` |
| `POST /v1/agents/from-template` | `client.agents.create_from_template(...)` |
| `POST /v1/agents/{id}/api-key` | `client.agents.rotate_runtime_key(id)` |
| `POST /v1/chat/tasks` | `client.tasks.create(agent_id=, message=)` |
| `POST /v1/chat/tasks/{id}/messages` | `client.tasks.append_message(...)` |
| `GET /v1/chat/tasks/{id}` | `client.tasks.get(id)` |
| `GET /v1/chat/tasks/{id}/steps` | `client.tasks.get_steps(id)` |
| polling helper | `client.tasks.wait_for_completion(id)` |

## Non-goals (separate follow-ups)

- WebSocket / streaming transport — polling only for now.
- File upload (`/api/files`) — depends on multipart shape decisions.
- CLI tool — separate roadmap item.
- Publishing `xagent-sdk` to PyPI — needs maintainer ownership of the package name.

## Open questions for maintainers

1. **Package name & PyPI ownership** — keep `xagent-sdk` under the org?
2. **Versioning policy** — independent semver tied to `/v1/*`, or pinned to server image tags?
3. **Streaming** — should phase 2 wrap the existing WebSocket trace stream, or wait for a dedicated SSE/HTTP-stream surface?
4. Anything in the v1 contract you'd prefer the SDK *not* expose yet?

## Test plan

```bash
pip install -e . && pip install -e ./sdks/python
cd sdks/python && pytest -v
# 26 passed in 11.09s
```

The new `sdk-python` CI job runs the same command in the cloud.

## Minor incidental change

[`.gitignore`](.gitignore) had a recursive `*.md` rule (originally intended to keep stray root-level `.md` files out of git). Added a `!sdks/**/*.md` exception so SDK docs can be tracked without affecting any other path.
````

Sources:
- [issue #82 — Xagent Development Roadmap](https://github.com/xorbitsai/xagent/issues/82)
- [Push 后的分支：xiaoyesoso/xagent feat/python-sdk-skeleton](https://github.com/xiaoyesoso/xagent/tree/feat/python-sdk-skeleton)