### PR TITLE
fix(openai): fall back to reasoning_content when content is empty

### DIFF
--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -284,8 +284,10 @@ class OpenAILLM(BaseLLM):
                 # final answer is produced. Surface the reasoning text as
                 # content so callers (notably the model connection test) do
                 # not treat a truncated-but-otherwise-healthy response as
-                # invalid.
-                if reasoning_content:
+                # invalid. Mirror the ``content`` whitespace check so a
+                # reasoning trace that is purely whitespace still falls
+                # through to the empty-response error.
+                if reasoning_content and reasoning_content.strip():
                     return {
                         "type": "text",
                         "content": reasoning_content,
@@ -643,8 +645,10 @@ class OpenAILLM(BaseLLM):
                 # See ``chat()``: reasoning models truncated by ``max_tokens``
                 # may return ``content=""`` with the partial answer in
                 # ``reasoning_content``. Surface it as content rather than
-                # treating the response as invalid.
-                if reasoning_content:
+                # treating the response as invalid. Mirror the ``content``
+                # whitespace check so a reasoning trace that is purely
+                # whitespace still falls through to the empty-response error.
+                if reasoning_content and reasoning_content.strip():
                     return {
                         "type": "text",
                         "content": reasoning_content,

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -273,6 +273,7 @@ class OpenAILLM(BaseLLM):
                 if hasattr(message, "reasoning_content")
                 else None
             )
+            finish_reason = getattr(choice, "finish_reason", None)
 
             # Handle None or empty content when no tool calls
             if not content or not content.strip():
@@ -287,7 +288,18 @@ class OpenAILLM(BaseLLM):
                 # invalid. Mirror the ``content`` whitespace check so a
                 # reasoning trace that is purely whitespace still falls
                 # through to the empty-response error.
-                if reasoning_content and reasoning_content.strip():
+                #
+                # Gate the fallback strictly on ``finish_reason == "length"``:
+                # any other terminal reason (``"stop"``, ``"content_filter"``,
+                # ``None`` …) means the model claims to be done but produced
+                # no final answer, which is a real failure that callers
+                # must see -- promoting the reasoning trace would silently
+                # hide the bug.
+                if (
+                    finish_reason == "length"
+                    and reasoning_content
+                    and reasoning_content.strip()
+                ):
                     return {
                         "type": "text",
                         "content": reasoning_content,
@@ -639,6 +651,7 @@ class OpenAILLM(BaseLLM):
                 if hasattr(message, "reasoning_content")
                 else None
             )
+            finish_reason = getattr(choice, "finish_reason", None)
 
             # Handle None or empty content when no tool calls
             if not content or not content.strip():
@@ -648,7 +661,15 @@ class OpenAILLM(BaseLLM):
                 # treating the response as invalid. Mirror the ``content``
                 # whitespace check so a reasoning trace that is purely
                 # whitespace still falls through to the empty-response error.
-                if reasoning_content and reasoning_content.strip():
+                # Gate strictly on ``finish_reason == "length"`` so a
+                # ``"stop"``/``"content_filter"``/``None`` choice with no
+                # final content still raises -- those mean the model claims
+                # to be done but produced nothing, which is a real failure.
+                if (
+                    finish_reason == "length"
+                    and reasoning_content
+                    and reasoning_content.strip()
+                ):
                     return {
                         "type": "text",
                         "content": reasoning_content,

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -268,9 +268,31 @@ class OpenAILLM(BaseLLM):
 
             # Handle text content
             content = message.content
+            reasoning_content = (
+                message.reasoning_content
+                if hasattr(message, "reasoning_content")
+                else None
+            )
 
             # Handle None or empty content when no tool calls
             if not content or not content.strip():
+                # Reasoning models (e.g. qwen3-thinking, deepseek-r1, served
+                # via OpenAI-compatible endpoints like Xinference) can return
+                # ``content=""`` while ``reasoning_content`` carries the
+                # partial answer when the generation is truncated by
+                # ``max_tokens`` (``finish_reason="length"``) before the
+                # final answer is produced. Surface the reasoning text as
+                # content so callers (notably the model connection test) do
+                # not treat a truncated-but-otherwise-healthy response as
+                # invalid.
+                if reasoning_content:
+                    return {
+                        "type": "text",
+                        "content": reasoning_content,
+                        "reasoning_content": reasoning_content,
+                        "reasoning": reasoning_content,
+                        "raw": resp.model_dump(),
+                    }
                 # If there are no tool calls and no content, this is an error
                 raise RuntimeError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
@@ -281,9 +303,9 @@ class OpenAILLM(BaseLLM):
                 "content": content,
                 "raw": resp.model_dump(),
             }
-            if hasattr(message, "reasoning_content") and message.reasoning_content:
-                result["reasoning_content"] = message.reasoning_content
-                result["reasoning"] = message.reasoning_content
+            if reasoning_content:
+                result["reasoning_content"] = reasoning_content
+                result["reasoning"] = reasoning_content
             return result
 
         try:
@@ -610,19 +632,40 @@ class OpenAILLM(BaseLLM):
 
             # Handle text content
             content = message.content
+            reasoning_content = (
+                message.reasoning_content
+                if hasattr(message, "reasoning_content")
+                else None
+            )
 
             # Handle None or empty content when no tool calls
             if not content or not content.strip():
+                # See ``chat()``: reasoning models truncated by ``max_tokens``
+                # may return ``content=""`` with the partial answer in
+                # ``reasoning_content``. Surface it as content rather than
+                # treating the response as invalid.
+                if reasoning_content:
+                    return {
+                        "type": "text",
+                        "content": reasoning_content,
+                        "reasoning_content": reasoning_content,
+                        "reasoning": reasoning_content,
+                        "raw": response.model_dump(),
+                    }
                 # If there are no tool calls and no content, this is an error
                 raise RuntimeError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                 )
 
