### PR TITLE
fix: normalize document search embedding responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ db.sqlite3-journal
 xagent_web.db
 xagent.db
 
+# xagent local data directory
+/.xagent_data/
+.xagent_data/
+
 # Test workspace directories
 test_workspace/
 test-task/

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/document_search.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import numbers
 import os
 from typing import (
     TYPE_CHECKING,
@@ -15,7 +14,6 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    cast,
 )
 
 import requests
@@ -42,6 +40,7 @@ from ..retrieval.search_dense import search_dense
 from ..retrieval.search_hybrid import _rrf_fusion, search_hybrid
 from ..retrieval.search_sparse import search_sparse
 from ..utils.config_utils import coerce_search_config
+from ..utils.embedding_utils import normalize_single_embedding
 from ..utils.model_resolver import resolve_embedding_adapter, resolve_rerank_adapter
 from ..utils.user_scope import resolve_user_scope
 
@@ -134,8 +133,15 @@ def _resolve_dashscope_rerank(
 def _encode_query_vector(adapter: BaseEmbedding, query_text: str) -> List[float]:
     """Encode query text into a single vector using embedding adapter.
 
+    Provider responses come in many shapes (``List[float]``, ``List[List[float]]``,
+    ``List[dict]`` with an ``"embedding"`` key, or even non-list types such as
+    ``numpy.ndarray``). Delegate to ``normalize_single_embedding`` so the
+    search path behaves consistently with the ingestion path, which already
+    uses the same helper.
+
     Raises:
-        VectorValidationError: If encoding fails or returns invalid data.
+        VectorValidationError: If encoding fails or the provider response
+            cannot be normalized to a single numeric vector.
     """
     try:
         raw_vector = adapter.encode(query_text)
@@ -144,27 +150,7 @@ def _encode_query_vector(adapter: BaseEmbedding, query_text: str) -> List[float]
             f"Embedding adapter failed to encode query: {exc}"
         ) from exc
 
-    if not isinstance(raw_vector, list):
-        raise VectorValidationError("Embedding provider returned invalid response type")
-
-    if not raw_vector:
-        raise VectorValidationError("Embedding provider returned empty vector")
-
-    first_item = raw_vector[0]
-    if isinstance(first_item, list):
-        # Treat as batch response
-        if len(raw_vector) != 1:
-            raise VectorValidationError(
-                "Embedding provider returned multiple vectors for single query"
-            )
-        vector = cast(List[float], first_item)
-    else:
-        vector = cast(List[float], raw_vector)
-
-    if not all(isinstance(value, numbers.Number) for value in vector):
-        raise VectorValidationError("Embedding vector contains non-numeric values")
-
-    return [float(value) for value in vector]
+    return normalize_single_embedding(raw_vector)
 
 
 def _serialize_warnings(warnings: Sequence) -> List[str]:

