### PR TITLE
feat: add agent trigger UI

### DIFF
--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -3,12 +3,13 @@
 import React, { useState, useEffect, useRef } from "react"
 import { SearchInput } from "@/components/ui/search-input"
 import { Button } from "@/components/ui/button"
-import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound } from "lucide-react"
+import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound, Webhook } from "lucide-react"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
 import { DeployAgentDialog, Agent } from "@/components/build/deploy-agent-dialog"
 import { AgentApiKeyDialog } from "@/components/build/agent-api-key-dialog"
+import { AgentTriggersDialog } from "@/components/build/agent-triggers-dialog"
 import { FeatureEmptyState } from "@/components/ui/feature-empty-state"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
@@ -77,6 +78,7 @@ export default function BuildsPage() {
   // Deploy Dialog State
   const [deployAgent, setDeployAgent] = useState<Agent | null>(null)
   const [apiKeyAgent, setApiKeyAgent] = useState<Agent | null>(null)
+  const [triggersAgent, setTriggersAgent] = useState<Agent | null>(null)
 
   // Check for template parameter and redirect to create page
   useEffect(() => {
@@ -418,6 +420,19 @@ export default function BuildsPage() {
                                       {t('builds.list.actions.apiKey') || 'API Key'}
                                     </Button>
                                   )}
+                                  {canEditAgent(agent) && (
+                                    <Button
+                                      variant="ghost"
+                                      className="justify-start px-2 py-1.5 h-auto font-normal text-sm"
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        setTriggersAgent(agent)
+                                      }}
+                                    >
+                                      <Webhook className="mr-2 h-4 w-4" />
+                                      {t('builds.list.actions.triggers') || 'Triggers'}
+                                    </Button>
+                                  )}
                                   {canEditAgent(agent) && (canPublishAgent(agent) || canDeleteAgent(agent)) && (
                                     <div className="h-px bg-border my-1 mx-1" />
                                   )}
@@ -570,6 +585,7 @@ export default function BuildsPage() {
           setAgents(agents.map(a => a.id === updatedAgent.id ? updatedAgent : a))
         }}
         onManageApiKey={() => { if (deployAgent) setApiKeyAgent(deployAgent) }}
+        onManageTriggers={() => { if (deployAgent) setTriggersAgent(deployAgent) }}
       />
 
       <AgentApiKeyDialog
@@ -577,6 +593,13 @@ export default function BuildsPage() {
         agentName={apiKeyAgent?.name}
         open={apiKeyAgent !== null}
         onOpenChange={(open) => { if (!open) setApiKeyAgent(null) }}
+      />
+
+      <AgentTriggersDialog
+        agentId={triggersAgent?.id ?? null}
+        agentName={triggersAgent?.name}
+        open={triggersAgent !== null}
+        onOpenChange={(open) => { if (!open) setTriggersAgent(null) }}
       />
 
       <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { apiRequest } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
-import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, ChevronLeft, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain } from "lucide-react"
+import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, ChevronLeft, Gauge, Sparkles, Loader2, X, XCircle, Trash2, Bot, Brain, Webhook, CalendarClock } from "lucide-react"
 import { ConnectMcpDialog } from "@/components/mcp/connect-mcp-dialog"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
@@ -38,6 +38,8 @@ import { cn } from "@/lib/utils"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { BuildFilePreviewSheet } from "./build-file-preview-sheet"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
+import { AgentTriggersDialog } from "./agent-triggers-dialog"
+import { AgentTrigger, AgentTriggerType, listAgentTriggers } from "@/lib/agent-triggers-api"
 
 interface KnowledgeBase {
   name: string
@@ -134,6 +136,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const [originalData, setOriginalData] = useState<any>(null)
   const [isKbModalOpen, setIsKbModalOpen] = useState(false)
   const [isModelConfigOpen, setIsModelConfigOpen] = useState(false)
+  const [isTriggersDialogOpen, setIsTriggersDialogOpen] = useState(false)
+  const [triggerDialogInitialType, setTriggerDialogInitialType] = useState<AgentTriggerType | null>(null)
+  const [triggerSummary, setTriggerSummary] = useState<AgentTrigger[]>([])
+  const [triggerSummaryLoading, setTriggerSummaryLoading] = useState(false)
   const [showAIAssistant, setShowAIAssistant] = useState(false)
   const [configSynced, setConfigSynced] = useState(false)
   const [notFound, setNotFound] = useState(false)
@@ -163,6 +169,41 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const [mcpServers, setMcpServers] = useState<any[]>([])
   const [isConnectMcpOpen, setIsConnectMcpOpen] = useState(false)
   const [isInitialDataLoaded, setIsInitialDataLoaded] = useState(false)
+
+  const refreshTriggerSummary = useCallback(async () => {
+    if (!localAgentId) {
+      setTriggerSummary([])
+      return
+    }
+
+    setTriggerSummaryLoading(true)
+    try {
+      setTriggerSummary(await listAgentTriggers(localAgentId))
+    } catch (error) {
+      console.error("Failed to load trigger summary:", error)
+    } finally {
+      setTriggerSummaryLoading(false)
+    }
+  }, [localAgentId])
+
+  useEffect(() => {
+    void refreshTriggerSummary()
+  }, [refreshTriggerSummary])
+
+  const triggerStats = useMemo(() => {
+    const stats = {
+      webhook: { total: 0, enabled: 0 },
+      scheduled: { total: 0, enabled: 0 },
+    }
+    triggerSummary.forEach((trigger) => {
+      if (trigger.type !== "webhook" && trigger.type !== "scheduled") return
+      stats[trigger.type].total += 1
+      if (trigger.enabled) {
+        stats[trigger.type].enabled += 1
+      }
+    })
+    return stats
+  }, [triggerSummary])
 
   // File picker state for Instructions
   const instructionsRef = useRef<HTMLDivElement>(null)
@@ -1721,6 +1762,116 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           )}
         </div>
 
