### PR TITLE
fix(xinference): handle reasoning models in chat response and test-connection

### DIFF
--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -254,22 +254,46 @@ class XinferenceLLM(BaseLLM):
         if choices:
             choice = choices[0]
             message = choice.get("message", {})
+            reasoning_content = message.get("reasoning_content") or ""
 
             # Check for tool calls
             tool_calls = message.get("tool_calls")
             if tool_calls:
-                return {
+                result: Dict[str, Any] = {
                     "type": "tool_call",
                     "tool_calls": tool_calls,
                     "raw": response_dict,
                 }
+                if reasoning_content:
+                    result["reasoning_content"] = reasoning_content
+                    result["reasoning"] = reasoning_content
+                return result
 
             # Handle text content
             content = message.get("content", "")
             if content:
-                return {
+                result = {
                     "type": "text",
                     "content": content,
+                    "raw": response_dict,
+                }
+                if reasoning_content:
+                    result["reasoning_content"] = reasoning_content
+                    result["reasoning"] = reasoning_content
+                return result
+
+            # Reasoning models (e.g. qwen3-thinking, deepseek-r1) may emit
+            # only ``reasoning_content`` and an empty ``content`` when the
+            # generation is truncated by ``max_tokens`` (finish_reason="length")
+            # before the final answer is produced. Surface the reasoning text
+            # as content so callers (notably the model connection test) do
+            # not treat a truncated-but-otherwise-healthy response as invalid.
+            if reasoning_content:
+                return {
+                    "type": "text",
+                    "content": reasoning_content,
+                    "reasoning_content": reasoning_content,
+                    "reasoning": reasoning_content,
                     "raw": response_dict,
                 }
 

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -255,6 +255,7 @@ class XinferenceLLM(BaseLLM):
             choice = choices[0]
             message = choice.get("message", {})
             reasoning_content = message.get("reasoning_content") or ""
+            finish_reason = choice.get("finish_reason")
 
             # Check for tool calls
             tool_calls = message.get("tool_calls")
@@ -288,7 +289,18 @@ class XinferenceLLM(BaseLLM):
             # before the final answer is produced. Surface the reasoning text
             # as content so callers (notably the model connection test) do
             # not treat a truncated-but-otherwise-healthy response as invalid.
-            if reasoning_content:
+            #
+            # Gate strictly on ``finish_reason == "length"`` and require a
+            # non-whitespace reasoning trace: any other terminal reason
+            # (``"stop"``, ``"content_filter"``, ``None`` …) means the model
+            # claims to be done but produced no final answer, which is a
+            # real failure that callers must see -- promoting the reasoning
+            # trace would silently hide the bug.
+            if (
+                finish_reason == "length"
+                and reasoning_content
+                and reasoning_content.strip()
+            ):
                 return {
                     "type": "text",
                     "content": reasoning_content,

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -522,8 +522,15 @@ async def test_model_connection(
             config = ChatModelConfig(**config_kwargs)
             llm = create_base_llm(config)
 
-            # Test chat connection with minimal tokens
-            chat_kwargs: dict[str, Any] = {"max_tokens": 1}
+            # Test chat connection with a small but non-trivial token budget.
+            # ``max_tokens=1`` is unsafe for reasoning models that aren't
+            # caught by the name-based heuristic above (e.g. qwen3-thinking
+            # variants advertised as ``qwen3.x_*``): they would consume the
+            # single token in ``reasoning_content`` and return an empty
+            # ``content``, which providers report as an invalid response.
+            # 16 tokens is still cheap and gives reasoning models room to
+            # produce at least the start of an answer.
+            chat_kwargs: dict[str, Any] = {"max_tokens": 16}
 
             # Claude models and OpenAI o1/o3 handle max_tokens differently or deprecate temperature
             if is_reasoning_model:
@@ -739,9 +746,13 @@ async def test_models(
                 )
                 continue
 
-            # Test with a simple message and minimal tokens for speed
+            # Test with a simple message. Use a small but non-trivial token
+            # budget so that reasoning models (e.g. qwen3-thinking,
+            # deepseek-r1) have room to produce at least the start of an
+            # answer instead of getting truncated mid-thought, which would
+            # otherwise surface as "Invalid response" from the provider.
             test_messages = [{"role": "user", "content": test_message}]
-            await llm.chat(test_messages, max_tokens=1)
+            await llm.chat(test_messages, max_tokens=16)
             response_time = time.time() - start_time
 
             test_results.append(

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -294,3 +294,141 @@ class TestXinferenceLLM:
                 "description": "Legacy chat model",
             }
         ]
+
+
+class TestProcessChatResponse:
+    """Tests for ``XinferenceLLM._process_chat_response``.
+
+    Reasoning-capable models served via Xinference (``qwen3-thinking``,
+    ``deepseek-r1``, etc.) can return a response whose ``content`` is empty
+    while ``reasoning_content`` carries the partial answer — most commonly
+    when ``max_tokens`` truncates the generation before the final answer is
+    produced. The adapter must surface those responses as text instead of
+    raising ``Invalid Xinference response``.
+    """
+
+    def _make_llm(self) -> XinferenceLLM:
+        return XinferenceLLM(model_name="qwen3-thinking")
+
+    def test_plain_text_response_is_returned_as_text(self) -> None:
+        llm = self._make_llm()
+        result = llm._process_chat_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello there",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+            }
+        )
+
+        assert result["type"] == "text"
+        assert result["content"] == "Hello there"
+        assert "reasoning_content" not in result
+
+    def test_text_response_with_reasoning_content_attaches_reasoning(self) -> None:
+        llm = self._make_llm()
+        result = llm._process_chat_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "42",
+                            "reasoning_content": "Need to compute 6 * 7",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+        )
+
+        assert result["type"] == "text"
+        assert result["content"] == "42"
+        assert result["reasoning_content"] == "Need to compute 6 * 7"
+        assert result["reasoning"] == "Need to compute 6 * 7"
+
+    def test_empty_content_with_reasoning_falls_back_to_reasoning(self) -> None:
+        """Reproduces the bug where ``max_tokens`` truncates a reasoning
+        model: ``content=""`` but ``reasoning_content`` is populated and
+        ``finish_reason="length"``. The adapter must NOT raise; it should
+        treat the reasoning text as the response content.
+        """
+        llm = self._make_llm()
+        result = llm._process_chat_response(
+            {
+                "id": "chat-1",
+                "object": "chat.completion",
+                "model": "qwen3-thinking",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning_content": "Here",
+                        },
+                        "finish_reason": "length",
+                    }
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 1},
+            }
+        )
+
+        assert result["type"] == "text"
+        assert result["content"] == "Here"
+        assert result["reasoning_content"] == "Here"
+        assert result["reasoning"] == "Here"
+
+    def test_tool_call_response_attaches_reasoning_when_present(self) -> None:
+        llm = self._make_llm()
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "do_thing", "arguments": "{}"},
+            }
+        ]
+        result = llm._process_chat_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": tool_calls,
+                            "reasoning_content": "I should call do_thing",
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+        )
+
+        assert result["type"] == "tool_call"
+        assert result["tool_calls"] == tool_calls
+        assert result["reasoning_content"] == "I should call do_thing"
+
+    def test_empty_response_without_reasoning_still_raises(self) -> None:
+        """If the response has neither ``content``, ``tool_calls`` nor
+        ``reasoning_content``, the adapter must keep raising so callers
+        can surface the underlying provider issue.
+        """
+        llm = self._make_llm()
+
+        with pytest.raises(RuntimeError, match="Invalid Xinference response"):
+            llm._process_chat_response(
+                {
+                    "choices": [
+                        {
+                            "message": {"role": "assistant", "content": ""},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            )

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -432,3 +432,58 @@ class TestProcessChatResponse:
                     ]
                 }
             )
