### PR TITLE
fix: update documentation domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/+2_-SAVLtuJNkNWFl)
 [![Twitter](https://img.shields.io/twitter/follow/xorbitsio?logo=x&style=for-the-badge)](https://twitter.com/xorbitsio)
 
-[![Documentation](https://img.shields.io/badge/docs-docs.xagent.run-blue?style=for-the-badge&logo=gitbook)](https://docs.xagent.run/)
+[![Documentation](https://img.shields.io/badge/docs-docs.xagent.co-blue?style=for-the-badge&logo=gitbook)](https://docs.xagent.co/)
 [![GitHub Release](https://img.shields.io/github/v/release/xorbitsai/xagent?logo=github&style=for-the-badge)](https://github.com/xorbitsai/xagent/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/xprobe/xagent-backend?style=for-the-badge&logo=docker)](https://hub.docker.com/r/xprobe/xagent-backend)
 
@@ -378,7 +378,7 @@ Follow our progress:
 
 ## Community & Contact
 
-**[Documentation](https://docs.xagent.run/)** - Full documentation and guides
+**[Documentation](https://docs.xagent.co/)** - Full documentation and guides
 
 **[GitHub Issues](https://github.com/xorbitsai/xagent/issues)** - Report bugs or propose features
 

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -1502,7 +1502,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                 <DialogDescription className="flex items-center gap-1.5">
                   {t("builds.configForm.model.configureDescription")}
                   <a
-                    href="https://docs.xagent.run/models/overview"
+                    href="https://docs.xagent.co/models/overview"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center text-muted-foreground hover:text-primary transition-colors"


### PR DESCRIPTION
## Summary
- update README documentation badge and link to docs.xagent.co
- update the agent builder model documentation link to docs.xagent.co

## Validation
- rg -n "docs\.xagent\.run" .
- pre-commit hooks from git commit, including codespell, npm lint, and npm type-check