--- a/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
@@ -37,12 +37,54 @@ def normalize_raw_embedding_to_vectors(raw: Any) -> List[List[float]]:
             for debugging.
     """
     if not isinstance(raw, list):
-        raise VectorValidationError(
-            "Embedding response must be a list",
-            details={
-                "response_type": type(raw).__name__,
-            },
-        )
+        # Provider returned the raw OpenAI-compatible response dict (e.g.
+        # {"object": "list", "data": [...], "model": "..."}). Extract the
+        # list of embeddings from the "data" key.
+        if isinstance(raw, dict):
+            data = raw.get("data")
+            if isinstance(data, list):
+                raw = data
+            elif isinstance(raw.get("embedding"), list):
+                # Provider returned a single embedding item without the
+                # outer list wrapper, e.g.
+                # {"index": 0, "object": "embedding", "embedding": [...]}.
+                raw = [raw]
+            else:
+                # Likely an API error response (code / message).
+                msg = raw.get("message")
+                raise VectorValidationError(
+                    "Embedding response must be a list",
+                    details={
+                        "response_type": "dict",
+                        "dict_keys": list(raw.keys()),
+                        "error_code": raw.get("code"),
+                        "error_message": msg[:120] if isinstance(msg, str) else msg,
+                    },
+                )
+        else:
+            # Some providers (e.g. local Xinference, sentence-transformers
+            # wrappers) return numpy.ndarray. Convert via .tolist() so
+            # downstream sees the standard list shape.
+            tolist = getattr(raw, "tolist", None)
+            if callable(tolist):
+                converted = tolist()
+                if isinstance(converted, list):
+                    raw = converted
+                else:
+                    raise VectorValidationError(
+                        "Embedding response must be a list",
+                        details={
+                            "response_type": type(raw).__name__,
+                            "tolist_result_type": type(converted).__name__,
+                        },
+                    )
+            else:
+                raise VectorValidationError(
+                    "Embedding response must be a list",
+                    details={
+                        "response_type": type(raw).__name__,
+                    },
+                )
 
     if not raw:
         return []

--- a/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
@@ -8,6 +8,7 @@ when provider returns list of dicts with 'embedding' key).
 
 from __future__ import annotations
 
+import numbers
 from typing import Any, List
 
 from ..core.exceptions import VectorValidationError
@@ -98,9 +99,9 @@ def normalize_raw_embedding_to_vectors(raw: Any) -> List[List[float]]:
 
     first = raw[0]
 
-    # Single vector: List[float]
-    if isinstance(first, (int, float)):
-        if not all(isinstance(x, (int, float)) for x in raw):
+    # Single vector: List[float] (or List[numeric] — numpy scalars etc.)
+    if isinstance(first, numbers.Number):
+        if not all(isinstance(x, numbers.Number) for x in raw):
             raise VectorValidationError(
                 "Embedding response is a list but not all elements are numbers",
                 details={

--- a/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
@@ -52,7 +52,11 @@ def normalize_raw_embedding_to_vectors(raw: Any) -> List[List[float]]:
             else:
                 # Likely an API error response. OpenAI-compatible providers
                 # often wrap errors in an outer "error" dict: {"error": {...}}.
-                error_data = raw.get("error") if isinstance(raw.get("error"), dict) else raw
+                nested_error = raw.get("error")
+                if isinstance(nested_error, dict):
+                    error_data = nested_error
+                else:
+                    error_data = raw
                 msg = error_data.get("message") or raw.get("message")
                 code = error_data.get("code") or raw.get("code")
                 raise VectorValidationError(

--- a/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/embedding_utils.py
@@ -50,14 +50,17 @@ def normalize_raw_embedding_to_vectors(raw: Any) -> List[List[float]]:
                 # {"index": 0, "object": "embedding", "embedding": [...]}.
                 raw = [raw]
             else:
-                # Likely an API error response (code / message).
-                msg = raw.get("message")
+                # Likely an API error response. OpenAI-compatible providers
+                # often wrap errors in an outer "error" dict: {"error": {...}}.
+                error_data = raw.get("error") if isinstance(raw.get("error"), dict) else raw
+                msg = error_data.get("message") or raw.get("message")
+                code = error_data.get("code") or raw.get("code")
                 raise VectorValidationError(
                     "Embedding response must be a list",
                     details={
                         "response_type": "dict",
                         "dict_keys": list(raw.keys()),
-                        "error_code": raw.get("code"),
+                        "error_code": code,
                         "error_message": msg[:120] if isinstance(msg, str) else msg,
                     },
                 )

--- a/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
@@ -49,6 +49,19 @@ class TestNormalizeRawEmbeddingToVectors:
             normalize_raw_embedding_to_vectors({"code": "X", "message": "y"})
         assert "list" in exc_info.value.message
         assert exc_info.value.details.get("response_type") == "dict"
+        assert exc_info.value.details.get("error_code") == "X"
+        assert exc_info.value.details.get("error_message") == "y"
+
+    def test_nested_openai_error_dict_is_unwrapped(self) -> None:
+        # OpenAI-compatible providers wrap errors inside an "error" object:
+        # {"error": {"code": "...", "message": "..."}}. The helper should
+        # surface those fields in details instead of swallowing them.
+        with pytest.raises(VectorValidationError) as exc_info:
+            normalize_raw_embedding_to_vectors(
+                {"error": {"code": "invalid_key", "message": "Unauthorized"}}
+            )
+        assert exc_info.value.details.get("error_code") == "invalid_key"
+        assert exc_info.value.details.get("error_message") == "Unauthorized"
 
     def test_openai_response_dict_with_data_is_unwrapped(self) -> None:
         # Provider returned the raw OpenAI-compatible response envelope

--- a/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
@@ -69,9 +69,7 @@ class TestNormalizeRawEmbeddingToVectors:
         # helper should transparently unwrap the "data" key.
         raw = {
             "object": "list",
-            "data": [
-                {"index": 0, "object": "embedding", "embedding": [0.1, 0.2]}
-            ],
+            "data": [{"index": 0, "object": "embedding", "embedding": [0.1, 0.2]}],
             "model": "text-embedding-3-small",
         }
         assert normalize_raw_embedding_to_vectors(raw) == [[0.1, 0.2]]

--- a/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
@@ -100,6 +100,12 @@ class TestNormalizeSingleEmbedding:
         got = normalize_single_embedding([raw])
         assert got == [0.1, -0.046]
 
+    def test_numpy_scalar_list(self) -> None:
+        np = pytest.importorskip("numpy")
+        raw = [np.float32(0.3), np.float32(-0.7)]
+        got = normalize_single_embedding(raw)
+        assert got == pytest.approx([0.3, -0.7])
+
     def test_empty_list_raises(self) -> None:
         with pytest.raises(VectorValidationError) as exc_info:
             normalize_single_embedding([])

--- a/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_embedding_utils.py
@@ -42,10 +42,26 @@ class TestNormalizeRawEmbeddingToVectors:
         assert got == [[1.0, 2.0]]
 
     def test_non_list_raises(self) -> None:
+        # An API-error dict (no "data" key) should still surface as a
+        # VectorValidationError with response_type=dict so callers can
+        # see why the provider rejected the request.
         with pytest.raises(VectorValidationError) as exc_info:
-            normalize_raw_embedding_to_vectors({"data": []})
+            normalize_raw_embedding_to_vectors({"code": "X", "message": "y"})
         assert "list" in exc_info.value.message
         assert exc_info.value.details.get("response_type") == "dict"
+
+    def test_openai_response_dict_with_data_is_unwrapped(self) -> None:
+        # Provider returned the raw OpenAI-compatible response envelope
+        # ({"object": "list", "data": [...]}) instead of just data; the
+        # helper should transparently unwrap the "data" key.
+        raw = {
+            "object": "list",
+            "data": [
+                {"index": 0, "object": "embedding", "embedding": [0.1, 0.2]}
+            ],
+            "model": "text-embedding-3-small",
+        }
+        assert normalize_raw_embedding_to_vectors(raw) == [[0.1, 0.2]]
 
     def test_list_of_dict_missing_embedding_key_raises(self) -> None:
         with pytest.raises(VectorValidationError) as exc_info:


### PR DESCRIPTION

even though the same embedding adapter worked fine for document **ingestion**.

### Root cause
`document_search._encode_query_vector` had its own strict `isinstance(raw, list)`
check, while `document_ingestion` already uses the shared
`normalize_single_embedding` / `normalize_raw_embedding_to_vectors` helpers.
Those helpers also did not yet cover several real provider response shapes:

- `numpy.ndarray` from sentence-transformers / local Xinference wrappers
- OpenAI-compatible response envelope `{"object": "list", "data": [...]}`
- Single embedding item `{"index": 0, "object": "embedding", "embedding": [...]}` (the one that actually triggered the bug)
- Error response dict `{"code": "...", "message": "..."}` without useful context

### What this PR changes
1. **`document_search._encode_query_vector`** now delegates to
   `normalize_single_embedding`, so search and ingestion share the same
   normalization path. Removes the now-unused `numbers` / `cast` imports.
2. **`normalize_raw_embedding_to_vectors`** gains four normalization branches
   for non-list inputs:
   - `dict` with `data: list` → `raw = raw["data"]`
   - `dict` with `embedding: list` (single item) → `raw = [raw]`
   - `dict` carrying error `code` / `message` → raised with readable details
   - Any object exposing `.tolist()` (e.g. `numpy.ndarray`) → converted to list
3. **Tests**: updates the existing `test_non_list_raises` to cover the
   error-dict path and adds `test_openai_response_dict_with_data_is_unwrapped`.
4. **`.gitignore`**: ignores the local `.xagent_data/` directory.

### Verification
- All 13 `test_embedding_utils.py` unit tests pass.
- Reproduced the original failure with a docx KB; after the fix the
  search succeeds end-to-end.

### Scope
Only touches the RAG embedding-response parsing. No changes to provider
calls, vector-store schemas, or public APIs.