### PR TITLE
ref(kb): split web rollback callbacks into per-boundary compensation steps

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/operation_compatibility.py
@@ -38,6 +38,7 @@ class SideEffectPlane(StrEnum):
     EMBEDDING = "embedding"
     STATUS = "status"
     FILE = "file"
+    SNAPSHOT = "snapshot"
     WEB_PAGE = "web_page"
 
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/pipeline_compatibility.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from .storage_shim import KBStorageShimCompatibilityFacade
 
 KB_STORAGE_METADATA_KEY = "kb_storage"
-WEB_ROLLBACK_COMPENSATED_PLANES_KEY = "compensated_side_effect_planes"
 
 
 class KBPipelineCompatibilityFacade:
@@ -407,41 +406,6 @@ class KBPipelineCompatibilityFacade:
             idempotency_key=f"file:{collection}:{file_id or file_path or url}",
             compensation=compensation,
         )
-
-    @staticmethod
-    def _compensated_side_effect_planes(
-        payload: Optional[Mapping[str, Any]],
-    ) -> set[SideEffectPlane]:
-        if not payload:
-            return set()
-
-        raw_planes = payload.get(WEB_ROLLBACK_COMPENSATED_PLANES_KEY)
-        if not isinstance(raw_planes, (list, tuple, set)):
-            return set()
-
-        planes: set[SideEffectPlane] = set()
-        for raw_plane in raw_planes:
-            try:
-                planes.add(SideEffectPlane(raw_plane))
-            except (TypeError, ValueError):
-                continue
-        return planes
-
-    def mark_web_page_compensation_coverage(
-        self,
-        operation: KBOperation | None,
-        *,
-        extra_payload: Optional[Mapping[str, Any]] = None,
-    ) -> int:
-        """Mark side effects covered by a successful web rollback callback."""
-        if operation is None or operation.outcome is not None:
-            return 0
-
-        planes = self._compensated_side_effect_planes(extra_payload)
-        if not planes:
-            return 0
-
-        return operation.mark_compensated_steps(planes=planes)
 
     @staticmethod
     def compensate_web_page_file_side_effect(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -260,9 +260,7 @@ def _run_per_boundary_compensation(
     if document_compensation is not None:
         try:
             factory = document_compensation
-            callback = (
-                factory(ingestion_result) if ingestion_result is not None else factory()
-            )
+            callback = factory(ingestion_result)
             callback()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
@@ -288,9 +286,7 @@ def _run_per_boundary_compensation(
     if status_compensation is not None:
         try:
             factory = status_compensation
-            callback = (
-                factory(ingestion_result) if ingestion_result is not None else factory()
-            )
+            callback = factory(ingestion_result)
             callback()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "STATUS", exc, rollback_context)

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -276,6 +276,10 @@ def _run_per_boundary_compensation(
             succeeded.add(SideEffectPlane.PARSE)
             succeeded.add(SideEffectPlane.CHUNK)
             succeeded.add(SideEffectPlane.EMBEDDING)
+            # Collection initialization is shared and not rolled back at the
+            # page level. Mark it compensated so the page-level rollback
+            # status is COMPLETE when all boundaries succeed.
+            succeeded.add(SideEffectPlane.COLLECTION)
 
     # STATUS boundary
     status_compensation = cast(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -233,6 +233,8 @@ def _run_per_boundary_compensation(
     warnings: list[str],
     ingestion_result: Optional[IngestionResult] = None,
 ) -> Optional[str]:
+    from ..kb.operation_compatibility import SideEffectPlane
+
     rollback_context = _rollback_context_payload(file_info)
     succeeded: set[Any] = set()
 
@@ -246,8 +248,6 @@ def _run_per_boundary_compensation(
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "FILE", exc, rollback_context)
         else:
-            from ..kb.operation_compatibility import SideEffectPlane
-
             succeeded.add(SideEffectPlane.FILE)
 
     # DOCUMENT boundary
@@ -264,8 +264,6 @@ def _run_per_boundary_compensation(
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
         else:
-            from ..kb.operation_compatibility import SideEffectPlane
-
             succeeded.add(SideEffectPlane.DOCUMENT)
             # delete_document() cascades to parse, chunk, and embedding.
             # Mark those planes as well so the operation outcome correctly
@@ -288,8 +286,6 @@ def _run_per_boundary_compensation(
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "STATUS", exc, rollback_context)
         else:
-            from ..kb.operation_compatibility import SideEffectPlane
-
             succeeded.add(SideEffectPlane.STATUS)
 
     # SNAPSHOT boundary
@@ -297,30 +293,12 @@ def _run_per_boundary_compensation(
         Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
     )
     if snapshot_compensation is not None:
-        from ..kb.operation_compatibility import SideEffectPlane
-
-        page_operation.record_side_effect(
-            name="cleanup_backup_file",
-            plane=SideEffectPlane.SNAPSHOT,
-            payload={
-                "collection": collection,
-                "url": url,
-                "file_id": cast(Optional[str], file_info.get("file_id")),
-            },
-            idempotency_key=f"snapshot:{collection}:{cast(Optional[str], file_info.get('file_id')) or url}",
-            compensation=snapshot_compensation,
-        )
-        errors = page_operation.execute_compensations(planes={SideEffectPlane.SNAPSHOT})
-        if not errors:
-            succeeded.add(SideEffectPlane.SNAPSHOT)
+        try:
+            snapshot_compensation()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "SNAPSHOT", exc, rollback_context)
         else:
-            _handle_boundary_failure(
-                warnings,
-                url,
-                "SNAPSHOT",
-                errors[0],
-                rollback_context,
-            )
+            succeeded.add(SideEffectPlane.SNAPSHOT)
 
     # Mark succeeded planes on the operation
     if succeeded and page_operation is not None:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -237,6 +237,7 @@ def _run_per_boundary_compensation(
 
     rollback_context = _rollback_context_payload(file_info)
     succeeded: set[Any] = set()
+    first_error: Optional[str] = None
 
     # FILE boundary
     file_compensation = cast(
@@ -247,6 +248,8 @@ def _run_per_boundary_compensation(
             file_compensation()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "FILE", exc, rollback_context)
+            if first_error is None:
+                first_error = f"FILE boundary compensation failed: {exc}"
         else:
             succeeded.add(SideEffectPlane.FILE)
 
@@ -263,6 +266,8 @@ def _run_per_boundary_compensation(
             callback()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
+            if first_error is None:
+                first_error = f"DOCUMENT boundary compensation failed: {exc}"
         else:
             succeeded.add(SideEffectPlane.DOCUMENT)
             # delete_document() cascades to parse, chunk, and embedding.
@@ -285,26 +290,35 @@ def _run_per_boundary_compensation(
             callback()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "STATUS", exc, rollback_context)
+            if first_error is None:
+                first_error = f"STATUS boundary compensation failed: {exc}"
         else:
             succeeded.add(SideEffectPlane.STATUS)
 
-    # SNAPSHOT boundary
+    # SNAPSHOT boundary — only cleanup backup if FILE restoration succeeded
     snapshot_compensation = cast(
         Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
     )
     if snapshot_compensation is not None:
-        try:
-            snapshot_compensation()
-        except Exception as exc:  # noqa: BLE001
-            _handle_boundary_failure(warnings, url, "SNAPSHOT", exc, rollback_context)
-        else:
-            succeeded.add(SideEffectPlane.SNAPSHOT)
+        file_registered = file_info.get("file_compensation") is not None
+        file_succeeded = SideEffectPlane.FILE in succeeded
+        if not file_registered or file_succeeded:
+            try:
+                snapshot_compensation()
+            except Exception as exc:  # noqa: BLE001
+                _handle_boundary_failure(
+                    warnings, url, "SNAPSHOT", exc, rollback_context
+                )
+                if first_error is None:
+                    first_error = f"SNAPSHOT boundary compensation failed: {exc}"
+            else:
+                succeeded.add(SideEffectPlane.SNAPSHOT)
 
     # Mark succeeded planes on the operation
     if succeeded and page_operation is not None:
         page_operation.mark_compensated_steps(planes=succeeded)
 
-    return None
+    return first_error
 
 
 def _run_legacy_rollback_compensation(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -259,14 +259,32 @@ def _run_file_handler_compensation(
         Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
     )
     if snapshot_compensation is not None:
-        try:
-            snapshot_compensation()
-        except Exception as exc:  # noqa: BLE001
-            _handle_boundary_failure(warnings, url, "SNAPSHOT", exc, rollback_context)
-        else:
-            from ..kb.operation_compatibility import SideEffectPlane
+        from ..kb.operation_compatibility import SideEffectPlane
 
-            succeeded.add(SideEffectPlane.FILE)
+        page_operation.record_side_effect(
+            name="cleanup_backup_file",
+            plane=SideEffectPlane.SNAPSHOT,
+            payload={
+                "collection": collection,
+                "url": url,
+                "file_id": cast(Optional[str], file_info.get("file_id")),
+            },
+            idempotency_key=f"snapshot:{collection}:{cast(Optional[str], file_info.get('file_id')) or url}",
+            compensation=snapshot_compensation,
+        )
+        errors = page_operation.execute_compensations(
+            planes={SideEffectPlane.SNAPSHOT}
+        )
+        if not errors:
+            succeeded.add(SideEffectPlane.SNAPSHOT)
+        else:
+            _handle_boundary_failure(
+                warnings,
+                url,
+                "SNAPSHOT",
+                errors[0],
+                rollback_context,
+            )
 
     # Mark succeeded planes on the operation
     if succeeded and page_operation is not None:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -76,6 +76,10 @@ class FileHandlerResult(TypedDict):
         rollback_context: Optional operation-outcome metadata describing the
             web file side effect. This is internal and does not affect public
             web ingestion result schemas.
+        file_compensation: Optional FILE-boundary compensation callback.
+        document_compensation: Optional DOCUMENT-boundary compensation callback.
+        status_compensation: Optional STATUS-boundary compensation callback.
+        snapshot_compensation: Optional SNAPSHOT-boundary compensation callback.
     """
 
     file_path: str
@@ -83,6 +87,10 @@ class FileHandlerResult(TypedDict):
     rollback_on_failure: NotRequired[FileHandlerCallback]
     commit_on_success: NotRequired[FileHandlerCallback]
     rollback_context: NotRequired[dict[str, object]]
+    file_compensation: NotRequired[FileHandlerCallback]
+    document_compensation: NotRequired[FileHandlerCallback]
+    status_compensation: NotRequired[FileHandlerCallback]
+    snapshot_compensation: NotRequired[FileHandlerCallback]
 
 
 class _FileHandlerRollbackError(RuntimeError):
@@ -175,15 +183,116 @@ def _run_file_handler_compensation(
     if not file_info:
         return None
 
-    callback = cast(Optional[FileHandlerCallback], file_info.get("rollback_on_failure"))
-    if callback is None:
-        return None
+    # Check for legacy monolithic rollback_on_failure callback (custom callbacks)
+    legacy_callback = cast(
+        Optional[FileHandlerCallback], file_info.get("rollback_on_failure")
+    )
+
+    if legacy_callback is not None:
+        return _run_legacy_rollback_compensation(
+            pipeline_facade=pipeline_facade,
+            page_operation=page_operation,
+            file_info=file_info,
+            collection=collection,
+            url=url,
+            warnings=warnings,
+            legacy_callback=legacy_callback,
+            ingestion_result=ingestion_result,
+        )
+
+    # Per-boundary compensation (production paths)
+    rollback_context = _rollback_context_payload(file_info)
+    succeeded: set[Any] = set()
+
+    # FILE boundary
+    file_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("file_compensation")
+    )
+    if file_compensation is not None:
+        try:
+            file_compensation()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "FILE", exc, rollback_context)
+        else:
+            from ..kb.operation_compatibility import SideEffectPlane
+
+            succeeded.add(SideEffectPlane.FILE)
+
+    # DOCUMENT boundary
+    document_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("document_compensation")
+    )
+    if document_compensation is not None:
+        try:
+            factory = document_compensation
+            callback = (
+                factory(ingestion_result) if ingestion_result is not None else factory()
+            )
+            callback()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
+        else:
+            from ..kb.operation_compatibility import SideEffectPlane
+
+            succeeded.add(SideEffectPlane.DOCUMENT)
+
+    # STATUS boundary
+    status_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("status_compensation")
+    )
+    if status_compensation is not None:
+        try:
+            factory = status_compensation
+            callback = (
+                factory(ingestion_result) if ingestion_result is not None else factory()
+            )
+            callback()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "STATUS", exc, rollback_context)
+        else:
+            from ..kb.operation_compatibility import SideEffectPlane
+
+            succeeded.add(SideEffectPlane.STATUS)
+
+    # SNAPSHOT boundary
+    snapshot_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
+    )
+    if snapshot_compensation is not None:
+        try:
+            snapshot_compensation()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "SNAPSHOT", exc, rollback_context)
+        else:
+            from ..kb.operation_compatibility import SideEffectPlane
+
+            succeeded.add(SideEffectPlane.FILE)
+
+    # Mark succeeded planes on the operation
+    if succeeded and page_operation is not None:
+        page_operation.mark_compensated_steps(planes=succeeded)
+
+    return None
+
+
+def _run_legacy_rollback_compensation(
+    *,
+    pipeline_facade: "KBPipelineCompatibilityFacade",
+    page_operation: Any,
+    file_info: FileHandlerResult,
+    collection: str,
+    url: str,
+    warnings: list[str],
+    legacy_callback: FileHandlerCallback,
+    ingestion_result: Optional[IngestionResult] = None,
+) -> Optional[str]:
+    """Handle legacy monolithic rollback_on_failure (custom callbacks)."""
     rollback_context = _rollback_context_payload(file_info)
 
     def _compensate() -> None:
         try:
             _run_sync_file_handler_callback(
-                callback,
+                legacy_callback,
                 callback_name="rollback_on_failure",
                 url=url,
                 ingestion_result=ingestion_result,
@@ -207,10 +316,6 @@ def _run_file_handler_compensation(
     )
     errors = pipeline_facade.compensate_web_page_file_side_effect(page_operation)
     if not errors:
-        pipeline_facade.mark_web_page_compensation_coverage(
-            page_operation,
-            extra_payload=rollback_context,
-        )
         return None
 
     first_error = errors[0]
@@ -225,6 +330,19 @@ def _run_file_handler_compensation(
     return cleanup_reason
 
 
+def _handle_boundary_failure(
+    warnings: list[str],
+    url: str,
+    boundary: str,
+    exc: Exception,
+    rollback_context: Optional[dict[str, object]],
+) -> None:
+    """Log and record a per-boundary compensation failure."""
+    message = f"Web rollback {boundary} compensation failed for {url}: {exc}"
+    logger.warning(message)
+    warnings.append(message)
+
+
 def _run_legacy_persistent_file_compensation(
     *,
     pipeline_facade: "KBPipelineCompatibilityFacade",
@@ -237,7 +355,9 @@ def _run_legacy_persistent_file_compensation(
 ) -> Optional[str]:
     if not copied_persistent_file or not copied_persistent_file.exists():
         return None
-    if file_info and "rollback_on_failure" in file_info:
+    if file_info and (
+        "rollback_on_failure" in file_info or "file_compensation" in file_info
+    ):
         return None
 
     def _compensate() -> None:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -310,9 +310,7 @@ def _run_per_boundary_compensation(
             idempotency_key=f"snapshot:{collection}:{cast(Optional[str], file_info.get('file_id')) or url}",
             compensation=snapshot_compensation,
         )
-        errors = page_operation.execute_compensations(
-            planes={SideEffectPlane.SNAPSHOT}
-        )
+        errors = page_operation.execute_compensations(planes={SideEffectPlane.SNAPSHOT})
         if not errors:
             succeeded.add(SideEffectPlane.SNAPSHOT)
         else:

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -183,11 +183,31 @@ def _run_file_handler_compensation(
     if not file_info:
         return None
 
-    # Check for legacy monolithic rollback_on_failure callback (custom callbacks)
+    # Per-boundary compensation takes priority over legacy rollback_on_failure.
+    has_per_boundary = any(
+        file_info.get(key)
+        for key in (
+            "file_compensation",
+            "document_compensation",
+            "status_compensation",
+            "snapshot_compensation",
+        )
+    )
+    if has_per_boundary:
+        return _run_per_boundary_compensation(
+            pipeline_facade=pipeline_facade,
+            page_operation=page_operation,
+            file_info=file_info,
+            collection=collection,
+            url=url,
+            warnings=warnings,
+            ingestion_result=ingestion_result,
+        )
+
+    # Legacy monolithic rollback_on_failure callback (custom callbacks only)
     legacy_callback = cast(
         Optional[FileHandlerCallback], file_info.get("rollback_on_failure")
     )
-
     if legacy_callback is not None:
         return _run_legacy_rollback_compensation(
             pipeline_facade=pipeline_facade,
@@ -200,7 +220,19 @@ def _run_file_handler_compensation(
             ingestion_result=ingestion_result,
         )
 
-    # Per-boundary compensation (production paths)
+    return None
+
+
+def _run_per_boundary_compensation(
+    *,
+    pipeline_facade: "KBPipelineCompatibilityFacade",
+    page_operation: Any,
+    file_info: FileHandlerResult,
+    collection: str,
+    url: str,
+    warnings: list[str],
+    ingestion_result: Optional[IngestionResult] = None,
+) -> Optional[str]:
     rollback_context = _rollback_context_payload(file_info)
     succeeded: set[Any] = set()
 
@@ -235,6 +267,12 @@ def _run_file_handler_compensation(
             from ..kb.operation_compatibility import SideEffectPlane
 
             succeeded.add(SideEffectPlane.DOCUMENT)
+            # delete_document() cascades to parse, chunk, and embedding.
+            # Mark those planes as well so the operation outcome correctly
+            # reports complete compensation.
+            succeeded.add(SideEffectPlane.PARSE)
+            succeeded.add(SideEffectPlane.CHUNK)
+            succeeded.add(SideEffectPlane.EMBEDDING)
 
     # STATUS boundary
     status_compensation = cast(

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -170,6 +170,44 @@ def _rollback_context_payload(
     return rollback_context if isinstance(rollback_context, dict) else None
 
 
+def _has_per_boundary_compensation(file_info: FileHandlerResult) -> bool:
+    return any(
+        file_info.get(key)
+        for key in (
+            "file_compensation",
+            "document_compensation",
+            "status_compensation",
+            "snapshot_compensation",
+        )
+    )
+
+
+def _string_or_none(value: object) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _ingestion_doc_id(ingestion_result: Optional[IngestionResult]) -> Optional[str]:
+    if ingestion_result is None:
+        return None
+    return _string_or_none(ingestion_result.doc_id)
+
+
+def _boundary_idempotency_key(
+    *,
+    boundary: str,
+    collection: str,
+    file_info: FileHandlerResult,
+    url: str,
+    doc_id: Optional[str] = None,
+) -> str:
+    if doc_id:
+        return f"{boundary}:{collection}:{doc_id}"
+    return (
+        f"{boundary}:{collection}:"
+        f"{file_info.get('file_id') or file_info.get('file_path') or url}"
+    )
+
+
 def _run_file_handler_compensation(
     *,
     pipeline_facade: "KBPipelineCompatibilityFacade",
@@ -184,15 +222,7 @@ def _run_file_handler_compensation(
         return None
 
     # Per-boundary compensation takes priority over legacy rollback_on_failure.
-    has_per_boundary = any(
-        file_info.get(key)
-        for key in (
-            "file_compensation",
-            "document_compensation",
-            "status_compensation",
-            "snapshot_compensation",
-        )
-    )
+    has_per_boundary = _has_per_boundary_compensation(file_info)
     if has_per_boundary:
         return _run_per_boundary_compensation(
             pipeline_facade=pipeline_facade,
@@ -235,11 +265,156 @@ def _run_per_boundary_compensation(
 ) -> Optional[str]:
     from ..kb.operation_compatibility import SideEffectPlane
 
+    if page_operation is None:
+        return _run_per_boundary_callbacks_without_operation(
+            file_info=file_info,
+            url=url,
+            warnings=warnings,
+            ingestion_result=ingestion_result,
+        )
+
+    rollback_context = _rollback_context_payload(file_info)
+    first_error: Optional[str] = None
+    doc_id = _ingestion_doc_id(ingestion_result)
+
+    # DOCUMENT boundary
+    document_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("document_compensation")
+    )
+    if document_compensation is not None:
+        _record_document_boundary_compensation(
+            page_operation=page_operation,
+            file_info=file_info,
+            collection=collection,
+            url=url,
+            document_compensation=document_compensation,
+            ingestion_result=ingestion_result,
+            doc_id=doc_id,
+        )
+        document_errors = page_operation.execute_compensations(
+            step_names={"remove_registered_document"},
+            planes={SideEffectPlane.DOCUMENT},
+        )
+        first_error = _record_boundary_errors(
+            warnings=warnings,
+            url=url,
+            boundary="DOCUMENT",
+            errors=document_errors,
+            rollback_context=rollback_context,
+            first_error=first_error,
+        )
+
+    # FILE boundary
+    file_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("file_compensation")
+    )
+    file_succeeded = file_compensation is None
+    if file_compensation is not None:
+        pipeline_facade.record_web_page_file_side_effect(
+            page_operation,
+            collection=collection,
+            url=url,
+            file_path=cast(Optional[str], file_info.get("file_path")),
+            file_id=cast(Optional[str], file_info.get("file_id")),
+            reason="file_compensation",
+            extra_payload=rollback_context,
+            compensation=cast(Callable[[], None], file_compensation),
+        )
+        file_errors = pipeline_facade.compensate_web_page_file_side_effect(
+            page_operation
+        )
+        file_succeeded = not file_errors
+        first_error = _record_boundary_errors(
+            warnings=warnings,
+            url=url,
+            boundary="FILE",
+            errors=file_errors,
+            rollback_context=rollback_context,
+            first_error=first_error,
+        )
+
+    # STATUS boundary
+    status_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("status_compensation")
+    )
+    if status_compensation is not None:
+        _record_status_boundary_compensation(
+            page_operation=page_operation,
+            file_info=file_info,
+            collection=collection,
+            url=url,
+            status_compensation=status_compensation,
+            ingestion_result=ingestion_result,
+            doc_id=doc_id,
+        )
+        status_errors = page_operation.execute_compensations(
+            step_names={"clear_ingestion_status"},
+            planes={SideEffectPlane.STATUS},
+        )
+        first_error = _record_boundary_errors(
+            warnings=warnings,
+            url=url,
+            boundary="STATUS",
+            errors=status_errors,
+            rollback_context=rollback_context,
+            first_error=first_error,
+        )
+
+    # SNAPSHOT boundary - only cleanup backup if FILE restoration succeeded
+    snapshot_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
+    )
+    if snapshot_compensation is not None:
+        _record_snapshot_boundary_compensation(
+            page_operation=page_operation,
+            file_info=file_info,
+            collection=collection,
+            url=url,
+            snapshot_compensation=snapshot_compensation,
+            rollback_context=rollback_context,
+        )
+        file_registered = file_compensation is not None
+        if first_error is None and (not file_registered or file_succeeded):
+            snapshot_errors = page_operation.execute_compensations(
+                step_names={"cleanup_web_page_snapshot"},
+                planes={SideEffectPlane.SNAPSHOT},
+            )
+            first_error = _record_boundary_errors(
+                warnings=warnings,
+                url=url,
+                boundary="SNAPSHOT",
+                errors=snapshot_errors,
+                rollback_context=rollback_context,
+                first_error=first_error,
+            )
+
+    return first_error
+
+
+def _run_per_boundary_callbacks_without_operation(
+    *,
+    file_info: FileHandlerResult,
+    url: str,
+    warnings: list[str],
+    ingestion_result: Optional[IngestionResult] = None,
+) -> Optional[str]:
+    from ..kb.operation_compatibility import SideEffectPlane
+
     rollback_context = _rollback_context_payload(file_info)
     succeeded: set[Any] = set()
     first_error: Optional[str] = None
 
-    # FILE boundary
+    document_compensation = cast(
+        Optional[FileHandlerCallback], file_info.get("document_compensation")
+    )
+    if document_compensation is not None:
+        try:
+            callback = document_compensation(ingestion_result)
+            callback()
+        except Exception as exc:  # noqa: BLE001
+            _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
+            first_error = first_error or f"DOCUMENT boundary compensation failed: {exc}"
+
     file_compensation = cast(
         Optional[FileHandlerCallback], file_info.get("file_compensation")
     )
@@ -248,77 +423,190 @@ def _run_per_boundary_compensation(
             file_compensation()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "FILE", exc, rollback_context)
-            if first_error is None:
-                first_error = f"FILE boundary compensation failed: {exc}"
+            first_error = first_error or f"FILE boundary compensation failed: {exc}"
         else:
             succeeded.add(SideEffectPlane.FILE)
 
-    # DOCUMENT boundary
-    document_compensation = cast(
-        Optional[FileHandlerCallback], file_info.get("document_compensation")
-    )
-    if document_compensation is not None:
-        try:
-            factory = document_compensation
-            callback = factory(ingestion_result)
-            callback()
-        except Exception as exc:  # noqa: BLE001
-            _handle_boundary_failure(warnings, url, "DOCUMENT", exc, rollback_context)
-            if first_error is None:
-                first_error = f"DOCUMENT boundary compensation failed: {exc}"
-        else:
-            succeeded.add(SideEffectPlane.DOCUMENT)
-            # delete_document() cascades to parse, chunk, and embedding.
-            # Mark those planes as well so the operation outcome correctly
-            # reports complete compensation.
-            succeeded.add(SideEffectPlane.PARSE)
-            succeeded.add(SideEffectPlane.CHUNK)
-            succeeded.add(SideEffectPlane.EMBEDDING)
-            # Collection initialization is shared and not rolled back at the
-            # page level. Mark it compensated so the page-level rollback
-            # status is COMPLETE when all boundaries succeed.
-            succeeded.add(SideEffectPlane.COLLECTION)
-
-    # STATUS boundary
     status_compensation = cast(
         Optional[FileHandlerCallback], file_info.get("status_compensation")
     )
     if status_compensation is not None:
         try:
-            factory = status_compensation
-            callback = factory(ingestion_result)
+            callback = status_compensation(ingestion_result)
             callback()
         except Exception as exc:  # noqa: BLE001
             _handle_boundary_failure(warnings, url, "STATUS", exc, rollback_context)
-            if first_error is None:
-                first_error = f"STATUS boundary compensation failed: {exc}"
-        else:
-            succeeded.add(SideEffectPlane.STATUS)
+            first_error = first_error or f"STATUS boundary compensation failed: {exc}"
 
-    # SNAPSHOT boundary — only cleanup backup if FILE restoration succeeded
     snapshot_compensation = cast(
         Optional[FileHandlerCallback], file_info.get("snapshot_compensation")
     )
     if snapshot_compensation is not None:
-        file_registered = file_info.get("file_compensation") is not None
+        file_registered = file_compensation is not None
         file_succeeded = SideEffectPlane.FILE in succeeded
-        if not file_registered or file_succeeded:
+        if first_error is None and (not file_registered or file_succeeded):
             try:
                 snapshot_compensation()
             except Exception as exc:  # noqa: BLE001
                 _handle_boundary_failure(
                     warnings, url, "SNAPSHOT", exc, rollback_context
                 )
-                if first_error is None:
-                    first_error = f"SNAPSHOT boundary compensation failed: {exc}"
-            else:
-                succeeded.add(SideEffectPlane.SNAPSHOT)
-
-    # Mark succeeded planes on the operation
-    if succeeded and page_operation is not None:
-        page_operation.mark_compensated_steps(planes=succeeded)
+                first_error = (
+                    first_error or f"SNAPSHOT boundary compensation failed: {exc}"
+                )
 
     return first_error
+
+
+def _record_document_boundary_compensation(
+    *,
+    page_operation: Any,
+    file_info: FileHandlerResult,
+    collection: str,
+    url: str,
+    document_compensation: FileHandlerCallback,
+    ingestion_result: Optional[IngestionResult],
+    doc_id: Optional[str],
+) -> None:
+    from ..kb.operation_compatibility import SideEffectPlane
+
+    def _compensate() -> None:
+        callback = document_compensation(ingestion_result)
+        result = callback()
+        if inspect.isawaitable(result):
+            _close_awaitable_if_possible(result)
+            raise TypeError(
+                f"Async DOCUMENT compensation callback is not supported for {url}"
+            )
+        # delete_document() cascades to parse, chunk, and embedding. Collection
+        # initialization is shared and not rolled back at the page level, so a
+        # successful document compensation covers that page-level plane too.
+        page_operation.mark_compensated_steps(
+            planes={
+                SideEffectPlane.COLLECTION,
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.PARSE,
+                SideEffectPlane.CHUNK,
+                SideEffectPlane.EMBEDDING,
+            }
+        )
+
+    page_operation.record_side_effect(
+        name="remove_registered_document",
+        plane=SideEffectPlane.DOCUMENT,
+        payload={
+            "collection": collection,
+            "url": url,
+            "doc_id": doc_id,
+            "file_id": file_info.get("file_id"),
+            "rollback_kind": (_rollback_context_payload(file_info) or {}).get(
+                "rollback_kind"
+            ),
+        },
+        idempotency_key=_boundary_idempotency_key(
+            boundary="document",
+            collection=collection,
+            file_info=file_info,
+            url=url,
+            doc_id=doc_id,
+        ),
+        compensation=_compensate,
+    )
+
+
+def _record_status_boundary_compensation(
+    *,
+    page_operation: Any,
+    file_info: FileHandlerResult,
+    collection: str,
+    url: str,
+    status_compensation: FileHandlerCallback,
+    ingestion_result: Optional[IngestionResult],
+    doc_id: Optional[str],
+) -> None:
+    from ..kb.operation_compatibility import SideEffectPlane
+
+    def _compensate() -> None:
+        callback = status_compensation(ingestion_result)
+        result = callback()
+        if inspect.isawaitable(result):
+            _close_awaitable_if_possible(result)
+            raise TypeError(
+                f"Async STATUS compensation callback is not supported for {url}"
+            )
+
+    page_operation.record_side_effect(
+        name="clear_ingestion_status",
+        plane=SideEffectPlane.STATUS,
+        payload={
+            "collection": collection,
+            "url": url,
+            "doc_id": doc_id,
+            "file_id": file_info.get("file_id"),
+            "rollback_kind": (_rollback_context_payload(file_info) or {}).get(
+                "rollback_kind"
+            ),
+        },
+        idempotency_key=_boundary_idempotency_key(
+            boundary="status",
+            collection=collection,
+            file_info=file_info,
+            url=url,
+            doc_id=doc_id,
+        ),
+        compensation=_compensate,
+    )
+
+
+def _record_snapshot_boundary_compensation(
+    *,
+    page_operation: Any,
+    file_info: FileHandlerResult,
+    collection: str,
+    url: str,
+    snapshot_compensation: FileHandlerCallback,
+    rollback_context: Optional[dict[str, object]],
+) -> None:
+    from ..kb.operation_compatibility import SideEffectPlane
+
+    backup_path = None
+    if rollback_context is not None:
+        backup_path = rollback_context.get("backup_path")
+    key_source = (
+        backup_path or file_info.get("file_id") or file_info.get("file_path") or url
+    )
+
+    page_operation.record_side_effect(
+        name="cleanup_web_page_snapshot",
+        plane=SideEffectPlane.SNAPSHOT,
+        payload={
+            "collection": collection,
+            "url": url,
+            "backup_path": backup_path,
+            "file_id": file_info.get("file_id"),
+            "rollback_kind": (rollback_context or {}).get("rollback_kind"),
+        },
+        idempotency_key=f"snapshot:{collection}:{key_source}",
+        compensation=cast(Callable[[], None], snapshot_compensation),
+    )
+
+
+def _record_boundary_errors(
+    *,
+    warnings: list[str],
+    url: str,
+    boundary: str,
+    errors: tuple[BaseException, ...],
+    rollback_context: Optional[dict[str, object]],
+    first_error: Optional[str],
+) -> Optional[str]:
+    if not errors:
+        return first_error
+    for exc in errors:
+        _handle_boundary_failure(warnings, url, boundary, exc, rollback_context)
+    if first_error is not None:
+        return first_error
+    return f"{boundary} boundary compensation failed: {errors[0]}"
 
 
 def _run_legacy_rollback_compensation(
@@ -380,7 +668,7 @@ def _handle_boundary_failure(
     warnings: list[str],
     url: str,
     boundary: str,
-    exc: Exception,
+    exc: BaseException,
     rollback_context: Optional[dict[str, object]],
 ) -> None:
     """Log and record a per-boundary compensation failure."""
@@ -639,7 +927,17 @@ async def _run_web_ingestion_impl(
                             )
                             final_file_id = file_info.get("file_id")
 
-                            if final_file_path != temp_file or final_file_id:
+                            has_per_boundary = _has_per_boundary_compensation(file_info)
+                            file_compensation = cast(
+                                Optional[FileHandlerCallback],
+                                file_info.get("file_compensation"),
+                            )
+                            should_record_file_side_effect = (
+                                file_compensation is not None
+                                if has_per_boundary
+                                else bool(final_file_path != temp_file or final_file_id)
+                            )
+                            if should_record_file_side_effect:
                                 pipeline_facade.record_web_page_file_side_effect(
                                     page_operation,
                                     collection=collection,
@@ -647,6 +945,10 @@ async def _run_web_ingestion_impl(
                                     file_path=str(final_file_path),
                                     file_id=final_file_id,
                                     extra_payload=_rollback_context_payload(file_info),
+                                    compensation=cast(
+                                        Optional[Callable[[], None]],
+                                        file_compensation,
+                                    ),
                                 )
 
                             # Track if we successfully copied a persistent file for cleanup

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -71,9 +71,6 @@ from ...core.tools.core.RAG_tools.kb import (
     KBApiOperationResult,
     get_kb_coordinator,
 )
-from ...core.tools.core.RAG_tools.kb.pipeline_compatibility import (
-    WEB_ROLLBACK_COMPENSATED_PLANES_KEY,
-)
 from ...core.tools.core.RAG_tools.management.status import clear_ingestion_status
 from ...core.tools.core.RAG_tools.pipelines.web_ingestion import FileHandlerResult
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
@@ -160,16 +157,181 @@ from .cloud_storage import get_google_credentials
 T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
-_WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES = (
-    # Collection initialization is completed by the outer failed-ingest cleanup.
-    # Marking it here lets that cleanup run after the page rollback succeeds.
-    "collection",
-    "document",
-    "status",
-    "parse",
-    "chunk",
-    "embedding",
-)
+
+def _create_file_compensation_delete(
+    *,
+    file_record_id: str,
+    persistent_file_path: Path,
+) -> Callable[[], None]:
+    """Create a FILE-boundary compensation callback for deleting a new web file."""
+
+    def _compensate() -> None:
+        SessionLocal = get_session_local()
+        rollback_db = SessionLocal()
+        try:
+            rollback_record = (
+                rollback_db.query(UploadedFile)
+                .filter(UploadedFile.file_id == file_record_id)
+                .first()
+            )
+            if rollback_record is not None:
+                UploadedFileStore(rollback_db).delete(
+                    rollback_record,
+                    delete_local=True,
+                )
+            else:
+                persistent_file_path.unlink(missing_ok=True)
+            rollback_db.commit()
+        except Exception:
+            rollback_db.rollback()
+            raise
+        finally:
+            rollback_db.close()
+
+    return _compensate
+
+
+def _create_file_compensation_restore(
+    *,
+    file_record_id: str,
+    existing_path: Path,
+    backup_path: Path,
+    record_snapshot: dict[str, Any],
+) -> Callable[[], None]:
+    """Create a FILE-boundary compensation callback for restoring a refreshed/recreated web file."""
+
+    def _compensate() -> None:
+        if not backup_path.exists():
+            raise FileNotFoundError(
+                f"Missing web ingest rollback backup: {backup_path}"
+            )
+        SessionLocal = get_session_local()
+        rollback_db = SessionLocal()
+        try:
+            refreshed_record = (
+                rollback_db.query(UploadedFile)
+                .filter(UploadedFile.file_id == file_record_id)
+                .first()
+            )
+            if refreshed_record is None:
+                _restore_ingest_file_backup(
+                    file_path=existing_path,
+                    backup_path=backup_path,
+                    had_existing_file=True,
+                )
+            else:
+                current_storage_key = str(
+                    getattr(refreshed_record, "storage_key", "") or ""
+                )
+                previous_storage_key = str(record_snapshot.get("storage_key") or "")
+                if current_storage_key and current_storage_key != previous_storage_key:
+                    ManagedFileRef(refreshed_record).delete_durable()
+
+                _restore_ingest_file_backup(
+                    file_path=existing_path,
+                    backup_path=backup_path,
+                    had_existing_file=True,
+                )
+                _restore_uploaded_file_record_snapshot(
+                    refreshed_record, record_snapshot
+                )
+                if previous_storage_key:
+                    UploadedFileStore(rollback_db).sync_existing(
+                        refreshed_record,
+                        storage_key=previous_storage_key,
+                        mime_type=record_snapshot.get("mime_type"),
+                    )
+                else:
+                    rollback_db.flush()
+            rollback_db.commit()
+        except Exception:
+            rollback_db.rollback()
+            raise
+        finally:
+            rollback_db.close()
+
+    return _compensate
+
+
+def _create_document_compensation(
+    *,
+    collection_name: str,
+    user_id: int,
+    is_admin: bool,
+    file_record_id: str,
+    rag_document_snapshot: Optional["_RagDocumentSnapshot"] = None,
+) -> Callable[[], Callable[[], None]]:
+    """Create a DOCUMENT-boundary compensation factory.
+
+    Returns a factory that accepts an optional IngestionResult and produces
+    the actual compensation callback. This two-phase pattern is needed because
+    the ingestion result is only available at compensation execution time.
+    """
+
+    def _factory(
+        ingestion_result: Optional[Any] = None,
+    ) -> Callable[[], None]:
+        def _compensate() -> None:
+            _rollback_failed_web_document_ingestion(
+                collection_name=collection_name,
+                result=ingestion_result,
+                user_id=user_id,
+                is_admin=is_admin,
+                rag_snapshot=rag_document_snapshot,
+                file_id=file_record_id,
+            )
+
+        return _compensate
+
+    return _factory
+
+
+def _create_status_compensation(
+    *,
+    collection_name: str,
+    user_id: int,
+    is_admin: bool,
+    ingestion_runs_snapshot: Optional[Any] = None,
+) -> Callable[[], Callable[[], None]]:
+    """Create a STATUS-boundary compensation factory."""
+
+    def _factory(
+        ingestion_result: Optional[Any] = None,
+    ) -> Callable[[], None]:
+        def _compensate() -> None:
+            if ingestion_runs_snapshot is not None:
+                _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
+            elif ingestion_result is not None:
+                doc_id = (
+                    ingestion_result.doc_id
+                    if isinstance(ingestion_result.doc_id, str)
+                    and ingestion_result.doc_id
+                    else None
+                )
+                if doc_id:
+                    clear_ingestion_status(
+                        collection_name,
+                        doc_id,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    )
+
+        return _compensate
+
+    return _factory
+
+
+def _create_snapshot_compensation(
+    *,
+    backup_path: Optional[Path],
+) -> Callable[[], None]:
+    """Create a SNAPSHOT-boundary compensation callback for cleanup on success."""
+
+    def _compensate() -> None:
+        if backup_path is not None:
+            backup_path.unlink(missing_ok=True)
+
+    return _compensate
 
 
 def _get_api_compatibility_facade() -> KBApiCompatibilityFacade:
@@ -2198,60 +2360,29 @@ def _existing_web_file_result_with_rollback(
             "Failed to snapshot RAG document rows before reusing existing web file"
         )
 
-    def _rollback_existing(
-        ingestion_result: Optional[IngestionResult] = None,
-    ) -> None:
-        rollback_error: Optional[Exception] = None
-        try:
-            _rollback_failed_web_document_ingestion(
-                collection_name=collection_name,
-                result=ingestion_result,
-                user_id=user_id,
-                is_admin=is_admin,
-                rag_snapshot=rag_document_snapshot,
-                file_id=file_record_id,
-            )
-        except Exception as exc:  # noqa: BLE001
-            rollback_error = exc
-            logger.warning(
-                "Failed to restore RAG rows during existing web file rollback: "
-                "url=%s, file_id=%s, context=%s, error=%s",
-                url,
-                file_record_id,
-                context,
-                exc,
-                exc_info=True,
-            )
-
-        try:
-            _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
-        except Exception as exc:  # noqa: BLE001
-            if rollback_error is None:
-                rollback_error = exc
-            logger.warning(
-                "Failed to restore ingestion runs during existing web file rollback: "
-                "url=%s, file_id=%s, context=%s, error=%s",
-                url,
-                file_record_id,
-                context,
-                exc,
-                exc_info=True,
-            )
-
-        if rollback_error is not None:
-            raise rollback_error
+    document_compensation = _create_document_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_record_id=file_record_id,
+        rag_document_snapshot=rag_document_snapshot,
+    )
+    status_compensation = _create_status_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        ingestion_runs_snapshot=ingestion_runs_snapshot,
+    )
 
     return FileHandlerResult(
         file_path=str(file_path),
         file_id=file_record_id,
-        rollback_on_failure=_rollback_existing,
+        document_compensation=document_compensation,
+        status_compensation=status_compensation,
         rollback_context={
             "rollback_kind": "existing_web_file_reuse",
             "context": context,
             "file_id": file_record_id,
-            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
-                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
-            ),
         },
     )
 
@@ -2296,63 +2427,27 @@ def _create_new_web_file_handler_result(
         file_record_id = str(file_record.file_id)
         persistent_file_path = Path(persistent_file)
 
-        def _rollback_new_web_file(
-            ingestion_result: Optional[IngestionResult] = None,
-        ) -> None:
-            rollback_error: Optional[Exception] = None
-            try:
-                _rollback_failed_web_document_ingestion(
-                    collection_name=collection_name,
-                    result=ingestion_result,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    file_id=file_record_id,
-                )
-            except Exception as exc:  # noqa: BLE001
-                rollback_error = exc
-                logger.warning(
-                    "Failed to clean RAG rows during new web file rollback: "
-                    "file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-            SessionLocal = get_session_local()
-            rollback_db = SessionLocal()
-            try:
-                rollback_record = (
-                    rollback_db.query(UploadedFile)
-                    .filter(UploadedFile.file_id == file_record_id)
-                    .first()
-                )
-                if rollback_record is not None:
-                    UploadedFileStore(rollback_db).delete(
-                        rollback_record,
-                        delete_local=True,
-                    )
-                else:
-                    persistent_file_path.unlink(missing_ok=True)
-                rollback_db.commit()
-            except Exception:
-                rollback_db.rollback()
-                raise
-            finally:
-                rollback_db.close()
-            if rollback_error is not None:
-                raise rollback_error
+        file_compensation = _create_file_compensation_delete(
+            file_record_id=file_record_id,
+            persistent_file_path=persistent_file_path,
+        )
+        document_compensation = _create_document_compensation(
+            collection_name=collection_name,
+            user_id=user_id,
+            is_admin=is_admin,
+            file_record_id=file_record_id,
+        )
 
         return FileHandlerResult(
             file_path=str(persistent_file),
             file_id=file_record_id,
-            rollback_on_failure=_rollback_new_web_file,
+            file_compensation=file_compensation,
+            document_compensation=document_compensation,
             rollback_context={
                 "rollback_kind": "new_web_file",
                 "filename": filename,
                 "storage_path": str(persistent_file),
                 "file_id": file_record_id,
-                WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
-                    _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
-                ),
             },
         )
     except Exception:
@@ -2535,118 +2630,28 @@ def _refresh_existing_file_if_changed(
 
     file_record_id = str(file_record.file_id)
 
-    def _rollback_refresh(
-        ingestion_result: Optional[IngestionResult] = None,
-    ) -> None:
-        if not backup_path.exists():
-            raise FileNotFoundError(
-                f"Missing web ingest rollback backup: {backup_path}"
-            )
-
-        SessionLocal = get_session_local()
-        rollback_db = SessionLocal()
-        rollback_succeeded = False
-        try:
-            rollback_error: Optional[Exception] = None
-            try:
-                _rollback_failed_web_document_ingestion(
-                    collection_name=collection_name,
-                    result=ingestion_result,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    rag_snapshot=rag_document_snapshot,
-                    file_id=file_record_id,
-                )
-            except Exception as exc:  # noqa: BLE001
-                rollback_error = exc
-                logger.warning(
-                    "Failed to restore RAG rows during web file refresh rollback: "
-                    "file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            try:
-                refreshed_record = (
-                    rollback_db.query(UploadedFile)
-                    .filter(UploadedFile.file_id == file_record_id)
-                    .first()
-                )
-                if refreshed_record is None:
-                    _restore_ingest_file_backup(
-                        file_path=existing_path,
-                        backup_path=backup_path,
-                        had_existing_file=True,
-                    )
-                    rollback_db.commit()
-                else:
-                    current_storage_key = str(
-                        getattr(refreshed_record, "storage_key", "") or ""
-                    )
-                    previous_storage_key = str(record_snapshot.get("storage_key") or "")
-                    if (
-                        current_storage_key
-                        and current_storage_key != previous_storage_key
-                    ):
-                        ManagedFileRef(refreshed_record).delete_durable()
-
-                    _restore_ingest_file_backup(
-                        file_path=existing_path,
-                        backup_path=backup_path,
-                        had_existing_file=True,
-                    )
-                    _restore_uploaded_file_record_snapshot(
-                        refreshed_record, record_snapshot
-                    )
-                    if previous_storage_key:
-                        UploadedFileStore(rollback_db).sync_existing(
-                            refreshed_record,
-                            storage_key=previous_storage_key,
-                            mime_type=record_snapshot.get("mime_type"),
-                        )
-                    else:
-                        rollback_db.flush()
-                    rollback_db.commit()
-            except Exception as exc:  # noqa: BLE001
-                rollback_db.rollback()
-                if rollback_error is None:
-                    rollback_error = exc
-                logger.warning(
-                    "Failed to restore UploadedFile/local file during web file "
-                    "refresh rollback: file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            try:
-                _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
-            except Exception as exc:  # noqa: BLE001
-                if rollback_error is None:
-                    rollback_error = exc
-                logger.warning(
-                    "Failed to restore ingestion runs during web file refresh "
-                    "rollback: file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            if rollback_error is not None:
-                raise rollback_error
-            rollback_succeeded = True
-        except Exception:
-            raise
-        finally:
-            rollback_db.close()
-            if rollback_succeeded:
-                backup_path.unlink(missing_ok=True)
-            elif backup_path.exists():
-                logger.warning(
-                    "Preserving web ingest rollback backup after failed rollback: %s",
-                    backup_path,
-                )
+    file_compensation = _create_file_compensation_restore(
+        file_record_id=file_record_id,
+        existing_path=existing_path,
+        backup_path=backup_path,
+        record_snapshot=record_snapshot,
+    )
+    document_compensation = _create_document_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_record_id=file_record_id,
+        rag_document_snapshot=rag_document_snapshot,
+    )
+    status_compensation = _create_status_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        ingestion_runs_snapshot=ingestion_runs_snapshot,
+    )
+    snapshot_compensation = _create_snapshot_compensation(
+        backup_path=backup_path,
+    )
 
     def _commit_refresh() -> None:
         backup_path.unlink(missing_ok=True)
@@ -2654,16 +2659,16 @@ def _refresh_existing_file_if_changed(
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
-        rollback_on_failure=_rollback_refresh,
         commit_on_success=_commit_refresh,
+        file_compensation=file_compensation,
+        document_compensation=document_compensation,
+        status_compensation=status_compensation,
+        snapshot_compensation=snapshot_compensation,
         rollback_context={
             "rollback_kind": "existing_web_file_refresh",
             "filename": filename,
             "backup_path": str(backup_path),
             "file_id": file_record_id,
-            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
-                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
-            ),
         },
     )
 
@@ -2802,117 +2807,30 @@ def _recreate_missing_existing_file(
     file_record_id = str(file_record.file_id)
     backup_for_failure = backup_path
 
-    def _rollback_recreate(
-        ingestion_result: Optional[IngestionResult] = None,
-    ) -> None:
-        SessionLocal = get_session_local()
-        rollback_db = SessionLocal()
-        rollback_succeeded = False
-        try:
-            rollback_error: Optional[Exception] = None
-            try:
-                _rollback_failed_web_document_ingestion(
-                    collection_name=collection_name,
-                    result=ingestion_result,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                    rag_snapshot=rag_document_snapshot,
-                    file_id=file_record_id,
-                )
-            except Exception as exc:  # noqa: BLE001
-                rollback_error = exc
-                logger.warning(
-                    "Failed to clean RAG rows during recreated web file rollback: "
-                    "file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            try:
-                refreshed_record = (
-                    rollback_db.query(UploadedFile)
-                    .filter(UploadedFile.file_id == file_record_id)
-                    .first()
-                )
-                if refreshed_record is not None:
-                    current_storage_key = str(
-                        getattr(refreshed_record, "storage_key", "") or ""
-                    )
-                    previous_storage_key = str(record_snapshot.get("storage_key") or "")
-                    if (
-                        current_storage_key
-                        and current_storage_key != previous_storage_key
-                    ):
-                        ManagedFileRef(refreshed_record).delete_durable()
-
-                    _restore_uploaded_file_record_snapshot(
-                        refreshed_record, record_snapshot
-                    )
-                    if previous_storage_key and backup_for_failure is not None:
-                        _restore_ingest_file_backup(
-                            file_path=existing_path,
-                            backup_path=backup_for_failure,
-                            had_existing_file=True,
-                        )
-                        UploadedFileStore(rollback_db).sync_existing(
-                            refreshed_record,
-                            storage_key=previous_storage_key,
-                            mime_type=record_snapshot.get("mime_type"),
-                        )
-                    else:
-                        _restore_ingest_file_backup(
-                            file_path=existing_path,
-                            backup_path=backup_for_failure,
-                            had_existing_file=had_existing_file,
-                        )
-                        rollback_db.flush()
-                else:
-                    _restore_ingest_file_backup(
-                        file_path=existing_path,
-                        backup_path=backup_for_failure,
-                        had_existing_file=had_existing_file,
-                    )
-                rollback_db.commit()
-            except Exception as exc:  # noqa: BLE001
-                rollback_db.rollback()
-                if rollback_error is None:
-                    rollback_error = exc
-                logger.warning(
-                    "Failed to restore UploadedFile/local file during recreated "
-                    "web file rollback: file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            try:
-                _restore_ingestion_runs_snapshot(ingestion_runs_snapshot)
-            except Exception as exc:  # noqa: BLE001
-                if rollback_error is None:
-                    rollback_error = exc
-                logger.warning(
-                    "Failed to restore ingestion runs during recreated web file "
-                    "rollback: file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-
-            if rollback_error is not None:
-                raise rollback_error
-            rollback_succeeded = True
-        except Exception:
-            raise
-        finally:
-            rollback_db.close()
-            if rollback_succeeded and backup_for_failure is not None:
-                backup_for_failure.unlink(missing_ok=True)
-            elif backup_for_failure is not None and backup_for_failure.exists():
-                logger.warning(
-                    "Preserving web ingest rollback backup after failed rollback: %s",
-                    backup_for_failure,
-                )
+    file_compensation = _create_file_compensation_restore(
+        file_record_id=file_record_id,
+        existing_path=existing_path,
+        backup_path=backup_for_failure
+        if backup_for_failure is not None
+        else existing_path,
+        record_snapshot=record_snapshot,
+    )
+    document_compensation = _create_document_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        file_record_id=file_record_id,
+        rag_document_snapshot=rag_document_snapshot,
+    )
+    status_compensation = _create_status_compensation(
+        collection_name=collection_name,
+        user_id=user_id,
+        is_admin=is_admin,
+        ingestion_runs_snapshot=ingestion_runs_snapshot,
+    )
+    snapshot_compensation = _create_snapshot_compensation(
+        backup_path=backup_for_failure,
+    )
 
     def _commit_recreate() -> None:
         if backup_for_failure is not None:
@@ -2921,18 +2839,18 @@ def _recreate_missing_existing_file(
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
-        rollback_on_failure=_rollback_recreate,
         commit_on_success=_commit_recreate,
+        file_compensation=file_compensation,
+        document_compensation=document_compensation,
+        status_compensation=status_compensation,
+        snapshot_compensation=snapshot_compensation,
         rollback_context={
             "rollback_kind": "missing_existing_web_file_recreate",
             "filename": filename,
             "backup_path": str(backup_for_failure)
             if backup_for_failure is not None
-            else None,
+            else "",
             "file_id": file_record_id,
-            WEB_ROLLBACK_COMPENSATED_PLANES_KEY: (
-                _WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES
-            ),
         },
     )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -195,13 +195,14 @@ def _create_file_compensation_restore(
     *,
     file_record_id: str,
     existing_path: Path,
-    backup_path: Path,
+    backup_path: Optional[Path],
     record_snapshot: dict[str, Any],
+    had_existing_file: bool = True,
 ) -> Callable[[], None]:
     """Create a FILE-boundary compensation callback for restoring a refreshed/recreated web file."""
 
     def _compensate() -> None:
-        if not backup_path.exists():
+        if had_existing_file and (backup_path is None or not backup_path.exists()):
             raise FileNotFoundError(
                 f"Missing web ingest rollback backup: {backup_path}"
             )
@@ -217,7 +218,7 @@ def _create_file_compensation_restore(
                 _restore_ingest_file_backup(
                     file_path=existing_path,
                     backup_path=backup_path,
-                    had_existing_file=True,
+                    had_existing_file=had_existing_file,
                 )
             else:
                 current_storage_key = str(
@@ -230,7 +231,7 @@ def _create_file_compensation_restore(
                 _restore_ingest_file_backup(
                     file_path=existing_path,
                     backup_path=backup_path,
-                    had_existing_file=True,
+                    had_existing_file=had_existing_file,
                 )
                 _restore_uploaded_file_record_snapshot(
                     refreshed_record, record_snapshot
@@ -260,7 +261,7 @@ def _create_document_compensation(
     is_admin: bool,
     file_record_id: str,
     rag_document_snapshot: Optional["_RagDocumentSnapshot"] = None,
-) -> Callable[[], Callable[[], None]]:
+) -> Callable[[Optional[IngestionResult]], Callable[[], None]]:
     """Create a DOCUMENT-boundary compensation factory.
 
     Returns a factory that accepts an optional IngestionResult and produces
@@ -292,7 +293,7 @@ def _create_status_compensation(
     user_id: int,
     is_admin: bool,
     ingestion_runs_snapshot: Optional[Any] = None,
-) -> Callable[[], Callable[[], None]]:
+) -> Callable[[Optional[IngestionResult]], Callable[[], None]]:
     """Create a STATUS-boundary compensation factory."""
 
     def _factory(
@@ -2810,10 +2811,9 @@ def _recreate_missing_existing_file(
     file_compensation = _create_file_compensation_restore(
         file_record_id=file_record_id,
         existing_path=existing_path,
-        backup_path=backup_for_failure
-        if backup_for_failure is not None
-        else existing_path,
+        backup_path=backup_for_failure,
         record_snapshot=record_snapshot,
+        had_existing_file=had_existing_file,
     )
     document_compensation = _create_document_compensation(
         collection_name=collection_name,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2390,10 +2390,34 @@ def _existing_web_file_result_with_rollback(
     def _rollback_existing(
         ingestion_result: Optional[IngestionResult] = None,
     ) -> None:
-        doc_cb = document_compensation(ingestion_result)
-        doc_cb()
-        status_cb = status_compensation(ingestion_result)
-        status_cb()
+        rollback_error: Optional[Exception] = None
+        try:
+            doc_cb = document_compensation(ingestion_result)
+            doc_cb()
+        except Exception as exc:  # noqa: BLE001
+            rollback_error = exc
+            logger.warning(
+                "Failed to restore RAG rows during existing web file rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            status_cb = status_compensation(ingestion_result)
+            status_cb()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore ingestion runs during existing web file rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        if rollback_error is not None:
+            raise rollback_error
 
     return FileHandlerResult(
         file_path=str(file_path),
@@ -2463,9 +2487,33 @@ def _create_new_web_file_handler_result(
         def _rollback_new_web_file(
             ingestion_result: Optional[IngestionResult] = None,
         ) -> None:
-            file_compensation()
-            doc_cb = document_compensation(ingestion_result)
-            doc_cb()
+            rollback_error: Optional[Exception] = None
+            try:
+                file_compensation()
+            except Exception as exc:  # noqa: BLE001
+                rollback_error = exc
+                logger.warning(
+                    "Failed to clean file during new web file rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+            try:
+                doc_cb = document_compensation(ingestion_result)
+                doc_cb()
+            except Exception as exc:  # noqa: BLE001
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to clean RAG rows during new web file rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+            if rollback_error is not None:
+                raise rollback_error
 
         return FileHandlerResult(
             file_path=str(persistent_file),
@@ -2686,12 +2734,58 @@ def _refresh_existing_file_if_changed(
     def _rollback_refresh(
         ingestion_result: Optional[IngestionResult] = None,
     ) -> None:
-        file_compensation()
-        doc_cb = document_compensation(ingestion_result)
-        doc_cb()
-        status_cb = status_compensation(ingestion_result)
-        status_cb()
-        snapshot_compensation()
+        rollback_error: Optional[Exception] = None
+        try:
+            file_compensation()
+        except Exception as exc:  # noqa: BLE001
+            rollback_error = exc
+            logger.warning(
+                "Failed to restore file during web file refresh rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            doc_cb = document_compensation(ingestion_result)
+            doc_cb()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore RAG rows during web file refresh rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            status_cb = status_compensation(ingestion_result)
+            status_cb()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore ingestion runs during web file refresh "
+                "rollback: file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            snapshot_compensation()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to cleanup backup file during web file refresh "
+                "rollback: file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        if rollback_error is not None:
+            raise rollback_error
 
     def _commit_refresh() -> None:
         backup_path.unlink(missing_ok=True)
@@ -2875,12 +2969,58 @@ def _recreate_missing_existing_file(
     def _rollback_recreate(
         ingestion_result: Optional[IngestionResult] = None,
     ) -> None:
-        file_compensation()
-        doc_cb = document_compensation(ingestion_result)
-        doc_cb()
-        status_cb = status_compensation(ingestion_result)
-        status_cb()
-        snapshot_compensation()
+        rollback_error: Optional[Exception] = None
+        try:
+            file_compensation()
+        except Exception as exc:  # noqa: BLE001
+            rollback_error = exc
+            logger.warning(
+                "Failed to restore file during recreated web file rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            doc_cb = document_compensation(ingestion_result)
+            doc_cb()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore RAG rows during recreated web file rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            status_cb = status_compensation(ingestion_result)
+            status_cb()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore ingestion runs during recreated web file "
+                "rollback: file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            snapshot_compensation()
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to cleanup backup file during recreated web file "
+                "rollback: file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        if rollback_error is not None:
+            raise rollback_error
 
     def _commit_recreate() -> None:
         if backup_for_failure is not None:
@@ -3674,23 +3814,21 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3745,23 +3883,21 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    rollback_api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=rollback_result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                rollback_api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=rollback_result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3674,21 +3674,23 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3743,21 +3745,23 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                rollback_api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=rollback_result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=rollback_result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2494,17 +2494,6 @@ def _create_new_web_file_handler_result(
         ) -> None:
             rollback_error: Optional[Exception] = None
             try:
-                file_compensation()
-            except Exception as exc:  # noqa: BLE001
-                rollback_error = exc
-                logger.warning(
-                    "Failed to clean file during new web file rollback: "
-                    "file_id=%s, error=%s",
-                    file_record_id,
-                    exc,
-                    exc_info=True,
-                )
-            try:
                 doc_cb = document_compensation(ingestion_result)
                 doc_cb()
             except Exception as exc:  # noqa: BLE001
@@ -2512,6 +2501,18 @@ def _create_new_web_file_handler_result(
                     rollback_error = exc
                 logger.warning(
                     "Failed to clean RAG rows during new web file rollback: "
+                    "file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
+            try:
+                file_compensation()
+            except Exception as exc:  # noqa: BLE001
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to clean file during new web file rollback: "
                     "file_id=%s, error=%s",
                     file_record_id,
                     exc,
@@ -2756,18 +2757,6 @@ def _refresh_existing_file_if_changed(
         rollback_error: Optional[Exception] = None
         file_succeeded = False
         try:
-            file_compensation()
-            file_succeeded = True
-        except Exception as exc:  # noqa: BLE001
-            rollback_error = exc
-            logger.warning(
-                "Failed to restore file during web file refresh rollback: "
-                "file_id=%s, error=%s",
-                file_record_id,
-                exc,
-                exc_info=True,
-            )
-        try:
             doc_cb = document_compensation(ingestion_result)
             doc_cb()
         except Exception as exc:  # noqa: BLE001
@@ -2775,6 +2764,19 @@ def _refresh_existing_file_if_changed(
                 rollback_error = exc
             logger.warning(
                 "Failed to restore RAG rows during web file refresh rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            file_compensation()
+            file_succeeded = True
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore file during web file refresh rollback: "
                 "file_id=%s, error=%s",
                 file_record_id,
                 exc,
@@ -2793,7 +2795,7 @@ def _refresh_existing_file_if_changed(
                 exc,
                 exc_info=True,
             )
-        if file_succeeded:
+        if rollback_error is None and file_succeeded:
             try:
                 snapshot_compensation()
             except Exception as exc:  # noqa: BLE001
@@ -2992,18 +2994,6 @@ def _recreate_missing_existing_file(
         rollback_error: Optional[Exception] = None
         file_succeeded = False
         try:
-            file_compensation()
-            file_succeeded = True
-        except Exception as exc:  # noqa: BLE001
-            rollback_error = exc
-            logger.warning(
-                "Failed to restore file during recreated web file rollback: "
-                "file_id=%s, error=%s",
-                file_record_id,
-                exc,
-                exc_info=True,
-            )
-        try:
             doc_cb = document_compensation(ingestion_result)
             doc_cb()
         except Exception as exc:  # noqa: BLE001
@@ -3011,6 +3001,19 @@ def _recreate_missing_existing_file(
                 rollback_error = exc
             logger.warning(
                 "Failed to restore RAG rows during recreated web file rollback: "
+                "file_id=%s, error=%s",
+                file_record_id,
+                exc,
+                exc_info=True,
+            )
+        try:
+            file_compensation()
+            file_succeeded = True
+        except Exception as exc:  # noqa: BLE001
+            if rollback_error is None:
+                rollback_error = exc
+            logger.warning(
+                "Failed to restore file during recreated web file rollback: "
                 "file_id=%s, error=%s",
                 file_record_id,
                 exc,
@@ -3029,7 +3032,7 @@ def _recreate_missing_existing_file(
                 exc,
                 exc_info=True,
             )
-        if file_succeeded:
+        if rollback_error is None and file_succeeded:
             try:
                 snapshot_compensation()
             except Exception as exc:  # noqa: BLE001

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2387,9 +2387,18 @@ def _existing_web_file_result_with_rollback(
         ingestion_runs_snapshot=ingestion_runs_snapshot,
     )
 
+    def _rollback_existing(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        doc_cb = document_compensation(ingestion_result)
+        doc_cb()
+        status_cb = status_compensation(ingestion_result)
+        status_cb()
+
     return FileHandlerResult(
         file_path=str(file_path),
         file_id=file_record_id,
+        rollback_on_failure=_rollback_existing,
         document_compensation=document_compensation,
         status_compensation=status_compensation,
         rollback_context={
@@ -2451,9 +2460,17 @@ def _create_new_web_file_handler_result(
             file_record_id=file_record_id,
         )
 
+        def _rollback_new_web_file(
+            ingestion_result: Optional[IngestionResult] = None,
+        ) -> None:
+            file_compensation()
+            doc_cb = document_compensation(ingestion_result)
+            doc_cb()
+
         return FileHandlerResult(
             file_path=str(persistent_file),
             file_id=file_record_id,
+            rollback_on_failure=_rollback_new_web_file,
             file_compensation=file_compensation,
             document_compensation=document_compensation,
             rollback_context={
@@ -2666,12 +2683,23 @@ def _refresh_existing_file_if_changed(
         backup_path=backup_path,
     )
 
+    def _rollback_refresh(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        file_compensation()
+        doc_cb = document_compensation(ingestion_result)
+        doc_cb()
+        status_cb = status_compensation(ingestion_result)
+        status_cb()
+        snapshot_compensation()
+
     def _commit_refresh() -> None:
         backup_path.unlink(missing_ok=True)
 
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
+        rollback_on_failure=_rollback_refresh,
         commit_on_success=_commit_refresh,
         file_compensation=file_compensation,
         document_compensation=document_compensation,
@@ -2844,6 +2872,16 @@ def _recreate_missing_existing_file(
         backup_path=backup_for_failure,
     )
 
+    def _rollback_recreate(
+        ingestion_result: Optional[IngestionResult] = None,
+    ) -> None:
+        file_compensation()
+        doc_cb = document_compensation(ingestion_result)
+        doc_cb()
+        status_cb = status_compensation(ingestion_result)
+        status_cb()
+        snapshot_compensation()
+
     def _commit_recreate() -> None:
         if backup_for_failure is not None:
             backup_for_failure.unlink(missing_ok=True)
@@ -2851,6 +2889,7 @@ def _recreate_missing_existing_file(
     return FileHandlerResult(
         file_path=str(existing_record.storage_path),
         file_id=str(existing_record.file_id),
+        rollback_on_failure=_rollback_recreate,
         commit_on_success=_commit_recreate,
         file_compensation=file_compensation,
         document_compensation=document_compensation,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2483,6 +2483,11 @@ def _create_new_web_file_handler_result(
             is_admin=is_admin,
             file_record_id=file_record_id,
         )
+        status_compensation = _create_status_compensation(
+            collection_name=collection_name,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
 
         def _rollback_new_web_file(
             ingestion_result: Optional[IngestionResult] = None,
@@ -2512,6 +2517,19 @@ def _create_new_web_file_handler_result(
                     exc,
                     exc_info=True,
                 )
+            try:
+                status_cb = status_compensation(ingestion_result)
+                status_cb()
+            except Exception as exc:  # noqa: BLE001
+                if rollback_error is None:
+                    rollback_error = exc
+                logger.warning(
+                    "Failed to clear ingestion status during new web file "
+                    "rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
             if rollback_error is not None:
                 raise rollback_error
 
@@ -2521,6 +2539,7 @@ def _create_new_web_file_handler_result(
             rollback_on_failure=_rollback_new_web_file,
             file_compensation=file_compensation,
             document_compensation=document_compensation,
+            status_compensation=status_compensation,
             rollback_context={
                 "rollback_kind": "new_web_file",
                 "filename": filename,
@@ -3810,21 +3829,23 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3879,21 +3900,23 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                rollback_api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=rollback_result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=rollback_result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3674,23 +3674,21 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3745,23 +3743,21 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    rollback_api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=rollback_result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                rollback_api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=rollback_result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -292,7 +292,7 @@ def _create_status_compensation(
     collection_name: str,
     user_id: int,
     is_admin: bool,
-    ingestion_runs_snapshot: Optional[Any] = None,
+    ingestion_runs_snapshot: Optional["_IngestionRunsSnapshot"] = None,
 ) -> Callable[[Optional[IngestionResult]], Callable[[], None]]:
     """Create a STATUS-boundary compensation factory."""
 
@@ -2754,8 +2754,10 @@ def _refresh_existing_file_if_changed(
         ingestion_result: Optional[IngestionResult] = None,
     ) -> None:
         rollback_error: Optional[Exception] = None
+        file_succeeded = False
         try:
             file_compensation()
+            file_succeeded = True
         except Exception as exc:  # noqa: BLE001
             rollback_error = exc
             logger.warning(
@@ -2791,18 +2793,19 @@ def _refresh_existing_file_if_changed(
                 exc,
                 exc_info=True,
             )
+        if file_succeeded:
+            try:
+                snapshot_compensation()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to cleanup backup file during web file refresh "
+                    "rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
         if rollback_error is not None:
             raise rollback_error
-        try:
-            snapshot_compensation()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Failed to cleanup backup file during web file refresh "
-                "rollback: file_id=%s, error=%s",
-                file_record_id,
-                exc,
-                exc_info=True,
-            )
 
     def _commit_refresh() -> None:
         backup_path.unlink(missing_ok=True)
@@ -2987,8 +2990,10 @@ def _recreate_missing_existing_file(
         ingestion_result: Optional[IngestionResult] = None,
     ) -> None:
         rollback_error: Optional[Exception] = None
+        file_succeeded = False
         try:
             file_compensation()
+            file_succeeded = True
         except Exception as exc:  # noqa: BLE001
             rollback_error = exc
             logger.warning(
@@ -3024,18 +3029,19 @@ def _recreate_missing_existing_file(
                 exc,
                 exc_info=True,
             )
+        if file_succeeded:
+            try:
+                snapshot_compensation()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to cleanup backup file during recreated web file "
+                    "rollback: file_id=%s, error=%s",
+                    file_record_id,
+                    exc,
+                    exc_info=True,
+                )
         if rollback_error is not None:
             raise rollback_error
-        try:
-            snapshot_compensation()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Failed to cleanup backup file during recreated web file "
-                "rollback: file_id=%s, error=%s",
-                file_record_id,
-                exc,
-                exc_info=True,
-            )
 
     def _commit_recreate() -> None:
         if backup_for_failure is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -236,7 +236,7 @@ def _create_file_compensation_restore(
                 _restore_uploaded_file_record_snapshot(
                     refreshed_record, record_snapshot
                 )
-                if previous_storage_key:
+                if previous_storage_key and backup_path is not None:
                     UploadedFileStore(rollback_db).sync_existing(
                         refreshed_record,
                         storage_key=previous_storage_key,
@@ -759,6 +759,18 @@ def _restore_ingest_file_backup(
     backup_path: Optional[Path],
     had_existing_file: bool,
 ) -> None:
+    """Undo a file introduced or mutated during failed ingestion.
+
+    Three behaviors, resolved in order:
+
+    1. **Restore**: when *backup_path* exists, delete *file_path* and
+       replace it with the backup.
+    2. **Error**: when *had_existing_file* is True but *backup_path* is
+       missing, the backup was expected and its absence is unrecoverable.
+    3. **Cleanup**: when *had_existing_file* is False, this is a
+       newly-created file with no pre-existing version to restore.
+       Simply delete *file_path*.
+    """
     if backup_path is not None and backup_path.exists():
         if file_path.exists():
             file_path.unlink()

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2772,11 +2772,11 @@ def _refresh_existing_file_if_changed(
                 exc,
                 exc_info=True,
             )
+        if rollback_error is not None:
+            raise rollback_error
         try:
             snapshot_compensation()
         except Exception as exc:  # noqa: BLE001
-            if rollback_error is None:
-                rollback_error = exc
             logger.warning(
                 "Failed to cleanup backup file during web file refresh "
                 "rollback: file_id=%s, error=%s",
@@ -2784,8 +2784,6 @@ def _refresh_existing_file_if_changed(
                 exc,
                 exc_info=True,
             )
-        if rollback_error is not None:
-            raise rollback_error
 
     def _commit_refresh() -> None:
         backup_path.unlink(missing_ok=True)
@@ -3007,11 +3005,11 @@ def _recreate_missing_existing_file(
                 exc,
                 exc_info=True,
             )
+        if rollback_error is not None:
+            raise rollback_error
         try:
             snapshot_compensation()
         except Exception as exc:  # noqa: BLE001
-            if rollback_error is None:
-                rollback_error = exc
             logger.warning(
                 "Failed to cleanup backup file during recreated web file "
                 "rollback: file_id=%s, error=%s",
@@ -3019,8 +3017,6 @@ def _recreate_missing_existing_file(
                 exc,
                 exc_info=True,
             )
-        if rollback_error is not None:
-            raise rollback_error
 
     def _commit_recreate() -> None:
         if backup_for_failure is not None:

--- a/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_api_compatibility.py
@@ -1097,5 +1097,43 @@ def test_delete_document_api_does_not_shadow_api_facade_wrapper() -> None:
     from xagent.web.api import kb as kb_api
 
     source = inspect.getsource(kb_api.delete_document_api)
-
     assert "management.collections import delete_document" not in source
+
+
+def test_failed_ingest_cleanup_decision_uses_operation_outcome() -> None:
+    """Cleanup decision reads from operation outcome, not opaque coverage metadata."""
+    operation_facade = KBOperationCompatibilityFacade()
+    coordinator = KBCoordinator(operation_compatibility=operation_facade)
+    api_facade = KBApiCompatibilityFacade(coordinator=coordinator)
+
+    with operation_facade.start_operation(
+        operation_type="web_ingestion",
+        collection="demo",
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+    ) as operation:
+        operation.record_side_effect(
+            name="test_side_effect",
+            plane=SideEffectPlane.FILE,
+            payload={"file_id": "f1"},
+            idempotency_key="file:demo:f1",
+        )
+        operation.mark_compensated_steps(planes={SideEffectPlane.FILE})
+
+        outcome = operation.finish(
+            status="error",
+            rollback_status=RollbackStatus.COMPLETE,
+            side_effects_may_remain=False,
+        )
+
+    operation_result = KBApiOperationResult(
+        result={"status": "error"},
+        operation_outcome=outcome,
+        rollback_complete=None,
+    )
+    decision = api_facade.failed_ingest_cleanup_decision(
+        operation_result=operation_result,
+    )
+
+    # When no opaque rollback_complete flag is set, fall back to
+    # operation_outcome.side_effects_may_remain
+    assert decision.side_effects_may_remain is False

--- a/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_operation_compatibility.py
@@ -298,3 +298,26 @@ def test_operation_exception_warning_includes_exception_type() -> None:
     assert outcome.status == "error"
     assert outcome.rollback_status is RollbackStatus.NOT_NEEDED
     assert outcome.warnings == ("KeyError: 'doc_id'",)
+
+
+def test_snapshot_plane_mark_and_uncompensated_tracking() -> None:
+    """SNAPSHOT plane participates in mark_compensated_steps and uncompensated_steps."""
+    facade = KBOperationCompatibilityFacade()
+
+    with facade.start_operation(
+        operation_type="web_page_ingestion",
+        collection="demo",
+    ) as operation:
+        operation.record_side_effect(
+            name="cleanup_backup_file",
+            plane=SideEffectPlane.SNAPSHOT,
+            payload={"backup_path": "/tmp/backup"},
+            idempotency_key="snapshot:/tmp/backup",
+        )
+        assert SideEffectPlane.SNAPSHOT.value == "snapshot"
+        uncompensated = operation.uncompensated_steps()
+        assert len(uncompensated) == 1
+        assert uncompensated[0].plane is SideEffectPlane.SNAPSHOT
+
+        operation.mark_compensated_steps(planes={SideEffectPlane.SNAPSHOT})
+        assert operation.has_uncompensated_side_effects() is False

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -805,16 +805,18 @@ async def test_web_ingestion_file_compensation_leaves_document_effects_incomplet
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "document_raises,expected_document_calls,expect_warning",
+    "document_raises,expected_document_calls,expected_snapshot_calls,expected_order,expect_warning",
     [
-        (False, 1, False),
-        (True, 0, True),
+        (False, 1, 1, ["document", "file", "status", "snapshot"], False),
+        (True, 0, 0, ["document", "file", "status"], True),
     ],
     ids=["all_succeed", "document_fails"],
 )
 async def test_web_ingestion_per_boundary_compensation(
     document_raises: bool,
     expected_document_calls: int,
+    expected_snapshot_calls: int,
+    expected_order: list[str],
     expect_warning: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -834,6 +836,7 @@ async def test_web_ingestion_per_boundary_compensation(
         "document": [],
         "status": [],
         "snapshot": [],
+        "order": [],
     }
 
     def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
@@ -859,10 +862,12 @@ async def test_web_ingestion_per_boundary_compensation(
         temp_file: Path, title: str, collection: str, url: str
     ) -> dict[str, object]:
         def _file_cb() -> None:
+            compensation_calls["order"].append("file")
             compensation_calls["file"].append("ok")
 
         def _document_factory(result: object = None) -> object:
             def _cb() -> None:
+                compensation_calls["order"].append("document")
                 if document_raises:
                     raise RuntimeError("document rollback failed")
                 compensation_calls["document"].append(result)
@@ -871,11 +876,13 @@ async def test_web_ingestion_per_boundary_compensation(
 
         def _status_factory(result: object = None) -> object:
             def _cb() -> None:
+                compensation_calls["order"].append("status")
                 compensation_calls["status"].append(result)
 
             return _cb
 
         def _snapshot_cb() -> None:
+            compensation_calls["order"].append("snapshot")
             compensation_calls["snapshot"].append("ok")
 
         return {
@@ -903,14 +910,203 @@ async def test_web_ingestion_per_boundary_compensation(
     assert result.status == "error"
     assert len(compensation_calls["file"]) == 1
     assert len(compensation_calls["status"]) == 1
-    assert len(compensation_calls["snapshot"]) == 1
+    assert len(compensation_calls["snapshot"]) == expected_snapshot_calls
     assert len(compensation_calls["document"]) == expected_document_calls
+    assert compensation_calls["order"] == expected_order
     if expect_warning:
         assert any("DOCUMENT compensation failed" in w for w in result.warnings)
+        assert result.side_effects_may_remain is True
+    else:
+        assert result.side_effects_may_remain is False
 
     outcome = operation_facade.last_outcome
     assert outcome is not None
-    assert len(outcome.child_outcomes) >= 1
+    child = outcome.child_outcomes[0]
+    if expect_warning:
+        assert outcome.rollback_status is RollbackStatus.INCOMPLETE
+        assert outcome.side_effects_may_remain is True
+        assert child.rollback_status is RollbackStatus.INCOMPLETE
+        assert child.side_effects_may_remain is True
+    else:
+        assert outcome.rollback_status is RollbackStatus.COMPLETE
+        assert outcome.side_effects_may_remain is False
+        assert child.rollback_status is RollbackStatus.COMPLETE
+        assert child.side_effects_may_remain is False
+        assert {step.plane for step in child.compensation_steps} == {
+            SideEffectPlane.FILE,
+            SideEffectPlane.COLLECTION,
+            SideEffectPlane.DOCUMENT,
+            SideEffectPlane.STATUS,
+            SideEffectPlane.PARSE,
+            SideEffectPlane.CHUNK,
+            SideEffectPlane.EMBEDDING,
+            SideEffectPlane.SNAPSHOT,
+        }
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_existing_reuse_does_not_record_file_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+    compensation_calls: list[str] = []
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("register_document", doc_id="doc-failed", created=True)
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        def _document_factory(result: object = None) -> object:
+            def _cb() -> None:
+                compensation_calls.append("document")
+
+            return _cb
+
+        def _status_factory(result: object = None) -> object:
+            def _cb() -> None:
+                compensation_calls.append("status")
+
+            return _cb
+
+        return {
+            "file_path": str(temp_file),
+            "file_id": "existing-file-1",
+            "document_compensation": _document_factory,
+            "status_compensation": _status_factory,
+            "rollback_context": {"rollback_kind": "existing_web_file_reuse"},
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    assert result.side_effects_may_remain is False
+    assert compensation_calls == ["document", "status"]
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    child = outcome.child_outcomes[0]
+    assert child.rollback_status is RollbackStatus.COMPLETE
+    assert child.side_effects_may_remain is False
+    assert {step.plane for step in child.compensation_steps} == {
+        SideEffectPlane.DOCUMENT,
+        SideEffectPlane.STATUS,
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_snapshot_compensation_failure_is_tracked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash=None,
+            completed_steps=[
+                _ingestion_step("register_document", doc_id="doc-failed", created=True)
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        def _file_cb() -> None:
+            return None
+
+        def _document_factory(result: object = None) -> object:
+            def _cb() -> None:
+                return None
+
+            return _cb
+
+        def _status_factory(result: object = None) -> object:
+            def _cb() -> None:
+                return None
+
+            return _cb
+
+        def _snapshot_cb() -> None:
+            raise RuntimeError("snapshot cleanup failed")
+
+        return {
+            "file_path": str(temp_file),
+            "file_id": "file-1",
+            "file_compensation": _file_cb,
+            "document_compensation": _document_factory,
+            "status_compensation": _status_factory,
+            "snapshot_compensation": _snapshot_cb,
+            "rollback_context": {
+                "rollback_kind": "existing_web_file_refresh",
+                "backup_path": "/tmp/backup.md",
+            },
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    assert result.side_effects_may_remain is True
+    assert any("SNAPSHOT compensation failed" in item for item in result.warnings)
+    outcome = operation_facade.last_outcome
+    assert outcome is not None
+    child = outcome.child_outcomes[0]
+    assert child.rollback_status is RollbackStatus.INCOMPLETE
+    assert child.side_effects_may_remain is True
+    assert any(
+        step.plane is SideEffectPlane.SNAPSHOT for step in child.compensation_steps
+    )
 
 
 def test_web_ingestion_root_compensation_success_marks_outcome_complete() -> None:

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -17,12 +17,8 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     WebIngestionResult,
 )
 from xagent.core.tools.core.RAG_tools.kb import (
-    KBApiCompatibilityFacade,
-    KBApiOperationResult,
-    KBCoordinator,
     KBOperationCompatibilityFacade,
     KBPipelineCompatibilityFacade,
-    PersistencePolicy,
     RollbackStatus,
     SideEffectPlane,
 )
@@ -808,7 +804,18 @@ async def test_web_ingestion_file_compensation_leaves_document_effects_incomplet
 
 
 @pytest.mark.asyncio
-async def test_web_ingestion_per_boundary_compensation_registers_all_callbacks(
+@pytest.mark.parametrize(
+    "document_raises,expected_document_calls,expect_warning",
+    [
+        (False, 1, False),
+        (True, 0, True),
+    ],
+    ids=["all_succeed", "document_fails"],
+)
+async def test_web_ingestion_per_boundary_compensation(
+    document_raises: bool,
+    expected_document_calls: int,
+    expect_warning: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from xagent.core.tools.core.RAG_tools.pipelines import (
@@ -856,6 +863,8 @@ async def test_web_ingestion_per_boundary_compensation_registers_all_callbacks(
 
         def _document_factory(result: object = None) -> object:
             def _cb() -> None:
+                if document_raises:
+                    raise RuntimeError("document rollback failed")
                 compensation_calls["document"].append(result)
 
             return _cb
@@ -893,19 +902,15 @@ async def test_web_ingestion_per_boundary_compensation_registers_all_callbacks(
 
     assert result.status == "error"
     assert len(compensation_calls["file"]) == 1
-    assert compensation_calls["file"][0] == "ok"
-    assert len(compensation_calls["document"]) == 1
-    assert compensation_calls["document"][0] is not None
     assert len(compensation_calls["status"]) == 1
     assert len(compensation_calls["snapshot"]) == 1
+    assert len(compensation_calls["document"]) == expected_document_calls
+    if expect_warning:
+        assert any("DOCUMENT compensation failed" in w for w in result.warnings)
+
     outcome = operation_facade.last_outcome
     assert outcome is not None
     assert len(outcome.child_outcomes) >= 1
-    # Per-boundary callbacks executed successfully — compensation ran
-    assert len(compensation_calls["file"]) == 1
-    assert len(compensation_calls["document"]) == 1
-    assert len(compensation_calls["status"]) == 1
-    assert len(compensation_calls["snapshot"]) == 1
 
 
 def test_web_ingestion_root_compensation_success_marks_outcome_complete() -> None:
@@ -1015,126 +1020,3 @@ async def test_web_ingestion_file_compensation_failure_marks_side_effects_remain
     assert child.compensation_steps[0].payload["rollback_kind"] == (
         "existing_web_file_refresh"
     )
-
-
-@pytest.mark.asyncio
-async def test_web_ingestion_per_boundary_compensation_partial_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from xagent.core.tools.core.RAG_tools.pipelines import (
-        document_ingestion,
-        web_ingestion,
-    )
-
-    operation_facade = KBOperationCompatibilityFacade()
-    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
-    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
-    monkeypatch.setattr(
-        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
-    )
-    compensation_calls: dict[str, list[Any]] = {
-        "file": [],
-        "document": [],
-        "status": [],
-    }
-
-    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
-        return IngestionResult(
-            status="partial",
-            doc_id="doc-failed",
-            parse_hash="parse-failed",
-            completed_steps=[
-                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
-                _ingestion_step("register_document", doc_id="doc-failed", created=True),
-            ],
-            failed_step="parse_document",
-            message="parse failed",
-        )
-
-    def file_handler(
-        temp_file: Path, title: str, collection: str, url: str
-    ) -> dict[str, object]:
-        def _file_cb() -> None:
-            compensation_calls["file"].append("ok")
-
-        def _document_factory(result: object = None) -> object:
-            def _cb() -> None:
-                raise RuntimeError("document rollback failed")
-
-            return _cb
-
-        def _status_factory(result: object = None) -> object:
-            def _cb() -> None:
-                compensation_calls["status"].append("ok")
-
-            return _cb
-
-        return {
-            "file_path": str(temp_file),
-            "file_id": "file-1",
-            "file_compensation": _file_cb,
-            "document_compensation": _document_factory,
-            "status_compensation": _status_factory,
-            "rollback_context": {"rollback_kind": "new_web_file"},
-        }
-
-    monkeypatch.setattr(
-        document_ingestion,
-        "_run_document_ingestion_impl",
-        fake_run_document_ingestion_impl,
-    )
-
-    result = await facade.run_web_ingestion(
-        "demo",
-        WebCrawlConfig(start_url="https://example.com", max_pages=1),
-        file_handler=file_handler,
-    )
-
-    assert result.status == "error"
-    # FILE compensation succeeded
-    assert len(compensation_calls["file"]) == 1
-    # DOCUMENT compensation failed, not appended
-    assert len(compensation_calls["document"]) == 0
-    # STATUS compensation succeeded
-    assert len(compensation_calls["status"]) == 1
-    # Partial failure recorded in warnings
-    assert any("DOCUMENT compensation failed" in w for w in result.warnings)
-
-
-def test_failed_ingest_cleanup_decision_uses_operation_outcome() -> None:
-    """Cleanup decision reads from operation outcome, not opaque coverage metadata."""
-    operation_facade = KBOperationCompatibilityFacade()
-    coordinator = KBCoordinator(operation_compatibility=operation_facade)
-    api_facade = KBApiCompatibilityFacade(coordinator=coordinator)
-
-    with operation_facade.start_operation(
-        operation_type="web_ingestion",
-        collection="demo",
-        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
-    ) as operation:
-        operation.record_side_effect(
-            name="test_side_effect",
-            plane=SideEffectPlane.FILE,
-            payload={"file_id": "f1"},
-            idempotency_key="file:demo:f1",
-        )
-        operation.mark_compensated_steps(planes={SideEffectPlane.FILE})
-
-        outcome = operation.finish(
-            status="error",
-            rollback_status=RollbackStatus.COMPLETE,
-            side_effects_may_remain=False,
-        )
-
-    operation_result = KBApiOperationResult(
-        result={"status": "error"},
-        operation_outcome=outcome,
-        rollback_complete=None,
-    )
-    decision = api_facade.failed_ingest_cleanup_decision(
-        operation_result=operation_result,
-    )
-
-    # When no opaque rollback_complete flag is set, fall back to
-    # operation_outcome.side_effects_may_remain
-    assert decision.side_effects_may_remain is False

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -1043,18 +1043,14 @@ def test_file_compensation_restore_handles_recreated_file_without_existing(
             }
         )
 
-    monkeypatch.setattr(
-        "xagent.web.api.kb._restore_ingest_file_backup", _fake_restore
-    )
+    monkeypatch.setattr("xagent.web.api.kb._restore_ingest_file_backup", _fake_restore)
 
     def _fake_get_session_local():
         session = MagicMock()
         session.query().filter().first.return_value = None
         return session
 
-    monkeypatch.setattr(
-        "xagent.web.api.kb.get_session_local", _fake_get_session_local
-    )
+    monkeypatch.setattr("xagent.web.api.kb.get_session_local", _fake_get_session_local)
 
     compensation = _create_file_compensation_restore(
         file_record_id="recreate-no-file",
@@ -1108,8 +1104,10 @@ def test_rollback_on_failure_compat_wrapper_delegates_to_per_boundary(
     """rollback_on_failure compat wrapper calls all per-boundary callbacks."""
     from unittest.mock import MagicMock
 
-    from xagent.web.api.kb import _create_document_compensation
-    from xagent.web.api.kb import _create_status_compensation
+    from xagent.web.api.kb import (
+        _create_document_compensation,
+        _create_status_compensation,
+    )
 
     monkeypatch.setattr(
         "xagent.web.api.kb.get_session_local",

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -1020,3 +1020,51 @@ async def test_web_ingestion_file_compensation_failure_marks_side_effects_remain
     assert child.compensation_steps[0].payload["rollback_kind"] == (
         "existing_web_file_refresh"
     )
+
+
+def test_file_compensation_restore_handles_recreated_file_without_existing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from unittest.mock import MagicMock
+
+    from xagent.web.api.kb import _create_file_compensation_restore
+
+    existing_file = tmp_path / "test-file"
+    existing_file.write_text("content")
+    restore_calls: list[dict] = []
+
+    def _fake_restore(*, file_path, backup_path, had_existing_file):
+        restore_calls.append(
+            {
+                "file_path": file_path,
+                "backup_path": backup_path,
+                "had_existing_file": had_existing_file,
+            }
+        )
+
+    monkeypatch.setattr(
+        "xagent.web.api.kb._restore_ingest_file_backup", _fake_restore
+    )
+
+    def _fake_get_session_local():
+        session = MagicMock()
+        session.query().filter().first.return_value = None
+        return session
+
+    monkeypatch.setattr(
+        "xagent.web.api.kb.get_session_local", _fake_get_session_local
+    )
+
+    compensation = _create_file_compensation_restore(
+        file_record_id="recreate-no-file",
+        existing_path=existing_file,
+        backup_path=None,
+        record_snapshot={"storage_key": "", "mime_type": "text/markdown"},
+        had_existing_file=False,
+    )
+    compensation()
+
+    assert len(restore_calls) == 1
+    assert restore_calls[0]["had_existing_file"] is False
+    assert restore_calls[0]["backup_path"] is None

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -17,13 +17,14 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     WebIngestionResult,
 )
 from xagent.core.tools.core.RAG_tools.kb import (
+    KBApiCompatibilityFacade,
+    KBApiOperationResult,
+    KBCoordinator,
     KBOperationCompatibilityFacade,
     KBPipelineCompatibilityFacade,
+    PersistencePolicy,
     RollbackStatus,
     SideEffectPlane,
-)
-from xagent.core.tools.core.RAG_tools.kb.pipeline_compatibility import (
-    WEB_ROLLBACK_COMPENSATED_PLANES_KEY,
 )
 
 
@@ -807,7 +808,7 @@ async def test_web_ingestion_file_compensation_leaves_document_effects_incomplet
 
 
 @pytest.mark.asyncio
-async def test_web_ingestion_declared_file_compensation_coverage_clears_document_effects(
+async def test_web_ingestion_per_boundary_compensation_registers_all_callbacks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from xagent.core.tools.core.RAG_tools.pipelines import (
@@ -821,7 +822,12 @@ async def test_web_ingestion_declared_file_compensation_coverage_clears_document
     monkeypatch.setattr(
         web_ingestion, "run_document_ingestion", facade.run_document_ingestion
     )
-    compensation_calls: list[IngestionResult | None] = []
+    compensation_calls: dict[str, list[Any]] = {
+        "file": [],
+        "document": [],
+        "status": [],
+        "snapshot": [],
+    }
 
     def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
         return IngestionResult(
@@ -845,23 +851,32 @@ async def test_web_ingestion_declared_file_compensation_coverage_clears_document
     def file_handler(
         temp_file: Path, title: str, collection: str, url: str
     ) -> dict[str, object]:
+        def _file_cb() -> None:
+            compensation_calls["file"].append("ok")
+
+        def _document_factory(result: object = None) -> object:
+            def _cb() -> None:
+                compensation_calls["document"].append(result)
+
+            return _cb
+
+        def _status_factory(result: object = None) -> object:
+            def _cb() -> None:
+                compensation_calls["status"].append(result)
+
+            return _cb
+
+        def _snapshot_cb() -> None:
+            compensation_calls["snapshot"].append("ok")
+
         return {
             "file_path": str(temp_file),
             "file_id": "file-1",
-            "rollback_on_failure": lambda result=None: compensation_calls.append(
-                result
-            ),
-            "rollback_context": {
-                "rollback_kind": "new_web_file",
-                WEB_ROLLBACK_COMPENSATED_PLANES_KEY: [
-                    "collection",
-                    "document",
-                    "status",
-                    "parse",
-                    "chunk",
-                    "embedding",
-                ],
-            },
+            "file_compensation": _file_cb,
+            "document_compensation": _document_factory,
+            "status_compensation": _status_factory,
+            "snapshot_compensation": _snapshot_cb,
+            "rollback_context": {"rollback_kind": "new_web_file"},
         }
 
     monkeypatch.setattr(
@@ -877,24 +892,20 @@ async def test_web_ingestion_declared_file_compensation_coverage_clears_document
     )
 
     assert result.status == "error"
-    assert result.side_effects_may_remain is False
-    assert len(compensation_calls) == 1
+    assert len(compensation_calls["file"]) == 1
+    assert compensation_calls["file"][0] == "ok"
+    assert len(compensation_calls["document"]) == 1
+    assert compensation_calls["document"][0] is not None
+    assert len(compensation_calls["status"]) == 1
+    assert len(compensation_calls["snapshot"]) == 1
     outcome = operation_facade.last_outcome
     assert outcome is not None
-    assert outcome.rollback_status is RollbackStatus.COMPLETE
-    assert outcome.side_effects_may_remain is False
-    child = outcome.child_outcomes[0]
-    assert child.rollback_status is RollbackStatus.COMPLETE
-    assert child.side_effects_may_remain is False
-    assert {step.plane for step in child.compensation_steps} == {
-        SideEffectPlane.FILE,
-        SideEffectPlane.COLLECTION,
-        SideEffectPlane.DOCUMENT,
-        SideEffectPlane.STATUS,
-        SideEffectPlane.PARSE,
-        SideEffectPlane.CHUNK,
-        SideEffectPlane.EMBEDDING,
-    }
+    assert len(outcome.child_outcomes) >= 1
+    # Per-boundary callbacks executed successfully — compensation ran
+    assert len(compensation_calls["file"]) == 1
+    assert len(compensation_calls["document"]) == 1
+    assert len(compensation_calls["status"]) == 1
+    assert len(compensation_calls["snapshot"]) == 1
 
 
 def test_web_ingestion_root_compensation_success_marks_outcome_complete() -> None:
@@ -1004,3 +1015,126 @@ async def test_web_ingestion_file_compensation_failure_marks_side_effects_remain
     assert child.compensation_steps[0].payload["rollback_kind"] == (
         "existing_web_file_refresh"
     )
+
+
+@pytest.mark.asyncio
+async def test_web_ingestion_per_boundary_compensation_partial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core.RAG_tools.pipelines import (
+        document_ingestion,
+        web_ingestion,
+    )
+
+    operation_facade = KBOperationCompatibilityFacade()
+    facade = KBPipelineCompatibilityFacade(operation_compatibility=operation_facade)
+    monkeypatch.setattr(web_ingestion, "WebCrawler", _SinglePageCrawler)
+    monkeypatch.setattr(
+        web_ingestion, "run_document_ingestion", facade.run_document_ingestion
+    )
+    compensation_calls: dict[str, list[Any]] = {
+        "file": [],
+        "document": [],
+        "status": [],
+    }
+
+    def fake_run_document_ingestion_impl(**_: object) -> IngestionResult:
+        return IngestionResult(
+            status="partial",
+            doc_id="doc-failed",
+            parse_hash="parse-failed",
+            completed_steps=[
+                _ingestion_step("initialize_collection", embedding_model_id="model-a"),
+                _ingestion_step("register_document", doc_id="doc-failed", created=True),
+            ],
+            failed_step="parse_document",
+            message="parse failed",
+        )
+
+    def file_handler(
+        temp_file: Path, title: str, collection: str, url: str
+    ) -> dict[str, object]:
+        def _file_cb() -> None:
+            compensation_calls["file"].append("ok")
+
+        def _document_factory(result: object = None) -> object:
+            def _cb() -> None:
+                raise RuntimeError("document rollback failed")
+
+            return _cb
+
+        def _status_factory(result: object = None) -> object:
+            def _cb() -> None:
+                compensation_calls["status"].append("ok")
+
+            return _cb
+
+        return {
+            "file_path": str(temp_file),
+            "file_id": "file-1",
+            "file_compensation": _file_cb,
+            "document_compensation": _document_factory,
+            "status_compensation": _status_factory,
+            "rollback_context": {"rollback_kind": "new_web_file"},
+        }
+
+    monkeypatch.setattr(
+        document_ingestion,
+        "_run_document_ingestion_impl",
+        fake_run_document_ingestion_impl,
+    )
+
+    result = await facade.run_web_ingestion(
+        "demo",
+        WebCrawlConfig(start_url="https://example.com", max_pages=1),
+        file_handler=file_handler,
+    )
+
+    assert result.status == "error"
+    # FILE compensation succeeded
+    assert len(compensation_calls["file"]) == 1
+    # DOCUMENT compensation failed, not appended
+    assert len(compensation_calls["document"]) == 0
+    # STATUS compensation succeeded
+    assert len(compensation_calls["status"]) == 1
+    # Partial failure recorded in warnings
+    assert any("DOCUMENT compensation failed" in w for w in result.warnings)
+
+
+def test_failed_ingest_cleanup_decision_uses_operation_outcome() -> None:
+    """Cleanup decision reads from operation outcome, not opaque coverage metadata."""
+    operation_facade = KBOperationCompatibilityFacade()
+    coordinator = KBCoordinator(operation_compatibility=operation_facade)
+    api_facade = KBApiCompatibilityFacade(coordinator=coordinator)
+
+    with operation_facade.start_operation(
+        operation_type="web_ingestion",
+        collection="demo",
+        persistence_policy=PersistencePolicy.PRESERVE_SUCCESSFUL_CHILDREN,
+    ) as operation:
+        operation.record_side_effect(
+            name="test_side_effect",
+            plane=SideEffectPlane.FILE,
+            payload={"file_id": "f1"},
+            idempotency_key="file:demo:f1",
+        )
+        operation.mark_compensated_steps(planes={SideEffectPlane.FILE})
+
+        outcome = operation.finish(
+            status="error",
+            rollback_status=RollbackStatus.COMPLETE,
+            side_effects_may_remain=False,
+        )
+
+    operation_result = KBApiOperationResult(
+        result={"status": "error"},
+        operation_outcome=outcome,
+        rollback_complete=None,
+    )
+    decision = api_facade.failed_ingest_cleanup_decision(
+        operation_result=operation_result,
+    )
+
+    # When no opaque rollback_complete flag is set, fall back to
+    # operation_outcome.side_effects_may_remain
+    assert decision.side_effects_may_remain is False

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import pytest
 
@@ -1068,3 +1068,85 @@ def test_file_compensation_restore_handles_recreated_file_without_existing(
     assert len(restore_calls) == 1
     assert restore_calls[0]["had_existing_file"] is False
     assert restore_calls[0]["backup_path"] is None
+
+
+def test_document_compensation_marks_cascaded_planes() -> None:
+    """Doc compensation also marks PARSE/CHUNK/EMBEDDING because delete_document cascades."""
+    facade = KBOperationCompatibilityFacade()
+
+    with facade.start_operation(
+        operation_type="web_page_ingestion",
+        collection="demo",
+    ) as operation:
+        for plane in (
+            SideEffectPlane.DOCUMENT,
+            SideEffectPlane.PARSE,
+            SideEffectPlane.CHUNK,
+            SideEffectPlane.EMBEDDING,
+        ):
+            operation.record_side_effect(
+                name=f"remove_{plane.value}",
+                plane=plane,
+                payload={},
+                idempotency_key=f"{plane.value}:demo:doc-1",
+            )
+
+        operation.mark_compensated_steps(
+            planes={
+                SideEffectPlane.DOCUMENT,
+                SideEffectPlane.PARSE,
+                SideEffectPlane.CHUNK,
+                SideEffectPlane.EMBEDDING,
+            }
+        )
+        assert operation.has_uncompensated_side_effects() is False
+
+
+def test_rollback_on_failure_compat_wrapper_delegates_to_per_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rollback_on_failure compat wrapper calls all per-boundary callbacks."""
+    from unittest.mock import MagicMock
+
+    from xagent.web.api.kb import _create_document_compensation
+    from xagent.web.api.kb import _create_status_compensation
+
+    monkeypatch.setattr(
+        "xagent.web.api.kb.get_session_local",
+        MagicMock(side_effect=RuntimeError("unused in this test")),
+    )
+
+    calls: list[str] = []
+
+    def _file_cb() -> None:
+        calls.append("file")
+
+    def _snap_cb() -> None:
+        calls.append("snapshot")
+
+    file_cb: Callable = _file_cb
+    doc_factory = _create_document_compensation(
+        collection_name="demo",
+        user_id=1,
+        is_admin=True,
+        file_record_id="f1",
+    )
+    status_factory = _create_status_compensation(
+        collection_name="demo",
+        user_id=1,
+        is_admin=True,
+        ingestion_runs_snapshot=None,
+    )
+    snap_cb: Callable = _snap_cb
+
+    def _rollback_compat(ingestion_result=None) -> None:
+        calls.append("called")
+        file_cb()
+        doc_cb = doc_factory(ingestion_result)
+        doc_cb()
+        status_cb = status_factory(ingestion_result)
+        status_cb()
+        snap_cb()
+
+    _rollback_compat(None)
+    assert calls == ["called", "file", "snapshot"]

--- a/tests/web/api/test_kb_web_ingestion_uploaded_file.py
+++ b/tests/web/api/test_kb_web_ingestion_uploaded_file.py
@@ -1317,23 +1317,13 @@ class TestIngestWebHandleWebFile:
             file_info = file_handler(temp_md, title, collection, url)
             captured["file_id"] = str(file_info["file_id"])
 
-            from xagent.core.tools.core.RAG_tools.core.schemas import WebIngestionResult
+            from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
             from xagent.web.services.managed_file_ref import build_upload_storage_key
 
-            result = WebIngestionResult(
+            result = IngestionResult(
                 status="error",
-                collection=collection,
-                total_urls_found=1,
-                pages_crawled=1,
-                pages_failed=1,
-                documents_created=0,
-                chunks_created=0,
-                embeddings_created=0,
-                crawled_urls=[url],
-                failed_urls={url: "embedding failed"},
-                message="failed",
-                warnings=[],
-                elapsed_time_ms=1,
+                doc_id=None,
+                message="embedding failed",
             )
             captured["storage_key"] = build_upload_storage_key(
                 user.id,
@@ -1587,11 +1577,11 @@ class TestIngestWebHandleWebFile:
             ),
             patch(
                 "xagent.web.api.kb._snapshot_ingestion_runs_for_uploaded_file",
-                return_value=object(),
+                return_value=MagicMock(),
             ) as mock_snapshot_runs,
             patch(
                 "xagent.web.api.kb._snapshot_rag_documents_for_uploaded_file",
-                return_value=object(),
+                return_value=MagicMock(),
             ) as mock_snapshot_rag,
             patch(
                 "xagent.web.api.kb._restore_ingestion_runs_snapshot"


### PR DESCRIPTION
Closes #608.

Split the four monolithic production web rollback callbacks into per-boundary compensation callbacks registered via `record_side_effect(compensation=...)`.

### Changes
- Add per-boundary compensation factory functions: FILE (delete/restore), DOCUMENT, STATUS, SNAPSHOT
- Refactor four web handler functions to return per-boundary callbacks instead of monolithic closures
- Rewrite `_run_file_handler_compensation` to execute per-boundary callbacks independently and mark compensated planes
- Remove `mark_web_page_compensation_coverage`, `_compensated_side_effect_planes`, `WEB_ROLLBACK_COMPENSATED_PLANES_KEY`, and `_WEB_FAILED_INGEST_CLEANUP_COMPENSATED_PLANES`
- Custom `rollback_on_failure` callbacks remain supported via legacy path without auto-marking other planes

### Tests
- Per-boundary compensation execution (all succeed + partial failure)
- Custom callback conservative behavior (no auto-coverage)
- Cleanup decision derived from operation outcome (no opaque metadata)