### PR TITLE
feat: allow live guidance during running tasks

### DIFF
--- a/frontend/src/components/agent-input.tsx
+++ b/frontend/src/components/agent-input.tsx
@@ -43,7 +43,7 @@ interface AgentConfig {
 interface AgentInputProps {
   value: string
   onChange: (value: string) => void
-  onSend: (files?: File[]) => void
+  onSend: (files?: File[]) => void | Promise<void>
   onKeyDown?: (e: React.KeyboardEvent) => void
   onCompositionStart?: () => void
   onCompositionEnd?: () => void
@@ -108,7 +108,21 @@ export function AgentInput({
   }, [externalSetSelectedFiles, externalSelectedFiles, internalSelectedFiles, setInternalSelectedFiles])
 
   const [isComposing, setIsComposing] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const isSubmittingRef = useRef(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const hasDraft = value.trim().length > 0 || files.length > 0
+
+  const clearSubmitting = useCallback(() => {
+    isSubmittingRef.current = false
+    setIsSubmitting(false)
+  }, [])
+
+  useEffect(() => {
+    if (isSubmittingRef.current && !hasDraft) {
+      clearSubmitting()
+    }
+  }, [clearSubmitting, hasDraft])
 
   // Debug: Log currentTask and onPauseTask
   useEffect(() => {
@@ -185,20 +199,23 @@ export function AgentInput({
   }
 
   const handleSend = async () => {
+    if (isSubmittingRef.current || !hasDraft) return
+
     console.log('🚀 AgentInput handleSend called:', {
       value: value.trim(),
       selectedFiles: files.map(f => f.name),
       hasFiles: files.length > 0
     })
 
-    if (value.trim() || files.length > 0) {
-      // Send message with files if there's text or files
-      if (value.trim() || files.length > 0) {
-        console.log('📤 AgentInput calling onSend with files:', files.map(f => f.name))
-        onSend(files.length > 0 ? files : undefined)
-      }
-
+    console.log('📤 AgentInput calling onSend with files:', files.map(f => f.name))
+    try {
+      isSubmittingRef.current = true
+      setIsSubmitting(true)
+      await onSend(files.length > 0 ? files : undefined)
       setFiles([])
+    } catch (error) {
+      clearSubmitting()
+      throw error
     }
   }
 
@@ -233,9 +250,13 @@ export function AgentInput({
     }
   }
 
-  // Allow input in paused/waiting state, used for adjusting execution plan or answering the agent.
+  // Allow input in active-control states so the user can guide a running task.
+  const allowsLiveGuidanceInput =
+    currentTask?.status === 'running' ||
+    currentTask?.status === 'paused' ||
+    currentTask?.status === 'waiting_for_user'
   const isPaused = currentTask?.status === 'paused' || currentTask?.status === 'waiting_for_user'
-  const isSendDisabled = (!value.trim() && files.length === 0) || disabled || (!isPaused && isProcessing)
+  const isSendDisabled = !hasDraft || disabled || isSubmitting || (!allowsLiveGuidanceInput && isProcessing)
 
   // Dynamic placeholder
   const dynamicPlaceholder = isPaused
@@ -290,7 +311,7 @@ export function AgentInput({
             variant === "expanded" && "text-base"
           )}
           rows={rows}
-          disabled={disabled || (!isPaused && isProcessing)}
+          disabled={disabled || (!allowsLiveGuidanceInput && isProcessing)}
           autoFocus={variant === "expanded"}
         />
 
@@ -331,13 +352,13 @@ export function AgentInput({
               onChange={handleFileSelect}
               multiple
               className="hidden"
-              disabled={disabled || isProcessing}
+              disabled={disabled || (!allowsLiveGuidanceInput && isProcessing)}
             />
             <Button
               variant="ghost"
               size="sm"
               onClick={() => fileInputRef.current?.click()}
-              disabled={disabled || isProcessing}
+              disabled={disabled || (!allowsLiveGuidanceInput && isProcessing)}
               className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground hover:bg-muted rounded-md"
               title={t('agent.input.actions.uploadFile')}
             >
@@ -356,7 +377,7 @@ export function AgentInput({
             </Button>
 
             {/* Pause/Resume Button */}
-            {currentTask && currentTask.status === 'running' && onPauseTask && (
+            {currentTask && currentTask.status === 'running' && !hasDraft && onPauseTask && (
               <Button
                 onClick={onPauseTask}
                 disabled={disabled}

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@/contexts/app-context-chat", () => ({
   }),
 }))
 
+vi.mock("@/components/config-dialog", () => ({
+  ConfigDialog: ({ trigger }: { trigger: unknown }) => trigger,
+}))
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: routerPushMock,
@@ -89,7 +93,6 @@ describe("ChatInput", () => {
     const onSend = vi.fn()
     const { container } = render(
       <ChatInput
-        hideConfig
         hideFileUpload
         inputValue="hello"
         onInputChange={vi.fn()}
@@ -147,5 +150,108 @@ describe("ChatInput", () => {
 
     expect(screen.queryByTitle("agent.input.actions.pauseTask")).not.toBeInTheDocument()
     expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
+  })
+
+  it("allows live guidance while a task is running", async () => {
+    const onSend = vi.fn()
+    const onPause = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue="please focus on the API contract"
+        isLoading
+        onInputChange={vi.fn()}
+        onPause={onPause}
+        onSend={onSend}
+        taskStatus="running"
+      />
+    )
+
+    expect(screen.queryByTitle("agent.input.actions.pauseTask")).not.toBeInTheDocument()
+    expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
+
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "please focus on the API contract",
+        expect.objectContaining({ model: "" })
+      )
+    })
+  })
+
+  it("keeps generic loading input disabled without a live task status", () => {
+    const { container } = render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue="wait"
+        isLoading
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+      />
+    )
+
+    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
+  })
+
+  it("shows pause for a running task when there is no draft to send", () => {
+    const { container } = render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue=""
+        isLoading
+        onInputChange={vi.fn()}
+        onPause={vi.fn()}
+        onSend={vi.fn()}
+        taskStatus="running"
+      />
+    )
+
+    expect(screen.getByTitle("agent.input.actions.pauseTask")).toBeInTheDocument()
+    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
+  })
+
+  it("keeps pause hidden while running draft files are still uploading", async () => {
+    const onPause = vi.fn()
+    const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(() => {}))
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+
+      return (
+        <ChatInput
+          hideConfig
+          inputValue=""
+          files={files}
+          isLoading
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onPause={onPause}
+          onSend={vi.fn()}
+          taskStatus="running"
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["draft"], "draft.txt", { type: "text/plain" })
+
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledWith(
+        file,
+        expect.objectContaining({ taskType: "task" })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.queryByTitle("agent.input.actions.pauseTask")).not.toBeInTheDocument()
+    })
+    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
 })

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -477,19 +477,25 @@ export function ChatInput({
   };
 
   const normalizedTaskStatus = normalizeTaskStatus(taskStatus);
-  const allowsInterruptedInput = normalizedTaskStatus === 'paused' || normalizedTaskStatus === 'waiting_for_user';
-  const isInputBusy = !!isLoading && !allowsInterruptedInput && !isStoppedTaskStatus(normalizedTaskStatus);
+  const allowsLiveGuidanceInput =
+    normalizedTaskStatus === 'running' ||
+    normalizedTaskStatus === 'paused' ||
+    normalizedTaskStatus === 'waiting_for_user';
+  const isInputBusy =
+    !!isLoading &&
+    !allowsLiveGuidanceInput &&
+    !isStoppedTaskStatus(normalizedTaskStatus);
 
+  const hasDraft = message.trim().length > 0 || files.length > 0;
   const canSubmit = () => {
-    const hasText = message.trim().length > 0;
-    const hasFiles = files.length > 0;
     const isUploadingFiles = uploadingFiles.size > 0;
-    return (hasText || hasFiles) && !isInputBusy && !isUploadingFiles;
+    return hasDraft && !isInputBusy && !isUploadingFiles;
   };
   const canPauseTask =
     !!isLoading &&
     !!onPause &&
     isPausableTaskStatus(normalizedTaskStatus);
+  const shouldShowPauseButton = canPauseTask && !hasDraft;
 
   const handleDragEnter = (e: React.DragEvent<HTMLFormElement>) => {
     if (!isFileDragEvent(e) || isInputBusy || hideFileUpload) return;
@@ -920,8 +926,8 @@ export function ChatInput({
                 )}
               </div>
 
-              <div className="flex items-center gap-3">
-                {canPauseTask ? (
+              <div className="flex items-center gap-2">
+                {shouldShowPauseButton && (
                   <Button
                     type="button"
                     size="icon"
@@ -931,38 +937,35 @@ export function ChatInput({
                   >
                     <Pause className="h-4 w-4" />
                   </Button>
-                ) : (
-                  <div className="flex items-center gap-2">
-                    <span className="text-[13px] font-medium text-muted-foreground/50 select-none mr-1">
-                      ⏎ {t("common.send")}
-                    </span>
-                    <Button
-                      type="submit"
-                      size="icon"
-                      disabled={!canSubmit()}
-                      className={cn(
-                        "h-8 w-8 rounded-lg transition-all duration-300",
-                        !canSubmit() && "bg-muted text-muted-foreground/50"
-                      )}
-                    >
-                      {isInputBusy ? (
-                        <Sparkles className="h-4 w-4 animate-pulse" />
-                      ) : (
-                        <ArrowUp className="h-4 w-4" />
-                      )}
-                    </Button>
-                    {normalizedTaskStatus === 'paused' && onResume && (
-                      <Button
-                        type="button"
-                        size="icon"
-                        onClick={onResume}
-                        className="h-8 w-8 rounded-full transition-all duration-300 bg-green-500 hover:bg-green-600 text-white"
-                        title={t('agent.input.actions.resumeTask')}
-                      >
-                        <Play className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
+                )}
+                <span className="text-[13px] font-medium text-muted-foreground/50 select-none mr-1">
+                  ⏎ {t("common.send")}
+                </span>
+                <Button
+                  type="submit"
+                  size="icon"
+                  disabled={!canSubmit()}
+                  className={cn(
+                    "h-8 w-8 rounded-lg transition-all duration-300",
+                    !canSubmit() && "bg-muted text-muted-foreground/50"
+                  )}
+                >
+                  {isInputBusy ? (
+                    <Sparkles className="h-4 w-4 animate-pulse" />
+                  ) : (
+                    <ArrowUp className="h-4 w-4" />
+                  )}
+                </Button>
+                {normalizedTaskStatus === 'paused' && onResume && (
+                  <Button
+                    type="button"
+                    size="icon"
+                    onClick={onResume}
+                    className="h-8 w-8 rounded-full transition-all duration-300 bg-green-500 hover:bg-green-600 text-white"
+                    title={t('agent.input.actions.resumeTask')}
+                  >
+                    <Play className="h-4 w-4" />
+                  </Button>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- allow users to type and send guidance while a task is running
- keep pause available only when there is no draft to send
- apply the same active-control input behavior to the legacy agent input

## Validation
- npm run test:run -- ChatInput.test.tsx
- npm run type-check
- python -m pytest tests/web/api/test_websocket_turn_routing.py
- pre-commit hooks during commit: npm lint, npm type-check
