### PR TITLE
fix: default channel tasks to auto mode

### DIFF
--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -32,6 +32,7 @@ from ..base import (
     RequiredToolCallError,
     append_user_message_preserving_turns,
     extract_required_tool_arguments,
+    truncate_prompt_preview,
 )
 from ..dag import DAGPattern
 from ..final_answer_stream import (
@@ -760,7 +761,10 @@ class AutoPattern(AgentPattern):
         )
 
         base_messages = context.get_messages_for_llm()
-        current_request = (latest_user_text(context) or "").strip()
+        current_request = truncate_prompt_preview(
+            latest_user_text(context) or "",
+            limit=400,
+        )
         decision_prompt = self._decision_prompt(
             tools,
             current_request=current_request,
@@ -898,10 +902,7 @@ class AutoPattern(AgentPattern):
         )
 
     def _truncate_retry_preview(self, value: str, *, limit: int = 1200) -> str:
-        stripped = value.strip()
-        if len(stripped) <= limit:
-            return stripped
-        return f"{stripped[:limit]}... [truncated]"
+        return truncate_prompt_preview(value, limit=limit)
 
     def _decision_prompt(
         self,

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -760,7 +760,11 @@ class AutoPattern(AgentPattern):
         )
 
         base_messages = context.get_messages_for_llm()
-        decision_prompt = self._decision_prompt(tools)
+        current_request = (latest_user_text(context) or "").strip()
+        decision_prompt = self._decision_prompt(
+            tools,
+            current_request=current_request,
+        )
         decision_tools = [self._decision_tool_schema()]
         retry_feedback: str | None = None
         for attempt in range(MAX_DECISION_PARSE_ATTEMPTS):
@@ -899,7 +903,12 @@ class AutoPattern(AgentPattern):
             return stripped
         return f"{stripped[:limit]}... [truncated]"
 
-    def _decision_prompt(self, tools: list[Any]) -> str:
+    def _decision_prompt(
+        self,
+        tools: list[Any],
+        *,
+        current_request: str = "",
+    ) -> str:
         tool_count = len(tools)
         tool_capability_summary = (
             f"{tool_count} execution tools are available to the downstream "
@@ -908,10 +917,19 @@ class AutoPattern(AgentPattern):
             else "No execution tools are available to the downstream execution pattern."
         )
         available_actions = ", ".join(self._available_auto_actions())