-            return {
+            result: Dict[str, Any] = {
                 "type": "text",
                 "content": content,
                 "raw": response.model_dump(),
             }
+            if reasoning_content:
+                result["reasoning_content"] = reasoning_content
+                result["reasoning"] = reasoning_content
+            return result
 
         except openai.APITimeoutError as e:
             # Handle timeout errors

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -502,6 +502,44 @@ class TestOpenAILLM:
             await llm.chat([{"role": "user", "content": "Hello"}])
 
     @pytest.mark.asyncio
+    async def test_finish_reason_stop_with_only_reasoning_still_raises(
+        self, openai_llm_config, mocker
+    ):
+        """The reasoning-content fallback is scoped to truncated responses
+        (``finish_reason="length"``) only.
+
+        If a provider returns ``finish_reason="stop"`` with empty content
+        and a populated reasoning trace, the model is claiming to be done
+        without producing a final answer -- that is a real model failure
+        and the adapter must surface it instead of silently promoting the
+        scratchpad to the assistant message.
+        """
+        mock_choice = MagicMock()
+        mock_choice.finish_reason = "stop"
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = None
+        mock_message.reasoning_content = "I should answer the user."
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+
+        with pytest.raises(
+            RuntimeError, match="LLM returned empty content and no tool calls"
+        ):
+            await llm.chat([{"role": "user", "content": "Hello"}])
+
+    @pytest.mark.asyncio
     async def test_empty_string_api_key(self, openai_llm_config, monkeypatch):
         """Test that empty string API key is allowed and does not fallback to environment variable."""
         # Set environment variable to ensure we can test that it's NOT used

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -465,6 +465,43 @@ class TestOpenAILLM:
         assert result["reasoning"] == "Here"
 
     @pytest.mark.asyncio
+    async def test_whitespace_only_reasoning_content_still_raises(
+        self, openai_llm_config, mocker
+    ):
+        """A whitespace-only reasoning trace must NOT be treated as a
+        usable answer.
+
+        The empty-content guard checks ``content.strip()``; the
+        reasoning fallback must apply the same rule, otherwise a
+        provider returning ``reasoning_content="   "`` would surface a
+        blank string as if it were a valid response.
+        """
+        mock_choice = MagicMock()
+        mock_choice.finish_reason = "length"
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = None
+        mock_message.reasoning_content = "   \n  "
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+
+        with pytest.raises(
+            RuntimeError, match="LLM returned empty content and no tool calls"
+        ):
+            await llm.chat([{"role": "user", "content": "Hello"}])
+
+    @pytest.mark.asyncio
     async def test_empty_string_api_key(self, openai_llm_config, monkeypatch):
         """Test that empty string API key is allowed and does not fallback to environment variable."""
         # Set environment variable to ensure we can test that it's NOT used

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -357,6 +357,9 @@ class TestOpenAILLM:
         mock_message = MagicMock()
         mock_message.content = None
         mock_message.tool_calls = None
+        # No reasoning trace either: this is a genuinely empty response and
+        # the adapter must keep raising so callers can surface the failure.
+        mock_message.reasoning_content = None
         mock_choice.message = mock_message
 
         mock_response = MagicMock()
@@ -386,6 +389,9 @@ class TestOpenAILLM:
         mock_message = MagicMock()
         mock_message.content = ""
         mock_message.tool_calls = None
+        # No reasoning trace either: ensures the empty-response error path
+        # still triggers when a provider returns nothing useful at all.
+        mock_message.reasoning_content = None
         mock_choice.message = mock_message
 
         mock_response = MagicMock()
@@ -405,6 +411,58 @@ class TestOpenAILLM:
             RuntimeError, match="LLM returned empty content and no tool calls"
         ):
             await llm.chat([{"role": "user", "content": "Hello"}])