+        <div className={cn(
+          "space-y-2 rounded-lg border bg-card/40 p-2.5",
+          triggerSummary.some((trigger) => trigger.enabled) && "border-primary/70",
+        )}>
+          <div className="flex flex-wrap items-center justify-between gap-3 px-0.5">
+            <div className="flex items-center gap-1.5">
+              <Label>{t("triggers.builder.title")}</Label>
+              <InfoTooltip content={localAgentId ? t("triggers.builder.tooltip") : t("triggers.builder.saveFirst")} />
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setTriggerDialogInitialType(null)
+                setIsTriggersDialogOpen(true)
+              }}
+              disabled={!localAgentId}
+              className="h-7 shrink-0 px-2 text-xs text-primary"
+            >
+              <Zap className="mr-1 h-3.5 w-3.5" />
+              {t("triggers.builder.open")}
+            </Button>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            {([
+              {
+                type: "webhook" as const,
+                icon: Webhook,
+                title: t("triggers.cards.webhook.title"),
+                description: t("triggers.cards.webhook.description"),
+                iconClass: "bg-fuchsia-50 text-fuchsia-600 dark:bg-fuchsia-950/40 dark:text-fuchsia-300",
+              },
+              {
+                type: "scheduled" as const,
+                icon: CalendarClock,
+                title: t("triggers.cards.scheduled.title"),
+                description: t("triggers.cards.scheduled.description"),
+                iconClass: "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300",
+              },
+            ]).map((item) => {
+              const stat = triggerStats[item.type]
+              const enabled = stat.enabled > 0
+              return (
+                <div
+                  key={item.type}
+                  className={cn(
+                    "flex min-w-0 items-center gap-2 rounded-md border bg-background px-2.5 py-2 text-left transition-colors",
+                    enabled && "border-primary/40 bg-primary/[0.03]",
+                    !localAgentId && "opacity-60",
+                  )}
+                >
+                  <button
+                    type="button"
+                    disabled={!localAgentId}
+                    onClick={() => {
+                      setTriggerDialogInitialType(item.type)
+                      setIsTriggersDialogOpen(true)
+                    }}
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left disabled:cursor-not-allowed"
+                  >
+                  <div className={cn("flex h-6 w-6 shrink-0 items-center justify-center rounded", item.iconClass)}>
+                    <item.icon className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium">{item.title}</span>
+                      {triggerSummaryLoading ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                      ) : enabled ? (
+                        <span className="rounded-full bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+                          {t("triggers.cards.activeCount", { count: stat.enabled })}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {item.description}
+                    </div>
+                  </div>
+                  </button>
+                  <Switch
+                    checked={enabled}
+                    disabled={!localAgentId}
+                    onCheckedChange={() => {
+                      setTriggerDialogInitialType(item.type)
+                      setIsTriggersDialogOpen(true)
+                    }}
+                    className="scale-75"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    disabled={!localAgentId}
+                    onClick={() => {
+                      setTriggerDialogInitialType(item.type)
+                      setIsTriggersDialogOpen(true)
+                    }}
+                    className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                    title={t("triggers.builder.configure")}
+                  >
+                    <Settings2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
         <div className={getConfigSectionClasses(shouldHighlightConnectorSection)}>
           <div className="flex items-center gap-1.5">
             <Label>{t("tools.mcp.dialog.connector")}</Label>
@@ -1966,6 +2117,21 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             }
           }
         }}
+      />
+
+      <AgentTriggersDialog
+        agentId={localAgentId ? Number(localAgentId) : null}
+        agentName={name}
+        open={isTriggersDialogOpen}
+        onOpenChange={(dialogOpen) => {
+          setIsTriggersDialogOpen(dialogOpen)
+          if (!dialogOpen) {
+            setTriggerDialogInitialType(null)
+            void refreshTriggerSummary()
+          }
+        }}
+        onChanged={refreshTriggerSummary}
+        initialType={triggerDialogInitialType}
       />
 
       {state.filePreview.isOpen && (

--- a/frontend/src/components/build/agent-triggers-dialog.tsx
+++ b/frontend/src/components/build/agent-triggers-dialog.tsx
@@ -1,0 +1,930 @@
+"use client"
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  AlertCircle,
+  CalendarClock,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Info,
+  Loader2,
+  Play,
+  Plus,
+  RefreshCcw,
+  RotateCcw,
+  Trash2,
+  Webhook,
+  Zap,
+} from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/sonner"
+import { useI18n } from "@/contexts/i18n-context"
+import {
+  AgentTrigger,
+  AgentTriggerRun,
+  AgentTriggerType,
+  createAgentTrigger,
+  deleteAgentTrigger,
+  listAgentTriggerRuns,
+  listAgentTriggers,
+  testAgentTrigger,
+  updateAgentTrigger,
+} from "@/lib/agent-triggers-api"
+import { copyToClipboard } from "@/lib/clipboard"
+import { cn, getApiUrl } from "@/lib/utils"
+
+interface AgentTriggersDialogProps {
+  agentId: number | null
+  agentName?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChanged?: () => void
+  initialType?: AgentTriggerType | null
+}
+
+interface TriggerFormState {
+  type: AgentTriggerType
+  name: string
+  enabled: boolean
+  intervalSeconds: string
+  nextRunAt: string
+  secret: string
+  promptTemplate: string
+}
+
+const TRIGGER_TYPES: AgentTriggerType[] = ["webhook", "scheduled"]
+const DEFAULT_TEST_PAYLOAD = "{\n  \"message\": \"test trigger\"\n}"
+
+function emptyForm(type: AgentTriggerType = "webhook"): TriggerFormState {
+  return {
+    type,
+    name: "",
+    enabled: true,
+    intervalSeconds: "3600",
+    nextRunAt: "",
+    secret: "",
+    promptTemplate: "",
+  }
+}
+
+function defaultConfigForType(type: AgentTriggerType): Record<string, unknown> {
+  return type === "scheduled" ? { interval_seconds: 3600 } : {}
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "-"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+function toDateTimeLocal(value: string | null): string {
+  if (!value) return ""
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ""
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+  return local.toISOString().slice(0, 16)
+}
+
+function configNumber(config: Record<string, unknown>, key: string): string {
+  const value = config[key]
+  return typeof value === "number" || typeof value === "string" ? String(value) : ""
+}
+
+function formFromTrigger(trigger: AgentTrigger): TriggerFormState {
+  return {
+    type: trigger.type,
+    name: trigger.name,
+    enabled: trigger.enabled,
+    intervalSeconds:
+      trigger.type === "scheduled"
+        ? configNumber(trigger.config, "interval_seconds") || "3600"
+        : "3600",
+    nextRunAt:
+      trigger.type === "scheduled" && typeof trigger.config.next_run_at === "string"
+        ? toDateTimeLocal(trigger.config.next_run_at)
+        : "",
+    secret: "",
+    promptTemplate: trigger.prompt_template ?? "",
+  }
+}
+
+function webhookUrl(trigger: AgentTrigger | null): string {
+  if (!trigger?.webhook_token) return ""
+  return `${getApiUrl()}/api/triggers/webhook/${trigger.webhook_token}`
+}
+
+function runStatusClass(status: string): string {
+  if (status === "completed") return "text-emerald-600"
+  if (status === "failed") return "text-destructive"
+  if (status === "running") return "text-blue-600"
+  return "text-muted-foreground"
+}
+
+function newestFirst(a: AgentTrigger, b: AgentTrigger): number {
+  return b.id - a.id
+}
+
+function isValidAgentId(agentId: number | null): agentId is number {
+  return typeof agentId === "number" && Number.isFinite(agentId)
+}
+
+export function AgentTriggersDialog({
+  agentId,
+  agentName,
+  open,
+  onOpenChange,
+  onChanged,
+  initialType = null,
+}: AgentTriggersDialogProps) {
+  const { t } = useI18n()
+  const router = useRouter()
+  const [triggers, setTriggers] = useState<AgentTrigger[]>([])
+  const [activeType, setActiveTypeState] = useState<AgentTriggerType | null>(null)
+  const [selectedTriggerId, setSelectedTriggerIdState] = useState<number | null>(null)
+  const [runs, setRuns] = useState<AgentTriggerRun[]>([])
+  const [loading, setLoading] = useState(false)
+  const [runsLoading, setRunsLoading] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [busyType, setBusyType] = useState<AgentTriggerType | null>(null)
+  const [form, setForm] = useState<TriggerFormState>(emptyForm)
+  const [testPayload, setTestPayload] = useState(DEFAULT_TEST_PAYLOAD)
+  const [sourceEventId, setSourceEventId] = useState("")
+  const [secretReveal, setSecretReveal] = useState<string | null>(null)
+  const [copied, setCopied] = useState<string | null>(null)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
+  const selectedTriggerIdRef = useRef<number | null>(null)
+  const activeTypeRef = useRef<AgentTriggerType | null>(null)
+
+  const setSelectedTriggerId = useCallback((id: number | null) => {
+    selectedTriggerIdRef.current = id
+    setSelectedTriggerIdState(id)
+  }, [])
+
+  const setActiveType = useCallback((type: AgentTriggerType | null) => {
+    activeTypeRef.current = type
+    setActiveTypeState(type)
+  }, [])
+
+  const triggerGroups = useMemo(() => {
+    return TRIGGER_TYPES.reduce<Record<AgentTriggerType, AgentTrigger[]>>(
+      (acc, type) => {
+        acc[type] = triggers.filter((trigger) => trigger.type === type).sort(newestFirst)
+        return acc
+      },
+      { webhook: [], scheduled: [] },
+    )
+  }, [triggers])
+
+  const activeTypeTriggers = activeType ? triggerGroups[activeType] : []
+  const selectedTrigger = useMemo(() => {
+    if (!activeType) return null
+    return (
+      activeTypeTriggers.find((trigger) => trigger.id === selectedTriggerId) ??
+      activeTypeTriggers[0] ??
+      null
+    )
+  }, [activeType, activeTypeTriggers, selectedTriggerId])
+
+  const selectedWebhookUrl = webhookUrl(selectedTrigger)
+
+  const defaultNameForType = useCallback((type: AgentTriggerType) => {
+    return type === "webhook"
+      ? t("triggers.defaults.webhookName")
+      : t("triggers.defaults.scheduledName")
+  }, [t])
+
+  const loadTriggers = useCallback(async (preferredTriggerId?: number | null) => {
+    if (!isValidAgentId(agentId)) return
+    setLoading(true)
+    try {
+      const data = await listAgentTriggers(agentId)
+      setTriggers(data)
+
+      const currentSelectedId = preferredTriggerId ?? selectedTriggerIdRef.current
+      if (currentSelectedId && data.some((trigger) => trigger.id === currentSelectedId)) {
+        setSelectedTriggerId(currentSelectedId)
+      } else if (activeTypeRef.current) {
+        const next = data
+          .filter((trigger) => trigger.type === activeTypeRef.current)
+          .sort(newestFirst)[0]
+        setSelectedTriggerId(next?.id ?? null)
+      }
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.loadFailed"))
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId, setSelectedTriggerId, t])
+
+  const loadRuns = useCallback(async () => {
+    if (!isValidAgentId(agentId) || !selectedTrigger) {
+      setRuns([])
+      return
+    }
+    setRunsLoading(true)
+    try {
+      setRuns(await listAgentTriggerRuns(agentId, selectedTrigger.id))
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.runsLoadFailed"))
+    } finally {
+      setRunsLoading(false)
+    }
+  }, [agentId, selectedTrigger, t])
+
+  useEffect(() => {
+    if (!open) return
+    setActiveType(initialType)
+    setSelectedTriggerId(null)
+    setSecretReveal(null)
+    setCopied(null)
+    setDeleteConfirmId(null)
+    setRuns([])
+    if (initialType) {
+      setForm(emptyForm(initialType))
+    }
+    void loadTriggers(null)
+  }, [initialType, loadTriggers, open, setActiveType, setSelectedTriggerId])
+
+  useEffect(() => {
+    if (!open || !activeType) return
+    if (selectedTrigger) {
+      setForm(formFromTrigger(selectedTrigger))
+      void loadRuns()
+    } else {
+      setForm(emptyForm(activeType))
+      setRuns([])
+    }
+  }, [activeType, loadRuns, open, selectedTrigger])
+
+  const openType = (type: AgentTriggerType) => {
+    const primary =
+      triggerGroups[type].find((trigger) => trigger.enabled) ??
+      triggerGroups[type][0] ??
+      null
+    setActiveType(type)
+    setSelectedTriggerId(primary?.id ?? null)
+    setSecretReveal(null)
+    setDeleteConfirmId(null)
+    setForm(primary ? formFromTrigger(primary) : emptyForm(type))
+  }
+
+  const beginCreateForType = (type: AgentTriggerType) => {
+    setActiveType(type)
+    setSelectedTriggerId(null)
+    setSecretReveal(null)
+    setDeleteConfirmId(null)
+    setForm(emptyForm(type))
+    setRuns([])
+  }
+
+  const beginEdit = (trigger: AgentTrigger) => {
+    setActiveType(trigger.type)
+    setSelectedTriggerId(trigger.id)
+    setSecretReveal(null)
+    setDeleteConfirmId(null)
+    setForm(formFromTrigger(trigger))
+  }
+
+  const setFormValue = <K extends keyof TriggerFormState>(
+    key: K,
+    value: TriggerFormState[K],
+  ) => {
+    setForm((current) => ({ ...current, [key]: value }))
+  }
+
+  const buildConfig = (): Record<string, unknown> => {
+    if (form.type === "webhook") return {}
+
+    const config: Record<string, unknown> = {}
+    const intervalValue = form.intervalSeconds.trim()
+    if (intervalValue) {
+      const interval = Number(intervalValue)
+      if (!Number.isInteger(interval) || interval <= 0) {
+        throw new Error(t("triggers.validation.interval"))
+      }
+      config.interval_seconds = interval
+    }
+
+    if (form.nextRunAt.trim()) {
+      const next = new Date(form.nextRunAt)
+      if (Number.isNaN(next.getTime())) {
+        throw new Error(t("triggers.validation.nextRunAt"))
+      }
+      config.next_run_at = next.toISOString()
+    }
+
+    if (!config.interval_seconds && !config.next_run_at) {
+      throw new Error(t("triggers.validation.scheduleRequired"))
+    }
+    return config
+  }
+
+  const buildPayload = () => {
+    const name = form.name.trim() || defaultNameForType(form.type)
+    if (name.length > 200) {
+      throw new Error(t("triggers.validation.nameLength"))
+    }
+
+    return {
+      type: form.type,
+      name,
+      enabled: form.enabled,
+      config: buildConfig(),
+      prompt_template: form.promptTemplate.trim() ? form.promptTemplate : null,
+      secret: form.type === "webhook" && form.secret.trim() ? form.secret.trim() : null,
+    }
+  }
+
+  const notifyChanged = () => {
+    onChanged?.()
+  }
+
+  const createDefaultTrigger = async (type: AgentTriggerType, enabled: boolean) => {
+    if (!isValidAgentId(agentId)) return null
+    const saved = await createAgentTrigger(agentId, {
+      type,
+      name: defaultNameForType(type),
+      enabled,
+      config: defaultConfigForType(type),
+      prompt_template: null,
+      secret: null,
+    })
+    setSecretReveal(saved.webhook_secret ?? null)
+    notifyChanged()
+    return saved
+  }
+
+  const handleTypeToggle = async (type: AgentTriggerType, checked: boolean) => {
+    if (!isValidAgentId(agentId)) return
+    const typeTriggers = triggerGroups[type]
+    const primary =
+      typeTriggers.find((trigger) => trigger.enabled) ??
+      typeTriggers[0] ??
+      null
+    setBusyType(type)
+    try {
+      let preferredId: number | null = primary?.id ?? null
+      if (checked) {
+        if (primary) {
+          const updated = await updateAgentTrigger(agentId, primary.id, { enabled: true })
+          preferredId = updated.id
+        } else {
+          const created = await createDefaultTrigger(type, true)
+          preferredId = created?.id ?? null
+          if (created) {
+            setActiveType(type)
+            setSelectedTriggerId(created.id)
+            setForm(formFromTrigger(created))
+          }
+        }
+      } else {
+        const enabledTriggers = typeTriggers.filter((trigger) => trigger.enabled)
+        await Promise.all(
+          enabledTriggers.map((trigger) =>
+            updateAgentTrigger(agentId, trigger.id, { enabled: false }),
+          ),
+        )
+      }
+      await loadTriggers(preferredId)
+      notifyChanged()
+      toast.success(checked ? t("triggers.messages.enabled") : t("triggers.messages.disabled"))
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+    } finally {
+      setBusyType(null)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!isValidAgentId(agentId)) return
+    let payload
+    try {
+      payload = buildPayload()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+      return
+    }
+
+    setBusy(true)
+    try {
+      const saved = selectedTrigger
+        ? await updateAgentTrigger(agentId, selectedTrigger.id, payload)
+        : await createAgentTrigger(agentId, payload)
+      setSecretReveal(saved.webhook_secret ?? null)
+      setSelectedTriggerId(saved.id)
+      setForm(formFromTrigger(saved))
+      await loadTriggers(saved.id)
+      notifyChanged()
+      toast.success(selectedTrigger ? t("triggers.messages.updated") : t("triggers.messages.created"))
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.saveFailed"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleRotateSecret = async () => {
+    if (!isValidAgentId(agentId) || !selectedTrigger || selectedTrigger.type !== "webhook") return
+    setBusy(true)
+    try {
+      const updated = await updateAgentTrigger(agentId, selectedTrigger.id, {
+        rotate_secret: true,
+      })
+      setSecretReveal(updated.webhook_secret ?? null)
+      await loadTriggers(updated.id)
+      notifyChanged()
+      toast.success(t("triggers.messages.secretRotated"))
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.secretRotateFailed"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDelete = async (trigger: AgentTrigger) => {
+    if (!isValidAgentId(agentId)) return
+    if (deleteConfirmId !== trigger.id) {
+      setDeleteConfirmId(trigger.id)
+      return
+    }
+    setBusy(true)
+    try {
+      await deleteAgentTrigger(agentId, trigger.id)
+      setSelectedTriggerId(null)
+      setRuns([])
+      setSecretReveal(null)
+      setDeleteConfirmId(null)
+      await loadTriggers(null)
+      notifyChanged()
+      toast.success(t("triggers.messages.deleted"))
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.deleteFailed"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleTest = async () => {
+    if (!isValidAgentId(agentId) || !selectedTrigger) return
+    let payload: Record<string, unknown>
+    try {
+      const parsed = JSON.parse(testPayload || "{}")
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error(t("triggers.validation.testPayload"))
+      }
+      payload = parsed as Record<string, unknown>
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("triggers.validation.testPayload"))
+      return
+    }
+
+    setBusy(true)
+    try {
+      const result = await testAgentTrigger(agentId, selectedTrigger.id, {
+        payload,
+        source_event_id: sourceEventId.trim() || null,
+      })
+      await loadRuns()
+      toast.success(
+        result.duplicate
+          ? t("triggers.messages.testDuplicate")
+          : t("triggers.messages.testStarted"),
+      )
+    } catch (err) {
+      console.error(err)
+      toast.error(err instanceof Error ? err.message : t("triggers.messages.testFailed"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCopy = async (id: string, value: string) => {
+    if (!value) return
+    if (await copyToClipboard(value)) {
+      setCopied(id)
+      toast.success(t("common.copied"))
+      window.setTimeout(() => setCopied(null), 2000)
+    } else {
+      toast.error(t("triggers.messages.copyFailed"))
+    }
+  }
+
+  const closeDialog = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setActiveType(null)
+      setSecretReveal(null)
+      setCopied(null)
+      setDeleteConfirmId(null)
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const renderTypeIcon = (type: AgentTriggerType, className?: string) => {
+    return type === "webhook" ? (
+      <Webhook className={className} />
+    ) : (
+      <CalendarClock className={className} />
+    )
+  }
+
+  const renderTypeCard = (type: AgentTriggerType) => {
+    const typeTriggers = triggerGroups[type]
+    const enabledCount = typeTriggers.filter((trigger) => trigger.enabled).length
+    const hasTriggers = typeTriggers.length > 0
+    const isEnabled = enabledCount > 0
+    const iconClass =
+      type === "webhook"
+        ? "bg-fuchsia-50 text-fuchsia-600 dark:bg-fuchsia-950/40 dark:text-fuchsia-300"
+        : "bg-amber-50 text-amber-600 dark:bg-amber-950/40 dark:text-amber-300"
+
+    return (
+      <div
+        key={type}
+        className={cn(
+          "group flex w-full items-center gap-4 rounded-lg border bg-background p-4 text-left transition-colors",
+          "hover:border-primary/50 hover:bg-muted/30",
+          isEnabled && "border-primary/40 bg-primary/[0.03]",
+        )}
+      >
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-4 text-left"
+          onClick={() => openType(type)}
+        >
+          <div className={cn("flex h-10 w-10 shrink-0 items-center justify-center rounded-lg", iconClass)}>
+            {renderTypeIcon(type, "h-5 w-5")}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <div className="truncate text-sm font-semibold">{t(`triggers.cards.${type}.title`)}</div>
+              {hasTriggers && (
+                <Badge variant={isEnabled ? "default" : "secondary"} className="h-5 px-1.5 text-[10px]">
+                  {isEnabled
+                    ? t("triggers.cards.activeCount", { count: enabledCount })
+                    : t("triggers.status.disabled")}
+                </Badge>
+              )}
+            </div>
+            <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+              {t(`triggers.cards.${type}.description`)}
+            </div>
+          </div>
+        </button>
+        <div className="flex items-center gap-3">
+          <Switch
+            checked={isEnabled}
+            disabled={busyType === type || !isValidAgentId(agentId)}
+            onCheckedChange={(checked) => void handleTypeToggle(type, checked)}
+          />
+          <button
+            type="button"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={() => openType(type)}
+            aria-label={t(`triggers.cards.${type}.title`)}
+          >
+            <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const renderOverview = () => (
+    <div className="space-y-4">
+      <Alert className="border-primary/20 bg-primary/5 text-primary">
+        <Info className="h-4 w-4" />
+        <AlertDescription className="text-sm text-foreground">
+          {t("triggers.overview.info")}
+        </AlertDescription>
+      </Alert>
+
+      <div className="space-y-3">
+        {loading ? (
+          <div className="flex items-center justify-center rounded-lg border border-dashed py-16 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : (
+          TRIGGER_TYPES.map(renderTypeCard)
+        )}
+      </div>
+    </div>
+  )
+
+  const renderTriggerPicker = () => {
+    if (!activeType || activeTypeTriggers.length === 0) return null
+    return (
+      <div className="flex flex-wrap items-center gap-2 border-b pb-4">
+        {activeTypeTriggers.map((trigger) => (
+          <button
+            key={trigger.id}
+            type="button"
+            className={cn(
+              "inline-flex max-w-full items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+              selectedTrigger?.id === trigger.id
+                ? "border-primary bg-primary/5 text-foreground"
+                : "bg-background text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => beginEdit(trigger)}
+          >
+            <span className={cn("h-2 w-2 rounded-full", trigger.enabled ? "bg-emerald-500" : "bg-muted-foreground/40")} />
+            <span className="truncate">{trigger.name}</span>
+          </button>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => beginCreateForType(activeType)}
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          {t("triggers.actions.addAnother")}
+        </Button>
+      </div>
+    )
+  }
+
+  const renderDetail = () => {
+    if (!activeType) return null
+    const isNew = !selectedTrigger
+
+    return (
+      <div className="space-y-5">
+        <div className="flex items-center justify-between gap-3 border-b pb-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button variant="ghost" size="sm" className="-ml-2" onClick={() => setActiveType(null)}>
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              {t("common.back")}
+            </Button>
+            <div className="flex min-w-0 items-center gap-2 border-l pl-3">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                {renderTypeIcon(activeType, "h-4 w-4")}
+              </div>
+              <div className="truncate text-sm font-semibold">
+                {t(`triggers.cards.${activeType}.title`)}
+              </div>
+            </div>
+          </div>
+          <Switch
+            checked={form.enabled}
+            onCheckedChange={(checked) => setFormValue("enabled", checked)}
+            disabled={busy}
+          />
+        </div>
+
+        {renderTriggerPicker()}
+
+        <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_220px]">
+          <div className="space-y-2">
+            <Label htmlFor="trigger-name">{t("triggers.form.name")}</Label>
+            <Input
+              id="trigger-name"
+              value={form.name}
+              maxLength={200}
+              onChange={(event) => setFormValue("name", event.target.value)}
+              placeholder={defaultNameForType(activeType)}
+            />
+          </div>
+
+          {activeType === "scheduled" ? (
+            <div className="space-y-2">
+              <Label htmlFor="trigger-interval">{t("triggers.form.intervalSeconds")}</Label>
+              <Input
+                id="trigger-interval"
+                type="number"
+                min={1}
+                value={form.intervalSeconds}
+                onChange={(event) => setFormValue("intervalSeconds", event.target.value)}
+              />
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="trigger-secret">{t("triggers.form.secret")}</Label>
+              <Input
+                id="trigger-secret"
+                type="password"
+                value={form.secret}
+                onChange={(event) => setFormValue("secret", event.target.value)}
+                placeholder={isNew ? t("triggers.form.secretPlaceholder") : t("triggers.form.secretEditPlaceholder")}
+              />
+            </div>
+          )}
+        </div>
+
+        {activeType === "scheduled" && (
+          <div className="space-y-2">
+            <Label htmlFor="trigger-next-run">{t("triggers.form.nextRunAt")}</Label>
+            <Input
+              id="trigger-next-run"
+              type="datetime-local"
+              value={form.nextRunAt}
+              onChange={(event) => setFormValue("nextRunAt", event.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="trigger-prompt">{t("triggers.form.promptTemplate")}</Label>
+          <Textarea
+            id="trigger-prompt"
+            value={form.promptTemplate}
+            onChange={(event) => setFormValue("promptTemplate", event.target.value)}
+            placeholder={t("triggers.form.promptPlaceholder")}
+            className="min-h-[112px]"
+          />
+        </div>
+
+        {secretReveal && (
+          <Alert className="border-amber-300 bg-amber-50 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>{t("triggers.secret.title")}</AlertTitle>
+            <AlertDescription>
+              <div className="mt-2 flex gap-2">
+                <code className="min-w-0 flex-1 break-all rounded bg-background/70 px-2 py-1.5 text-xs">
+                  {secretReveal}
+                </code>
+                <Button
+                  size="icon"
+                  variant="secondary"
+                  onClick={() => void handleCopy("secret", secretReveal)}
+                  title={t("common.copy")}
+                >
+                  {copied === "secret" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {selectedTrigger?.type === "webhook" && (
+          <section className="space-y-3 rounded-lg border bg-muted/20 p-4">
+            <div className="text-sm font-medium">{t("triggers.webhook.title")}</div>
+            <div className="flex gap-2">
+              <Input readOnly value={selectedWebhookUrl} className="font-mono text-xs" />
+              <Button
+                variant="secondary"
+                onClick={() => void handleCopy("webhook-url", selectedWebhookUrl)}
+              >
+                {copied === "webhook-url" ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+                {t("common.copy")}
+              </Button>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("triggers.webhook.secretHeader")}
+            </div>
+          </section>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-4">
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleSubmit} disabled={busy || !isValidAgentId(agentId)}>
+              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isNew ? t("triggers.actions.enable") : t("triggers.actions.save")}
+            </Button>
+            {selectedTrigger && (
+              <Button variant="outline" onClick={handleTest} disabled={busy}>
+                <Play className="mr-2 h-4 w-4" />
+                {t("triggers.actions.test")}
+              </Button>
+            )}
+            {selectedTrigger?.type === "webhook" && (
+              <Button variant="outline" onClick={handleRotateSecret} disabled={busy}>
+                <RotateCcw className="mr-2 h-4 w-4" />
+                {t("triggers.actions.rotateSecret")}
+              </Button>
+            )}
+          </div>
+          {selectedTrigger && (
+            <Button
+              variant={deleteConfirmId === selectedTrigger.id ? "destructive" : "ghost"}
+              className={cn(deleteConfirmId !== selectedTrigger.id && "text-destructive hover:text-destructive")}
+              onClick={() => void handleDelete(selectedTrigger)}
+              disabled={busy}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              {deleteConfirmId === selectedTrigger.id
+                ? t("triggers.actions.confirmDelete")
+                : t("triggers.actions.delete")}
+            </Button>
+          )}
+        </div>
+
+        {selectedTrigger && (
+          <section className="space-y-3 rounded-lg border p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-medium">{t("triggers.runs.title")}</h3>
+                <p className="text-xs text-muted-foreground">
+                  {selectedTrigger.next_run_at
+                    ? `${t("triggers.runs.nextRun")}: ${formatDateTime(selectedTrigger.next_run_at)}`
+                    : t("triggers.runs.noNextRun")}
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => void loadRuns()} disabled={runsLoading}>
+                <RefreshCcw className={cn("mr-2 h-4 w-4", runsLoading && "animate-spin")} />
+                {t("common.refresh")}
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              {runsLoading ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">{t("common.loading")}</div>
+              ) : runs.length === 0 ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">{t("triggers.runs.empty")}</div>
+              ) : (
+                runs.slice(0, 5).map((run) => (
+                  <div key={run.id} className="flex items-center gap-3 rounded-md bg-muted/40 px-3 py-2 text-sm">
+                    <span className={cn("font-medium", runStatusClass(run.status))}>
+                      {t(`triggers.runStatus.${run.status}`)}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                      {run.source_event_id || run.idempotency_key}
+                    </span>
+                    {run.task_id ? (
+                      <Button
+                        variant="link"
+                        className="h-auto p-0 text-xs"
+                        onClick={() => router.push(`/task/${run.task_id}`)}
+                      >
+                        #{run.task_id}
+                      </Button>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">-</span>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        )}
+
+        {selectedTrigger && (
+          <section className="space-y-3 rounded-lg border p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-medium">{t("triggers.test.title")}</h3>
+                <p className="text-xs text-muted-foreground">{t("triggers.test.subtitle")}</p>
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_200px]">
+              <Textarea
+                value={testPayload}
+                onChange={(event) => setTestPayload(event.target.value)}
+                className="min-h-[112px] font-mono text-xs"
+              />
+              <div className="space-y-2">
+                <Label htmlFor="trigger-source-event">{t("triggers.test.sourceEventId")}</Label>
+                <Input
+                  id="trigger-source-event"
+                  value={sourceEventId}
+                  onChange={(event) => setSourceEventId(event.target.value)}
+                  placeholder={t("triggers.test.sourceEventPlaceholder")}
+                />
+              </div>
+            </div>
+          </section>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={closeDialog}>
+      <DialogContent
+        aria-describedby="agent-triggers-dialog-description"
+        className="flex max-h-[88vh] w-[calc(100vw-2rem)] max-w-none flex-col overflow-hidden p-0 sm:max-w-[680px]"
+      >
+        <DialogHeader className="border-b px-5 py-4 pr-12">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Zap className="h-4 w-4 text-primary" />
+            {t("triggers.title")}
+          </DialogTitle>
+          <DialogDescription id="agent-triggers-dialog-description">
+            {agentName ? `${agentName} · ${t("triggers.subtitle")}` : t("triggers.subtitle")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-5">
+          {activeType ? renderDetail() : renderOverview()}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -49,9 +49,10 @@ interface DeployAgentDialogProps {
   // Opens the shared API-key dialog (a single instance lives in the parent),
   // so this dialog never nests its own Radix Dialog.
   onManageApiKey?: () => void
+  onManageTriggers?: () => void
 }
 
-export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiKey }: DeployAgentDialogProps) {
+export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiKey, onManageTriggers }: DeployAgentDialogProps) {
   const { t } = useI18n()
   const [activeView, setActiveView] = useState<"options" | "embed" | "api" | "share">("options")
   const [apiTab, setApiTab] = useState<ApiSnippetTab>("curl")
@@ -352,7 +353,8 @@ with AgentClient(api_key="YOUR_API_KEY", base_url="${apiBase}") as agent:
       desc: t("deploy_agent.options.webhook.desc") || "Trigger agent runs via webhook events from external systems",
       actionText: t("deploy_agent.options.webhook.action") || "Configure",
       actionColor: "text-emerald-600",
-      className: "opacity-50 cursor-not-allowed shadow-sm",
+      className: "cursor-pointer hover:border-primary transition-colors shadow-sm",
+      onClick: onManageTriggers,
     },
   ]
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2059,6 +2059,7 @@ Build when you need.`,
         delete: "Delete",
         edit: "Edit",
         apiKey: "API Key",
+        triggers: "Triggers",
         deleteConfirm: "Are you sure you want to delete this agent?",
       },
       createModal: {
@@ -3091,6 +3092,129 @@ Build when you need.`,
       revoke_failed: "Failed to revoke API key",
       copied: "Copied to clipboard",
       copy_failed: "Failed to copy to clipboard"
+    }
+  },
+  triggers: {
+    title: "Triggers",
+    subtitle: "Choose how this agent gets activated",
+    defaults: {
+      webhookName: "API / Webhook",
+      scheduledName: "Schedule"
+    },
+    overview: {
+      info: "Triggers define when this agent runs. Enable one or more ways to automatically activate the agent in response to external events or schedules."
+    },
+    cards: {
+      webhook: {
+        title: "API / Webhook",
+        description: "Trigger via REST API call or incoming webhook"
+      },
+      scheduled: {
+        title: "Schedule",
+        description: "Run the agent automatically on a recurring interval"
+      },
+      activeCount: "{count} Active"
+    },
+    builder: {
+      title: "Triggers",
+      description: "Choose automatic entry points for this agent.",
+      saveFirst: "Save the agent before configuring triggers.",
+      tooltip: "Triggers automatically start this agent when an external event or schedule fires.",
+      open: "Triggers",
+      configure: "Configure trigger"
+    },
+    type: {
+      webhook: "Webhook",
+      scheduled: "Scheduled"
+    },
+    status: {
+      enabled: "Enabled",
+      disabled: "Disabled"
+    },
+    runStatus: {
+      pending: "Pending",
+      running: "Running",
+      completed: "Completed",
+      failed: "Failed"
+    },
+    list: {
+      title: "Triggers",
+      empty: "No triggers yet"
+    },
+    form: {
+      createTitle: "New trigger",
+      createSubtitle: "Create a webhook or scheduled trigger for this agent.",
+      editTitle: "Trigger settings",
+      editSubtitle: "Update the trigger definition and execution prompt.",
+      name: "Name",
+      namePlaceholder: "Daily report, CRM webhook...",
+      type: "Type",
+      intervalSeconds: "Repeat every seconds",
+      nextRunAt: "First run at",
+      secret: "Webhook secret",
+      secretPlaceholder: "Leave blank to generate one",
+      secretEditPlaceholder: "Leave blank to keep the current secret",
+      promptTemplate: "Prompt template",
+      promptPlaceholder: "Use {{payload}}, {{trigger_type}}, {{source_event_id}}, and {{test}}."
+    },
+    actions: {
+      new: "New",
+      create: "Create trigger",
+      enable: "Enable trigger",
+      save: "Save changes",
+      delete: "Delete",
+      confirmDelete: "Confirm delete",
+      rotateSecret: "Rotate secret",
+      test: "Test trigger",
+      addAnother: "Add"
+    },
+    secret: {
+      title: "Copy this secret now. It is shown only once."
+    },
+    webhook: {
+      title: "Webhook endpoint",
+      secretHeader: "Send the secret with the x-xagent-trigger-secret header."
+    },
+    test: {
+      title: "Test run",
+      subtitle: "Start a trigger run with a sample payload.",
+      sourceEventId: "Source event ID",
+      sourceEventPlaceholder: "optional-event-id"
+    },
+    runs: {
+      title: "Recent runs",
+      nextRun: "Next run",
+      noNextRun: "No next run scheduled",
+      status: "Status",
+      source: "Source",
+      task: "Task",
+      created: "Created",
+      empty: "No runs yet"
+    },
+    validation: {
+      name: "Trigger name is required",
+      nameLength: "Trigger name must be at most 200 characters",
+      interval: "Interval must be a positive integer",
+      nextRunAt: "First run time is invalid",
+      scheduleRequired: "Scheduled triggers need an interval or a first run time",
+      testPayload: "Test payload must be a JSON object"
+    },
+    messages: {
+      loadFailed: "Failed to load triggers",
+      runsLoadFailed: "Failed to load trigger runs",
+      created: "Trigger created",
+      updated: "Trigger updated",
+      enabled: "Trigger enabled",
+      disabled: "Trigger disabled",
+      deleted: "Trigger deleted",
+      saveFailed: "Failed to save trigger",
+      deleteFailed: "Failed to delete trigger",
+      secretRotated: "Webhook secret rotated",
+      secretRotateFailed: "Failed to rotate webhook secret",
+      testStarted: "Test trigger started",
+      testDuplicate: "Duplicate trigger run reused",
+      testFailed: "Failed to test trigger",
+      copyFailed: "Failed to copy to clipboard"
     }
   },
   workforces: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2059,6 +2059,7 @@ Build when you need.`,
         delete: "删除",
         edit: "编辑",
         apiKey: "API Key",
+        triggers: "Triggers",
         deleteConfirm: "确定要删除这个 Agent 吗？",
       },
       createModal: {
@@ -3091,6 +3092,129 @@ Build when you need.`,
       revoke_failed: "撤销 API Key 失败",
       copied: "已复制到剪贴板",
       copy_failed: "复制到剪贴板失败"
+    }
+  },
+  triggers: {
+    title: "Triggers",
+    subtitle: "选择此 Agent 的触发方式",
+    defaults: {
+      webhookName: "API / Webhook",
+      scheduledName: "Schedule"
+    },
+    overview: {
+      info: "Triggers 定义此 Agent 什么时候运行。启用一个或多个触发方式，让外部事件或定时计划自动启动 Agent。"
+    },
+    cards: {
+      webhook: {
+        title: "API / Webhook",
+        description: "通过 REST API 调用或 incoming webhook 触发"
+      },
+      scheduled: {
+        title: "Schedule",
+        description: "按固定时间间隔自动运行 Agent"
+      },
+      activeCount: "{count} Active"
+    },
+    builder: {
+      title: "Triggers",
+      description: "选择此 Agent 的自动触发入口。",
+      saveFirst: "保存 Agent 后即可配置 Triggers。",
+      tooltip: "Triggers 会在外部事件或定时计划发生时自动启动此 Agent。",
+      open: "Triggers",
+      configure: "配置 Trigger"
+    },
+    type: {
+      webhook: "Webhook",
+      scheduled: "定时"
+    },
+    status: {
+      enabled: "已启用",
+      disabled: "已停用"
+    },
+    runStatus: {
+      pending: "等待中",
+      running: "运行中",
+      completed: "已完成",
+      failed: "失败"
+    },
+    list: {
+      title: "Triggers",
+      empty: "还没有 Trigger"
+    },
+    form: {
+      createTitle: "新建 Trigger",
+      createSubtitle: "为此 Agent 创建 webhook 或定时触发入口。",
+      editTitle: "Trigger 设置",
+      editSubtitle: "更新触发定义和执行提示词。",
+      name: "名称",
+      namePlaceholder: "日报、CRM webhook...",
+      type: "类型",
+      intervalSeconds: "每多少秒重复",
+      nextRunAt: "首次运行时间",
+      secret: "Webhook Secret",
+      secretPlaceholder: "留空则自动生成",
+      secretEditPlaceholder: "留空则保留当前 secret",
+      promptTemplate: "提示词模板",
+      promptPlaceholder: "可使用 {{payload}}、{{trigger_type}}、{{source_event_id}} 和 {{test}}。"
+    },
+    actions: {
+      new: "新建",
+      create: "创建 Trigger",
+      enable: "启用 Trigger",
+      save: "保存修改",
+      delete: "删除",
+      confirmDelete: "确认删除",
+      rotateSecret: "轮换 secret",
+      test: "测试触发",
+      addAnother: "新增"
+    },
+    secret: {
+      title: "请立即复制此 secret，它只显示一次。"
+    },
+    webhook: {
+      title: "Webhook 地址",
+      secretHeader: "调用时通过 x-xagent-trigger-secret header 传入 secret。"
+    },
+    test: {
+      title: "测试运行",
+      subtitle: "使用示例 payload 启动一次 trigger run。",
+      sourceEventId: "Source event ID",
+      sourceEventPlaceholder: "可选事件 ID"
+    },
+    runs: {
+      title: "最近运行",
+      nextRun: "下次运行",
+      noNextRun: "暂无下次运行计划",
+      status: "状态",
+      source: "来源",
+      task: "任务",
+      created: "创建时间",
+      empty: "还没有运行记录"
+    },
+    validation: {
+      name: "Trigger 名称不能为空",
+      nameLength: "Trigger 名称最多 200 个字符",
+      interval: "重复间隔必须是正整数",
+      nextRunAt: "首次运行时间无效",
+      scheduleRequired: "定时 Trigger 需要重复间隔或首次运行时间",
+      testPayload: "测试 payload 必须是 JSON object"
+    },
+    messages: {
+      loadFailed: "加载 Triggers 失败",
+      runsLoadFailed: "加载 Trigger 运行记录失败",
+      created: "Trigger 已创建",
+      updated: "Trigger 已更新",
+      enabled: "Trigger 已启用",
+      disabled: "Trigger 已停用",
+      deleted: "Trigger 已删除",
+      saveFailed: "保存 Trigger 失败",
+      deleteFailed: "删除 Trigger 失败",
+      secretRotated: "Webhook secret 已轮换",
+      secretRotateFailed: "轮换 webhook secret 失败",
+      testStarted: "测试触发已启动",
+      testDuplicate: "复用了重复的 trigger run",
+      testFailed: "测试 Trigger 失败",
+      copyFailed: "复制到剪贴板失败"
     }
   },
   workforces: {

--- a/frontend/src/lib/agent-triggers-api.test.ts
+++ b/frontend/src/lib/agent-triggers-api.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: apiRequestMock,
+}))
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: () => "http://api.local",
+}))
+
+import {
+  createAgentTrigger,
+  listAgentTriggerRuns,
+  updateAgentTrigger,
+} from "./agent-triggers-api"
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("agent trigger API client", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+  })
+
+  it("creates webhook triggers with the expected endpoint and payload", async () => {
+    apiRequestMock.mockResolvedValue(
+      jsonResponse({
+        id: 7,
+        user_id: 1,
+        agent_id: 42,
+        type: "webhook",
+        name: "CRM webhook",
+        enabled: true,
+        config: {},
+        prompt_template: "Handle {{payload}}",
+        webhook_token: "token-123",
+        webhook_secret: "secret-123",
+        next_run_at: null,
+        last_run_at: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+      }),
+    )
+
+    const result = await createAgentTrigger(42, {
+      type: "webhook",
+      name: "CRM webhook",
+      enabled: true,
+      config: {},
+      prompt_template: "Handle {{payload}}",
+      secret: null,
+    })
+
+    expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/agents/42/triggers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "webhook",
+        name: "CRM webhook",
+        enabled: true,
+        config: {},
+        prompt_template: "Handle {{payload}}",
+        secret: null,
+      }),
+    })
+    expect(result.webhook_secret).toBe("secret-123")
+  })
+
+  it("updates triggers with PATCH and surfaces backend validation details", async () => {
+    apiRequestMock.mockResolvedValue(
+      jsonResponse({ detail: "Trigger name must not be empty" }, { status: 400 }),
+    )
+
+    await expect(updateAgentTrigger(42, 7, { name: "   " })).rejects.toThrow(
+      "Trigger name must not be empty",
+    )
+
+    expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/agents/42/triggers/7", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "   " }),
+    })
+  })
+
+  it("loads trigger runs from the agent-scoped route", async () => {
+    apiRequestMock.mockResolvedValue(
+      jsonResponse([
+        {
+          id: 12,
+          trigger_id: 7,
+          task_id: 99,
+          background_job_id: null,
+          status: "completed",
+          source_event_id: "event-1",
+          payload_snapshot: {},
+          idempotency_key: "key",
+          error_message: null,
+          started_at: null,
+          finished_at: null,
+          created_at: null,
+          updated_at: null,
+        },
+      ]),
+    )
+
+    const runs = await listAgentTriggerRuns(42, 7)
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/agents/42/triggers/7/runs",
+    )
+    expect(runs).toHaveLength(1)
+    expect(runs[0].task_id).toBe(99)
+  })
+})

--- a/frontend/src/lib/agent-triggers-api.ts
+++ b/frontend/src/lib/agent-triggers-api.ts
@@ -1,0 +1,181 @@
+"use client"
+
+import { apiRequest } from "@/lib/api-wrapper"
+import { getApiUrl } from "@/lib/utils"
+
+export type AgentTriggerType = "webhook" | "scheduled"
+export type AgentTriggerRunStatus = "pending" | "running" | "completed" | "failed"
+
+export interface AgentTrigger {
+  id: number
+  user_id: number
+  agent_id: number
+  type: AgentTriggerType
+  name: string
+  enabled: boolean
+  config: Record<string, unknown>
+  prompt_template: string | null
+  webhook_token: string | null
+  webhook_secret?: string | null
+  next_run_at: string | null
+  last_run_at: string | null
+  last_error: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface AgentTriggerRun {
+  id: number
+  trigger_id: number
+  task_id: number | null
+  background_job_id: string | null
+  status: AgentTriggerRunStatus
+  source_event_id: string | null
+  payload_snapshot: Record<string, unknown> | null
+  idempotency_key: string
+  error_message: string | null
+  started_at: string | null
+  finished_at: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface AgentTriggerPayload {
+  type?: AgentTriggerType
+  name?: string | null
+  enabled?: boolean
+  config?: Record<string, unknown>
+  prompt_template?: string | null
+  secret?: string | null
+  rotate_secret?: boolean
+}
+
+export interface AgentTriggerTestPayload {
+  payload: Record<string, unknown>
+  source_event_id?: string | null
+}
+
+export interface AgentTriggerTestResponse {
+  trigger_run: AgentTriggerRun
+  duplicate: boolean
+}
+
+function jsonHeaders(): HeadersInit {
+  return {
+    "Content-Type": "application/json",
+  }
+}
+
+function triggerUrl(agentId: number | string, triggerId?: number | string): string {
+  const base = `${getApiUrl()}/api/agents/${agentId}/triggers`
+  return triggerId === undefined ? base : `${base}/${triggerId}`
+}
+
+function formatApiDetail(detail: unknown, fallback: string): string {
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => {
+        if (item && typeof item === "object" && "msg" in item) {
+          return String(item.msg)
+        }
+        return null
+      })
+      .filter(Boolean)
+    if (messages.length > 0) {
+      return messages.join("; ")
+    }
+  }
+  return fallback
+}
+
+async function parseApiError(response: Response, fallback: string): Promise<Error> {
+  try {
+    const data = await response.json()
+    return new Error(formatApiDetail(data?.detail, fallback))
+  } catch {
+    return new Error(fallback)
+  }
+}
+
+export async function listAgentTriggers(
+  agentId: number | string,
+): Promise<AgentTrigger[]> {
+  const response = await apiRequest(triggerUrl(agentId))
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load triggers")
+  }
+  return response.json()
+}
+
+export async function createAgentTrigger(
+  agentId: number | string,
+  payload: AgentTriggerPayload & { type: AgentTriggerType },
+): Promise<AgentTrigger> {
+  const response = await apiRequest(triggerUrl(agentId), {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to create trigger")
+  }
+  return response.json()
+}
+
+export async function updateAgentTrigger(
+  agentId: number | string,
+  triggerId: number | string,
+  payload: AgentTriggerPayload,
+): Promise<AgentTrigger> {
+  const response = await apiRequest(triggerUrl(agentId, triggerId), {
+    method: "PATCH",
+    headers: jsonHeaders(),
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to update trigger")
+  }
+  return response.json()
+}
+
+export async function deleteAgentTrigger(
+  agentId: number | string,
+  triggerId: number | string,
+): Promise<void> {
+  const response = await apiRequest(triggerUrl(agentId, triggerId), {
+    method: "DELETE",
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to delete trigger")
+  }
+}
+
+export async function listAgentTriggerRuns(
+  agentId: number | string,
+  triggerId: number | string,
+): Promise<AgentTriggerRun[]> {
+  const response = await apiRequest(`${triggerUrl(agentId, triggerId)}/runs`)
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to load trigger runs")
+  }
+  return response.json()
+}
+
+export async function testAgentTrigger(
+  agentId: number | string,
+  triggerId: number | string,
+  payload: AgentTriggerTestPayload,
+): Promise<AgentTriggerTestResponse> {
+  const response = await apiRequest(`${triggerUrl(agentId, triggerId)}/test`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw await parseApiError(response, "Failed to test trigger")
+  }
+  return response.json()
+}


### PR DESCRIPTION
## Summary
- Add a trigger management dialog for API/Webhook and Schedule triggers
- Add trigger entry points in the agent builder, deploy dialog, and agent list actions
- Add a frontend trigger API client, focused unit tests, and EN/ZH copy

## Scope
- Frontend only. Backend trigger APIs are already available upstream.
- No admin management backend changes are included.

## Tests
- `npm run test:run -- agent-triggers-api.test.ts`
- `npm run type-check`
- `npm run lint`