### PR TITLE
feat: add agent triggers

### DIFF
--- a/example.env
+++ b/example.env
@@ -64,6 +64,11 @@ PORT="80"
 # XAGENT_BACKGROUND_JOB_STALE_SECONDS="7200"
 # Scheduler interval for scanning stale background jobs.
 # XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS="300"
+# Backend dispatcher for prepared trigger runs. Celery scans scheduled triggers,
+# but agent execution is started by backend processes.
+# XAGENT_TRIGGER_DISPATCHER_ENABLED="true"
+# XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS="5"
+# XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE="20"
 
 # ===========================================
 # LLM API Keys

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -73,6 +73,9 @@ BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS = (
 BACKGROUND_JOB_MAX_RETRIES = "XAGENT_BACKGROUND_JOB_MAX_RETRIES"
 BACKGROUND_JOB_STALE_SECONDS = "XAGENT_BACKGROUND_JOB_STALE_SECONDS"
 BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS = "XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS"
+TRIGGER_DISPATCHER_ENABLED = "XAGENT_TRIGGER_DISPATCHER_ENABLED"
+TRIGGER_DISPATCHER_INTERVAL_SECONDS = "XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS"
+TRIGGER_DISPATCHER_BATCH_SIZE = "XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE"
 PASSWORD_RESET_EXPIRE_MINUTES = "XAGENT_PASSWORD_RESET_EXPIRE_MINUTES"
 APP_BASE_URL = "XAGENT_APP_BASE_URL"
 SMTP_HOST = "XAGENT_SMTP_HOST"
@@ -388,6 +391,29 @@ def get_background_job_sweep_interval_seconds() -> int:
         BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS,
         300,
         minimum=30,
+    )
+
+
+def get_trigger_dispatcher_enabled() -> bool:
+    """Return whether the backend should start prepared trigger runs."""
+    return _get_bool_env(TRIGGER_DISPATCHER_ENABLED, True)
+
+
+def get_trigger_dispatcher_interval_seconds() -> int:
+    """Return how often backend processes poll prepared trigger runs."""
+    return _get_positive_int_env(
+        TRIGGER_DISPATCHER_INTERVAL_SECONDS,
+        5,
+        minimum=1,
+    )
+
+
+def get_trigger_dispatcher_batch_size() -> int:
+    """Return max prepared trigger runs one backend poll should start."""
+    return _get_positive_int_env(
+        TRIGGER_DISPATCHER_BATCH_SIZE,
+        20,
+        minimum=1,
     )
 
 