+
+    @pytest.mark.asyncio
+    async def test_empty_content_falls_back_to_reasoning_content(
+        self, openai_llm_config, mocker
+    ):
+        """Reasoning models (e.g. qwen3-thinking, deepseek-r1) served via
+        OpenAI-compatible endpoints can return ``content=""`` while the
+        partial answer lives in ``reasoning_content`` when the generation
+        is truncated by ``max_tokens`` (``finish_reason="length"``).
+
+        The adapter must surface the reasoning text as content instead of
+        treating the response as invalid — otherwise the model connection
+        test endpoint can never validate a reasoning model.
+        """
+        mock_choice = MagicMock()
+        mock_choice.finish_reason = "length"
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = None
+        mock_message.reasoning_content = "Here"
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.model_dump.return_value = {
+            "choices": [
+                {
+                    "finish_reason": "length",
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "Here",
+                    },
+                }
+            ]
+        }
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+
+        result = await llm.chat([{"role": "user", "content": "Hello"}])
+
+        assert result["type"] == "text"
+        assert result["content"] == "Here"
+        assert result["reasoning_content"] == "Here"
+        assert result["reasoning"] == "Here"
 
     @pytest.mark.asyncio
     async def test_empty_string_api_key(self, openai_llm_config, monkeypatch):


### PR DESCRIPTION
Reasoning models served via OpenAI-compatible endpoints (Xinference, vLLM, etc.) -- e.g. qwen3-thinking, deepseek-r1 -- can return content='' with the partial answer in reasoning_content when the generation is truncated by max_tokens (finish_reason='length'). The OpenAI adapter previously raised 'LLM returned empty content and no tool calls' in that case, which made it impossible to validate or activate such a model from the UI's connect-test flow.

* chat() and vision_chat() now read reasoning_content once and, when content is empty/None and there are no tool calls but reasoning_content is populated, surface the reasoning text as content (with reasoning_content/reasoning fields preserved on the result). The hard error is still raised when both content and reasoning_content are empty.

* Mirrors the Xinference adapter behaviour landed in #625, so both adapters handle truncated reasoning responses consistently.

* test_none_content_response and test_empty_content_response now explicitly pin reasoning_content=None so the empty-response error path keeps being exercised; new test_empty_content_falls_back_to_reasoning_content covers the recovery path.