### PR TITLE
refactor(kb): route tool flows through compatibility facade

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_kb_service.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_kb_service.py
@@ -1,12 +1,23 @@
 import logging
+from typing import TYPE_CHECKING
 
 from ...core.RAG_tools.core.schemas import IngestionConfig
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ...core.RAG_tools.kb import KBToolCompatibilityFacade
+
 
 class AgentKnowledgeBaseError(RuntimeError):
     """Raised when agent-triggered knowledge base setup cannot be completed."""
+
+
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned KB tool compatibility facade."""
+    from ...core.RAG_tools.kb import get_kb_coordinator
+
+    return get_kb_coordinator().tool_compatibility
 
 
 class AgentKnowledgeBaseService:
@@ -21,50 +32,77 @@ class AgentKnowledgeBaseService:
         collection_name: str,
         ingestion_config: IngestionConfig,
     ) -> str:
-        from .....web.config import sanitize_path_component
-        from ...core.RAG_tools.storage.factory import get_metadata_store
-
-        safe_collection = sanitize_path_component(collection_name, "collection")
-        metadata_store = get_metadata_store()
-
-        try:
-            await metadata_store.save_collection_config(
-                collection=safe_collection,
-                config_json=ingestion_config.model_dump_json(exclude_unset=True),
-                user_id=self.user_id,
-            )
-        except Exception as exc:
-            logger.error(
-                "Failed to save collection config for agent knowledge base %s: %s",
-                safe_collection,
-                exc,
-            )
-            raise AgentKnowledgeBaseError(
-                f"Failed to save collection config for knowledge base '{safe_collection}'"
-            ) from exc
-
-        return safe_collection
+        return await _get_tool_compatibility_facade().prepare_agent_collection(
+            collection_name=collection_name,
+            ingestion_config=ingestion_config,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+        )
 
     async def refresh_collection_metadata(self, collection_name: str) -> None:
-        from ...core.RAG_tools.management.collections import list_collections
+        await _get_tool_compatibility_facade().refresh_agent_collection_metadata(
+            collection_name,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+        )
 
-        if not self.is_admin:
-            # Non-admin realtime refreshes do not persist metadata and only add scan cost.
-            return
 
-        try:
-            # Refresh metadata cache so agent-created KBs are visible like API-created ones.
-            await list_collections(
-                user_id=self.user_id,
-                is_admin=self.is_admin,
-                force_realtime=True,
-            )
-        except Exception as exc:
-            logger.error(
-                "Failed to refresh collection metadata after agent ingestion for %s: %s",
-                collection_name,
-                exc,
-            )
-            raise AgentKnowledgeBaseError(
-                f"Failed to refresh knowledge base metadata for '{collection_name}'"
-            ) from exc
+async def _prepare_collection_impl(
+    *,
+    collection_name: str,
+    ingestion_config: IngestionConfig,
+    user_id: int,
+) -> str:
+    from .....web.config import sanitize_path_component
+    from ...core.RAG_tools.storage.factory import get_metadata_store
+
+    safe_collection = sanitize_path_component(collection_name, "collection")
+    metadata_store = get_metadata_store()
+
+    try:
+        await metadata_store.save_collection_config(
+            collection=safe_collection,
+            config_json=ingestion_config.model_dump_json(exclude_unset=True),
+            user_id=user_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to save collection config for agent knowledge base %s: %s",
+            safe_collection,
+            exc,
+        )
+        raise AgentKnowledgeBaseError(
+            f"Failed to save collection config for knowledge base '{safe_collection}'"
+        ) from exc
+
+    return safe_collection
+
+
+async def _refresh_collection_metadata_impl(
+    *,
+    collection_name: str,
+    user_id: int,
+    is_admin: bool = False,
+) -> None:
+    from ...core.RAG_tools.management.collections import list_collections
+
+    if not is_admin:
+        # Non-admin realtime refreshes do not persist metadata and only add scan cost.
+        return
+
+    try:
+        # Refresh metadata cache so agent-created KBs are visible like API-created ones.
+        await list_collections(
+            user_id=user_id,
+            is_admin=is_admin,
+            force_realtime=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to refresh collection metadata after agent ingestion for %s: %s",
+            collection_name,
+            exc,
+        )
+        raise AgentKnowledgeBaseError(
+            f"Failed to refresh knowledge base metadata for '{collection_name}'"
+        ) from exc

--- a/src/xagent/core/tools/adapters/vibe/document_search.py
+++ b/src/xagent/core/tools/adapters/vibe/document_search.py
@@ -1,7 +1,7 @@
 """Knowledge base search tools for Vibe agents."""
 
 import logging
-from typing import Any, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 
 from pydantic import BaseModel
 
@@ -10,12 +10,20 @@ from ...core.document_search import (
     KnowledgeSearchResult,
     ListKnowledgeBasesArgs,
     ListKnowledgeBasesResult,
-    list_knowledge_bases,
-    search_knowledge_base,
 )
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ...core.RAG_tools.kb import KBToolCompatibilityFacade
+
+
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned KB tool compatibility facade."""
+    from ...core.RAG_tools.kb import get_kb_coordinator
+
+    return get_kb_coordinator().tool_compatibility
 
 
 class ListKnowledgeBasesTool(AbstractBaseTool):
@@ -64,12 +72,25 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
             args = dict(args)
             args.setdefault("allowed_collections", self.allowed_collections)
         tool_args = ListKnowledgeBasesArgs.model_validate(args)