--- a/src/xagent/migrations/versions/20260616_add_agent_triggers.py
+++ b/src/xagent/migrations/versions/20260616_add_agent_triggers.py
@@ -1,0 +1,184 @@
+"""add agent triggers
+
+Revision ID: 20260616_add_agent_triggers
+Revises: 20260611_backfill_basic_agents_web_search
+Create Date: 2026-06-16 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260616_add_agent_triggers"
+down_revision: Union[str, tuple[str, str], None] = (
+    "20260611_backfill_basic_agents_web_search"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _index_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "agent_triggers" not in existing_tables:
+        constraints = [
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("webhook_token"),
+        ]
+        if "users" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE")
+            )
+        if "agents" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="CASCADE")
+            )
+
+        op.create_table(
+            "agent_triggers",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("agent_id", sa.Integer(), nullable=False),
+            sa.Column("type", sa.String(length=32), nullable=False),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column(
+                "enabled",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.true(),
+            ),
+            sa.Column("config", sa.JSON(), nullable=False),
+            sa.Column("prompt_template", sa.Text(), nullable=True),
+            sa.Column("webhook_token", sa.String(length=128), nullable=True),
+            sa.Column("secret_hash", sa.String(length=64), nullable=True),
+            sa.Column("next_run_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            *constraints,
+        )
+
+    if "trigger_runs" not in existing_tables:
+        constraints = [
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("idempotency_key"),
+        ]
+        if "agent_triggers" in inspector.get_table_names():
+            constraints.append(
+                sa.ForeignKeyConstraint(
+                    ["trigger_id"], ["agent_triggers.id"], ondelete="CASCADE"
+                )
+            )
+        if "tasks" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="SET NULL")
+            )
+        if "background_jobs" in existing_tables:
+            constraints.append(
+                sa.ForeignKeyConstraint(
+                    ["background_job_id"], ["background_jobs.id"], ondelete="SET NULL"
+                )
+            )
+
+        op.create_table(
+            "trigger_runs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("trigger_id", sa.Integer(), nullable=False),
+            sa.Column("task_id", sa.Integer(), nullable=True),
+            sa.Column("background_job_id", sa.String(length=36), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("source_event_id", sa.String(length=255), nullable=True),
+            sa.Column("payload_snapshot", sa.JSON(), nullable=True),
+            sa.Column("idempotency_key", sa.String(length=255), nullable=False),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=True,
+            ),
+            *constraints,
+        )
+
+    for table_name, index_name, columns in (
+        ("agent_triggers", "ix_agent_triggers_id", ["id"]),
+        ("agent_triggers", "ix_agent_triggers_user_id", ["user_id"]),
+        ("agent_triggers", "ix_agent_triggers_agent_id", ["agent_id"]),
+        ("agent_triggers", "ix_agent_triggers_type", ["type"]),
+        ("agent_triggers", "ix_agent_triggers_webhook_token", ["webhook_token"]),
+        ("agent_triggers", "ix_agent_triggers_next_run_at", ["next_run_at"]),
+        ("trigger_runs", "ix_trigger_runs_id", ["id"]),
+        ("trigger_runs", "ix_trigger_runs_trigger_id", ["trigger_id"]),
+        ("trigger_runs", "ix_trigger_runs_task_id", ["task_id"]),
+        ("trigger_runs", "ix_trigger_runs_background_job_id", ["background_job_id"]),
+        ("trigger_runs", "ix_trigger_runs_status", ["status"]),
+        ("trigger_runs", "ix_trigger_runs_source_event_id", ["source_event_id"]),
+        ("trigger_runs", "ix_trigger_runs_idempotency_key", ["idempotency_key"]),
+    ):
+        if table_name in inspector.get_table_names() and index_name not in _index_names(
+            table_name
+        ):
+            op.create_index(index_name, table_name, columns, unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "trigger_runs" in inspector.get_table_names():
+        for index_name in (
+            "ix_trigger_runs_idempotency_key",
+            "ix_trigger_runs_source_event_id",
+            "ix_trigger_runs_status",
+            "ix_trigger_runs_background_job_id",
+            "ix_trigger_runs_task_id",
+            "ix_trigger_runs_trigger_id",
+            "ix_trigger_runs_id",
+        ):
+            if index_name in _index_names("trigger_runs"):
+                op.drop_index(index_name, table_name="trigger_runs")
+        op.drop_table("trigger_runs")
+
+    if "agent_triggers" in inspector.get_table_names():
+        for index_name in (
+            "ix_agent_triggers_next_run_at",
+            "ix_agent_triggers_webhook_token",
+            "ix_agent_triggers_type",
+            "ix_agent_triggers_agent_id",
+            "ix_agent_triggers_user_id",
+            "ix_agent_triggers_id",
+        ):
+            if index_name in _index_names("agent_triggers"):
+                op.drop_index(index_name, table_name="agent_triggers")
+        op.drop_table("agent_triggers")

--- a/src/xagent/web/api/triggers.py
+++ b/src/xagent/web/api/triggers.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Literal, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ..auth_dependencies import get_current_user
+from ..models.database import get_db
+from ..models.trigger import AgentTrigger, TriggerRun
+from ..models.user import User
+from ..services.triggers import (
+    TriggerNotFoundError,
+    TriggerSecretError,
+    TriggerServiceError,
+    create_agent_trigger,
+    delete_agent_trigger,
+    find_webhook_trigger,
+    fire_trigger,
+    get_owned_agent,
+    get_owned_trigger,
+    update_agent_trigger,
+    verify_webhook_secret,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["triggers"])
+
+
+class TriggerCreateRequest(BaseModel):
+    type: Literal["webhook", "scheduled"]
+    name: str | None = Field(default=None, max_length=200)
+    enabled: bool = True
+    config: dict[str, Any] = Field(default_factory=dict)
+    prompt_template: str | None = None
+    secret: str | None = None
+
+
+class TriggerUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, max_length=200)
+    enabled: bool | None = None
+    config: dict[str, Any] | None = None
+    prompt_template: str | None = None
+    secret: str | None = None
+    rotate_secret: bool = False
+
+
+class TriggerTestRequest(BaseModel):
+    payload: dict[str, Any] = Field(default_factory=dict)
+    source_event_id: str | None = None
+
+
+class TriggerResponse(BaseModel):
+    id: int
+    user_id: int
+    agent_id: int
+    type: str
+    name: str
+    enabled: bool
+    config: dict[str, Any]
+    prompt_template: str | None
+    webhook_token: str | None
+    webhook_secret: str | None = None
+    next_run_at: str | None
+    last_run_at: str | None
+    last_error: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
+class TriggerRunResponse(BaseModel):
+    id: int
+    trigger_id: int
+    task_id: int | None
+    background_job_id: str | None
+    status: str
+    source_event_id: str | None
+    payload_snapshot: dict[str, Any] | None
+    idempotency_key: str
+    error_message: str | None
+    started_at: str | None
+    finished_at: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
+class TriggerFireResponse(BaseModel):
+    trigger_run: TriggerRunResponse
+    duplicate: bool = False
+
+
+class PublicTriggerFireResponse(BaseModel):
+    trigger_run_id: int
+    status: str
+    duplicate: bool = False
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _serialize_trigger(
+    trigger: AgentTrigger, *, webhook_secret: str | None = None
+) -> TriggerResponse:
+    return TriggerResponse(
+        id=int(trigger.id),
+        user_id=int(trigger.user_id),
+        agent_id=int(trigger.agent_id),
+        type=str(trigger.type),
+        name=str(trigger.name),
+        enabled=bool(trigger.enabled),
+        config=dict(trigger.config or {}),
+        prompt_template=trigger.prompt_template,
+        webhook_token=trigger.webhook_token,
+        webhook_secret=webhook_secret,
+        next_run_at=_dt(cast(datetime | None, trigger.next_run_at)),
+        last_run_at=_dt(cast(datetime | None, trigger.last_run_at)),
+        last_error=trigger.last_error,
+        created_at=_dt(cast(datetime | None, trigger.created_at)),
+        updated_at=_dt(cast(datetime | None, trigger.updated_at)),
+    )
+
+
+def _serialize_run(run: TriggerRun) -> TriggerRunResponse:
+    payload = run.payload_snapshot if isinstance(run.payload_snapshot, dict) else None
+    return TriggerRunResponse(
+        id=int(run.id),
+        trigger_id=int(run.trigger_id),
+        task_id=int(run.task_id) if run.task_id is not None else None,
+        background_job_id=run.background_job_id,
+        status=str(run.status),
+        source_event_id=run.source_event_id,
+        payload_snapshot=payload,
+        idempotency_key=str(run.idempotency_key),
+        error_message=run.error_message,
+        started_at=_dt(getattr(run, "started_at", None)),
+        finished_at=_dt(getattr(run, "finished_at", None)),
+        created_at=_dt(getattr(run, "created_at", None)),
+        updated_at=_dt(getattr(run, "updated_at", None)),
+    )
+
+
+def _agent_or_404(db: Session, *, user_id: int, agent_id: int) -> None:
+    if get_owned_agent(db, user_id=user_id, agent_id=agent_id) is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+
+def _trigger_or_404(
+    db: Session,
+    *,
+    user_id: int,
+    agent_id: int,
+    trigger_id: int,
+) -> AgentTrigger:
+    trigger = get_owned_trigger(
+        db, user_id=user_id, agent_id=agent_id, trigger_id=trigger_id
+    )
+    if trigger is None:
+        raise HTTPException(status_code=404, detail="Trigger not found")
+    return trigger
+
+
+def _handle_service_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, TriggerNotFoundError):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, TriggerSecretError):
+        return HTTPException(status_code=401, detail=str(exc))
+    if isinstance(exc, TriggerServiceError):
+        return HTTPException(status_code=400, detail=str(exc))
+    logger.exception("Unhandled trigger API error")
+    return HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get(
+    "/api/agents/{agent_id}/triggers",
+    response_model=list[TriggerResponse],
+)
+async def list_triggers(
+    agent_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[TriggerResponse]:
+    user_id = int(current_user.id)
+    _agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    rows = (
+        db.query(AgentTrigger)
+        .filter(AgentTrigger.user_id == user_id, AgentTrigger.agent_id == agent_id)
+        .order_by(AgentTrigger.created_at.desc(), AgentTrigger.id.desc())
+        .all()
+    )
+    return [_serialize_trigger(row) for row in rows]
+
+
+@router.post(
+    "/api/agents/{agent_id}/triggers",
+    response_model=TriggerResponse,
+)
+async def create_trigger(
+    agent_id: int,
+    request: TriggerCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TriggerResponse:
+    try:
+        trigger, secret = create_agent_trigger(
+            db,
+            user_id=int(current_user.id),
+            agent_id=agent_id,
+            trigger_type=request.type,
+            name=request.name,
+            enabled=request.enabled,
+            config=request.config,
+            prompt_template=request.prompt_template,
+            secret=request.secret,
+        )
+        return _serialize_trigger(trigger, webhook_secret=secret)
+    except Exception as exc:
+        raise _handle_service_error(exc)
+
+
+@router.patch(
+    "/api/agents/{agent_id}/triggers/{trigger_id}",
+    response_model=TriggerResponse,
+)
+async def update_trigger(
+    agent_id: int,
+    trigger_id: int,
+    request: TriggerUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TriggerResponse:
+    try:
+        trigger, secret = update_agent_trigger(
+            db,
+            user_id=int(current_user.id),
+            agent_id=agent_id,
+            trigger_id=trigger_id,
+            updates=request.model_dump(exclude_unset=True),
+        )
+        return _serialize_trigger(trigger, webhook_secret=secret)
+    except Exception as exc:
+        raise _handle_service_error(exc)
+
+
+@router.delete("/api/agents/{agent_id}/triggers/{trigger_id}")
+async def delete_trigger(
+    agent_id: int,
+    trigger_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, str]:
+    try:
+        delete_agent_trigger(
+            db,
+            user_id=int(current_user.id),
+            agent_id=agent_id,
+            trigger_id=trigger_id,
+        )
+        return {"message": "Trigger deleted"}
+    except Exception as exc:
+        raise _handle_service_error(exc)
+
+
+@router.get(
+    "/api/agents/{agent_id}/triggers/{trigger_id}/runs",
+    response_model=list[TriggerRunResponse],
+)
+async def list_trigger_runs(
+    agent_id: int,
+    trigger_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[TriggerRunResponse]:
+    trigger = _trigger_or_404(
+        db,
+        user_id=int(current_user.id),
+        agent_id=agent_id,
+        trigger_id=trigger_id,
+    )
+    rows = (
+        db.query(TriggerRun)
+        .filter(TriggerRun.trigger_id == int(trigger.id))
+        .order_by(TriggerRun.created_at.desc(), TriggerRun.id.desc())
+        .limit(100)
+        .all()
+    )
+    return [_serialize_run(row) for row in rows]
+
+
+@router.post(
+    "/api/agents/{agent_id}/triggers/{trigger_id}/test",
+    response_model=TriggerFireResponse,
+)
+async def test_trigger(
+    agent_id: int,
+    trigger_id: int,
+    request: TriggerTestRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TriggerFireResponse:
+    trigger = _trigger_or_404(
+        db,
+        user_id=int(current_user.id),
+        agent_id=agent_id,
+        trigger_id=trigger_id,
+    )
+    try:
+        run, created = await fire_trigger(
+            db,
+            trigger=trigger,
+            event_payload=request.payload,
+            source_event_id=request.source_event_id,
+            test=True,
+        )
+        return TriggerFireResponse(
+            trigger_run=_serialize_run(run), duplicate=not created
+        )
+    except Exception as exc:
+        raise _handle_service_error(exc)
+
+
+async def _read_payload(request: Request) -> dict[str, Any]:
+    body = await request.body()
+    if not body:
+        return {}
+    try:
+        decoded = json.loads(body.decode("utf-8"))
+    except ValueError:
+        return {"body": body.decode("utf-8", errors="replace")}
+    if isinstance(decoded, dict):
+        return decoded
+    return {"value": decoded}
+
+
+@router.post(
+    "/api/triggers/webhook/{webhook_token}",
+    response_model=PublicTriggerFireResponse,
+)
+async def receive_webhook_trigger(
+    webhook_token: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> PublicTriggerFireResponse:
+    trigger = find_webhook_trigger(db, webhook_token)
+    if trigger is None:
+        raise HTTPException(status_code=404, detail="Trigger not found")
+    if not trigger.enabled:
+        raise HTTPException(status_code=409, detail="Trigger is disabled")
+
+    secret = request.headers.get("x-xagent-trigger-secret")
+    try:
+        verify_webhook_secret(trigger, secret)
+        payload = await _read_payload(request)
+        source_event_id = (
+            request.headers.get("x-xagent-event-id")
+            or request.headers.get("x-event-id")
+            or request.headers.get("x-request-id")
+        )
+        run, created = await fire_trigger(
+            db,
+            trigger=trigger,
+            event_payload=payload,
+            source_event_id=source_event_id,
+        )
+        return PublicTriggerFireResponse(
+            trigger_run_id=int(run.id),
+            status=str(run.status),
+            duplicate=not created,
+        )
+    except Exception as exc:
+        logger.warning("Webhook trigger %s rejected: %s", trigger.id, exc)
+        raise _handle_service_error(exc)

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -17,6 +17,9 @@ from ..config import (
     get_agent_runtime,
     get_file_storage_startup_sync_enabled,
     get_session_secret,
+    get_trigger_dispatcher_batch_size,
+    get_trigger_dispatcher_enabled,
+    get_trigger_dispatcher_interval_seconds,
     get_uploads_dir,
 )
 from ..core.tracing.langfuse import flush_langfuse, initialize_langfuse
@@ -42,6 +45,7 @@ from .api.skills import router as skills_router
 from .api.system import system_router
 from .api.templates import router as templates_router
 from .api.tools import tools_router
+from .api.triggers import router as triggers_router
 from .api.v1 import v1_router
 from .api.v1.errors import V1ApiError, v1_api_error_handler
 from .api.websocket import ws_router
@@ -73,6 +77,7 @@ app = FastAPI(
 # Track background migration task for graceful shutdown cleanup.
 _migration_task: asyncio.Task[None] | None = None
 _file_storage_startup_sync_task: asyncio.Task[Any] | None = None
+_trigger_dispatcher_task: asyncio.Task[Any] | None = None
 
 FILE_STORAGE_STARTUP_SYNC_EXEMPT_PATHS = frozenset({"/health", "/ready"})
 FILE_STORAGE_STARTUP_SYNC_RETRY_INTERVAL_SECONDS = 5.0
@@ -176,6 +181,62 @@ def start_file_storage_startup_sync_task(
 
     task.add_done_callback(_record_file_storage_sync_result)
     logger.info("Started background startup file storage sync task")
+    return task
+
+
+async def _run_trigger_dispatcher(
+    *,
+    poll_interval_seconds: int,
+    batch_size: int,
+) -> None:
+    from .models.database import get_session_local
+    from .services.triggers import dispatch_pending_trigger_runs
+
+    while True:
+        try:
+            SessionLocal = get_session_local()
+            db = SessionLocal()
+            try:
+                started = await dispatch_pending_trigger_runs(db, limit=batch_size)
+                if started:
+                    logger.info("Trigger dispatcher started %s trigger run(s)", started)
+            finally:
+                db.close()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Trigger dispatcher tick failed: %s", exc, exc_info=True)
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
+def start_trigger_dispatcher_task(app_instance: FastAPI) -> asyncio.Task[Any] | None:
+    """Start backend-side trigger execution dispatcher."""
+    global _trigger_dispatcher_task
+
+    app_instance.state.trigger_dispatcher_task = None
+    if not get_trigger_dispatcher_enabled():
+        logger.info("Trigger dispatcher is disabled")
+        return None
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        logger.info("Skipping trigger dispatcher (test environment)")
+        return None
+
+    poll_interval_seconds = get_trigger_dispatcher_interval_seconds()
+    batch_size = get_trigger_dispatcher_batch_size()
+    task = asyncio.create_task(
+        _run_trigger_dispatcher(
+            poll_interval_seconds=poll_interval_seconds,
+            batch_size=batch_size,
+        )
+    )
+    _trigger_dispatcher_task = task
+    app_instance.state.trigger_dispatcher_task = task
+    logger.info(
+        "Started trigger dispatcher task (interval=%ss, batch_size=%s)",
+        poll_interval_seconds,
+        batch_size,
+    )
     return task
 
 
@@ -462,6 +523,7 @@ app.include_router(skills_router)
 app.include_router(system_router)
 app.include_router(templates_router)
 app.include_router(agents_router)
+app.include_router(triggers_router)
 app.include_router(workforces_router)
 app.include_router(channel_router, prefix="/api/channels", tags=["Channels"])
 app.include_router(widget_router)
@@ -480,6 +542,7 @@ async def startup_event() -> None:
     init_db()
     logger.info("Database initialized successfully")
     start_file_storage_startup_sync_task(app)
+    start_trigger_dispatcher_task(app)
 
     initialize_langfuse()
 
@@ -905,7 +968,7 @@ async def startup_event() -> None:
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
-    global _file_storage_startup_sync_task, _migration_task
+    global _file_storage_startup_sync_task, _migration_task, _trigger_dispatcher_task
 
     flush_langfuse()
 
@@ -915,6 +978,13 @@ async def shutdown_event() -> None:
         with suppress(asyncio.CancelledError):
             await _file_storage_startup_sync_task
     _file_storage_startup_sync_task = None
+
+    if _trigger_dispatcher_task and not _trigger_dispatcher_task.done():
+        logger.info("Cancelling trigger dispatcher task...")
+        _trigger_dispatcher_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _trigger_dispatcher_task
+    _trigger_dispatcher_task = None
 
     if _migration_task and not _migration_task.done():
         logger.info("Cancelling background LanceDB migration task...")

--- a/src/xagent/web/jobs/trigger_tasks.py
+++ b/src/xagent/web/jobs/trigger_tasks.py
@@ -12,6 +12,7 @@ from ..services.background_jobs import (
     requeue_stale_background_jobs,
     update_job_progress,
 )
+from ..services.triggers import prepare_trigger_run, scan_due_scheduled_triggers
 from .celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,30 @@ def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
     """
     payload = dict(job.payload or {})
     update_job_progress(db, job, message="Processing trigger event")
