### PR TITLE
refactor(kb): add API compatibility facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -1,5 +1,6 @@
 """KB semantic coordinator public surface."""
 
+from .api_compatibility import KBApiCompatibilityFacade
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .coordinator import (
     KBCoordinator,
@@ -48,6 +49,7 @@ from .version_compatibility import (
 
 __all__ = [
     "KBAccessMode",
+    "KBApiCompatibilityFacade",
     "KBBackendCapabilities",
     "KBCollectionContext",
     "KBContextRequest",

--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -1,6 +1,10 @@
 """KB semantic coordinator public surface."""
 
-from .api_compatibility import KBApiCompatibilityFacade
+from .api_compatibility import (
+    KBApiCompatibilityFacade,
+    KBApiFailedIngestCleanupDecision,
+    KBApiOperationResult,
+)
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .coordinator import (
     KBCoordinator,
@@ -50,6 +54,8 @@ from .version_compatibility import (
 __all__ = [
     "KBAccessMode",
     "KBApiCompatibilityFacade",
+    "KBApiFailedIngestCleanupDecision",
+    "KBApiOperationResult",
     "KBBackendCapabilities",
     "KBCollectionContext",
     "KBContextRequest",

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -435,10 +435,14 @@ class KBApiCompatibilityFacade:
         user_id: Optional[int],
         is_admin: bool = False,
         max_results: Optional[int] = None,
+        vector_store: Any | None = None,
     ) -> list[Any]:
-        from ..storage.factory import get_vector_index_store
-
         with self._storage_context():
+            store = vector_store
+            if store is None:
+                from ..storage.factory import get_vector_index_store
+
+                store = get_vector_index_store()
             kwargs: dict[str, Any] = {
                 "collection_name": collection_name,
                 "user_id": user_id,
@@ -446,7 +450,7 @@ class KBApiCompatibilityFacade:
             }
             if max_results is not None:
                 kwargs["max_results"] = max_results
-            return get_vector_index_store().list_document_records(**kwargs)
+            return store.list_document_records(**kwargs)
 
     def delete_document(
         self,
@@ -498,11 +502,15 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
+        vector_store: Any | None = None,
     ) -> list[str]:
-        from ..storage.factory import get_vector_index_store
-
         with self._storage_context():
-            return get_vector_index_store().rename_collection_data(
+            store = vector_store
+            if store is None:
+                from ..storage.factory import get_vector_index_store
+
+                store = get_vector_index_store()
+            return store.rename_collection_data(
                 collection_name=collection_name,
                 new_name=new_name,
                 user_id=user_id,
@@ -516,11 +524,15 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
+        metadata_store: Any | None = None,
     ) -> None:
-        from ..storage.factory import get_metadata_store
-
         with self._storage_context():
-            await get_metadata_store().rename_collection(
+            store = metadata_store
+            if store is None:
+                from ..storage.factory import get_metadata_store
+
+                store = get_metadata_store()
+            await store.rename_collection(
                 old_name=old_name,
                 new_name=new_name,
                 user_id=user_id,
@@ -534,11 +546,15 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
+        status_store: Any | None = None,
     ) -> list[str]:
-        from ..storage.factory import get_ingestion_status_store
-
         with self._storage_context():
-            return get_ingestion_status_store().rename_collection_status(
+            store = status_store
+            if store is None:
+                from ..storage.factory import get_ingestion_status_store
+
+                store = get_ingestion_status_store()
+            return store.rename_collection_status(
                 old_name=old_name,
                 new_name=new_name,
                 user_id=user_id,

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import unittest.mock
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -40,7 +41,9 @@ async def _maybe_await(value: Any) -> Any:
 
 def _has_store_method(metadata_store: object, name: str) -> bool:
     """Return True for real MetadataStore implementations, not loose mocks."""
-    return callable(getattr(type(metadata_store), name, None))
+    if isinstance(metadata_store, unittest.mock.NonCallableMock):
+        return False
+    return callable(getattr(metadata_store, name, None))
 
 
 @dataclass(frozen=True)
@@ -118,7 +121,7 @@ class KBApiCompatibilityFacade:
     ) -> KBApiOperationResult[T_Result]:
         """Attach the current coordinator outcome to an API-compatible result."""
         outcome = self.last_operation_outcome()
-        if outcome is previous_outcome:
+        if outcome == previous_outcome:
             outcome = None
         if outcome is not None and operation_type is not None:
             expected = (
@@ -245,13 +248,18 @@ class KBApiCompatibilityFacade:
 
     @staticmethod
     def _legacy_successful_document_count(result: Any) -> int:
-        documents_created = getattr(result, "documents_created", None)
+        if isinstance(result, dict):
+            documents_created = result.get("documents_created")
+            status = result.get("status")
+        else:
+            documents_created = getattr(result, "documents_created", None)
+            status = getattr(result, "status", None)
         if documents_created is not None:
             try:
                 return int(documents_created)
             except (TypeError, ValueError):
                 return 0
-        return 1 if getattr(result, "status", None) == "success" else 0
+        return 1 if status == "success" else 0
 
     @staticmethod
     def _side_effects_may_remain_after_api_rollback(
@@ -271,7 +279,10 @@ class KBApiCompatibilityFacade:
                 or outcome.rollback_status is RollbackStatus.INCOMPLETE
             )
 
-        return bool(getattr(operation_result.result, "side_effects_may_remain", False))
+        result = operation_result.result
+        if isinstance(result, dict):
+            return bool(result.get("side_effects_may_remain", False))
+        return bool(getattr(result, "side_effects_may_remain", False))
 
     async def save_collection_config(
         self,
@@ -328,6 +339,8 @@ class KBApiCompatibilityFacade:
                 else:
                     if isinstance(loaded, CollectionInfo):
                         collection_info = loaded
+                    elif loaded is None:
+                        collection_info = CollectionInfo(name=collection)
             else:
                 collection_info = CollectionInfo(name=collection)
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -1,0 +1,502 @@
+"""API compatibility facade for KB route-facing operations."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Optional
+
+from ..core.schemas import (
+    CollectionInfo,
+    CollectionOperationResult,
+    DocumentListResult,
+    DocumentOperationResult,
+    IngestionResult,
+    ListCollectionsResult,
+    SearchConfig,
+    SearchPipelineResult,
+    WebCrawlConfig,
+    WebIngestionResult,
+)
+from .models import KBStorageBackend
+from .pipeline_compatibility import KB_STORAGE_METADATA_KEY
+
+if TYPE_CHECKING:
+    from .coordinator import KBCoordinator
+    from .storage_shim import KBStorageShimCompatibilityFacade
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _has_store_method(metadata_store: object, name: str) -> bool:
+    """Return True for real MetadataStore implementations, not loose mocks."""
+    return callable(getattr(type(metadata_store), name, None))
+
+
+class KBApiCompatibilityFacade:
+    """Compatibility boundary for KB API route semantics.
+
+    FastAPI request parsing, dependency handling, response wrappers, and HTTP
+    error mapping stay in ``web.api.kb``. This facade owns the normalized KB
+    operations that routes call after those API-layer concerns are resolved.
+    """
+
+    def __init__(
+        self,
+        coordinator: KBCoordinator | None = None,
+        storage_shim: KBStorageShimCompatibilityFacade | None = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._storage_shim = storage_shim
+
+    def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
+        if self._storage_shim is not None:
+            return self._storage_shim
+        if self._coordinator is not None:
+            return self._coordinator.storage_shim
+        return None
+
+    @contextmanager
+    def _storage_context(self) -> Iterator[None]:
+        storage_shim = self._active_storage_shim()
+        if storage_shim is None:
+            yield
+            return
+
+        from ..storage.factory import bind_storage_shim_for_current_context
+
+        with bind_storage_shim_for_current_context(storage_shim):
+            yield
+
+    async def save_collection_config(
+        self,
+        *,
+        collection: str,
+        config_json: str,
+        user_id: int,
+        metadata_store: Any | None = None,
+    ) -> None:
+        """Save tenant-scoped config and ensure owner-neutral backend binding."""
+        with self._storage_context():
+            store = metadata_store
+            if store is None:
+                from ..storage.factory import get_metadata_store
+
+                store = get_metadata_store()
+
+            await _maybe_await(
+                store.save_collection_config(
+                    collection=collection,
+                    config_json=config_json,
+                    user_id=user_id,
+                )
+            )
+            await self.ensure_collection_backend_binding(
+                collection,
+                metadata_store=store,
+            )
+
+    async def ensure_collection_backend_binding(
+        self,
+        collection: str,
+        *,
+        metadata_store: Any | None = None,
+    ) -> CollectionInfo | None:
+        """Create a collection-level backend binding without changing owners."""
+        with self._storage_context():
+            store = metadata_store
+            if store is None:
+                from ..storage.factory import get_metadata_store
+
+                store = get_metadata_store()
+
+            if not _has_store_method(store, "save_collection"):
+                return None
+
+            collection_info: CollectionInfo | None = None
+            if _has_store_method(store, "get_collection"):
+                try:
+                    loaded = store.get_collection(collection)
+                    loaded = await _maybe_await(loaded)
+                except ValueError:
+                    collection_info = CollectionInfo(name=collection)
+                else:
+                    if isinstance(loaded, CollectionInfo):
+                        collection_info = loaded
+            else:
+                collection_info = CollectionInfo(name=collection)
+
+            if collection_info is None:
+                return None
+
+            extra_metadata = dict(collection_info.extra_metadata or {})
+            if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
+                return collection_info
+
+            extra_metadata[KB_STORAGE_METADATA_KEY] = {
+                "backend": KBStorageBackend.LANCEDB.value
+            }
+            updated_collection = collection_info.model_copy(
+                update={"extra_metadata": extra_metadata}
+            )
+            await _maybe_await(store.save_collection(updated_collection))
+            return updated_collection
+
+    def get_collection_sync(self, collection_name: str) -> CollectionInfo:
+        if self._coordinator is not None:
+            return self._coordinator.maintenance_compatibility.get_collection_sync(
+                collection_name
+            )
+
+        from ..management.collection_manager import get_collection_sync
+
+        with self._storage_context():
+            return get_collection_sync(collection_name)
+
+    def delete_collection_metadata_sync(
+        self,
+        *,
+        collection_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+        delete_orphaned_metadata: bool = False,
+    ) -> dict[str, int]:
+        if self._coordinator is not None:
+            return (
+                self._coordinator.maintenance_compatibility.delete_collection_metadata_sync(
+                    collection_name=collection_name,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    delete_orphaned_metadata=delete_orphaned_metadata,
+                )
+            )
+
+        from ..management.collection_manager import delete_collection_metadata_sync
+
+        with self._storage_context():
+            return delete_collection_metadata_sync(
+                collection_name=collection_name,
+                user_id=user_id,
+                is_admin=is_admin,
+                delete_orphaned_metadata=delete_orphaned_metadata,
+            )
+
+    async def list_collections(
+        self,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        force_realtime: bool = False,
+    ) -> ListCollectionsResult:
+        if self._coordinator is not None:
+            return await self._coordinator.management.list_collections(
+                user_id=user_id,
+                is_admin=is_admin,
+                force_realtime=force_realtime,
+            )
+
+        from ..management.collections import list_collections
+
+        with self._storage_context():
+            return await list_collections(
+                user_id=user_id,
+                is_admin=is_admin,
+                force_realtime=force_realtime,
+            )
+
+    def list_documents(
+        self,
+        collection: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DocumentListResult:
+        if self._coordinator is not None:
+            return self._coordinator.management.list_documents(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+        from ..management.collections import list_documents
+
+        with self._storage_context():
+            return list_documents(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def list_document_records(
+        self,
+        *,
+        collection_name: Optional[str],
+        user_id: Optional[int],
+        is_admin: bool = False,
+        max_results: Optional[int] = None,
+    ) -> list[Any]:
+        from ..storage.factory import get_vector_index_store
+
+        with self._storage_context():
+            kwargs: dict[str, Any] = {
+                "collection_name": collection_name,
+                "user_id": user_id,
+                "is_admin": is_admin,
+            }
+            if max_results is not None:
+                kwargs["max_results"] = max_results
+            return get_vector_index_store().list_document_records(**kwargs)
+
+    def delete_document(
+        self,
+        collection: str,
+        doc_id: str,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> DocumentOperationResult:
+        if self._coordinator is not None:
+            return self._coordinator.management.delete_document(
+                collection=collection,
+                doc_id=doc_id,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+        from ..management.collections import delete_document
+
+        with self._storage_context():
+            return delete_document(
+                collection,
+                doc_id,
+                user_id,
+                is_admin,
+            )
+
+    def delete_collection(
+        self,
+        collection: str,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> CollectionOperationResult:
+        if self._coordinator is not None:
+            return self._coordinator.management.delete_collection(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+        from ..management.collections import delete_collection
+
+        with self._storage_context():
+            return delete_collection(collection, user_id, is_admin)
+
+    def rename_collection_data(
+        self,
+        *,
+        collection_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> list[str]:
+        from ..storage.factory import get_vector_index_store
+
+        with self._storage_context():
+            return get_vector_index_store().rename_collection_data(
+                collection_name=collection_name,
+                new_name=new_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def rename_collection_metadata(
+        self,
+        *,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> None:
+        from ..storage.factory import get_metadata_store
+
+        with self._storage_context():
+            await get_metadata_store().rename_collection(
+                old_name=old_name,
+                new_name=new_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def rename_collection_status(
+        self,
+        *,
+        old_name: str,
+        new_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> list[str]:
+        from ..storage.factory import get_ingestion_status_store
+
+        with self._storage_context():
+            return get_ingestion_status_store().rename_collection_status(
+                old_name=old_name,
+                new_name=new_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def run_document_ingestion(
+        self,
+        collection: str,
+        source_path: str,
+        *,
+        ingestion_config: Optional[Any] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        file_id: Optional[str] = None,
+        metadata_source_path: Optional[str] = None,
+        commit_gate: Optional[Any] = None,
+    ) -> IngestionResult:
+        if self._coordinator is not None:
+            return self._coordinator.pipeline_compatibility.run_document_ingestion(
+                collection=collection,
+                source_path=source_path,
+                ingestion_config=ingestion_config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_id=file_id,
+                metadata_source_path=metadata_source_path,
+                commit_gate=commit_gate,
+            )
+
+        from ..pipelines.document_ingestion import run_document_ingestion
+
+        with self._storage_context():
+            return run_document_ingestion(
+                collection=collection,
+                source_path=source_path,
+                ingestion_config=ingestion_config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_id=file_id,
+                metadata_source_path=metadata_source_path,
+                commit_gate=commit_gate,
+            )
+
+    def run_document_search(
+        self,
+        collection: str,
+        query_text: str,
+        *,
+        config: Optional[SearchConfig | Mapping[str, Any]] = None,
+        progress_manager: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+    ) -> SearchPipelineResult:
+        if self._coordinator is not None:
+            return self._coordinator.pipeline_compatibility.run_document_search(
+                collection=collection,
+                query_text=query_text,
+                config=config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+        from ..pipelines.document_search import run_document_search
+
+        with self._storage_context():
+            return run_document_search(
+                collection=collection,
+                query_text=query_text,
+                config=config,
+                progress_manager=progress_manager,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    async def run_web_ingestion(
+        self,
+        collection: str,
+        crawl_config: WebCrawlConfig,
+        *,
+        ingestion_config: Optional[Any] = None,
+        progress_callback: Optional[Any] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        file_handler: Optional[Any] = None,
+    ) -> WebIngestionResult:
+        if self._coordinator is not None:
+            return await self._coordinator.pipeline_compatibility.run_web_ingestion(
+                collection=collection,
+                crawl_config=crawl_config,
+                ingestion_config=ingestion_config,
+                progress_callback=progress_callback,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_handler=file_handler,
+            )
+
+        from ..pipelines.web_ingestion import run_web_ingestion
+
+        with self._storage_context():
+            return await run_web_ingestion(
+                collection=collection,
+                crawl_config=crawl_config,
+                ingestion_config=ingestion_config,
+                progress_callback=progress_callback,
+                user_id=user_id,
+                is_admin=is_admin,
+                file_handler=file_handler,
+            )
+
+    def reconstruct_parse_result_from_db(
+        self,
+        collection: str,
+        doc_id: str,
+        parse_hash: Optional[str] = None,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        if self._coordinator is not None:
+            return self._coordinator.parse_display_compatibility.reconstruct_parse_result_from_db(
+                collection=collection,
+                doc_id=doc_id,
+                parse_hash=parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+        from ..parse.parse_display import reconstruct_parse_result_from_db
+
+        with self._storage_context():
+            return reconstruct_parse_result_from_db(
+                collection,
+                doc_id,
+                parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+
+    def paginate_parse_results(
+        self,
+        elements: list[dict[str, Any]],
+        page: int,
+        page_size: int,
+    ) -> tuple[list[Any], dict[str, Any]]:
+        if self._coordinator is not None:
+            return self._coordinator.parse_display_compatibility.paginate_parse_results(
+                elements,
+                page,
+                page_size,
+            )
+
+        from ..parse.parse_display import paginate_parse_results
+
+        return paginate_parse_results(elements, page, page_size)

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -7,7 +7,16 @@ import unittest.mock
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 from ..core.schemas import (
     CollectionInfo,
@@ -292,15 +301,12 @@ class KBApiCompatibilityFacade:
         collection: str,
         config_json: str,
         user_id: int,
-        metadata_store: Any | None = None,
     ) -> None:
         """Save tenant-scoped config and ensure owner-neutral backend binding."""
         with self._storage_context():
-            store = metadata_store
-            if store is None:
-                from ..storage.factory import get_metadata_store
+            from ..storage.factory import get_metadata_store
 
-                store = get_metadata_store()
+            store = get_metadata_store()
 
             await _maybe_await(
                 store.save_collection_config(
@@ -309,58 +315,126 @@ class KBApiCompatibilityFacade:
                     user_id=user_id,
                 )
             )
-            await self.ensure_collection_backend_binding(
-                collection,
-                metadata_store=store,
-            )
+            await self._ensure_collection_backend_binding_with_store(collection, store)
 
     async def ensure_collection_backend_binding(
         self,
         collection: str,
-        *,
-        metadata_store: Any | None = None,
     ) -> CollectionInfo | None:
         """Create a collection-level backend binding without changing owners."""
         with self._storage_context():
-            store = metadata_store
-            if store is None:
-                from ..storage.factory import get_metadata_store
+            from ..storage.factory import get_metadata_store
 
-                store = get_metadata_store()
-
-            if not _has_store_method(store, "save_collection"):
-                return None
-
-            collection_info: CollectionInfo | None = None
-            if _has_store_method(store, "get_collection"):
-                try:
-                    loaded = store.get_collection(collection)
-                    loaded = await _maybe_await(loaded)
-                except ValueError:
-                    collection_info = CollectionInfo(name=collection)
-                else:
-                    if isinstance(loaded, CollectionInfo):
-                        collection_info = loaded
-                    elif loaded is None:
-                        collection_info = CollectionInfo(name=collection)
-            else:
-                collection_info = CollectionInfo(name=collection)
-
-            if collection_info is None:
-                return None
-
-            extra_metadata = dict(collection_info.extra_metadata or {})
-            if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
-                return collection_info
-
-            extra_metadata[KB_STORAGE_METADATA_KEY] = {
-                "backend": KBStorageBackend.LANCEDB.value
-            }
-            updated_collection = collection_info.model_copy(
-                update={"extra_metadata": extra_metadata}
+            store = get_metadata_store()
+            return await self._ensure_collection_backend_binding_with_store(
+                collection,
+                store,
             )
-            await _maybe_await(store.save_collection(updated_collection))
-            return updated_collection
+
+    async def _ensure_collection_backend_binding_with_store(
+        self,
+        collection: str,
+        store: Any,
+    ) -> CollectionInfo | None:
+        if not _has_store_method(store, "save_collection"):
+            return None
+
+        collection_info: CollectionInfo | None = None
+        if _has_store_method(store, "get_collection"):
+            try:
+                loaded = store.get_collection(collection)
+                loaded = await _maybe_await(loaded)
+            except ValueError:
+                collection_info = CollectionInfo(name=collection)
+            else:
+                if isinstance(loaded, CollectionInfo):
+                    collection_info = loaded
+                elif loaded is None:
+                    collection_info = CollectionInfo(name=collection)
+        else:
+            collection_info = CollectionInfo(name=collection)
+
+        if collection_info is None:
+            return None
+
+        extra_metadata = dict(collection_info.extra_metadata or {})
+        if extra_metadata.get(KB_STORAGE_METADATA_KEY) is not None:
+            return collection_info
+
+        extra_metadata[KB_STORAGE_METADATA_KEY] = {
+            "backend": KBStorageBackend.LANCEDB.value
+        }
+        updated_collection = collection_info.model_copy(
+            update={"extra_metadata": extra_metadata}
+        )
+        await _maybe_await(store.save_collection(updated_collection))
+        return updated_collection
+
+    async def get_collection_config(
+        self,
+        *,
+        collection: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+    ) -> str | None:
+        """Read tenant-scoped config through the facade-bound metadata store."""
+        with self._storage_context():
+            from ..storage.factory import get_metadata_store
+
+            return cast(
+                str | None,
+                await _maybe_await(
+                    get_metadata_store().get_collection_config(
+                        collection=collection,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    )
+                ),
+            )
+
+    async def delete_collection_metadata(
+        self,
+        *,
+        collection_name: str,
+        user_id: Optional[int],
+        is_admin: bool = False,
+        delete_orphaned_metadata: bool = False,
+    ) -> dict[str, int]:
+        """Delete collection metadata through the facade-bound metadata store."""
+        with self._storage_context():
+            from ..storage.factory import get_metadata_store
+
+            return cast(
+                dict[str, int],
+                await _maybe_await(
+                    get_metadata_store().delete_collection_metadata(
+                        collection_name=collection_name,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                        delete_orphaned_metadata=delete_orphaned_metadata,
+                    )
+                ),
+            )
+
+    async def delete_collection_metadata_entry(self, collection_name: str) -> bool:
+        """Delete the collection metadata row when the store supports it."""
+        with self._storage_context():
+            from ..storage.factory import get_metadata_store
+
+            delete_metadata = getattr(get_metadata_store(), "delete_collection", None)
+            if not callable(delete_metadata):
+                return False
+            await _maybe_await(delete_metadata(collection_name))
+            return True
+
+    def list_collection_config_owner_ids(self, collection_name: str) -> set[int]:
+        """List tenant config owners through the facade-bound metadata store."""
+        with self._storage_context():
+            from ..storage.factory import get_metadata_store
+
+            return set(
+                get_metadata_store().list_collection_config_owner_ids(collection_name)
+            )
 
     def get_collection_sync(self, collection_name: str) -> CollectionInfo:
         if self._coordinator is not None:
@@ -450,14 +524,11 @@ class KBApiCompatibilityFacade:
         user_id: Optional[int],
         is_admin: bool = False,
         max_results: Optional[int] = None,
-        vector_store: Any | None = None,
     ) -> list[Any]:
         with self._storage_context():
-            store = vector_store
-            if store is None:
-                from ..storage.factory import get_vector_index_store
+            from ..storage.factory import get_vector_index_store
 
-                store = get_vector_index_store()
+            store = get_vector_index_store()
             kwargs: dict[str, Any] = {
                 "collection_name": collection_name,
                 "user_id": user_id,
@@ -517,14 +588,11 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
-        vector_store: Any | None = None,
     ) -> list[str]:
         with self._storage_context():
-            store = vector_store
-            if store is None:
-                from ..storage.factory import get_vector_index_store
+            from ..storage.factory import get_vector_index_store
 
-                store = get_vector_index_store()
+            store = get_vector_index_store()
             return store.rename_collection_data(
                 collection_name=collection_name,
                 new_name=new_name,
@@ -539,14 +607,11 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
-        metadata_store: Any | None = None,
     ) -> None:
         with self._storage_context():
-            store = metadata_store
-            if store is None:
-                from ..storage.factory import get_metadata_store
+            from ..storage.factory import get_metadata_store
 
-                store = get_metadata_store()
+            store = get_metadata_store()
             await store.rename_collection(
                 old_name=old_name,
                 new_name=new_name,
@@ -561,14 +626,11 @@ class KBApiCompatibilityFacade:
         new_name: str,
         user_id: Optional[int],
         is_admin: bool = False,
-        status_store: Any | None = None,
     ) -> list[str]:
         with self._storage_context():
-            store = status_store
-            if store is None:
-                from ..storage.factory import get_ingestion_status_store
+            from ..storage.factory import get_ingestion_status_store
 
-                store = get_ingestion_status_store()
+            store = get_ingestion_status_store()
             return store.rename_collection_status(
                 old_name=old_name,
                 new_name=new_name,

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-import unittest.mock
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -49,9 +48,7 @@ async def _maybe_await(value: Any) -> Any:
 
 
 def _has_store_method(metadata_store: object, name: str) -> bool:
-    """Return True for real MetadataStore implementations, not loose mocks."""
-    if isinstance(metadata_store, unittest.mock.NonCallableMock):
-        return False
+    """Return True when the store exposes a callable method."""
     return callable(getattr(metadata_store, name, None))
 
 
@@ -442,10 +439,10 @@ class KBApiCompatibilityFacade:
                 collection_name
             )
 
-        from ..management.collection_manager import get_collection_sync
+        from ..management import collection_manager as collection_manager_module
 
         with self._storage_context():
-            return get_collection_sync(collection_name)
+            return collection_manager_module.get_collection_sync(collection_name)
 
     def delete_collection_metadata_sync(
         self,
@@ -463,10 +460,10 @@ class KBApiCompatibilityFacade:
                 delete_orphaned_metadata=delete_orphaned_metadata,
             )
 
-        from ..management.collection_manager import delete_collection_metadata_sync
+        from ..management import collection_manager as collection_manager_module
 
         with self._storage_context():
-            return delete_collection_metadata_sync(
+            return collection_manager_module.delete_collection_metadata_sync(
                 collection_name=collection_name,
                 user_id=user_id,
                 is_admin=is_admin,
@@ -486,10 +483,10 @@ class KBApiCompatibilityFacade:
                 force_realtime=force_realtime,
             )
 
-        from ..management.collections import list_collections
+        from ..management import collections as collections_module
 
         with self._storage_context():
-            return await list_collections(
+            return await collections_module.list_collections(
                 user_id=user_id,
                 is_admin=is_admin,
                 force_realtime=force_realtime,
@@ -508,10 +505,10 @@ class KBApiCompatibilityFacade:
                 is_admin=is_admin,
             )
 
-        from ..management.collections import list_documents
+        from ..management import collections as collections_module
 
         with self._storage_context():
-            return list_documents(
+            return collections_module.list_documents(
                 collection=collection,
                 user_id=user_id,
                 is_admin=is_admin,
@@ -553,10 +550,10 @@ class KBApiCompatibilityFacade:
                 is_admin=is_admin,
             )
 
-        from ..management.collections import delete_document
+        from ..management import collections as collections_module
 
         with self._storage_context():
-            return delete_document(
+            return collections_module.delete_document(
                 collection,
                 doc_id,
                 user_id,
@@ -576,10 +573,10 @@ class KBApiCompatibilityFacade:
                 is_admin=is_admin,
             )
 
-        from ..management.collections import delete_collection
+        from ..management import collections as collections_module
 
         with self._storage_context():
-            return delete_collection(collection, user_id, is_admin)
+            return collections_module.delete_collection(collection, user_id, is_admin)
 
     def rename_collection_data(
         self,
@@ -664,10 +661,10 @@ class KBApiCompatibilityFacade:
                 commit_gate=commit_gate,
             )
 
-        from ..pipelines.document_ingestion import run_document_ingestion
+        from ..pipelines import document_ingestion as document_ingestion_pipeline
 
         with self._storage_context():
-            return run_document_ingestion(
+            return document_ingestion_pipeline.run_document_ingestion(
                 collection=collection,
                 source_path=source_path,
                 ingestion_config=ingestion_config,
@@ -699,10 +696,10 @@ class KBApiCompatibilityFacade:
                 is_admin=is_admin,
             )
 
-        from ..pipelines.document_search import run_document_search
+        from ..pipelines import document_search as document_search_pipeline
 
         with self._storage_context():
-            return run_document_search(
+            return document_search_pipeline.run_document_search(
                 collection=collection,
                 query_text=query_text,
                 config=config,
@@ -733,10 +730,10 @@ class KBApiCompatibilityFacade:
                 file_handler=file_handler,
             )
 
-        from ..pipelines.web_ingestion import run_web_ingestion
+        from ..pipelines import web_ingestion as web_ingestion_pipeline
 
         with self._storage_context():
-            return await run_web_ingestion(
+            return await web_ingestion_pipeline.run_web_ingestion(
                 collection=collection,
                 crawl_config=crawl_config,
                 ingestion_config=ingestion_config,
@@ -764,10 +761,10 @@ class KBApiCompatibilityFacade:
                 is_admin=is_admin,
             )
 
-        from ..parse.parse_display import reconstruct_parse_result_from_db
+        from ..parse import parse_display as parse_display_module
 
         with self._storage_context():
-            return reconstruct_parse_result_from_db(
+            return parse_display_module.reconstruct_parse_result_from_db(
                 collection,
                 doc_id,
                 parse_hash,
@@ -788,6 +785,6 @@ class KBApiCompatibilityFacade:
                 page_size,
             )
 
-        from ..parse.parse_display import paginate_parse_results
+        from ..parse import parse_display as parse_display_module
 
-        return paginate_parse_results(elements, page, page_size)
+        return parse_display_module.paginate_parse_results(elements, page, page_size)

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import inspect
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, TypeVar
 
 from ..core.schemas import (
     CollectionInfo,
@@ -20,11 +21,15 @@ from ..core.schemas import (
     WebIngestionResult,
 )
 from .models import KBStorageBackend
+from .operation_compatibility import KBOperationOutcome, RollbackStatus
 from .pipeline_compatibility import KB_STORAGE_METADATA_KEY
 
 if TYPE_CHECKING:
     from .coordinator import KBCoordinator
+    from .operation_compatibility import KBOperationCompatibilityFacade
     from .storage_shim import KBStorageShimCompatibilityFacade
+
+T_Result = TypeVar("T_Result")
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -36,6 +41,23 @@ async def _maybe_await(value: Any) -> Any:
 def _has_store_method(metadata_store: object, name: str) -> bool:
     """Return True for real MetadataStore implementations, not loose mocks."""
     return callable(getattr(type(metadata_store), name, None))
+
+
+@dataclass(frozen=True)
+class KBApiOperationResult(Generic[T_Result]):
+    """Route-internal result plus the rollback outcome produced by the coordinator."""
+
+    result: T_Result
+    operation_outcome: KBOperationOutcome | None = None
+    rollback_complete: bool | None = None
+
+
+@dataclass(frozen=True)
+class KBApiFailedIngestCleanupDecision:
+    """API-facing cleanup policy derived from operation rollback state."""
+
+    successful_documents: int = 0
+    side_effects_may_remain: bool = False
 
 
 class KBApiCompatibilityFacade:
@@ -61,6 +83,18 @@ class KBApiCompatibilityFacade:
             return self._coordinator.storage_shim
         return None
 
+    def _active_operation_facade(self) -> KBOperationCompatibilityFacade | None:
+        if self._coordinator is not None:
+            return self._coordinator.operation_compatibility
+        return None
+
+    def last_operation_outcome(self) -> KBOperationOutcome | None:
+        """Return the last finalized coordinator operation in the current context."""
+        operation_facade = self._active_operation_facade()
+        if operation_facade is None:
+            return None
+        return operation_facade.last_outcome
+
     @contextmanager
     def _storage_context(self) -> Iterator[None]:
         storage_shim = self._active_storage_shim()
@@ -72,6 +106,172 @@ class KBApiCompatibilityFacade:
 
         with bind_storage_shim_for_current_context(storage_shim):
             yield
+
+    def wrap_operation_result(
+        self,
+        result: T_Result,
+        *,
+        previous_outcome: KBOperationOutcome | None = None,
+        operation_type: str | tuple[str, ...] | None = None,
+        collection: str | None = None,
+        rollback_complete: bool | None = None,
+    ) -> KBApiOperationResult[T_Result]:
+        """Attach the current coordinator outcome to an API-compatible result."""
+        outcome = self.last_operation_outcome()
+        if outcome is previous_outcome:
+            outcome = None
+        if outcome is not None and operation_type is not None:
+            expected = (
+                (operation_type,) if isinstance(operation_type, str) else operation_type
+            )
+            if outcome.operation_type not in expected:
+                outcome = None
+        if (
+            outcome is not None
+            and collection is not None
+            and outcome.collection != collection
+        ):
+            outcome = None
+
+        return KBApiOperationResult(
+            result=result,
+            operation_outcome=outcome,
+            rollback_complete=rollback_complete,
+        )
+
+    def run_with_operation_outcome(
+        self,
+        operation: Callable[[], T_Result],
+        *,
+        operation_type: str | tuple[str, ...],
+        collection: str,
+        rollback_complete: bool | None = None,
+    ) -> KBApiOperationResult[T_Result]:
+        """Run a sync API operation and consume its coordinator outcome."""
+        previous_outcome = self.last_operation_outcome()
+        result = operation()
+        return self.wrap_operation_result(
+            result,
+            previous_outcome=previous_outcome,
+            operation_type=operation_type,
+            collection=collection,
+            rollback_complete=rollback_complete,
+        )
+
+    async def run_async_with_operation_outcome(
+        self,
+        operation: Callable[[], Awaitable[T_Result]],
+        *,
+        operation_type: str | tuple[str, ...],
+        collection: str,
+        rollback_complete: bool | None = None,
+    ) -> KBApiOperationResult[T_Result]:
+        """Run an async API operation and consume its coordinator outcome."""
+        previous_outcome = self.last_operation_outcome()
+        result = await operation()
+        return self.wrap_operation_result(
+            result,
+            previous_outcome=previous_outcome,
+            operation_type=operation_type,
+            collection=collection,
+            rollback_complete=rollback_complete,
+        )
+
+    @staticmethod
+    def with_result(
+        operation_result: KBApiOperationResult[Any],
+        result: T_Result,
+    ) -> KBApiOperationResult[T_Result]:
+        """Replace the legacy result while preserving internal operation metadata."""
+        return KBApiOperationResult(
+            result=result,
+            operation_outcome=operation_result.operation_outcome,
+            rollback_complete=operation_result.rollback_complete,
+        )
+
+    @staticmethod
+    def with_rollback_complete(
+        operation_result: KBApiOperationResult[T_Result],
+        rollback_complete: bool,
+    ) -> KBApiOperationResult[T_Result]:
+        """Record whether API-level compensation completed after a failed operation."""
+        return replace(operation_result, rollback_complete=rollback_complete)
+
+    def failed_ingest_cleanup_decision(
+        self,
+        operation_result: KBApiOperationResult[Any],
+        *,
+        successful_documents: int | None = None,
+        rollback_complete: bool | None = None,
+    ) -> KBApiFailedIngestCleanupDecision:
+        """Derive config/metadata cleanup inputs from operation rollback state."""
+        effective_rollback_complete = (
+            operation_result.rollback_complete
+            if rollback_complete is None
+            else rollback_complete
+        )
+        if successful_documents is None:
+            successful_documents = self._legacy_successful_document_count(
+                operation_result.result
+            )
+
+        return KBApiFailedIngestCleanupDecision(
+            successful_documents=max(0, int(successful_documents)),
+            side_effects_may_remain=self._side_effects_may_remain_after_api_rollback(
+                operation_result,
+                rollback_complete=effective_rollback_complete,
+            ),
+        )
+
+    def failed_batch_ingest_cleanup_decision(
+        self,
+        operation_results: list[KBApiOperationResult[Any]],
+        *,
+        successful_documents: int | None = None,
+    ) -> KBApiFailedIngestCleanupDecision:
+        """Aggregate child operation rollback state for batch/cloud ingest cleanup."""
+        if successful_documents is None:
+            successful_documents = sum(
+                self._legacy_successful_document_count(item.result)
+                for item in operation_results
+            )
+        return KBApiFailedIngestCleanupDecision(
+            successful_documents=max(0, int(successful_documents)),
+            side_effects_may_remain=any(
+                self.failed_ingest_cleanup_decision(item).side_effects_may_remain
+                for item in operation_results
+            ),
+        )
+
+    @staticmethod
+    def _legacy_successful_document_count(result: Any) -> int:
+        documents_created = getattr(result, "documents_created", None)
+        if documents_created is not None:
+            try:
+                return int(documents_created)
+            except (TypeError, ValueError):
+                return 0
+        return 1 if getattr(result, "status", None) == "success" else 0
+
+    @staticmethod
+    def _side_effects_may_remain_after_api_rollback(
+        operation_result: KBApiOperationResult[Any],
+        *,
+        rollback_complete: bool | None,
+    ) -> bool:
+        if rollback_complete is False:
+            return True
+        if rollback_complete is True:
+            return False
+
+        outcome = operation_result.operation_outcome
+        if outcome is not None:
+            return bool(
+                outcome.side_effects_may_remain
+                or outcome.rollback_status is RollbackStatus.INCOMPLETE
+            )
+
+        return bool(getattr(operation_result.result, "side_effects_may_remain", False))
 
     async def save_collection_config(
         self,
@@ -167,13 +367,11 @@ class KBApiCompatibilityFacade:
         delete_orphaned_metadata: bool = False,
     ) -> dict[str, int]:
         if self._coordinator is not None:
-            return (
-                self._coordinator.maintenance_compatibility.delete_collection_metadata_sync(
-                    collection_name=collection_name,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    delete_orphaned_metadata=delete_orphaned_metadata,
-                )
+            return self._coordinator.maintenance_compatibility.delete_collection_metadata_sync(
+                collection_name=collection_name,
+                user_id=user_id,
+                is_admin=is_admin,
+                delete_orphaned_metadata=delete_orphaned_metadata,
             )
 
         from ..management.collection_manager import delete_collection_metadata_sync

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -152,7 +152,8 @@ class KBApiCompatibilityFacade:
     ) -> KBApiOperationResult[T_Result]:
         """Run a sync API operation and consume its coordinator outcome."""
         previous_outcome = self.last_operation_outcome()
-        result = operation()
+        with self._storage_context():
+            result = operation()
         return self.wrap_operation_result(
             result,
             previous_outcome=previous_outcome,
@@ -171,7 +172,8 @@ class KBApiCompatibilityFacade:
     ) -> KBApiOperationResult[T_Result]:
         """Run an async API operation and consume its coordinator outcome."""
         previous_outcome = self.last_operation_outcome()
-        result = await operation()
+        with self._storage_context():
+            result = await operation()
         return self.wrap_operation_result(
             result,
             previous_outcome=previous_outcome,

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, TypeVar
 
 from ..storage.factory import StorageFactory
 from ..utils.user_scope import resolve_user_scope
+from .api_compatibility import KBApiCompatibilityFacade
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
 from .file_compatibility import KBFileCompatibilityFacade
 from .legacy_step_compatibility import KBLegacyStepCompatibilityFacade
@@ -58,6 +59,7 @@ class KBCoordinator:
         pipeline_compatibility: KBPipelineCompatibilityFacade | None = None,
         legacy_step_compatibility: KBLegacyStepCompatibilityFacade | None = None,
         tool_compatibility: KBToolCompatibilityFacade | None = None,
+        api_compatibility: KBApiCompatibilityFacade | None = None,
     ) -> None:
         self._storage_factory = storage_factory or StorageFactory.get_factory()
         self._handle_provider = handle_provider or KBHandleProvider()
@@ -98,6 +100,9 @@ class KBCoordinator:
             or KBLegacyStepCompatibilityFacade(coordinator=self)
         )
         self._tool_compatibility = tool_compatibility or KBToolCompatibilityFacade(
+            coordinator=self
+        )
+        self._api_compatibility = api_compatibility or KBApiCompatibilityFacade(
             coordinator=self
         )
 
@@ -210,6 +215,16 @@ class KBCoordinator:
     def tools(self) -> KBToolCompatibilityFacade:
         """Backward-friendly short alias for the tool facade."""
         return self._tool_compatibility
+
+    @property
+    def api_compatibility(self) -> KBApiCompatibilityFacade:
+        """Return the API route compatibility facade."""
+        return self._api_compatibility
+
+    @property
+    def api(self) -> KBApiCompatibilityFacade:
+        """Backward-friendly short alias for the API facade."""
+        return self._api_compatibility
 
     async def get_context(self, request: KBContextRequest) -> KBCollectionContext:
         """Resolve collection, caller scope, stores, backend, and capabilities."""

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -908,6 +908,67 @@ async def _restore_or_cleanup_collection_config_after_failed_ingest(
     )
 
 
+async def _restore_or_cleanup_collection_config_after_failed_api_ingest(
+    *,
+    api_result: KBApiOperationResult[Any],
+    snapshot: Optional["_CollectionConfigSnapshot"],
+    collection_existed_before: bool,
+    collection_name: str,
+    user: User,
+    context: str,
+    successful_documents: int | None = None,
+    rollback_complete: bool | None = None,
+) -> KBApiOperationResult[Any]:
+    """Apply failed-ingest config cleanup using API rollback outcome semantics."""
+    if rollback_complete is not None:
+        api_result = _get_api_compatibility_facade().with_rollback_complete(
+            api_result,
+            rollback_complete,
+        )
+    cleanup_decision = _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+        api_result,
+        successful_documents=successful_documents,
+    )
+    await _restore_or_cleanup_collection_config_after_failed_ingest(
+        snapshot=snapshot,
+        collection_existed_before=collection_existed_before,
+        collection_name=collection_name,
+        user=user,
+        context=context,
+        successful_documents=cleanup_decision.successful_documents,
+        side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+    )
+    return api_result
+
+
+async def _restore_or_cleanup_collection_config_after_failed_batch_api_ingest(
+    *,
+    api_results: list[KBApiOperationResult[Any]],
+    snapshot: Optional["_CollectionConfigSnapshot"],
+    collection_existed_before: bool,
+    collection_name: str,
+    user: User,
+    context: str,
+    successful_documents: int | None = None,
+) -> None:
+    """Apply batch failed-ingest config cleanup using API rollback outcomes."""
+    cleanup_decision = (
+        _get_api_compatibility_facade().failed_batch_ingest_cleanup_decision(
+            api_results,
+            successful_documents=successful_documents,
+        )
+    )
+    await _restore_or_cleanup_collection_config_after_failed_ingest(
+        snapshot=snapshot,
+        collection_existed_before=collection_existed_before,
+        collection_name=collection_name,
+        user=user,
+        context=context,
+        successful_documents=cleanup_decision.successful_documents,
+        side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+    )
+
+
 async def _rollback_failed_ingestion(
     *,
     db: Session,
@@ -3619,24 +3680,22 @@ async def ingest(
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
-            api_result = _get_api_compatibility_facade().with_rollback_complete(
-                api_result,
-                True,
-            )
             if effective_collection_existed_before:
-                cleanup_decision = (
-                    _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                        api_result
+                api_result = (
+                    await _restore_or_cleanup_collection_config_after_failed_api_ingest(
+                        api_result=api_result,
+                        snapshot=config_snapshot,
+                        collection_existed_before=collection_existed_before,
+                        collection_name=collection,
+                        user=_user,
+                        context="ingest",
+                        rollback_complete=True,
                     )
                 )
-                await _restore_or_cleanup_collection_config_after_failed_ingest(
-                    snapshot=config_snapshot,
-                    collection_existed_before=collection_existed_before,
-                    collection_name=collection,
-                    user=_user,
-                    context="ingest",
-                    successful_documents=cleanup_decision.successful_documents,
-                    side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+            else:
+                api_result = _get_api_compatibility_facade().with_rollback_complete(
+                    api_result,
+                    True,
                 )
 
         if result.status == "error":
@@ -3690,26 +3749,24 @@ async def ingest(
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
-            rollback_api_result = (
-                _get_api_compatibility_facade().with_rollback_complete(
-                    rollback_api_result,
-                    True,
-                )
-            )
             if effective_collection_existed_before:
-                cleanup_decision = (
-                    _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                        rollback_api_result
+                rollback_api_result = (
+                    await _restore_or_cleanup_collection_config_after_failed_api_ingest(
+                        api_result=rollback_api_result,
+                        snapshot=config_snapshot,
+                        collection_existed_before=collection_existed_before,
+                        collection_name=collection,
+                        user=_user,
+                        context="ingest",
+                        rollback_complete=True,
                     )
                 )
-                await _restore_or_cleanup_collection_config_after_failed_ingest(
-                    snapshot=config_snapshot,
-                    collection_existed_before=collection_existed_before,
-                    collection_name=collection,
-                    user=_user,
-                    context="ingest",
-                    successful_documents=cleanup_decision.successful_documents,
-                    side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+            else:
+                rollback_api_result = (
+                    _get_api_compatibility_facade().with_rollback_complete(
+                        rollback_api_result,
+                        True,
+                    )
                 )
         else:
             _restore_ingest_file_backup(
@@ -3725,19 +3782,13 @@ async def ingest(
                 ),
                 rollback_complete=True,
             )
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    rollback_api_result
-                )
-            )
-            await _restore_or_cleanup_collection_config_after_failed_ingest(
+            await _restore_or_cleanup_collection_config_after_failed_api_ingest(
+                api_result=rollback_api_result,
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=collection,
                 user=_user,
                 context="ingest",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
         raise
 
@@ -4293,22 +4344,16 @@ async def ingest_cloud(
     has_failure = any(result.status in {"error", "partial"} for result in results)
 
     if has_failure:
-        cleanup_decision = (
-            _get_api_compatibility_facade().failed_batch_ingest_cleanup_decision(
-                list(api_results),
-                successful_documents=sum(
-                    1 for result in results if result.status == "success"
-                ),
-            )
-        )
-        await _restore_or_cleanup_collection_config_after_failed_ingest(
+        await _restore_or_cleanup_collection_config_after_failed_batch_api_ingest(
+            api_results=list(api_results),
             snapshot=config_snapshot,
             collection_existed_before=collection_existed_before,
             collection_name=safe_collection,
             user=_user,
             context="ingest_cloud",
-            successful_documents=cleanup_decision.successful_documents,
-            side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+            successful_documents=sum(
+                1 for result in results if result.status == "success"
+            ),
         )
 
     return results
@@ -5151,20 +5196,14 @@ async def ingest_web(
             )
 
         if result.status == "error":
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    api_result,
-                    successful_documents=result.documents_created,
-                )
-            )
-            await _restore_or_cleanup_collection_config_after_failed_ingest(
+            await _restore_or_cleanup_collection_config_after_failed_api_ingest(
+                api_result=api_result,
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=safe_collection,
                 user=_user,
                 context="ingest_web",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+                successful_documents=result.documents_created,
             )
             return JSONResponse(status_code=500, content=result.model_dump())
         if result.status == "partial":
@@ -5175,20 +5214,14 @@ async def ingest_web(
                 _user.id,
                 result.message,
             )
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    api_result,
-                    successful_documents=result.documents_created,
-                )
-            )
-            await _restore_or_cleanup_collection_config_after_failed_ingest(
+            await _restore_or_cleanup_collection_config_after_failed_api_ingest(
+                api_result=api_result,
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=safe_collection,
                 user=_user,
                 context="ingest_web",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+                successful_documents=result.documents_created,
             )
 
         return result

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -76,6 +76,7 @@ from ...core.tools.core.RAG_tools.pipelines.web_ingestion import FileHandlerResu
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from ...core.tools.core.RAG_tools.storage.factory import (
+    get_ingestion_status_store,
     get_metadata_store,
     get_vector_index_store,
 )
@@ -224,6 +225,7 @@ def list_document_records(
         user_id=user_id,
         is_admin=is_admin,
         max_results=max_results,
+        vector_store=get_vector_index_store(),
     )
 
 
@@ -295,18 +297,23 @@ def run_document_ingestion_with_outcome(
 ) -> KBApiOperationResult[IngestionResult]:
     """Run local-file ingestion and attach coordinator rollback outcome."""
     facade = _get_api_compatibility_facade()
+
+    ingestion_kwargs: dict[str, Any] = {
+        "collection": collection,
+        "source_path": source_path,
+        "ingestion_config": ingestion_config,
+        "progress_manager": progress_manager,
+        "user_id": user_id,
+        "is_admin": is_admin,
+        "file_id": file_id,
+    }
+    if metadata_source_path is not None:
+        ingestion_kwargs["metadata_source_path"] = metadata_source_path
+    if commit_gate is not None:
+        ingestion_kwargs["commit_gate"] = commit_gate
+
     return facade.run_with_operation_outcome(
-        lambda: run_document_ingestion(
-            collection=collection,
-            source_path=source_path,
-            ingestion_config=ingestion_config,
-            progress_manager=progress_manager,
-            user_id=user_id,
-            is_admin=is_admin,
-            file_id=file_id,
-            metadata_source_path=metadata_source_path,
-            commit_gate=commit_gate,
-        ),
+        lambda: run_document_ingestion(**ingestion_kwargs),
         operation_type="document_ingestion",
         collection=collection,
     )
@@ -366,16 +373,20 @@ async def run_web_ingestion_with_outcome(
 ) -> KBApiOperationResult[WebIngestionResult]:
     """Run web ingestion and attach coordinator rollback outcome."""
     facade = _get_api_compatibility_facade()
+
+    ingestion_kwargs: dict[str, Any] = {
+        "collection": collection,
+        "crawl_config": crawl_config,
+        "ingestion_config": ingestion_config,
+        "user_id": user_id,
+        "is_admin": is_admin,
+        "file_handler": file_handler,
+    }
+    if progress_callback is not None:
+        ingestion_kwargs["progress_callback"] = progress_callback
+
     return await facade.run_async_with_operation_outcome(
-        lambda: run_web_ingestion(
-            collection=collection,
-            crawl_config=crawl_config,
-            ingestion_config=ingestion_config,
-            progress_callback=progress_callback,
-            user_id=user_id,
-            is_admin=is_admin,
-            file_handler=file_handler,
-        ),
+        lambda: run_web_ingestion(**ingestion_kwargs),
         operation_type="web_ingestion",
         collection=collection,
     )
@@ -7145,6 +7156,7 @@ async def rename_collection_api(
             new_name=safe_new_collection,
             user_id=int(_user.id),
             is_admin=bool(_user.is_admin),
+            vector_store=vector_store,
         )
     )
 
@@ -7154,6 +7166,7 @@ async def rename_collection_api(
             new_name=safe_new_collection,
             user_id=int(_user.id),
             is_admin=bool(_user.is_admin),
+            metadata_store=get_metadata_store(),
         )
     except Exception as e:
         logger.warning("Failed to rename metadata store keys: %s", e)
@@ -7168,6 +7181,7 @@ async def rename_collection_api(
                 new_name=safe_new_collection,
                 user_id=int(_user.id),
                 is_admin=bool(_user.is_admin),
+                status_store=get_ingestion_status_store(),
             )
         )
     except Exception as e:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4104,14 +4104,14 @@ async def ingest_cloud(
                                 ),
                                 rollback_complete=False,
                             )
-                            return KBApiOperationResult(
-                                result=IngestionResult(
-                                    status="error",
-                                    message=f"Download failed: {str(e)}",
-                                    doc_id=file_info.fileName,
-                                ),
-                                rollback_complete=True,
-                            )
+                        return KBApiOperationResult(
+                            result=IngestionResult(
+                                status="error",
+                                message=f"Download failed: {str(e)}",
+                                doc_id=file_info.fileName,
+                            ),
+                            rollback_complete=True,
+                        )
 
                     uploaded_file_existed_before = (
                         db.query(UploadedFile)

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -68,6 +68,7 @@ from ...core.tools.core.RAG_tools.core.schemas import (
 )
 from ...core.tools.core.RAG_tools.kb import (
     KBApiCompatibilityFacade,
+    KBApiOperationResult,
     get_kb_coordinator,
 )
 from ...core.tools.core.RAG_tools.management.status import clear_ingestion_status
@@ -280,6 +281,37 @@ def run_document_ingestion(
     )
 
 
+def run_document_ingestion_with_outcome(
+    collection: str,
+    source_path: str,
+    *,
+    ingestion_config: Optional[Any] = None,
+    progress_manager: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_id: Optional[str] = None,
+    metadata_source_path: Optional[str] = None,
+    commit_gate: Optional[Callable[[], None]] = None,
+) -> KBApiOperationResult[IngestionResult]:
+    """Run local-file ingestion and attach coordinator rollback outcome."""
+    facade = _get_api_compatibility_facade()
+    return facade.run_with_operation_outcome(
+        lambda: run_document_ingestion(
+            collection=collection,
+            source_path=source_path,
+            ingestion_config=ingestion_config,
+            progress_manager=progress_manager,
+            user_id=user_id,
+            is_admin=is_admin,
+            file_id=file_id,
+            metadata_source_path=metadata_source_path,
+            commit_gate=commit_gate,
+        ),
+        operation_type="document_ingestion",
+        collection=collection,
+    )
+
+
 def run_document_search(
     collection: str,
     query_text: str,
@@ -319,6 +351,33 @@ async def run_web_ingestion(
         user_id=user_id,
         is_admin=is_admin,
         file_handler=file_handler,
+    )
+
+
+async def run_web_ingestion_with_outcome(
+    collection: str,
+    crawl_config: WebCrawlConfig,
+    *,
+    ingestion_config: Optional[Any] = None,
+    progress_callback: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_handler: Optional[Any] = None,
+) -> KBApiOperationResult[WebIngestionResult]:
+    """Run web ingestion and attach coordinator rollback outcome."""
+    facade = _get_api_compatibility_facade()
+    return await facade.run_async_with_operation_outcome(
+        lambda: run_web_ingestion(
+            collection=collection,
+            crawl_config=crawl_config,
+            ingestion_config=ingestion_config,
+            progress_callback=progress_callback,
+            user_id=user_id,
+            is_admin=is_admin,
+            file_handler=file_handler,
+        ),
+        operation_type="web_ingestion",
+        collection=collection,
     )
 
 
@@ -3526,8 +3585,8 @@ async def ingest(
             file_size=int(total_size),
         )
 
-        def _run_ingestion() -> IngestionResult:
-            return run_document_ingestion(
+        def _run_ingestion() -> KBApiOperationResult[IngestionResult]:
+            return run_document_ingestion_with_outcome(
                 collection=safe_collection,
                 source_path=str(file_path),
                 ingestion_config=config,
@@ -3538,11 +3597,13 @@ async def ingest(
             )
 
         loop = asyncio.get_running_loop()
-        result: IngestionResult = await loop.run_in_executor(None, _run_ingestion)
+        api_result = await loop.run_in_executor(None, _run_ingestion)
+        result = api_result.result
         result = _with_user_actionable_ingestion_message(
             result,
             embedding_model_id=embedding_model_id,
         )
+        api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
             await _rollback_failed_ingestion(
@@ -3558,13 +3619,24 @@ async def ingest(
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
+            api_result = _get_api_compatibility_facade().with_rollback_complete(
+                api_result,
+                True,
+            )
             if effective_collection_existed_before:
+                cleanup_decision = (
+                    _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                        api_result
+                    )
+                )
                 await _restore_or_cleanup_collection_config_after_failed_ingest(
                     snapshot=config_snapshot,
                     collection_existed_before=collection_existed_before,
                     collection_name=collection,
                     user=_user,
                     context="ingest",
+                    successful_documents=cleanup_decision.successful_documents,
+                    side_effects_may_remain=cleanup_decision.side_effects_may_remain,
                 )
 
         if result.status == "error":
@@ -3604,6 +3676,7 @@ async def ingest(
                 doc_id=safe_filename,
                 message="Ingestion setup failed before completion.",
             )
+            rollback_api_result = KBApiOperationResult(result=rollback_result)
             await _rollback_failed_ingestion(
                 db=db,
                 user=_user,
@@ -3617,13 +3690,26 @@ async def ingest(
                 had_existing_file=had_existing_file,
                 embedding_model_id=embedding_model_id,
             )
+            rollback_api_result = (
+                _get_api_compatibility_facade().with_rollback_complete(
+                    rollback_api_result,
+                    True,
+                )
+            )
             if effective_collection_existed_before:
+                cleanup_decision = (
+                    _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                        rollback_api_result
+                    )
+                )
                 await _restore_or_cleanup_collection_config_after_failed_ingest(
                     snapshot=config_snapshot,
                     collection_existed_before=collection_existed_before,
                     collection_name=collection,
                     user=_user,
                     context="ingest",
+                    successful_documents=cleanup_decision.successful_documents,
+                    side_effects_may_remain=cleanup_decision.side_effects_may_remain,
                 )
         else:
             _restore_ingest_file_backup(
@@ -3631,12 +3717,27 @@ async def ingest(
                 backup_path=file_backup_path,
                 had_existing_file=had_existing_file,
             )
+            rollback_api_result = KBApiOperationResult(
+                result=IngestionResult(
+                    status="error",
+                    doc_id=safe_filename,
+                    message="Ingestion setup failed before document registration.",
+                ),
+                rollback_complete=True,
+            )
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    rollback_api_result
+                )
+            )
             await _restore_or_cleanup_collection_config_after_failed_ingest(
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=collection,
                 user=_user,
                 context="ingest",
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
         raise
 
@@ -3912,7 +4013,9 @@ async def ingest_cloud(
     # Concurrency limit for cloud ingestion to avoid overloading
     semaphore = asyncio.Semaphore(5)
 
-    async def process_file(file_info: CloudFile) -> IngestionResult:
+    async def process_file(
+        file_info: CloudFile,
+    ) -> KBApiOperationResult[IngestionResult]:
         async with semaphore:
             file_record: Optional[UploadedFile] = None
             file_backup_path: Optional[Path] = None
@@ -3931,10 +4034,12 @@ async def ingest_cloud(
                     user_id=int(_user.id),
                 )
             except HTTPException as ve:
-                return IngestionResult(
-                    status="error",
-                    message=ve.detail,
-                    doc_id=file_info.fileName,
+                return KBApiOperationResult(
+                    result=IngestionResult(
+                        status="error",
+                        message=ve.detail,
+                        doc_id=file_info.fileName,
+                    )
                 )
             try:
                 if file_info.provider == "google-drive":
@@ -3944,10 +4049,12 @@ async def ingest_cloud(
                             get_google_credentials, int(_user.id), db
                         )
                     except HTTPException as e:
-                        return IngestionResult(
-                            status="error",
-                            message=f"Authentication error: {e.detail}",
-                            doc_id=file_info.fileName,
+                        return KBApiOperationResult(
+                            result=IngestionResult(
+                                status="error",
+                                message=f"Authentication error: {e.detail}",
+                                doc_id=file_info.fileName,
+                            )
                         )
 
                     # Build service (blocking)
@@ -3986,19 +4093,25 @@ async def ingest_cloud(
                                 had_existing_file=had_existing_file,
                             )
                         except Exception as restore_exc:  # noqa: BLE001
-                            return IngestionResult(
-                                status="error",
-                                message=(
-                                    "Failed to fully roll back cloud ingest for "
-                                    f"{safe_collection}/{file_info.fileName}: {restore_exc}"
+                            return KBApiOperationResult(
+                                result=IngestionResult(
+                                    status="error",
+                                    message=(
+                                        "Failed to fully roll back cloud ingest for "
+                                        f"{safe_collection}/{file_info.fileName}: {restore_exc}"
+                                    ),
+                                    doc_id=file_info.fileName,
                                 ),
-                                doc_id=file_info.fileName,
+                                rollback_complete=False,
                             )
-                        return IngestionResult(
-                            status="error",
-                            message=f"Download failed: {str(e)}",
-                            doc_id=file_info.fileName,
-                        )
+                            return KBApiOperationResult(
+                                result=IngestionResult(
+                                    status="error",
+                                    message=f"Download failed: {str(e)}",
+                                    doc_id=file_info.fileName,
+                                ),
+                                rollback_complete=True,
+                            )
 
                     uploaded_file_existed_before = (
                         db.query(UploadedFile)
@@ -4028,8 +4141,8 @@ async def ingest_cloud(
                         file_config = config.model_copy(
                             update={"parse_method": normalized_parse_method}
                         )
-                        result = await asyncio.to_thread(
-                            run_document_ingestion,
+                        api_result = await asyncio.to_thread(
+                            run_document_ingestion_with_outcome,
                             collection=safe_collection,
                             source_path=str(file_path),
                             ingestion_config=file_config,
@@ -4038,9 +4151,14 @@ async def ingest_cloud(
                             is_admin=bool(_user.is_admin),
                             file_id=str(file_record.file_id),
                         )
+                        result = api_result.result
                         result = _with_user_actionable_ingestion_message(
                             result,
                             embedding_model_id=request.embedding_model_id,
+                        )
+                        api_result = _get_api_compatibility_facade().with_result(
+                            api_result,
+                            result,
                         )
                         if result.status in {"error", "partial"}:
                             await _rollback_failed_cloud_ingestion(
@@ -4056,23 +4174,41 @@ async def ingest_cloud(
                                 had_existing_file=had_existing_file,
                                 embedding_model_id=request.embedding_model_id,
                             )
+                            api_result = (
+                                _get_api_compatibility_facade().with_rollback_complete(
+                                    api_result,
+                                    True,
+                                )
+                            )
                         elif file_backup_path is not None:
                             try:
                                 file_backup_path.unlink(missing_ok=True)
                             except OSError:
                                 pass
-                        return result
+                        return api_result
                     except RollbackFailureError as rollback_exc:
-                        return IngestionResult(
-                            status="error",
-                            message=str(rollback_exc),
-                            doc_id=file_info.fileName,
+                        return KBApiOperationResult(
+                            result=IngestionResult(
+                                status="error",
+                                message=str(rollback_exc),
+                                doc_id=file_info.fileName,
+                            ),
+                            operation_outcome=api_result.operation_outcome
+                            if "api_result" in locals()
+                            else None,
+                            rollback_complete=False,
                         )
                     except Exception as e:
                         rollback_result = IngestionResult(
                             status="error",
                             doc_id=file_info.fileName,
                             message=f"Ingestion failed: {str(e)}",
+                        )
+                        rollback_api_result = KBApiOperationResult(
+                            result=rollback_result,
+                            operation_outcome=api_result.operation_outcome
+                            if "api_result" in locals()
+                            else None,
                         )
                         await _rollback_failed_cloud_ingestion(
                             db=db,
@@ -4087,25 +4223,34 @@ async def ingest_cloud(
                             had_existing_file=had_existing_file,
                             embedding_model_id=request.embedding_model_id,
                         )
-                        return IngestionResult(
-                            status="error",
-                            message=f"Ingestion failed: {str(e)}",
-                            doc_id=file_info.fileName,
+                        return KBApiOperationResult(
+                            result=IngestionResult(
+                                status="error",
+                                message=f"Ingestion failed: {str(e)}",
+                                doc_id=file_info.fileName,
+                            ),
+                            operation_outcome=rollback_api_result.operation_outcome,
+                            rollback_complete=True,
                         )
 
                 else:
-                    return IngestionResult(
-                        status="error",
-                        message=f"Unsupported provider: {file_info.provider}",
-                        doc_id=file_info.fileName,
+                    return KBApiOperationResult(
+                        result=IngestionResult(
+                            status="error",
+                            message=f"Unsupported provider: {file_info.provider}",
+                            doc_id=file_info.fileName,
+                        )
                     )
 
             except RollbackFailureError as e:
                 logger.exception("Rollback failed for %s: %s", file_info.fileName, e)
-                return IngestionResult(
-                    status="error",
-                    message=str(e),
-                    doc_id=file_info.fileName,
+                return KBApiOperationResult(
+                    result=IngestionResult(
+                        status="error",
+                        message=str(e),
+                        doc_id=file_info.fileName,
+                    ),
+                    rollback_complete=False,
                 )
             except Exception as e:
                 try:
@@ -4118,37 +4263,52 @@ async def ingest_cloud(
                     logger.exception(
                         "Rollback failed for %s: %s", file_info.fileName, restore_exc
                     )
-                    return IngestionResult(
-                        status="error",
-                        message=(
-                            "Failed to fully roll back cloud ingest for "
-                            f"{safe_collection}/{file_info.fileName}: {restore_exc}"
+                    return KBApiOperationResult(
+                        result=IngestionResult(
+                            status="error",
+                            message=(
+                                "Failed to fully roll back cloud ingest for "
+                                f"{safe_collection}/{file_info.fileName}: {restore_exc}"
+                            ),
+                            doc_id=file_info.fileName,
                         ),
-                        doc_id=file_info.fileName,
+                        rollback_complete=False,
                     )
                 logger.exception(
                     "Unexpected error ingesting %s: %s", file_info.fileName, e
                 )
-                return IngestionResult(
-                    status="error",
-                    message=f"Unexpected error: {str(e)}",
-                    doc_id=file_info.fileName,
+                return KBApiOperationResult(
+                    result=IngestionResult(
+                        status="error",
+                        message=f"Unexpected error: {str(e)}",
+                        doc_id=file_info.fileName,
+                    ),
+                    rollback_complete=True,
                 )
 
     # Run all file processings concurrently
-    results = await asyncio.gather(*[process_file(f) for f in request.files])
+    api_results = await asyncio.gather(*[process_file(f) for f in request.files])
+    results = [api_result.result for api_result in api_results]
 
-    has_success = any(result.status == "success" for result in results)
     has_failure = any(result.status in {"error", "partial"} for result in results)
 
     if has_failure:
+        cleanup_decision = (
+            _get_api_compatibility_facade().failed_batch_ingest_cleanup_decision(
+                list(api_results),
+                successful_documents=sum(
+                    1 for result in results if result.status == "success"
+                ),
+            )
+        )
         await _restore_or_cleanup_collection_config_after_failed_ingest(
             snapshot=config_snapshot,
             collection_existed_before=collection_existed_before,
             collection_name=safe_collection,
             user=_user,
             context="ingest_cloud",
-            successful_documents=1 if has_success else 0,
+            successful_documents=cleanup_decision.successful_documents,
+            side_effects_may_remain=cleanup_decision.side_effects_may_remain,
         )
 
     return results
@@ -4965,10 +5125,10 @@ async def ingest_web(
             finally:
                 db_session.close()
 
-        result = await asyncio.get_event_loop().run_in_executor(
+        api_result = await asyncio.get_event_loop().run_in_executor(
             None,
             lambda: asyncio.run(
-                run_web_ingestion(
+                run_web_ingestion_with_outcome(
                     collection=safe_collection,
                     crawl_config=crawl_config,
                     ingestion_config=ingestion_config,
@@ -4978,22 +5138,33 @@ async def ingest_web(
                 )
             ),
         )
+        result = api_result.result
         web_updated_message = _build_user_actionable_ingestion_message(
             result.message,
             embedding_model_id=embedding_model_id,
         )
         if web_updated_message != result.message:
             result = result.model_copy(update={"message": web_updated_message})
+            api_result = _get_api_compatibility_facade().with_result(
+                api_result,
+                result,
+            )
 
         if result.status == "error":
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    api_result,
+                    successful_documents=result.documents_created,
+                )
+            )
             await _restore_or_cleanup_collection_config_after_failed_ingest(
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=safe_collection,
                 user=_user,
                 context="ingest_web",
-                successful_documents=result.documents_created,
-                side_effects_may_remain=result.side_effects_may_remain,
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
             return JSONResponse(status_code=500, content=result.model_dump())
         if result.status == "partial":
@@ -5004,14 +5175,20 @@ async def ingest_web(
                 _user.id,
                 result.message,
             )
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    api_result,
+                    successful_documents=result.documents_created,
+                )
+            )
             await _restore_or_cleanup_collection_config_after_failed_ingest(
                 snapshot=config_snapshot,
                 collection_existed_before=collection_existed_before,
                 collection_name=safe_collection,
                 user=_user,
                 context="ingest_web",
-                successful_documents=result.documents_created,
-                side_effects_may_remain=result.side_effects_may_remain,
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
 
         return result

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -6297,9 +6297,6 @@ async def delete_document_api(
         This endpoint prefers `file_id` or `doc_id` when provided. The path
         `filename` is retained as a compatibility fallback for older clients.
     """
-    # NOTE: Exceptions are normalized by @handle_kb_exceptions for consistent API responses.
-    from ...core.tools.core.RAG_tools.management.collections import delete_document
-
     # Parameter validation
     try:
         safe_collection_name = sanitize_path_component(collection_name, "collection")

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -22,6 +22,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    Mapping,
     Optional,
     TypedDict,
     TypeVar,
@@ -65,33 +66,15 @@ from ...core.tools.core.RAG_tools.core.schemas import (
     WebCrawlConfig,
     WebIngestionResult,
 )
-from ...core.tools.core.RAG_tools.management.collection_manager import (
-    delete_collection_metadata_sync,
-    get_collection_sync,
-)
-from ...core.tools.core.RAG_tools.management.collections import (
-    delete_collection,
-    delete_document,
-    list_collections,
-    list_documents,
+from ...core.tools.core.RAG_tools.kb import (
+    KBApiCompatibilityFacade,
+    get_kb_coordinator,
 )
 from ...core.tools.core.RAG_tools.management.status import clear_ingestion_status
-from ...core.tools.core.RAG_tools.parse.parse_display import (
-    paginate_parse_results,
-    reconstruct_parse_result_from_db,
-)
-from ...core.tools.core.RAG_tools.pipelines.document_ingestion import (
-    run_document_ingestion,
-)
-from ...core.tools.core.RAG_tools.pipelines.document_search import run_document_search
-from ...core.tools.core.RAG_tools.pipelines.web_ingestion import (
-    FileHandlerResult,
-    run_web_ingestion,
-)
+from ...core.tools.core.RAG_tools.pipelines.web_ingestion import FileHandlerResult
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from ...core.tools.core.RAG_tools.storage.factory import (
-    get_ingestion_status_store,
     get_metadata_store,
     get_vector_index_store,
 )
@@ -173,6 +156,202 @@ from .cloud_storage import get_google_credentials
 
 T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
+
+
+def _get_api_compatibility_facade() -> KBApiCompatibilityFacade:
+    """Return the coordinator-owned KB API compatibility facade."""
+    return get_kb_coordinator().api_compatibility
+
+
+def get_collection_sync(collection_name: str) -> Any:
+    """API compatibility wrapper for legacy collection metadata lookup."""
+    return _get_api_compatibility_facade().get_collection_sync(collection_name)
+
+
+def delete_collection_metadata_sync(
+    *,
+    collection_name: str,
+    user_id: Optional[int],
+    is_admin: bool = False,
+    delete_orphaned_metadata: bool = False,
+) -> dict[str, int]:
+    """API compatibility wrapper for collection config/metadata cleanup."""
+    return _get_api_compatibility_facade().delete_collection_metadata_sync(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        delete_orphaned_metadata=delete_orphaned_metadata,
+    )
+
+
+async def list_collections(
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    force_realtime: bool = False,
+) -> ListCollectionsResult:
+    """API compatibility wrapper for collection listing."""
+    return await _get_api_compatibility_facade().list_collections(
+        user_id=user_id,
+        is_admin=is_admin,
+        force_realtime=force_realtime,
+    )
+
+
+def list_documents(
+    collection: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> Any:
+    """API compatibility wrapper for document listing."""
+    return _get_api_compatibility_facade().list_documents(
+        collection=collection,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def list_document_records(
+    *,
+    collection_name: Optional[str],
+    user_id: Optional[int],
+    is_admin: bool = False,
+    max_results: Optional[int] = None,
+) -> list[Any]:
+    """API compatibility wrapper for document-record scans."""
+    return _get_api_compatibility_facade().list_document_records(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        max_results=max_results,
+    )
+
+
+def delete_document(
+    collection: str,
+    doc_id: str,
+    user_id: int,
+    is_admin: bool = False,
+) -> Any:
+    """API compatibility wrapper for document deletion."""
+    return _get_api_compatibility_facade().delete_document(
+        collection=collection,
+        doc_id=doc_id,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def delete_collection(
+    collection: str,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> CollectionOperationResult:
+    """API compatibility wrapper for collection deletion."""
+    return _get_api_compatibility_facade().delete_collection(
+        collection=collection,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def run_document_ingestion(
+    collection: str,
+    source_path: str,
+    *,
+    ingestion_config: Optional[Any] = None,
+    progress_manager: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_id: Optional[str] = None,
+    metadata_source_path: Optional[str] = None,
+    commit_gate: Optional[Callable[[], None]] = None,
+) -> IngestionResult:
+    """API compatibility wrapper for local-file ingestion."""
+    return _get_api_compatibility_facade().run_document_ingestion(
+        collection=collection,
+        source_path=source_path,
+        ingestion_config=ingestion_config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_id=file_id,
+        metadata_source_path=metadata_source_path,
+        commit_gate=commit_gate,
+    )
+
+
+def run_document_search(
+    collection: str,
+    query_text: str,
+    *,
+    config: Optional[SearchConfig | Mapping[str, Any]] = None,
+    progress_manager: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+) -> SearchPipelineResult:
+    """API compatibility wrapper for document search."""
+    return _get_api_compatibility_facade().run_document_search(
+        collection=collection,
+        query_text=query_text,
+        config=config,
+        progress_manager=progress_manager,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+async def run_web_ingestion(
+    collection: str,
+    crawl_config: WebCrawlConfig,
+    *,
+    ingestion_config: Optional[Any] = None,
+    progress_callback: Optional[Any] = None,
+    user_id: Optional[int] = None,
+    is_admin: Optional[bool] = None,
+    file_handler: Optional[Any] = None,
+) -> WebIngestionResult:
+    """API compatibility wrapper for web ingestion."""
+    return await _get_api_compatibility_facade().run_web_ingestion(
+        collection=collection,
+        crawl_config=crawl_config,
+        ingestion_config=ingestion_config,
+        progress_callback=progress_callback,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_handler=file_handler,
+    )
+
+
+def reconstruct_parse_result_from_db(
+    collection: str,
+    doc_id: str,
+    parse_hash: Optional[str] = None,
+    *,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """API compatibility wrapper for parse result reconstruction."""
+    return _get_api_compatibility_facade().reconstruct_parse_result_from_db(
+        collection=collection,
+        doc_id=doc_id,
+        parse_hash=parse_hash,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def paginate_parse_results(
+    elements: list[dict[str, Any]],
+    page: int,
+    page_size: int,
+) -> tuple[list[Any], dict[str, Any]]:
+    """API compatibility wrapper for parse-result pagination."""
+    return _get_api_compatibility_facade().paginate_parse_results(
+        elements,
+        page,
+        page_size,
+    )
+
 
 _SQL_LIKE_ESCAPE = "\\"
 _PDF_ONLY_PARSE_METHODS = {
@@ -2800,10 +2979,11 @@ async def _save_collection_config_with_snapshot(
         )
 
     try:
-        await metadata_store.save_collection_config(
+        await _get_api_compatibility_facade().save_collection_config(
             collection=collection,
             config_json=config_json,
             user_id=int(user.id),
+            metadata_store=metadata_store,
         )
         return _CollectionConfigSnapshot(
             metadata_store=metadata_store,
@@ -3080,10 +3260,11 @@ async def save_collection_config(
 
     try:
         metadata_store = get_metadata_store()
-        await metadata_store.save_collection_config(
+        await _get_api_compatibility_facade().save_collection_config(
             collection=safe_collection,
             config_json=config_json,
             user_id=int(_user.id),
+            metadata_store=metadata_store,
         )
 
         return CollectionOperationResult(
@@ -5869,9 +6050,8 @@ async def check_documents_exist_api(
 
         await _ensure_collection_access(safe_collection, _user, allow_create=True)
 
-        # Use storage abstraction layer to fetch document records
-        vector_store = get_vector_index_store()
-        records = vector_store.list_document_records(
+        # Fetch document records through the API compatibility boundary.
+        records = list_document_records(
             collection_name=safe_collection,
             user_id=int(_user.id),
             is_admin=False,
@@ -6753,7 +6933,7 @@ async def rename_collection_api(
     # Step 2: Update collection name in all tables (documents, parses, chunks, embeddings)
     # Use storage abstraction layer which handles all tables including embeddings
     warnings.extend(
-        vector_store.rename_collection_data(
+        _get_api_compatibility_facade().rename_collection_data(
             collection_name=safe_old_collection,
             new_name=safe_new_collection,
             user_id=int(_user.id),
@@ -6762,8 +6942,7 @@ async def rename_collection_api(
     )
 
     try:
-        metadata_store = get_metadata_store()
-        await metadata_store.rename_collection(
+        await _get_api_compatibility_facade().rename_collection_metadata(
             old_name=safe_old_collection,
             new_name=safe_new_collection,
             user_id=int(_user.id),
@@ -6777,7 +6956,7 @@ async def rename_collection_api(
     # collection/user filters map to its backend tables.
     try:
         warnings.extend(
-            get_ingestion_status_store().rename_collection_status(
+            _get_api_compatibility_facade().rename_collection_status(
                 old_name=safe_old_collection,
                 new_name=safe_new_collection,
                 user_id=int(_user.id),

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -76,8 +76,6 @@ from ...core.tools.core.RAG_tools.pipelines.web_ingestion import FileHandlerResu
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
 from ...core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from ...core.tools.core.RAG_tools.storage.factory import (
-    get_ingestion_status_store,
-    get_metadata_store,
     get_vector_index_store,
 )
 from ...core.tools.core.RAG_tools.utils.string_utils import (
@@ -225,7 +223,6 @@ def list_document_records(
         user_id=user_id,
         is_admin=is_admin,
         max_results=max_results,
-        vector_store=get_vector_index_store(),
     )
 
 
@@ -818,10 +815,7 @@ async def _cleanup_failed_new_collection_metadata(
     user: User,
 ) -> None:
     """Remove config rows left behind when a brand-new collection ingest fails."""
-    from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-    metadata_store = get_metadata_store()
-    cleanup_result = await metadata_store.delete_collection_metadata(
+    cleanup_result = await _get_api_compatibility_facade().delete_collection_metadata(
         collection_name=collection_name,
         user_id=int(user.id),
         is_admin=bool(user.is_admin),
@@ -889,11 +883,9 @@ async def _restore_or_cleanup_collection_config_after_failed_ingest(
             and not side_effects_may_remain
             and snapshot is not None
         ):
-            delete_metadata = getattr(
-                snapshot.metadata_store, "delete_collection", None
-            )
-            if callable(delete_metadata):
-                await _maybe_await(delete_metadata(collection_name))
+            if await _get_api_compatibility_facade().delete_collection_metadata_entry(
+                collection_name
+            ):
                 logger.info(
                     "Removed collection metadata created by failed %s while "
                     "preserving previous config: %s/user_%s",
@@ -3037,7 +3029,6 @@ class RollbackFailureError(RuntimeError):
 
 @dataclass
 class _CollectionConfigSnapshot:
-    metadata_store: Any
     collection: str
     user_id: int
     previous_config_json: Optional[str]
@@ -3059,32 +3050,26 @@ async def _save_collection_config_with_snapshot(
     context: str,
 ) -> _CollectionConfigSnapshot:
     """Save collection config while retaining the caller's previous config."""
-    from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
-    metadata_store = get_metadata_store()
     previous_config_json: Optional[str] = None
     previous_config_known = False
 
     try:
-        get_config = getattr(metadata_store, "get_collection_config", None)
-        if callable(get_config):
-            loaded = get_config(
-                collection=collection,
-                user_id=int(user.id),
-                is_admin=False,
+        loaded = await _get_api_compatibility_facade().get_collection_config(
+            collection=collection,
+            user_id=int(user.id),
+            is_admin=False,
+        )
+        if isinstance(loaded, str):
+            previous_config_json = loaded
+            previous_config_known = True
+        elif loaded is None:
+            previous_config_known = True
+        else:
+            logger.warning(
+                "Unexpected collection config snapshot type during %s: %s",
+                context,
+                type(loaded).__name__,
             )
-            loaded = await _maybe_await(loaded)
-            if isinstance(loaded, str):
-                previous_config_json = loaded
-                previous_config_known = True
-            elif loaded is None:
-                previous_config_known = True
-            else:
-                logger.warning(
-                    "Unexpected collection config snapshot type during %s: %s",
-                    context,
-                    type(loaded).__name__,
-                )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "Failed to snapshot collection config during %s: %s",
@@ -3101,7 +3086,6 @@ async def _save_collection_config_with_snapshot(
             int(user.id),
         )
         return _CollectionConfigSnapshot(
-            metadata_store=metadata_store,
             collection=collection,
             user_id=int(user.id),
             previous_config_json=previous_config_json,
@@ -3114,10 +3098,8 @@ async def _save_collection_config_with_snapshot(
             collection=collection,
             config_json=config_json,
             user_id=int(user.id),
-            metadata_store=metadata_store,
         )
         return _CollectionConfigSnapshot(
-            metadata_store=metadata_store,
             collection=collection,
             user_id=int(user.id),
             previous_config_json=previous_config_json,
@@ -3127,7 +3109,6 @@ async def _save_collection_config_with_snapshot(
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to save collection config during %s: %s", context, exc)
         return _CollectionConfigSnapshot(
-            metadata_store=metadata_store,
             collection=collection,
             user_id=int(user.id),
             previous_config_json=previous_config_json,
@@ -3148,7 +3129,7 @@ async def _restore_collection_config_after_failed_ingest(
 
     try:
         if snapshot.previous_config_json is not None:
-            await snapshot.metadata_store.save_collection_config(
+            await _get_api_compatibility_facade().save_collection_config(
                 collection=snapshot.collection,
                 config_json=snapshot.previous_config_json,
                 user_id=snapshot.user_id,
@@ -3171,13 +3152,12 @@ async def _restore_collection_config_after_failed_ingest(
             )
             return
 
-        delete_result = snapshot.metadata_store.delete_collection_metadata(
+        await _get_api_compatibility_facade().delete_collection_metadata(
             collection_name=snapshot.collection,
             user_id=snapshot.user_id,
             is_admin=False,
             delete_orphaned_metadata=not collection_existed_before,
         )
-        await _maybe_await(delete_result)
         logger.info(
             "Removed collection config created by failed %s: %s/user_%s",
             context,
@@ -3376,8 +3356,6 @@ async def save_collection_config(
     _user: User = Depends(get_current_user),
 ) -> CollectionOperationResult:
     """Save ingestion configuration for a specific collection."""
-    from ...core.tools.core.RAG_tools.storage.factory import get_metadata_store
-
     try:
         safe_collection = sanitize_path_component(collection, "collection")
     except ValueError as e:
@@ -3390,12 +3368,10 @@ async def save_collection_config(
     config_json = config.model_dump_json(exclude_unset=True)
 
     try:
-        metadata_store = get_metadata_store()
         await _get_api_compatibility_facade().save_collection_config(
             collection=safe_collection,
             config_json=config_json,
             user_id=int(_user.id),
-            metadata_store=metadata_store,
         )
 
         return CollectionOperationResult(
@@ -5605,12 +5581,9 @@ def _resolve_collection_mutation_scope(
     requester_user_id: int,
     is_admin: bool,
     db: Session,
-    vector_store: Any = None,
 ) -> CollectionMutationScope:
     """Resolve tenant/global mutation ownership once for delete and rename."""
-    if vector_store is None:
-        vector_store = get_vector_index_store()
-    document_records = vector_store.list_document_records(
+    document_records = list_document_records(
         collection_name=collection_name,
         user_id=requester_user_id,
         is_admin=is_admin,
@@ -5642,7 +5615,9 @@ def _resolve_collection_mutation_scope(
         else set()
     )
     owner_user_ids.update(
-        get_metadata_store().list_collection_config_owner_ids(collection_name)
+        _get_api_compatibility_facade().list_collection_config_owner_ids(
+            collection_name
+        )
     )
     owner_user_ids.update(
         list_collection_uploaded_file_owner_ids(db, collection_name=collection_name)
@@ -7008,8 +6983,6 @@ async def rename_collection_api(
     Returns:
         Success message
     """
-    vector_store = get_vector_index_store()
-
     if not new_name or not new_name.strip():
         raise HTTPException(
             status_code=422,
@@ -7062,7 +7035,6 @@ async def rename_collection_api(
         requester_user_id=int(_user.id),
         is_admin=bool(_user.is_admin),
         db=db,
-        vector_store=vector_store,
     )
 
     for owner_id in sorted(mutation_scope.owner_user_ids):
@@ -7149,7 +7121,6 @@ async def rename_collection_api(
             new_name=safe_new_collection,
             user_id=int(_user.id),
             is_admin=bool(_user.is_admin),
-            vector_store=vector_store,
         )
     )
 
@@ -7159,7 +7130,6 @@ async def rename_collection_api(
             new_name=safe_new_collection,
             user_id=int(_user.id),
             is_admin=bool(_user.is_admin),
-            metadata_store=get_metadata_store(),
         )
     except Exception as e:
         logger.warning("Failed to rename metadata store keys: %s", e)
@@ -7174,7 +7144,6 @@ async def rename_collection_api(
                 new_name=safe_new_collection,
                 user_id=int(_user.id),
                 is_admin=bool(_user.is_admin),
-                status_store=get_ingestion_status_store(),
             )
         )
     except Exception as e:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -5150,7 +5150,7 @@ async def ingest_web(
             finally:
                 db_session.close()
 
-        api_result = await asyncio.get_event_loop().run_in_executor(
+        api_result = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: asyncio.run(
                 run_web_ingestion_with_outcome(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3772,13 +3772,6 @@ async def ingest(
                         rollback_complete=True,
                     )
                 )
-            else:
-                rollback_api_result = (
-                    _get_api_compatibility_facade().with_rollback_complete(
-                        rollback_api_result,
-                        True,
-                    )
-                )
         else:
             _restore_ingest_file_backup(
                 file_path=file_path,

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -14,6 +14,10 @@ from ...core.tools.core.RAG_tools.core.schemas import (
     IngestionResult,
     WebCrawlConfig,
 )
+from ...core.tools.core.RAG_tools.kb import (
+    KBApiCompatibilityFacade,
+    get_kb_coordinator,
+)
 from ...core.tools.core.RAG_tools.pipelines.document_ingestion import (
     run_document_ingestion,
 )
@@ -39,6 +43,10 @@ _SUPERSEDED_STAGED_INGEST_MESSAGE = "KB ingest job superseded by a newer upload"
 
 class StagedDocumentIngestSuperseded(RuntimeError):
     pass
+
+
+def _get_api_compatibility_facade() -> KBApiCompatibilityFacade:
+    return get_kb_coordinator().api_compatibility
 
 
 def _get_job_user(
@@ -142,17 +150,22 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
             user_id=int(payload["user_id"]),
             is_admin=bool(payload.get("is_admin", False)),
         ):
-            result = run_document_ingestion(
+            api_result = _get_api_compatibility_facade().run_with_operation_outcome(
+                lambda: run_document_ingestion(
+                    collection=str(payload["collection"]),
+                    source_path=str(payload["source_path"]),
+                    ingestion_config=ingestion_config,
+                    progress_manager=progress_manager,
+                    user_id=int(payload["user_id"]),
+                    is_admin=bool(payload.get("is_admin", False)),
+                    file_id=str(file_id) if file_id else None,
+                    metadata_source_path=str(target_path) if target_path else None,
+                    commit_gate=_assert_latest_generation if is_staged_input else None,
+                ),
+                operation_type="document_ingestion",
                 collection=str(payload["collection"]),
-                source_path=str(payload["source_path"]),
-                ingestion_config=ingestion_config,
-                progress_manager=progress_manager,
-                user_id=int(payload["user_id"]),
-                is_admin=bool(payload.get("is_admin", False)),
-                file_id=str(file_id) if file_id else None,
-                metadata_source_path=str(target_path) if target_path else None,
-                commit_gate=_assert_latest_generation if is_staged_input else None,
             )
+            result = api_result.result
     except StagedDocumentIngestSuperseded:
         _restore_or_cleanup_failed_staged_job_collection_config_if_current(
             db,
@@ -203,11 +216,22 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document ingest",
                 )
                 return _superseded_staged_document_result(payload)
+            api_result = _get_api_compatibility_facade().with_rollback_complete(
+                api_result,
+                True,
+            )
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    api_result
+                )
+            )
             _restore_or_cleanup_failed_job_collection_config(
                 db,
                 payload,
                 snapshot=config_snapshot,
                 context="background staged document ingest",
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
         else:
             _rollback_failed_document_ingestion(
@@ -216,11 +240,22 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                 result,
                 config_snapshot=config_snapshot,
             )
+            api_result = _get_api_compatibility_facade().with_rollback_complete(
+                api_result,
+                True,
+            )
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    api_result
+                )
+            )
             _restore_or_cleanup_failed_job_collection_config(
                 db,
                 payload,
                 snapshot=config_snapshot,
                 context="background document ingest",
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
         raise BackgroundJobHandlerError(
             result.message,
@@ -258,11 +293,23 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document publish rollback",
                 )
                 return _superseded_staged_document_result(payload)
+            api_result = _get_api_compatibility_facade().with_rollback_complete(
+                api_result,
+                True,
+            )
+            cleanup_decision = (
+                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                    api_result,
+                    successful_documents=0,
+                )
+            )
             _restore_or_cleanup_failed_job_collection_config(
                 db,
                 payload,
                 snapshot=config_snapshot,
                 context="background staged document publish",
+                successful_documents=cleanup_decision.successful_documents,
+                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
             )
             raise BackgroundJobHandlerError(
                 f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
@@ -324,17 +371,22 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
     update_job_progress(db, job, message="Crawling website")
     try:
         with user_scope_context(user_id=user_id, is_admin=is_admin):
-            result = asyncio.run(
-                run_web_ingestion(
+            api_result = asyncio.run(
+                _get_api_compatibility_facade().run_async_with_operation_outcome(
+                    lambda: run_web_ingestion(
+                        collection=collection,
+                        crawl_config=crawl_config,
+                        ingestion_config=ingestion_config,
+                        progress_callback=_progress,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                        file_handler=_file_handler_with_db,
+                    ),
+                    operation_type="web_ingestion",
                     collection=collection,
-                    crawl_config=crawl_config,
-                    ingestion_config=ingestion_config,
-                    progress_callback=_progress,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    file_handler=_file_handler_with_db,
                 )
             )
+            result = api_result.result
     except Exception:
         _cleanup_failed_web_collection_metadata_if_new(
             db,
@@ -345,12 +397,18 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
 
     result_payload = result.model_dump(mode="json")
     if result.status in {"error", "partial"}:
+        cleanup_decision = (
+            _get_api_compatibility_facade().failed_ingest_cleanup_decision(
+                api_result,
+                successful_documents=int(result.documents_created or 0),
+            )
+        )
         _cleanup_failed_web_collection_metadata_if_new(
             db,
             payload,
             snapshot=config_snapshot,
-            successful_documents=int(result.documents_created or 0),
-            side_effects_may_remain=bool(result.side_effects_may_remain),
+            successful_documents=cleanup_decision.successful_documents,
+            side_effects_may_remain=cleanup_decision.side_effects_may_remain,
         )
     if result.status == "error":
         raise BackgroundJobHandlerError(result.message, result=result_payload)

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -16,6 +16,7 @@ from ...core.tools.core.RAG_tools.core.schemas import (
 )
 from ...core.tools.core.RAG_tools.kb import (
     KBApiCompatibilityFacade,
+    KBApiOperationResult,
     get_kb_coordinator,
 )
 from ...core.tools.core.RAG_tools.pipelines.document_ingestion import (
@@ -121,6 +122,42 @@ def _restore_or_cleanup_failed_job_collection_config(
     )
 
 
+def _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
+    db: Session,
+    payload: dict[str, Any],
+    *,
+    api_result: KBApiOperationResult[Any],
+    snapshot: Any,
+    context: str,
+    successful_documents: int | None = None,
+    rollback_complete: bool | None = None,
+) -> None:
+    user = _get_job_user(
+        db,
+        payload,
+        context=f"restore failed-ingest collection config during {context}",
+    )
+    if user is None:
+        return
+
+    from ..api.kb import _restore_or_cleanup_collection_config_after_failed_api_ingest
+
+    asyncio.run(
+        _restore_or_cleanup_collection_config_after_failed_api_ingest(
+            api_result=api_result,
+            snapshot=snapshot,
+            collection_existed_before=bool(
+                payload.get("collection_existed_before", True)
+            ),
+            collection_name=str(payload["collection"]),
+            user=user,
+            context=context,
+            successful_documents=successful_documents,
+            rollback_complete=rollback_complete,
+        )
+    )
+
+
 def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]:
     payload = dict(job.payload or {})
     ingestion_config = IngestionConfig.model_validate(payload["ingestion_config"])
@@ -216,22 +253,13 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document ingest",
                 )
                 return _superseded_staged_document_result(payload)
-            api_result = _get_api_compatibility_facade().with_rollback_complete(
-                api_result,
-                True,
-            )
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    api_result
-                )
-            )
-            _restore_or_cleanup_failed_job_collection_config(
+            _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
                 db,
                 payload,
+                api_result=api_result,
                 snapshot=config_snapshot,
                 context="background staged document ingest",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+                rollback_complete=True,
             )
         else:
             _rollback_failed_document_ingestion(
@@ -240,22 +268,13 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                 result,
                 config_snapshot=config_snapshot,
             )
-            api_result = _get_api_compatibility_facade().with_rollback_complete(
-                api_result,
-                True,
-            )
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    api_result
-                )
-            )
-            _restore_or_cleanup_failed_job_collection_config(
+            _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
                 db,
                 payload,
+                api_result=api_result,
                 snapshot=config_snapshot,
                 context="background document ingest",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+                rollback_complete=True,
             )
         raise BackgroundJobHandlerError(
             result.message,
@@ -293,23 +312,14 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document publish rollback",
                 )
                 return _superseded_staged_document_result(payload)
-            api_result = _get_api_compatibility_facade().with_rollback_complete(
-                api_result,
-                True,
-            )
-            cleanup_decision = (
-                _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                    api_result,
-                    successful_documents=0,
-                )
-            )
-            _restore_or_cleanup_failed_job_collection_config(
+            _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
                 db,
                 payload,
+                api_result=api_result,
                 snapshot=config_snapshot,
                 context="background staged document publish",
-                successful_documents=cleanup_decision.successful_documents,
-                side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+                successful_documents=0,
+                rollback_complete=True,
             )
             raise BackgroundJobHandlerError(
                 f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
@@ -397,18 +407,12 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
 
     result_payload = result.model_dump(mode="json")
     if result.status in {"error", "partial"}:
-        cleanup_decision = (
-            _get_api_compatibility_facade().failed_ingest_cleanup_decision(
-                api_result,
-                successful_documents=int(result.documents_created or 0),
-            )
-        )
         _cleanup_failed_web_collection_metadata_if_new(
             db,
             payload,
+            api_result=api_result,
             snapshot=config_snapshot,
-            successful_documents=cleanup_decision.successful_documents,
-            side_effects_may_remain=cleanup_decision.side_effects_may_remain,
+            successful_documents=int(result.documents_created or 0),
         )
     if result.status == "error":
         raise BackgroundJobHandlerError(result.message, result=result_payload)
@@ -832,15 +836,25 @@ def _cleanup_failed_web_collection_metadata_if_new(
     db: Session,
     payload: dict[str, Any],
     *,
+    api_result: KBApiOperationResult[Any] | None = None,
     snapshot: Any = None,
-    successful_documents: int = 0,
-    side_effects_may_remain: bool = False,
+    successful_documents: int | None = None,
 ) -> None:
-    _restore_or_cleanup_failed_job_collection_config(
+    if api_result is None:
+        _restore_or_cleanup_failed_job_collection_config(
+            db,
+            payload,
+            snapshot=snapshot,
+            context="background web ingest",
+            successful_documents=int(successful_documents or 0),
+        )
+        return
+
+    _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
         db,
         payload,
+        api_result=api_result,
         snapshot=snapshot,
         context="background web ingest",
         successful_documents=successful_documents,
-        side_effects_may_remain=side_effects_may_remain,
     )

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -10,6 +10,8 @@ import pytest
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     CollectionInfo,
     IngestionResult,
+    WebCrawlConfig,
+    WebIngestionResult,
 )
 from xagent.core.tools.core.RAG_tools.kb import (
     KBApiCompatibilityFacade,
@@ -257,6 +259,159 @@ def test_list_document_records_omits_none_max_results(
             "collection_name": "demo",
             "user_id": 7,
             "is_admin": False,
+        }
+    ]
+
+
+def test_web_api_list_document_records_uses_route_vector_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api import kb as kb_api
+
+    calls: list[dict[str, object]] = []
+
+    class VectorStore:
+        def list_document_records(self, **kwargs: object) -> list[str]:
+            calls.append(kwargs)
+            return ["record"]
+
+    monkeypatch.setattr(kb_api, "get_vector_index_store", lambda: VectorStore())
+
+    records = kb_api.list_document_records(
+        collection_name="demo",
+        user_id=7,
+        is_admin=False,
+        max_results=25,
+    )
+
+    assert records == ["record"]
+    assert calls == [
+        {
+            "collection_name": "demo",
+            "user_id": 7,
+            "is_admin": False,
+            "max_results": 25,
+        }
+    ]
+
+
+def test_web_api_document_ingestion_outcome_keeps_legacy_runner_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api import kb as kb_api
+
+    calls: list[dict[str, object]] = []
+
+    def fake_run_document_ingestion(
+        collection: str,
+        source_path: str,
+        *,
+        ingestion_config: object,
+        file_id: str | None = None,
+        user_id: int | None = None,
+        progress_manager: object | None = None,
+        is_admin: bool = False,
+    ) -> IngestionResult:
+        calls.append(
+            {
+                "collection": collection,
+                "source_path": source_path,
+                "ingestion_config": ingestion_config,
+                "file_id": file_id,
+                "user_id": user_id,
+                "progress_manager": progress_manager,
+                "is_admin": is_admin,
+            }
+        )
+        return IngestionResult(status="success", message="ok")
+
+    config = object()
+    monkeypatch.setattr(kb_api, "run_document_ingestion", fake_run_document_ingestion)
+
+    result = kb_api.run_document_ingestion_with_outcome(
+        collection="demo",
+        source_path="/tmp/demo.txt",
+        ingestion_config=config,
+        user_id=7,
+        is_admin=False,
+        file_id="file-1",
+    )
+
+    assert result.result.status == "success"
+    assert calls == [
+        {
+            "collection": "demo",
+            "source_path": "/tmp/demo.txt",
+            "ingestion_config": config,
+            "file_id": "file-1",
+            "user_id": 7,
+            "progress_manager": None,
+            "is_admin": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_api_web_ingestion_outcome_keeps_legacy_runner_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api import kb as kb_api
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_run_web_ingestion(
+        collection: str,
+        crawl_config: WebCrawlConfig,
+        *,
+        ingestion_config: object,
+        user_id: int,
+        is_admin: bool = False,
+        file_handler: object | None = None,
+    ) -> WebIngestionResult:
+        calls.append(
+            {
+                "collection": collection,
+                "crawl_config": crawl_config,
+                "ingestion_config": ingestion_config,
+                "user_id": user_id,
+                "is_admin": is_admin,
+                "file_handler": file_handler,
+            }
+        )
+        return WebIngestionResult(
+            status="success",
+            collection=collection,
+            total_urls_found=0,
+            pages_crawled=0,
+            pages_failed=0,
+            documents_created=0,
+            chunks_created=0,
+            embeddings_created=0,
+            message="ok",
+            elapsed_time_ms=0,
+        )
+
+    crawl_config = WebCrawlConfig(start_url="https://example.com")
+    config = object()
+    monkeypatch.setattr(kb_api, "run_web_ingestion", fake_run_web_ingestion)
+
+    result = await kb_api.run_web_ingestion_with_outcome(
+        collection="web",
+        crawl_config=crawl_config,
+        ingestion_config=config,
+        user_id=7,
+        is_admin=True,
+    )
+
+    assert result.result.status == "success"
+    assert calls == [
+        {
+            "collection": "web",
+            "crawl_config": crawl_config,
+            "ingestion_config": config,
+            "user_id": 7,
+            "is_admin": True,
+            "file_handler": None,
         }
     ]
 

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -6,10 +6,15 @@ from typing import Optional
 
 import pytest
 
-from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    IngestionResult,
+)
 from xagent.core.tools.core.RAG_tools.kb import (
     KBApiCompatibilityFacade,
     KBCoordinator,
+    KBOperationCompatibilityFacade,
+    RollbackStatus,
     get_kb_coordinator,
     reset_kb_coordinator_for_tests,
 )
@@ -67,9 +72,7 @@ def test_kb_api_facade_public_surface_imports() -> None:
 
     assert hasattr(kb, "KBApiCompatibilityFacade")
     reset_kb_coordinator_for_tests()
-    assert isinstance(
-        get_kb_coordinator().api_compatibility, KBApiCompatibilityFacade
-    )
+    assert isinstance(get_kb_coordinator().api_compatibility, KBApiCompatibilityFacade)
     assert get_kb_coordinator().api is get_kb_coordinator().api_compatibility
 
 
@@ -108,7 +111,7 @@ async def test_save_collection_config_preserves_existing_backend_binding() -> No
         user_id=7,
     )
 
-    assert metadata_store.saved_configs == [('demo', '{"chunk_size": 1000}', 7)]
+    assert metadata_store.saved_configs == [("demo", '{"chunk_size": 1000}', 7)]
     assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
     assert existing.extra_metadata["other"] == "kept"
     assert metadata_store.saved_collections == []
@@ -134,6 +137,63 @@ def test_coordinator_accepts_injected_api_facade() -> None:
 
     assert coordinator.api_compatibility is facade
     assert coordinator.api is facade
+
+
+def test_api_operation_result_consumes_new_operation_outcome() -> None:
+    operation_facade = KBOperationCompatibilityFacade()
+    coordinator = KBCoordinator(operation_compatibility=operation_facade)
+    facade = coordinator.api_compatibility
+
+    def operation() -> IngestionResult:
+        with operation_facade.start_operation(
+            operation_type="document_ingestion",
+            collection="demo",
+        ) as active_operation:
+            active_operation.finish(
+                status="error",
+                rollback_status=RollbackStatus.INCOMPLETE,
+                side_effects_may_remain=True,
+            )
+        return IngestionResult(status="error", message="failed")
+
+    api_result = facade.run_with_operation_outcome(
+        operation,
+        operation_type="document_ingestion",
+        collection="demo",
+    )
+
+    assert api_result.result.status == "error"
+    assert api_result.operation_outcome is operation_facade.last_outcome
+    cleanup_decision = facade.failed_ingest_cleanup_decision(api_result)
+    assert cleanup_decision.successful_documents == 0
+    assert cleanup_decision.side_effects_may_remain is True
+
+    completed_rollback = facade.with_rollback_complete(api_result, True)
+    cleanup_after_rollback = facade.failed_ingest_cleanup_decision(completed_rollback)
+    assert cleanup_after_rollback.side_effects_may_remain is False
+
+
+def test_api_operation_result_ignores_stale_operation_outcome() -> None:
+    operation_facade = KBOperationCompatibilityFacade()
+    coordinator = KBCoordinator(operation_compatibility=operation_facade)
+    facade = coordinator.api_compatibility
+
+    with operation_facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as active_operation:
+        active_operation.finish(status="success")
+    assert operation_facade.last_outcome is not None
+
+    api_result = facade.run_with_operation_outcome(
+        lambda: IngestionResult(status="error", message="patched failure"),
+        operation_type="document_ingestion",
+        collection="demo",
+    )
+
+    assert api_result.operation_outcome is None
+    cleanup_decision = facade.failed_ingest_cleanup_decision(api_result)
+    assert cleanup_decision.side_effects_may_remain is False
 
 
 def test_list_document_records_omits_none_max_results(

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -229,6 +229,75 @@ def test_api_operation_result_consumes_new_operation_outcome() -> None:
     assert cleanup_after_rollback.side_effects_may_remain is False
 
 
+def test_run_with_operation_outcome_rebinds_storage_context() -> None:
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        bind_storage_shim_for_current_context,
+        get_bound_storage_shim_for_current_context,
+    )
+
+    outer_shim = _FakeStorageShim(_ConfigOnlyMetadataStore())
+    inner_shim = _FakeStorageShim(_ConfigOnlyMetadataStore())
+    facade = KBApiCompatibilityFacade(storage_shim=inner_shim)
+    seen_shims: list[object | None] = []
+
+    def operation() -> IngestionResult:
+        seen_shims.append(get_bound_storage_shim_for_current_context())
+        return IngestionResult(status="success", message="ok")
+
+    with bind_storage_shim_for_current_context(outer_shim):
+        api_result = facade.run_with_operation_outcome(
+            operation,
+            operation_type="document_ingestion",
+            collection="demo",
+        )
+        assert get_bound_storage_shim_for_current_context() is outer_shim
+
+    assert api_result.result.status == "success"
+    assert seen_shims == [inner_shim]
+
+
+@pytest.mark.asyncio
+async def test_run_async_with_operation_outcome_rebinds_storage_context() -> None:
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        bind_storage_shim_for_current_context,
+        get_bound_storage_shim_for_current_context,
+    )
+
+    outer_shim = _FakeStorageShim(_ConfigOnlyMetadataStore())
+    inner_shim = _FakeStorageShim(_ConfigOnlyMetadataStore())
+    facade = KBApiCompatibilityFacade(storage_shim=inner_shim)
+    seen_shims: list[object | None] = []
+
+    async def operation() -> WebIngestionResult:
+        seen_shims.append(get_bound_storage_shim_for_current_context())
+        return WebIngestionResult(
+            status="success",
+            collection="demo",
+            total_urls_found=0,
+            pages_crawled=0,
+            pages_failed=0,
+            documents_created=0,
+            chunks_created=0,
+            embeddings_created=0,
+            crawled_urls=[],
+            failed_urls={},
+            message="ok",
+            warnings=[],
+            elapsed_time_ms=0,
+        )
+
+    with bind_storage_shim_for_current_context(outer_shim):
+        api_result = await facade.run_async_with_operation_outcome(
+            operation,
+            operation_type="web_ingestion",
+            collection="demo",
+        )
+        assert get_bound_storage_shim_for_current_context() is outer_shim
+
+    assert api_result.result.status == "success"
+    assert seen_shims == [inner_shim]
+
+
 def test_api_operation_result_ignores_stale_operation_outcome() -> None:
     operation_facade = KBOperationCompatibilityFacade()
     coordinator = KBCoordinator(operation_compatibility=operation_facade)

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -65,6 +65,11 @@ class _ConfigOnlyMetadataStore:
         self.saved_configs.append((collection, config_json, user_id))
 
 
+class _NoneReturningMetadataStore(_FakeMetadataStore):
+    async def get_collection(self, collection: str) -> CollectionInfo | None:
+        return None
+
+
 class _FakeStorageShim:
     def __init__(self, metadata_store: object) -> None:
         self.metadata_store = metadata_store
@@ -121,6 +126,51 @@ async def test_save_collection_config_preserves_existing_backend_binding() -> No
     assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
     assert existing.extra_metadata["other"] == "kept"
     assert metadata_store.saved_collections == []
+
+
+@pytest.mark.asyncio
+async def test_save_collection_config_creates_backend_binding_when_store_returns_none() -> (
+    None
+):
+    metadata_store = _NoneReturningMetadataStore(None)
+    facade = KBApiCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    await facade.save_collection_config(
+        collection="demo",
+        config_json="{}",
+        user_id=7,
+    )
+
+    assert metadata_store.saved_collections == [metadata_store.collection]
+    assert metadata_store.collection is not None
+    assert metadata_store.collection.name == "demo"
+    assert metadata_store.collection.extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
+
+
+@pytest.mark.asyncio
+async def test_save_collection_config_uses_proxy_store_methods() -> None:
+    metadata_store = _FakeMetadataStore(None)
+
+    class MetadataStoreProxy:
+        def __getattr__(self, name: str) -> object:
+            return getattr(metadata_store, name)
+
+    facade = KBApiCompatibilityFacade(
+        storage_shim=_FakeStorageShim(MetadataStoreProxy())
+    )
+
+    await facade.save_collection_config(
+        collection="demo",
+        config_json="{}",
+        user_id=7,
+    )
+
+    assert metadata_store.collection is not None
+    assert metadata_store.collection.extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
 
 
 @pytest.mark.asyncio
@@ -202,6 +252,42 @@ def test_api_operation_result_ignores_stale_operation_outcome() -> None:
     assert cleanup_decision.side_effects_may_remain is False
 
 
+def test_api_operation_result_ignores_equal_stale_operation_outcome_copy() -> None:
+    operation_facade = KBOperationCompatibilityFacade()
+    coordinator = KBCoordinator(operation_compatibility=operation_facade)
+    facade = coordinator.api_compatibility
+
+    with operation_facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as active_operation:
+        active_operation.finish(status="success")
+    assert operation_facade.last_outcome is not None
+
+    copied_previous_outcome = KBOperationOutcome(
+        operation_id=operation_facade.last_outcome.operation_id,
+        operation_type=operation_facade.last_outcome.operation_type,
+        collection=operation_facade.last_outcome.collection,
+        status=operation_facade.last_outcome.status,
+        rollback_status=operation_facade.last_outcome.rollback_status,
+        persistence_policy=operation_facade.last_outcome.persistence_policy,
+        compensation_steps=operation_facade.last_outcome.compensation_steps,
+        child_outcomes=operation_facade.last_outcome.child_outcomes,
+        warnings=operation_facade.last_outcome.warnings,
+        side_effects_may_remain=operation_facade.last_outcome.side_effects_may_remain,
+        details=operation_facade.last_outcome.details,
+    )
+
+    api_result = facade.wrap_operation_result(
+        IngestionResult(status="error", message="patched failure"),
+        previous_outcome=copied_previous_outcome,
+        operation_type="document_ingestion",
+        collection="demo",
+    )
+
+    assert api_result.operation_outcome is None
+
+
 def test_failed_batch_ingest_cleanup_decision_aggregates_operation_outcomes() -> None:
     facade = KBApiCompatibilityFacade()
     side_effect_outcome = KBOperationOutcome(
@@ -231,6 +317,37 @@ def test_failed_batch_ingest_cleanup_decision_aggregates_operation_outcomes() ->
 
     assert cleanup_decision.successful_documents == 1
     assert cleanup_decision.side_effects_may_remain is True
+
+
+def test_failed_ingest_cleanup_decision_accepts_dict_results() -> None:
+    facade = KBApiCompatibilityFacade()
+
+    cleanup_decision = facade.failed_ingest_cleanup_decision(
+        KBApiOperationResult(
+            result={
+                "status": "partial",
+                "documents_created": "2",
+                "side_effects_may_remain": True,
+            }
+        )
+    )
+
+    assert cleanup_decision.successful_documents == 2
+    assert cleanup_decision.side_effects_may_remain is True
+
+
+def test_failed_batch_ingest_cleanup_decision_counts_dict_successes() -> None:
+    facade = KBApiCompatibilityFacade()
+
+    cleanup_decision = facade.failed_batch_ingest_cleanup_decision(
+        [
+            KBApiOperationResult(result={"status": "success"}),
+            KBApiOperationResult(result={"status": "error"}),
+        ]
+    )
+
+    assert cleanup_decision.successful_documents == 1
+    assert cleanup_decision.side_effects_may_remain is False
 
 
 def test_list_document_records_omits_none_max_results(

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -71,11 +71,28 @@ class _NoneReturningMetadataStore(_FakeMetadataStore):
 
 
 class _FakeStorageShim:
-    def __init__(self, metadata_store: object) -> None:
+    def __init__(
+        self,
+        metadata_store: object,
+        vector_store: object | None = None,
+        status_store: object | None = None,
+    ) -> None:
         self.metadata_store = metadata_store
+        self.vector_store = vector_store
+        self.status_store = status_store
 
     def get_metadata_store(self) -> object:
         return self.metadata_store
+
+    def get_vector_index_store(self) -> object:
+        if self.vector_store is None:
+            raise AssertionError("vector store was not configured")
+        return self.vector_store
+
+    def get_ingestion_status_store(self) -> object:
+        if self.status_store is None:
+            raise AssertionError("status store was not configured")
+        return self.status_store
 
 
 def test_kb_api_facade_public_surface_imports() -> None:
@@ -298,6 +315,167 @@ async def test_run_async_with_operation_outcome_rebinds_storage_context() -> Non
     assert seen_shims == [inner_shim]
 
 
+@pytest.mark.asyncio
+async def test_api_facade_storage_operations_rebind_storage_context() -> None:
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        bind_storage_shim_for_current_context,
+        get_bound_storage_shim_for_current_context,
+    )
+
+    class VectorStore:
+        def __init__(self) -> None:
+            self.list_calls: list[dict[str, object]] = []
+            self.rename_calls: list[dict[str, object]] = []
+
+        def list_document_records(self, **kwargs: object) -> list[str]:
+            self.list_calls.append(kwargs)
+            return ["record"]
+
+        def rename_collection_data(self, **kwargs: object) -> list[str]:
+            self.rename_calls.append(kwargs)
+            return ["vector warning"]
+
+    class MetadataStore(_FakeMetadataStore):
+        def __init__(self) -> None:
+            super().__init__(CollectionInfo(name="old"))
+            self.loaded_configs: list[dict[str, object]] = []
+            self.deleted_metadata: list[dict[str, object]] = []
+            self.deleted_entries: list[str] = []
+            self.renamed: list[dict[str, object]] = []
+            self.config_owner_ids = {7, 8}
+
+        async def get_collection_config(
+            self,
+            *,
+            collection: str,
+            user_id: int | None,
+            is_admin: bool = False,
+        ) -> str | None:
+            self.loaded_configs.append(
+                {"collection": collection, "user_id": user_id, "is_admin": is_admin}
+            )
+            return "{}"
+
+        async def delete_collection_metadata(self, **kwargs: object) -> dict[str, int]:
+            self.deleted_metadata.append(kwargs)
+            return {"collection_config": 1}
+
+        async def delete_collection(self, collection_name: str) -> None:
+            self.deleted_entries.append(collection_name)
+
+        def list_collection_config_owner_ids(self, collection_name: str) -> set[int]:
+            assert collection_name == "old"
+            return self.config_owner_ids
+
+        async def rename_collection(self, **kwargs: object) -> None:
+            self.renamed.append(kwargs)
+
+    class StatusStore:
+        def __init__(self) -> None:
+            self.renamed: list[dict[str, object]] = []
+
+        def rename_collection_status(self, **kwargs: object) -> list[str]:
+            self.renamed.append(kwargs)
+            return ["status warning"]
+
+    outer_metadata = MetadataStore()
+    outer_vector = VectorStore()
+    outer_status = StatusStore()
+    inner_metadata = MetadataStore()
+    inner_vector = VectorStore()
+    inner_status = StatusStore()
+    outer_shim = _FakeStorageShim(outer_metadata, outer_vector, outer_status)
+    inner_shim = _FakeStorageShim(inner_metadata, inner_vector, inner_status)
+    facade = KBApiCompatibilityFacade(storage_shim=inner_shim)
+
+    with bind_storage_shim_for_current_context(outer_shim):
+        assert facade.list_document_records(
+            collection_name="old",
+            user_id=7,
+            is_admin=False,
+        ) == ["record"]
+        await facade.save_collection_config(
+            collection="old",
+            config_json="{}",
+            user_id=7,
+        )
+        assert (
+            await facade.get_collection_config(
+                collection="old",
+                user_id=7,
+                is_admin=False,
+            )
+            == "{}"
+        )
+        await facade.delete_collection_metadata(
+            collection_name="old",
+            user_id=7,
+            is_admin=False,
+            delete_orphaned_metadata=True,
+        )
+        assert await facade.delete_collection_metadata_entry("old") is True
+        assert facade.list_collection_config_owner_ids("old") == {7, 8}
+        assert facade.rename_collection_data(
+            collection_name="old",
+            new_name="new",
+            user_id=7,
+            is_admin=False,
+        ) == ["vector warning"]
+        await facade.rename_collection_metadata(
+            old_name="old",
+            new_name="new",
+            user_id=7,
+            is_admin=False,
+        )
+        assert facade.rename_collection_status(
+            old_name="old",
+            new_name="new",
+            user_id=7,
+            is_admin=False,
+        ) == ["status warning"]
+        assert get_bound_storage_shim_for_current_context() is outer_shim
+
+    assert outer_vector.list_calls == []
+    assert outer_vector.rename_calls == []
+    assert outer_metadata.saved_configs == []
+    assert outer_metadata.loaded_configs == []
+    assert outer_metadata.deleted_metadata == []
+    assert outer_metadata.deleted_entries == []
+    assert outer_metadata.renamed == []
+    assert outer_status.renamed == []
+
+    assert inner_vector.list_calls == [
+        {"collection_name": "old", "user_id": 7, "is_admin": False}
+    ]
+    assert inner_vector.rename_calls == [
+        {
+            "collection_name": "old",
+            "new_name": "new",
+            "user_id": 7,
+            "is_admin": False,
+        }
+    ]
+    assert inner_metadata.saved_configs == [("old", "{}", 7)]
+    assert inner_metadata.loaded_configs == [
+        {"collection": "old", "user_id": 7, "is_admin": False}
+    ]
+    assert inner_metadata.deleted_metadata == [
+        {
+            "collection_name": "old",
+            "user_id": 7,
+            "is_admin": False,
+            "delete_orphaned_metadata": True,
+        }
+    ]
+    assert inner_metadata.deleted_entries == ["old"]
+    assert inner_metadata.renamed == [
+        {"old_name": "old", "new_name": "new", "user_id": 7, "is_admin": False}
+    ]
+    assert inner_status.renamed == [
+        {"old_name": "old", "new_name": "new", "user_id": 7, "is_admin": False}
+    ]
+
+
 def test_api_operation_result_ignores_stale_operation_outcome() -> None:
     operation_facade = KBOperationCompatibilityFacade()
     coordinator = KBCoordinator(operation_compatibility=operation_facade)
@@ -449,19 +627,23 @@ def test_list_document_records_omits_none_max_results(
     ]
 
 
-def test_web_api_list_document_records_uses_route_vector_store(
+def test_web_api_list_document_records_routes_through_api_facade(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from xagent.web.api import kb as kb_api
 
     calls: list[dict[str, object]] = []
 
-    class VectorStore:
+    class Facade:
         def list_document_records(self, **kwargs: object) -> list[str]:
             calls.append(kwargs)
             return ["record"]
 
-    monkeypatch.setattr(kb_api, "get_vector_index_store", lambda: VectorStore())
+    monkeypatch.setattr(
+        kb_api,
+        "_get_api_compatibility_facade",
+        lambda: Facade(),
+    )
 
     records = kb_api.list_document_records(
         collection_name="demo",

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Optional
 
 import pytest
@@ -338,3 +339,47 @@ def test_web_api_search_wrapper_routes_through_api_facade(monkeypatch) -> None:
 
     assert result is sentinel
     assert calls == [("demo", "question", 7, True)]
+
+
+def test_web_api_delete_document_wrapper_routes_through_api_facade(
+    monkeypatch,
+) -> None:
+    from xagent.web.api import kb as kb_api
+
+    sentinel = object()
+    calls: list[tuple[str, str, int, bool]] = []
+
+    class Facade:
+        def delete_document(
+            self,
+            collection: str,
+            doc_id: str,
+            user_id: int,
+            is_admin: bool,
+        ) -> object:
+            calls.append((collection, doc_id, user_id, is_admin))
+            return sentinel
+
+    monkeypatch.setattr(
+        kb_api,
+        "_get_api_compatibility_facade",
+        lambda: Facade(),
+    )
+
+    result = kb_api.delete_document(
+        collection="demo",
+        doc_id="doc-1",
+        user_id=7,
+        is_admin=True,
+    )
+
+    assert result is sentinel
+    assert calls == [("demo", "doc-1", 7, True)]
+
+
+def test_delete_document_api_does_not_shadow_api_facade_wrapper() -> None:
+    from xagent.web.api import kb as kb_api
+
+    source = inspect.getsource(kb_api.delete_document_api)
+
+    assert "management.collections import delete_document" not in source

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -13,8 +13,11 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
 )
 from xagent.core.tools.core.RAG_tools.kb import (
     KBApiCompatibilityFacade,
+    KBApiOperationResult,
     KBCoordinator,
     KBOperationCompatibilityFacade,
+    KBOperationOutcome,
+    PersistencePolicy,
     RollbackStatus,
     get_kb_coordinator,
     reset_kb_coordinator_for_tests,
@@ -195,6 +198,37 @@ def test_api_operation_result_ignores_stale_operation_outcome() -> None:
     assert api_result.operation_outcome is None
     cleanup_decision = facade.failed_ingest_cleanup_decision(api_result)
     assert cleanup_decision.side_effects_may_remain is False
+
+
+def test_failed_batch_ingest_cleanup_decision_aggregates_operation_outcomes() -> None:
+    facade = KBApiCompatibilityFacade()
+    side_effect_outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="error",
+        rollback_status=RollbackStatus.INCOMPLETE,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        side_effects_may_remain=True,
+    )
+    clean_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="rolled back"),
+        rollback_complete=True,
+    )
+    dirty_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="rollback failed"),
+        operation_outcome=side_effect_outcome,
+    )
+    success_result = KBApiOperationResult(
+        result=IngestionResult(status="success", message="ok")
+    )
+
+    cleanup_decision = facade.failed_batch_ingest_cleanup_decision(
+        [clean_result, dirty_result, success_result]
+    )
+
+    assert cleanup_decision.successful_documents == 1
+    assert cleanup_decision.side_effects_may_remain is True
 
 
 def test_list_document_records_omits_none_max_results(

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -1,0 +1,280 @@
+"""Tests for the KB API compatibility facade."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import CollectionInfo
+from xagent.core.tools.core.RAG_tools.kb import (
+    KBApiCompatibilityFacade,
+    KBCoordinator,
+    get_kb_coordinator,
+    reset_kb_coordinator_for_tests,
+)
+
+
+class _FakeMetadataStore:
+    def __init__(self, collection: Optional[CollectionInfo]) -> None:
+        self.collection = collection
+        self.saved_configs: list[tuple[str, str, int]] = []
+        self.saved_collections: list[CollectionInfo] = []
+
+    async def get_collection(self, collection: str) -> CollectionInfo:
+        if self.collection is None or self.collection.name != collection:
+            raise ValueError(f"Collection {collection!r} not found")
+        return self.collection
+
+    async def save_collection(self, collection: CollectionInfo) -> None:
+        self.saved_collections.append(collection)
+        self.collection = collection
+
+    async def save_collection_config(
+        self,
+        *,
+        collection: str,
+        config_json: str,
+        user_id: int,
+    ) -> None:
+        self.saved_configs.append((collection, config_json, user_id))
+
+
+class _ConfigOnlyMetadataStore:
+    def __init__(self) -> None:
+        self.saved_configs: list[tuple[str, str, int]] = []
+
+    async def save_collection_config(
+        self,
+        *,
+        collection: str,
+        config_json: str,
+        user_id: int,
+    ) -> None:
+        self.saved_configs.append((collection, config_json, user_id))
+
+
+class _FakeStorageShim:
+    def __init__(self, metadata_store: object) -> None:
+        self.metadata_store = metadata_store
+
+    def get_metadata_store(self) -> object:
+        return self.metadata_store
+
+
+def test_kb_api_facade_public_surface_imports() -> None:
+    import xagent.core.tools.core.RAG_tools.kb as kb
+
+    assert hasattr(kb, "KBApiCompatibilityFacade")
+    reset_kb_coordinator_for_tests()
+    assert isinstance(
+        get_kb_coordinator().api_compatibility, KBApiCompatibilityFacade
+    )
+    assert get_kb_coordinator().api is get_kb_coordinator().api_compatibility
+
+
+@pytest.mark.asyncio
+async def test_save_collection_config_creates_owner_neutral_backend_binding() -> None:
+    metadata_store = _FakeMetadataStore(None)
+    facade = KBApiCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    await facade.save_collection_config(
+        collection="demo",
+        config_json="{}",
+        user_id=7,
+    )
+
+    assert metadata_store.saved_configs == [("demo", "{}", 7)]
+    assert metadata_store.saved_collections == [metadata_store.collection]
+    assert metadata_store.collection is not None
+    assert metadata_store.collection.owners == []
+    assert metadata_store.collection.extra_metadata["kb_storage"] == {
+        "backend": "lancedb"
+    }
+
+
+@pytest.mark.asyncio
+async def test_save_collection_config_preserves_existing_backend_binding() -> None:
+    existing = CollectionInfo(
+        name="demo",
+        extra_metadata={"kb_storage": {"backend": "postgresql"}, "other": "kept"},
+    )
+    metadata_store = _FakeMetadataStore(existing)
+    facade = KBApiCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    await facade.save_collection_config(
+        collection="demo",
+        config_json='{"chunk_size": 1000}',
+        user_id=7,
+    )
+
+    assert metadata_store.saved_configs == [('demo', '{"chunk_size": 1000}', 7)]
+    assert existing.extra_metadata["kb_storage"] == {"backend": "postgresql"}
+    assert existing.extra_metadata["other"] == "kept"
+    assert metadata_store.saved_collections == []
+
+
+@pytest.mark.asyncio
+async def test_save_collection_config_tolerates_config_only_test_stores() -> None:
+    metadata_store = _ConfigOnlyMetadataStore()
+    facade = KBApiCompatibilityFacade(storage_shim=_FakeStorageShim(metadata_store))
+
+    await facade.save_collection_config(
+        collection="demo",
+        config_json="{}",
+        user_id=7,
+    )
+
+    assert metadata_store.saved_configs == [("demo", "{}", 7)]
+
+
+def test_coordinator_accepts_injected_api_facade() -> None:
+    facade = KBApiCompatibilityFacade()
+    coordinator = KBCoordinator(api_compatibility=facade)
+
+    assert coordinator.api_compatibility is facade
+    assert coordinator.api is facade
+
+
+def test_list_document_records_omits_none_max_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.storage import factory
+
+    calls: list[dict[str, object]] = []
+
+    class VectorStore:
+        def list_document_records(self, **kwargs: object) -> list[str]:
+            calls.append(kwargs)
+            return ["record"]
+
+    monkeypatch.setattr(factory, "get_vector_index_store", lambda: VectorStore())
+
+    records = KBApiCompatibilityFacade().list_document_records(
+        collection_name="demo",
+        user_id=7,
+        is_admin=False,
+    )
+
+    assert records == ["record"]
+    assert calls == [
+        {
+            "collection_name": "demo",
+            "user_id": 7,
+            "is_admin": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rename_collection_routes_storage_metadata_and_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.storage import factory
+
+    calls: list[tuple[str, str, int, bool]] = []
+
+    class VectorStore:
+        def rename_collection_data(
+            self,
+            *,
+            collection_name: str,
+            new_name: str,
+            user_id: int,
+            is_admin: bool,
+        ) -> list[str]:
+            calls.append((collection_name, new_name, user_id, is_admin))
+            return ["vector warning"]
+
+    class MetadataStore:
+        async def rename_collection(
+            self,
+            *,
+            old_name: str,
+            new_name: str,
+            user_id: int,
+            is_admin: bool,
+        ) -> None:
+            calls.append((old_name, new_name, user_id, is_admin))
+
+    class StatusStore:
+        def rename_collection_status(
+            self,
+            *,
+            old_name: str,
+            new_name: str,
+            user_id: int,
+            is_admin: bool,
+        ) -> list[str]:
+            calls.append((old_name, new_name, user_id, is_admin))
+            return ["status warning"]
+
+    monkeypatch.setattr(factory, "get_vector_index_store", lambda: VectorStore())
+    monkeypatch.setattr(factory, "get_metadata_store", lambda: MetadataStore())
+    monkeypatch.setattr(factory, "get_ingestion_status_store", lambda: StatusStore())
+
+    facade = KBApiCompatibilityFacade()
+
+    assert facade.rename_collection_data(
+        collection_name="old",
+        new_name="new",
+        user_id=7,
+        is_admin=False,
+    ) == ["vector warning"]
+    await facade.rename_collection_metadata(
+        old_name="old",
+        new_name="new",
+        user_id=7,
+        is_admin=False,
+    )
+    assert facade.rename_collection_status(
+        old_name="old",
+        new_name="new",
+        user_id=7,
+        is_admin=False,
+    ) == ["status warning"]
+    assert calls == [
+        ("old", "new", 7, False),
+        ("old", "new", 7, False),
+        ("old", "new", 7, False),
+    ]
+
+
+def test_web_api_search_wrapper_routes_through_api_facade(monkeypatch) -> None:
+    from xagent.web.api import kb as kb_api
+
+    sentinel = object()
+    calls: list[tuple[str, str, int, bool]] = []
+
+    class Facade:
+        def run_document_search(
+            self,
+            collection: str,
+            query_text: str,
+            **kwargs: object,
+        ) -> object:
+            calls.append(
+                (
+                    collection,
+                    query_text,
+                    int(kwargs["user_id"]),
+                    bool(kwargs["is_admin"]),
+                )
+            )
+            return sentinel
+
+    monkeypatch.setattr(
+        kb_api,
+        "_get_api_compatibility_facade",
+        lambda: Facade(),
+    )
+
+    result = kb_api.run_document_search(
+        collection="demo",
+        query_text="question",
+        user_id=7,
+        is_admin=True,
+    )
+
+    assert result is sentinel
+    assert calls == [("demo", "question", 7, True)]

--- a/tests/core/tools/core/RAG_tools/test_multitenancy.py
+++ b/tests/core/tools/core/RAG_tools/test_multitenancy.py
@@ -952,7 +952,7 @@ class TestAPIMultiTenancy:
         "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
         return_value=set(),
     )
-    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store")
     @patch("xagent.web.api.kb.delete_collection_uploaded_files")
     @patch("xagent.web.api.kb.delete_collection_physical_dir")
     @patch("xagent.web.api.kb.delete_collection")
@@ -1007,7 +1007,13 @@ class TestAPIMultiTenancy:
             deleted_counts={},
         )
 
-        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+        with patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+            return_value=mock_get_vector_store.return_value,
+        ):
+            result = await delete_collection_api(
+                "team", _user=mock_user, db=MagicMock()
+            )
 
         mock_delete_collection.assert_called_once_with("team", 999, True)
         assert mock_delete_collection_physical_dir.call_args_list == [
@@ -1033,9 +1039,11 @@ class TestAPIMultiTenancy:
         assert result.status == "success"
 
     @pytest.mark.asyncio
-    @patch("xagent.web.api.kb.get_ingestion_status_store")
-    @patch("xagent.web.api.kb.get_metadata_store")
-    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+    )
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store")
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store")
     @patch("xagent.web.api.kb._list_collections_with_retry", new_callable=AsyncMock)
     @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
     @patch(
@@ -1140,9 +1148,11 @@ class TestAPIMultiTenancy:
         assert result["status"] == "partial_success"
 
     @pytest.mark.asyncio
-    @patch("xagent.web.api.kb.get_ingestion_status_store")
-    @patch("xagent.web.api.kb.get_metadata_store")
-    @patch("xagent.web.api.kb.get_vector_index_store")
+    @patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+    )
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store")
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store")
     @patch("xagent.web.api.kb._list_collections_with_retry", new_callable=AsyncMock)
     @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)
     @patch("xagent.web.api.kb.rename_collection_storage")
@@ -1230,7 +1240,7 @@ class TestAPIMultiTenancy:
         "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
         return_value=set(),
     )
-    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store")
     @patch("xagent.web.api.kb.delete_collection_uploaded_files")
     @patch("xagent.web.api.kb.delete_collection_physical_dir")
     @patch("xagent.web.api.kb.delete_collection")
@@ -1275,7 +1285,13 @@ class TestAPIMultiTenancy:
             deleted_counts={},
         )
 
-        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+        with patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+            return_value=mock_get_vector_store.return_value,
+        ):
+            result = await delete_collection_api(
+                "team", _user=mock_user, db=MagicMock()
+            )
 
         mock_delete_collection_physical_dir.assert_called_once_with(
             user_id=101,
@@ -1297,7 +1313,7 @@ class TestAPIMultiTenancy:
         "xagent.web.api.kb.list_collection_uploaded_file_owner_ids",
         return_value={101},
     )
-    @patch("xagent.web.api.kb.get_metadata_store")
+    @patch("xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store")
     @patch("xagent.web.api.kb.delete_collection_uploaded_files")
     @patch("xagent.web.api.kb.delete_collection_physical_dir")
     @patch("xagent.web.api.kb.delete_collection")
@@ -1340,7 +1356,13 @@ class TestAPIMultiTenancy:
             deleted_counts={},
         )
 
-        result = await delete_collection_api("team", _user=mock_user, db=MagicMock())
+        with patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store",
+            return_value=mock_get_vector_store.return_value,
+        ):
+            result = await delete_collection_api(
+                "team", _user=mock_user, db=MagicMock()
+            )
 
         mock_delete_collection_physical_dir.assert_called_once_with(
             user_id=101,

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2910,6 +2910,57 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
     assert "Failed to fully roll back cloud ingest" in data[0]["message"]
 
 
+def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
+    test_env, temp_uploads
+):
+    """Cloud download failures should stop after restoring the local backup."""
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    class _FakeFilesService:
+        def get_media(self, fileId: str):
+            return {"fileId": fileId}
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FailingDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            raise RuntimeError("download blew up")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_coll",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-file-1",
+                        "fileName": "cloud.csv",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["status"] == "error"
+    assert "Download failed: download blew up" in data[0]["message"]
+    run_ingestion.assert_not_called()
+
+
 def test_kb_ingest_cloud_surfaces_restore_failure_on_unexpected_error(
     test_env, temp_uploads
 ):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -1625,9 +1625,16 @@ def test_kb_rename_physical_directory_rename(test_env, temp_uploads):
         patch(
             "xagent.core.tools.core.RAG_tools.management.collections._list_table_names"
         ) as mock_list_tables,
-        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+        ) as mock_get_metadata_store,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+        ) as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1636,6 +1643,9 @@ def test_kb_rename_physical_directory_rename(test_env, temp_uploads):
         mock_store.list_document_records.return_value = []  # No documents
         mock_store.rename_collection_data.return_value = []  # No warnings
         mock_store_factory.return_value = mock_store
+        mock_metadata_store = mock_get_metadata_store.return_value
+        mock_metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_metadata_store.rename_collection = AsyncMock()
 
         # Mock rename_collection_storage to simulate success
         mock_rename_result = MagicMock()
@@ -1677,9 +1687,16 @@ def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
         patch(
             "xagent.core.tools.core.RAG_tools.management.collections._list_table_names"
         ) as mock_list_tables,
-        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+        ) as mock_get_metadata_store,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+        ) as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1688,6 +1705,9 @@ def test_kb_rename_normalizes_padded_collection_names(test_env, temp_uploads):
         mock_store.list_document_records.return_value = []
         mock_store.rename_collection_data.return_value = []
         mock_store_factory.return_value = mock_store
+        mock_metadata_store = mock_get_metadata_store.return_value
+        mock_metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_metadata_store.rename_collection = AsyncMock()
 
         # Mock rename_collection_storage
         mock_rename_result = MagicMock()
@@ -1732,9 +1752,16 @@ def test_kb_rename_accepts_unicode_collection_name(test_env, temp_uploads):
         patch(
             "xagent.core.tools.core.RAG_tools.management.collections._list_table_names"
         ) as mock_list_tables,
-        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+        ) as mock_get_metadata_store,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+        ) as mock_get_status_store,
     ):
         mock_list_tables.return_value = []
 
@@ -1743,6 +1770,9 @@ def test_kb_rename_accepts_unicode_collection_name(test_env, temp_uploads):
         mock_store.list_document_records.return_value = []
         mock_store.rename_collection_data.return_value = []
         mock_store_factory.return_value = mock_store
+        mock_metadata_store = mock_get_metadata_store.return_value
+        mock_metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_metadata_store.rename_collection = AsyncMock()
 
         # Mock rename_collection_storage
         mock_rename_result = MagicMock()
@@ -1949,15 +1979,25 @@ def test_delete_after_rename_not_denied_by_stale_list_collections(test_env):
     with (
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb._list_collections_with_retry") as mock_retry,
-        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+        ) as mock_get_metadata_store,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+        ) as mock_get_status_store,
     ):
         mock_retry.side_effect = [stale_old_only, stale_old_only]
         mock_store = MagicMock()
         mock_store.list_document_records.return_value = []
         mock_store.rename_collection_data.return_value = []
         mock_store_factory.return_value = mock_store
+        mock_metadata_store = mock_get_metadata_store.return_value
+        mock_metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_metadata_store.rename_collection = AsyncMock()
         mock_rename_result = MagicMock()
         mock_rename_result.status = "not_found"
         mock_rename_result.error = None
@@ -2042,15 +2082,25 @@ def test_delete_after_rename_not_blocked_when_new_collection_is_visible(test_env
     with (
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb._list_collections_with_retry") as mock_retry,
-        patch("xagent.web.api.kb.get_vector_index_store") as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_store_factory,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store"
+        ) as mock_get_metadata_store,
         patch("xagent.web.api.kb.rename_collection_storage") as mock_rename_storage,
-        patch("xagent.web.api.kb.get_ingestion_status_store") as mock_get_status_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_ingestion_status_store"
+        ) as mock_get_status_store,
     ):
         mock_retry.side_effect = [visible_old, visible_old]
         mock_store = MagicMock()
         mock_store.list_document_records.return_value = []
         mock_store.rename_collection_data.return_value = []
         mock_store_factory.return_value = mock_store
+        mock_metadata_store = mock_get_metadata_store.return_value
+        mock_metadata_store.list_collection_config_owner_ids.return_value = set()
+        mock_metadata_store.rename_collection = AsyncMock()
         mock_rename_result = MagicMock()
         mock_rename_result.status = "not_found"
         mock_rename_result.error = None
@@ -2278,25 +2328,25 @@ async def test_failed_ingest_config_restore_skips_delete_when_snapshot_unknown()
         _restore_collection_config_after_failed_ingest,
     )
 
-    metadata_store = MagicMock()
-    metadata_store.save_collection_config = AsyncMock()
-    metadata_store.delete_collection_metadata = AsyncMock()
+    facade = MagicMock()
+    facade.save_collection_config = AsyncMock()
+    facade.delete_collection_metadata = AsyncMock()
 
-    await _restore_collection_config_after_failed_ingest(
-        snapshot=_CollectionConfigSnapshot(
-            metadata_store=metadata_store,
-            collection="existing_collection",
-            user_id=1,
-            previous_config_json=None,
-            previous_config_known=False,
-            saved=True,
-        ),
-        collection_existed_before=True,
-        context="unit-test",
-    )
+    with patch("xagent.web.api.kb._get_api_compatibility_facade", return_value=facade):
+        await _restore_collection_config_after_failed_ingest(
+            snapshot=_CollectionConfigSnapshot(
+                collection="existing_collection",
+                user_id=1,
+                previous_config_json=None,
+                previous_config_known=False,
+                saved=True,
+            ),
+            collection_existed_before=True,
+            context="unit-test",
+        )
 
-    metadata_store.save_collection_config.assert_not_awaited()
-    metadata_store.delete_collection_metadata.assert_not_awaited()
+    facade.save_collection_config.assert_not_awaited()
+    facade.delete_collection_metadata.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -3154,7 +3204,9 @@ def test_check_documents_exist_prefers_uploaded_file_filename(test_env, temp_upl
         ),
     ]
 
-    with patch("xagent.web.api.kb.get_vector_index_store") as mock_get_store:
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+    ) as mock_get_store:
         mock_store = mock_get_store.return_value
         mock_store.list_document_records.return_value = records
         response = client.post(
@@ -3173,7 +3225,9 @@ def test_check_documents_exist_accepts_unicode_collection_name(test_env, temp_up
 
     collection_name = "示例知识库集合"
 
-    with patch("xagent.web.api.kb.get_vector_index_store") as mock_get_store:
+    with patch(
+        "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+    ) as mock_get_store:
         mock_store = mock_get_store.return_value
         mock_store.list_document_records.return_value = []
 
@@ -4407,9 +4461,13 @@ def test_kb_delete_collection_cleans_file_id_managed_root_file(
     with (
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_store,
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_vector_index_store"
+        ) as mock_factory_get_store,
         patch("xagent.web.api.kb.delete_collection") as mock_delete,
     ):
         mock_store = mock_get_store.return_value
+        mock_factory_get_store.return_value = mock_store
         mock_store.list_document_records.side_effect = _fake_list_documents_for_user
         from xagent.core.tools.core.RAG_tools.core.schemas import (
             CollectionOperationResult,

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3269,7 +3269,7 @@ def test_delete_document_prefers_file_id_and_cleans_orphan_file(
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3359,7 +3359,7 @@ def test_delete_document_keeps_uploaded_file_when_other_docs_still_reference_it(
             side_effect=_fake_list_documents_for_user,
         ),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3452,7 +3452,7 @@ def test_delete_document_skips_orphan_cleanup_when_remaining_doc_refresh_fails(
             side_effect=_fake_list_documents_for_user,
         ),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3542,7 +3542,7 @@ def test_delete_document_does_not_cleanup_uploaded_file_when_delete_fails(
             side_effect=_fake_list_documents_for_user,
         ),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3600,7 +3600,7 @@ def test_delete_document_accepts_unicode_collection_name(test_env, temp_uploads)
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3728,7 +3728,7 @@ def test_delete_document_by_doc_id_disambiguates_duplicate_filename(
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3785,7 +3785,7 @@ def test_delete_document_by_file_id_survives_degraded_document_listing(
         ),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3847,7 +3847,7 @@ def test_delete_document_by_file_id_prefers_documents_table_doc_id(
         ),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -3926,7 +3926,7 @@ def test_delete_document_without_file_id_does_not_resurface_on_collection_refres
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -4014,7 +4014,7 @@ def test_delete_document_without_file_id_preserves_uploaded_file_on_cleanup_refr
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -4090,7 +4090,7 @@ def test_delete_document_by_file_id_resolves_doc_id_via_list_documents(
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch("xagent.web.api.kb.list_documents", return_value=doc_list),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -4144,7 +4144,7 @@ def test_delete_document_by_doc_id_succeeds_without_uploaded_file_record(
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch("xagent.web.api.kb.list_documents", return_value=doc_list),
         patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+            "xagent.web.api.kb.delete_document",
             side_effect=_fake_delete_document,
         ),
     ):
@@ -4213,9 +4213,7 @@ def test_delete_document_by_file_id_rejects_unlinked_basename_match(
         patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock),
         patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
         patch("xagent.web.api.kb.list_documents", return_value=doc_list),
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
+        patch("xagent.web.api.kb.delete_document") as mock_delete_document,
     ):
         response = client.delete(
             f"/api/kb/collections/demo/documents/shared-name.txt?file_id={target_file_id}",
@@ -4289,7 +4287,7 @@ def test_delete_document_reports_cleanup_commit_failure(test_env, temp_uploads):
             ),
             patch("xagent.web.api.kb.get_vector_index_store", return_value=mock_store),
             patch(
-                "xagent.core.tools.core.RAG_tools.management.collections.delete_document",
+                "xagent.web.api.kb.delete_document",
                 side_effect=_fake_delete_document,
             ),
         ):
@@ -4343,9 +4341,7 @@ def test_delete_document_rejects_mismatched_doc_id_and_file_id(test_env, temp_up
             "xagent.web.api.kb.list_documents",
             side_effect=RuntimeError("documents unavailable"),
         ),
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
+        patch("xagent.web.api.kb.delete_document") as mock_delete_document,
     ):
         response = client.delete(
             (

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -687,9 +687,7 @@ def test_delete_document_forbidden_for_non_admin_other_users_doc(
         patch(
             "xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils.query_to_list"
         ) as mock_query_to_list,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
+        patch("xagent.web.api.kb.delete_document") as mock_delete_document,
     ):
         mock_ensure_docs.return_value = None
 
@@ -724,9 +722,7 @@ def test_delete_document_keeps_success_when_config_cleanup_fails(
 
     with (
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
+        patch("xagent.web.api.kb.delete_document") as mock_delete_document,
         patch(
             "xagent.web.api.kb._cleanup_collection_config_if_no_owned_documents",
             side_effect=_HTTPException(
@@ -767,9 +763,7 @@ def test_delete_document_allowed_for_admin_any_doc(app_with_kb_admin, admin_user
     """Admin user can delete documents regardless of owner."""
     with (
         patch("xagent.web.api.kb.get_vector_index_store") as mock_get_vector_store,
-        patch(
-            "xagent.core.tools.core.RAG_tools.management.collections.delete_document"
-        ) as mock_delete_document,
+        patch("xagent.web.api.kb.delete_document") as mock_delete_document,
     ):
         # New API flow resolves by vector_store.list_document_records first.
         mock_record = MagicMock()

--- a/tests/web/api/test_kb_ingest_separators.py
+++ b/tests/web/api/test_kb_ingest_separators.py
@@ -891,7 +891,10 @@ def test_ingest_job_uses_staged_snapshot_in_payload(app_with_kb):
                 new=AsyncMock(),
             ),
             patch("xagent.web.api.kb.get_collection_sync", side_effect=ValueError),
-            patch("xagent.web.api.kb.get_metadata_store", return_value=metadata_store),
+            patch(
+                "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+                return_value=metadata_store,
+            ),
             patch(
                 "xagent.web.api.kb.get_non_terminal_background_job_by_idempotency_key",
                 return_value=None,
@@ -960,7 +963,6 @@ def test_ingest_web_job_payload_records_new_collection_state(app_with_kb):
             new=AsyncMock(),
         ),
         patch("xagent.web.api.kb.get_collection_sync", side_effect=ValueError),
-        patch("xagent.web.api.kb.get_metadata_store", return_value=metadata_store),
         patch(
             "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
             return_value=metadata_store,
@@ -1024,7 +1026,6 @@ def test_ingest_web_job_does_not_write_collection_config_when_enqueue_fails(
             new=AsyncMock(),
         ),
         patch("xagent.web.api.kb.get_collection_sync", side_effect=ValueError),
-        patch("xagent.web.api.kb.get_metadata_store", return_value=metadata_store),
         patch(
             "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
             return_value=metadata_store,

--- a/tests/web/test_kb_ingest_lifecycle.py
+++ b/tests/web/test_kb_ingest_lifecycle.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+from xagent.core.tools.core.RAG_tools.kb import KBApiOperationResult
+from xagent.web.api import kb as kb_module
+from xagent.web.models.user import User
+
+
+class _Facade:
+    def __init__(self) -> None:
+        self.rollback_complete_inputs: list[tuple[KBApiOperationResult[Any], bool]] = []
+        self.single_cleanup_inputs: list[
+            tuple[KBApiOperationResult[Any], int | None]
+        ] = []
+        self.batch_cleanup_inputs: list[
+            tuple[list[KBApiOperationResult[Any]], int | None]
+        ] = []
+
+    def with_rollback_complete(
+        self,
+        api_result: KBApiOperationResult[Any],
+        rollback_complete: bool,
+    ) -> KBApiOperationResult[Any]:
+        self.rollback_complete_inputs.append((api_result, rollback_complete))
+        return KBApiOperationResult(
+            result=api_result.result,
+            operation_outcome=api_result.operation_outcome,
+            rollback_complete=rollback_complete,
+        )
+
+    def failed_ingest_cleanup_decision(
+        self,
+        api_result: KBApiOperationResult[Any],
+        *,
+        successful_documents: int | None = None,
+    ) -> Any:
+        self.single_cleanup_inputs.append((api_result, successful_documents))
+        return type(
+            "Decision",
+            (),
+            {
+                "successful_documents": 3,
+                "side_effects_may_remain": api_result.rollback_complete is False,
+            },
+        )()
+
+    def failed_batch_ingest_cleanup_decision(
+        self,
+        api_results: list[KBApiOperationResult[Any]],
+        *,
+        successful_documents: int | None = None,
+    ) -> Any:
+        self.batch_cleanup_inputs.append((api_results, successful_documents))
+        return type(
+            "Decision",
+            (),
+            {
+                "successful_documents": 5,
+                "side_effects_may_remain": True,
+            },
+        )()
+
+
+@pytest.mark.asyncio
+async def test_api_failed_ingest_config_cleanup_uses_api_outcome_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    facade = _Facade()
+    restore_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(kb_module, "_get_api_compatibility_facade", lambda: facade)
+
+    async def fake_restore(**kwargs: Any) -> None:
+        restore_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        kb_module,
+        "_restore_or_cleanup_collection_config_after_failed_ingest",
+        fake_restore,
+    )
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed")
+    )
+    user = User()
+    user.id = 7
+
+    updated = (
+        await kb_module._restore_or_cleanup_collection_config_after_failed_api_ingest(
+            api_result=api_result,
+            snapshot="snapshot",
+            collection_existed_before=True,
+            collection_name="demo",
+            user=user,
+            context="ingest",
+            successful_documents=1,
+            rollback_complete=False,
+        )
+    )
+
+    assert updated.rollback_complete is False
+    assert facade.rollback_complete_inputs == [(api_result, False)]
+    assert facade.single_cleanup_inputs == [(updated, 1)]
+    assert restore_calls == [
+        {
+            "snapshot": "snapshot",
+            "collection_existed_before": True,
+            "collection_name": "demo",
+            "user": user,
+            "context": "ingest",
+            "successful_documents": 3,
+            "side_effects_may_remain": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_api_failed_batch_ingest_config_cleanup_uses_api_outcome_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    facade = _Facade()
+    restore_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(kb_module, "_get_api_compatibility_facade", lambda: facade)
+
+    async def fake_restore(**kwargs: Any) -> None:
+        restore_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        kb_module,
+        "_restore_or_cleanup_collection_config_after_failed_ingest",
+        fake_restore,
+    )
+    api_results = [
+        KBApiOperationResult(result=IngestionResult(status="success", message="ok")),
+        KBApiOperationResult(result=IngestionResult(status="error", message="failed")),
+    ]
+    user = User()
+    user.id = 9
+
+    await kb_module._restore_or_cleanup_collection_config_after_failed_batch_api_ingest(
+        api_results=api_results,
+        snapshot="snapshot",
+        collection_existed_before=False,
+        collection_name="demo",
+        user=user,
+        context="ingest_cloud",
+        successful_documents=1,
+    )
+
+    assert facade.batch_cleanup_inputs == [(api_results, 1)]
+    assert restore_calls == [
+        {
+            "snapshot": "snapshot",
+            "collection_existed_before": False,
+            "collection_name": "demo",
+            "user": user,
+            "context": "ingest_cloud",
+            "successful_documents": 5,
+            "side_effects_may_remain": True,
+        }
+    ]
+
+
+def test_background_failed_ingest_config_cleanup_reuses_api_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.jobs import kb_tasks
+
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed")
+    )
+    user = User()
+    user.id = 11
+    db = object()
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(kb_tasks, "_get_job_user", lambda *args, **kwargs: user)
+
+    async def fake_api_helper(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        kb_module,
+        "_restore_or_cleanup_collection_config_after_failed_api_ingest",
+        fake_api_helper,
+    )
+
+    kb_tasks._restore_or_cleanup_failed_job_collection_config_after_api_ingest(
+        db,  # type: ignore[arg-type]
+        {
+            "collection": "job-kb",
+            "collection_existed_before": False,
+        },
+        api_result=api_result,
+        snapshot="snapshot",
+        context="background document ingest",
+        successful_documents=2,
+        rollback_complete=True,
+    )
+
+    assert calls == [
+        {
+            "api_result": api_result,
+            "snapshot": "snapshot",
+            "collection_existed_before": False,
+            "collection_name": "job-kb",
+            "user": user,
+            "context": "background document ingest",
+            "successful_documents": 2,
+            "rollback_complete": True,
+        }
+    ]
+
+
+def test_background_web_cleanup_keeps_early_exception_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.jobs import kb_tasks
+
+    fallback = MagicMock()
+    api_helper = MagicMock()
+    db = object()
+    payload = {"collection": "job-kb"}
+    monkeypatch.setattr(
+        kb_tasks,
+        "_restore_or_cleanup_failed_job_collection_config",
+        fallback,
+    )
+    monkeypatch.setattr(
+        kb_tasks,
+        "_restore_or_cleanup_failed_job_collection_config_after_api_ingest",
+        api_helper,
+    )
+
+    kb_tasks._cleanup_failed_web_collection_metadata_if_new(
+        db,  # type: ignore[arg-type]
+        payload,
+        snapshot="snapshot",
+    )
+
+    fallback.assert_called_once_with(
+        db,
+        payload,
+        snapshot="snapshot",
+        context="background web ingest",
+        successful_documents=0,
+    )
+    api_helper.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `KBApiCompatibilityFacade` for route-facing KB operations and wire `/api/kb` wrappers through it.
- Consume rollback operation outcomes for direct, cloud, web, and background ingest cleanup decisions.
- Preserve backend binding, delete, rename, parse pagination, and document cleanup compatibility through focused regression coverage.

Closes #506

## Validation
- `/home/jicheng/github/xagent/.venv/bin/pre-commit run --all-files`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/pytest -p no:cacheprovider tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py tests/web/test_kb_ingest_lifecycle.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src /home/jicheng/github/xagent/.venv/bin/pytest -p no:cacheprovider tests/web/test_background_jobs.py::test_kb_document_job_existing_collection_failure_restores_previous_config tests/web/test_background_jobs.py::test_kb_web_job_existing_collection_failure_restores_previous_config tests/web/test_background_jobs.py::test_kb_web_job_keeps_new_collection_metadata_when_side_effects_may_remain`

## Notes
- Local `tests/web/api/...` collection is blocked in this environment by missing `authlib`; this was present before this branch.