### PR TITLE
feat: surface agent API keys and REST API call snippets

### DIFF
--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -569,6 +569,7 @@ export default function BuildsPage() {
           setDeployAgent(updatedAgent)
           setAgents(agents.map(a => a.id === updatedAgent.id ? updatedAgent : a))
         }}
+        onManageApiKey={() => { if (deployAgent) setApiKeyAgent(deployAgent) }}
       />
 
       <AgentApiKeyDialog

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -3,11 +3,12 @@
 import React, { useState, useEffect, useRef } from "react"
 import { SearchInput } from "@/components/ui/search-input"
 import { Button } from "@/components/ui/button"
-import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug } from "lucide-react"
+import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound } from "lucide-react"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
 import { DeployAgentDialog, Agent } from "@/components/build/deploy-agent-dialog"
+import { AgentApiKeyDialog } from "@/components/build/agent-api-key-dialog"
 import { FeatureEmptyState } from "@/components/ui/feature-empty-state"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
@@ -75,6 +76,7 @@ export default function BuildsPage() {
 
   // Deploy Dialog State
   const [deployAgent, setDeployAgent] = useState<Agent | null>(null)
+  const [apiKeyAgent, setApiKeyAgent] = useState<Agent | null>(null)
 
   // Check for template parameter and redirect to create page
   useEffect(() => {
@@ -393,7 +395,7 @@ export default function BuildsPage() {
                             </div>
                           </div>
                         </div>
-                        {(canPublishAgent(agent) || canDeleteAgent(agent)) && (
+                        {(canPublishAgent(agent) || canDeleteAgent(agent) || canEditAgent(agent)) && (
                           <div className="absolute right-4 top-1" onClick={(e) => e.stopPropagation()}>
                             <Popover>
                               <PopoverTrigger asChild>
@@ -401,8 +403,24 @@ export default function BuildsPage() {
                                   <MoreVertical className="h-4 w-4" />
                                 </Button>
                               </PopoverTrigger>
-                              <PopoverContent align="end" className="w-32 p-1" onClick={(e) => e.stopPropagation()}>
+                              <PopoverContent align="end" className="w-40 p-1" onClick={(e) => e.stopPropagation()}>
                                 <div className="flex flex-col">
+                                  {canEditAgent(agent) && (
+                                    <Button
+                                      variant="ghost"
+                                      className="justify-start px-2 py-1.5 h-auto font-normal text-sm"
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        setApiKeyAgent(agent)
+                                      }}
+                                    >
+                                      <KeyRound className="mr-2 h-4 w-4" />
+                                      {t('builds.list.actions.apiKey') || 'API Key'}
+                                    </Button>
+                                  )}
+                                  {canEditAgent(agent) && (canPublishAgent(agent) || canDeleteAgent(agent)) && (
+                                    <div className="h-px bg-border my-1 mx-1" />
+                                  )}
                                   {canPublishAgent(agent) && (
                                     <Button
                                       variant="ghost"
@@ -551,6 +569,13 @@ export default function BuildsPage() {
           setDeployAgent(updatedAgent)
           setAgents(agents.map(a => a.id === updatedAgent.id ? updatedAgent : a))
         }}
+      />
+
+      <AgentApiKeyDialog
+        agentId={apiKeyAgent?.id ?? null}
+        agentName={apiKeyAgent?.name}
+        open={apiKeyAgent !== null}
+        onOpenChange={(open) => { if (!open) setApiKeyAgent(null) }}
       />
 
       <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>

--- a/frontend/src/components/build/agent-api-key-dialog.tsx
+++ b/frontend/src/components/build/agent-api-key-dialog.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label"
 import { KeyRound, Copy, Check, AlertTriangle, Loader2 } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
+import { copyToClipboard } from "@/lib/clipboard"
 import {
   AgentApiKeyMetadata,
   generateAgentApiKey,
@@ -105,12 +106,15 @@ export function AgentApiKeyDialog({
     }
   }
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!fullKey) return
-    navigator.clipboard.writeText(fullKey)
-    setCopied(true)
-    toast.success(t("api_key.messages.copied") || "Copied to clipboard")
-    setTimeout(() => setCopied(false), 2000)
+    if (await copyToClipboard(fullKey)) {
+      setCopied(true)
+      toast.success(t("api_key.messages.copied") || "Copied to clipboard")
+      setTimeout(() => setCopied(false), 2000)
+    } else {
+      toast.error(t("api_key.messages.copy_failed") || "Failed to copy to clipboard")
+    }
   }
 
   const handleOpenChange = (next: boolean) => {

--- a/frontend/src/components/build/agent-api-key-dialog.tsx
+++ b/frontend/src/components/build/agent-api-key-dialog.tsx
@@ -73,17 +73,34 @@ export function AgentApiKeyDialog({
   const handleGenerate = async () => {
     if (agentId === null) return
     setBusy(true)
+    let result
     try {
-      const result = await generateAgentApiKey(agentId)
-      setFullKey(result.full_key)
-      // Re-read so the masked "active key" view matches the backend's
-      // canonical format instead of a locally synthesized one.
-      setMetadata(await getAgentApiKeyMetadata(agentId))
-      setMode("view")
-      toast.success(t("api_key.messages.generated") || "API key generated")
+      result = await generateAgentApiKey(agentId)
     } catch (err) {
       console.error(err)
       toast.error(t("api_key.messages.generate_failed") || "Failed to generate API key")
+      setBusy(false)
+      return
+    }
+    // Generation already succeeded (the old key, if any, is now rotated and
+    // this plaintext is the only copy). Commit that state from the POST
+    // response BEFORE any follow-up read, so a transient metadata-refresh
+    // failure can never present a successful rotation as a failure and prompt
+    // the user to retry -- which would invalidate the key they just copied.
+    setFullKey(result.full_key)
+    setMetadata({
+      key_prefix: result.key_prefix,
+      masked_key: "",
+      created_at: result.created_at,
+    })
+    setMode("view")
+    toast.success(t("api_key.messages.generated") || "API key generated")
+    // Best-effort upgrade to the backend's canonical masked form; non-fatal.
+    try {
+      const meta = await getAgentApiKeyMetadata(agentId)
+      if (meta) setMetadata(meta)
+    } catch (err) {
+      console.error(err)
     } finally {
       setBusy(false)
     }

--- a/frontend/src/components/build/agent-api-key-dialog.tsx
+++ b/frontend/src/components/build/agent-api-key-dialog.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import React, { useCallback, useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { KeyRound, Copy, Check, AlertTriangle, Loader2 } from "lucide-react"
+import { useI18n } from "@/contexts/i18n-context"
+import { toast } from "@/components/ui/sonner"
+import {
+  AgentApiKeyMetadata,
+  generateAgentApiKey,
+  getAgentApiKeyMetadata,
+  revokeAgentApiKey,
+} from "@/lib/agents-api"
+
+interface AgentApiKeyDialogProps {
+  agentId: number | null
+  agentName?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type Mode = "view" | "confirmRegenerate" | "confirmRevoke"
+
+export function AgentApiKeyDialog({
+  agentId,
+  agentName,
+  open,
+  onOpenChange,
+}: AgentApiKeyDialogProps) {
+  const { t } = useI18n()
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [metadata, setMetadata] = useState<AgentApiKeyMetadata | null>(null)
+  // Plaintext key, held in memory only and shown exactly once after a
+  // generate/rotate. Cleared on dialog close.
+  const [fullKey, setFullKey] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [mode, setMode] = useState<Mode>("view")
+
+  const loadMetadata = useCallback(async () => {
+    if (agentId === null) return
+    setLoading(true)
+    try {
+      setMetadata(await getAgentApiKeyMetadata(agentId))
+    } catch (err) {
+      console.error(err)
+      toast.error(t("api_key.messages.load_failed") || "Failed to load API key")
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId, t])
+
+  useEffect(() => {
+    if (open && agentId !== null) {
+      // Clear any state carried over from a previously-opened agent so we
+      // never flash a stale masked key before this agent's GET resolves.
+      setFullKey(null)
+      setMetadata(null)
+      setMode("view")
+      loadMetadata()
+    }
+  }, [open, agentId, loadMetadata])
+
+  const handleGenerate = async () => {
+    if (agentId === null) return
+    setBusy(true)
+    try {
+      const result = await generateAgentApiKey(agentId)
+      setFullKey(result.full_key)
+      // Re-read so the masked "active key" view matches the backend's
+      // canonical format instead of a locally synthesized one.
+      setMetadata(await getAgentApiKeyMetadata(agentId))
+      setMode("view")
+      toast.success(t("api_key.messages.generated") || "API key generated")
+    } catch (err) {
+      console.error(err)
+      toast.error(t("api_key.messages.generate_failed") || "Failed to generate API key")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleRevoke = async () => {
+    if (agentId === null) return
+    setBusy(true)
+    try {
+      await revokeAgentApiKey(agentId)
+      setFullKey(null)
+      setMetadata(null)
+      setMode("view")
+      toast.success(t("api_key.messages.revoked") || "API key revoked")
+    } catch (err) {
+      console.error(err)
+      toast.error(t("api_key.messages.revoke_failed") || "Failed to revoke API key")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCopy = () => {
+    if (!fullKey) return
+    navigator.clipboard.writeText(fullKey)
+    setCopied(true)
+    toast.success(t("api_key.messages.copied") || "Copied to clipboard")
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      // Drop the plaintext key from memory when the dialog closes.
+      setFullKey(null)
+      setMode("view")
+    }
+    onOpenChange(next)
+  }
+
+  const hasKey = metadata !== null
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5" />
+            {t("api_key.title") || "API Key"}
+          </DialogTitle>
+          <DialogDescription>
+            {agentName
+              ? `${agentName} · ${t("api_key.subtitle") || "SDK / REST API credential"}`
+              : t("api_key.subtitle") || "SDK / REST API credential"}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-4">
+          {/* One-time plaintext reveal after generate/rotate. */}
+          {fullKey && (
+            <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 p-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="h-4 w-4" />
+                {t("api_key.reveal.warning") || "Copy this key now — it is shown only once."}
+              </div>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 break-all rounded bg-muted px-2 py-1.5 text-xs font-mono">
+                  {fullKey}
+                </code>
+                <Button size="icon" variant="secondary" onClick={handleCopy} title={t("api_key.reveal.copy") || "Copy"}>
+                  {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex items-center justify-center py-6 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+          ) : mode === "confirmRegenerate" ? (
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="text-sm text-destructive">
+                {t("api_key.confirm.regenerate") ||
+                  "Regenerating immediately invalidates the current key. Any app using it will stop working until updated."}
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={() => setMode("view")} disabled={busy}>
+                  {t("api_key.actions.cancel") || "Cancel"}
+                </Button>
+                <Button variant="destructive" size="sm" onClick={handleGenerate} disabled={busy}>
+                  {t("api_key.actions.regenerate") || "Regenerate"}
+                </Button>
+              </div>
+            </div>
+          ) : mode === "confirmRevoke" ? (
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="text-sm text-destructive">
+                {t("api_key.confirm.revoke") ||
+                  "Revoking invalidates the current key. Any app using it will stop working."}
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={() => setMode("view")} disabled={busy}>
+                  {t("api_key.actions.cancel") || "Cancel"}
+                </Button>
+                <Button variant="destructive" size="sm" onClick={handleRevoke} disabled={busy}>
+                  {t("api_key.actions.revoke") || "Revoke"}
+                </Button>
+              </div>
+            </div>
+          ) : hasKey ? (
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">
+                  {t("api_key.active_key") || "Active key"}
+                </Label>
+                <div className="rounded-md bg-muted px-3 py-2 font-mono text-sm">
+                  {metadata?.masked_key || `${metadata?.key_prefix}••••••••`}
+                </div>
+                {metadata?.created_at && (
+                  <div className="text-xs text-muted-foreground">
+                    {t("api_key.created_at") || "Created"}:{" "}
+                    {new Date(metadata.created_at).toLocaleString()}
+                  </div>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => setMode("confirmRegenerate")} disabled={busy}>
+                  {t("api_key.actions.regenerate") || "Regenerate"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                  onClick={() => setMode("confirmRevoke")}
+                  disabled={busy}
+                >
+                  {t("api_key.actions.revoke") || "Revoke"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="text-sm text-muted-foreground">
+                {t("api_key.empty") || "No API key yet. Generate one to call this agent via the SDK or REST API."}
+              </div>
+              <Button size="sm" onClick={handleGenerate} disabled={busy}>
+                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t("api_key.actions.generate") || "Generate API Key"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -12,6 +12,7 @@ import { Rocket, LayoutGrid, Code2, Share, Webhook, ArrowRight, Copy, Check } fr
 import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getApiUrl } from "@/lib/utils"
+import { copyToClipboard } from "@/lib/clipboard"
 import { apiRequest } from "@/lib/api-wrapper"
 type ApiSnippetTab = "curl" | "python"
 
@@ -72,11 +73,14 @@ with AgentClient(api_key="YOUR_API_KEY", base_url="${apiBase}") as agent:
     }
   }, [agentId])
 
-  const handleCopyApiSnippet = () => {
-    navigator.clipboard.writeText(apiSnippets[apiTab])
-    setCopiedSnippet(true)
-    toast.success(t("deploy_agent.messages.copied") || "Copied to clipboard")
-    setTimeout(() => setCopiedSnippet(false), 2000)
+  const handleCopyApiSnippet = async () => {
+    if (await copyToClipboard(apiSnippets[apiTab])) {
+      setCopiedSnippet(true)
+      toast.success(t("deploy_agent.messages.copied") || "Copied to clipboard")
+      setTimeout(() => setCopiedSnippet(false), 2000)
+    } else {
+      toast.error(t("deploy_agent.messages.copy_failed") || "Failed to copy to clipboard")
+    }
   }
 
   const handleUpdateWidgetConfig = async (updates: { widget_enabled?: boolean, allowed_domains?: string[] }) => {

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"
@@ -13,6 +13,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
+type ApiSnippetTab = "curl" | "python"
 
 export interface Agent {
   id: number
@@ -35,14 +36,48 @@ interface DeployAgentDialogProps {
   deployAgent: Agent | null
   onClose: () => void
   onUpdate: (updatedAgent: Agent) => void
+  // Opens the shared API-key dialog (a single instance lives in the parent),
+  // so this dialog never nests its own Radix Dialog.
+  onManageApiKey?: () => void
 }
 
-export function DeployAgentDialog({ deployAgent, onClose, onUpdate }: DeployAgentDialogProps) {
+export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiKey }: DeployAgentDialogProps) {
   const { t } = useI18n()
   const [showSnippet, setShowSnippet] = useState(false)
+  const [showApiPanel, setShowApiPanel] = useState(false)
+  const [apiTab, setApiTab] = useState<ApiSnippetTab>("curl")
+  const [copiedSnippet, setCopiedSnippet] = useState(false)
   const [copied, setCopied] = useState(false)
   const [isUpdatingWidget, setIsUpdatingWidget] = useState(false)
   const [newDomain, setNewDomain] = useState("")
+
+  const agentId = deployAgent?.id ?? 0
+  const apiSnippets: Record<ApiSnippetTab, string> = useMemo(() => {
+    const apiBase =
+      getApiUrl() || (typeof window !== "undefined" ? window.location.origin : "")
+    return {
+      curl: `curl -X POST ${apiBase}/v1/chat/tasks \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "agent_id": ${agentId},
+    "message": { "role": "user", "content": "Hello" }
+  }'`,
+      python: `# pip install "xagent-sdk @ git+https://github.com/xorbitsai/xagent-sdk@v0.3.0#subdirectory=python"
+from xagent_sdk import AgentClient
+
+with AgentClient(api_key="YOUR_API_KEY", base_url="${apiBase}") as agent:
+    result = agent.tasks.run(agent_id=${agentId}, message="Hello")
+    print(result.output)`,
+    }
+  }, [agentId])
+
+  const handleCopyApiSnippet = () => {
+    navigator.clipboard.writeText(apiSnippets[apiTab])
+    setCopiedSnippet(true)
+    toast.success(t("deploy_agent.messages.copied") || "Copied to clipboard")
+    setTimeout(() => setCopiedSnippet(false), 2000)
+  }
 
   const handleUpdateWidgetConfig = async (updates: { widget_enabled?: boolean, allowed_domains?: string[] }) => {
     if (!deployAgent) return
@@ -104,7 +139,11 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate }: DeployAgen
     if (!open) {
       onClose()
       // Reset state when closing
-      setTimeout(() => setShowSnippet(false), 300)
+      setTimeout(() => {
+        setShowSnippet(false)
+        setShowApiPanel(false)
+        setApiTab("curl")
+      }, 300)
     }
   }
 
@@ -130,7 +169,8 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate }: DeployAgen
       desc: t("deploy_agent.options.rest_api.desc") || "Call the agent programmatically from your backend or app",
       actionText: t("deploy_agent.options.rest_api.action") || "View endpoints",
       actionColor: "text-purple-600",
-      className: "opacity-50 cursor-not-allowed shadow-sm",
+      className: "cursor-pointer hover:border-primary transition-colors shadow-sm",
+      onClick: () => setShowApiPanel(true),
     },
     {
       id: "shareable_link",
@@ -167,7 +207,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate }: DeployAgen
           <DialogDescription>{deployAgent?.name}</DialogDescription>
         </DialogHeader>
 
-        {!showSnippet ? (
+        {!showSnippet && !showApiPanel ? (
           <div className="mt-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {deploymentOptions.map((option) => (
@@ -192,6 +232,58 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate }: DeployAgen
                   </CardContent>
                 </Card>
               ))}
+            </div>
+          </div>
+        ) : showApiPanel ? (
+          <div className="mt-4 space-y-4">
+            <div className="flex items-center text-sm text-muted-foreground cursor-pointer hover:text-foreground" onClick={() => setShowApiPanel(false)}>
+              <ArrowRight className="h-4 w-4 mr-1 rotate-180" /> {t("deploy_agent.back_to_options") || "Back to Deploy Options"}
+            </div>
+
+            <div className="space-y-1">
+              <div className="font-medium">{t("deploy_agent.api_panel.title") || "Call this agent via REST API"}</div>
+              <div className="text-sm text-muted-foreground">
+                {t("deploy_agent.api_panel.desc") || "Submit a task to the agent. Poll GET /v1/chat/tasks/{id} for the result."}
+              </div>
+            </div>
+
+            <div className="flex gap-1 border-b">
+              {(["curl", "python"] as ApiSnippetTab[]).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setApiTab(tab)}
+                  className={`px-3 py-1.5 text-sm font-medium border-b-2 -mb-px transition-colors ${apiTab === tab ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+                >
+                  {tab === "curl" ? "cURL" : "Python"}
+                </button>
+              ))}
+            </div>
+
+            <div className="bg-muted p-4 rounded-md text-xs font-mono relative overflow-hidden group">
+              <pre className="whitespace-pre-wrap break-all text-muted-foreground max-h-80 overflow-auto">
+                {apiSnippets[apiTab]}
+              </pre>
+              <Button
+                variant="secondary"
+                size="icon"
+                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={handleCopyApiSnippet}
+                title={t("deploy_agent.api_panel.copy_btn") || "Copy"}
+              >
+                {copiedSnippet ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+
+            <div className="text-sm text-muted-foreground">
+              {t("deploy_agent.api_panel.key_hint") || "Replace YOUR_API_KEY with this agent's API key."}{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline font-medium"
+                onClick={() => onManageApiKey?.()}
+              >
+                {t("deploy_agent.api_panel.manage_key") || "Manage API Key"}
+              </button>
             </div>
           </div>
         ) : (

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3020,7 +3020,8 @@ Build when you need.`,
     messages: {
       update_success: "Widget configuration updated",
       update_failed: "Failed to update widget configuration",
-      copied: "Copied to clipboard"
+      copied: "Copied to clipboard",
+      copy_failed: "Failed to copy to clipboard"
     },
     api_panel: {
       title: "Call this agent via REST API",
@@ -3056,7 +3057,8 @@ Build when you need.`,
       generate_failed: "Failed to generate API key",
       revoked: "API key revoked",
       revoke_failed: "Failed to revoke API key",
-      copied: "Copied to clipboard"
+      copied: "Copied to clipboard",
+      copy_failed: "Failed to copy to clipboard"
     }
   },
   workforces: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3021,6 +3021,13 @@ Build when you need.`,
       update_success: "Widget configuration updated",
       update_failed: "Failed to update widget configuration",
       copied: "Copied to clipboard"
+    },
+    api_panel: {
+      title: "Call this agent via REST API",
+      desc: "Submit a task to the agent, then poll GET /v1/chat/tasks/{id} for the result.",
+      copy_btn: "Copy",
+      key_hint: "Replace YOUR_API_KEY with this agent's API key.",
+      manage_key: "Manage API Key"
     }
   },
   api_key: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2043,6 +2043,7 @@ Build when you need.`,
         publish: "Publish",
         delete: "Delete",
         edit: "Edit",
+        apiKey: "API Key",
         deleteConfirm: "Are you sure you want to delete this agent?",
       },
       createModal: {
@@ -3019,6 +3020,35 @@ Build when you need.`,
     messages: {
       update_success: "Widget configuration updated",
       update_failed: "Failed to update widget configuration",
+      copied: "Copied to clipboard"
+    }
+  },
+  api_key: {
+    title: "API Key",
+    subtitle: "SDK / REST API credential",
+    empty: "No API key yet. Generate one to call this agent via the SDK or REST API.",
+    active_key: "Active key",
+    created_at: "Created",
+    reveal: {
+      warning: "Copy this key now — it is shown only once.",
+      copy: "Copy"
+    },
+    actions: {
+      generate: "Generate API Key",
+      regenerate: "Regenerate",
+      revoke: "Revoke",
+      cancel: "Cancel"
+    },
+    confirm: {
+      regenerate: "Regenerating immediately invalidates the current key. Any app using it will stop working until updated.",
+      revoke: "Revoking invalidates the current key. Any app using it will stop working."
+    },
+    messages: {
+      load_failed: "Failed to load API key",
+      generated: "API key generated",
+      generate_failed: "Failed to generate API key",
+      revoked: "API key revoked",
+      revoke_failed: "Failed to revoke API key",
       copied: "Copied to clipboard"
     }
   },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3020,7 +3020,8 @@ Build when you need.`,
     messages: {
       update_success: "Widget 配置已更新",
       update_failed: "Widget 配置更新失败",
-      copied: "已复制到剪贴板"
+      copied: "已复制到剪贴板",
+      copy_failed: "复制到剪贴板失败"
     },
     api_panel: {
       title: "通过 REST API 调用此 Agent",
@@ -3056,7 +3057,8 @@ Build when you need.`,
       generate_failed: "生成 API Key 失败",
       revoked: "API Key 已撤销",
       revoke_failed: "撤销 API Key 失败",
-      copied: "已复制到剪贴板"
+      copied: "已复制到剪贴板",
+      copy_failed: "复制到剪贴板失败"
     }
   },
   workforces: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2043,6 +2043,7 @@ Build when you need.`,
         publish: "发布",
         delete: "删除",
         edit: "编辑",
+        apiKey: "API Key",
         deleteConfirm: "确定要删除这个 Agent 吗？",
       },
       createModal: {
@@ -3019,6 +3020,35 @@ Build when you need.`,
     messages: {
       update_success: "Widget 配置已更新",
       update_failed: "Widget 配置更新失败",
+      copied: "已复制到剪贴板"
+    }
+  },
+  api_key: {
+    title: "API Key",
+    subtitle: "SDK / REST API 凭证",
+    empty: "尚未创建 API Key。生成一个即可通过 SDK 或 REST API 调用此 Agent。",
+    active_key: "当前 Key",
+    created_at: "创建于",
+    reveal: {
+      warning: "请立即复制此 Key —— 它只显示一次。",
+      copy: "复制"
+    },
+    actions: {
+      generate: "生成 API Key",
+      regenerate: "重新生成",
+      revoke: "撤销",
+      cancel: "取消"
+    },
+    confirm: {
+      regenerate: "重新生成会立即使当前 Key 失效，正在使用它的应用将停止工作，直到更新为新 Key。",
+      revoke: "撤销会使当前 Key 失效，正在使用它的应用将停止工作。"
+    },
+    messages: {
+      load_failed: "加载 API Key 失败",
+      generated: "API Key 已生成",
+      generate_failed: "生成 API Key 失败",
+      revoked: "API Key 已撤销",
+      revoke_failed: "撤销 API Key 失败",
       copied: "已复制到剪贴板"
     }
   },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3021,6 +3021,13 @@ Build when you need.`,
       update_success: "Widget 配置已更新",
       update_failed: "Widget 配置更新失败",
       copied: "已复制到剪贴板"
+    },
+    api_panel: {
+      title: "通过 REST API 调用此 Agent",
+      desc: "向 Agent 提交一个任务，然后轮询 GET /v1/chat/tasks/{id} 获取结果。",
+      copy_btn: "复制",
+      key_hint: "将 YOUR_API_KEY 替换为此 Agent 的 API Key。",
+      manage_key: "管理 API Key"
     }
   },
   api_key: {

--- a/frontend/src/lib/agents-api.ts
+++ b/frontend/src/lib/agents-api.ts
@@ -1,0 +1,62 @@
+import { apiRequest } from "@/lib/api-wrapper"
+import { getApiUrl } from "@/lib/utils"
+
+// Mirrors the backend ``APIKeyMetadataResponse`` (no plaintext secret).
+export interface AgentApiKeyMetadata {
+  key_prefix: string
+  masked_key: string
+  created_at: string
+}
+
+// Mirrors the backend ``APIKeyGenerateResponse``. ``full_key`` is the
+// plaintext secret returned exactly once -- the server only stores a hash.
+export interface AgentApiKeyGenerated {
+  full_key: string
+  key_prefix: string
+  created_at: string
+}
+
+export interface AgentApiKeyRevoke {
+  revoked: boolean
+  revoked_at: string | null
+}
+
+function apiKeyUrl(agentId: number): string {
+  return `${getApiUrl()}/api/agents/${agentId}/api-key`
+}
+
+/**
+ * Read the agent's active API key metadata. Returns ``null`` when no
+ * active key exists (the backend answers 404 in that case) so the UI can
+ * render the "no key yet" state without treating it as an error.
+ */
+export async function getAgentApiKeyMetadata(
+  agentId: number
+): Promise<AgentApiKeyMetadata | null> {
+  const res = await apiRequest(apiKeyUrl(agentId), { method: "GET" })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Failed to load API key (${res.status})`)
+  return (await res.json()) as AgentApiKeyMetadata
+}
+
+/**
+ * Generate (or rotate) the agent's API key. Rotating revokes the existing
+ * active key, so the caller must confirm intent before invoking this. The
+ * returned ``full_key`` is shown to the user exactly once.
+ */
+export async function generateAgentApiKey(
+  agentId: number
+): Promise<AgentApiKeyGenerated> {
+  const res = await apiRequest(apiKeyUrl(agentId), { method: "POST" })
+  if (!res.ok) throw new Error(`Failed to generate API key (${res.status})`)
+  return (await res.json()) as AgentApiKeyGenerated
+}
+
+/** Revoke the agent's active API key. Idempotent on the backend. */
+export async function revokeAgentApiKey(
+  agentId: number
+): Promise<AgentApiKeyRevoke> {
+  const res = await apiRequest(apiKeyUrl(agentId), { method: "DELETE" })
+  if (!res.ok) throw new Error(`Failed to revoke API key (${res.status})`)
+  return (await res.json()) as AgentApiKeyRevoke
+}

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,32 @@
+/**
+ * Copy text to the clipboard, tolerating non-secure contexts (plain HTTP on a
+ * non-localhost host) and older browsers where ``navigator.clipboard`` is
+ * undefined -- accessing it directly there throws. Falls back to a hidden
+ * textarea + ``execCommand('copy')`` and reports success so callers can toast
+ * accordingly. Never throws.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // Secure-context API unavailable or blocked; fall through to the legacy path.
+  }
+  if (typeof document === "undefined") return false
+  try {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    const ok = document.execCommand("copy")
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

The deploy modal's "REST API" option was a disabled placeholder, and there was no way to mint an agent's SDK API key from the UI — even though the backend already exposes both the key-management endpoints and the `/v1/chat/tasks` runtime. This adds the frontend surface for both. Backend is unchanged.

## What's included

- **Agent API key management** (`217c230`): a reusable dialog to generate / view (masked) / rotate / revoke an agent's API key, reachable from the per-agent kebab menu (owner-gated). Thin client over `POST/GET/DELETE /api/agents/{id}/api-key`. The plaintext key is revealed once on generation (copy to clipboard) and shown masked afterwards; rotate and revoke require explicit confirmation since they invalidate the active key.
- **Deploy REST API panel** (`654c8c1`): enables the REST API deploy card. It shows cURL and Python (official SDK) snippets prefilled with the agent id and the configured API base, using the real `/v1/chat/tasks` request shape (`{agent_id, message:{role, content}}`). A "Manage API Key" link opens the same key dialog.

## Scope / notes

- Frontend only — the v1 runtime endpoints and the agent key endpoints already exist.
- The API base shown in snippets comes from `NEXT_PUBLIC_API_URL` (falls back to the page origin at runtime).
- TypeScript/JavaScript SDK snippets are intentionally omitted for now (those SDK clients are not published yet); cURL covers raw HTTP.

## Testing

- `cd frontend && npm run type-check && npm run lint` — both pass.
- Manual: agent list → kebab → API Key (generate → one-time reveal → masked on reopen); Deploy → REST API → snippets + "Manage API Key" link opens the dialog.
- Verified end to end against a local backend: generate a key → `POST /v1/chat/tasks` with it → 202; a bad or rotated key → 401.