+    trigger_id = payload.get("trigger_id")
+    if trigger_id:
+        from ..models.trigger import AgentTrigger
+
+        trigger = (
+            db.query(AgentTrigger).filter(AgentTrigger.id == int(trigger_id)).first()
+        )
+        if trigger is None:
+            raise ValueError(f"Trigger not found: {trigger_id}")
+        run, created = prepare_trigger_run(
+            db,
+            trigger=trigger,
+            event_payload=dict(payload.get("event_payload") or {}),
+            source_event_id=payload.get("source_event_id"),
+            background_job_id=str(job.id),
+        )
+        return {
+            "status": "prepared" if created else "duplicate",
+            "trigger_id": int(trigger.id),
+            "trigger_run_id": int(run.id),
+            "task_id": int(run.task_id) if run.task_id is not None else None,
+            "processed_at": datetime.now(timezone.utc).isoformat(),
+        }
+
     logger.info(
         "Processed trigger event job=%s source=%s event=%s",
         job.id,
@@ -44,10 +69,12 @@ def handle_trigger_scan(db: Session, job: BackgroundJob) -> dict[str, Any]:
     payload = dict(job.payload or {})
     update_job_progress(db, job, message="Scanning scheduled triggers")
     requeued_jobs = requeue_stale_background_jobs(db)
+    runs = scan_due_scheduled_triggers(db)
     return {
         "status": "scanned",
         "scan_scope": payload.get("scope", "all"),
         "requeued_stale_jobs": len(requeued_jobs),
+        "trigger_runs_created": len(runs),
         "processed_at": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -69,9 +96,11 @@ def scan_due_triggers() -> dict[str, Any]:
     db = SessionLocal()
     try:
         requeued_jobs = requeue_stale_background_jobs(db)
+        runs = scan_due_scheduled_triggers(db)
         return {
             "status": "ok",
             "requeued_stale_jobs": len(requeued_jobs),
+            "trigger_runs_created": len(runs),
             "processed_at": datetime.now(timezone.utc).isoformat(),
         }
     finally:

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -15,6 +15,7 @@ from .system_setting import SystemSetting
 from .task import DAGExecution, Task
 from .template_stats import TemplateStats, UserTemplateRelation
 from .tool_config import ToolConfig, ToolUsage
+from .trigger import AgentTrigger, TriggerRun, TriggerRunStatus, TriggerType
 from .uploaded_file import UploadedFile
 from .user import User, UserDefaultModel, UserModel
 from .user_api_key import UserApiKey
@@ -46,6 +47,10 @@ __all__ = [
     "UserTemplateRelation",
     "ToolConfig",
     "ToolUsage",
+    "AgentTrigger",
+    "TriggerRun",
+    "TriggerRunStatus",
+    "TriggerType",
     "SystemSetting",
     "Agent",
     "AgentApiKey",

--- a/src/xagent/web/models/agent.py
+++ b/src/xagent/web/models/agent.py
@@ -99,6 +99,9 @@ class Agent(Base):  # type: ignore
 
     # Relationships
     user = relationship("User", back_populates="agents")
+    triggers = relationship(
+        "AgentTrigger", back_populates="agent", cascade="all, delete-orphan"
+    )
 
     @property
     def is_workforce_generated_manager(self) -> bool:

--- a/src/xagent/web/models/trigger.py
+++ b/src/xagent/web/models/trigger.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    true,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class TriggerType(str, enum.Enum):
+    WEBHOOK = "webhook"
+    SCHEDULED = "scheduled"
+
+
+class TriggerRunStatus(str, enum.Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class AgentTrigger(Base):  # type: ignore
+    """Reusable automatic entry point for an agent."""
+
+    __tablename__ = "agent_triggers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    agent_id = Column(
+        Integer,
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    type = Column(String(32), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    enabled = Column(Boolean, nullable=False, default=True, server_default=true())
+    config = Column(JSON, nullable=False, default=dict)
+    prompt_template = Column(Text, nullable=True)
+
+    webhook_token = Column(String(128), nullable=True, unique=True, index=True)
+    secret_hash = Column(String(64), nullable=True)
+
+    next_run_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    last_run_at = Column(DateTime(timezone=True), nullable=True)
+    last_error = Column(Text, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user = relationship("User", back_populates="agent_triggers")
+    agent = relationship("Agent", back_populates="triggers")
+    runs = relationship(
+        "TriggerRun",
+        back_populates="trigger",
+        cascade="all, delete-orphan",
+        order_by="TriggerRun.id.desc()",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AgentTrigger(id={self.id}, agent_id={self.agent_id}, "
+            f"type='{self.type}', enabled={self.enabled})>"
+        )
+
+
+class TriggerRun(Base):  # type: ignore
+    """One accepted trigger event and its generated task, if any."""
+
+    __tablename__ = "trigger_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    trigger_id = Column(
+        Integer,
+        ForeignKey("agent_triggers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    task_id = Column(
+        Integer, ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    background_job_id = Column(
+        String(36),
+        ForeignKey("background_jobs.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    status = Column(
+        String(32),
+        nullable=False,
+        default=TriggerRunStatus.PENDING.value,
+        index=True,
+    )
+    source_event_id = Column(String(255), nullable=True, index=True)
+    payload_snapshot: Any = Column(JSON, nullable=True)
+    idempotency_key = Column(String(255), nullable=False, unique=True, index=True)
+    error_message = Column(Text, nullable=True)
+
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    trigger = relationship("AgentTrigger", back_populates="runs")
+    task = relationship("Task")
+    background_job = relationship("BackgroundJob")
+
+    def __repr__(self) -> str:
+        return (
+            f"<TriggerRun(id={self.id}, trigger_id={self.trigger_id}, "
+            f"status='{self.status}', task_id={self.task_id})>"
+        )

--- a/src/xagent/web/models/user.py
+++ b/src/xagent/web/models/user.py
@@ -72,6 +72,9 @@ class User(Base):  # type: ignore
     background_jobs = relationship(
         "BackgroundJob", back_populates="user", cascade="all, delete-orphan"
     )
+    agent_triggers = relationship(
+        "AgentTrigger", back_populates="user", cascade="all, delete-orphan"
+    )
     tool_configs = relationship(
         "UserToolConfig", back_populates="user", cascade="all, delete-orphan"
     )

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -628,6 +628,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             fresh.output = latest_assistant.content
             fresh.error_message = None
             sync_workforce_run_status(bg_db, fresh, TaskStatus.COMPLETED)
+            _sync_trigger_run_status(bg_db, fresh, TaskStatus.COMPLETED)
             bg_db.commit()
             invalidate_task_cache(task_id)
             logger.info(
@@ -640,7 +641,11 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
                 "finish_turn: task %s completed but no assistant message found",
                 task_id,
             )
-            if sync_workforce_run_status(bg_db, fresh, TaskStatus.COMPLETED):
+            run_changed = sync_workforce_run_status(bg_db, fresh, TaskStatus.COMPLETED)
+            trigger_run_changed = _sync_trigger_run_status(
+                bg_db, fresh, TaskStatus.COMPLETED
+            )
+            if run_changed or trigger_run_changed:
                 bg_db.commit()
                 invalidate_task_cache(task_id)
         return
@@ -658,7 +663,8 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
             fresh.output = None
             changed = True
         run_changed = sync_workforce_run_status(bg_db, fresh, TaskStatus.FAILED)
-        if changed or run_changed:
+        trigger_run_changed = _sync_trigger_run_status(bg_db, fresh, TaskStatus.FAILED)
+        if changed or run_changed or trigger_run_changed:
             bg_db.commit()
             invalidate_task_cache(task_id)
             logger.info(
@@ -697,6 +703,7 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         fresh.error_message = "Task execution failed without status update; see /steps."
         fresh.output = None  # latest-turn snapshot invariant
         sync_workforce_run_status(bg_db, fresh, TaskStatus.FAILED)
+        _sync_trigger_run_status(bg_db, fresh, TaskStatus.FAILED)
         bg_db.commit()
         invalidate_task_cache(task_id)
         logger.warning(
@@ -707,6 +714,49 @@ def finish_turn(bg_db: Any, task_id: int) -> None:
         return
 
     # PAUSED / WAITING_FOR_USER / other: leave alone.
+
+
+def finish_turn_isolated(task_id: int) -> None:
+    """Run finish_turn with a short-lived session owned by this thread."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as finalize_db:
+        finish_turn(finalize_db, task_id)
+
+
+def _sync_trigger_run_status(bg_db: Any, task: Task, status: TaskStatus) -> bool:
+    """Best-effort mirror from task terminal state to trigger run history."""
+    from ..models.trigger import TriggerRun, TriggerRunStatus
+
+    rows = (
+        bg_db.query(TriggerRun)
+        .filter(
+            TriggerRun.task_id == int(task.id),
+            TriggerRun.status.in_(
+                [TriggerRunStatus.PENDING.value, TriggerRunStatus.RUNNING.value]
+            ),
+        )
+        .all()
+    )
+    if not rows:
+        return False
+
+    now = datetime.now(timezone.utc)
+    run_status = (
+        TriggerRunStatus.COMPLETED.value
+        if status == TaskStatus.COMPLETED
+        else TriggerRunStatus.FAILED.value
+    )
+    for run in rows:
+        run.status = run_status
+        run.finished_at = now
+        if status == TaskStatus.FAILED:
+            run.error_message = task.error_message
+        else:
+            run.error_message = None
+        bg_db.add(run)
+    return True
 
 
 def _schedule_bg(
@@ -854,19 +904,18 @@ def _schedule_bg(
                     # not stuck mid-lifecycle.
 
                 # Short-lived finalize session. ``finish_turn`` only
-                # reads / updates the task row once; opening here keeps
-                # the pool slot freed for the entire agent run above.
-                SessionLocal = get_session_local()
-                with SessionLocal() as finalize_db:
-                    try:
-                        finish_turn(finalize_db, task_id)
-                    except Exception as e:
-                        logger.error(
-                            "finish_turn failed for task %s: %s",
-                            task_id,
-                            e,
-                            exc_info=True,
-                        )
+                # reads / updates the task row once, but the DB work can
+                # still block the event loop under load; run it in a
+                # worker-thread session.
+                try:
+                    await asyncio.to_thread(finish_turn_isolated, task_id)
+                except Exception as e:
+                    logger.error(
+                        "finish_turn failed for task %s: %s",
+                        task_id,
+                        e,
+                        exc_info=True,
+                    )
             finally:
                 stop_event.set()
                 try:

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import bcrypt
+from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from ..models.agent import Agent
 from ..models.background_job import BackgroundJob, BackgroundJobType
+from ..models.task import Task, TaskStatus
+from ..models.trigger import AgentTrigger, TriggerRun, TriggerRunStatus, TriggerType
 from .background_jobs import create_background_job, enqueue_background_job
+from .task_orchestrator import (
+    TaskTurnError,
+    TaskTurnNotFoundError,
+    TaskTurnOrchestrator,
+    TaskTurnPayload,
+    TurnKind,
+)
+
+logger = logging.getLogger(__name__)
 
 _TRIGGER_SCOPE_PAYLOAD_KEYS = (
     "integration_id",
@@ -14,6 +36,934 @@ _TRIGGER_SCOPE_PAYLOAD_KEYS = (
     "channel_id",
     "tenant_id",
 )
+
+_PAYLOAD_PREVIEW_LIMIT = 64_000
+_WEBHOOK_SECRET_BCRYPT_COST = 12
+_TRIGGER_NAME_MAX_LENGTH = 200
+
+
+class TriggerServiceError(ValueError):
+    """Validation or state error raised by trigger service helpers."""
+
+
+class TriggerNotFoundError(LookupError):
+    """Raised when a trigger is missing or not owned by the caller."""
+
+
+class TriggerSecretError(PermissionError):
+    """Raised when a webhook secret does not match."""
+
+
+@dataclass(frozen=True)
+class _PreparedTriggerStart:
+    run_id: int
+    trigger_id: int
+    task_id: int
+    task_owner_user_id: int
+    prompt: str
+    trigger_type: str
+    test: bool
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _payload_snapshot(payload: dict[str, Any]) -> dict[str, Any]:
+    encoded = _json_dumps(payload)
+    if len(encoded) <= _PAYLOAD_PREVIEW_LIMIT:
+        return payload
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return {
+        "truncated": True,
+        "sha256": digest,
+        "preview": encoded[:_PAYLOAD_PREVIEW_LIMIT],
+    }
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(_json_dumps(payload).encode("utf-8")).hexdigest()
+
+
+def _hash_secret(secret: str) -> str:
+    return bcrypt.hashpw(
+        secret.encode("utf-8"),
+        bcrypt.gensalt(rounds=_WEBHOOK_SECRET_BCRYPT_COST),
+    ).decode("utf-8")
+
+
+def verify_webhook_secret(trigger: AgentTrigger, provided_secret: str | None) -> None:
+    expected = trigger.secret_hash
+    if not expected:
+        return
+    if not provided_secret:
+        raise TriggerSecretError("Missing webhook secret")
+    try:
+        matched = bcrypt.checkpw(
+            provided_secret.encode("utf-8"),
+            str(expected).encode("utf-8"),
+        )
+    except (TypeError, ValueError):
+        matched = False
+    if not matched:
+        raise TriggerSecretError("Invalid webhook secret")
+
+
+def _new_webhook_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _new_webhook_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _normalize_trigger_type(trigger_type: str) -> str:
+    try:
+        normalized = TriggerType(trigger_type).value
+    except ValueError as exc:
+        raise TriggerServiceError(f"Unsupported trigger type: {trigger_type}") from exc
+    return normalized
+
+
+def _default_trigger_name(trigger_type: str) -> str:
+    if trigger_type == TriggerType.WEBHOOK.value:
+        return "Webhook trigger"
+    if trigger_type == TriggerType.SCHEDULED.value:
+        return "Scheduled trigger"
+    return "Agent trigger"
+
+
+def _normalize_trigger_name(name: str | None, *, default: str | None = None) -> str:
+    resolved = default if name is None else name
+    value = str(resolved or "").strip()
+    if not value:
+        raise TriggerServiceError("Trigger name must not be empty")
+    if len(value) > _TRIGGER_NAME_MAX_LENGTH:
+        raise TriggerServiceError(
+            f"Trigger name must be at most {_TRIGGER_NAME_MAX_LENGTH} characters"
+        )
+    return value
+
+
+def _compute_next_run_at(
+    config: dict[str, Any],
+    *,
+    from_time: datetime | None = None,
+    previous_due_at: datetime | None = None,
+    include_explicit: bool = True,
+) -> datetime | None:
+    """Compute the next scheduled fire time for the supported MVP config."""
+    base = _coerce_utc(previous_due_at) or from_time or _now()
+    base = _coerce_utc(base) or _now()
+
+    if include_explicit:
+        explicit_next = config.get("next_run_at")
+        if isinstance(explicit_next, str) and explicit_next.strip():
+            try:
+                return _coerce_utc(datetime.fromisoformat(explicit_next))
+            except ValueError as exc:
+                raise TriggerServiceError("Invalid next_run_at") from exc
+
+    interval = config.get("interval_seconds")
+    if interval is None:
+        return None
+    try:
+        interval_seconds = int(interval)
+    except (TypeError, ValueError) as exc:
+        raise TriggerServiceError("interval_seconds must be an integer") from exc
+    if interval_seconds <= 0:
+        raise TriggerServiceError("interval_seconds must be positive")
+
+    candidate = base + timedelta(seconds=interval_seconds)
+    now = from_time or _now()
+    now = _coerce_utc(now) or _now()
+    if candidate <= now:
+        elapsed_seconds = (now - base).total_seconds()
+        steps = int(elapsed_seconds // interval_seconds) + 1
+        candidate = base + timedelta(seconds=steps * interval_seconds)
+    return candidate
+
+
+def _validate_config(trigger_type: str, config: dict[str, Any]) -> None:
+    if not isinstance(config, dict):
+        raise TriggerServiceError("config must be an object")
+    if trigger_type == TriggerType.SCHEDULED.value:
+        if "interval_seconds" not in config and "next_run_at" not in config:
+            raise TriggerServiceError(
+                "scheduled trigger requires interval_seconds or next_run_at"
+            )
+        _compute_next_run_at(config)
+
+
+def get_owned_agent(db: Session, *, user_id: int, agent_id: int) -> Agent | None:
+    return (
+        db.query(Agent).filter(Agent.id == agent_id, Agent.user_id == user_id).first()
+    )
+
+
+def get_owned_trigger(
+    db: Session,
+    *,
+    user_id: int,
+    agent_id: int,
+    trigger_id: int,
+) -> AgentTrigger | None:
+    return (
+        db.query(AgentTrigger)
+        .filter(
+            AgentTrigger.id == trigger_id,
+            AgentTrigger.agent_id == agent_id,
+            AgentTrigger.user_id == user_id,
+        )
+        .first()
+    )
+
+
+def create_agent_trigger(
+    db: Session,
+    *,
+    user_id: int,
+    agent_id: int,
+    trigger_type: str,
+    name: str | None = None,
+    enabled: bool = True,
+    config: dict[str, Any] | None = None,
+    prompt_template: str | None = None,
+    secret: str | None = None,
+) -> tuple[AgentTrigger, str | None]:
+    agent = get_owned_agent(db, user_id=user_id, agent_id=agent_id)
+    if agent is None:
+        raise TriggerNotFoundError("Agent not found")
+
+    resolved_type = _normalize_trigger_type(trigger_type)
+    resolved_config = dict(config or {})
+    _validate_config(resolved_type, resolved_config)
+
+    plain_secret: str | None = None
+    webhook_token: str | None = None
+    secret_hash: str | None = None
+    if resolved_type == TriggerType.WEBHOOK.value:
+        webhook_token = _new_webhook_token()
+        plain_secret = secret or _new_webhook_secret()
+        secret_hash = _hash_secret(plain_secret)
+
+    next_run_at = None
+    if resolved_type == TriggerType.SCHEDULED.value and enabled:
+        next_run_at = _compute_next_run_at(resolved_config)
+
+    trigger = AgentTrigger(
+        user_id=user_id,
+        agent_id=agent_id,
+        type=resolved_type,
+        name=_normalize_trigger_name(
+            name, default=_default_trigger_name(resolved_type)
+        ),
+        enabled=enabled,
+        config=resolved_config,
+        prompt_template=prompt_template,
+        webhook_token=webhook_token,
+        secret_hash=secret_hash,
+        next_run_at=next_run_at,
+    )
+    db.add(trigger)
+    db.commit()
+    db.refresh(trigger)
+    return trigger, plain_secret
+
+
+def update_agent_trigger(
+    db: Session,
+    *,
+    user_id: int,
+    agent_id: int,
+    trigger_id: int,
+    updates: dict[str, Any],
+) -> tuple[AgentTrigger, str | None]:
+    trigger = get_owned_trigger(
+        db, user_id=user_id, agent_id=agent_id, trigger_id=trigger_id
+    )
+    if trigger is None:
+        raise TriggerNotFoundError("Trigger not found")
+
+    plain_secret: str | None = None
+    if "name" in updates and updates["name"] is not None:
+        setattr(trigger, "name", _normalize_trigger_name(str(updates["name"])))
+    if "enabled" in updates and updates["enabled"] is not None:
+        setattr(trigger, "enabled", bool(updates["enabled"]))
+    if "prompt_template" in updates:
+        setattr(trigger, "prompt_template", updates["prompt_template"])
+    if "config" in updates and updates["config"] is not None:
+        config = dict(updates["config"])
+        _validate_config(str(trigger.type), config)
+        setattr(trigger, "config", config)
+    if "secret" in updates and updates["secret"]:
+        plain_secret = str(updates["secret"])
+        setattr(trigger, "secret_hash", _hash_secret(plain_secret))
+    elif updates.get("rotate_secret"):
+        plain_secret = _new_webhook_secret()
+        setattr(trigger, "secret_hash", _hash_secret(plain_secret))
+
+    if trigger.type == TriggerType.SCHEDULED.value:
+        if trigger.enabled:
+            setattr(
+                trigger,
+                "next_run_at",
+                _compute_next_run_at(dict(trigger.config or {})),
+            )
+        else:
+            setattr(trigger, "next_run_at", None)
+
+    db.add(trigger)
+    db.commit()
+    db.refresh(trigger)
+    return trigger, plain_secret
+
+
+def delete_agent_trigger(
+    db: Session,
+    *,
+    user_id: int,
+    agent_id: int,
+    trigger_id: int,
+) -> None:
+    trigger = get_owned_trigger(
+        db, user_id=user_id, agent_id=agent_id, trigger_id=trigger_id
+    )
+    if trigger is None:
+        raise TriggerNotFoundError("Trigger not found")
+    db.delete(trigger)
+    db.commit()
+
+
+def render_trigger_prompt(
+    trigger: AgentTrigger,
+    *,
+    event_payload: dict[str, Any],
+    source_event_id: str | None = None,
+    test: bool = False,
+) -> str:
+    payload_json = json.dumps(event_payload, ensure_ascii=False, indent=2, default=str)
+    template = (trigger.prompt_template or "").strip()
+    if template:
+        replacements = {
+            "{{payload}}": payload_json,
+            "{{trigger_type}}": str(trigger.type),
+            "{{source_event_id}}": source_event_id or "",
+            "{{test}}": "true" if test else "false",
+        }
+        rendered = template
+        for key, value in replacements.items():
+            rendered = rendered.replace(key, value)
+        return rendered
+
+    label = "test " if test else ""
+    return (
+        f"Handle this {label}{trigger.type} trigger event.\n\n"
+        f"Trigger: {trigger.name}\n"
+        f"Source event ID: {source_event_id or 'none'}\n\n"
+        f"Event payload:\n{payload_json}"
+    )
+
+
+def _event_source_id(event_payload: dict[str, Any], source_event_id: str | None) -> str:
+    if source_event_id:
+        return source_event_id
+    for key in ("id", "event_id", "message_id"):
+        value = event_payload.get(key)
+        if value:
+            return str(value)
+    return f"payload:{_payload_hash(event_payload)}"
+
+
+def _trigger_run_idempotency_key(
+    trigger: AgentTrigger,
+    *,
+    event_payload: dict[str, Any],
+    source_event_id: str | None,
+    test: bool,
+) -> str:
+    if test:
+        return f"trigger-run:test:{trigger.id}:{secrets.token_urlsafe(16)}"
+    event_identity = _event_source_id(event_payload, source_event_id)
+    return f"trigger-run:{trigger.id}:{event_identity}"
+
+
+def _get_or_create_trigger_run(
+    db: Session,
+    *,
+    trigger: AgentTrigger,
+    event_payload: dict[str, Any],
+    source_event_id: str | None,
+    background_job_id: str | None,
+    test: bool,
+) -> tuple[TriggerRun, bool]:
+    idempotency_key = _trigger_run_idempotency_key(
+        trigger,
+        event_payload=event_payload,
+        source_event_id=source_event_id,
+        test=test,
+    )
+    existing = (
+        db.query(TriggerRun)
+        .filter(TriggerRun.idempotency_key == idempotency_key)
+        .first()
+    )
+    if existing is not None:
+        return existing, False
+
+    run = TriggerRun(
+        trigger_id=int(trigger.id),
+        background_job_id=background_job_id,
+        status=TriggerRunStatus.PENDING.value,
+        source_event_id=source_event_id,
+        payload_snapshot=_payload_snapshot(event_payload),
+        idempotency_key=idempotency_key,
+    )
+    db.add(run)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(TriggerRun)
+            .filter(TriggerRun.idempotency_key == idempotency_key)
+            .first()
+        )
+        if existing is not None:
+            return existing, False
+        raise
+    db.refresh(run)
+    return run, True
+
+
+def _mark_run_failed(
+    db: Session,
+    *,
+    trigger: AgentTrigger,
+    run: TriggerRun,
+    error_message: str,
+) -> None:
+    setattr(run, "status", TriggerRunStatus.FAILED.value)
+    setattr(run, "error_message", error_message)
+    setattr(run, "finished_at", _now())
+    setattr(trigger, "last_error", error_message)
+    db.add(run)
+    db.add(trigger)
+    db.commit()
+
+
+def _trigger_task_title(trigger: AgentTrigger, prompt: str) -> str:
+    title = f"{trigger.name}: {prompt[:50]}"
+    if len(title) > 80:
+        title = title[:77] + "..."
+    return title
+
+
+def _trigger_execution_context(
+    *,
+    trigger: AgentTrigger,
+    run: TriggerRun,
+    test: bool,
+) -> dict[str, Any]:
+    return {
+        "trigger_id": int(trigger.id),
+        "trigger_run_id": int(run.id),
+        "trigger_type": str(trigger.type),
+        "trigger_test": test,
+    }
+
+
+def _attach_task_to_trigger_run(
+    db: Session,
+    *,
+    trigger: AgentTrigger,
+    run: TriggerRun,
+    event_payload: dict[str, Any],
+    source_event_id: str | None,
+    test: bool,
+) -> TriggerRun:
+    if run.task_id is not None:
+        return run
+
+    prompt = render_trigger_prompt(
+        trigger,
+        event_payload=event_payload,
+        source_event_id=source_event_id,
+        test=test,
+    )
+    agent = db.query(Agent).filter(Agent.id == trigger.agent_id).first()
+    task = Task(
+        user_id=int(trigger.user_id),
+        title=_trigger_task_title(trigger, prompt),
+        description=prompt,
+        status=TaskStatus.PENDING,
+        agent_id=int(trigger.agent_id),
+        execution_mode=getattr(agent, "execution_mode", None) or "balanced",
+        source="trigger",
+        is_visible=False,
+        input=prompt,
+        agent_config=_trigger_execution_context(
+            trigger=trigger,
+            run=run,
+            test=test,
+        ),
+    )
+    db.add(task)
+    db.flush()
+    run.task_id = int(task.id)
+    run.status = TriggerRunStatus.PENDING.value
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    return run
+
+
+def prepare_trigger_run(
+    db: Session,
+    *,
+    trigger: AgentTrigger,
+    event_payload: dict[str, Any],
+    source_event_id: str | None = None,
+    background_job_id: str | None = None,
+    test: bool = False,
+) -> tuple[TriggerRun, bool]:
+    """Persist a trigger run and hidden task without starting agent execution."""
+    if not test and not trigger.enabled:
+        raise TriggerServiceError("Trigger is disabled")
+
+    run, created = _get_or_create_trigger_run(
+        db,
+        trigger=trigger,
+        event_payload=event_payload,
+        source_event_id=source_event_id,
+        background_job_id=background_job_id,
+        test=test,
+    )
+    if not created and run.task_id is not None:
+        return run, False
+
+    try:
+        run = _attach_task_to_trigger_run(
+            db,
+            trigger=trigger,
+            run=run,
+            event_payload=event_payload,
+            source_event_id=source_event_id,
+            test=test,
+        )
+        return run, created
+    except Exception as exc:
+        db.rollback()
+        error_message = f"{type(exc).__name__}: {exc}"
+        _mark_run_failed(db, trigger=trigger, run=run, error_message=error_message)
+        logger.exception("Trigger run %s failed to prepare task", run.id)
+        return run, True
+
+
+def _with_session() -> Session:
+    from ..models.database import get_session_local
+
+    return get_session_local()()
+
+
+def _rowcount(result: Any) -> int:
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
+def _claim_pending_trigger_run(db: Session, run_id: int) -> bool:
+    claim_time = _now()
+    result = db.execute(
+        update(TriggerRun)
+        .where(TriggerRun.id == run_id)
+        .where(TriggerRun.status == TriggerRunStatus.PENDING.value)
+        .values(
+            status=TriggerRunStatus.RUNNING.value,
+            started_at=claim_time,
+            error_message=None,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    db.commit()
+    return _rowcount(result) == 1
+
+
+def _load_prepared_trigger_start(run_id: int) -> _PreparedTriggerStart | None:
+    db = _with_session()
+    try:
+        if not _claim_pending_trigger_run(db, run_id):
+            return None
+        run = db.query(TriggerRun).filter(TriggerRun.id == run_id).first()
+        if run is None:
+            return None
+        trigger = (
+            db.query(AgentTrigger)
+            .filter(AgentTrigger.id == int(run.trigger_id))
+            .first()
+        )
+        if run.task_id is None:
+            if trigger is not None:
+                _mark_run_failed(
+                    db,
+                    trigger=trigger,
+                    run=run,
+                    error_message="Trigger run has no prepared task",
+                )
+            return None
+
+        task = db.query(Task).filter(Task.id == int(run.task_id)).first()
+        if task is None or trigger is None:
+            if trigger is not None:
+                _mark_run_failed(
+                    db,
+                    trigger=trigger,
+                    run=run,
+                    error_message="Prepared trigger task or trigger is missing",
+                )
+            return None
+
+        if task.status == TaskStatus.RUNNING:
+            setattr(run, "status", TriggerRunStatus.RUNNING.value)
+            setattr(run, "started_at", run.started_at or _now())
+            db.add(run)
+            db.commit()
+            return None
+        if task.status == TaskStatus.COMPLETED:
+            setattr(run, "status", TriggerRunStatus.COMPLETED.value)
+            setattr(run, "error_message", None)
+            setattr(run, "finished_at", run.finished_at or _now())
+            db.add(run)
+            db.commit()
+            return None
+        if task.status == TaskStatus.FAILED:
+            setattr(run, "status", TriggerRunStatus.FAILED.value)
+            setattr(run, "error_message", task.error_message)
+            setattr(run, "finished_at", run.finished_at or _now())
+            db.add(run)
+            db.commit()
+            return None
+        if task.status != TaskStatus.PENDING:
+            return None
+
+        task_config = dict(task.agent_config or {})
+        return _PreparedTriggerStart(
+            run_id=int(run.id),
+            trigger_id=int(trigger.id),
+            task_id=int(task.id),
+            task_owner_user_id=int(task.user_id),
+            prompt=str(task.input or task.description or ""),
+            trigger_type=str(trigger.type),
+            test=bool(task_config.get("trigger_test")),
+        )
+    finally:
+        db.close()
+
+
+def _mark_trigger_run_started(start: _PreparedTriggerStart) -> None:
+    db = _with_session()
+    try:
+        run = db.query(TriggerRun).filter(TriggerRun.id == start.run_id).first()
+        trigger = (
+            db.query(AgentTrigger).filter(AgentTrigger.id == start.trigger_id).first()
+        )
+        if run is None or trigger is None:
+            return
+        started_at = run.started_at or _now()
+        setattr(run, "status", TriggerRunStatus.RUNNING.value)
+        setattr(run, "started_at", started_at)
+        setattr(run, "error_message", None)
+        setattr(trigger, "last_run_at", started_at)
+        setattr(trigger, "last_error", None)
+        db.add(run)
+        db.add(trigger)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _mark_trigger_run_failed_by_id(run_id: int, error_message: str) -> None:
+    db = _with_session()
+    try:
+        run = db.query(TriggerRun).filter(TriggerRun.id == run_id).first()
+        if run is None:
+            return
+        trigger = (
+            db.query(AgentTrigger)
+            .filter(AgentTrigger.id == int(run.trigger_id))
+            .first()
+        )
+        if trigger is None:
+            return
+        _mark_run_failed(db, trigger=trigger, run=run, error_message=error_message)
+    finally:
+        db.close()
+
+
+def _mark_trigger_run_running_if_task_running(run_id: int, task_id: int) -> bool:
+    db = _with_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        run = db.query(TriggerRun).filter(TriggerRun.id == run_id).first()
+        if task is None or run is None or task.status != TaskStatus.RUNNING:
+            return False
+        setattr(run, "status", TriggerRunStatus.RUNNING.value)
+        setattr(run, "started_at", run.started_at or _now())
+        db.add(run)
+        db.commit()
+        return True
+    finally:
+        db.close()
+
+
+def _finish_trigger_run_after_task(start: _PreparedTriggerStart) -> None:
+    db = _with_session()
+    try:
+        task = db.query(Task).filter(Task.id == start.task_id).first()
+        run = db.query(TriggerRun).filter(TriggerRun.id == start.run_id).first()
+        if task is None or run is None:
+            return
+        if task.status == TaskStatus.COMPLETED:
+            setattr(run, "status", TriggerRunStatus.COMPLETED.value)
+            setattr(run, "error_message", None)
+        elif task.status == TaskStatus.FAILED:
+            setattr(run, "status", TriggerRunStatus.FAILED.value)
+            setattr(run, "error_message", task.error_message)
+        setattr(run, "finished_at", _now())
+        db.add(run)
+        db.commit()
+    finally:
+        db.close()
+
+
+async def _start_prepared_trigger_run_id(
+    run_id: int,
+    *,
+    wait_for_completion: bool = False,
+) -> bool:
+    """Start one prepared trigger task from the backend process."""
+    start = await asyncio.to_thread(_load_prepared_trigger_start, run_id)
+    if start is None:
+        return False
+
+    context = {
+        "trigger_id": start.trigger_id,
+        "trigger_run_id": start.run_id,
+        "trigger_type": start.trigger_type,
+        "trigger_test": start.test,
+    }
+    try:
+        started = await TaskTurnOrchestrator.begin_turn(
+            task_id=start.task_id,
+            task_owner_user_id=start.task_owner_user_id,
+            payload=TaskTurnPayload(transcript_message=start.prompt),
+            kind=TurnKind.CREATE,
+            force_fresh=False,
+            context=context,
+            actor_user_id=start.task_owner_user_id,
+        )
+    except TaskTurnError as exc:
+        marked_running = await asyncio.to_thread(
+            _mark_trigger_run_running_if_task_running,
+            start.run_id,
+            start.task_id,
+        )
+        if marked_running:
+            return False
+        await asyncio.to_thread(
+            _mark_trigger_run_failed_by_id,
+            start.run_id,
+            f"TaskTurnError: {exc.reason}",
+        )
+        logger.info("Trigger run %s was not started: %s", start.run_id, exc.reason)
+        return False
+    except TaskTurnNotFoundError as exc:
+        await asyncio.to_thread(
+            _mark_trigger_run_failed_by_id,
+            start.run_id,
+            f"{type(exc).__name__}: {exc}",
+        )
+        return False
+    except Exception as exc:
+        await asyncio.to_thread(
+            _mark_trigger_run_failed_by_id,
+            start.run_id,
+            f"{type(exc).__name__}: {exc}",
+        )
+        logger.exception("Trigger run %s failed to start task", start.run_id)
+        return False
+
+    await asyncio.to_thread(_mark_trigger_run_started, start)
+
+    if wait_for_completion and asyncio.isfuture(started.background_task):
+        await started.background_task
+        await asyncio.to_thread(_finish_trigger_run_after_task, start)
+
+    return True
+
+
+async def start_prepared_trigger_run(
+    db: Session,
+    *,
+    run: TriggerRun,
+    wait_for_completion: bool = False,
+) -> bool:
+    """Start one prepared trigger task from the backend process."""
+    return await _start_prepared_trigger_run_id(
+        int(run.id),
+        wait_for_completion=wait_for_completion,
+    )
+
+
+async def fire_trigger(
+    db: Session,
+    *,
+    trigger: AgentTrigger,
+    event_payload: dict[str, Any],
+    source_event_id: str | None = None,
+    background_job_id: str | None = None,
+    test: bool = False,
+    wait_for_completion: bool = False,
+) -> tuple[TriggerRun, bool]:
+    """Prepare a trigger event and start it in the current backend process."""
+    run, created = prepare_trigger_run(
+        db,
+        trigger=trigger,
+        event_payload=event_payload,
+        source_event_id=source_event_id,
+        background_job_id=background_job_id,
+        test=test,
+    )
+    if created:
+        await start_prepared_trigger_run(
+            db,
+            run=run,
+            wait_for_completion=wait_for_completion,
+        )
+        db.refresh(run)
+    return run, created
+
+
+def _get_pending_trigger_run_ids(limit: int) -> list[int]:
+    """Fetch pending run ids using a thread-local database session."""
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(TriggerRun.id)
+            .join(Task, TriggerRun.task_id == Task.id)
+            .filter(
+                TriggerRun.status == TriggerRunStatus.PENDING.value,
+                Task.status == TaskStatus.PENDING,
+            )
+            .order_by(TriggerRun.created_at.asc(), TriggerRun.id.asc())
+            .limit(limit)
+            .all()
+        )
+        return [int(row[0]) for row in rows]
+    finally:
+        db.close()
+
+
+async def dispatch_pending_trigger_runs(
+    db: Session,
+    *,
+    limit: int = 20,
+    wait_for_completion: bool = False,
+) -> int:
+    """Start prepared trigger tasks from the backend process."""
+    pending_run_ids = await asyncio.to_thread(
+        _get_pending_trigger_run_ids,
+        max(1, min(limit, 100)),
+    )
+    if not pending_run_ids:
+        return 0
+
+    started_count = 0
+    for run_id in pending_run_ids:
+        if await _start_prepared_trigger_run_id(
+            run_id,
+            wait_for_completion=wait_for_completion,
+        ):
+            started_count += 1
+    return started_count
+
+
+def find_webhook_trigger(db: Session, webhook_token: str) -> AgentTrigger | None:
+    return (
+        db.query(AgentTrigger)
+        .filter(
+            AgentTrigger.webhook_token == webhook_token,
+            AgentTrigger.type == TriggerType.WEBHOOK.value,
+        )
+        .first()
+    )
+
+
+def scan_due_scheduled_triggers(
+    db: Session,
+    *,
+    now: datetime | None = None,
+    limit: int = 100,
+) -> list[TriggerRun]:
+    """Prepare due scheduled triggers; backend dispatcher starts the tasks."""
+    scan_time = _coerce_utc(now) or _now()
+    due_triggers = (
+        db.query(AgentTrigger)
+        .filter(
+            AgentTrigger.type == TriggerType.SCHEDULED.value,
+            AgentTrigger.enabled.is_(True),
+            AgentTrigger.next_run_at.is_not(None),
+            AgentTrigger.next_run_at <= scan_time,
+        )
+        .order_by(AgentTrigger.next_run_at.asc())
+        .limit(max(1, min(limit, 500)))
+        .all()
+    )
+    runs: list[TriggerRun] = []
+    for trigger in due_triggers:
+        due_at = _coerce_utc(getattr(trigger, "next_run_at", None)) or scan_time
+        payload = {
+            "trigger_id": int(trigger.id),
+            "scheduled_at": scan_time.isoformat(),
+            "due_at": due_at.isoformat(),
+        }
+        source_event_id = f"scheduled:{trigger.id}:{due_at.isoformat()}"
+        run, _created = prepare_trigger_run(
+            db,
+            trigger=trigger,
+            event_payload=payload,
+            source_event_id=source_event_id,
+            background_job_id=None,
+            test=False,
+        )
+
+        config = dict(trigger.config or {})
+        next_run_at = _compute_next_run_at(
+            config,
+            from_time=scan_time,
+            previous_due_at=due_at,
+            include_explicit=False,
+        )
+        setattr(trigger, "next_run_at", next_run_at)
+        if next_run_at is None:
+            setattr(trigger, "enabled", False)
+        db.add(trigger)
+        db.commit()
+        runs.append(run)
+    return runs
 
 
 def _trigger_idempotency_scope(event_payload: dict[str, Any]) -> str:
@@ -32,8 +982,13 @@ def enqueue_trigger_event_job(
     event_type: str,
     event_payload: dict[str, Any],
     source_event_id: str | None = None,
+    trigger_id: int | None = None,
 ) -> BackgroundJob:
-    """Persist and enqueue a trigger event without running the agent in Celery."""
+    """Persist and enqueue a trigger event job.
+
+    Generic source_type/event_type payloads remain supported for the existing
+    background-job tests. New agent-trigger callers can include trigger_id.
+    """
     idempotency_key = (
         f"trigger:{user_id}:{source_type}:"
         f"{_trigger_idempotency_scope(event_payload)}:{source_event_id}"
@@ -46,6 +1001,7 @@ def enqueue_trigger_event_job(
         job_type=BackgroundJobType.TRIGGER_EVENT,
         payload={
             "user_id": user_id,
+            "trigger_id": trigger_id,
             "source_type": source_type,
             "event_type": event_type,
             "source_event_id": source_event_id,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -53,6 +53,9 @@ from xagent.config import (
     SMTP_USE_TLS,
     SMTP_USERNAME,
     STORAGE_ROOT,
+    TRIGGER_DISPATCHER_BATCH_SIZE,
+    TRIGGER_DISPATCHER_ENABLED,
+    TRIGGER_DISPATCHER_INTERVAL_SECONDS,
     UPLOADS_DIR,
     WEB_CRAWL_TLS_IMPERSONATE,
     WEB_DIR,
@@ -107,6 +110,9 @@ from xagent.config import (
     get_smtp_use_tls,
     get_smtp_username,
     get_storage_root,
+    get_trigger_dispatcher_batch_size,
+    get_trigger_dispatcher_enabled,
+    get_trigger_dispatcher_interval_seconds,
     get_uploads_dir,
     get_web_crawl_tls_impersonate,
     get_web_dir,
@@ -211,6 +217,12 @@ class TestEnvironmentVariableConstants:
             BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS
             == "XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS"
         )
+        assert TRIGGER_DISPATCHER_ENABLED == "XAGENT_TRIGGER_DISPATCHER_ENABLED"
+        assert (
+            TRIGGER_DISPATCHER_INTERVAL_SECONDS
+            == "XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS"
+        )
+        assert TRIGGER_DISPATCHER_BATCH_SIZE == "XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE"
 
     def test_auth_email_config_constants(self):
         assert PASSWORD_RESET_EXPIRE_MINUTES == "XAGENT_PASSWORD_RESET_EXPIRE_MINUTES"
@@ -366,6 +378,21 @@ class TestCeleryBackgroundJobConfig:
         assert get_background_job_max_retries() == 3
         assert get_background_job_stale_seconds() == 7200
         assert get_background_job_sweep_interval_seconds() == 300
+
+    def test_trigger_dispatcher_tuning(self, monkeypatch):
+        monkeypatch.delenv(TRIGGER_DISPATCHER_ENABLED, raising=False)
+        monkeypatch.delenv(TRIGGER_DISPATCHER_INTERVAL_SECONDS, raising=False)
+        monkeypatch.delenv(TRIGGER_DISPATCHER_BATCH_SIZE, raising=False)
+        assert get_trigger_dispatcher_enabled() is True
+        assert get_trigger_dispatcher_interval_seconds() == 5
+        assert get_trigger_dispatcher_batch_size() == 20
+
+        monkeypatch.setenv(TRIGGER_DISPATCHER_ENABLED, "false")
+        monkeypatch.setenv(TRIGGER_DISPATCHER_INTERVAL_SECONDS, "9")
+        monkeypatch.setenv(TRIGGER_DISPATCHER_BATCH_SIZE, "3")
+        assert get_trigger_dispatcher_enabled() is False
+        assert get_trigger_dispatcher_interval_seconds() == 9
+        assert get_trigger_dispatcher_batch_size() == 3
 
 
 class TestGetWebSearchProvider:

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -37,6 +37,7 @@ from xagent.web.api.auth import auth_router
 from xagent.web.api.files import file_router
 from xagent.web.api.me import router as me_router
 from xagent.web.api.share import share_router
+from xagent.web.api.triggers import router as triggers_router
 from xagent.web.api.v1 import v1_router
 from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
 from xagent.web.api.widget import widget_router
@@ -68,6 +69,7 @@ app_for_tests.include_router(workforces_router)
 app_for_tests.include_router(file_router)
 app_for_tests.include_router(widget_router)
 app_for_tests.include_router(share_router)
+app_for_tests.include_router(triggers_router)
 app_for_tests.include_router(v1_router)
 app_for_tests.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: ignore[arg-type]
 

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.trigger import AgentTrigger, TriggerRun, TriggerRunStatus
+from xagent.web.services.task_orchestrator import TurnStarted, finish_turn
+from xagent.web.services.triggers import (
+    _compute_next_run_at,
+    _start_prepared_trigger_run_id,
+    dispatch_pending_trigger_runs,
+    scan_due_scheduled_triggers,
+)
+
+from .conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+@pytest.fixture(autouse=True)
+def mock_bg_scheduler():
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as mocked:
+        yield mocked
+
+
+def _create_agent(headers: dict[str, str], name: str = "Trigger Agent") -> int:
+    resp = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "test",
+            "instructions": "You are a trigger test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["id"])
+
+
+def test_webhook_trigger_crud_returns_secret_once() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "webhook",
+            "name": "Inbound webhook",
+            "prompt_template": "payload={{payload}}",
+            "config": {"source": "crm"},
+        },
+    )
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert body["type"] == "webhook"
+    assert body["webhook_token"]
+    assert body["webhook_secret"]
+
+    db = _direct_db_session()
+    try:
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == body["id"]).one()
+        assert str(trigger.secret_hash).startswith("$2")
+        assert trigger.secret_hash != body["webhook_secret"]
+    finally:
+        db.close()
+
+    listed = client.get(f"/api/agents/{agent_id}/triggers", headers=headers)
+    assert listed.status_code == 200, listed.text
+    assert len(listed.json()) == 1
+    assert listed.json()[0]["webhook_secret"] is None
+
+    patched = client.patch(
+        f"/api/agents/{agent_id}/triggers/{body['id']}",
+        headers=headers,
+        json={"name": "Renamed webhook", "rotate_secret": True},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["name"] == "Renamed webhook"
+    assert patched.json()["webhook_secret"]
+
+
+def test_trigger_test_run_creates_hidden_agent_task(mock_bg_scheduler) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "webhook",
+            "name": "Test webhook",
+            "prompt_template": "Handle {{payload}}",
+        },
+    )
+    trigger_id = created.json()["id"]
+
+    fired = client.post(
+        f"/api/agents/{agent_id}/triggers/{trigger_id}/test",
+        headers=headers,
+        json={"payload": {"subject": "hello"}, "source_event_id": "test-event"},
+    )
+    assert fired.status_code == 200, fired.text
+    run_body = fired.json()["trigger_run"]
+    assert run_body["status"] == TriggerRunStatus.RUNNING.value
+    assert run_body["task_id"]
+    assert fired.json()["duplicate"] is False
+    assert mock_bg_scheduler.call_count == 1
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == run_body["task_id"]).one()
+        assert task.agent_id == agent_id
+        assert task.source == "trigger"
+        assert task.is_visible is False
+        assert task.status == TaskStatus.RUNNING
+        assert "hello" in (task.description or "")
+    finally:
+        db.close()
+
+
+def test_public_webhook_validates_secret_and_deduplicates(mock_bg_scheduler) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "Public webhook"},
+    )
+    body = created.json()
+    url = f"/api/triggers/webhook/{body['webhook_token']}"
+
+    rejected = client.post(url, json={"subject": "hello"})
+    assert rejected.status_code == 401
+
+    event_headers = {
+        "x-xagent-trigger-secret": body["webhook_secret"],
+        "x-xagent-event-id": "evt-1",
+    }
+    first = client.post(url, headers=event_headers, json={"subject": "hello"})
+    assert first.status_code == 200, first.text
+    assert set(first.json()) == {"trigger_run_id", "status", "duplicate"}
+    assert first.json()["duplicate"] is False
+
+    second = client.post(url, headers=event_headers, json={"subject": "hello"})
+    assert second.status_code == 200, second.text
+    assert second.json()["duplicate"] is True
+    assert second.json()["trigger_run_id"] == first.json()["trigger_run_id"]
+    assert mock_bg_scheduler.call_count == 1
+
+    db = _direct_db_session()
+    try:
+        assert db.query(TriggerRun).count() == 1
+        assert db.query(Task).filter(Task.source == "trigger").count() == 1
+    finally:
+        db.close()
+
+
+def test_public_webhook_invalid_utf8_body_falls_back_to_text(
+    mock_bg_scheduler,
+) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "Invalid UTF-8 webhook"},
+    )
+    body = created.json()
+    url = f"/api/triggers/webhook/{body['webhook_token']}"
+
+    fired = client.post(
+        url,
+        headers={"x-xagent-trigger-secret": body["webhook_secret"]},
+        content=b'\xff{"subject":"hello"}',
+    )
+    assert fired.status_code == 200, fired.text
+
+    db = _direct_db_session()
+    try:
+        run_id = fired.json()["trigger_run_id"]
+        run = db.query(TriggerRun).filter(TriggerRun.id == run_id).one()
+        assert run.payload_snapshot == {"body": '\ufffd{"subject":"hello"}'}
+    finally:
+        db.close()
+
+    assert mock_bg_scheduler.call_count == 1
+
+
+def test_trigger_name_validation_rejects_empty_and_oversized() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+
+    empty = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "   "},
+    )
+    assert empty.status_code == 400
+
+    oversized = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "x" * 201},
+    )
+    assert oversized.status_code == 422
+
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "Valid"},
+    )
+    assert created.status_code == 200, created.text
+
+    patched = client.patch(
+        f"/api/agents/{agent_id}/triggers/{created.json()['id']}",
+        headers=headers,
+        json={"name": " "},
+    )
+    assert patched.status_code == 400
+
+
+def test_scheduled_next_run_skips_stale_intervals_without_iteration() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    stale_due_at = now - timedelta(days=3650)
+
+    next_run_at = _compute_next_run_at(
+        {"interval_seconds": 1},
+        from_time=now,
+        previous_due_at=stale_due_at,
+        include_explicit=False,
+    )
+
+    assert next_run_at == now + timedelta(seconds=1)
+
+
+def test_scheduled_scan_fires_due_trigger_and_advances_next_run(
+    mock_bg_scheduler,
+) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "scheduled",
+            "name": "Every minute",
+            "config": {"interval_seconds": 60},
+        },
+    )
+    assert created.status_code == 200, created.text
+    trigger_id = created.json()["id"]
+
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    db = _direct_db_session()
+    try:
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+        trigger.next_run_at = due_at
+        db.add(trigger)
+        db.commit()
+
+        runs = scan_due_scheduled_triggers(db, now=datetime.now(timezone.utc))
+        assert len(runs) == 1
+        db.refresh(trigger)
+        assert trigger.next_run_at is not None
+        next_run_at = trigger.next_run_at
+        if next_run_at.tzinfo is None:
+            next_run_at = next_run_at.replace(tzinfo=timezone.utc)
+        assert next_run_at > due_at
+        run = db.query(TriggerRun).filter(TriggerRun.id == runs[0].id).one()
+        assert run.status == TriggerRunStatus.PENDING.value
+        assert run.task_id is not None
+        task = db.query(Task).filter(Task.id == run.task_id).one()
+        assert task.agent_id == agent_id
+        assert task.source == "trigger"
+        assert task.is_visible is False
+        assert task.status == TaskStatus.PENDING
+
+        assert mock_bg_scheduler.call_count == 0
+        assert asyncio.run(dispatch_pending_trigger_runs(db)) == 1
+        db.refresh(run)
+        db.refresh(task)
+        assert run.status == TriggerRunStatus.RUNNING.value
+        assert task.status == TaskStatus.RUNNING
+    finally:
+        db.close()
+
+    assert mock_bg_scheduler.call_count == 1
+
+
+def test_dispatch_claims_pending_trigger_run_once_under_concurrency() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "scheduled",
+            "name": "Concurrent scheduled",
+            "config": {"interval_seconds": 60},
+        },
+    )
+    assert created.status_code == 200, created.text
+
+    db = _direct_db_session()
+    try:
+        trigger = (
+            db.query(AgentTrigger).filter(AgentTrigger.id == created.json()["id"]).one()
+        )
+        trigger.next_run_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+        db.add(trigger)
+        db.commit()
+        runs = scan_due_scheduled_triggers(db, now=datetime.now(timezone.utc))
+        assert len(runs) == 1
+        run_id = int(runs[0].id)
+    finally:
+        db.close()
+
+    begin_calls = 0
+
+    async def fake_begin_turn(**kwargs):
+        nonlocal begin_calls
+        begin_calls += 1
+        await asyncio.sleep(0.05)
+
+        async def done() -> None:
+            return None
+
+        return TurnStarted(
+            task_id=int(kwargs["task_id"]),
+            status=TaskStatus.RUNNING,
+            updated_at=None,
+            before_message_id=None,
+            task_source="trigger",
+            background_task=asyncio.create_task(done()),
+        )
+
+    async def start_twice() -> list[bool]:
+        first, second = await asyncio.gather(
+            _start_prepared_trigger_run_id(run_id),
+            _start_prepared_trigger_run_id(run_id),
+        )
+        return [first, second]
+
+    with patch(
+        "xagent.web.services.triggers.TaskTurnOrchestrator.begin_turn",
+        new=fake_begin_turn,
+    ):
+        results = asyncio.run(start_twice())
+
+    assert results.count(True) == 1
+    assert begin_calls == 1
+
+
+def test_scheduled_scan_disables_one_shot_trigger(mock_bg_scheduler) -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "scheduled",
+            "name": "One shot",
+            "config": {"next_run_at": due_at.isoformat()},
+        },
+    )
+    assert created.status_code == 200, created.text
+    trigger_id = created.json()["id"]
+
+    db = _direct_db_session()
+    try:
+        runs = scan_due_scheduled_triggers(db, now=datetime.now(timezone.utc))
+        assert len(runs) == 1
+
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+        assert trigger.enabled is False
+        assert trigger.next_run_at is None
+        run = db.query(TriggerRun).filter(TriggerRun.id == runs[0].id).one()
+        assert run.status == TriggerRunStatus.PENDING.value
+    finally:
+        db.close()
+
+    assert mock_bg_scheduler.call_count == 0
+
+
+def test_finish_turn_syncs_trigger_run_status() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "Completion webhook"},
+    )
+    trigger_id = created.json()["id"]
+
+    fired = client.post(
+        f"/api/agents/{agent_id}/triggers/{trigger_id}/test",
+        headers=headers,
+        json={"payload": {"subject": "done"}},
+    )
+    run_body = fired.json()["trigger_run"]
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == run_body["task_id"]).one()
+        task.status = TaskStatus.COMPLETED
+        db.add(
+            TaskChatMessage(
+                task_id=int(task.id),
+                user_id=int(task.user_id),
+                role="assistant",
+                content="done",
+                message_type="assistant_message",
+            )
+        )
+        db.add(task)
+        db.commit()
+
+        finish_turn(db, int(task.id))
+
+        run = db.query(TriggerRun).filter(TriggerRun.id == run_body["id"]).one()
+        assert run.status == TriggerRunStatus.COMPLETED.value
+        assert run.finished_at is not None
+        assert run.error_message is None
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add agent-bound webhook and scheduled trigger persistence, API routes, and run history
- keep scheduled trigger scans in Celery as prepare-only work and dispatch agent execution from backend processes
- add trigger run status synchronization when hidden trigger tasks finish

## Validation
- pytest tests/web/api/test_agent_triggers.py tests/web/test_background_jobs.py::test_trigger_event_job_runs_with_eager_celery tests/web/test_background_jobs.py::test_trigger_event_idempotency_is_scoped_by_user tests/web/api/v1/test_tasks.py::test_create_task_happy_path tests/web/api/v1/test_tasks.py::test_get_task_returns_404_for_non_sdk_source tests/web/api/v1/test_tasks.py::test_append_message_returns_404_for_non_sdk_source tests/web/api/v1/test_tasks.py::test_get_steps_returns_404_for_non_sdk_source tests/core/test_config.py::TestEnvironmentVariableConstants::test_celery_background_job_constants tests/core/test_config.py::TestCeleryBackgroundJobConfig -q
- ruff check src/xagent/web/models/trigger.py src/xagent/web/services/triggers.py src/xagent/web/api/triggers.py src/xagent/web/jobs/trigger_tasks.py src/xagent/web/services/task_orchestrator.py src/xagent/web/app.py src/xagent/config.py tests/web/api/test_agent_triggers.py tests/core/test_config.py src/xagent/migrations/versions/20260616_add_agent_triggers.py
- pre-commit hooks via git commit