### PR TITLE
fix: add accessible titles to DialogContent and SheetContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ db.sqlite3-journal
 xagent_web.db
 xagent.db
 
+# xagent local data directory
+/.xagent_data/
+.xagent_data/
+
 # Test workspace directories
 test_workspace/
 test-task/

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Menu } from "lucide-react";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useI18n } from "@/contexts/i18n-context";
 import { getBrandingFromEnv } from "@/lib/branding";
 
@@ -87,6 +87,7 @@ export function AppHeader() {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
+            <SheetTitle className="sr-only">Navigation menu</SheetTitle>
             <Sidebar className="w-full border-r-0" allowCollapse={false} />
           </SheetContent>
         </Sheet>

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -83,11 +83,11 @@ export function AppHeader() {
           <SheetTrigger asChild>
             <Button variant="ghost" size="icon" className="xl:hidden">
               <Menu className="h-5 w-5" />
-              <span className="sr-only">Open navigation</span>
+              <span className="sr-only">{t("nav.openMenu")}</span>
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
-            <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+            <SheetTitle className="sr-only">{t("nav.menu")}</SheetTitle>
             <Sidebar className="w-full border-r-0" allowCollapse={false} />
           </SheetContent>
         </Sheet>

--- a/frontend/src/components/layout/mobile-header.tsx
+++ b/frontend/src/components/layout/mobile-header.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button"
 import {
   Sheet,
   SheetContent,
+  SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet"
 
@@ -42,6 +43,7 @@ export function MobileHeader() {
           </Button>
         </SheetTrigger>
         <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
+          <SheetTitle className="sr-only">Navigation menu</SheetTitle>
           <Sidebar className="w-full border-r-0" allowCollapse={false} />
         </SheetContent>
       </Sheet>

--- a/frontend/src/components/layout/mobile-header.tsx
+++ b/frontend/src/components/layout/mobile-header.tsx
@@ -7,6 +7,7 @@ import { Menu } from "lucide-react"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { Sidebar } from "@/components/layout/sidebar"
 import { Button } from "@/components/ui/button"
+import { useI18n } from "@/contexts/i18n-context"
 import {
   Sheet,
   SheetContent,
@@ -17,6 +18,7 @@ import {
 export function MobileHeader() {
   const pathname = usePathname()
   const branding = getBrandingFromEnv()
+  const { t } = useI18n()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   useEffect(() => {
@@ -39,11 +41,11 @@ export function MobileHeader() {
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" className="h-10 w-10">
             <Menu className="h-5 w-5" />
-            <span className="sr-only">Open navigation</span>
+            <span className="sr-only">{t("nav.openMenu")}</span>
           </Button>
         </SheetTrigger>
         <SheetContent side="left" className="w-[85vw] max-w-sm p-0">
-          <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+          <SheetTitle className="sr-only">{t("nav.menu")}</SheetTitle>
           <Sidebar className="w-full border-r-0" allowCollapse={false} />
         </SheetContent>
       </Sheet>

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { getApiUrl } from "@/lib/utils"
 import { Settings, Unlink, Plus } from "lucide-react"
@@ -159,9 +159,9 @@ export function OfficialMcpSettingsDialog({
             )}
           </div>
 
-          <h2 className="text-2xl font-bold text-slate-900 mb-3 tracking-tight">
+          <DialogTitle className="text-2xl font-bold text-slate-900 mb-3 tracking-tight">
             {app.name}
-          </h2>
+          </DialogTitle>
 
           {isGloballyConnected && app.connected_account && (
             <div className="mb-4 inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 border border-blue-100 text-blue-700 text-sm font-medium">

--- a/frontend/src/components/welcome-modal.tsx
+++ b/frontend/src/components/welcome-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
 import { useI18n } from "@/contexts/i18n-context";
 import { getBrandingFromEnv } from "@/lib/branding";
@@ -40,9 +40,9 @@ export function WelcomeModal() {
                     <span className="mb-3 text-[11px] font-bold uppercase tracking-[0.2em] text-primary sm:mb-4">
                         {t("dashboard.welcome.title", { appName: branding.appName.toUpperCase() })}
                     </span>
-                    <h2 className="mb-3 text-2xl font-extrabold tracking-tight text-foreground sm:text-3xl md:text-4xl">
+                    <DialogTitle className="mb-3 text-2xl font-extrabold tracking-tight text-foreground sm:text-3xl md:text-4xl">
                         {t("dashboard.welcome.heading")}
-                    </h2>
+                    </DialogTitle>
                     <p className="text-[14px] text-muted-foreground sm:text-[15px]">
                         {t("dashboard.welcome.subtitle")}
                     </p>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -65,6 +65,8 @@ const en = {
     templates: "Templates",
     channels: "Channels",
     more: "More",
+    menu: "Navigation menu",
+    openMenu: "Open navigation",
     sections: {
       agentDevelopment: "Agent Development",
       resources: "Resources",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -65,6 +65,8 @@ const zh = {
     templates: "模板",
     channels: "渠道",
     more: "更多",
+    menu: "导航菜单",
+    openMenu: "打开导航",
     sections: {
       agentDevelopment: "Agent 开发",
       resources: "资源",


### PR DESCRIPTION
Radix UI warns in development when DialogContent / SheetContent lacks a DialogTitle / SheetTitle child. Add the missing titles so screen readers get an accessible name for every modal/sheet:

- welcome-modal: promote visible <h2> heading to DialogTitle
- official-mcp-settings-dialog: promote visible <h2> to DialogTitle
- mobile-header / app-header: add sr-only "Navigation menu" SheetTitle (the sheet only contains a Sidebar, so a visible title would be redundant)

Also untrack .xagent_data/ in .gitignore so the local data directory stays out of git.