### PR TITLE
fix: preserve auth refresh cache

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,16 +1,21 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState, ReactNode } from "react"
+import { createContext, useContext, useEffect, useRef, useState, ReactNode } from "react"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
-import { AUTH_CACHE_KEY, AUTH_TOKEN_UPDATED_EVENT } from "@/lib/auth-cache"
+import {
+  AUTH_CACHE_DURATION_MS,
+  AUTH_CACHE_KEY,
+  AUTH_TOKEN_UPDATED_EVENT,
+  AuthCacheUser,
+  clearStoredAuth,
+  LEGACY_AUTH_TOKEN_KEY,
+  LEGACY_AUTH_USER_KEY,
+  readAuthCache,
+  writeAuthCache,
+} from "@/lib/auth-cache"
 
-interface User {
-  id: string
-  username: string
-  email?: string | null
-  is_admin?: boolean
-}
+type User = AuthCacheUser
 
 interface AuthContextType {
   user: User | null
@@ -26,71 +31,20 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
-// Cache configuration
-const CACHE_DURATION = 120 * 60 * 1000 // 120 minutes
-
-interface AuthCache {
-  user: User | null
-  token: string | null
-  refreshToken: string | null
-  timestamp: number
-  expiresAt?: number  // access token expiration time
-  refreshExpiresAt?: number  // refresh token expiration time
-}
-
-function getAuthCache(): AuthCache | null {
-  try {
-    const cached = localStorage.getItem(AUTH_CACHE_KEY)
-    if (!cached) return null
-
-    const cache: AuthCache = JSON.parse(cached)
-    // Check if cache is expired
-    if (Date.now() - cache.timestamp > CACHE_DURATION) {
-      localStorage.removeItem(AUTH_CACHE_KEY)
-      return null
-    }
-
-    return cache
-  } catch {
-    return null
-  }
-}
-
-function setAuthCache(
-  user: User | null,
-  token: string | null,
-  refreshToken: string | null = null,
-  expiresIn?: number,  // access token expiration time (seconds)
-  refreshExpiresIn?: number  // refresh token expiration time (seconds)
-) {
-  const cache: AuthCache = {
-    user,
-    token,
-    refreshToken,
-    timestamp: Date.now(),
-    expiresAt: expiresIn ? Date.now() + expiresIn * 1000 : undefined,
-    refreshExpiresAt: refreshExpiresIn ? Date.now() + refreshExpiresIn * 1000 : undefined,
-  }
-  localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify(cache))
-}
-
-function clearAuthCache() {
-  localStorage.removeItem(AUTH_CACHE_KEY)
-}
-
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [token, setToken] = useState<string | null>(null)
   const [refreshToken, setRefreshToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [lastCheckTime, setLastCheckTime] = useState(0)
+  const refreshAccessTokenRef = useRef<() => Promise<boolean>>(async () => false)
 
   // Timer for active token refresh
   useEffect(() => {
     if (!token || !refreshToken) return
 
     const refreshInterval = setInterval(async () => {
-      const cache = getAuthCache()
+      const cache = readAuthCache()
       if (!cache) return
 
       if (cache.expiresAt) {
@@ -100,20 +54,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         if (shouldRefresh) {
           console.log("Token is about to expire, refreshing actively...")
-          const success = await refreshAccessToken()
+          const success = await refreshAccessTokenRef.current()
           if (!success) {
             // Refresh failed, stop timer (will automatically redirect to login page)
             clearInterval(refreshInterval)
           }
         }
       } else {
-        // No expiration time info, use old logic
         const timeSinceCreation = Date.now() - cache.timestamp
-        const shouldRefresh = timeSinceCreation > (CACHE_DURATION - 5 * 60 * 1000) // 5 minutes in advance
+        const shouldRefreshAccess = timeSinceCreation > (AUTH_CACHE_DURATION_MS - 5 * 60 * 1000)
+        const timeUntilRefreshExpiry = cache.refreshExpiresAt
+          ? cache.refreshExpiresAt - Date.now()
+          : Number.POSITIVE_INFINITY
+        const shouldRefreshToken = timeUntilRefreshExpiry < 5 * 60 * 1000
+        const shouldRefresh = shouldRefreshAccess || shouldRefreshToken
 
         if (shouldRefresh) {
-          console.log("Token is about to expire (based on creation time), refreshing actively...")
-          const success = await refreshAccessToken()
+          console.log("Token cache is missing access expiry info, refreshing actively...")
+          const success = await refreshAccessTokenRef.current()
           if (!success) {
             clearInterval(refreshInterval)
           }
@@ -122,21 +80,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }, 60000) // Check every minute
 
     return () => clearInterval(refreshInterval)
-  }, [token, refreshToken, user])
+  }, [token, refreshToken])
 
   // Check cache on initialization
   useEffect(() => {
     const timer = setTimeout(() => {
       // Try new cache format first
-      const cache = getAuthCache()
+      const cache = readAuthCache()
       if (cache && cache.user && cache.token) {
         setUser(cache.user)
         setToken(cache.token)
         setRefreshToken(cache.refreshToken)
       } else {
         // Fall back to old format for backward compatibility
-        const savedToken = localStorage.getItem("auth_token")
-        const savedUser = localStorage.getItem("auth_user")
+        const savedToken = localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)
+        const savedUser = localStorage.getItem(LEGACY_AUTH_USER_KEY)
 
         if (savedToken && savedUser) {
           try {
@@ -145,12 +103,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setUser(userData)
 
             // Migrate to new cache format
-            setAuthCache(userData, savedToken)
+            writeAuthCache(userData, savedToken)
           } catch (error) {
             console.error("Failed to parse saved user data:", error)
-            // Clear invalid data
-            localStorage.removeItem("auth_token")
-            localStorage.removeItem("auth_user")
+            clearStoredAuth()
           }
         }
       }
@@ -206,7 +162,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(userData)
 
         // Update cache
-        setAuthCache(
+        writeAuthCache(
           userData,
           data.access_token,
           data.refresh_token,
@@ -227,10 +183,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null)
     setToken(null)
     setRefreshToken(null)
-    // Clear all auth-related data
-    localStorage.removeItem("auth_token")
-    localStorage.removeItem("auth_user")
-    clearAuthCache()
+    clearStoredAuth()
     window.location.href = "/login"
   }
 
@@ -270,7 +223,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setUser(null)
             setToken(null)
             setRefreshToken(null)
-            clearAuthCache()
+            clearStoredAuth()
             return false
           }
         }
@@ -281,7 +234,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const data = await response.json()
       if (data.success === true) {
         // Auth success, sync update state (because apiRequest may have updated cache)
-        const updatedCache = getAuthCache()
+        const updatedCache = readAuthCache()
         if (updatedCache && updatedCache.token && updatedCache.user) {
           setToken(updatedCache.token)
           setUser(updatedCache.user)
@@ -319,7 +272,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
 
           // Update cache with new tokens and expiration times
-          setAuthCache(
+          writeAuthCache(
             user,
             data.access_token,
             data.refresh_token || refreshToken,
@@ -337,6 +290,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logout()
     return false
   }
+
+  refreshAccessTokenRef.current = refreshAccessToken
 
   const value: AuthContextType = {
     user,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2478,7 +2478,7 @@ Build when you need.`,
               },
               guide: {
                 title: "Dual token mechanism explanation:",
-                accessToken: "Access Token: expires in 30 minutes, used for API calls",
+                accessToken: "Access Token: expires in 120 minutes, used for API calls",
                 refreshToken: "Refresh Token: expires in 7 days, used to refresh access token",
                 autoRefresh: "Auto refresh: refreshes 1 minute before access token expiry",
                 offlineRecovery: "Offline recovery: come back after hours and still auto restore login",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2478,7 +2478,7 @@ Build when you need.`,
               },
               guide: {
                 title: "双Token机制功能说明:",
-                accessToken: "Access Token: 30分钟过期，用于API调用",
+                accessToken: "Access Token: 120分钟过期，用于API调用",
                 refreshToken: "Refresh Token: 7天过期，用于刷新access token",
                 autoRefresh: "自动刷新: Access token过期前1分钟自动刷新",
                 offlineRecovery: "离线恢复: 离开几小时回来仍可自动恢复登录状态",

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -1,7 +1,15 @@
 "lib/api-wrapper"
 
 import { getApiUrl } from "@/lib/utils"
-import { AUTH_CACHE_KEY, AUTH_TOKEN_UPDATED_EVENT } from "@/lib/auth-cache"
+import {
+  AUTH_CACHE_KEY,
+  AUTH_TOKEN_UPDATED_EVENT,
+  clearStoredAuth,
+  LEGACY_AUTH_TOKEN_KEY,
+  readAuthCache,
+  syncLegacyAuthStorage,
+  writeAuthCache,
+} from "@/lib/auth-cache"
 
 let isRefreshing = false
 let refreshSubscribers: ((token: string) => void)[] = []
@@ -78,25 +86,17 @@ function notifyRefreshSubscribers(token: string) {
 // Get current tokens
 function getCurrentTokens(): { accessToken: string | null; refreshToken: string | null } {
   // Try new cache format first
-  const cache = localStorage.getItem(AUTH_CACHE_KEY)
-  if (cache) {
-    try {
-      const authCache = JSON.parse(cache)
-      return {
-        accessToken: authCache.token || null,
-        refreshToken: authCache.refreshToken || null,
-      }
-    } catch {
-      return {
-        accessToken: localStorage.getItem("auth_token"),
-        refreshToken: null,
-      }
+  const authCache = readAuthCache()
+  if (authCache) {
+    return {
+      accessToken: authCache.token || null,
+      refreshToken: authCache.refreshToken || null,
     }
   }
 
   // Fall back to old format
   return {
-    accessToken: localStorage.getItem("auth_token"),
+    accessToken: localStorage.getItem(LEGACY_AUTH_TOKEN_KEY),
     refreshToken: null,
   }
 }
@@ -118,30 +118,18 @@ async function refreshToken(): Promise<string | null> {
     if (response.ok) {
       const data = await response.json()
       if (data.success && data.access_token) {
-        // Update tokens in cache
-        const cache = localStorage.getItem(AUTH_CACHE_KEY)
-        if (cache) {
-          try {
-            const authCache = JSON.parse(cache)
-            authCache.token = data.access_token
-            if (data.expires_in) {
-              authCache.expiresAt = Date.now() + data.expires_in * 1000
-            }
-            if (data.refresh_token) {
-              authCache.refreshToken = data.refresh_token
-            }
-            if (data.refresh_expires_in) {
-              authCache.refreshExpiresAt = Date.now() + data.refresh_expires_in * 1000
-            }
-            authCache.timestamp = Date.now()  // Update timestamp
-            localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify(authCache))
-          } catch {
-            // If parsing fails, use old format
-            localStorage.setItem("auth_token", data.access_token)
-          }
+        const authCache = readAuthCache()
+        if (authCache) {
+          writeAuthCache(
+            authCache.user,
+            data.access_token,
+            data.refresh_token || authCache.refreshToken,
+            data.expires_in ? data.expires_in : undefined,
+            data.refresh_expires_in ? data.refresh_expires_in : undefined
+          )
         } else {
           // Use old format
-          localStorage.setItem("auth_token", data.access_token)
+          syncLegacyAuthStorage(undefined, data.access_token)
         }
 
         // Trigger a storage event to notify AuthContext to update state
@@ -189,9 +177,7 @@ export async function apiRequest(
 
     if (!isExpired) {
       // Explicitly invalid token, redirect to login page directly
-      localStorage.removeItem("auth_token")
-      localStorage.removeItem("auth_user")
-      localStorage.removeItem(AUTH_CACHE_KEY)
+      clearStoredAuth()
       window.location.href = "/login"
       return response
     }
@@ -228,9 +214,7 @@ export async function apiRequest(
       } else {
         // Refresh failed, clear auth data and redirect to login page
         console.error("Token refresh failed, redirecting to login")
-        localStorage.removeItem("auth_token")
-        localStorage.removeItem("auth_user")
-        localStorage.removeItem(AUTH_CACHE_KEY)
+        clearStoredAuth()
         window.location.href = "/login"
       }
     } finally {
@@ -385,10 +369,7 @@ export const api = {
 // Check response status, if auth error redirect to login
 export function handleAuthError(response: Response) {
   if (response.status === 401) {
-    // Clear auth data and redirect to login page
-    localStorage.removeItem("auth_token")
-    localStorage.removeItem("auth_user")
-    localStorage.removeItem(AUTH_CACHE_KEY)
+    clearStoredAuth()
     window.location.href = "/login"
     return true
   }

--- a/frontend/src/lib/auth-cache.test.ts
+++ b/frontend/src/lib/auth-cache.test.ts
@@ -1,11 +1,26 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
 import {
   AUTH_CACHE_KEY,
   clearAuthTokenPayload,
+  clearStoredAuth,
+  LEGACY_AUTH_TOKEN_KEY,
+  LEGACY_AUTH_USER_KEY,
+  readAuthCache,
   storeAuthTokenPayload,
-} from "./auth-cache"
+  syncLegacyAuthStorage,
+  writeAuthCache,
+} from "@/lib/auth-cache"
+
+const user = { id: "1", username: "alice", email: null, is_admin: false }
 
 describe("auth cache helpers", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
   it("stores the same token payload shape used by password login", () => {
     const dispatch = vi.spyOn(window, "dispatchEvent")
 
@@ -17,9 +32,9 @@ describe("auth cache helpers", () => {
       refresh_expires_in: 240,
     })
 
-    expect(localStorage.getItem("auth_token")).toBe("access-token")
-    expect(JSON.parse(localStorage.getItem("auth_user") || "{}")).toEqual({
-      id: 42,
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBe("access-token")
+    expect(JSON.parse(localStorage.getItem(LEGACY_AUTH_USER_KEY) || "{}")).toEqual({
+      id: "42",
       username: "person@example.com",
       is_admin: false,
     })
@@ -32,14 +47,105 @@ describe("auth cache helpers", () => {
   })
 
   it("clears legacy and current auth cache keys", () => {
-    localStorage.setItem("auth_token", "access-token")
-    localStorage.setItem("auth_user", "{}")
+    localStorage.setItem(LEGACY_AUTH_TOKEN_KEY, "access-token")
+    localStorage.setItem(LEGACY_AUTH_USER_KEY, "{}")
     localStorage.setItem(AUTH_CACHE_KEY, "{}")
 
     clearAuthTokenPayload()
 
-    expect(localStorage.getItem("auth_token")).toBeNull()
-    expect(localStorage.getItem("auth_user")).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_USER_KEY)).toBeNull()
     expect(localStorage.getItem(AUTH_CACHE_KEY)).toBeNull()
+  })
+
+  it("keeps an old cache when the refresh token is still valid", () => {
+    const now = Date.now()
+    localStorage.setItem(
+      AUTH_CACHE_KEY,
+      JSON.stringify({
+        user,
+        token: "expired-access",
+        refreshToken: "valid-refresh",
+        timestamp: now - 130 * 60 * 1000,
+        expiresAt: now - 10 * 1000,
+        refreshExpiresAt: now + 6 * 24 * 60 * 60 * 1000,
+      })
+    )
+
+    const cache = readAuthCache(now)
+
+    expect(cache?.token).toBe("expired-access")
+    expect(cache?.refreshToken).toBe("valid-refresh")
+  })
+
+  it("removes the cache after the refresh token expires", () => {
+    const now = Date.now()
+    localStorage.setItem(LEGACY_AUTH_TOKEN_KEY, "expired-access")
+    localStorage.setItem(LEGACY_AUTH_USER_KEY, JSON.stringify(user))
+    localStorage.setItem(
+      AUTH_CACHE_KEY,
+      JSON.stringify({
+        user,
+        token: "expired-access",
+        refreshToken: "expired-refresh",
+        timestamp: now - 130 * 60 * 1000,
+        expiresAt: now - 10 * 1000,
+        refreshExpiresAt: now - 10 * 1000,
+      })
+    )
+
+    expect(readAuthCache(now)).toBeNull()
+    expect(localStorage.getItem(AUTH_CACHE_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_USER_KEY)).toBeNull()
+  })
+
+  it("expires legacy caches that do not have refresh tokens", () => {
+    const now = Date.now()
+    localStorage.setItem(
+      AUTH_CACHE_KEY,
+      JSON.stringify({
+        user,
+        token: "old-access",
+        refreshToken: null,
+        timestamp: now - 130 * 60 * 1000,
+      })
+    )
+
+    expect(readAuthCache(now)).toBeNull()
+  })
+
+  it("removes corrupted auth cache while preserving legacy fallback data", () => {
+    localStorage.setItem(LEGACY_AUTH_TOKEN_KEY, "legacy-access")
+    localStorage.setItem(LEGACY_AUTH_USER_KEY, JSON.stringify(user))
+    localStorage.setItem(AUTH_CACHE_KEY, "{not-json")
+
+    expect(readAuthCache()).toBeNull()
+    expect(localStorage.getItem(AUTH_CACHE_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBe("legacy-access")
+    expect(JSON.parse(localStorage.getItem(LEGACY_AUTH_USER_KEY) || "{}")).toEqual(user)
+  })
+
+  it("can update only the legacy access token during refresh", () => {
+    localStorage.setItem(LEGACY_AUTH_TOKEN_KEY, "old-access")
+    localStorage.setItem(LEGACY_AUTH_USER_KEY, JSON.stringify(user))
+
+    syncLegacyAuthStorage(undefined, "new-access")
+
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBe("new-access")
+    expect(JSON.parse(localStorage.getItem(LEGACY_AUTH_USER_KEY) || "{}")).toEqual(user)
+  })
+
+  it("keeps legacy token storage in sync when writing the cache", () => {
+    writeAuthCache(user, "access", "refresh", 120, 7 * 24 * 60 * 60)
+
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBe("access")
+    expect(JSON.parse(localStorage.getItem(LEGACY_AUTH_USER_KEY) || "{}")).toEqual(user)
+
+    clearStoredAuth()
+
+    expect(localStorage.getItem(AUTH_CACHE_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_TOKEN_KEY)).toBeNull()
+    expect(localStorage.getItem(LEGACY_AUTH_USER_KEY)).toBeNull()
   })
 })

--- a/frontend/src/lib/auth-cache.ts
+++ b/frontend/src/lib/auth-cache.ts
@@ -1,9 +1,21 @@
 export const AUTH_CACHE_KEY = "auth_cache"
 export const AUTH_TOKEN_UPDATED_EVENT = "auth-token-updated"
+export const LEGACY_AUTH_TOKEN_KEY = "auth_token"
+export const LEGACY_AUTH_USER_KEY = "auth_user"
+
+export const AUTH_CACHE_DURATION_MS = 120 * 60 * 1000
 
 export interface AuthUser {
   id: string | number
   username: string
+  email?: string | null
+  is_admin?: boolean
+}
+
+export interface AuthCacheUser {
+  id: string
+  username: string
+  email?: string | null
   is_admin?: boolean
 }
 
@@ -15,32 +27,119 @@ export interface AuthTokenPayload {
   refresh_expires_in?: number
 }
 
-export function storeAuthTokenPayload(data: AuthTokenPayload) {
-  const userData = {
-    id: data.user.id,
-    username: data.user.username,
-    is_admin: data.user.is_admin,
-  }
+export interface AuthCache {
+  user: AuthCacheUser | null
+  token: string | null
+  refreshToken: string | null
+  timestamp: number
+  expiresAt?: number
+  refreshExpiresAt?: number
+}
 
-  localStorage.setItem("auth_token", data.access_token)
-  localStorage.setItem("auth_user", JSON.stringify(userData))
-  localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify({
-    user: userData,
-    token: data.access_token,
-    refreshToken: data.refresh_token,
-    expiresAt: Date.now() + (data.expires_in || 1800) * 1000,
-    refreshExpiresAt: Date.now() + (data.refresh_expires_in || 604800) * 1000,
-    timestamp: Date.now(),
-  }))
+function isNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
 
+function dispatchAuthTokenUpdated() {
   window.dispatchEvent(new StorageEvent(AUTH_TOKEN_UPDATED_EVENT, {
     key: AUTH_CACHE_KEY,
     newValue: localStorage.getItem(AUTH_CACHE_KEY),
   }))
 }
 
-export function clearAuthTokenPayload() {
-  localStorage.removeItem("auth_token")
-  localStorage.removeItem("auth_user")
+export function isAuthCacheUsable(cache: AuthCache, now: number = Date.now()): boolean {
+  if (cache.refreshToken && isNumber(cache.refreshExpiresAt)) {
+    return cache.refreshExpiresAt > now
+  }
+
+  return now - cache.timestamp <= AUTH_CACHE_DURATION_MS
+}
+
+export function readAuthCache(now: number = Date.now()): AuthCache | null {
+  try {
+    const cached = localStorage.getItem(AUTH_CACHE_KEY)
+    if (!cached) return null
+
+    const cache = JSON.parse(cached) as AuthCache
+    if (!isAuthCacheUsable(cache, now)) {
+      clearStoredAuth()
+      return null
+    }
+
+    return cache
+  } catch {
+    localStorage.removeItem(AUTH_CACHE_KEY)
+    return null
+  }
+}
+
+export function syncLegacyAuthStorage(
+  user: AuthCacheUser | null | undefined,
+  token: string | null | undefined
+) {
+  if (token !== undefined) {
+    if (token) {
+      localStorage.setItem(LEGACY_AUTH_TOKEN_KEY, token)
+    } else {
+      localStorage.removeItem(LEGACY_AUTH_TOKEN_KEY)
+    }
+  }
+
+  if (user !== undefined) {
+    if (user) {
+      localStorage.setItem(LEGACY_AUTH_USER_KEY, JSON.stringify(user))
+    } else {
+      localStorage.removeItem(LEGACY_AUTH_USER_KEY)
+    }
+  }
+}
+
+export function writeAuthCache(
+  user: AuthCacheUser | null,
+  token: string | null,
+  refreshToken: string | null = null,
+  expiresIn?: number,
+  refreshExpiresIn?: number
+) {
+  const now = Date.now()
+  const cache: AuthCache = {
+    user,
+    token,
+    refreshToken,
+    timestamp: now,
+    expiresAt: expiresIn ? now + expiresIn * 1000 : undefined,
+    refreshExpiresAt: refreshExpiresIn
+      ? now + refreshExpiresIn * 1000
+      : undefined,
+  }
+  localStorage.setItem(AUTH_CACHE_KEY, JSON.stringify(cache))
+  syncLegacyAuthStorage(user, token)
+}
+
+export function storeAuthTokenPayload(data: AuthTokenPayload) {
+  const userData = {
+    id: String(data.user.id),
+    username: data.user.username,
+    email: data.user.email,
+    is_admin: data.user.is_admin,
+  }
+
+  writeAuthCache(
+    userData,
+    data.access_token,
+    data.refresh_token || null,
+    data.expires_in,
+    data.refresh_expires_in
+  )
+  dispatchAuthTokenUpdated()
+}
+
+export function clearStoredAuth() {
   localStorage.removeItem(AUTH_CACHE_KEY)
+  localStorage.removeItem(LEGACY_AUTH_TOKEN_KEY)
+  localStorage.removeItem(LEGACY_AUTH_USER_KEY)
+}
+
+export function clearAuthTokenPayload() {
+  clearStoredAuth()
 }


### PR DESCRIPTION
## Summary
- keep auth cache valid until the refresh token expires instead of dropping it at the access-token cache TTL
- centralize password/OIDC auth token storage while keeping legacy localStorage keys in sync
- add auth cache coverage for refresh-token expiry, cache clearing, and legacy key sync

## Tests
- npm run test:run -- src/lib/auth-cache.test.ts
- npm run type-check
- npm run lint -- src/lib/auth-cache.ts src/lib/auth-cache.test.ts src/lib/api-wrapper.ts src/contexts/auth-context.tsx src/components/pages/login.tsx src/i18n/locales/en.ts src/i18n/locales/zh.ts