-        return await list_knowledge_bases(
+        return await _get_tool_compatibility_facade().list_knowledge_bases(
             tool_args, user_id=self.user_id, is_admin=self.is_admin
         )
 
 
 def get_list_knowledge_bases_tool(
+    allowed_collections: Optional[list[str]] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> ListKnowledgeBasesTool:
+    """Create a tool to list all knowledge bases through the tool facade."""
+    return _get_tool_compatibility_facade().get_list_knowledge_bases_tool(
+        allowed_collections=allowed_collections,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _get_list_knowledge_bases_tool_impl(
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,
     is_admin: bool = False,
@@ -151,12 +172,27 @@ class KnowledgeSearchTool(AbstractBaseTool):
             )
 
         tool_args = KnowledgeSearchArgs.model_validate(args)
-        return await search_knowledge_base(
+        return await _get_tool_compatibility_facade().search_knowledge_base(
             tool_args, user_id=self.user_id, is_admin=self.is_admin
         )
 
 
 def get_knowledge_search_tool(
+    embedding_model_id: Optional[str] = None,
+    allowed_collections: Optional[list[str]] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> KnowledgeSearchTool:
+    """Create a knowledge base search tool through the tool facade."""
+    return _get_tool_compatibility_facade().get_knowledge_search_tool(
+        embedding_model_id=embedding_model_id,
+        allowed_collections=allowed_collections,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _get_knowledge_search_tool_impl(
     embedding_model_id: Optional[str] = None,
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -4,7 +4,7 @@ import re
 import time
 from functools import partial
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type
 
 from pydantic import BaseModel, Field
 
@@ -13,6 +13,9 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .factory import register_tool
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ...core.RAG_tools.kb import KBToolCompatibilityFacade
 
 
 class CreateKnowledgeBaseFromFileArgs(BaseModel):
@@ -65,145 +68,172 @@ class CreateKnowledgeBaseFromFileTool(AbstractBaseTool):
         raise NotImplementedError("Only supports async execution.")
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        return await _get_tool_compatibility_facade().create_knowledge_base_from_file(
+            args,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+        )
+
+
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned KB tool compatibility facade."""
+    from ...core.RAG_tools.kb import get_kb_coordinator
+
+    return get_kb_coordinator().tool_compatibility
+
+
+async def _create_knowledge_base_from_file_impl(
+    args: Mapping[str, Any],
+    *,
+    user_id: int,
+    is_admin: bool = False,
+) -> Any:
+    try:
+        from sqlalchemy.orm import Session
+
+        from .....web.models.database import get_db
+        from .....web.models.uploaded_file import UploadedFile
+        from .....web.services.managed_file_ref import (
+            DurableStorageOperationError,
+            ensure_uploaded_file_local_path,
+        )
+        from ...core.RAG_tools.core.schemas import (
+            DEFAULT_EMBEDDING_MODEL_ID,
+            IngestionConfig,
+        )
+        from ...core.RAG_tools.pipelines.document_ingestion import (
+            run_document_ingestion,
+        )
+        from .agent_kb_service import AgentKnowledgeBaseService
+
+        tool_args = CreateKnowledgeBaseFromFileArgs.model_validate(args)
+
+        db_gen = get_db()
+        db: Session = next(db_gen)
+
         try:
-            from sqlalchemy.orm import Session
-
-            from .....web.models.database import get_db
-            from .....web.models.uploaded_file import UploadedFile
-            from .....web.services.managed_file_ref import (
-                DurableStorageOperationError,
-                ensure_uploaded_file_local_path,
+            query = db.query(UploadedFile).filter(
+                UploadedFile.file_id.in_(tool_args.file_ids)
             )
-            from ...core.RAG_tools.core.schemas import (
-                DEFAULT_EMBEDDING_MODEL_ID,
-                IngestionConfig,
-            )
-            from ...core.RAG_tools.pipelines.document_ingestion import (
-                run_document_ingestion,
-            )
-            from .agent_kb_service import AgentKnowledgeBaseService
+            if not is_admin:
+                query = query.filter(UploadedFile.user_id == user_id)
+            file_records = query.all()
 
-            tool_args = CreateKnowledgeBaseFromFileArgs.model_validate(args)
-
-            db_gen = get_db()
-            db: Session = next(db_gen)
-
-            try:
-                query = db.query(UploadedFile).filter(
-                    UploadedFile.file_id.in_(tool_args.file_ids)
-                )
-                if not self.is_admin:
-                    query = query.filter(UploadedFile.user_id == self.user_id)
-                file_records = query.all()
-
-                if not file_records:
-                    return CreateKnowledgeBaseFromFileResult(
-                        success=False,
-                        collection_name="",
-                        message=f"No files found for the provided file_ids: {tool_args.file_ids}",
-                        files_ingested=0,
-                    ).model_dump()
-
-                if tool_args.collection_name:
-                    collection_name = tool_args.collection_name
-                else:
-                    base_name = re.sub(
-                        r"[^a-zA-Z0-9_-]",
-                        "_",
-                        Path(file_records[0].filename).stem,
-                    )[:30]
-                    collection_name = f"{base_name}_{int(time.time())}"
-
-                config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
-                kb_service = AgentKnowledgeBaseService(
-                    user_id=self.user_id,
-                    is_admin=self.is_admin,
-                )
-                collection_name = await kb_service.prepare_collection(
-                    collection_name=collection_name,
-                    ingestion_config=config,
-                )
-
-                ingested_count = 0
-                errors = []
-
-                for record in file_records:
-                    try:
-                        source_path = ensure_uploaded_file_local_path(record)
-                    except DurableStorageOperationError as exc:
-                        errors.append(
-                            f"Failed to restore {record.filename} from durable storage: {exc}"
-                        )
-                        continue
-                    if not source_path.exists():
-                        errors.append(
-                            f"File not found on disk: {record.filename} (file_id={record.file_id})"
-                        )
-                        continue
-
-                    loop = asyncio.get_running_loop()
-                    func = partial(
-                        run_document_ingestion,
-                        collection=collection_name,
-                        source_path=str(source_path),
-                        ingestion_config=config,
-                        user_id=self.user_id,
-                        is_admin=self.is_admin,
-                        file_id=str(record.file_id),
-                    )
-                    result = await loop.run_in_executor(None, func)
-
-                    if result.status == "error":
-                        errors.append(
-                            f"Failed to ingest {record.filename}: {result.message}"
-                        )
-                    else:
-                        ingested_count += 1
-                        logger.info(
-                            "Ingested file %s into collection %s",
-                            record.filename,
-                            collection_name,
-                        )
-
-                if ingested_count == 0:
-                    return CreateKnowledgeBaseFromFileResult(
-                        success=False,
-                        collection_name=collection_name,
-                        message=f"Failed to ingest any files. Errors: {'; '.join(errors)}",
-                        files_ingested=0,
-                    ).model_dump()
-
-                message = (
-                    f"Successfully created knowledge base '{collection_name}' "
-                    f"with {ingested_count} file(s)."
-                )
-                if errors:
-                    message += f" Warnings: {'; '.join(errors)}"
-
-                await kb_service.refresh_collection_metadata(collection_name)
-
+            if not file_records:
                 return CreateKnowledgeBaseFromFileResult(
-                    success=True,
-                    collection_name=collection_name,
-                    message=message,
-                    files_ingested=ingested_count,
+                    success=False,
+                    collection_name="",
+                    message=f"No files found for the provided file_ids: {tool_args.file_ids}",
+                    files_ingested=0,
                 ).model_dump()
 
-            finally:
-                db.close()
+            if tool_args.collection_name:
+                collection_name = tool_args.collection_name
+            else:
+                base_name = re.sub(
+                    r"[^a-zA-Z0-9_-]",
+                    "_",
+                    Path(file_records[0].filename).stem,
+                )[:30]
+                collection_name = f"{base_name}_{int(time.time())}"
 
-        except Exception as e:
-            logger.exception("Error creating knowledge base from file: %s", e)
+            config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+            kb_service = AgentKnowledgeBaseService(
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            collection_name = await kb_service.prepare_collection(
+                collection_name=collection_name,
+                ingestion_config=config,
+            )
+
+            ingested_count = 0
+            errors = []
+
+            for record in file_records:
+                try:
+                    source_path = ensure_uploaded_file_local_path(record)
+                except DurableStorageOperationError as exc:
+                    errors.append(
+                        f"Failed to restore {record.filename} from durable storage: {exc}"
+                    )
+                    continue
+                if not source_path.exists():
+                    errors.append(
+                        f"File not found on disk: {record.filename} (file_id={record.file_id})"
+                    )
+                    continue
+
+                loop = asyncio.get_running_loop()
+                func = partial(
+                    run_document_ingestion,
+                    collection=collection_name,
+                    source_path=str(source_path),
+                    ingestion_config=config,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    file_id=str(record.file_id),
+                )
+                result = await loop.run_in_executor(None, func)
+
+                if result.status == "error":
+                    errors.append(
+                        f"Failed to ingest {record.filename}: {result.message}"
+                    )
+                else:
+                    ingested_count += 1
+                    logger.info(
+                        "Ingested file %s into collection %s",
+                        record.filename,
+                        collection_name,
+                    )
+
+            if ingested_count == 0:
+                return CreateKnowledgeBaseFromFileResult(
+                    success=False,
+                    collection_name=collection_name,
+                    message=f"Failed to ingest any files. Errors: {'; '.join(errors)}",
+                    files_ingested=0,
+                ).model_dump()
+
+            message = (
+                f"Successfully created knowledge base '{collection_name}' "
+                f"with {ingested_count} file(s)."
+            )
+            if errors:
+                message += f" Warnings: {'; '.join(errors)}"
+
+            await kb_service.refresh_collection_metadata(collection_name)
+
             return CreateKnowledgeBaseFromFileResult(
-                success=False,
-                collection_name="",
-                message=str(e),
-                files_ingested=0,
+                success=True,
+                collection_name=collection_name,
+                message=message,
+                files_ingested=ingested_count,
             ).model_dump()
+
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.exception("Error creating knowledge base from file: %s", e)
+        return CreateKnowledgeBaseFromFileResult(
+            success=False,
+            collection_name="",
+            message=str(e),
+            files_ingested=0,
+        ).model_dump()
 
 
 @register_tool(categories={"knowledge"})
 async def create_file_ingestion_tools(config: WebToolConfig) -> list[AbstractBaseTool]:
+    """Create file ingestion tools."""
+    return await _get_tool_compatibility_facade().create_file_ingestion_tools(config)
+
+
+async def _create_file_ingestion_tools_impl(
+    config: WebToolConfig,
+) -> list[AbstractBaseTool]:
     """Create file ingestion tools."""
     try:
         user_id = config.get_user_id()

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -4,7 +4,8 @@ import re
 import time
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type, cast
 
 from pydantic import BaseModel, Field
 
@@ -82,6 +83,17 @@ def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
     return get_kb_coordinator().tool_compatibility
 
 
+def _snapshot_uploaded_file_record(record: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        file_id=str(record.file_id),
+        filename=str(record.filename),
+        storage_path=str(record.storage_path),
+        storage_key=getattr(record, "storage_key", None),
+        storage_status=getattr(record, "storage_status", None),
+        checksum=getattr(record, "checksum", None),
+    )
+
+
 async def _create_knowledge_base_from_file_impl(
     args: Mapping[str, Any],
     *,
@@ -117,113 +129,114 @@ async def _create_knowledge_base_from_file_impl(
             )
             if not is_admin:
                 query = query.filter(UploadedFile.user_id == user_id)
-            file_records = query.all()
-
-            if not file_records:
-                return CreateKnowledgeBaseFromFileResult(
-                    success=False,
-                    collection_name="",
-                    message=f"No files found for the provided file_ids: {tool_args.file_ids}",
-                    files_ingested=0,
-                ).model_dump()
-
-            if tool_args.collection_name:
-                collection_name = tool_args.collection_name
-            else:
-                base_name = re.sub(
-                    r"[^a-zA-Z0-9_-]",
-                    "_",
-                    Path(file_records[0].filename).stem,
-                )[:30]
-                collection_name = f"{base_name}_{int(time.time())}"
-
-            config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
-            kb_service = AgentKnowledgeBaseService(
-                user_id=user_id,
-                is_admin=is_admin,
-            )
-            collection_name = await kb_service.prepare_collection(
-                collection_name=collection_name,
-                ingestion_config=config,
-            )
-
-            ingested_count = 0
-            errors = []
-
-            for record in file_records:
-                try:
-                    source_path = ensure_uploaded_file_local_path(record)
-                except DurableStorageOperationError as exc:
-                    errors.append(
-                        f"Failed to restore {record.filename} from durable storage: {exc}"
-                    )
-                    continue
-                if not source_path.exists():
-                    errors.append(
-                        f"File not found on disk: {record.filename} (file_id={record.file_id})"
-                    )
-                    continue
-
-                loop = asyncio.get_running_loop()
-                func = partial(
-                    run_document_ingestion,
-                    collection=collection_name,
-                    source_path=str(source_path),
-                    ingestion_config=config,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    file_id=str(record.file_id),
-                )
-                try:
-                    result = await loop.run_in_executor(None, func)
-                except Exception as exc:
-                    errors.append(
-                        f"Failed to ingest {record.filename} due to unexpected error: {exc}"
-                    )
-                    logger.exception(
-                        "Unexpected error ingesting file %s",
-                        record.filename,
-                    )
-                    continue
-
-                if result.status == "error":
-                    errors.append(
-                        f"Failed to ingest {record.filename}: {result.message}"
-                    )
-                else:
-                    ingested_count += 1
-                    logger.info(
-                        "Ingested file %s into collection %s",
-                        record.filename,
-                        collection_name,
-                    )
-
-            if ingested_count == 0:
-                return CreateKnowledgeBaseFromFileResult(
-                    success=False,
-                    collection_name=collection_name,
-                    message=f"Failed to ingest any files. Errors: {'; '.join(errors)}",
-                    files_ingested=0,
-                ).model_dump()
-
-            message = (
-                f"Successfully created knowledge base '{collection_name}' "
-                f"with {ingested_count} file(s)."
-            )
-            if errors:
-                message += f" Warnings: {'; '.join(errors)}"
-
-            await kb_service.refresh_collection_metadata(collection_name)
-
-            return CreateKnowledgeBaseFromFileResult(
-                success=True,
-                collection_name=collection_name,
-                message=message,
-                files_ingested=ingested_count,
-            ).model_dump()
-
+            file_records = [
+                _snapshot_uploaded_file_record(record) for record in query.all()
+            ]
         finally:
             db_gen.close()
+
+        if not file_records:
+            return CreateKnowledgeBaseFromFileResult(
+                success=False,
+                collection_name="",
+                message=f"No files found for the provided file_ids: {tool_args.file_ids}",
+                files_ingested=0,
+            ).model_dump()
+
+        if tool_args.collection_name:
+            collection_name = tool_args.collection_name
+        else:
+            base_name = re.sub(
+                r"[^a-zA-Z0-9_-]",
+                "_",
+                Path(file_records[0].filename).stem,
+            )[:30]
+            collection_name = f"{base_name}_{int(time.time())}"
+
+        config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+        kb_service = AgentKnowledgeBaseService(
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        collection_name = await kb_service.prepare_collection(
+            collection_name=collection_name,
+            ingestion_config=config,
+        )
+
+        ingested_count = 0
+        errors = []
+
+        for record in file_records:
+            try:
+                source_path = ensure_uploaded_file_local_path(
+                    cast(UploadedFile, record)
+                )
+            except DurableStorageOperationError as exc:
+                errors.append(
+                    f"Failed to restore {record.filename} from durable storage: {exc}"
+                )
+                continue
+            if not source_path.exists():
+                errors.append(
+                    f"File not found on disk: {record.filename} (file_id={record.file_id})"
+                )
+                continue
+
+            loop = asyncio.get_running_loop()
+            func = partial(
+                run_document_ingestion,
+                collection=collection_name,
+                source_path=str(source_path),
+                ingestion_config=config,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_id=str(record.file_id),
+            )
+            try:
+                result = await loop.run_in_executor(None, func)
+            except Exception as exc:
+                errors.append(
+                    f"Failed to ingest {record.filename} due to unexpected error: {exc}"
+                )
+                logger.exception(
+                    "Unexpected error ingesting file %s",
+                    record.filename,
+                )
+                continue
+
+            if result.status == "error":
+                errors.append(f"Failed to ingest {record.filename}: {result.message}")
+            else:
+                ingested_count += 1
+                logger.info(
+                    "Ingested file %s into collection %s",
+                    record.filename,
+                    collection_name,
+                )
+
+        if ingested_count == 0:
+            return CreateKnowledgeBaseFromFileResult(
+                success=False,
+                collection_name=collection_name,
+                message=f"Failed to ingest any files. Errors: {'; '.join(errors)}",
+                files_ingested=0,
+            ).model_dump()
+
+        message = (
+            f"Successfully created knowledge base '{collection_name}' "
+            f"with {ingested_count} file(s)."
+        )
+        if errors:
+            message += f" Warnings: {'; '.join(errors)}"
+
+        await kb_service.refresh_collection_metadata(collection_name)
+
+        return CreateKnowledgeBaseFromFileResult(
+            success=True,
+            collection_name=collection_name,
+            message=message,
+            files_ingested=ingested_count,
+        ).model_dump()
 
     except Exception as e:
         logger.exception("Error creating knowledge base from file: %s", e)

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 import time
+from contextvars import copy_context
 from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
@@ -193,7 +194,10 @@ async def _create_knowledge_base_from_file_impl(
                 file_id=str(record.file_id),
             )
             try:
-                result = await loop.run_in_executor(None, func)
+                request_context = copy_context()
+                result = await loop.run_in_executor(
+                    None, lambda: request_context.run(func)
+                )
             except Exception as exc:
                 errors.append(
                     f"Failed to ingest {record.filename} due to unexpected error: {exc}"

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -3,10 +3,10 @@ import logging
 import re
 import time
 from contextvars import copy_context
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type
 
 from pydantic import BaseModel, Field
 
@@ -18,6 +18,18 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...core.RAG_tools.kb import KBToolCompatibilityFacade
+
+
+@dataclass(frozen=True)
+class UploadedFileSnapshot:
+    """Scalar upload metadata retained after closing the DB session."""
+
+    file_id: str
+    filename: str
+    storage_path: str
+    storage_key: str | None
+    storage_status: str | None
+    checksum: str | None
 
 
 class CreateKnowledgeBaseFromFileArgs(BaseModel):
@@ -84,8 +96,8 @@ def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
     return get_kb_coordinator().tool_compatibility
 
 
-def _snapshot_uploaded_file_record(record: Any) -> SimpleNamespace:
-    return SimpleNamespace(
+def _snapshot_uploaded_file_record(record: Any) -> UploadedFileSnapshot:
+    return UploadedFileSnapshot(
         file_id=str(record.file_id),
         filename=str(record.filename),
         storage_path=str(record.storage_path),
@@ -169,9 +181,7 @@ async def _create_knowledge_base_from_file_impl(
 
         for record in file_records:
             try:
-                source_path = ensure_uploaded_file_local_path(
-                    cast(UploadedFile, record)
-                )
+                source_path = ensure_uploaded_file_local_path(record)
             except DurableStorageOperationError as exc:
                 errors.append(
                     f"Failed to restore {record.filename} from durable storage: {exc}"

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -205,9 +205,7 @@ async def _create_knowledge_base_from_file_impl(
             )
             try:
                 request_context = copy_context()
-                result = await loop.run_in_executor(
-                    None, lambda: request_context.run(func)
-                )
+                result = await loop.run_in_executor(None, request_context.run, func)
             except Exception as exc:
                 errors.append(
                     f"Failed to ingest {record.filename} due to unexpected error: {exc}"

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -174,7 +174,17 @@ async def _create_knowledge_base_from_file_impl(
                     is_admin=is_admin,
                     file_id=str(record.file_id),
                 )
-                result = await loop.run_in_executor(None, func)
+                try:
+                    result = await loop.run_in_executor(None, func)
+                except Exception as exc:
+                    errors.append(
+                        f"Failed to ingest {record.filename} due to unexpected error: {exc}"
+                    )
+                    logger.exception(
+                        "Unexpected error ingesting file %s",
+                        record.filename,
+                    )
+                    continue
 
                 if result.status == "error":
                     errors.append(
@@ -213,7 +223,7 @@ async def _create_knowledge_base_from_file_impl(
             ).model_dump()
 
         finally:
-            db.close()
+            db_gen.close()
 
     except Exception as e:
         logger.exception("Error creating knowledge base from file: %s", e)

--- a/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
@@ -6,13 +6,26 @@ from typing import TYPE_CHECKING, Any, List
 from .factory import register_tool
 
 if TYPE_CHECKING:
+    from ...core.RAG_tools.kb import KBToolCompatibilityFacade
     from .config import BaseToolConfig
 
 logger = logging.getLogger(__name__)
 
 
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned KB tool compatibility facade."""
+    from ...core.RAG_tools.kb import get_kb_coordinator
+
+    return get_kb_coordinator().tool_compatibility
+
+
 @register_tool(categories={"knowledge"})
 async def create_knowledge_tools(config: "BaseToolConfig") -> List[Any]:
+    """Create knowledge base search tools through the tool facade."""
+    return await _get_tool_compatibility_facade().create_knowledge_tools(config)
+
+
+async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
     """Create knowledge base search tools."""
     tools: List[Any] = []
 

--- a/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -8,6 +8,9 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .factory import register_tool
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ...core.RAG_tools.kb import KBToolCompatibilityFacade
 
 
 class CreateKnowledgeBaseFromUrlArgs(BaseModel):
@@ -65,106 +68,129 @@ class CreateKnowledgeBaseFromUrlTool(AbstractBaseTool):
         raise NotImplementedError("Only supports async execution.")
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        try:
-            import time
+        return await _get_tool_compatibility_facade().create_knowledge_base_from_url(
+            args,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+        )
 
-            from ...core.RAG_tools.core.schemas import (
-                DEFAULT_EMBEDDING_MODEL_ID,
-                IngestionConfig,
-                WebCrawlConfig,
-            )
-            from ...core.RAG_tools.pipelines.web_ingestion import run_web_ingestion
-            from .agent_kb_service import AgentKnowledgeBaseService
 
-            tool_args = CreateKnowledgeBaseFromUrlArgs.model_validate(args)
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned KB tool compatibility facade."""
+    from ...core.RAG_tools.kb import get_kb_coordinator
 
-            # Generate a safe collection name if not provided
-            if not tool_args.collection_name:
-                import hashlib
-                import re
+    return get_kb_coordinator().tool_compatibility
 
-                base_name = re.sub(
-                    r"[^a-zA-Z0-9_-]", "_", tool_args.url.split("//")[-1].split("/")[0]
-                )[:30]
-                url_hash = hashlib.md5(tool_args.url.encode()).hexdigest()[:6]
-                collection_name = f"{base_name}_{url_hash}_{int(time.time())}"
-            else:
-                collection_name = tool_args.collection_name
 
-            crawl_config = WebCrawlConfig(
-                start_url=tool_args.url,
-                max_pages=min(
-                    tool_args.max_pages, 50
-                ),  # Cap at 50 to avoid long blocking
-                max_depth=2,
-            )
+async def _create_knowledge_base_from_url_impl(
+    args: Mapping[str, Any],
+    *,
+    user_id: int,
+    is_admin: bool = False,
+) -> Any:
+    try:
+        import hashlib
+        import re
+        import time
 
-            ingest_config = IngestionConfig(
-                embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID
-            )
-            kb_service = AgentKnowledgeBaseService(
-                user_id=self.user_id,
-                is_admin=self.is_admin,
-            )
-            collection_name = await kb_service.prepare_collection(
-                collection_name=collection_name,
-                ingestion_config=ingest_config,
-            )
+        from ...core.RAG_tools.core.schemas import (
+            DEFAULT_EMBEDDING_MODEL_ID,
+            IngestionConfig,
+            WebCrawlConfig,
+        )
+        from ...core.RAG_tools.pipelines.web_ingestion import run_web_ingestion
+        from .agent_kb_service import AgentKnowledgeBaseService
 
-            logger.info(
-                f"Starting background web ingestion for {tool_args.url} into {collection_name}"
-            )
+        tool_args = CreateKnowledgeBaseFromUrlArgs.model_validate(args)
 
-            # Run ingestion
-            result = await run_web_ingestion(
-                collection=collection_name,
-                crawl_config=crawl_config,
-                ingestion_config=ingest_config,
-                user_id=self.user_id,
-                is_admin=self.is_admin,
-            )
+        # Generate a safe collection name if not provided
+        if not tool_args.collection_name:
+            base_name = re.sub(
+                r"[^a-zA-Z0-9_-]", "_", tool_args.url.split("//")[-1].split("/")[0]
+            )[:30]
+            url_hash = hashlib.md5(tool_args.url.encode()).hexdigest()[:6]
+            collection_name = f"{base_name}_{url_hash}_{int(time.time())}"
+        else:
+            collection_name = tool_args.collection_name
 
-            if result.status == "error":
-                return CreateKnowledgeBaseFromUrlResult(
-                    success=False,
-                    collection_name=collection_name,
-                    message=f"Failed to crawl website: {result.message}",
-                    pages_crawled=0,
-                ).model_dump()
+        crawl_config = WebCrawlConfig(
+            start_url=tool_args.url,
+            max_pages=min(tool_args.max_pages, 50),
+            max_depth=2,
+        )
 
-            await kb_service.refresh_collection_metadata(collection_name)
+        ingest_config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+        kb_service = AgentKnowledgeBaseService(
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        collection_name = await kb_service.prepare_collection(
+            collection_name=collection_name,
+            ingestion_config=ingest_config,
+        )
 
-            return CreateKnowledgeBaseFromUrlResult(
-                success=True,
-                collection_name=collection_name,
-                message=f"Successfully imported website {tool_args.url} into knowledge base '{collection_name}'",
-                pages_crawled=result.pages_crawled,
-            ).model_dump()
-        except ValidationError as e:
-            errors = e.errors()
-            message = errors[0]["msg"] if errors else str(e)
-            if isinstance(message, str) and message.startswith("Value error, "):
-                message = message.removeprefix("Value error, ")
-            logger.warning("Invalid URL for knowledge base creation: %s", message)
+        logger.info(
+            "Starting background web ingestion for %s into %s",
+            tool_args.url,
+            collection_name,
+        )
+
+        result = await run_web_ingestion(
+            collection=collection_name,
+            crawl_config=crawl_config,
+            ingestion_config=ingest_config,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        if result.status == "error":
             return CreateKnowledgeBaseFromUrlResult(
                 success=False,
-                collection_name="",
-                message=message,
+                collection_name=collection_name,
+                message=f"Failed to crawl website: {result.message}",
                 pages_crawled=0,
             ).model_dump()
 
-        except Exception as e:
-            logger.exception(f"Error creating knowledge base from URL: {e}")
-            return CreateKnowledgeBaseFromUrlResult(
-                success=False,
-                collection_name="",
-                message=str(e),
-                pages_crawled=0,
-            ).model_dump()
+        await kb_service.refresh_collection_metadata(collection_name)
+
+        return CreateKnowledgeBaseFromUrlResult(
+            success=True,
+            collection_name=collection_name,
+            message=f"Successfully imported website {tool_args.url} into knowledge base '{collection_name}'",
+            pages_crawled=result.pages_crawled,
+        ).model_dump()
+    except ValidationError as e:
+        errors = e.errors()
+        message = errors[0]["msg"] if errors else str(e)
+        if isinstance(message, str) and message.startswith("Value error, "):
+            message = message.removeprefix("Value error, ")
+        logger.warning("Invalid URL for knowledge base creation: %s", message)
+        return CreateKnowledgeBaseFromUrlResult(
+            success=False,
+            collection_name="",
+            message=message,
+            pages_crawled=0,
+        ).model_dump()
+
+    except Exception as e:
+        logger.exception("Error creating knowledge base from URL: %s", e)
+        return CreateKnowledgeBaseFromUrlResult(
+            success=False,
+            collection_name="",
+            message=str(e),
+            pages_crawled=0,
+        ).model_dump()
 
 
 @register_tool(categories={"knowledge"})
 async def create_web_ingestion_tools(config: WebToolConfig) -> list[AbstractBaseTool]:
+    """Create web ingestion tools."""
+    return await _get_tool_compatibility_facade().create_web_ingestion_tools(config)
+
+
+async def _create_web_ingestion_tools_impl(
+    config: WebToolConfig,
+) -> list[AbstractBaseTool]:
     """Create web ingestion tools."""
     try:
         user_id = config.get_user_id()

--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -34,6 +34,7 @@ from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .tool_compatibility import KBToolCompatibilityFacade
 from .vector_storage_compatibility import (
     KBVectorStorageCleanupResult,
     KBVectorStorageCompatibilityFacade,
@@ -71,6 +72,7 @@ __all__ = [
     "KBStorageBackend",
     "KBVectorStorageCleanupResult",
     "KBVectorStorageCompatibilityFacade",
+    "KBToolCompatibilityFacade",
     "KBUserScope",
     "KBVersionCompatibilityFacade",
     "LanceDBCollectionHandle",

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -28,6 +28,7 @@ from .parse_display_compatibility import KBParseDisplayCompatibilityFacade
 from .pipeline_compatibility import KBPipelineCompatibilityFacade
 from .retrieval_compatibility import KBRetrievalHelperCompatibilityFacade
 from .storage_shim import KBStorageShimCompatibilityFacade
+from .tool_compatibility import KBToolCompatibilityFacade
 from .vector_storage_compatibility import KBVectorStorageCompatibilityFacade
 from .version_compatibility import KBVersionCompatibilityFacade
 
@@ -56,6 +57,7 @@ class KBCoordinator:
         operation_compatibility: KBOperationCompatibilityFacade | None = None,
         pipeline_compatibility: KBPipelineCompatibilityFacade | None = None,
         legacy_step_compatibility: KBLegacyStepCompatibilityFacade | None = None,
+        tool_compatibility: KBToolCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -94,6 +96,9 @@ class KBCoordinator:
         self._legacy_step_compatibility = (
             legacy_step_compatibility
             or KBLegacyStepCompatibilityFacade(coordinator=self)
+        )
+        self._tool_compatibility = tool_compatibility or KBToolCompatibilityFacade(
+            coordinator=self
         )
 
     @property
@@ -195,6 +200,16 @@ class KBCoordinator:
     def legacy_steps(self) -> KBLegacyStepCompatibilityFacade:
         """Backward-friendly short alias for the legacy step facade."""
         return self._legacy_step_compatibility
+
+    @property
+    def tool_compatibility(self) -> KBToolCompatibilityFacade:
+        """Return the agent/tool compatibility facade."""
+        return self._tool_compatibility
+
+    @property
+    def tools(self) -> KBToolCompatibilityFacade:
+        """Backward-friendly short alias for the tool facade."""
+        return self._tool_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -11,6 +11,7 @@ from .models import KBStorageBackend
 from .pipeline_compatibility import KB_STORAGE_METADATA_KEY
 
 if TYPE_CHECKING:
+    from ......web.tools.config import WebToolConfig
     from ....adapters.vibe.base import AbstractBaseTool
     from ....adapters.vibe.config import BaseToolConfig
     from ....adapters.vibe.document_search import (
@@ -23,7 +24,6 @@ if TYPE_CHECKING:
         ListKnowledgeBasesArgs,
         ListKnowledgeBasesResult,
     )
-    from ......web.tools.config import WebToolConfig
     from .coordinator import KBCoordinator
     from .storage_shim import KBStorageShimCompatibilityFacade
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -250,14 +250,20 @@ class KBToolCompatibilityFacade:
                 collection_info = CollectionInfo(name=collection, owners=owners)
 
             extra_metadata = dict(collection_info.extra_metadata or {})
-            if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
+            has_backend_binding = (
+                extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None
+            )
+            owners = list(collection_info.owners)
+            has_owner = user_id is None or user_id in owners
+            if has_backend_binding and has_owner:
                 return collection_info
 
-            extra_metadata[KB_STORAGE_METADATA_KEY] = {
-                "backend": KBStorageBackend.LANCEDB.value
-            }
-            update: dict[str, Any] = {"extra_metadata": extra_metadata}
-            owners = list(collection_info.owners)
+            update: dict[str, Any] = {}
+            if not has_backend_binding:
+                extra_metadata[KB_STORAGE_METADATA_KEY] = {
+                    "backend": KBStorageBackend.LANCEDB.value
+                }
+                update["extra_metadata"] = extra_metadata
             if user_id is not None and user_id not in owners:
                 owners.append(user_id)
                 update["owners"] = owners

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -210,7 +210,10 @@ class KBToolCompatibilityFacade:
                 ingestion_config=ingestion_config,
                 user_id=user_id,
             )
-            await self.ensure_agent_collection_backend_binding(safe_collection)
+            await self.ensure_agent_collection_backend_binding(
+                safe_collection,
+                user_id=user_id,
+            )
             return safe_collection
 
     async def refresh_agent_collection_metadata(
@@ -232,6 +235,8 @@ class KBToolCompatibilityFacade:
     async def ensure_agent_collection_backend_binding(
         self,
         collection: str,
+        *,
+        user_id: Optional[int] = None,
     ) -> CollectionInfo:
         """Create a collection-level backend binding for agent/tool-created KBs."""
         from ..storage.factory import get_metadata_store
@@ -241,7 +246,8 @@ class KBToolCompatibilityFacade:
             try:
                 collection_info = await metadata_store.get_collection(collection)
             except ValueError:
-                collection_info = CollectionInfo(name=collection)
+                owners = [user_id] if user_id is not None else []
+                collection_info = CollectionInfo(name=collection, owners=owners)
 
             extra_metadata = dict(collection_info.extra_metadata or {})
             if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
@@ -250,8 +256,11 @@ class KBToolCompatibilityFacade:
             extra_metadata[KB_STORAGE_METADATA_KEY] = {
                 "backend": KBStorageBackend.LANCEDB.value
             }
-            updated_collection = collection_info.model_copy(
-                update={"extra_metadata": extra_metadata}
-            )
+            update: dict[str, Any] = {"extra_metadata": extra_metadata}
+            owners = list(collection_info.owners)
+            if user_id is not None and user_id not in owners:
+                owners.append(user_id)
+                update["owners"] = owners
+            updated_collection = collection_info.model_copy(update=update)
             await metadata_store.save_collection(updated_collection)
             return updated_collection

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -212,7 +212,6 @@ class KBToolCompatibilityFacade:
             )
             await self.ensure_agent_collection_backend_binding(
                 safe_collection,
-                user_id=user_id,
             )
             return safe_collection
 
@@ -235,8 +234,6 @@ class KBToolCompatibilityFacade:
     async def ensure_agent_collection_backend_binding(
         self,
         collection: str,
-        *,
-        user_id: Optional[int] = None,
     ) -> CollectionInfo:
         """Create a collection-level backend binding for agent/tool-created KBs."""
         from ..storage.factory import get_metadata_store
@@ -246,27 +243,17 @@ class KBToolCompatibilityFacade:
             try:
                 collection_info = await metadata_store.get_collection(collection)
             except ValueError:
-                owners = [user_id] if user_id is not None else []
-                collection_info = CollectionInfo(name=collection, owners=owners)
+                collection_info = CollectionInfo(name=collection)
 
             extra_metadata = dict(collection_info.extra_metadata or {})
-            has_backend_binding = (
-                extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None
-            )
-            owners = list(collection_info.owners)
-            has_owner = user_id is None or user_id in owners
-            if has_backend_binding and has_owner:
+            if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
                 return collection_info
 
-            update: dict[str, Any] = {}
-            if not has_backend_binding:
-                extra_metadata[KB_STORAGE_METADATA_KEY] = {
-                    "backend": KBStorageBackend.LANCEDB.value
-                }
-                update["extra_metadata"] = extra_metadata
-            if user_id is not None and user_id not in owners:
-                owners.append(user_id)
-                update["owners"] = owners
-            updated_collection = collection_info.model_copy(update=update)
+            extra_metadata[KB_STORAGE_METADATA_KEY] = {
+                "backend": KBStorageBackend.LANCEDB.value
+            }
+            updated_collection = collection_info.model_copy(
+                update={"extra_metadata": extra_metadata}
+            )
             await metadata_store.save_collection(updated_collection)
             return updated_collection

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -1,0 +1,257 @@
+"""Tool compatibility facade for KB agent/tool entry points."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Optional
+
+from ..core.schemas import CollectionInfo, IngestionConfig
+from .models import KBStorageBackend
+from .pipeline_compatibility import KB_STORAGE_METADATA_KEY
+
+if TYPE_CHECKING:
+    from ....adapters.vibe.base import AbstractBaseTool
+    from ....adapters.vibe.config import BaseToolConfig
+    from ....adapters.vibe.document_search import (
+        KnowledgeSearchTool,
+        ListKnowledgeBasesTool,
+    )
+    from ...document_search import (
+        KnowledgeSearchArgs,
+        KnowledgeSearchResult,
+        ListKnowledgeBasesArgs,
+        ListKnowledgeBasesResult,
+    )
+    from ......web.tools.config import WebToolConfig
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+
+class KBToolCompatibilityFacade:
+    """Compatibility boundary for KB-facing agent and tool surfaces.
+
+    Tool modules keep their historical imports, factories, names, schemas, and
+    sync/async behavior while this facade routes their KB semantics through the
+    coordinator-owned management, pipeline, and storage boundaries.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    async def list_knowledge_bases(
+        self,
+        tool_args: ListKnowledgeBasesArgs,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> ListKnowledgeBasesResult:
+        from ... import document_search as core_document_search
+
+        with self._storage_context():
+            return await core_document_search._list_knowledge_bases_impl(
+                tool_args,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def find_missing_knowledge_bases(
+        self,
+        knowledge_bases: list[str],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> list[str]:
+        from ... import document_search as core_document_search
+
+        with self._storage_context():
+            return await core_document_search._find_missing_knowledge_bases_impl(
+                knowledge_bases,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def search_knowledge_base(
+        self,
+        tool_args: KnowledgeSearchArgs,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> KnowledgeSearchResult:
+        from ... import document_search as core_document_search
+
+        with self._storage_context():
+            return await core_document_search._search_knowledge_base_impl(
+                tool_args,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def get_list_knowledge_bases_tool(
+        self,
+        allowed_collections: Optional[list[str]] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> ListKnowledgeBasesTool:
+        from ....adapters.vibe import document_search as vibe_document_search
+
+        return vibe_document_search._get_list_knowledge_bases_tool_impl(
+            allowed_collections=allowed_collections,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def get_knowledge_search_tool(
+        self,
+        embedding_model_id: Optional[str] = None,
+        allowed_collections: Optional[list[str]] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> KnowledgeSearchTool:
+        from ....adapters.vibe import document_search as vibe_document_search
+
+        return vibe_document_search._get_knowledge_search_tool_impl(
+            embedding_model_id=embedding_model_id,
+            allowed_collections=allowed_collections,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    async def create_knowledge_tools(
+        self,
+        config: BaseToolConfig,
+    ) -> list[Any]:
+        from ....adapters.vibe import knowledge_tools
+
+        return await knowledge_tools._create_knowledge_tools_impl(config)
+
+    async def create_knowledge_base_from_file(
+        self,
+        args: Mapping[str, Any],
+        *,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> Any:
+        from ....adapters.vibe import file_ingestion_tool
+
+        with self._storage_context():
+            return await file_ingestion_tool._create_knowledge_base_from_file_impl(
+                args,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def create_knowledge_base_from_url(
+        self,
+        args: Mapping[str, Any],
+        *,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> Any:
+        from ....adapters.vibe import web_ingestion_tool
+
+        with self._storage_context():
+            return await web_ingestion_tool._create_knowledge_base_from_url_impl(
+                args,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def create_file_ingestion_tools(
+        self,
+        config: WebToolConfig,
+    ) -> list[AbstractBaseTool]:
+        from ....adapters.vibe import file_ingestion_tool
+
+        return await file_ingestion_tool._create_file_ingestion_tools_impl(config)
+
+    async def create_web_ingestion_tools(
+        self,
+        config: WebToolConfig,
+    ) -> list[AbstractBaseTool]:
+        from ....adapters.vibe import web_ingestion_tool
+
+        return await web_ingestion_tool._create_web_ingestion_tools_impl(config)
+
+    async def prepare_agent_collection(
+        self,
+        *,
+        collection_name: str,
+        ingestion_config: IngestionConfig,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> str:
+        from ....adapters.vibe import agent_kb_service
+
+        with self._storage_context():
+            safe_collection = await agent_kb_service._prepare_collection_impl(
+                collection_name=collection_name,
+                ingestion_config=ingestion_config,
+                user_id=user_id,
+            )
+            await self.ensure_agent_collection_backend_binding(safe_collection)
+            return safe_collection
+
+    async def refresh_agent_collection_metadata(
+        self,
+        collection_name: str,
+        *,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> None:
+        from ....adapters.vibe import agent_kb_service
+
+        with self._storage_context():
+            await agent_kb_service._refresh_collection_metadata_impl(
+                collection_name=collection_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def ensure_agent_collection_backend_binding(
+        self,
+        collection: str,
+    ) -> CollectionInfo:
+        """Create a collection-level backend binding for agent/tool-created KBs."""
+        from ..storage.factory import get_metadata_store
+
+        with self._storage_context():
+            metadata_store = get_metadata_store()
+            try:
+                collection_info = await metadata_store.get_collection(collection)
+            except ValueError:
+                collection_info = CollectionInfo(name=collection)
+
+            extra_metadata = dict(collection_info.extra_metadata or {})
+            if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
+                return collection_info
+
+            extra_metadata[KB_STORAGE_METADATA_KEY] = {
+                "backend": KBStorageBackend.LANCEDB.value
+            }
+            updated_collection = collection_info.model_copy(
+                update={"extra_metadata": extra_metadata}
+            )
+            await metadata_store.save_collection(updated_collection)
+            return updated_collection

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -1,7 +1,7 @@
 """Core document search functionality for RAG pipelines."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -9,6 +9,16 @@ from .RAG_tools.management.collections import list_collections
 from .RAG_tools.pipelines.document_search import run_document_search
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .RAG_tools.kb import KBToolCompatibilityFacade
+
+
+def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
+    """Return the coordinator-owned tool compatibility facade."""
+    from .RAG_tools.kb import get_kb_coordinator
+
+    return get_kb_coordinator().tool_compatibility
 
 
 class ListKnowledgeBasesArgs(BaseModel):
@@ -75,6 +85,19 @@ async def list_knowledge_bases(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> ListKnowledgeBasesResult:
+    """List all available knowledge bases through the tool compatibility facade."""
+    return await _get_tool_compatibility_facade().list_knowledge_bases(
+        tool_args,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _list_knowledge_bases_impl(
+    tool_args: ListKnowledgeBasesArgs,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> ListKnowledgeBasesResult:
     """List all available knowledge bases with their statistics.
 
     Args:
@@ -123,6 +146,19 @@ async def find_missing_knowledge_bases(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> List[str]:
+    """Return missing KB names through the tool compatibility facade."""
+    return await _get_tool_compatibility_facade().find_missing_knowledge_bases(
+        knowledge_bases,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _find_missing_knowledge_bases_impl(
+    knowledge_bases: List[str],
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> List[str]:
     """Return requested knowledge base names that are not visible to the user."""
     requested = [name.strip() for name in knowledge_bases if name and name.strip()]
     if not requested:
@@ -134,6 +170,19 @@ async def find_missing_knowledge_bases(
 
 
 async def search_knowledge_base(
+    tool_args: KnowledgeSearchArgs,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> KnowledgeSearchResult:
+    """Search across knowledge bases through the tool compatibility facade."""
+    return await _get_tool_compatibility_facade().search_knowledge_base(
+        tool_args,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def _search_knowledge_base_impl(
     tool_args: KnowledgeSearchArgs,
     user_id: Optional[int] = None,
     is_admin: bool = False,

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -8,7 +8,7 @@ import mimetypes
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, BinaryIO, Literal, NoReturn
+from typing import Any, BinaryIO, Literal, NoReturn, Protocol
 
 from ...core.file_storage import FsspecFileStorage, StoredObject, get_file_storage
 from ..models.uploaded_file import UploadedFile
@@ -29,6 +29,28 @@ class DurableStorageOperationError(RuntimeError):
 
 class DurableObjectIntegrityError(DurableStorageOperationError):
     """Raised when restored durable bytes do not match the DB checksum."""
+
+
+class UploadedFileLocalPathRecord(Protocol):
+    """Fields needed to restore or locate an uploaded file without an ORM session."""
+
+    @property
+    def file_id(self) -> Any: ...
+
+    @property
+    def filename(self) -> Any: ...
+
+    @property
+    def storage_path(self) -> Any: ...
+
+    @property
+    def storage_key(self) -> Any: ...
+
+    @property
+    def storage_status(self) -> Any: ...
+
+    @property
+    def checksum(self) -> Any: ...
 
 
 def safe_storage_filename(filename: str) -> str:
@@ -107,7 +129,7 @@ def _checksum_matches(expected_checksum: str, actual_checksum: str) -> bool:
 class ManagedFileRef:
     """Registered file handle with local-first durable fallback semantics."""
 
-    record: UploadedFile
+    record: UploadedFileLocalPathRecord
     storage: FsspecFileStorage = field(default_factory=get_file_storage)
 
     @property
@@ -383,7 +405,7 @@ def managed_file_from_record(file_record: UploadedFile) -> ManagedFileRef:
     return ManagedFileRef(file_record)
 
 
-def ensure_uploaded_file_local_path(file_record: UploadedFile) -> Path:
+def ensure_uploaded_file_local_path(file_record: UploadedFileLocalPathRecord) -> Path:
     try:
         return ManagedFileRef(file_record).ensure_local()
     except DurableObjectMissingError:

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -112,6 +112,13 @@ def _successful_ingestion_result(doc_id: str = "doc-ok") -> IngestionResult:
     )
 
 
+def _fake_db_generator(db):
+    try:
+        yield db
+    finally:
+        db.close()
+
+
 @pytest.mark.asyncio
 async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes():
     metadata_store = MagicMock()
@@ -359,7 +366,7 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
     db.query.return_value = query
 
     def fake_get_db():
-        yield db
+        yield from _fake_db_generator(db)
 
     ingest_result = IngestionResult(
         status="success",
@@ -407,6 +414,83 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_create_kb_from_file_continues_after_unexpected_ingest_error(tmp_path):
+    bad_file = tmp_path / "bad.txt"
+    good_file = tmp_path / "good.txt"
+    bad_file.write_text("bad", encoding="utf-8")
+    good_file.write_text("good", encoding="utf-8")
+    bad_record = SimpleNamespace(
+        filename="bad.txt",
+        storage_path=str(bad_file),
+        file_id="file-bad",
+    )
+    good_record = SimpleNamespace(
+        filename="good.txt",
+        storage_path=str(good_file),
+        file_id="file-good",
+    )
+
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [bad_record, good_record]
+
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    def fake_run_ingestion(*, source_path: str, file_id: str, **_: object):
+        if source_path == str(bad_file):
+            raise RuntimeError("parser exploded")
+        return IngestionResult(
+            status="success",
+            doc_id=f"doc-{file_id}",
+            parse_hash="parse-good",
+            chunk_count=2,
+            embedding_count=2,
+            vector_count=2,
+            completed_steps=[],
+            failed_step=None,
+            message="ok",
+            warnings=[],
+            file_id=file_id,
+        )
+
+    service = MagicMock()
+    service.prepare_collection = AsyncMock(return_value="agent_file_kb")
+    service.refresh_collection_metadata = AsyncMock()
+    run_ingestion = Mock(side_effect=fake_run_ingestion)
+
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.core.tools.adapters.vibe.agent_kb_service.AgentKnowledgeBaseService",
+            return_value=service,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.document_ingestion.run_document_ingestion",
+            new=run_ingestion,
+        ),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=71, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-bad", "file-good"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is True
+    assert result["collection_name"] == "agent_file_kb"
+    assert result["files_ingested"] == 1
+    assert (
+        "Failed to ingest bad.txt due to unexpected error: parser exploded"
+        in result["message"]
+    )
+    service.refresh_collection_metadata.assert_awaited_once_with("agent_file_kb")
+    assert run_ingestion.call_count == 2
+    db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
     tmp_path,
     monkeypatch,
@@ -430,7 +514,7 @@ async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
     db.query.return_value = query
 
     def fake_get_db():
-        yield db
+        yield from _fake_db_generator(db)
 
     def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
         return IngestionResult(
@@ -526,7 +610,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
     db.query.return_value = query
 
     def fake_get_db():
-        yield db
+        yield from _fake_db_generator(db)
 
     ingest_result = IngestionResult(
         status="success",
@@ -591,7 +675,7 @@ async def test_create_kb_from_file_returns_error_when_metadata_refresh_fails(tmp
     db.query.return_value = query
 
     def fake_get_db():
-        yield db
+        yield from _fake_db_generator(db)
 
     ingest_result = IngestionResult(
         status="success",

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -154,7 +154,7 @@ async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes
 
 
 @pytest.mark.asyncio
-async def test_agent_kb_service_prepare_collection_preserves_existing_backend_binding():
+async def test_agent_kb_service_prepare_collection_preserves_existing_backend_binding_and_adds_owner():
     existing = CollectionInfo(
         name="agent url kb",
         extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
@@ -176,8 +176,11 @@ async def test_agent_kb_service_prepare_collection_preserves_existing_backend_bi
 
     assert collection_name == "agent url kb"
     metadata_store.save_collection_config.assert_awaited_once()
-    metadata_store.save_collection.assert_not_awaited()
-    assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    metadata_store.save_collection.assert_awaited_once()
+    saved_collection = metadata_store.save_collection.await_args.args[0]
+    assert saved_collection.owners == [71]
+    assert saved_collection.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    assert saved_collection.extra_metadata["other"] == "kept"
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -17,6 +17,7 @@ from xagent.core.tools.adapters.vibe.web_ingestion_tool import (
 )
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     DEFAULT_EMBEDDING_MODEL_ID,
+    CollectionInfo,
     IngestionConfig,
     IngestionResult,
     WebIngestionResult,
@@ -27,6 +28,10 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
 async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes():
     metadata_store = MagicMock()
     metadata_store.save_collection_config = AsyncMock()
+    metadata_store.get_collection = AsyncMock(
+        side_effect=ValueError("Collection 'agent url kb' not found")
+    )
+    metadata_store.save_collection = AsyncMock()
     service = AgentKnowledgeBaseService(user_id=71, is_admin=False)
     ingest_config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
 
@@ -46,6 +51,37 @@ async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes
     assert json.loads(save_kwargs["config_json"]) == {
         "embedding_model_id": DEFAULT_EMBEDDING_MODEL_ID
     }
+    metadata_store.save_collection.assert_awaited_once()
+    saved_collection = metadata_store.save_collection.await_args.args[0]
+    assert saved_collection.name == "agent url kb"
+    assert saved_collection.extra_metadata["kb_storage"] == {"backend": "lancedb"}
+
+
+@pytest.mark.asyncio
+async def test_agent_kb_service_prepare_collection_preserves_existing_backend_binding():
+    existing = CollectionInfo(
+        name="agent url kb",
+        extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
+    )
+    metadata_store = MagicMock()
+    metadata_store.save_collection_config = AsyncMock()
+    metadata_store.get_collection = AsyncMock(return_value=existing)
+    metadata_store.save_collection = AsyncMock()
+    service = AgentKnowledgeBaseService(user_id=71, is_admin=False)
+    ingest_config = IngestionConfig(embedding_model_id=DEFAULT_EMBEDDING_MODEL_ID)
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+        return_value=metadata_store,
+    ):
+        collection_name = await service.prepare_collection(
+            "agent url kb", ingest_config
+        )
+
+    assert collection_name == "agent url kb"
+    metadata_store.save_collection_config.assert_awaited_once()
+    metadata_store.save_collection.assert_not_awaited()
+    assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -154,7 +154,7 @@ async def test_agent_kb_service_prepare_collection_persists_config_and_sanitizes
 
 
 @pytest.mark.asyncio
-async def test_agent_kb_service_prepare_collection_preserves_existing_backend_binding_and_adds_owner():
+async def test_agent_kb_service_prepare_collection_preserves_existing_backend_binding():
     existing = CollectionInfo(
         name="agent url kb",
         extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
@@ -176,11 +176,9 @@ async def test_agent_kb_service_prepare_collection_preserves_existing_backend_bi
 
     assert collection_name == "agent url kb"
     metadata_store.save_collection_config.assert_awaited_once()
-    metadata_store.save_collection.assert_awaited_once()
-    saved_collection = metadata_store.save_collection.await_args.args[0]
-    assert saved_collection.owners == [71]
-    assert saved_collection.extra_metadata["kb_storage"] == {"backend": "postgresql"}
-    assert saved_collection.extra_metadata["other"] == "kept"
+    metadata_store.save_collection.assert_not_awaited()
+    assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    assert existing.extra_metadata["other"] == "kept"
 
 
 @pytest.mark.asyncio
@@ -572,8 +570,10 @@ async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
     assert result["success"] is False
     assert result["collection_name"] == "agent_file_kb"
     assert "embedding failed" in result["message"]
+    assert metadata_store.saved_configs[-1]["collection"] == "agent_file_kb"
+    assert metadata_store.saved_configs[-1]["user_id"] == 71
     assert metadata_store.saved_collections
-    assert metadata_store.saved_collections[-1].owners == [71]
+    assert metadata_store.saved_collections[-1].owners == []
     assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
         "backend": "lancedb"
     }
@@ -879,8 +879,10 @@ async def test_create_kb_from_url_partial_failure_preserves_pipeline_policy(
         "message": "Successfully imported website https://example.com into knowledge base 'agent_url_kb'",
         "pages_crawled": 2,
     }
+    assert metadata_store.saved_configs[-1]["collection"] == "agent_url_kb"
+    assert metadata_store.saved_configs[-1]["user_id"] == 71
     assert metadata_store.saved_collections
-    assert metadata_store.saved_collections[-1].owners == [71]
+    assert metadata_store.saved_collections[-1].owners == []
     assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
         "backend": "lancedb"
     }

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -20,8 +21,95 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     CollectionInfo,
     IngestionConfig,
     IngestionResult,
+    IngestionStepResult,
     WebIngestionResult,
 )
+from xagent.core.tools.core.RAG_tools.kb import KBCoordinator
+from xagent.core.tools.core.RAG_tools.kb.operation_compatibility import (
+    KBOperationCompatibilityFacade,
+    RollbackStatus,
+    SideEffectPlane,
+)
+
+
+class _FakeMetadataStore:
+    def __init__(self, collection: CollectionInfo | None) -> None:
+        self.collection = collection
+        self.saved_configs: list[dict[str, object]] = []
+        self.saved_collections: list[CollectionInfo] = []
+
+    async def save_collection_config(
+        self,
+        collection: str,
+        config_json: str,
+        user_id: int,
+    ) -> None:
+        self.saved_configs.append(
+            {
+                "collection": collection,
+                "config_json": config_json,
+                "user_id": user_id,
+            }
+        )
+
+    async def get_collection(self, collection: str) -> CollectionInfo:
+        if self.collection is None or self.collection.name != collection:
+            raise ValueError(f"Collection {collection!r} not found")
+        return self.collection
+
+    async def save_collection(self, collection: CollectionInfo) -> None:
+        self.saved_collections.append(collection)
+        self.collection = collection
+
+
+class _FakeStorageShim:
+    def __init__(self, metadata_store: _FakeMetadataStore) -> None:
+        self.metadata_store = metadata_store
+
+    def get_metadata_store(self) -> _FakeMetadataStore:
+        return self.metadata_store
+
+    def reset_kb_write_coordinator(self) -> None:
+        return None
+
+    def reset_rag_storage_for_tests(self) -> None:
+        return None
+
+
+class _RecordingOperationFacade(KBOperationCompatibilityFacade):
+    def __init__(self) -> None:
+        super().__init__()
+        self.outcomes = []
+
+    @contextmanager
+    def start_operation(self, **kwargs):
+        with super().start_operation(**kwargs) as operation:
+            yield operation
+        if operation.outcome is not None:
+            self.outcomes.append(operation.outcome)
+
+
+def _ingestion_step(name: str, **metadata: object) -> IngestionStepResult:
+    return IngestionStepResult(name=name, metadata=dict(metadata))
+
+
+def _successful_ingestion_result(doc_id: str = "doc-ok") -> IngestionResult:
+    return IngestionResult(
+        status="success",
+        doc_id=doc_id,
+        parse_hash="parse-ok",
+        chunk_count=1,
+        embedding_count=1,
+        vector_count=1,
+        completed_steps=[
+            _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+            _ingestion_step("register_document", doc_id=doc_id, created=True),
+            _ingestion_step("parse_document", parse_hash="parse-ok", written=True),
+            _ingestion_step("chunk_document", chunk_count=1, created=True),
+            _ingestion_step("write_vectors_to_db", vector_count=1),
+        ],
+        message="ok",
+    )
 
 
 @pytest.mark.asyncio
@@ -319,6 +407,105 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
+    tmp_path,
+    monkeypatch,
+):
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield db
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="error",
+            doc_id="doc-failed",
+            parse_hash="parse-failed",
+            chunk_count=2,
+            embedding_count=0,
+            vector_count=0,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-failed", created=True),
+                _ingestion_step(
+                    "parse_document",
+                    parse_hash="parse-failed",
+                    written=True,
+                ),
+                _ingestion_step("chunk_document", chunk_count=2, created=True),
+            ],
+            failed_step="write_vectors_to_db",
+            message="embedding failed",
+            file_id="file-1",
+        )
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    operation_facade = _RecordingOperationFacade()
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=operation_facade,
+    )
+
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            return_value=source_file,
+        ),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=71, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is False
+    assert result["collection_name"] == "agent_file_kb"
+    assert "embedding failed" in result["message"]
+    assert metadata_store.saved_collections
+    assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
+
+    assert len(operation_facade.outcomes) == 1
+    outcome = operation_facade.outcomes[0]
+    assert outcome.operation_type == "document_ingestion"
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert {step.plane for step in outcome.compensation_steps} == {
+        SideEffectPlane.COLLECTION,
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.STATUS,
+        SideEffectPlane.PARSE,
+        SideEffectPlane.CHUNK,
+    }
+    db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion(
     tmp_path,
 ):
@@ -444,3 +631,107 @@ async def test_create_kb_from_file_returns_error_when_metadata_refresh_fails(tmp
     assert result["success"] is False
     assert result["message"] == "metadata refresh failed"
     db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_kb_from_url_partial_failure_preserves_pipeline_policy(
+    monkeypatch,
+):
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    def fake_run_document_ingestion_impl(
+        source_path: str,
+        **_: object,
+    ) -> IngestionResult:
+        if source_path.endswith("ok.md"):
+            return _successful_ingestion_result("doc-ok")
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-bad",
+            parse_hash=None,
+            chunk_count=0,
+            embedding_count=0,
+            vector_count=0,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-bad", created=True),
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    async def fake_run_web_ingestion_impl(
+        collection: str,
+        crawl_config,
+        *,
+        pipeline_facade,
+        **_: object,
+    ) -> WebIngestionResult:
+        pipeline_facade.run_document_ingestion(collection, "/tmp/ok.md")
+        pipeline_facade.run_document_ingestion(collection, "/tmp/bad.md")
+        return WebIngestionResult(
+            status="partial",
+            collection=collection,
+            total_urls_found=2,
+            pages_crawled=2,
+            pages_failed=1,
+            documents_created=1,
+            chunks_created=1,
+            embeddings_created=1,
+            crawled_urls=[crawl_config.start_url, "https://example.com/bad"],
+            failed_urls={"https://example.com/bad": "parse failed"},
+            message="partial web ingest",
+            warnings=["parse failed"],
+            elapsed_time_ms=1,
+        )
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_url_kb"))
+    operation_facade = _RecordingOperationFacade()
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=operation_facade,
+    )
+
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+    monkeypatch.setattr(
+        web_ingestion,
+        "_run_web_ingestion_impl",
+        fake_run_web_ingestion_impl,
+    )
+
+    tool = CreateKnowledgeBaseFromUrlTool(user_id=71, is_admin=False)
+    result = await tool.run_json_async(
+        {"url": "https://example.com", "collection_name": "agent_url_kb"}
+    )
+
+    assert result == {
+        "success": True,
+        "collection_name": "agent_url_kb",
+        "message": "Successfully imported website https://example.com into knowledge base 'agent_url_kb'",
+        "pages_crawled": 2,
+    }
+    assert metadata_store.saved_collections
+    assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
+
+    root_outcome = operation_facade.outcomes[-1]
+    assert root_outcome.operation_type == "web_ingestion"
+    assert root_outcome.status == "partial"
+    assert root_outcome.rollback_status is RollbackStatus.SKIPPED_BY_POLICY
+    assert root_outcome.side_effects_may_remain is True
+    assert [child.status for child in root_outcome.child_outcomes] == [
+        "success",
+        "partial",
+    ]
+    assert root_outcome.details["documents_created"] == 1
+    assert root_outcome.details["pages_failed"] == 1

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -612,6 +612,13 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
     def fake_get_db():
         yield from _fake_db_generator(db)
 
+    def fake_ensure_local(record):
+        db.close.assert_called_once()
+        assert record.filename == file_record.filename
+        assert record.storage_path == file_record.storage_path
+        assert record.file_id == file_record.file_id
+        return restored_source
+
     ingest_result = IngestionResult(
         status="success",
         doc_id="doc-1",
@@ -638,7 +645,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
         ),
         patch(
             "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
-            return_value=restored_source,
+            side_effect=fake_ensure_local,
         ) as ensure_local,
         patch(
             "xagent.core.tools.core.RAG_tools.pipelines.document_ingestion.run_document_ingestion",
@@ -651,7 +658,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
         )
 
     assert result["success"] is True
-    ensure_local.assert_called_once_with(file_record)
+    ensure_local.assert_called_once()
     _, ingestion_kwargs = run_ingestion.call_args
     assert ingestion_kwargs["source_path"] == str(restored_source)
     db.close.assert_called_once()

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -12,6 +12,7 @@ from xagent.core.tools.adapters.vibe.agent_kb_service import (
 )
 from xagent.core.tools.adapters.vibe.file_ingestion_tool import (
     CreateKnowledgeBaseFromFileTool,
+    UploadedFileSnapshot,
 )
 from xagent.core.tools.adapters.vibe.web_ingestion_tool import (
     CreateKnowledgeBaseFromUrlTool,
@@ -569,6 +570,7 @@ async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
     assert result["collection_name"] == "agent_file_kb"
     assert "embedding failed" in result["message"]
     assert metadata_store.saved_collections
+    assert metadata_store.saved_collections[-1].owners == [71]
     assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
         "backend": "lancedb"
     }
@@ -677,6 +679,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
 
     def fake_ensure_local(record):
         db.close.assert_called_once()
+        assert isinstance(record, UploadedFileSnapshot)
         assert record.filename == file_record.filename
         assert record.storage_path == file_record.storage_path
         assert record.file_id == file_record.file_id
@@ -874,6 +877,7 @@ async def test_create_kb_from_url_partial_failure_preserves_pipeline_policy(
         "pages_crawled": 2,
     }
     assert metadata_store.saved_collections
+    assert metadata_store.saved_collections[-1].owners == [71]
     assert metadata_store.saved_collections[-1].extra_metadata["kb_storage"] == {
         "backend": "lancedb"
     }

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -590,6 +590,69 @@ async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
 
 
 @pytest.mark.asyncio
+async def test_create_kb_from_file_preserves_storage_context_in_executor(
+    tmp_path,
+    monkeypatch,
+):
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.core.tools.core.RAG_tools.pipelines import document_ingestion
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        get_bound_storage_shim_for_current_context,
+    )
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=_RecordingOperationFacade(),
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        assert get_bound_storage_shim_for_current_context() is coordinator.storage_shim
+        return _successful_ingestion_result("doc-1")
+
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            return_value=source_file,
+        ),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=71, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is True
+    assert result["files_ingested"] == 1
+    db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion(
     tmp_path,
 ):

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -93,16 +93,18 @@ async def test_ensure_agent_collection_backend_binding_creates_missing_metadata(
     metadata_store = _FakeMetadataStore(None)
     facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
 
-    updated = await facade.ensure_agent_collection_backend_binding("demo", user_id=7)
+    updated = await facade.ensure_agent_collection_backend_binding("demo")
 
     assert updated.name == "demo"
-    assert updated.owners == [7]
+    assert updated.owners == []
     assert updated.extra_metadata["kb_storage"] == {"backend": "lancedb"}
     assert metadata_store.saved == [updated]
 
 
 @pytest.mark.asyncio
-async def test_prepare_agent_collection_passes_owner_to_backend_binding(monkeypatch):
+async def test_prepare_agent_collection_saves_user_config_before_backend_binding(
+    monkeypatch,
+):
     from xagent.core.tools.adapters.vibe import agent_kb_service
 
     metadata_store = _FakeMetadataStore(None)
@@ -132,7 +134,7 @@ async def test_prepare_agent_collection_passes_owner_to_backend_binding(monkeypa
 
     assert collection == "demo"
     assert prepare_calls == [7]
-    assert metadata_store.saved[-1].owners == [7]
+    assert metadata_store.saved[-1].owners == []
     assert metadata_store.saved[-1].extra_metadata["kb_storage"] == {
         "backend": "lancedb"
     }
@@ -156,7 +158,7 @@ async def test_ensure_agent_collection_backend_binding_preserves_existing_bindin
 
 
 @pytest.mark.asyncio
-async def test_ensure_agent_collection_backend_binding_adds_owner_to_existing_binding():
+async def test_ensure_agent_collection_backend_binding_preserves_existing_owners():
     existing = CollectionInfo(
         name="demo",
         owners=[3],
@@ -165,12 +167,13 @@ async def test_ensure_agent_collection_backend_binding_adds_owner_to_existing_bi
     metadata_store = _FakeMetadataStore(existing)
     facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
 
-    result = await facade.ensure_agent_collection_backend_binding("demo", user_id=7)
+    result = await facade.ensure_agent_collection_backend_binding("demo")
 
-    assert result.owners == [3, 7]
+    assert result is existing
+    assert result.owners == [3]
     assert result.extra_metadata["kb_storage"] == {"backend": "postgresql"}
     assert result.extra_metadata["other"] == "kept"
-    assert metadata_store.saved == [result]
+    assert metadata_store.saved == []
 
 
 def test_tool_factories_keep_names_models_and_async_only_sync_errors() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -155,6 +155,24 @@ async def test_ensure_agent_collection_backend_binding_preserves_existing_bindin
     assert metadata_store.saved == []
 
 
+@pytest.mark.asyncio
+async def test_ensure_agent_collection_backend_binding_adds_owner_to_existing_binding():
+    existing = CollectionInfo(
+        name="demo",
+        owners=[3],
+        extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
+    )
+    metadata_store = _FakeMetadataStore(existing)
+    facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    result = await facade.ensure_agent_collection_backend_binding("demo", user_id=7)
+
+    assert result.owners == [3, 7]
+    assert result.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    assert result.extra_metadata["other"] == "kept"
+    assert metadata_store.saved == [result]
+
+
 def test_tool_factories_keep_names_models_and_async_only_sync_errors() -> None:
     facade = KBToolCompatibilityFacade()
 

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -1,0 +1,169 @@
+"""Tests for the KB tool compatibility facade."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.document_search import (
+    KnowledgeSearchTool,
+    ListKnowledgeBasesTool,
+)
+from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBCoordinator,
+    KBToolCompatibilityFacade,
+    get_kb_coordinator,
+    reset_kb_coordinator_for_tests,
+)
+
+
+class _FakeMetadataStore:
+    def __init__(self, collection: Optional[CollectionInfo]) -> None:
+        self.collection = collection
+        self.saved: list[CollectionInfo] = []
+
+    async def get_collection(self, collection: str) -> CollectionInfo:
+        if self.collection is None or self.collection.name != collection:
+            raise ValueError(f"Collection {collection!r} not found")
+        return self.collection
+
+    async def save_collection(self, collection: CollectionInfo) -> None:
+        self.saved.append(collection)
+        self.collection = collection
+
+
+class _FakeStorageShim:
+    def __init__(self, metadata_store: _FakeMetadataStore) -> None:
+        self.metadata_store = metadata_store
+
+    def get_metadata_store(self) -> _FakeMetadataStore:
+        return self.metadata_store
+
+
+def test_kb_tool_facade_public_surface_imports() -> None:
+    import xagent.core.tools.core.RAG_tools.kb as kb
+
+    assert hasattr(kb, "KBToolCompatibilityFacade")
+    reset_kb_coordinator_for_tests()
+    assert isinstance(
+        get_kb_coordinator().tool_compatibility, KBToolCompatibilityFacade
+    )
+    assert get_kb_coordinator().tools is get_kb_coordinator().tool_compatibility
+
+
+@pytest.mark.asyncio
+async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatch):
+    from xagent.core.tools.core import document_search
+
+    sentinel = object()
+    calls: list[tuple[object, int, bool]] = []
+
+    class Facade:
+        async def list_knowledge_bases(
+            self,
+            tool_args: object,
+            user_id: Optional[int] = None,
+            is_admin: bool = False,
+        ) -> object:
+            calls.append((tool_args, user_id or 0, is_admin))
+            return sentinel
+
+    args = document_search.ListKnowledgeBasesArgs()
+    monkeypatch.setattr(document_search, "_get_tool_compatibility_facade", Facade)
+
+    result = await document_search.list_knowledge_bases(
+        args,
+        user_id=7,
+        is_admin=True,
+    )
+
+    assert result is sentinel
+    assert calls == [(args, 7, True)]
+
+
+@pytest.mark.asyncio
+async def test_ensure_agent_collection_backend_binding_creates_missing_metadata():
+    metadata_store = _FakeMetadataStore(None)
+    facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    updated = await facade.ensure_agent_collection_backend_binding("demo")
+
+    assert updated.name == "demo"
+    assert updated.extra_metadata["kb_storage"] == {"backend": "lancedb"}
+    assert metadata_store.saved == [updated]
+
+
+@pytest.mark.asyncio
+async def test_ensure_agent_collection_backend_binding_preserves_existing_binding():
+    existing = CollectionInfo(
+        name="demo",
+        extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
+    )
+    metadata_store = _FakeMetadataStore(existing)
+    facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    result = await facade.ensure_agent_collection_backend_binding("demo")
+
+    assert result is existing
+    assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    assert existing.extra_metadata["other"] == "kept"
+    assert metadata_store.saved == []
+
+
+def test_tool_factories_keep_names_models_and_async_only_sync_errors() -> None:
+    facade = KBToolCompatibilityFacade()
+
+    list_tool = facade.get_list_knowledge_bases_tool(allowed_collections=["kb1"])
+    search_tool = facade.get_knowledge_search_tool(allowed_collections=["kb1"])
+
+    assert isinstance(list_tool, ListKnowledgeBasesTool)
+    assert list_tool.name == "list_knowledge_bases"
+    assert list_tool.args_type().__name__ == "ListKnowledgeBasesArgs"
+    assert list_tool.return_type().__name__ == "ListKnowledgeBasesResult"
+    assert isinstance(search_tool, KnowledgeSearchTool)
+    assert search_tool.name == "knowledge_search"
+    assert search_tool.args_type().__name__ == "KnowledgeSearchArgs"
+    assert search_tool.return_type().__name__ == "KnowledgeSearchResult"
+    assert not inspect.iscoroutinefunction(list_tool.run_json_sync)
+    assert not inspect.iscoroutinefunction(search_tool.run_json_sync)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="ListKnowledgeBasesTool only supports async execution.",
+    ):
+        list_tool.run_json_sync({})
+    with pytest.raises(
+        NotImplementedError,
+        match="KnowledgeSearchTool only supports async execution.",
+    ):
+        search_tool.run_json_sync({})
+
+
+@pytest.mark.asyncio
+async def test_ingestion_tool_factories_keep_tool_names_and_sync_errors() -> None:
+    facade = KBToolCompatibilityFacade()
+    config = MagicMock()
+    config.get_user_id.return_value = 7
+    config.is_admin.return_value = False
+
+    file_tools = await facade.create_file_ingestion_tools(config)
+    web_tools = await facade.create_web_ingestion_tools(config)
+
+    assert [tool.name for tool in file_tools] == ["create_knowledge_base_from_file"]
+    assert [tool.name for tool in web_tools] == ["create_knowledge_base_from_url"]
+    with pytest.raises(NotImplementedError, match="Only supports async execution."):
+        file_tools[0].run_json_sync({})
+    with pytest.raises(NotImplementedError, match="Only supports async execution."):
+        web_tools[0].run_json_sync({})
+
+
+def test_coordinator_accepts_injected_tool_facade() -> None:
+    facade = KBToolCompatibilityFacade()
+    coordinator = KBCoordinator(tool_compatibility=facade)
+
+    assert coordinator.tool_compatibility is facade
+    assert coordinator.tools is facade

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -12,7 +12,10 @@ from xagent.core.tools.adapters.vibe.document_search import (
     KnowledgeSearchTool,
     ListKnowledgeBasesTool,
 )
-from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    IngestionConfig,
+)
 from xagent.core.tools.core.RAG_tools.kb import (
     KBCoordinator,
     KBToolCompatibilityFacade,
@@ -90,11 +93,49 @@ async def test_ensure_agent_collection_backend_binding_creates_missing_metadata(
     metadata_store = _FakeMetadataStore(None)
     facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
 
-    updated = await facade.ensure_agent_collection_backend_binding("demo")
+    updated = await facade.ensure_agent_collection_backend_binding("demo", user_id=7)
 
     assert updated.name == "demo"
+    assert updated.owners == [7]
     assert updated.extra_metadata["kb_storage"] == {"backend": "lancedb"}
     assert metadata_store.saved == [updated]
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_collection_passes_owner_to_backend_binding(monkeypatch):
+    from xagent.core.tools.adapters.vibe import agent_kb_service
+
+    metadata_store = _FakeMetadataStore(None)
+    facade = KBToolCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+    prepare_calls: list[int] = []
+
+    async def fake_prepare_collection_impl(
+        *,
+        collection_name: str,
+        ingestion_config: IngestionConfig,
+        user_id: int,
+    ) -> str:
+        prepare_calls.append(user_id)
+        return collection_name
+
+    monkeypatch.setattr(
+        agent_kb_service,
+        "_prepare_collection_impl",
+        fake_prepare_collection_impl,
+    )
+
+    collection = await facade.prepare_agent_collection(
+        collection_name="demo",
+        ingestion_config=IngestionConfig(),
+        user_id=7,
+    )
+
+    assert collection == "demo"
+    assert prepare_calls == [7]
+    assert metadata_store.saved[-1].owners == [7]
+    assert metadata_store.saved[-1].extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a coordinator-owned KB tool compatibility facade for agent/tool KB entry points.
- Route knowledge list/search plus file and URL KB creation through the facade while preserving existing tool names, schemas, and pipeline implementations.
- Bind agent/tool-created KB collections to the LanceDB backend metadata convention and add rollback/outcome coverage for tool-level ingest flows.

Closes #505.

## Validation

- `PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/pytest tests/core/tools/adapters/vibe/test_kb_creation_tools.py tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py`
- `/home/jicheng/github/xagent/.venv/bin/pre-commit run --all-files`