+        language_anchor = (
+            "Latest user request text, quoted for response_language selection:\n"
+            f"{current_request or '(unavailable)'}\n\n"
+            "Choose response_language from that latest user request, including "
+            "any explicit language change requested inside it. Do not choose "
+            "response_language from retrieved memories, source documents, "
+            "tool results, or earlier turns. "
+        )
         return (
             "Choose how the agent should handle the user request. "
             f"You must call the {DECISION_TOOL_NAME} tool exactly once. "
             f"action must be one of: {available_actions}. "
+            f"{language_anchor}"
             "Use final_answer for simple conversational replies that need no tools; "
             "when action is final_answer, you must include a complete non-empty "
             "answer field in the same tool call. Put action before answer in the "

--- a/src/xagent/core/agent/pattern/base.py
+++ b/src/xagent/core/agent/pattern/base.py
@@ -9,6 +9,13 @@ from ..context import ExecutionContext
 REQUIRED_TOOL_CALL_FAILURE_REASON = "missing_required_tool_call"
 
 
+def truncate_prompt_preview(value: str, *, limit: int = 1200) -> str:
+    stripped = value.strip()
+    if len(stripped) <= limit:
+        return stripped
+    return f"{stripped[:limit]}... [truncated]"
+
+
 class RequiredToolCallError(ValueError):
     """Raised when an LLM response omits a tool call the caller requires."""
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -17,7 +17,7 @@ from ...context.enrichment import (
 from ...language import final_answer_language_rule
 from ...result import unwrap_final_answer_content
 from ...runtime import LLMCallInterrupted, PatternRuntime
-from ..base import AgentPattern, PatternResult
+from ..base import AgentPattern, PatternResult, truncate_prompt_preview
 from ..final_answer_stream import (
     FinalAnswerStreamSession,
     ReActFinalAnswerStreamer,
@@ -1437,8 +1437,10 @@ class ReActPattern(AgentPattern):
                 )
             else:
                 call_context = f"{count_text} to {tool_name}."
-        task_text = self._task_text(context)
-        current_request = task_text.strip() if task_text else ""
+        current_request = truncate_prompt_preview(
+            latest_user_text(context) or "",
+            limit=400,
+        )
         language_anchor = (
             "Latest user request text, quoted for response_language selection:\n"
             f"{current_request or '(unavailable)'}\n\n"

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1437,9 +1437,19 @@ class ReActPattern(AgentPattern):
                 )
             else:
                 call_context = f"{count_text} to {tool_name}."
+        current_request = self._task_text(context).strip()
+        language_anchor = (
+            "Latest user request text, quoted for response_language selection:\n"
+            f"{current_request or '(unavailable)'}\n\n"
+            "Choose response_language from that latest user request, including "
+            "any explicit language change requested inside it. Do not choose "
+            "response_language from tool results, source documents, retrieved "
+            "memories, or earlier turns."
+        )
         prompt = (
             f"You must call {REACT_DECISION_TOOL_NAME} exactly once. Decide whether "
             "the current ReAct run should finish or make another work-tool call. "
+            f"{language_anchor} "
             f"You have just made {call_context} action must be "
             f"{REACT_DECISION_FINAL_ANSWER} or {REACT_DECISION_TOOL_CALL}. Choose "
             f"{REACT_DECISION_FINAL_ANSWER} when the conversation and accumulated "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1437,7 +1437,8 @@ class ReActPattern(AgentPattern):
                 )
             else:
                 call_context = f"{count_text} to {tool_name}."
-        current_request = self._task_text(context).strip()
+        task_text = self._task_text(context)
+        current_request = task_text.strip() if task_text else ""
         language_anchor = (
             "Latest user request text, quoted for response_language selection:\n"
             f"{current_request or '(unavailable)'}\n\n"

--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -12,6 +12,7 @@ from lark_oapi.api.im.v1 import (
     PatchMessageRequestBody,
 )
 
+from ....config import get_default_task_execution_mode
 from ...api.chat import get_agent_manager
 from ...models.database import get_db
 from ...models.task import Task, TaskStatus
@@ -233,6 +234,7 @@ class FeishuBotInstance:
                     title=task_title,
                     description=text,
                     status=TaskStatus.PENDING,
+                    execution_mode=get_default_task_execution_mode(),
                     channel_id=self.channel_id,
                     channel_name=self.channel_name,
                 )

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -17,6 +17,7 @@ from aiogram.filters import CommandStart
 from aiogram.types import FSInputFile
 from sqlalchemy.orm import Session
 
+from ....config import get_default_task_execution_mode
 from ...api.chat import get_agent_manager
 from ...models.database import get_db
 from ...models.task import Task, TaskStatus
@@ -518,6 +519,7 @@ class TelegramBotInstance:
                         title=task_title,
                         description=text,
                         status=TaskStatus.PENDING,
+                        execution_mode=get_default_task_execution_mode(),
                         channel_id=self.channel_id,
                         channel_name=self.channel_name,
                     )

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -112,7 +112,7 @@ class Task(Base):  # type: ignore
 
     # Execution mode configuration
     execution_mode = Column(
-        String(20), default=ExecutionMode.BALANCED.value, nullable=True
+        String(20), default=ExecutionMode.AUTO.value, nullable=True
     )  # "flash" | "balanced" | "think" | "auto"
     process_description = Column(
         Text, nullable=True
@@ -186,10 +186,10 @@ class Task(Base):  # type: ignore
             return (
                 ExecutionMode(self.execution_mode)
                 if self.execution_mode
-                else ExecutionMode.BALANCED
+                else ExecutionMode.AUTO
             )
         except ValueError:
-            return ExecutionMode.BALANCED
+            return ExecutionMode.AUTO
 
     @execution_mode_enum.setter
     def execution_mode_enum(self, value: ExecutionMode) -> None:

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -623,6 +623,29 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
 
 
 @pytest.mark.asyncio
+async def test_auto_pattern_truncates_language_anchor_request_preview() -> None:
+    llm = FakeLLM(
+        [decision_tool_response("final_answer", "Greeting only.", answer="done")]
+    )
+    pattern = AutoPattern()
+    context = ExecutionContext()
+    tail = "TAIL_SHOULD_NOT_BE_IN_LANGUAGE_ANCHOR"
+    context.add_user_message(f"{'x' * 450}{tail}")
+    runtime = PatternRuntime()
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    prompt = llm.calls[0]["messages"][-1]["content"]
+    anchor_start = prompt.index("Latest user request text")
+    anchor_end = prompt.index("Choose response_language", anchor_start)
+    anchor = prompt[anchor_start:anchor_end]
+    assert "x" * 400 in anchor
+    assert "... [truncated]" in anchor
+    assert tail not in anchor
+
+
+@pytest.mark.asyncio
 async def test_auto_pattern_rederives_output_language_per_run() -> None:
     llm = FakeLLM(
         [

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -573,6 +573,11 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     )
     decision_prompt = llm.calls[0]["messages"][-1]["content"]
     assert llm.calls[0]["messages"][-1]["role"] == "user"
+    assert "Latest user request text" in decision_prompt
+    assert "hi" in decision_prompt
+    assert "Choose response_language from that latest user request" in decision_prompt
+    assert "retrieved memories, source documents" in decision_prompt
+    assert "tool results, or earlier turns" in decision_prompt
     assert "must include a complete non-empty answer field" in decision_prompt
     assert (
         "available retrieved context already provide enough evidence" in decision_prompt

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -874,6 +874,33 @@ async def test_react_pattern_uses_decision_for_repeated_tools() -> None:
     assert pattern.pending_tool_calls == []
 
 
+def test_react_repeated_decision_anchors_latest_user_text_not_cached_task() -> None:
+    pattern = ReActPattern()
+    pattern.task_text = "search AI news"
+    context = ExecutionContext()
+    context.add_user_message("search AI news")
+    tail = "TAIL_SHOULD_NOT_BE_IN_LANGUAGE_ANCHOR"
+    context.add_user_message(f"请用简体中文回答 {'x' * 430}{tail}")
+
+    messages = pattern._messages_for_repeated_tool_decision(
+        context,
+        {
+            "tool_name": "zhipu_web_search",
+            "latest_tool_name": "zhipu_web_search",
+            "consecutive_tool_calls": 2,
+        },
+    )
+
+    prompt = messages[-1]["content"]
+    anchor_start = prompt.index("Latest user request text")
+    anchor_end = prompt.index("Choose response_language", anchor_start)
+    anchor = prompt[anchor_start:anchor_end]
+    assert "请用简体中文回答" in anchor
+    assert "search AI news" not in anchor
+    assert "... [truncated]" in anchor
+    assert tail not in anchor
+
+
 @pytest.mark.asyncio
 async def test_react_repeated_decision_drains_current_tool_call_batch() -> None:
     llm = FakeLLM(

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -861,6 +861,10 @@ async def test_react_pattern_uses_decision_for_repeated_tools() -> None:
     assert "Traditional Chinese" in response_language_schema["description"]
     assert "generic Chinese" in response_language_schema["description"]
     decision_prompt = llm.calls[2]["messages"][-1]["content"]
+    assert "Latest user request text" in decision_prompt
+    assert "最近 AI 新闻" in decision_prompt
+    assert "Choose response_language from that latest user request" in decision_prompt
+    assert "Do not choose response_language from tool results" in decision_prompt
     assert "Set response_language" in decision_prompt
     assert "answer must match response_language" in decision_prompt
     assert "When choosing final_answer" in decision_prompt

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -6,7 +6,7 @@ import pytest
 
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, LEGACY_CHECKPOINT_TYPES
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.task import ExecutionMode, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
 from xagent.web.services.task_lease_service import (
     acquire_task_lease,
@@ -44,6 +44,26 @@ def _create_task(db, *, status=TaskStatus.PENDING) -> Task:
     db.commit()
     db.refresh(task)
     return task
+
+
+def test_task_model_default_execution_mode_is_auto(db_session) -> None:
+    user = User(username="default-mode-user", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    task = Task(
+        user_id=user.id,
+        title="Default mode",
+        description="Default mode",
+        status=TaskStatus.PENDING,
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    assert task.execution_mode == "auto"
+    assert task.execution_mode_enum == ExecutionMode.AUTO
 
 
 def test_task_lease_acquire_refresh_and_release(db_session) -> None:


### PR DESCRIPTION
## Summary
- default direct-created channel tasks to auto execution mode
- explicitly set auto mode for Telegram and Feishu channel-created tasks
- anchor ReAct repeated-tool response_language selection to the latest user request

## Tests
- ruff check src/xagent/web/models/task.py src/xagent/web/channels/telegram/bot.py src/xagent/web/channels/feishu/bot.py src/xagent/core/agent/pattern/react/react.py tests/core/agent/test_react.py tests/web/test_task_lease_service.py
- PYTHONPATH=src pytest tests/core/agent/test_react.py tests/web/test_task_lease_service.py tests/core/test_config.py
- PYTHONPATH=src pytest tests/web/test_telegram_message_queue.py tests/web/test_telegram_image_output.py
- PYTHONPATH=src python - <<'PY'
from xagent.web.channels.feishu.bot import FeishuBotInstance
from xagent.web.channels.telegram.bot import TelegramBotInstance
print(FeishuBotInstance.__name__, TelegramBotInstance.__name__)
PY