### PR TITLE
refactor(kb): unify ingest rollback facade

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/__init__.py
@@ -3,6 +3,7 @@
 from .api_compatibility import (
     KBApiCompatibilityFacade,
     KBApiFailedIngestCleanupDecision,
+    KBApiFailedIngestRollbackResult,
     KBApiOperationResult,
 )
 from .collection_handle import KBHandleProvider, LanceDBCollectionHandle
@@ -55,6 +56,7 @@ __all__ = [
     "KBAccessMode",
     "KBApiCompatibilityFacade",
     "KBApiFailedIngestCleanupDecision",
+    "KBApiFailedIngestRollbackResult",
     "KBApiOperationResult",
     "KBBackendCapabilities",
     "KBCollectionContext",

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -47,6 +47,13 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+def _close_awaitable_if_possible(value: Any) -> None:
+    """Close coroutine-like objects that cannot be awaited by a sync caller."""
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
 def _has_store_method(metadata_store: object, name: str) -> bool:
     """Return True when the store exposes a callable method."""
     return callable(getattr(metadata_store, name, None))
@@ -264,6 +271,7 @@ class KBApiCompatibilityFacade:
             with self._storage_context():
                 result = rollback()
                 if inspect.isawaitable(result):
+                    _close_awaitable_if_possible(result)
                     raise TypeError(
                         "run_failed_ingest_rollback_async must be used for "
                         "awaitable rollback callbacks"

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -69,6 +69,19 @@ class KBApiFailedIngestCleanupDecision:
     side_effects_may_remain: bool = False
 
 
+@dataclass(frozen=True)
+class KBApiFailedIngestRollbackResult(Generic[T_Result]):
+    """Result of executing API-level rollback for a failed ingest operation."""
+
+    operation_result: KBApiOperationResult[T_Result]
+    error: Exception | None = None
+
+    @property
+    def rollback_complete(self) -> bool:
+        """Return whether the rollback callback completed without an exception."""
+        return self.error is None
+
+
 class KBApiCompatibilityFacade:
     """Compatibility boundary for KB API route semantics.
 
@@ -204,9 +217,101 @@ class KBApiCompatibilityFacade:
     def with_rollback_complete(
         operation_result: KBApiOperationResult[T_Result],
         rollback_complete: bool,
+        *,
+        force: bool = False,
     ) -> KBApiOperationResult[T_Result]:
         """Record whether API-level compensation completed after a failed operation."""
-        return replace(operation_result, rollback_complete=rollback_complete)
+        outcome = operation_result.operation_outcome
+        if outcome is None or (outcome.status == "success" and not force):
+            return replace(operation_result, rollback_complete=rollback_complete)
+
+        rollback_status: RollbackStatus
+        if rollback_complete:
+            if outcome.rollback_status is RollbackStatus.SKIPPED_BY_POLICY:
+                rollback_status = outcome.rollback_status
+            else:
+                rollback_status = (
+                    RollbackStatus.COMPLETE
+                    if (
+                        outcome.compensation_steps
+                        or outcome.child_outcomes
+                        or outcome.rollback_status is RollbackStatus.INCOMPLETE
+                    )
+                    else outcome.rollback_status
+                )
+            side_effects_may_remain = False
+        else:
+            rollback_status = RollbackStatus.INCOMPLETE
+            side_effects_may_remain = True
+
+        return replace(
+            operation_result,
+            operation_outcome=replace(
+                outcome,
+                rollback_status=rollback_status,
+                side_effects_may_remain=side_effects_may_remain,
+            ),
+            rollback_complete=rollback_complete,
+        )
+
+    def run_failed_ingest_rollback(
+        self,
+        operation_result: KBApiOperationResult[T_Result],
+        rollback: Callable[[], Any],
+    ) -> KBApiFailedIngestRollbackResult[T_Result]:
+        """Execute sync failed-ingest rollback and update operation outcome state."""
+        try:
+            with self._storage_context():
+                result = rollback()
+                if inspect.isawaitable(result):
+                    raise TypeError(
+                        "run_failed_ingest_rollback_async must be used for "
+                        "awaitable rollback callbacks"
+                    )
+        except Exception as exc:
+            return KBApiFailedIngestRollbackResult(
+                operation_result=self.with_rollback_complete(
+                    operation_result,
+                    False,
+                    force=True,
+                ),
+                error=exc,
+            )
+
+        return KBApiFailedIngestRollbackResult(
+            operation_result=self.with_rollback_complete(
+                operation_result,
+                True,
+                force=True,
+            )
+        )
+
+    async def run_failed_ingest_rollback_async(
+        self,
+        operation_result: KBApiOperationResult[T_Result],
+        rollback: Callable[[], Any],
+    ) -> KBApiFailedIngestRollbackResult[T_Result]:
+        """Execute async failed-ingest rollback and update operation outcome state."""
+        try:
+            with self._storage_context():
+                await _maybe_await(rollback())
+        except Exception as exc:
+            return KBApiFailedIngestRollbackResult(
+                operation_result=self.with_rollback_complete(
+                    operation_result,
+                    False,
+                    force=True,
+                ),
+                error=exc,
+            )
+
+        return KBApiFailedIngestRollbackResult(
+            operation_result=self.with_rollback_complete(
+                operation_result,
+                True,
+                force=True,
+            )
+        )
 
     def failed_ingest_cleanup_decision(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/api_compatibility.py
@@ -30,7 +30,11 @@ from ..core.schemas import (
     WebIngestionResult,
 )
 from .models import KBStorageBackend
-from .operation_compatibility import KBOperationOutcome, RollbackStatus
+from .operation_compatibility import (
+    KBOperationOutcome,
+    RollbackStatus,
+    _close_awaitable_if_possible,
+)
 from .pipeline_compatibility import KB_STORAGE_METADATA_KEY
 
 if TYPE_CHECKING:
@@ -45,13 +49,6 @@ async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
     return value
-
-
-def _close_awaitable_if_possible(value: Any) -> None:
-    """Close coroutine-like objects that cannot be awaited by a sync caller."""
-    close = getattr(value, "close", None)
-    if callable(close):
-        close()
 
 
 def _has_store_method(metadata_store: object, name: str) -> bool:

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -208,7 +208,7 @@ class KBOperation:
             attempted = True
             try:
                 callback()
-            except BaseException as exc:  # noqa: BLE001 - preserve retryability
+            except Exception as exc:  # noqa: BLE001 - preserve retryability
                 errors.append(exc)
                 self.warnings.append(f"{step.name}: {_format_exception_warning(exc)}")
             else:

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -218,7 +218,7 @@ class KBOperation:
             side_effects_may_remain = self._infer_side_effects_may_remain(status)
 
         if rollback_status is None:
-            rollback_status = self._infer_rollback_status(
+            rollback_status = self.infer_rollback_status(
                 status,
                 side_effects_may_remain=side_effects_may_remain,
             )
@@ -246,12 +246,13 @@ class KBOperation:
             return self._compensation_errors_pending
         return self.has_side_effects()
 
-    def _infer_rollback_status(
+    def infer_rollback_status(
         self,
         status: str,
         *,
         side_effects_may_remain: bool,
     ) -> RollbackStatus:
+        """Infer rollback status from current compensation and child state."""
         if status == "success":
             return RollbackStatus.NOT_NEEDED
 
@@ -276,6 +277,8 @@ class KBOperation:
             for child in self.child_outcomes
         ):
             return RollbackStatus.COMPLETE
+        if self.has_side_effects():
+            return RollbackStatus.INCOMPLETE
         return RollbackStatus.NOT_NEEDED
 
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
 
@@ -96,6 +96,10 @@ class KBOperation:
         self.warnings: list[str] = []
         self.side_effects_may_remain = False
         self._idempotency_keys: set[str] = set()
+        self._compensation_callbacks: dict[str, Callable[[], Any]] = {}
+        self._completed_compensation_keys: set[str] = set()
+        self._compensation_attempted = False
+        self._compensation_errors_pending = False
         self._outcome: KBOperationOutcome | None = None
 
     @property
@@ -110,6 +114,11 @@ class KBOperation:
             for child in self.child_outcomes
         )
 
+    @property
+    def compensation_attempted(self) -> bool:
+        """Return whether this operation attempted executable compensation."""
+        return self._compensation_attempted
+
     def update_details(self, **details: Any) -> None:
         """Merge operation metadata captured during execution."""
         self.details.update(details)
@@ -121,14 +130,19 @@ class KBOperation:
         plane: SideEffectPlane,
         payload: Optional[Mapping[str, Any]] = None,
         idempotency_key: Optional[str] = None,
+        compensation: Optional[Callable[[], Any]] = None,
     ) -> None:
         """Register an idempotent compensation boundary for one side effect."""
         step_payload = dict(payload or {})
         dedupe_key = idempotency_key or f"{plane.value}:{name}:{step_payload!r}"
         if dedupe_key in self._idempotency_keys:
+            if compensation is not None:
+                self._compensation_callbacks.setdefault(dedupe_key, compensation)
             return
 
         self._idempotency_keys.add(dedupe_key)
+        if compensation is not None:
+            self._compensation_callbacks[dedupe_key] = compensation
         self.compensation_steps.append(
             CompensationStep(
                 name=name,
@@ -141,6 +155,49 @@ class KBOperation:
     def add_child_outcome(self, outcome: KBOperationOutcome) -> None:
         """Attach a finalized child operation outcome."""
         self.child_outcomes.append(outcome)
+
+    def execute_compensations(
+        self,
+        *,
+        step_names: Optional[set[str]] = None,
+        planes: Optional[set[SideEffectPlane]] = None,
+    ) -> tuple[BaseException, ...]:
+        """Execute registered compensation callbacks in LIFO order.
+
+        Callbacks are kept outside the immutable outcome so public result shapes
+        stay serializable. Successful callbacks are not re-run, while failed
+        callbacks remain retryable because the idempotency key stays registered.
+        """
+        errors: list[BaseException] = []
+        attempted = False
+        for step in reversed(self.compensation_steps):
+            if step_names is not None and step.name not in step_names:
+                continue
+            if planes is not None and step.plane not in planes:
+                continue
+            if step.idempotency_key is None:
+                continue
+            if step.idempotency_key in self._completed_compensation_keys:
+                continue
+
+            callback = self._compensation_callbacks.get(step.idempotency_key)
+            if callback is None:
+                continue
+
+            self._compensation_attempted = True
+            attempted = True
+            try:
+                callback()
+            except BaseException as exc:  # noqa: BLE001 - preserve retryability
+                errors.append(exc)
+                self.warnings.append(f"{step.name}: {_format_exception_warning(exc)}")
+            else:
+                self._completed_compensation_keys.add(step.idempotency_key)
+
+        if attempted:
+            self._compensation_errors_pending = bool(errors)
+            self.side_effects_may_remain = bool(errors)
+        return tuple(errors)
 
     def finish(
         self,
@@ -185,6 +242,8 @@ class KBOperation:
     def _infer_side_effects_may_remain(self, status: str) -> bool:
         if status == "success":
             return False
+        if self._compensation_attempted:
+            return self._compensation_errors_pending
         return self.has_side_effects()
 
     def _infer_rollback_status(
@@ -210,6 +269,13 @@ class KBOperation:
 
         if side_effects_may_remain:
             return RollbackStatus.INCOMPLETE
+        if self._compensation_attempted and self.has_side_effects():
+            return RollbackStatus.COMPLETE
+        if any(
+            child.rollback_status is RollbackStatus.COMPLETE
+            for child in self.child_outcomes
+        ):
+            return RollbackStatus.COMPLETE
         return RollbackStatus.NOT_NEEDED
 
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -184,6 +184,34 @@ class KBOperation:
         """Attach a finalized child operation outcome."""
         self.child_outcomes.append(outcome)
 
+    def mark_compensated_steps(
+        self,
+        *,
+        step_names: Optional[set[str]] = None,
+        planes: Optional[set[SideEffectPlane]] = None,
+    ) -> int:
+        """Mark steps covered by a broader successful compensation callback."""
+        if step_names is None and planes is None:
+            return 0
+
+        completed = 0
+        for step in self.compensation_steps:
+            if step_names is not None and step.name not in step_names:
+                continue
+            if planes is not None and step.plane not in planes:
+                continue
+            if step.idempotency_key is None:
+                continue
+            if step.idempotency_key in self._completed_compensation_keys:
+                continue
+
+            self._completed_compensation_keys.add(step.idempotency_key)
+            completed += 1
+
+        if completed:
+            self.side_effects_may_remain = self.has_uncompensated_side_effects()
+        return completed
+
     def execute_compensations(
         self,
         *,

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -347,11 +347,6 @@ class KBOperationCompatibilityFacade:
             if operation.outcome is None:
                 operation.finish(
                     status="error",
-                    rollback_status=(
-                        RollbackStatus.INCOMPLETE
-                        if operation.has_side_effects()
-                        else RollbackStatus.NOT_NEEDED
-                    ),
                     side_effects_may_remain=operation.has_side_effects(),
                     warnings=(_format_exception_warning(exc),),
                 )

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -99,7 +99,6 @@ class KBOperation:
         self._compensation_callbacks: dict[str, Callable[[], Any]] = {}
         self._completed_compensation_keys: set[str] = set()
         self._compensation_attempted = False
-        self._compensation_errors_pending = False
         self._outcome: KBOperationOutcome | None = None
 
     @property
@@ -111,6 +110,27 @@ class KBOperation:
         """Return whether this operation or any child recorded side effects."""
         return bool(self.compensation_steps) or any(
             child.side_effects_may_remain or child.compensation_steps
+            for child in self.child_outcomes
+        )
+
+    def uncompensated_steps(self) -> tuple[CompensationStep, ...]:
+        """Return own side effects not covered by successful compensation."""
+        return tuple(
+            step
+            for step in self.compensation_steps
+            if (
+                step.idempotency_key is None
+                or step.idempotency_key not in self._completed_compensation_keys
+            )
+        )
+
+    def has_uncompensated_side_effects(self) -> bool:
+        """Return whether any recorded side effect still lacks compensation."""
+        if self.uncompensated_steps():
+            return True
+        return any(
+            child.side_effects_may_remain
+            or child.rollback_status is RollbackStatus.INCOMPLETE
             for child in self.child_outcomes
         )
 
@@ -195,7 +215,6 @@ class KBOperation:
                 self._completed_compensation_keys.add(step.idempotency_key)
 
         if attempted:
-            self._compensation_errors_pending = bool(errors)
             self.side_effects_may_remain = bool(errors)
         return tuple(errors)
 
@@ -214,8 +233,13 @@ class KBOperation:
         if warnings:
             self.warnings.extend(warnings)
 
+        inferred_side_effects_may_remain = self._infer_side_effects_may_remain(status)
         if side_effects_may_remain is None:
-            side_effects_may_remain = self._infer_side_effects_may_remain(status)
+            side_effects_may_remain = inferred_side_effects_may_remain
+        elif status != "success":
+            side_effects_may_remain = (
+                side_effects_may_remain or inferred_side_effects_may_remain
+            )
 
         if rollback_status is None:
             rollback_status = self.infer_rollback_status(
@@ -242,9 +266,7 @@ class KBOperation:
     def _infer_side_effects_may_remain(self, status: str) -> bool:
         if status == "success":
             return False
-        if self._compensation_attempted:
-            return self._compensation_errors_pending
-        return self.has_side_effects()
+        return self.has_uncompensated_side_effects()
 
     def infer_rollback_status(
         self,
@@ -268,7 +290,7 @@ class KBOperation:
         ):
             return RollbackStatus.SKIPPED_BY_POLICY
 
-        if side_effects_may_remain:
+        if side_effects_may_remain or self.has_uncompensated_side_effects():
             return RollbackStatus.INCOMPLETE
         if self._compensation_attempted and self.has_side_effects():
             return RollbackStatus.COMPLETE

--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 from uuid import uuid4
 
 
@@ -72,6 +73,13 @@ class KBOperationOutcome:
         return tuple(reversed(self.compensation_steps))
 
 
+def _close_awaitable_if_possible(value: Any) -> None:
+    """Close coroutine-like objects that cannot be awaited by a sync caller."""
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
 class KBOperation:
     """Mutable operation builder stored only in the current execution context."""
 
@@ -96,7 +104,7 @@ class KBOperation:
         self.warnings: list[str] = []
         self.side_effects_may_remain = False
         self._idempotency_keys: set[str] = set()
-        self._compensation_callbacks: dict[str, Callable[[], Any]] = {}
+        self._compensation_callbacks: dict[str, Callable[[], None]] = {}
         self._completed_compensation_keys: set[str] = set()
         self._compensation_attempted = False
         self._outcome: KBOperationOutcome | None = None
@@ -150,7 +158,7 @@ class KBOperation:
         plane: SideEffectPlane,
         payload: Optional[Mapping[str, Any]] = None,
         idempotency_key: Optional[str] = None,
-        compensation: Optional[Callable[[], Any]] = None,
+        compensation: Optional[Callable[[], None]] = None,
     ) -> None:
         """Register an idempotent compensation boundary for one side effect."""
         step_payload = dict(payload or {})
@@ -207,7 +215,13 @@ class KBOperation:
             self._compensation_attempted = True
             attempted = True
             try:
-                callback()
+                result = cast(Callable[[], Any], callback)()
+                if inspect.isawaitable(result):
+                    _close_awaitable_if_possible(result)
+                    raise TypeError(
+                        "Async compensation callback is not supported in synchronous "
+                        f"execute_compensations for step {step.name}"
+                    )
             except Exception as exc:  # noqa: BLE001 - preserve retryability
                 errors.append(exc)
                 self.warnings.append(f"{step.name}: {_format_exception_warning(exc)}")

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -421,12 +421,9 @@ class KBPipelineCompatibilityFacade:
 
         planes: set[SideEffectPlane] = set()
         for raw_plane in raw_planes:
-            if isinstance(raw_plane, SideEffectPlane):
-                planes.add(raw_plane)
-                continue
             try:
-                planes.add(SideEffectPlane(str(raw_plane)))
-            except ValueError:
+                planes.add(SideEffectPlane(raw_plane))
+            except (TypeError, ValueError):
                 continue
         return planes
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -20,7 +20,6 @@ from .operation_compatibility import (
     KBOperation,
     KBOperationCompatibilityFacade,
     PersistencePolicy,
-    RollbackStatus,
     SideEffectPlane,
 )
 
@@ -566,14 +565,12 @@ class KBPipelineCompatibilityFacade:
         side_effects_may_remain = (
             result.status != "success" and operation.has_side_effects()
         )
-        rollback_status = (
-            RollbackStatus.NOT_NEEDED
-            if result.status == "success" or not side_effects_may_remain
-            else RollbackStatus.INCOMPLETE
-        )
         operation.finish(
             status=result.status,
-            rollback_status=rollback_status,
+            rollback_status=operation.infer_rollback_status(
+                result.status,
+                side_effects_may_remain=side_effects_may_remain,
+            ),
             side_effects_may_remain=side_effects_may_remain,
             details={"message": result.message},
         )

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -386,7 +386,7 @@ class KBPipelineCompatibilityFacade:
         file_id: Optional[str],
         reason: str = "file_handler",
         extra_payload: Optional[Mapping[str, Any]] = None,
-        compensation: Optional[Callable[[], Any]] = None,
+        compensation: Optional[Callable[[], None]] = None,
     ) -> None:
         if operation is None:
             return

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -423,19 +423,12 @@ class KBPipelineCompatibilityFacade:
             side_effects_may_remain = (
                 status != "success" and operation.has_side_effects()
             )
-        if status == "success":
-            rollback_status = RollbackStatus.NOT_NEEDED
-        elif side_effects_may_remain:
-            rollback_status = RollbackStatus.INCOMPLETE
-        elif operation.compensation_attempted and operation.has_side_effects():
-            rollback_status = RollbackStatus.COMPLETE
-        elif operation.has_side_effects():
-            rollback_status = RollbackStatus.INCOMPLETE
-        else:
-            rollback_status = RollbackStatus.NOT_NEEDED
         operation.finish(
             status=status,
-            rollback_status=rollback_status,
+            rollback_status=operation.infer_rollback_status(
+                status,
+                side_effects_may_remain=side_effects_may_remain,
+            ),
             side_effects_may_remain=side_effects_may_remain,
             details={"message": message},
         )
@@ -599,38 +592,20 @@ class KBPipelineCompatibilityFacade:
         own_side_effects_may_remain = bool(operation.compensation_steps) and not (
             operation.compensation_attempted
         )
-        successful_child_count = sum(
-            1 for child in operation.child_outcomes if child.status == "success"
-        )
-        failed_child_count = sum(
-            1 for child in operation.child_outcomes if child.status != "success"
-        )
 
         if result.status == "success":
-            rollback_status = RollbackStatus.NOT_NEEDED
             side_effects_may_remain = False
-        elif successful_child_count > 0 and failed_child_count > 0:
-            rollback_status = RollbackStatus.SKIPPED_BY_POLICY
-            side_effects_may_remain = child_side_effects_may_remain
         else:
             side_effects_may_remain = (
                 child_side_effects_may_remain or own_side_effects_may_remain
             )
-            if side_effects_may_remain:
-                rollback_status = RollbackStatus.INCOMPLETE
-            elif any(
-                child.rollback_status is RollbackStatus.COMPLETE
-                for child in operation.child_outcomes
-            ):
-                rollback_status = RollbackStatus.COMPLETE
-            elif operation.has_side_effects():
-                rollback_status = RollbackStatus.INCOMPLETE
-            else:
-                rollback_status = RollbackStatus.NOT_NEEDED
 
         operation.finish(
             status=result.status,
-            rollback_status=rollback_status,
+            rollback_status=operation.infer_rollback_status(
+                result.status,
+                side_effects_may_remain=side_effects_may_remain,
+            ),
             side_effects_may_remain=side_effects_may_remain,
             details={
                 "documents_created": result.documents_created,

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -200,7 +200,8 @@ class KBPipelineCompatibilityFacade:
                     is_admin=is_admin,
                 )
                 self.ensure_collection_backend_binding(collection)
-                self._finish_document_ingestion_outcome(operation, result)
+                if self._should_finish_document_ingestion_operation(operation):
+                    self._finish_document_ingestion_outcome(operation, result)
                 return result
 
     def run_document_ingestion(
@@ -251,7 +252,8 @@ class KBPipelineCompatibilityFacade:
                         is_admin=is_admin,
                     )
                     self.ensure_collection_backend_binding(collection)
-                    self._finish_document_ingestion_outcome(operation, result)
+                    if self._should_finish_document_ingestion_operation(operation):
+                        self._finish_document_ingestion_outcome(operation, result)
                 elif operation is None:
                     self.ensure_collection_backend_binding(collection)
                 return result
@@ -373,20 +375,38 @@ class KBPipelineCompatibilityFacade:
         file_path: Optional[str],
         file_id: Optional[str],
         reason: str = "file_handler",
+        extra_payload: Optional[Mapping[str, Any]] = None,
+        compensation: Optional[Callable[[], Any]] = None,
     ) -> None:
         if operation is None:
             return
+        payload = {
+            "collection": collection,
+            "url": url,
+            "file_path": file_path,
+            "file_id": file_id,
+            "reason": reason,
+        }
+        if extra_payload:
+            payload.update(dict(extra_payload))
         operation.record_side_effect(
             name="cleanup_web_page_persistence",
             plane=SideEffectPlane.FILE,
-            payload={
-                "collection": collection,
-                "url": url,
-                "file_path": file_path,
-                "file_id": file_id,
-                "reason": reason,
-            },
+            payload=payload,
             idempotency_key=f"file:{collection}:{file_id or file_path or url}",
+            compensation=compensation,
+        )
+
+    @staticmethod
+    def compensate_web_page_file_side_effect(
+        operation: KBOperation | None,
+    ) -> tuple[BaseException, ...]:
+        """Execute registered web-file compensation callbacks for a page."""
+        if operation is None or operation.outcome is not None:
+            return ()
+        return operation.execute_compensations(
+            step_names={"cleanup_web_page_persistence"},
+            planes={SideEffectPlane.FILE},
         )
 
     @staticmethod
@@ -403,11 +423,16 @@ class KBPipelineCompatibilityFacade:
             side_effects_may_remain = (
                 status != "success" and operation.has_side_effects()
             )
-        rollback_status = (
-            RollbackStatus.NOT_NEEDED
-            if status == "success" or not side_effects_may_remain
-            else RollbackStatus.INCOMPLETE
-        )
+        if status == "success":
+            rollback_status = RollbackStatus.NOT_NEEDED
+        elif side_effects_may_remain:
+            rollback_status = RollbackStatus.INCOMPLETE
+        elif operation.compensation_attempted and operation.has_side_effects():
+            rollback_status = RollbackStatus.COMPLETE
+        elif operation.has_side_effects():
+            rollback_status = RollbackStatus.INCOMPLETE
+        else:
+            rollback_status = RollbackStatus.NOT_NEEDED
         operation.finish(
             status=status,
             rollback_status=rollback_status,
@@ -526,6 +551,19 @@ class KBPipelineCompatibilityFacade:
             )
 
     @staticmethod
+    def _should_finish_document_ingestion_operation(
+        operation: KBOperation | None,
+    ) -> bool:
+        if operation is None:
+            return False
+        if operation.operation_type == "document_ingestion":
+            return True
+        return (
+            operation.operation_type == "web_page_ingestion"
+            and "url" not in operation.details
+        )
+
+    @staticmethod
     def _finish_document_ingestion_outcome(
         operation: KBOperation | None,
         result: IngestionResult,
@@ -558,6 +596,9 @@ class KBPipelineCompatibilityFacade:
         child_side_effects_may_remain = any(
             child.side_effects_may_remain for child in operation.child_outcomes
         )
+        own_side_effects_may_remain = bool(operation.compensation_steps) and not (
+            operation.compensation_attempted
+        )
         successful_child_count = sum(
             1 for child in operation.child_outcomes if child.status == "success"
         )
@@ -573,13 +614,19 @@ class KBPipelineCompatibilityFacade:
             side_effects_may_remain = child_side_effects_may_remain
         else:
             side_effects_may_remain = (
-                child_side_effects_may_remain or operation.has_side_effects()
+                child_side_effects_may_remain or own_side_effects_may_remain
             )
-            rollback_status = (
-                RollbackStatus.INCOMPLETE
-                if side_effects_may_remain
-                else RollbackStatus.NOT_NEEDED
-            )
+            if side_effects_may_remain:
+                rollback_status = RollbackStatus.INCOMPLETE
+            elif any(
+                child.rollback_status is RollbackStatus.COMPLETE
+                for child in operation.child_outcomes
+            ):
+                rollback_status = RollbackStatus.COMPLETE
+            elif operation.has_side_effects():
+                rollback_status = RollbackStatus.INCOMPLETE
+            else:
+                rollback_status = RollbackStatus.NOT_NEEDED
 
         operation.finish(
             status=result.status,

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .storage_shim import KBStorageShimCompatibilityFacade
 
 KB_STORAGE_METADATA_KEY = "kb_storage"
+WEB_ROLLBACK_COMPENSATED_PLANES_KEY = "compensated_side_effect_planes"
 
 
 class KBPipelineCompatibilityFacade:
@@ -406,6 +407,44 @@ class KBPipelineCompatibilityFacade:
             idempotency_key=f"file:{collection}:{file_id or file_path or url}",
             compensation=compensation,
         )
+
+    @staticmethod
+    def _compensated_side_effect_planes(
+        payload: Optional[Mapping[str, Any]],
+    ) -> set[SideEffectPlane]:
+        if not payload:
+            return set()
+
+        raw_planes = payload.get(WEB_ROLLBACK_COMPENSATED_PLANES_KEY)
+        if not isinstance(raw_planes, (list, tuple, set)):
+            return set()
+
+        planes: set[SideEffectPlane] = set()
+        for raw_plane in raw_planes:
+            if isinstance(raw_plane, SideEffectPlane):
+                planes.add(raw_plane)
+                continue
+            try:
+                planes.add(SideEffectPlane(str(raw_plane)))
+            except ValueError:
+                continue
+        return planes
+
+    def mark_web_page_compensation_coverage(
+        self,
+        operation: KBOperation | None,
+        *,
+        extra_payload: Optional[Mapping[str, Any]] = None,
+    ) -> int:
+        """Mark side effects covered by a successful web rollback callback."""
+        if operation is None or operation.outcome is not None:
+            return 0
+
+        planes = self._compensated_side_effect_planes(extra_payload)
+        if not planes:
+            return 0
+
+        return operation.mark_compensated_steps(planes=planes)
 
     @staticmethod
     def compensate_web_page_file_side_effect(

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -19,6 +19,7 @@ from .models import KBStorageBackend
 from .operation_compatibility import (
     KBOperation,
     KBOperationCompatibilityFacade,
+    KBOperationOutcome,
     PersistencePolicy,
     SideEffectPlane,
 )
@@ -332,7 +333,17 @@ class KBPipelineCompatibilityFacade:
                     pipeline_facade=self,
                 )
                 await self.ensure_collection_backend_binding_async(collection)
-                self._record_web_ingestion_outcome(operation, result)
+                outcome = self._record_web_ingestion_outcome(operation, result)
+                if (
+                    outcome is not None
+                    and result.side_effects_may_remain
+                    != outcome.side_effects_may_remain
+                ):
+                    result = result.model_copy(
+                        update={
+                            "side_effects_may_remain": outcome.side_effects_may_remain
+                        }
+                    )
                 return result
 
     @contextmanager
@@ -579,16 +590,16 @@ class KBPipelineCompatibilityFacade:
         self,
         operation: KBOperation | None,
         result: WebIngestionResult,
-    ) -> None:
-        if operation is None or operation.outcome is not None:
-            return
+    ) -> KBOperationOutcome | None:
+        if operation is None:
+            return None
+        if operation.outcome is not None:
+            return operation.outcome
 
         child_side_effects_may_remain = any(
             child.side_effects_may_remain for child in operation.child_outcomes
         )
-        own_side_effects_may_remain = bool(operation.compensation_steps) and not (
-            operation.compensation_attempted
-        )
+        own_side_effects_may_remain = bool(operation.uncompensated_steps())
 
         if result.status == "success":
             side_effects_may_remain = False
@@ -597,7 +608,7 @@ class KBPipelineCompatibilityFacade:
                 child_side_effects_may_remain or own_side_effects_may_remain
             )
 
-        operation.finish(
+        return operation.finish(
             status=result.status,
             rollback_status=operation.infer_rollback_status(
                 result.status,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -183,6 +183,7 @@ def _run_file_handler_compensation(
     callback = cast(Optional[FileHandlerCallback], file_info.get("rollback_on_failure"))
     if callback is None:
         return None
+    rollback_context = _rollback_context_payload(file_info)
 
     def _compensate() -> None:
         try:
@@ -206,11 +207,15 @@ def _run_file_handler_compensation(
         file_path=cast(Optional[str], file_info.get("file_path")),
         file_id=cast(Optional[str], file_info.get("file_id")),
         reason="rollback_on_failure",
-        extra_payload=_rollback_context_payload(file_info),
+        extra_payload=rollback_context,
         compensation=_compensate,
     )
     errors = pipeline_facade.compensate_web_page_file_side_effect(page_operation)
     if not errors:
+        pipeline_facade.mark_web_page_compensation_coverage(
+            page_operation,
+            extra_payload=rollback_context,
+        )
         return None
 
     first_error = errors[0]

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -27,6 +27,7 @@ from ..core.schemas import (
     WebCrawlConfig,
     WebIngestionResult,
 )
+from ..kb.operation_compatibility import _close_awaitable_if_possible
 from ..progress import get_progress_manager
 from ..utils.config_utils import coerce_ingestion_config
 from ..utils.string_utils import sanitize_for_doc_id
@@ -103,12 +104,6 @@ def _callback_accepts_ingestion_result(callback: FileHandlerCallback) -> bool:
     except TypeError:
         return False
     return True
-
-
-def _close_awaitable_if_possible(value: Any) -> None:
-    close = getattr(value, "close", None)
-    if callable(close):
-        close()
 
 
 def _run_sync_file_handler_callback(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -10,7 +10,15 @@ import tempfile
 from contextvars import copy_context
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, NotRequired, Optional, TypedDict, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    NotRequired,
+    Optional,
+    TypedDict,
+    cast,
+)
 
 from ..core.schemas import (
     CrawlResult,
@@ -64,12 +72,24 @@ class FileHandlerResult(TypedDict):
             when the subsequent document ingestion does not succeed.
         commit_on_success: Optional callback to finalize temporary rollback
             resources once the subsequent document ingestion succeeds.
+        rollback_context: Optional operation-outcome metadata describing the
+            web file side effect. This is internal and does not affect public
+            web ingestion result schemas.
     """
 
     file_path: str
     file_id: Optional[str]
     rollback_on_failure: NotRequired[FileHandlerCallback]
     commit_on_success: NotRequired[FileHandlerCallback]
+    rollback_context: NotRequired[dict[str, object]]
+
+
+class _FileHandlerRollbackError(RuntimeError):
+    def __init__(self, callback_name: str, url: str, reason: str) -> None:
+        self.callback_name = callback_name
+        self.url = url
+        self.reason = reason
+        super().__init__(f"File persistence {callback_name} failed for {url}: {reason}")
 
 
 def _callback_accepts_ingestion_result(callback: FileHandlerCallback) -> bool:
@@ -112,6 +132,116 @@ def _run_file_handler_callback(
         warnings.append(message)
         return cleanup_reason
     return None
+
+
+def _rollback_context_payload(
+    file_info: Optional[FileHandlerResult],
+) -> Optional[dict[str, object]]:
+    if not file_info:
+        return None
+    rollback_context = file_info.get("rollback_context")
+    return rollback_context if isinstance(rollback_context, dict) else None
+
+
+def _run_file_handler_compensation(
+    *,
+    pipeline_facade: "KBPipelineCompatibilityFacade",
+    page_operation: Any,
+    file_info: Optional[FileHandlerResult],
+    collection: str,
+    url: str,
+    warnings: list[str],
+    ingestion_result: Optional[IngestionResult] = None,
+) -> Optional[str]:
+    if not file_info:
+        return None
+
+    callback = cast(Optional[FileHandlerCallback], file_info.get("rollback_on_failure"))
+    if callback is None:
+        return None
+
+    def _compensate() -> None:
+        try:
+            if _callback_accepts_ingestion_result(callback):
+                callback(ingestion_result)
+            else:
+                callback()
+        except Exception as cleanup_error:  # noqa: BLE001
+            raise _FileHandlerRollbackError(
+                "rollback_on_failure",
+                url,
+                str(cleanup_error),
+            ) from cleanup_error
+
+    pipeline_facade.record_web_page_file_side_effect(
+        page_operation,
+        collection=collection,
+        url=url,
+        file_path=cast(Optional[str], file_info.get("file_path")),
+        file_id=cast(Optional[str], file_info.get("file_id")),
+        reason="rollback_on_failure",
+        extra_payload=_rollback_context_payload(file_info),
+        compensation=_compensate,
+    )
+    errors = pipeline_facade.compensate_web_page_file_side_effect(page_operation)
+    if not errors:
+        return None
+
+    first_error = errors[0]
+    cleanup_reason = (
+        first_error.reason
+        if isinstance(first_error, _FileHandlerRollbackError)
+        else str(first_error)
+    )
+    message = f"File persistence rollback_on_failure failed for {url}: {cleanup_reason}"
+    logger.warning(message)
+    warnings.append(message)
+    return cleanup_reason
+
+
+def _run_legacy_persistent_file_compensation(
+    *,
+    pipeline_facade: "KBPipelineCompatibilityFacade",
+    page_operation: Any,
+    collection: str,
+    url: str,
+    copied_persistent_file: Optional[Path],
+    file_info: Optional[FileHandlerResult],
+    warnings: list[str],
+) -> Optional[str]:
+    if not copied_persistent_file or not copied_persistent_file.exists():
+        return None
+    if file_info and "rollback_on_failure" in file_info:
+        return None
+
+    def _compensate() -> None:
+        copied_persistent_file.unlink()
+
+    pipeline_facade.record_web_page_file_side_effect(
+        page_operation,
+        collection=collection,
+        url=url,
+        file_path=str(copied_persistent_file),
+        file_id=cast(Optional[str], file_info.get("file_id")) if file_info else None,
+        reason="legacy_persistent_file",
+        extra_payload={"rollback_kind": "legacy_persistent_file"},
+        compensation=_compensate,
+    )
+    errors = pipeline_facade.compensate_web_page_file_side_effect(page_operation)
+    if not errors:
+        logger.info(
+            "Cleaned up persistent file due to ingestion failure: %s",
+            copied_persistent_file,
+        )
+        return None
+
+    cleanup_reason = str(errors[0])
+    message = (
+        f"Failed to clean up persistent file {copied_persistent_file}: {cleanup_reason}"
+    )
+    logger.warning(message)
+    warnings.append(message)
+    return cleanup_reason
 
 
 def _looks_like_crawler_block(error: str) -> bool:
@@ -324,6 +454,7 @@ async def _run_web_ingestion_impl(
                                     url=crawl_result.url,
                                     file_path=str(final_file_path),
                                     file_id=final_file_id,
+                                    extra_payload=_rollback_context_payload(file_info),
                                 )
 
                             # Track if we successfully copied a persistent file for cleanup
@@ -418,13 +549,27 @@ async def _run_web_ingestion_impl(
                                 f"{ingest_result.message}"
                             )
                             warnings.append(msg)
-                            rollback_error = _run_file_handler_callback(
-                                file_info,
-                                "rollback_on_failure",
+                            rollback_error = _run_file_handler_compensation(
+                                pipeline_facade=pipeline_facade,
+                                page_operation=page_operation,
+                                file_info=file_info,
+                                collection=collection,
                                 url=crawl_result.url,
                                 warnings=warnings,
                                 ingestion_result=ingest_result,
                             )
+                            legacy_cleanup_error = (
+                                _run_legacy_persistent_file_compensation(
+                                    pipeline_facade=pipeline_facade,
+                                    page_operation=page_operation,
+                                    collection=collection,
+                                    url=crawl_result.url,
+                                    copied_persistent_file=copied_persistent_file,
+                                    file_info=file_info,
+                                    warnings=warnings,
+                                )
+                            )
+                            rollback_error = rollback_error or legacy_cleanup_error
                             if rollback_error:
                                 rollback_failed_urls[crawl_result.url] = rollback_error
                             pipeline_facade.finish_web_page_operation(
@@ -443,9 +588,11 @@ async def _run_web_ingestion_impl(
                         )
                         warnings.append(failure_message)
 
-                        rollback_error = _run_file_handler_callback(
-                            file_info,
-                            "rollback_on_failure",
+                        rollback_error = _run_file_handler_compensation(
+                            pipeline_facade=pipeline_facade,
+                            page_operation=page_operation,
+                            file_info=file_info,
+                            collection=collection,
                             url=crawl_result.url,
                             warnings=warnings,
                         )
@@ -453,23 +600,18 @@ async def _run_web_ingestion_impl(
                             rollback_failed_urls[crawl_result.url] = rollback_error
 
                         # Legacy cleanup for handlers that only returned a file path.
-                        if (
-                            (not file_info or "rollback_on_failure" not in file_info)
-                            and copied_persistent_file
-                            and copied_persistent_file.exists()
-                        ):
-                            try:
-                                copied_persistent_file.unlink()
-                                logger.info(
-                                    "Cleaned up persistent file due to ingestion failure: %s",
-                                    copied_persistent_file,
-                                )
-                            except Exception as cleanup_error:
-                                logger.warning(
-                                    "Failed to clean up persistent file %s: %s",
-                                    copied_persistent_file,
-                                    cleanup_error,
-                                )
+                        legacy_cleanup_error = _run_legacy_persistent_file_compensation(
+                            pipeline_facade=pipeline_facade,
+                            page_operation=page_operation,
+                            collection=collection,
+                            url=crawl_result.url,
+                            copied_persistent_file=copied_persistent_file,
+                            file_info=file_info,
+                            warnings=warnings,
+                        )
+                        rollback_error = rollback_error or legacy_cleanup_error
+                        if rollback_error:
+                            rollback_failed_urls[crawl_result.url] = rollback_error
                         copied_persistent_file = None
                         pipeline_facade.finish_web_page_operation(
                             page_operation,

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-FileHandlerCallback = Callable[..., None]
+FileHandlerCallback = Callable[..., Any]
 
 
 _CRAWLER_BLOCK_ERROR_MARKERS: tuple[str, ...] = (
@@ -105,6 +105,28 @@ def _callback_accepts_ingestion_result(callback: FileHandlerCallback) -> bool:
     return True
 
 
+def _close_awaitable_if_possible(value: Any) -> None:
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
+def _run_sync_file_handler_callback(
+    callback: FileHandlerCallback,
+    *,
+    callback_name: str,
+    url: str,
+    ingestion_result: Optional[IngestionResult],
+) -> None:
+    if _callback_accepts_ingestion_result(callback):
+        result = callback(ingestion_result)
+    else:
+        result = callback()
+    if inspect.isawaitable(result):
+        _close_awaitable_if_possible(result)
+        raise TypeError(f"Async {callback_name} callback is not supported for {url}")
+
+
 def _run_file_handler_callback(
     file_info: Optional[FileHandlerResult],
     callback_name: str,
@@ -121,10 +143,12 @@ def _run_file_handler_callback(
         return None
 
     try:
-        if _callback_accepts_ingestion_result(callback):
-            callback(ingestion_result)
-        else:
-            callback()
+        _run_sync_file_handler_callback(
+            callback,
+            callback_name=callback_name,
+            url=url,
+            ingestion_result=ingestion_result,
+        )
     except Exception as cleanup_error:  # noqa: BLE001
         cleanup_reason = str(cleanup_error)
         message = f"File persistence {callback_name} failed for {url}: {cleanup_reason}"
@@ -162,10 +186,12 @@ def _run_file_handler_compensation(
 
     def _compensate() -> None:
         try:
-            if _callback_accepts_ingestion_result(callback):
-                callback(ingestion_result)
-            else:
-                callback()
+            _run_sync_file_handler_callback(
+                callback,
+                callback_name="rollback_on_failure",
+                url=url,
+                ingestion_result=ingestion_result,
+            )
         except Exception as cleanup_error:  # noqa: BLE001
             raise _FileHandlerRollbackError(
                 "rollback_on_failure",

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -71,6 +71,9 @@ from ...core.tools.core.RAG_tools.kb import (
     KBApiOperationResult,
     get_kb_coordinator,
 )
+from ...core.tools.core.RAG_tools.kb.pipeline_compatibility import (
+    WEB_ROLLBACK_COMPENSATED_PLANES_KEY,
+)
 from ...core.tools.core.RAG_tools.management.status import clear_ingestion_status
 from ...core.tools.core.RAG_tools.pipelines.web_ingestion import FileHandlerResult
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
@@ -156,6 +159,17 @@ from .cloud_storage import get_google_credentials
 
 T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
+
+_WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES = (
+    # Collection initialization is completed by the outer failed-ingest cleanup.
+    # Marking it here lets that cleanup run after the page rollback succeeds.
+    "collection",
+    "document",
+    "status",
+    "parse",
+    "chunk",
+    "embedding",
+)
 
 
 def _get_api_compatibility_facade() -> KBApiCompatibilityFacade:
@@ -2235,6 +2249,9 @@ def _existing_web_file_result_with_rollback(
             "rollback_kind": "existing_web_file_reuse",
             "context": context,
             "file_id": file_record_id,
+            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
+                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
+            ),
         },
     )
 
@@ -2333,6 +2350,9 @@ def _create_new_web_file_handler_result(
                 "filename": filename,
                 "storage_path": str(persistent_file),
                 "file_id": file_record_id,
+                WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
+                    _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
+                ),
             },
         )
     except Exception:
@@ -2641,6 +2661,9 @@ def _refresh_existing_file_if_changed(
             "filename": filename,
             "backup_path": str(backup_path),
             "file_id": file_record_id,
+            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
+                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
+            ),
         },
     )
 
@@ -2907,6 +2930,9 @@ def _recreate_missing_existing_file(
             if backup_for_failure is not None
             else None,
             "file_id": file_record_id,
+            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
+                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
+            ),
         },
     )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2231,6 +2231,11 @@ def _existing_web_file_result_with_rollback(
         file_path=str(file_path),
         file_id=file_record_id,
         rollback_on_failure=_rollback_existing,
+        rollback_context={
+            "rollback_kind": "existing_web_file_reuse",
+            "context": context,
+            "file_id": file_record_id,
+        },
     )
 
 
@@ -2323,6 +2328,12 @@ def _create_new_web_file_handler_result(
             file_path=str(persistent_file),
             file_id=file_record_id,
             rollback_on_failure=_rollback_new_web_file,
+            rollback_context={
+                "rollback_kind": "new_web_file",
+                "filename": filename,
+                "storage_path": str(persistent_file),
+                "file_id": file_record_id,
+            },
         )
     except Exception:
         if persistent_file.exists():
@@ -2625,6 +2636,12 @@ def _refresh_existing_file_if_changed(
         file_id=str(existing_record.file_id),
         rollback_on_failure=_rollback_refresh,
         commit_on_success=_commit_refresh,
+        rollback_context={
+            "rollback_kind": "existing_web_file_refresh",
+            "filename": filename,
+            "backup_path": str(backup_path),
+            "file_id": file_record_id,
+        },
     )
 
 
@@ -2883,6 +2900,14 @@ def _recreate_missing_existing_file(
         file_id=str(existing_record.file_id),
         rollback_on_failure=_rollback_recreate,
         commit_on_success=_commit_recreate,
+        rollback_context={
+            "rollback_kind": "missing_existing_web_file_recreate",
+            "filename": filename,
+            "backup_path": str(backup_for_failure)
+            if backup_for_failure is not None
+            else None,
+            "file_id": file_record_id,
+        },
     )
 
 
@@ -3654,19 +3679,27 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            await _rollback_failed_ingestion(
-                db=db,
-                user=_user,
-                collection_name=collection,
-                result=result,
-                file_path=file_path,
-                file_record=file_record,
-                collection_existed_before=effective_collection_existed_before,
-                uploaded_file_existed_before=uploaded_file_existed_before,
-                file_backup_path=file_backup_path,
-                had_existing_file=had_existing_file,
-                embedding_model_id=embedding_model_id,
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
+            api_result = rollback_execution.operation_result
+            if rollback_execution.error is not None:
+                raise rollback_execution.error
             if effective_collection_existed_before:
                 api_result = (
                     await _restore_or_cleanup_collection_config_after_failed_api_ingest(
@@ -3676,13 +3709,7 @@ async def ingest(
                         collection_name=collection,
                         user=_user,
                         context="ingest",
-                        rollback_complete=True,
                     )
-                )
-            else:
-                api_result = _get_api_compatibility_facade().with_rollback_complete(
-                    api_result,
-                    True,
                 )
 
         if result.status == "error":
@@ -3723,19 +3750,27 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            await _rollback_failed_ingestion(
-                db=db,
-                user=_user,
-                collection_name=collection,
-                result=rollback_result,
-                file_path=file_path,
-                file_record=file_record,
-                collection_existed_before=effective_collection_existed_before,
-                uploaded_file_existed_before=uploaded_file_existed_before,
-                file_backup_path=file_backup_path,
-                had_existing_file=had_existing_file,
-                embedding_model_id=embedding_model_id,
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=rollback_result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
+            rollback_api_result = rollback_execution.operation_result
+            if rollback_execution.error is not None:
+                raise rollback_execution.error
             if effective_collection_existed_before:
                 rollback_api_result = (
                     await _restore_or_cleanup_collection_config_after_failed_api_ingest(
@@ -3745,23 +3780,29 @@ async def ingest(
                         collection_name=collection,
                         user=_user,
                         context="ingest",
-                        rollback_complete=True,
                     )
                 )
         else:
-            _restore_ingest_file_backup(
-                file_path=file_path,
-                backup_path=file_backup_path,
-                had_existing_file=had_existing_file,
-            )
             rollback_api_result = KBApiOperationResult(
                 result=IngestionResult(
                     status="error",
                     doc_id=safe_filename,
                     message="Ingestion setup failed before document registration.",
                 ),
-                rollback_complete=True,
             )
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _restore_ingest_file_backup(
+                        file_path=file_path,
+                        backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                    ),
+                )
+            )
+            rollback_api_result = rollback_execution.operation_result
+            if rollback_execution.error is not None:
+                raise rollback_execution.error
             await _restore_or_cleanup_collection_config_after_failed_api_ingest(
                 api_result=rollback_api_result,
                 snapshot=config_snapshot,
@@ -4117,32 +4158,35 @@ async def ingest_cloud(
                         await asyncio.to_thread(_download_file)
 
                     except Exception as e:
-                        try:
-                            _restore_ingest_file_backup(
-                                file_path=file_path,
-                                backup_path=file_backup_path,
-                                had_existing_file=had_existing_file,
-                            )
-                        except Exception as restore_exc:  # noqa: BLE001
-                            return KBApiOperationResult(
-                                result=IngestionResult(
-                                    status="error",
-                                    message=(
-                                        "Failed to fully roll back cloud ingest for "
-                                        f"{safe_collection}/{file_info.fileName}: {restore_exc}"
-                                    ),
-                                    doc_id=file_info.fileName,
-                                ),
-                                rollback_complete=False,
-                            )
-                        return KBApiOperationResult(
+                        rollback_api_result = KBApiOperationResult(
                             result=IngestionResult(
                                 status="error",
                                 message=f"Download failed: {str(e)}",
                                 doc_id=file_info.fileName,
-                            ),
-                            rollback_complete=True,
+                            )
                         )
+                        rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                            rollback_api_result,
+                            lambda: _restore_ingest_file_backup(
+                                file_path=file_path,
+                                backup_path=file_backup_path,
+                                had_existing_file=had_existing_file,
+                            ),
+                        )
+                        if rollback_execution.error is not None:
+                            return _get_api_compatibility_facade().with_result(
+                                rollback_execution.operation_result,
+                                IngestionResult(
+                                    status="error",
+                                    message=(
+                                        "Failed to fully roll back cloud ingest for "
+                                        f"{safe_collection}/{file_info.fileName}: "
+                                        f"{rollback_execution.error}"
+                                    ),
+                                    doc_id=file_info.fileName,
+                                ),
+                            )
+                        return rollback_execution.operation_result
 
                     uploaded_file_existed_before = (
                         db.query(UploadedFile)
@@ -4192,25 +4236,32 @@ async def ingest_cloud(
                             result,
                         )
                         if result.status in {"error", "partial"}:
-                            await _rollback_failed_cloud_ingestion(
-                                db=db,
-                                user=_user,
-                                collection_name=safe_collection,
-                                result=result,
-                                file_path=file_path,
-                                file_record=file_record,
-                                collection_existed_before=effective_collection_existed_before,
-                                uploaded_file_existed_before=uploaded_file_existed_before,
-                                file_backup_path=file_backup_path,
-                                had_existing_file=had_existing_file,
-                                embedding_model_id=request.embedding_model_id,
+                            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                                api_result,
+                                lambda: _rollback_failed_cloud_ingestion(
+                                    db=db,
+                                    user=_user,
+                                    collection_name=safe_collection,
+                                    result=result,
+                                    file_path=file_path,
+                                    file_record=file_record,
+                                    collection_existed_before=effective_collection_existed_before,
+                                    uploaded_file_existed_before=uploaded_file_existed_before,
+                                    file_backup_path=file_backup_path,
+                                    had_existing_file=had_existing_file,
+                                    embedding_model_id=request.embedding_model_id,
+                                ),
                             )
-                            api_result = (
-                                _get_api_compatibility_facade().with_rollback_complete(
+                            api_result = rollback_execution.operation_result
+                            if rollback_execution.error is not None:
+                                return _get_api_compatibility_facade().with_result(
                                     api_result,
-                                    True,
+                                    IngestionResult(
+                                        status="error",
+                                        message=str(rollback_execution.error),
+                                        doc_id=file_info.fileName,
+                                    ),
                                 )
-                            )
                         elif file_backup_path is not None:
                             try:
                                 file_backup_path.unlink(missing_ok=True)
@@ -4241,28 +4292,32 @@ async def ingest_cloud(
                             if "api_result" in locals()
                             else None,
                         )
-                        await _rollback_failed_cloud_ingestion(
-                            db=db,
-                            user=_user,
-                            collection_name=safe_collection,
-                            result=rollback_result,
-                            file_path=file_path,
-                            file_record=file_record,
-                            collection_existed_before=effective_collection_existed_before,
-                            uploaded_file_existed_before=uploaded_file_existed_before,
-                            file_backup_path=file_backup_path,
-                            had_existing_file=had_existing_file,
-                            embedding_model_id=request.embedding_model_id,
-                        )
-                        return KBApiOperationResult(
-                            result=IngestionResult(
-                                status="error",
-                                message=f"Ingestion failed: {str(e)}",
-                                doc_id=file_info.fileName,
+                        rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                            rollback_api_result,
+                            lambda: _rollback_failed_cloud_ingestion(
+                                db=db,
+                                user=_user,
+                                collection_name=safe_collection,
+                                result=rollback_result,
+                                file_path=file_path,
+                                file_record=file_record,
+                                collection_existed_before=effective_collection_existed_before,
+                                uploaded_file_existed_before=uploaded_file_existed_before,
+                                file_backup_path=file_backup_path,
+                                had_existing_file=had_existing_file,
+                                embedding_model_id=request.embedding_model_id,
                             ),
-                            operation_outcome=rollback_api_result.operation_outcome,
-                            rollback_complete=True,
                         )
+                        if rollback_execution.error is not None:
+                            return _get_api_compatibility_facade().with_result(
+                                rollback_execution.operation_result,
+                                IngestionResult(
+                                    status="error",
+                                    message=str(rollback_execution.error),
+                                    doc_id=file_info.fileName,
+                                ),
+                            )
+                        return rollback_execution.operation_result
 
                 else:
                     return KBApiOperationResult(
@@ -4284,38 +4339,43 @@ async def ingest_cloud(
                     rollback_complete=False,
                 )
             except Exception as e:
-                try:
-                    _restore_ingest_file_backup(
-                        file_path=file_path,
-                        backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                    )
-                except Exception as restore_exc:  # noqa: BLE001
-                    logger.exception(
-                        "Rollback failed for %s: %s", file_info.fileName, restore_exc
-                    )
-                    return KBApiOperationResult(
-                        result=IngestionResult(
-                            status="error",
-                            message=(
-                                "Failed to fully roll back cloud ingest for "
-                                f"{safe_collection}/{file_info.fileName}: {restore_exc}"
-                            ),
-                            doc_id=file_info.fileName,
-                        ),
-                        rollback_complete=False,
-                    )
-                logger.exception(
-                    "Unexpected error ingesting %s: %s", file_info.fileName, e
-                )
-                return KBApiOperationResult(
+                rollback_api_result = KBApiOperationResult(
                     result=IngestionResult(
                         status="error",
                         message=f"Unexpected error: {str(e)}",
                         doc_id=file_info.fileName,
-                    ),
-                    rollback_complete=True,
+                    )
                 )
+                rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _restore_ingest_file_backup(
+                        file_path=file_path,
+                        backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                    ),
+                )
+                if rollback_execution.error is not None:
+                    logger.exception(
+                        "Rollback failed for %s: %s",
+                        file_info.fileName,
+                        rollback_execution.error,
+                    )
+                    return _get_api_compatibility_facade().with_result(
+                        rollback_execution.operation_result,
+                        IngestionResult(
+                            status="error",
+                            message=(
+                                "Failed to fully roll back cloud ingest for "
+                                f"{safe_collection}/{file_info.fileName}: "
+                                f"{rollback_execution.error}"
+                            ),
+                            doc_id=file_info.fileName,
+                        ),
+                    )
+                logger.exception(
+                    "Unexpected error ingesting %s: %s", file_info.fileName, e
+                )
+                return rollback_execution.operation_result
 
     # Run all file processings concurrently
     api_results = await asyncio.gather(*[process_file(f) for f in request.files])

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -5,7 +5,7 @@ import hashlib
 import logging
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
@@ -243,9 +243,14 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background staged document superseded result",
                 )
                 return _superseded_staged_document_result(payload)
-            if not _rollback_failed_staged_document_ingestion_if_current(
-                db, payload, result, config_snapshot=config_snapshot
-            ):
+            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
+                db,
+                payload,
+                result,
+                api_result=api_result,
+                config_snapshot=config_snapshot,
+            )
+            if rollback_api_result is False:
                 _restore_or_cleanup_failed_staged_job_collection_config_if_current(
                     db,
                     payload,
@@ -253,19 +258,20 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document ingest",
                 )
                 return _superseded_staged_document_result(payload)
+            api_result = rollback_api_result
             _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
                 db,
                 payload,
                 api_result=api_result,
                 snapshot=config_snapshot,
                 context="background staged document ingest",
-                rollback_complete=True,
             )
         else:
-            _rollback_failed_document_ingestion(
+            api_result = _rollback_failed_document_ingestion(
                 db,
                 payload,
                 result,
+                api_result=api_result,
                 config_snapshot=config_snapshot,
             )
             _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
@@ -274,7 +280,6 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                 api_result=api_result,
                 snapshot=config_snapshot,
                 context="background document ingest",
-                rollback_complete=True,
             )
         raise BackgroundJobHandlerError(
             result.message,
@@ -302,9 +307,14 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
             )
             return _superseded_staged_document_result(payload)
         except Exception as exc:  # noqa: BLE001
-            if not _rollback_failed_staged_document_ingestion_if_current(
-                db, payload, result, config_snapshot=config_snapshot
-            ):
+            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
+                db,
+                payload,
+                result,
+                api_result=api_result,
+                config_snapshot=config_snapshot,
+            )
+            if rollback_api_result is False:
                 _restore_or_cleanup_failed_staged_job_collection_config_if_current(
                     db,
                     payload,
@@ -312,6 +322,7 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                     context="background stale staged document publish rollback",
                 )
                 return _superseded_staged_document_result(payload)
+            api_result = rollback_api_result
             _restore_or_cleanup_failed_job_collection_config_after_api_ingest(
                 db,
                 payload,
@@ -319,7 +330,6 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
                 snapshot=config_snapshot,
                 context="background staged document publish",
                 successful_documents=0,
-                rollback_complete=True,
             )
             raise BackgroundJobHandlerError(
                 f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
@@ -605,10 +615,10 @@ def _rollback_failed_staged_document_ingestion(
     payload: dict[str, Any],
     result: IngestionResult,
     *,
+    api_result: KBApiOperationResult[Any],
     config_snapshot: Any = None,
-) -> None:
+) -> KBApiOperationResult[Any]:
     from ..api.kb import (
-        RollbackFailureError,
         _collection_or_config_existed_before,
         _rollback_failed_cloud_ingestion,
     )
@@ -635,27 +645,42 @@ def _rollback_failed_staged_document_ingestion(
     )
 
     try:
-        asyncio.run(
-            _rollback_failed_cloud_ingestion(
-                db=db,
-                user=user,
-                collection_name=str(payload["collection"]),
-                result=result,
-                file_path=Path(str(payload["source_path"])),
-                file_record=None,
-                collection_existed_before=effective_collection_existed_before,
-                uploaded_file_existed_before=False,
-                file_backup_path=None,
-                had_existing_file=False,
-                embedding_model_id=embedding_model_id,
+        try:
+            rollback_execution = (
+                _get_api_compatibility_facade().run_failed_ingest_rollback(
+                    api_result,
+                    lambda: asyncio.run(
+                        _rollback_failed_cloud_ingestion(
+                            db=db,
+                            user=user,
+                            collection_name=str(payload["collection"]),
+                            result=result,
+                            file_path=Path(str(payload["source_path"])),
+                            file_record=None,
+                            collection_existed_before=(
+                                effective_collection_existed_before
+                            ),
+                            uploaded_file_existed_before=False,
+                            file_backup_path=None,
+                            had_existing_file=False,
+                            embedding_model_id=embedding_model_id,
+                        )
+                    ),
+                )
             )
-        )
-    except RollbackFailureError as exc:
-        raise BackgroundJobHandlerError(
-            str(exc),
-            result=result.model_dump(mode="json"),
-            retryable=False,
-        ) from exc
+        except Exception as exc:
+            raise BackgroundJobHandlerError(
+                str(exc),
+                result=result.model_dump(mode="json"),
+                retryable=False,
+            ) from exc
+        if rollback_execution.error is not None:
+            raise BackgroundJobHandlerError(
+                str(rollback_execution.error),
+                result=result.model_dump(mode="json"),
+                retryable=False,
+            ) from rollback_execution.error
+        return rollback_execution.operation_result
     finally:
         _cleanup_staged_document_input(payload)
 
@@ -665,18 +690,19 @@ def _rollback_failed_staged_document_ingestion_if_current(
     payload: dict[str, Any],
     result: IngestionResult,
     *,
+    api_result: KBApiOperationResult[Any],
     config_snapshot: Any = None,
-) -> bool:
+) -> KBApiOperationResult[Any] | Literal[False]:
     if not _is_staged_document_generation_latest(db, payload):
         _cleanup_staged_document_input(payload)
         return False
-    _rollback_failed_staged_document_ingestion(
+    return _rollback_failed_staged_document_ingestion(
         db,
         payload,
         result,
+        api_result=api_result,
         config_snapshot=config_snapshot,
     )
-    return True
 
 
 def _publish_staged_document_ingestion(
@@ -753,10 +779,10 @@ def _rollback_failed_document_ingestion(
     payload: dict[str, Any],
     result: IngestionResult,
     *,
+    api_result: KBApiOperationResult[Any],
     config_snapshot: Any = None,
-) -> None:
+) -> KBApiOperationResult[Any]:
     from ..api.kb import (
-        RollbackFailureError,
         _collection_or_config_existed_before,
         _rollback_failed_ingestion,
     )
@@ -795,28 +821,38 @@ def _rollback_failed_document_ingestion(
         config_snapshot,
     )
     try:
-        asyncio.run(
-            _rollback_failed_ingestion(
-                db=db,
-                user=user,
-                collection_name=str(payload["collection"]),
-                result=result,
-                file_path=Path(str(payload["source_path"])),
-                file_record=file_record,
-                collection_existed_before=effective_collection_existed_before,
-                uploaded_file_existed_before=bool(
-                    payload.get("uploaded_file_existed_before", True)
-                ),
-                file_backup_path=Path(str(backup_path)) if backup_path else None,
-                had_existing_file=bool(payload.get("had_existing_file", True)),
-            )
+        rollback_execution = _get_api_compatibility_facade().run_failed_ingest_rollback(
+            api_result,
+            lambda: asyncio.run(
+                _rollback_failed_ingestion(
+                    db=db,
+                    user=user,
+                    collection_name=str(payload["collection"]),
+                    result=result,
+                    file_path=Path(str(payload["source_path"])),
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=bool(
+                        payload.get("uploaded_file_existed_before", True)
+                    ),
+                    file_backup_path=Path(str(backup_path)) if backup_path else None,
+                    had_existing_file=bool(payload.get("had_existing_file", True)),
+                )
+            ),
         )
-    except RollbackFailureError as exc:
+    except Exception as exc:
         raise BackgroundJobHandlerError(
             str(exc),
             result=result.model_dump(mode="json"),
             retryable=False,
         ) from exc
+    if rollback_execution.error is not None:
+        raise BackgroundJobHandlerError(
+            str(rollback_execution.error),
+            result=result.model_dump(mode="json"),
+            retryable=False,
+        ) from rollback_execution.error
+    return rollback_execution.operation_result
 
 
 def _discard_ingest_backup(payload: dict[str, Any]) -> None:

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -645,35 +645,24 @@ def _rollback_failed_staged_document_ingestion(
     )
 
     try:
-        try:
-            rollback_execution = (
-                _get_api_compatibility_facade().run_failed_ingest_rollback(
-                    api_result,
-                    lambda: asyncio.run(
-                        _rollback_failed_cloud_ingestion(
-                            db=db,
-                            user=user,
-                            collection_name=str(payload["collection"]),
-                            result=result,
-                            file_path=Path(str(payload["source_path"])),
-                            file_record=None,
-                            collection_existed_before=(
-                                effective_collection_existed_before
-                            ),
-                            uploaded_file_existed_before=False,
-                            file_backup_path=None,
-                            had_existing_file=False,
-                            embedding_model_id=embedding_model_id,
-                        )
-                    ),
+        rollback_execution = _get_api_compatibility_facade().run_failed_ingest_rollback(
+            api_result,
+            lambda: asyncio.run(
+                _rollback_failed_cloud_ingestion(
+                    db=db,
+                    user=user,
+                    collection_name=str(payload["collection"]),
+                    result=result,
+                    file_path=Path(str(payload["source_path"])),
+                    file_record=None,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=False,
+                    file_backup_path=None,
+                    had_existing_file=False,
+                    embedding_model_id=embedding_model_id,
                 )
-            )
-        except Exception as exc:
-            raise BackgroundJobHandlerError(
-                str(exc),
-                result=result.model_dump(mode="json"),
-                retryable=False,
-            ) from exc
+            ),
+        )
         if rollback_execution.error is not None:
             raise BackgroundJobHandlerError(
                 str(rollback_execution.error),
@@ -820,32 +809,25 @@ def _rollback_failed_document_ingestion(
         bool(payload.get("collection_existed_before", True)),
         config_snapshot,
     )
-    try:
-        rollback_execution = _get_api_compatibility_facade().run_failed_ingest_rollback(
-            api_result,
-            lambda: asyncio.run(
-                _rollback_failed_ingestion(
-                    db=db,
-                    user=user,
-                    collection_name=str(payload["collection"]),
-                    result=result,
-                    file_path=Path(str(payload["source_path"])),
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=bool(
-                        payload.get("uploaded_file_existed_before", True)
-                    ),
-                    file_backup_path=Path(str(backup_path)) if backup_path else None,
-                    had_existing_file=bool(payload.get("had_existing_file", True)),
-                )
-            ),
-        )
-    except Exception as exc:
-        raise BackgroundJobHandlerError(
-            str(exc),
-            result=result.model_dump(mode="json"),
-            retryable=False,
-        ) from exc
+    rollback_execution = _get_api_compatibility_facade().run_failed_ingest_rollback(
+        api_result,
+        lambda: asyncio.run(
+            _rollback_failed_ingestion(
+                db=db,
+                user=user,
+                collection_name=str(payload["collection"]),
+                result=result,
+                file_path=Path(str(payload["source_path"])),
+                file_record=file_record,
+                collection_existed_before=effective_collection_existed_before,
+                uploaded_file_existed_before=bool(
+                    payload.get("uploaded_file_existed_before", True)
+                ),
+                file_backup_path=Path(str(backup_path)) if backup_path else None,
+                had_existing_file=bool(payload.get("had_existing_file", True)),
+            )
+        ),
+    )
     if rollback_execution.error is not None:
         raise BackgroundJobHandlerError(
             str(rollback_execution.error),

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -347,6 +347,33 @@ def test_run_failed_ingest_rollback_marks_failed_compensation_incomplete() -> No
     )
 
 
+def test_run_failed_ingest_rollback_closes_awaitable_result(recwarn) -> None:
+    facade = KBApiCompatibilityFacade()
+    outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="error",
+        rollback_status=RollbackStatus.INCOMPLETE,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        side_effects_may_remain=True,
+    )
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed"),
+        operation_outcome=outcome,
+    )
+
+    async def rollback() -> None:
+        return None
+
+    rollback_result = facade.run_failed_ingest_rollback(api_result, rollback)
+
+    assert rollback_result.rollback_complete is False
+    assert isinstance(rollback_result.error, TypeError)
+    assert "run_failed_ingest_rollback_async" in str(rollback_result.error)
+    assert not any("was never awaited" in str(item.message) for item in recwarn)
+
+
 def test_run_failed_ingest_rollback_can_compensate_successful_operation() -> None:
     facade = KBApiCompatibilityFacade()
     outcome = KBOperationOutcome(

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -14,6 +14,7 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     WebIngestionResult,
 )
 from xagent.core.tools.core.RAG_tools.kb import (
+    CompensationStep,
     KBApiCompatibilityFacade,
     KBApiOperationResult,
     KBCoordinator,
@@ -21,6 +22,7 @@ from xagent.core.tools.core.RAG_tools.kb import (
     KBOperationOutcome,
     PersistencePolicy,
     RollbackStatus,
+    SideEffectPlane,
     get_kb_coordinator,
     reset_kb_coordinator_for_tests,
 )
@@ -244,6 +246,136 @@ def test_api_operation_result_consumes_new_operation_outcome() -> None:
     completed_rollback = facade.with_rollback_complete(api_result, True)
     cleanup_after_rollback = facade.failed_ingest_cleanup_decision(completed_rollback)
     assert cleanup_after_rollback.side_effects_may_remain is False
+    assert completed_rollback.operation_outcome is not None
+    assert (
+        completed_rollback.operation_outcome.rollback_status is RollbackStatus.COMPLETE
+    )
+    assert completed_rollback.operation_outcome.side_effects_may_remain is False
+
+
+def test_api_rollback_failure_updates_operation_outcome_incomplete() -> None:
+    incomplete_outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="error",
+        rollback_status=RollbackStatus.INCOMPLETE,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        side_effects_may_remain=True,
+    )
+    facade = KBApiCompatibilityFacade()
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed"),
+        operation_outcome=incomplete_outcome,
+    )
+
+    failed_rollback = facade.with_rollback_complete(api_result, False)
+
+    assert failed_rollback.rollback_complete is False
+    assert failed_rollback.operation_outcome is not None
+    assert (
+        failed_rollback.operation_outcome.rollback_status is RollbackStatus.INCOMPLETE
+    )
+    assert failed_rollback.operation_outcome.side_effects_may_remain is True
+
+
+def test_run_failed_ingest_rollback_marks_successful_compensation_complete() -> None:
+    facade = KBApiCompatibilityFacade()
+    incomplete_outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="error",
+        rollback_status=RollbackStatus.INCOMPLETE,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        side_effects_may_remain=True,
+    )
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed"),
+        operation_outcome=incomplete_outcome,
+    )
+
+    rollback_result = facade.run_failed_ingest_rollback(api_result, lambda: None)
+
+    assert rollback_result.rollback_complete is True
+    assert rollback_result.error is None
+    assert rollback_result.operation_result.rollback_complete is True
+    assert rollback_result.operation_result.operation_outcome is not None
+    assert (
+        rollback_result.operation_result.operation_outcome.rollback_status
+        is RollbackStatus.COMPLETE
+    )
+    assert (
+        rollback_result.operation_result.operation_outcome.side_effects_may_remain
+        is False
+    )
+
+
+def test_run_failed_ingest_rollback_marks_failed_compensation_incomplete() -> None:
+    facade = KBApiCompatibilityFacade()
+    outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="error",
+        rollback_status=RollbackStatus.INCOMPLETE,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        side_effects_may_remain=True,
+    )
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="error", message="failed"),
+        operation_outcome=outcome,
+    )
+    error = RuntimeError("rollback failed")
+
+    rollback_result = facade.run_failed_ingest_rollback(
+        api_result,
+        lambda: (_ for _ in ()).throw(error),
+    )
+
+    assert rollback_result.rollback_complete is False
+    assert rollback_result.error is error
+    assert rollback_result.operation_result.rollback_complete is False
+    assert rollback_result.operation_result.operation_outcome is not None
+    assert (
+        rollback_result.operation_result.operation_outcome.rollback_status
+        is RollbackStatus.INCOMPLETE
+    )
+    assert (
+        rollback_result.operation_result.operation_outcome.side_effects_may_remain
+        is True
+    )
+
+
+def test_run_failed_ingest_rollback_can_compensate_successful_operation() -> None:
+    facade = KBApiCompatibilityFacade()
+    outcome = KBOperationOutcome(
+        operation_id="op-1",
+        operation_type="document_ingestion",
+        collection="demo",
+        status="success",
+        rollback_status=RollbackStatus.NOT_NEEDED,
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+        compensation_steps=(
+            CompensationStep(
+                name="remove_registered_document",
+                plane=SideEffectPlane.DOCUMENT,
+            ),
+        ),
+    )
+    api_result = KBApiOperationResult(
+        result=IngestionResult(status="success", message="ok"),
+        operation_outcome=outcome,
+    )
+
+    rollback_result = facade.run_failed_ingest_rollback(api_result, lambda: None)
+
+    assert rollback_result.operation_result.rollback_complete is True
+    assert rollback_result.operation_result.operation_outcome is not None
+    assert (
+        rollback_result.operation_result.operation_outcome.rollback_status
+        is RollbackStatus.COMPLETE
+    )
 
 
 def test_run_with_operation_outcome_rebinds_storage_context() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextvars import Context
+from typing import Callable, cast
 
 import pytest
 
@@ -160,6 +161,43 @@ def test_failed_compensation_remains_retryable_until_it_succeeds() -> None:
     assert outcome.rollback_status is RollbackStatus.COMPLETE
     assert outcome.side_effects_may_remain is False
     assert "first failure" in outcome.warnings[0]
+
+
+def test_async_compensation_is_rejected_without_marking_complete(recwarn) -> None:
+    facade = KBOperationCompatibilityFacade()
+    calls: list[str] = []
+
+    async def compensation() -> None:
+        calls.append("compensated")
+
+    with facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="remove_document",
+            plane=SideEffectPlane.DOCUMENT,
+            idempotency_key="document:doc-1",
+            compensation=cast(Callable[[], None], compensation),
+        )
+
+        first_errors = operation.execute_compensations()
+        second_errors = operation.execute_compensations()
+        operation.finish(status="error")
+
+    outcome = facade.last_outcome
+
+    assert calls == []
+    assert len(first_errors) == 1
+    assert len(second_errors) == 1
+    assert isinstance(first_errors[0], TypeError)
+    assert isinstance(second_errors[0], TypeError)
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert len(outcome.warnings) == 2
+    assert "Async compensation callback is not supported" in outcome.warnings[0]
+    assert not any("was never awaited" in str(item.message) for item in recwarn)
 
 
 def test_system_exit_from_compensation_propagates_and_records_outcome() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -91,6 +91,41 @@ def test_operation_executes_registered_compensations_lifo_and_marks_complete() -
     assert outcome.side_effects_may_remain is False
 
 
+def test_operation_partial_compensation_leaves_uncovered_steps_incomplete() -> None:
+    facade = KBOperationCompatibilityFacade()
+    calls: list[str] = []
+
+    with facade.start_operation(
+        operation_type="web_page_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="cleanup_web_page_persistence",
+            plane=SideEffectPlane.FILE,
+            idempotency_key="file:page-1",
+            compensation=lambda: calls.append("file"),
+        )
+        operation.record_side_effect(
+            name="remove_registered_document",
+            plane=SideEffectPlane.DOCUMENT,
+            idempotency_key="document:doc-1",
+        )
+
+        assert operation.execute_compensations(planes={SideEffectPlane.FILE}) == ()
+        operation.finish(status="error", side_effects_may_remain=False)
+
+    outcome = facade.last_outcome
+
+    assert calls == ["file"]
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert [step.plane for step in outcome.compensation_steps] == [
+        SideEffectPlane.FILE,
+        SideEffectPlane.DOCUMENT,
+    ]
+
+
 def test_failed_compensation_remains_retryable_until_it_succeeds() -> None:
     facade = KBOperationCompatibilityFacade()
     attempts = 0

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -59,6 +59,74 @@ def test_operation_compensation_steps_are_idempotent_and_lifo() -> None:
     assert outcome.side_effects_may_remain is True
 
 
+def test_operation_executes_registered_compensations_lifo_and_marks_complete() -> None:
+    facade = KBOperationCompatibilityFacade()
+    calls: list[str] = []
+
+    with facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="remove_document",
+            plane=SideEffectPlane.DOCUMENT,
+            idempotency_key="document:doc-1",
+            compensation=lambda: calls.append("document"),
+        )
+        operation.record_side_effect(
+            name="remove_parse",
+            plane=SideEffectPlane.PARSE,
+            idempotency_key="parse:parse-1",
+            compensation=lambda: calls.append("parse"),
+        )
+
+        assert operation.execute_compensations() == ()
+        operation.finish(status="error")
+
+    outcome = facade.last_outcome
+
+    assert calls == ["parse", "document"]
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.COMPLETE
+    assert outcome.side_effects_may_remain is False
+
+
+def test_failed_compensation_remains_retryable_until_it_succeeds() -> None:
+    facade = KBOperationCompatibilityFacade()
+    attempts = 0
+
+    def compensation() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("first failure")
+
+    with facade.start_operation(
+        operation_type="document_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="remove_document",
+            plane=SideEffectPlane.DOCUMENT,
+            idempotency_key="document:doc-1",
+            compensation=compensation,
+        )
+
+        first_errors = operation.execute_compensations()
+        second_errors = operation.execute_compensations()
+        operation.finish(status="error", side_effects_may_remain=bool(second_errors))
+
+    outcome = facade.last_outcome
+
+    assert len(first_errors) == 1
+    assert second_errors == ()
+    assert attempts == 2
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.COMPLETE
+    assert outcome.side_effects_may_remain is False
+    assert "first failure" in outcome.warnings[0]
+
+
 def test_last_outcome_is_isolated_by_execution_context() -> None:
     facade = KBOperationCompatibilityFacade()
     initial_current_context_outcome = facade.last_outcome

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -162,6 +162,33 @@ def test_failed_compensation_remains_retryable_until_it_succeeds() -> None:
     assert "first failure" in outcome.warnings[0]
 
 
+def test_system_exit_from_compensation_propagates_and_records_outcome() -> None:
+    facade = KBOperationCompatibilityFacade()
+
+    def compensation() -> None:
+        raise SystemExit("stop")
+
+    with pytest.raises(SystemExit):
+        with facade.start_operation(
+            operation_type="document_ingestion",
+            collection="demo",
+        ) as operation:
+            operation.record_side_effect(
+                name="remove_document",
+                plane=SideEffectPlane.DOCUMENT,
+                idempotency_key="document:doc-1",
+                compensation=compensation,
+            )
+            operation.execute_compensations()
+
+    outcome = facade.last_outcome
+    assert outcome is not None
+    assert outcome.status == "error"
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
+    assert outcome.warnings == ("SystemExit: stop",)
+
+
 def test_last_outcome_is_isolated_by_execution_context() -> None:
     facade = KBOperationCompatibilityFacade()
     initial_current_context_outcome = facade.last_outcome

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -798,6 +798,46 @@ async def test_web_ingestion_file_compensation_success_marks_child_complete(
     assert child.compensation_steps[0].payload["rollback_kind"] == "new_web_file"
 
 
+def test_web_ingestion_root_compensation_success_marks_outcome_complete() -> None:
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+
+    with operation_facade.start_operation(
+        operation_type="web_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="cleanup_root_persistence",
+            plane=SideEffectPlane.FILE,
+            idempotency_key="root:file",
+            compensation=lambda: None,
+        )
+        assert operation.execute_compensations() == ()
+        facade._record_web_ingestion_outcome(
+            operation,
+            WebIngestionResult(
+                status="error",
+                collection="demo",
+                total_urls_found=1,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=0,
+                chunks_created=0,
+                embeddings_created=0,
+                crawled_urls=[],
+                failed_urls={"https://example.com": "failed"},
+                message="failed",
+                warnings=[],
+                elapsed_time_ms=1,
+            ),
+        )
+
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.COMPLETE
+    assert outcome.side_effects_may_remain is False
+
+
 @pytest.mark.asyncio
 async def test_web_ingestion_file_compensation_failure_marks_side_effects_remaining(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -22,6 +22,9 @@ from xagent.core.tools.core.RAG_tools.kb import (
     RollbackStatus,
     SideEffectPlane,
 )
+from xagent.core.tools.core.RAG_tools.kb.pipeline_compatibility import (
+    WEB_ROLLBACK_COMPENSATED_PLANES_KEY,
+)
 
 
 class _FakeMetadataStore:
@@ -800,6 +803,97 @@ async def test_web_ingestion_file_compensation_leaves_document_effects_incomplet
         SideEffectPlane.FILE,
         SideEffectPlane.DOCUMENT,
         SideEffectPlane.STATUS,
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_declared_file_compensation_coverage_clears_document_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+    compensation_calls: list[IngestionResult | None] = []
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash="parse-failed",
+            chunk_count=2,
+            embedding_count=2,
+            vector_count=2,
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-failed", created=True),
+                _ingestion_step("parse_document", parse_hash="parse-failed"),
+                _ingestion_step("chunk_document", chunk_count=2, created=True),
+                _ingestion_step("write_vectors_to_db", vector_count=2),
+            ],
+            failed_step="finalize_document",
+            message="finalize failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        return {
+            "file_path": str(temp_file),
+            "file_id": "file-1",
+            "rollback_on_failure": lambda result=None: compensation_calls.append(
+                result
+            ),
+            "rollback_context": {
+                "rollback_kind": "new_web_file",
+                WEB_ROLLBACK_COMPENSATED_PLANES_KEY: [
+                    "collection",
+                    "document",
+                    "status",
+                    "parse",
+                    "chunk",
+                    "embedding",
+                ],
+            },
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    assert result.side_effects_may_remain is False
+    assert len(compensation_calls) == 1
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.COMPLETE
+    assert outcome.side_effects_may_remain is False
+    child = outcome.child_outcomes[0]
+    assert child.rollback_status is RollbackStatus.COMPLETE
+    assert child.side_effects_may_remain is False
+    assert {step.plane for step in child.compensation_steps} == {
+        SideEffectPlane.FILE,
+        SideEffectPlane.COLLECTION,
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.STATUS,
+        SideEffectPlane.PARSE,
+        SideEffectPlane.CHUNK,
+        SideEffectPlane.EMBEDDING,
     }
 
 

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -732,7 +732,7 @@ async def test_web_ingestion_file_and_document_side_effects_share_page_child(
 
 
 @pytest.mark.asyncio
-async def test_web_ingestion_file_compensation_success_marks_child_complete(
+async def test_web_ingestion_file_compensation_leaves_document_effects_incomplete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from xagent.core.tools.core.RAG_tools.pipelines import (
@@ -785,17 +785,22 @@ async def test_web_ingestion_file_compensation_success_marks_child_complete(
     )
 
     assert result.status == "error"
-    assert result.side_effects_may_remain is False
+    assert result.side_effects_may_remain is True
     assert len(compensation_calls) == 1
     assert compensation_calls[0] is not None
     outcome = operation_facade.last_outcome
     assert outcome is not None
-    assert outcome.rollback_status is RollbackStatus.COMPLETE
-    assert outcome.side_effects_may_remain is False
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    assert outcome.side_effects_may_remain is True
     child = outcome.child_outcomes[0]
-    assert child.rollback_status is RollbackStatus.COMPLETE
-    assert child.side_effects_may_remain is False
+    assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert child.side_effects_may_remain is True
     assert child.compensation_steps[0].payload["rollback_kind"] == "new_web_file"
+    assert {step.plane for step in child.compensation_steps} == {
+        SideEffectPlane.FILE,
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.STATUS,
+    }
 
 
 def test_web_ingestion_root_compensation_success_marks_outcome_complete() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -729,3 +729,139 @@ async def test_web_ingestion_file_and_document_side_effects_share_page_child(
         SideEffectPlane.DOCUMENT,
         SideEffectPlane.STATUS,
     }
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_file_compensation_success_marks_child_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+    compensation_calls: list[IngestionResult | None] = []
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("register_document", doc_id="doc-failed", created=True)
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        return {
+            "file_path": str(temp_file),
+            "file_id": "file-1",
+            "rollback_on_failure": lambda result=None: compensation_calls.append(
+                result
+            ),
+            "rollback_context": {"rollback_kind": "new_web_file"},
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    assert result.side_effects_may_remain is False
+    assert len(compensation_calls) == 1
+    assert compensation_calls[0] is not None
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.COMPLETE
+    assert outcome.side_effects_may_remain is False
+    child = outcome.child_outcomes[0]
+    assert child.rollback_status is RollbackStatus.COMPLETE
+    assert child.side_effects_may_remain is False
+    assert child.compensation_steps[0].payload["rollback_kind"] == "new_web_file"
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_file_compensation_failure_marks_side_effects_remaining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("register_document", doc_id="doc-failed", created=True)
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def rollback(_result=None) -> None:
+        raise RuntimeError("rollback exploded")
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        return {
+            "file_path": str(temp_file),
+            "file_id": "file-1",
+            "rollback_on_failure": rollback,
+            "rollback_context": {"rollback_kind": "existing_web_file_refresh"},
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    assert result.side_effects_may_remain is True
+    assert result.failed_urls == {"https://example.com/page": "parse failed"}
+    assert "rollback exploded" in result.message
+    assert any("rollback_on_failure failed" in item for item in result.warnings)
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+    child = outcome.child_outcomes[0]
+    assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert child.side_effects_may_remain is True
+    assert child.compensation_steps[0].payload["rollback_kind"] == (
+        "existing_web_file_refresh"
+    )

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -1140,6 +1140,70 @@ class TestWebIngestionFileHandler:
         assert any("rollback_on_failure failed" in item for item in result.warnings)
 
     @pytest.mark.asyncio
+    async def test_async_file_handler_rollback_is_reported_as_failure(
+        self, crawl_config, ingestion_config, recwarn
+    ):
+        """Async rollback callbacks should not be silently marked successful."""
+        mock_crawl_results = [
+            MagicMock(
+                url="https://example.com/page1",
+                title="Page 1",
+                content="Content 1",
+                content_markdown="# Page 1\n\nContent 1",
+                status="success",
+            )
+        ]
+        failed_ingestion = IngestionResult(
+            status="error",
+            doc_id="doc1",
+            parse_hash="hash1",
+            message="embedding failed",
+        )
+        events: list[str] = []
+
+        async def rollback(_result=None):
+            events.append("rollback")
+
+        def file_handler(
+            temp_file_path: Path, title: str, collection: str, url: str
+        ) -> dict[str, Any]:
+            return {
+                "file_path": str(temp_file_path),
+                "file_id": "file-1",
+                "rollback_on_failure": rollback,
+            }
+
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl = AsyncMock(return_value=mock_crawl_results)
+            mock_crawler.total_urls_found = 1
+            mock_crawler.failed_urls = {}
+            mock_crawler_class.return_value = mock_crawler
+
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion."
+                "run_document_ingestion",
+                return_value=failed_ingestion,
+            ):
+                result = await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                    file_handler=file_handler,
+                )
+
+        assert events == []
+        assert result.status == "error"
+        assert result.side_effects_may_remain is True
+        assert any(
+            "Async rollback_on_failure callback is not supported" in item
+            for item in result.warnings
+        )
+        assert not any("was never awaited" in str(item.message) for item in recwarn)
+
+    @pytest.mark.asyncio
     async def test_file_handler_commit_runs_on_ingestion_success(
         self, crawl_config, ingestion_config
     ):

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -600,7 +600,7 @@ def test_kb_document_job_existing_collection_failure_restores_previous_config(
         )
         monkeypatch.setattr(
             "xagent.web.jobs.kb_tasks._rollback_failed_staged_document_ingestion",
-            lambda *args, **kwargs: None,
+            lambda *args, **kwargs: kwargs["api_result"],
         )
 
         with pytest.raises(BackgroundJobHandlerError):


### PR DESCRIPTION
## Summary
- Add API-level failed-ingest rollback result handling and cleanup decisions backed by `KBOperationOutcome`.
- Route direct, cloud, background, web, and tool-created ingest paths through the same rollback outcome semantics.
- Add LIFO/idempotent compensation execution and web page child-operation aggregation for rollback reporting.

Closes #570

## Tests
- `pre-commit run --all-files`
- `PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 /home/jicheng/github/xagent/.venv/bin/pytest -q tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py tests/web/test_kb_ingest_lifecycle.py tests/core/tools/adapters/vibe/test_kb_creation_tools.py`
- `PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 /home/jicheng/github/xagent/.venv/bin/pytest -q tests/web/test_background_jobs.py -k 'not celery_worker_app_import_registers_tasks and not trigger_event_job_runs_with_eager_celery'`