### PR TITLE
fix(context): stabilize system message timestamp for prefix cache

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -344,7 +344,7 @@ class ExecutionContext:
     def _current_time_context(self) -> str:
         return (
             "Current date and time: "
-            f"{self.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
+            f"{self.created_at.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}. "
             "Use this as the reference for relative dates such as today, recent, "
             "latest, yesterday, and tomorrow."
         )

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -342,10 +342,9 @@ class ExecutionContext:
         return messages
 
     def _current_time_context(self) -> str:
-        current_time = _utcnow()
         return (
             "Current date and time: "
-            f"{current_time.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
+            f"{self.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
             "Use this as the reference for relative dates such as today, recent, "
             "latest, yesterday, and tomorrow."
         )

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -482,7 +482,9 @@ class ReActPattern(AgentPattern):
             )
         elif has_tools:
             available_tools = ", ".join(tool_names or []) or "(none)"
-            current_date = context.created_at.astimezone(timezone.utc).date().isoformat()
+            current_date = (
+                context.created_at.astimezone(timezone.utc).date().isoformat()
+            )
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -4,7 +4,6 @@ import asyncio
 import inspect
 import json
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, cast
 
@@ -482,7 +481,7 @@ class ReActPattern(AgentPattern):
             )
         elif has_tools:
             available_tools = ", ".join(tool_names or []) or "(none)"
-            current_date = datetime.now(timezone.utc).date().isoformat()
+            current_date = context.created_at.date().isoformat()
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import json
 from dataclasses import dataclass, replace
+from datetime import timezone
 from enum import Enum
 from typing import Any, cast
 
@@ -481,7 +482,7 @@ class ReActPattern(AgentPattern):
             )
         elif has_tools:
             available_tools = ", ".join(tool_names or []) or "(none)"
-            current_date = context.created_at.date().isoformat()
+            current_date = context.created_at.astimezone(timezone.utc).date().isoformat()
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "


### PR DESCRIPTION
## Summary

- `ExecutionContext._current_time_context()` was calling `datetime.now()` on every `get_messages_for_llm()` invocation, injecting a live per-second timestamp into the system message. This caused the system message to differ across every LLM iteration, making prefix caching impossible.
- `ReActPattern._messages_for_llm()` was similarly injecting `datetime.now().date()` into the tools instruction on every call.
- Both are now fixed to use `context.created_at`, which is set once when the context is created and remains stable for the entire execution lifetime.

## Effect

For all models that support prefix caching (OpenAI, vLLM, SGLang, etc.), the system message prefix is now identical across all iterations within a single ReAct run, enabling cache hits from the second iteration onward.

The only remaining expected cache miss is the `force_final_answer` iteration (last call in a run), which intentionally uses a different system instruction — this is a model-behavior constraint, not a bug.

## Test plan

- [ ] Existing context tests pass: `pytest tests/core/agent/test_context.py` (60 passed)
- [ ] Full agent test suite passes: `pytest tests/core/agent/` (355 passed)