### PR TITLE
fix: show only published agents on home

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,168 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequestMock = vi.hoisted(() => vi.fn());
+const routerPushMock = vi.hoisted(() => vi.fn());
+const setPendingMessageMock = vi.hoisted(() => vi.fn());
+const setTaskIdMock = vi.hoisted(() => vi.fn());
+const translateMock = vi.hoisted(
+  () => (key: string, vars?: Record<string, string | number>) => {
+    const translations: Record<string, string> = {
+      "home.agents.newAgent": "New agent",
+      "home.agents.buildTime": "Build in minutes",
+      "home.agents.manageAll": "Manage all",
+      "home.agents.subtitle": "Click to chat - these are your published, ready-to-run workers",
+      "home.agents.title": "Your agents",
+      "home.revamp.greeting": "Hello",
+      "home.revamp.greetingAfternoon": "Good afternoon",
+      "home.revamp.greetingEvening": "Good evening",
+      "home.revamp.greetingMorning": "Good morning",
+    };
+    const value = translations[key] ?? key;
+    if (!vars) return value;
+    return Object.entries(vars).reduce(
+      (current, [name, replacement]) => current.replace(`{${name}}`, String(replacement)),
+      value
+    );
+  }
+);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    setPendingMessage: setPendingMessageMock,
+    setTaskId: setTaskIdMock,
+  }),
+}));
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({
+    user: { username: "Test User" },
+  }),
+}));
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: translateMock,
+  }),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: apiRequestMock,
+}));
+
+vi.mock("@/components/welcome-modal", () => ({
+  WelcomeModal: () => null,
+}));
+
+vi.mock("@/components/templates/home-template-card", () => ({
+  HomeTemplateCard: ({ template }: { template: { name: string } }) => <div>{template.name}</div>,
+}));
+
+import Home from "./page";
+
+const okJson = (data: unknown) =>
+  ({
+    ok: true,
+    json: async () => data,
+  }) as Response;
+
+const mockHomeData = (agents: unknown[], templates: unknown[] = []) => {
+  apiRequestMock.mockImplementation((url: string) => {
+    if (url.includes("/api/templates/")) {
+      return Promise.resolve(okJson(templates));
+    }
+    if (url.includes("/api/chat/tasks")) {
+      return Promise.resolve(okJson({ tasks: [] }));
+    }
+    if (url.endsWith("/api/agents")) {
+      return Promise.resolve(okJson(agents));
+    }
+    return Promise.reject(new Error(`Unexpected request: ${url}`));
+  });
+};
+
+describe("Home", () => {
+  beforeEach(() => {
+    localStorage.setItem("hasVisitedXagent", "true");
+    apiRequestMock.mockReset();
+    routerPushMock.mockReset();
+    setPendingMessageMock.mockReset();
+    setTaskIdMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("does not fall back to showing draft agents in the published agents section", async () => {
+    mockHomeData(
+      [
+        {
+          id: 1,
+          name: "Draft-only agent",
+          status: "draft",
+          updated_at: "2026-06-01T12:00:00Z",
+        },
+      ],
+      [
+        {
+          id: "template-1",
+          name: "Test Template",
+          category: "Test Category",
+          description: "Template used to wait for async home data.",
+          connections: [],
+          setup_time: "5 min",
+          used_count: 0,
+        },
+      ]
+    );
+
+    render(<Home />);
+
+    expect(await screen.findByText("Test Template")).toBeInTheDocument();
+    expect(screen.getByText("New agent")).toBeInTheDocument();
+    expect(screen.queryByText("Draft-only agent")).not.toBeInTheDocument();
+  });
+
+  it("shows published agents in the published agents section", async () => {
+    mockHomeData([
+      {
+        id: 1,
+        name: "Draft agent",
+        status: "draft",
+        updated_at: "2026-06-01T12:00:00Z",
+      },
+      {
+        id: 2,
+        name: "Published agent",
+        status: "published",
+        updated_at: "2026-06-02T12:00:00Z",
+      },
+    ]);
+
+    render(<Home />);
+
+    expect(await screen.findByText("Published agent")).toBeInTheDocument();
+    expect(screen.queryByText("Draft agent")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -36,7 +36,7 @@ import { HomeTemplateCard } from "@/components/templates/home-template-card";
 import { useApp } from "@/contexts/app-context-chat";
 import { useAuth } from "@/contexts/auth-context";
 import { useI18n } from "@/contexts/i18n-context";
-import { getAgentChatHref } from "@/lib/agent-ui-access";
+import { getAgentChatHref, isPublishedAgent } from "@/lib/agent-ui-access";
 import { getApiUrl } from "@/lib/utils";
 import type { Template } from "@/types/template";
 import { WelcomeModal } from "@/components/welcome-modal";
@@ -392,9 +392,7 @@ export default function Home() {
     ? Math.min(100, Math.max(8, Math.floor((now - primaryTaskCreatedAtMs) / 18000)))
     : 0;
   const displayAgents = useMemo(() => {
-    const published = agents.filter((agent) => agent.status === "published");
-    const source = published.length > 0 ? published : agents;
-    return source.slice(0, 9);
+    return agents.filter(isPublishedAgent).slice(0, 9);
   }, [agents]);
   const greetingLabel = t(
     currentHour === null ? "home.revamp.greeting" : getGreetingTranslationKey(currentHour)


### PR DESCRIPTION
## Summary
- show only published agents in the home page Your agents section
- remove the fallback that displayed draft agents when no published agents existed
- add a regression test for draft-only and mixed published/draft agent lists

## Root cause
The home page filtered published agents first, but fell back to the complete agent list when no published agents were found. That made the section copy say the cards were published, ready-to-run workers while displaying draft agents.

## Validation
- npm run test:run -- src/app/page.test.tsx
- npm run lint -- src/app/page.tsx src/app/page.test.tsx
- npm run type-check
- pre-commit npm lint
- pre-commit npm type-check