+
+    def test_finish_reason_stop_with_only_reasoning_still_raises(self) -> None:
+        """The reasoning-content fallback is scoped to truncated responses
+        (``finish_reason="length"``) only.
+
+        If a provider returns ``finish_reason="stop"`` with empty content
+        and a populated reasoning trace, the model is claiming to be done
+        without producing a final answer -- that is a real model failure
+        and the adapter must surface it instead of silently promoting the
+        scratchpad to the assistant message.
+        """
+        llm = self._make_llm()
+
+        with pytest.raises(RuntimeError, match="Invalid Xinference response"):
+            llm._process_chat_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "",
+                                "reasoning_content": "I should answer the user.",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            )
+
+    def test_whitespace_only_reasoning_with_length_finish_still_raises(
+        self,
+    ) -> None:
+        """A whitespace-only reasoning trace must NOT be treated as a
+        usable answer even when ``finish_reason="length"``.
+
+        Otherwise a provider returning ``reasoning_content="   "`` would
+        surface a blank string as the assistant message.
+        """
+        llm = self._make_llm()
+
+        with pytest.raises(RuntimeError, match="Invalid Xinference response"):
+            llm._process_chat_response(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "",
+                                "reasoning_content": "   \n  ",
+                            },
+                            "finish_reason": "length",
+                        }
+                    ]
+                }
+            )

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -856,6 +856,6 @@ class TestModelAPI:
         assert response.json()["status"] == "passed"
         mock_llm.chat.assert_awaited_once_with(
             [{"role": "user", "content": "Hello"}],
-            max_tokens=1,
+            max_tokens=16,
             thinking={"type": "disabled"},
         )


### PR DESCRIPTION
Reasoning-capable models served via Xinference (e.g. qwen3-thinking, qwen3.x_*, deepseek-r1) can return content='' with the partial answer in reasoning_content when the generation is truncated by max_tokens (finish_reason='length'). The chat adapter previously treated such responses as invalid, and the model connection-test endpoints used max_tokens=1 which guaranteed truncation for these models -- together they made it impossible to validate or activate a reasoning model from the UI.

* xinference.py: _process_chat_response now falls back to reasoning_content when content is empty, and attaches reasoning_content/reasoning fields on text and tool-call responses (mirrors the OpenAI adapter behaviour).

* api/model.py: bump max_tokens from 1 to 16 in both the /test-connection and /test endpoints. 16 tokens is still cheap for plain chat models but gives reasoning models room to produce the start of an answer.

* New TestProcessChatResponse cases cover plain text, text with reasoning, the empty-content + reasoning fallback (the reported bug), tool-calls with reasoning, and the still-empty case which must keep raising.