### PR TITLE
ref(kb): H01 move document lifecycle into collection handle

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1623,6 +1623,105 @@ class DocumentListResult(BaseModel):
     )
 
 
+class DocumentRecordDetail(BaseModel):
+    """Semantic record for a single ``documents`` table row.
+
+    This is the handle-owned, lean document-row type introduced in #508. It
+    mirrors the full ``documents`` table schema (see LanceDB schema_manager) so
+    it can be mapped losslessly back to the legacy ``list[dict]`` shape used by
+    the file-level ``get_document`` / ``list_documents`` helpers.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    collection: str = Field(..., description="Collection name for data isolation")
+    doc_id: str = Field(..., description="Document identifier inside the collection")
+    file_id: Optional[str] = Field(
+        None, description="UploadedFile file_id for stable file association"
+    )
+    source_path: Optional[str] = Field(
+        None, description="Stored (metadata) source path for the document"
+    )
+    file_type: Optional[str] = Field(None, description="Detected document file type")
+    content_hash: Optional[str] = Field(
+        None, description="SHA256 hash of the document content"
+    )
+    uploaded_at: Optional[datetime] = Field(None, description="Upload timestamp")
+    title: Optional[str] = Field(None, description="Optional document title")
+    language: Optional[str] = Field(None, description="Optional document language")
+    user_id: Optional[int] = Field(
+        None, description="Owner user id for multi-tenancy (None for legacy data)"
+    )
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "DocumentRecordDetail":
+        """Build a record from a raw ``documents`` table row dict.
+
+        Pandas null sentinels (``None``, ``NaN``, ``NaT``) are normalized to
+        ``None``; ``user_id`` is coerced to a plain Python ``int``.
+        """
+
+        def clean(value: Any) -> Any:
+            if value is None:
+                return None
+            try:
+                # NaN / NaT are never equal to themselves.
+                if value != value:  # noqa: PLR0124
+                    return None
+            except Exception:  # noqa: BLE001 - non-comparable values are kept
+                pass
+            return value
+
+        user_id = clean(row.get("user_id"))
+        return cls(
+            collection=clean(row.get("collection")),
+            doc_id=clean(row.get("doc_id")),
+            file_id=clean(row.get("file_id")),
+            source_path=clean(row.get("source_path")),
+            file_type=clean(row.get("file_type")),
+            content_hash=clean(row.get("content_hash")),
+            uploaded_at=clean(row.get("uploaded_at")),
+            title=clean(row.get("title")),
+            language=clean(row.get("language")),
+            user_id=int(user_id) if user_id is not None else None,
+        )
+
+    def to_legacy_dict(self) -> Dict[str, Any]:
+        """Return the legacy raw-row dict shape (all ``documents`` columns)."""
+        return {
+            "collection": self.collection,
+            "doc_id": self.doc_id,
+            "file_id": self.file_id,
+            "source_path": self.source_path,
+            "file_type": self.file_type,
+            "content_hash": self.content_hash,
+            "uploaded_at": self.uploaded_at,
+            "title": self.title,
+            "language": self.language,
+            "user_id": self.user_id,
+        }
+
+
+class DocumentRecordListResult(BaseModel):
+    """Lean result for handle-level document-row listings (#508).
+
+    Distinct from :class:`DocumentListResult` (which aggregates parse/chunk/
+    embedding/status counts); this carries only ``documents`` rows and maps
+    back to the legacy ``list[dict]`` shape.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    documents: List[DocumentRecordDetail] = Field(
+        default_factory=list, description="Document rows for the collection"
+    )
+    total_count: int = Field(..., ge=0, description="Number of document rows returned")
+
+    def to_legacy_dicts(self) -> List[Dict[str, Any]]:
+        """Return the legacy ``list[dict]`` shape for all rows."""
+        return [record.to_legacy_dict() for record in self.documents]
+
+
 class DocumentOperationResult(BaseModel):
     """Standard response for document management operations."""
 

--- a/src/xagent/core/tools/core/RAG_tools/file/register_document.py
+++ b/src/xagent/core/tools/core/RAG_tools/file/register_document.py
@@ -1,42 +1,19 @@
-"""Document registration functionality for RAG tools.
+"""Public document-row helpers (compatibility wrappers).
 
-This module provides the core functionality for registering uploaded documents
-into the LanceDB system. It handles document metadata extraction, validation,
-and database insertion with proper error handling and idempotency.
-
-The register_document function serves as the main entry point for document
-registration in the RAG pipeline.
+These module-level functions preserve the historical import paths and call
+signatures for document registration, loading, and listing. They delegate to
+the coordinator-owned ``KBLegacyStepCompatibilityFacade``, which converts legacy
+inputs into semantic requests and routes document-row lifecycle operations
+through ``KBCoordinator`` and ``KBCollectionHandle`` (#508).
 """
 
 import logging
-import uuid
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
-
-import pandas as pd
-
-from ..core.exceptions import (
-    ConfigurationError,
-    DatabaseOperationError,
-    DocumentValidationError,
-    HashComputationError,
-)
-from ..core.schemas import RegisterDocumentRequest, RegisterDocumentResponse
-from ..storage.factory import get_vector_index_store
-from ..utils import check_file_type, compute_file_hash
-from ..utils.string_utils import (
-    generate_deterministic_doc_id,
-)
 
 if TYPE_CHECKING:
     from ..kb import KBLegacyStepCompatibilityFacade
 
 logger = logging.getLogger(__name__)
-
-
-# Public entry with explicit arguments (for LG/CLI/FastAPI). Returns plain dict.
-# Internally constructs Pydantic request and delegates to _register_document.
 
 
 def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
@@ -56,7 +33,23 @@ def register_document(
     file_id: Optional[str] = None,
     metadata_source_path: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Register a document into the LanceDB system."""
+    """Register a document into the LanceDB system.
+
+    Args:
+        collection: LanceDB collection name (data isolation)
+        source_path: Absolute path to the uploaded file
+        file_type: Optional file type; auto-detected from extension if not provided
+        doc_id: Optional document ID; deterministic/UUID generated if not provided
+        uploaded_at: Optional ISO8601 timestamp string (supports trailing 'Z');
+            defaults to now if not provided or parse fails
+        user_id: Optional user ID for multi-tenancy ownership
+        file_id: Optional UploadedFile file_id for stable file association
+        metadata_source_path: Optional canonical source path to store in metadata
+            when the file is read from a temporary immutable path
+
+    Returns:
+        A plain dict with ``doc_id``, ``created``, and ``content_hash``.
+    """
     return _get_legacy_step_compatibility_facade().register_document(
         collection=collection,
         source_path=source_path,
@@ -69,275 +62,23 @@ def register_document(
     )
 
 
-def _register_document_public_impl(
-    collection: str,
-    source_path: str,
-    file_type: Optional[str] = None,
-    doc_id: Optional[str] = None,
-    uploaded_at: Optional[str] = None,
-    user_id: Optional[int] = None,
-    file_id: Optional[str] = None,
-    metadata_source_path: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Register a document into the LanceDB system.
-
-    Args:
-        collection: LanceDB collection name (data isolation)
-        source_path: Absolute path to the uploaded file
-        file_type: Optional file type; auto-detected from extension if not provided
-        doc_id: Optional document ID; UUIDv4 generated if not provided
-        uploaded_at: Optional ISO8601 timestamp string (supports trailing 'Z');
-            defaults to now if not provided or parse fails
-        user_id: Optional user ID for multi-tenancy ownership
-        file_id: Optional UploadedFile file_id for stable file association
-        metadata_source_path: Optional canonical source path to store in metadata
-            when the file is read from a temporary immutable path
-
-    Returns:
-        A plain dict converted from RegisterDocumentResponse
-    """
-    uploaded_at_dt: Optional[datetime] = None
-    if uploaded_at:
-        try:
-            if uploaded_at.endswith("Z"):
-                uploaded_at_dt = datetime.fromisoformat(
-                    uploaded_at.replace("Z", "+00:00")
-                )
-            else:
-                uploaded_at_dt = datetime.fromisoformat(uploaded_at)
-            if uploaded_at_dt.tzinfo is None:
-                uploaded_at_dt = uploaded_at_dt.replace(tzinfo=timezone.utc)
-        except ValueError:
-            uploaded_at_dt = None
-
-    request = RegisterDocumentRequest(
-        collection=collection,
-        file_id=file_id,
-        source_path=source_path,
-        metadata_source_path=metadata_source_path,
-        file_type=file_type,
-        doc_id=doc_id,
-        uploaded_at=uploaded_at_dt,
-        user_id=user_id,
-    )
-    response = _register_document(request)
-    result: Dict[str, Any] = response.model_dump()
-    return result
-
-
-# Private entry that accepts the Pydantic model and returns the Pydantic response.
-def _register_document(request: RegisterDocumentRequest) -> RegisterDocumentResponse:
-    """Register a document into the LanceDB system using a typed request object.
-
-    This function takes an uploaded document and registers it into the specified
-    LanceDB collection. It performs validation, computes content hash, and
-    ensures idempotent registration based on document ID.
-
-    Returns:
-        RegisterDocumentResponse containing the document ID, creation status,
-        and content hash.
-
-
-    Raises:
-        DocumentValidationError: If the document path is invalid or file is corrupted.
-        HashComputationError: If content hash computation fails.
-        DocumentRegistrationError: If database operation fails.
-        DatabaseOperationError: If LanceDB connection or table operations fail.
-    """
-    collection = request.collection
-    file_id = request.file_id
-    source_path = request.source_path
-    metadata_source_path = request.metadata_source_path or source_path
-    file_type = request.file_type
-    doc_id = request.doc_id
-    uploaded_at = request.uploaded_at
-
-    # Input validation
-    if not collection:
-        raise DocumentValidationError("Collection name cannot be empty")
-
-    if not source_path or not Path(source_path).exists():
-        raise DocumentValidationError(f"Source path does not exist: {source_path}")
-
-    # Auto-detect file type if not provided
-    if not file_type:
-        try:
-            file_type = check_file_type(source_path)
-        except DocumentValidationError as e:
-            raise DocumentValidationError(f"File type detection failed: {e}") from e
-
-    # Generate document ID if not provided
-    # Use deterministic ID from (collection, file_id/source_path) for idempotent registration:
-    # same file re-upload or double-submit updates one record instead of creating two
-    if not doc_id:
-        try:
-            stable_key = file_id or metadata_source_path
-            doc_id = generate_deterministic_doc_id(collection, stable_key)
-        except Exception as e:
-            # Fallback to UUID if deterministic generation fails
-            logger.debug(
-                "Deterministic doc_id generation failed (%s), falling back to UUID", e
-            )
-            doc_id = str(uuid.uuid4())
-
-    # Set upload timestamp
-    if not uploaded_at:
-        uploaded_at = pd.Timestamp.now(tz="UTC")
-    else:
-        if uploaded_at.tzinfo is None:
-            uploaded_at = uploaded_at.replace(tzinfo=timezone.utc)
-
-    # Compute content hash using utility function
-    try:
-        content_hash = compute_file_hash(source_path)
-    except Exception as e:
-        raise HashComputationError(f"Failed to compute content hash: {e}") from e
-
-    # LanceDB operations using abstraction layer
-    try:
-        vector_store = get_vector_index_store()
-
-        # Check if document already exists (for idempotency) using count_rows
-        query_filters = {
-            "collection": collection,
-            "doc_id": doc_id,
-        }
-        # For existence check, use admin mode to see all records including legacy data
-        # count_rows_or_zero returns 0 if table doesn't exist
-        exists = (
-            vector_store.count_rows_or_zero(
-                "documents",
-                filters=query_filters,
-                user_id=request.user_id,
-                is_admin=True,
-            )
-            > 0
-        )
-
-        # Prepare document record
-        doc_record = {
-            "collection": collection,
-            "doc_id": doc_id,
-            "file_id": file_id,
-            "source_path": metadata_source_path,
-            "file_type": file_type,
-            "content_hash": content_hash,
-            # Store timestamp object directly, let Arrow handle precision conversion
-            "uploaded_at": uploaded_at,
-            "title": None,  # Optional field, can be filled later
-            "language": None,  # Optional field, can be filled later
-            "user_id": request.user_id,  # Add user_id for multi-tenancy
-        }
-
-        # Use abstraction layer for upsert
-        vector_store.upsert_documents([doc_record])
-
-        created = not exists
-
-    except ConfigurationError:
-        raise
-    except Exception as e:
-        raise DatabaseOperationError(
-            f"Failed to register document in database: {e}"
-        ) from e
-
-    return RegisterDocumentResponse(
-        doc_id=doc_id,
-        created=created,
-        content_hash=content_hash,
-    )
-
-
 def get_document(db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
-    """Retrieve a document record from LanceDB using abstraction layer."""
+    """Retrieve a document record from LanceDB (legacy raw-dict shape or None).
+
+    ``db_dir`` is accepted for backward compatibility and ignored.
+    """
     return _get_legacy_step_compatibility_facade().get_document(
         db_dir, collection, doc_id
     )
 
 
-def _get_document_impl(db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
-    """Retrieve a document record from LanceDB using abstraction layer.
-
-
-    Args:
-        db_dir: LanceDB directory path (unused, kept for compatibility)
-        collection: Collection name to filter by (only returns documents from this collection)
-        doc_id: Document ID to retrieve
-
-    Returns:
-        Document record dict if found, None otherwise
-
-    Raises:
-        DatabaseOperationError: If database operation fails
-    """
-    try:
-        vector_store = get_vector_index_store()
-
-        # Check if document exists
-        query_filters = {"collection": collection, "doc_id": doc_id}
-        if vector_store.count_rows_or_zero("documents", filters=query_filters) == 0:
-            return None
-
-        # Use iter_batches to load the document
-        for batch in vector_store.iter_batches(
-            table_name="documents",
-            filters=query_filters,
-        ):
-            batch_df = batch.to_pandas()
-            for _, row in batch_df.iterrows():
-                return row.to_dict()
-
-        return None
-
-    except Exception as e:
-        raise DatabaseOperationError(f"Failed to retrieve document: {e}") from e
-
-
 def list_documents(
     db_dir: str, collection: str, limit: int = 100
 ) -> list[Dict[str, Any]]:
-    """List documents in the collection using abstraction layer."""
+    """List documents in the collection (legacy raw-dict list).
+
+    ``db_dir`` is accepted for backward compatibility and ignored.
+    """
     return _get_legacy_step_compatibility_facade().list_documents(
         db_dir, collection, limit
     )
-
-
-def _list_documents_impl(
-    db_dir: str, collection: str, limit: int = 100
-) -> list[Dict[str, Any]]:
-    """List documents in the collection using abstraction layer.
-
-    Args:
-        db_dir: LanceDB directory path (unused, kept for compatibility)
-        collection: Collection name to filter by (only documents in this KB are returned)
-        limit: Maximum number of documents to return
-
-    Returns:
-        List of document records for the given collection
-
-    Raises:
-        DatabaseOperationError: If database operation fails
-    """
-    try:
-        vector_store = get_vector_index_store()
-        query_filters = {"collection": collection}
-
-        results = []
-        for batch in vector_store.iter_batches(
-            table_name="documents",
-            filters=query_filters,
-            user_id=None,
-            is_admin=True,  # Use admin mode to see all documents including legacy data
-        ):
-            batch_df = batch.to_pandas()
-            for _, row in batch_df.iterrows():
-                results.append(row.to_dict())
-                if len(results) >= limit:
-                    break
-            if len(results) >= limit:
-                break
-
-        return results
-
-    except Exception as e:
-        raise DatabaseOperationError(f"Failed to list documents: {e}") from e

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -276,9 +276,11 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 user_id=user_id,
                 is_admin=is_admin,
             ):
-                batch_df = batch.to_pandas()
-                for _, row in batch_df.iterrows():
-                    return DocumentRecordDetail.from_row(row.to_dict())
+                # to_pylist() converts the Arrow batch directly to native Python
+                # objects in C++, avoiding Pandas' int->float upcasting on null
+                # columns (the reason from_row still normalizes defensively).
+                for row_dict in batch.to_pylist():
+                    return DocumentRecordDetail.from_row(row_dict)
             return None
         except Exception as e:
             raise DatabaseOperationError(f"Failed to retrieve document: {e}") from e
@@ -301,9 +303,10 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 user_id=user_id,
                 is_admin=is_admin,
             ):
-                batch_df = batch.to_pandas()
-                for _, row in batch_df.iterrows():
-                    records.append(DocumentRecordDetail.from_row(row.to_dict()))
+                # to_pylist() bypasses Pandas (see load_document) when materializing
+                # rows; from_row still normalizes any residual null sentinels.
+                for row_dict in batch.to_pylist():
+                    records.append(DocumentRecordDetail.from_row(row_dict))
                     if len(records) >= limit:
                         break
                 if len(records) >= limit:

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -92,6 +92,16 @@ class KBCollectionHandle(ABC):
     ) -> DocumentRecordListResult:
         """List document rows for this collection as a semantic result."""
 
+    @abstractmethod
+    def delete_document_record(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Delete only this document's row (no cascade).
+
+        Idempotent; returns the number of rows deleted. Parse/chunk/embedding
+        cleanup is intentionally out of scope here.
+        """
+
 
 @dataclass(frozen=True)
 class LanceDBCollectionHandle(KBCollectionHandle):
@@ -283,3 +293,14 @@ class LanceDBCollectionHandle(KBCollectionHandle):
         except Exception as e:
             raise DatabaseOperationError(f"Failed to list documents: {e}") from e
         return DocumentRecordListResult(documents=records, total_count=len(records))
+
+    def delete_document_record(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Delete only this document's row via the bound store (no cascade)."""
+        return self.vector_index_store.delete_document_record(
+            collection_name=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -102,6 +102,24 @@ class KBCollectionHandle(ABC):
         cleanup is intentionally out of scope here.
         """
 
+    # --- Rollback compensation (document plane only) ---
+
+    @abstractmethod
+    def snapshot_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Capture the current document row for later restore (None if absent)."""
+
+    @abstractmethod
+    def restore_document(self, snapshot: DocumentRecordDetail) -> None:
+        """Restore a previously snapshotted document row, preserving all fields."""
+
+    @abstractmethod
+    def delete_created_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Idempotently delete a newly created document row (compensation)."""
+
 
 @dataclass(frozen=True)
 class LanceDBCollectionHandle(KBCollectionHandle):
@@ -304,3 +322,29 @@ class LanceDBCollectionHandle(KBCollectionHandle):
             user_id=user_id,
             is_admin=is_admin,
         )
+
+    def snapshot_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Capture the current document row before a destructive operation.
+
+        Returns ``None`` when there is no existing row to snapshot. Note that
+        these compensation methods are added for #514 to wire into the live
+        rollback path; #508 only provides the mechanics.
+        """
+        return self.load_document(doc_id, user_id=user_id, is_admin=is_admin)
+
+    def restore_document(self, snapshot: DocumentRecordDetail) -> None:
+        """Restore a snapshotted document row, preserving every field.
+
+        Re-upserts the full row (keyed by collection + doc_id), so ``file_id``,
+        ``user_id``, collection, metadata, content hash, and file type are all
+        restored exactly.
+        """
+        self.vector_index_store.upsert_documents([snapshot.to_legacy_dict()])
+
+    def delete_created_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Idempotently delete a newly created document row (row-only)."""
+        return self.delete_document_record(doc_id, user_id=user_id, is_admin=is_admin)

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -1,11 +1,36 @@
-"""Collection-scoped KB backend handle skeletons."""
+"""Collection-scoped KB backend handle.
+
+``KBCollectionHandle`` is the collection-scoped backend boundary that owns
+backend-specific data-plane mechanics (starting with the document-row
+lifecycle in #508). ``LanceDBCollectionHandle`` is the first implementation and
+delegates to the current LanceDB documents-table mechanics via the bound
+vector index store.
+"""
 
 from __future__ import annotations
 
+import logging
+import uuid
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import timezone
+from pathlib import Path
 
+import pandas as pd
+
+from ..core.exceptions import (
+    ConfigurationError,
+    DatabaseOperationError,
+    DocumentValidationError,
+    HashComputationError,
+)
+from ..core.schemas import RegisterDocumentRequest, RegisterDocumentResponse
 from ..storage.contracts import MetadataStore, VectorIndexStore
+from ..utils import check_file_type, compute_file_hash
+from ..utils.string_utils import generate_deterministic_doc_id
 from .models import KBBackendCapabilities, KBCollectionContext, KBStorageBackend
+
+logger = logging.getLogger(__name__)
 
 
 class KBHandleProvider:
@@ -28,9 +53,33 @@ class KBHandleProvider:
         """
 
 
+class KBCollectionHandle(ABC):
+    """Collection-scoped backend handle for KB data-plane operations.
+
+    Phase 2 moves backend-specific, collection-local data-plane mechanics here.
+    The first family (#508) is the document-row lifecycle. The coordinator owns
+    context resolution, access policy, and orchestration; the handle owns the
+    backend mechanics for a single collection.
+    """
+
+    @abstractmethod
+    def register_document(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Idempotently register (upsert) a document row for this collection.
+
+        Preserves deterministic doc_id generation, content-hash calculation,
+        file-type detection, and the exact persisted field set.
+        """
+
+
 @dataclass(frozen=True)
-class LanceDBCollectionHandle:
-    """Thin LanceDB-backed collection handle for #495 compatibility wiring."""
+class LanceDBCollectionHandle(KBCollectionHandle):
+    """LanceDB-backed collection handle.
+
+    The initial delegate is the current LanceDB documents-table implementation,
+    reached through the bound vector index store.
+    """
 
     context: KBCollectionContext
 
@@ -53,3 +102,99 @@ class LanceDBCollectionHandle:
     def capabilities(self) -> KBBackendCapabilities:
         """Return backend capabilities for this collection."""
         return self.context.capabilities
+
+    def register_document(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Register a document row in this collection's documents table.
+
+        Behavior mirrors the legacy ``_register_document`` helper: input
+        validation, file-type detection, deterministic doc_id (with UUID
+        fallback), SHA256 content hash, an admin-scoped existence check for the
+        ``created`` flag, and an idempotent upsert of the full row.
+        """
+        collection = request.collection
+        file_id = request.file_id
+        source_path = request.source_path
+        metadata_source_path = request.metadata_source_path or source_path
+        file_type = request.file_type
+        doc_id = request.doc_id
+        uploaded_at = request.uploaded_at
+
+        if not collection:
+            raise DocumentValidationError("Collection name cannot be empty")
+
+        if not source_path or not Path(source_path).exists():
+            raise DocumentValidationError(f"Source path does not exist: {source_path}")
+
+        # Auto-detect file type if not provided.
+        if not file_type:
+            try:
+                file_type = check_file_type(source_path)
+            except DocumentValidationError as e:
+                raise DocumentValidationError(f"File type detection failed: {e}") from e
+
+        # Deterministic doc_id from (collection, file_id/source_path) for
+        # idempotent registration; fall back to a UUID if generation fails.
+        if not doc_id:
+            try:
+                stable_key = file_id or metadata_source_path
+                doc_id = generate_deterministic_doc_id(collection, stable_key)
+            except Exception as e:  # noqa: BLE001 - fallback keeps registration working
+                logger.debug(
+                    "Deterministic doc_id generation failed (%s), falling back to UUID",
+                    e,
+                )
+                doc_id = str(uuid.uuid4())
+
+        if not uploaded_at:
+            uploaded_at = pd.Timestamp.now(tz="UTC")
+        elif uploaded_at.tzinfo is None:
+            uploaded_at = uploaded_at.replace(tzinfo=timezone.utc)
+
+        try:
+            content_hash = compute_file_hash(source_path)
+        except Exception as e:
+            raise HashComputationError(f"Failed to compute content hash: {e}") from e
+
+        try:
+            vector_store = self.vector_index_store
+
+            # Existence check uses admin mode to see all records (incl. legacy).
+            exists = (
+                vector_store.count_rows_or_zero(
+                    "documents",
+                    filters={"collection": collection, "doc_id": doc_id},
+                    user_id=request.user_id,
+                    is_admin=True,
+                )
+                > 0
+            )
+
+            doc_record = {
+                "collection": collection,
+                "doc_id": doc_id,
+                "file_id": file_id,
+                "source_path": metadata_source_path,
+                "file_type": file_type,
+                "content_hash": content_hash,
+                "uploaded_at": uploaded_at,
+                "title": None,
+                "language": None,
+                "user_id": request.user_id,
+            }
+
+            vector_store.upsert_documents([doc_record])
+            created = not exists
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError(
+                f"Failed to register document in database: {e}"
+            ) from e
+
+        return RegisterDocumentResponse(
+            doc_id=doc_id,
+            created=created,
+            content_hash=content_hash,
+        )

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -161,7 +161,12 @@ class LanceDBCollectionHandle(KBCollectionHandle):
         fallback), SHA256 content hash, an admin-scoped existence check for the
         ``created`` flag, and an idempotent upsert of the full row.
         """
-        collection = request.collection
+        # The handle is collection-scoped: persist into the bound context
+        # collection rather than trusting request.collection, so a reused handle
+        # can never write outside its resolved collection. Through the
+        # coordinator the two already match (context.collection is the
+        # normalized form of request.collection).
+        collection = self.context.collection
         file_id = request.file_id
         source_path = request.source_path
         metadata_source_path = request.metadata_source_path or source_path
@@ -333,8 +338,14 @@ class LanceDBCollectionHandle(KBCollectionHandle):
 
         Re-upserts the full row (keyed by collection + doc_id), so ``file_id``,
         ``user_id``, collection, metadata, content hash, and file type are all
-        restored exactly.
+        restored exactly. Refuses snapshots from another collection so the
+        collection-scoped boundary holds even on direct handle reuse.
         """
+        if snapshot.collection != self.context.collection:
+            raise DocumentValidationError(
+                f"Handle bound to collection {self.context.collection!r} "
+                f"cannot restore a snapshot from {snapshot.collection!r}"
+            )
         self.vector_index_store.upsert_documents([snapshot.to_legacy_dict()])
 
     def delete_created_document(

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -24,7 +24,12 @@ from ..core.exceptions import (
     DocumentValidationError,
     HashComputationError,
 )
-from ..core.schemas import RegisterDocumentRequest, RegisterDocumentResponse
+from ..core.schemas import (
+    DocumentRecordDetail,
+    DocumentRecordListResult,
+    RegisterDocumentRequest,
+    RegisterDocumentResponse,
+)
 from ..storage.contracts import MetadataStore, VectorIndexStore
 from ..utils import check_file_type, compute_file_hash
 from ..utils.string_utils import generate_deterministic_doc_id
@@ -71,6 +76,21 @@ class KBCollectionHandle(ABC):
         Preserves deterministic doc_id generation, content-hash calculation,
         file-type detection, and the exact persisted field set.
         """
+
+    @abstractmethod
+    def load_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Load a single document row by id within the given scope.
+
+        Returns ``None`` when the row is absent or not visible to the scope.
+        """
+
+    @abstractmethod
+    def list_documents(
+        self, *, user_id: int | None = None, is_admin: bool = False, limit: int = 100
+    ) -> DocumentRecordListResult:
+        """List document rows for this collection as a semantic result."""
 
 
 @dataclass(frozen=True)
@@ -198,3 +218,68 @@ class LanceDBCollectionHandle(KBCollectionHandle):
             created=created,
             content_hash=content_hash,
         )
+
+    def load_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Load a document row by id within this collection's scope.
+
+        Mirrors the legacy ``_get_document_impl``: an existence check followed
+        by a single-row read. Returns ``None`` when the row is absent or not
+        visible to the given scope.
+        """
+        vector_store = self.vector_index_store
+        query_filters = {"collection": self.context.collection, "doc_id": doc_id}
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "documents",
+                    filters=query_filters,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                == 0
+            ):
+                return None
+
+            for batch in vector_store.iter_batches(
+                table_name="documents",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                batch_df = batch.to_pandas()
+                for _, row in batch_df.iterrows():
+                    return DocumentRecordDetail.from_row(row.to_dict())
+            return None
+        except Exception as e:
+            raise DatabaseOperationError(f"Failed to retrieve document: {e}") from e
+
+    def list_documents(
+        self, *, user_id: int | None = None, is_admin: bool = False, limit: int = 100
+    ) -> DocumentRecordListResult:
+        """List document rows for this collection.
+
+        Mirrors the legacy file-level ``_list_documents_impl``: a batch scan of
+        the documents table filtered by collection, honoring ``limit``.
+        """
+        vector_store = self.vector_index_store
+        query_filters = {"collection": self.context.collection}
+        records: list[DocumentRecordDetail] = []
+        try:
+            for batch in vector_store.iter_batches(
+                table_name="documents",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                batch_df = batch.to_pandas()
+                for _, row in batch_df.iterrows():
+                    records.append(DocumentRecordDetail.from_row(row.to_dict()))
+                    if len(records) >= limit:
+                        break
+                if len(records) >= limit:
+                    break
+        except Exception as e:
+            raise DatabaseOperationError(f"Failed to list documents: {e}") from e
+        return DocumentRecordListResult(documents=records, total_count=len(records))

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -252,24 +252,15 @@ class LanceDBCollectionHandle(KBCollectionHandle):
     ) -> DocumentRecordDetail | None:
         """Load a document row by id within this collection's scope.
 
-        Mirrors the legacy ``_get_document_impl``: an existence check followed
-        by a single-row read. Returns ``None`` when the row is absent or not
-        visible to the given scope.
+        Streams the single matching row via ``iter_batches``. Returns ``None``
+        when the row is absent or not visible to the given scope.
         """
         vector_store = self.vector_index_store
         query_filters = {"collection": self.context.collection, "doc_id": doc_id}
         try:
-            if (
-                vector_store.count_rows_or_zero(
-                    "documents",
-                    filters=query_filters,
-                    user_id=user_id,
-                    is_admin=is_admin,
-                )
-                == 0
-            ):
-                return None
-
+            # iter_batches yields only non-empty batches under the same scope
+            # filter, so an absent or out-of-scope row yields nothing and we fall
+            # through to None -- a separate existence count would be redundant.
             for batch in vector_store.iter_batches(
                 table_name="documents",
                 filters=query_filters,

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -296,7 +296,9 @@ class KBCoordinator:
                 hide_missing=True,
             )
         )
-        return handle.register_document(request)
+        # The handle call is synchronous and blocking (file hashing + LanceDB
+        # I/O); offload it so awaiting this method never stalls the event loop.
+        return await asyncio.to_thread(handle.register_document, request)
 
     def register_document_sync(
         self, request: RegisterDocumentRequest
@@ -321,7 +323,10 @@ class KBCoordinator:
                 hide_missing=True,
             )
         )
-        return handle.load_document(doc_id, user_id=user_id, is_admin=is_admin)
+        # Blocking LanceDB read; offload so awaiting this never stalls the loop.
+        return await asyncio.to_thread(
+            handle.load_document, doc_id, user_id=user_id, is_admin=is_admin
+        )
 
     def load_document_sync(
         self,
@@ -353,7 +358,10 @@ class KBCoordinator:
                 hide_missing=True,
             )
         )
-        return handle.list_documents(user_id=user_id, is_admin=is_admin, limit=limit)
+        # Blocking LanceDB scan; offload so awaiting this never stalls the loop.
+        return await asyncio.to_thread(
+            handle.list_documents, user_id=user_id, is_admin=is_admin, limit=limit
+        )
 
     def list_document_records_sync(
         self,
@@ -387,7 +395,10 @@ class KBCoordinator:
                 hide_missing=True,
             )
         )
-        return handle.delete_document_record(doc_id, user_id=user_id, is_admin=is_admin)
+        # Blocking LanceDB delete; offload so awaiting this never stalls the loop.
+        return await asyncio.to_thread(
+            handle.delete_document_record, doc_id, user_id=user_id, is_admin=is_admin
+        )
 
     def delete_document_record_sync(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -8,6 +8,12 @@ from collections.abc import Coroutine
 from contextvars import copy_context
 from typing import Any, Optional, TypeVar
 
+from ..core.schemas import (
+    DocumentRecordDetail,
+    DocumentRecordListResult,
+    RegisterDocumentRequest,
+    RegisterDocumentResponse,
+)
 from ..storage.factory import StorageFactory
 from ..utils.user_scope import resolve_user_scope
 from .api_compatibility import KBApiCompatibilityFacade
@@ -275,6 +281,128 @@ class KBCoordinator:
     ) -> LanceDBCollectionHandle:
         """Synchronous wrapper for opening a collection handle."""
         return _run_in_separate_loop(self.open_collection(request))
+
+    # --- Document-row lifecycle (delegated to the collection handle) ---
+
+    async def register_document(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Open the collection handle and register a document row."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=request.collection,
+                user_id=request.user_id,
+                access_mode=KBAccessMode.WRITE,
+                hide_missing=True,
+            )
+        )
+        return handle.register_document(request)
+
+    def register_document_sync(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Synchronous wrapper for :meth:`register_document`."""
+        return _run_in_separate_loop(self.register_document(request))
+
+    async def load_document(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DocumentRecordDetail | None:
+        """Open the collection handle and load a document row by id."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+                hide_missing=True,
+            )
+        )
+        return handle.load_document(doc_id, user_id=user_id, is_admin=is_admin)
+
+    def load_document_sync(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> DocumentRecordDetail | None:
+        """Synchronous wrapper for :meth:`load_document`."""
+        return _run_in_separate_loop(
+            self.load_document(collection, doc_id, user_id=user_id, is_admin=is_admin)
+        )
+
+    async def list_document_records(
+        self,
+        collection: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        limit: int = 100,
+    ) -> DocumentRecordListResult:
+        """Open the collection handle and list document rows."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+                hide_missing=True,
+            )
+        )
+        return handle.list_documents(user_id=user_id, is_admin=is_admin, limit=limit)
+
+    def list_document_records_sync(
+        self,
+        collection: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        limit: int = 100,
+    ) -> DocumentRecordListResult:
+        """Synchronous wrapper for :meth:`list_document_records`."""
+        return _run_in_separate_loop(
+            self.list_document_records(
+                collection, user_id=user_id, is_admin=is_admin, limit=limit
+            )
+        )
+
+    async def delete_document_record(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Open the collection handle and delete a document row (no cascade)."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+                hide_missing=True,
+            )
+        )
+        return handle.delete_document_record(doc_id, user_id=user_id, is_admin=is_admin)
+
+    def delete_document_record_sync(
+        self,
+        collection: str,
+        doc_id: str,
+        *,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Synchronous wrapper for :meth:`delete_document_record`."""
+        return _run_in_separate_loop(
+            self.delete_document_record(
+                collection, doc_id, user_id=user_id, is_admin=is_admin
+            )
+        )
 
     @staticmethod
     def _normalize_collection(collection: str) -> str:

--- a/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
@@ -53,6 +53,9 @@ class KBLegacyStepCompatibilityFacade:
         self._coordinator = coordinator
         self._storage_shim = storage_shim
         self._operation_compatibility = operation_compatibility
+        # Lazily-built coordinator bound to an injected shim (see
+        # _active_coordinator); cached so repeated calls reuse one instance.
+        self._shim_coordinator: KBCoordinator | None = None
 
     def _active_storage_shim(self) -> KBStorageShimCompatibilityFacade | None:
         if self._storage_shim is not None:
@@ -71,7 +74,17 @@ class KBLegacyStepCompatibilityFacade:
     def _active_coordinator(self) -> KBCoordinator:
         if self._coordinator is not None:
             return self._coordinator
-        from .coordinator import get_kb_coordinator
+
+        from .coordinator import KBCoordinator, get_kb_coordinator
+
+        # An injected shim without a coordinator must keep document lifecycle
+        # calls bound to that shim instead of leaking onto the process-global
+        # coordinator's independent stores. Back a dedicated coordinator with
+        # the injected shim so the facade's injection boundary is preserved.
+        if self._storage_shim is not None:
+            if self._shim_coordinator is None:
+                self._shim_coordinator = KBCoordinator(storage_shim=self._storage_shim)
+            return self._shim_coordinator
 
         return get_kb_coordinator()
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/legacy_step_compatibility.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ..core.config import (
@@ -11,12 +12,14 @@ from ..core.config import (
     DEFAULT_TABLE_CONTEXT_SIZE,
     DEFAULT_TIKTOKEN_ENCODING,
 )
+from ..core.exceptions import DocumentValidationError
 from ..core.schemas import (
     ChunkStrategy,
     DenseSearchResponse,
     FusionConfig,
     HybridSearchResponse,
     ParseMethod,
+    RegisterDocumentRequest,
     SparseSearchResponse,
 )
 from .operation_compatibility import (
@@ -65,6 +68,56 @@ class KBLegacyStepCompatibilityFacade:
             return self._coordinator.operation_compatibility
         return None
 
+    def _active_coordinator(self) -> KBCoordinator:
+        if self._coordinator is not None:
+            return self._coordinator
+        from .coordinator import get_kb_coordinator
+
+        return get_kb_coordinator()
+
+    @staticmethod
+    def _build_register_request(
+        *,
+        collection: str,
+        source_path: str,
+        file_type: Optional[str],
+        doc_id: Optional[str],
+        uploaded_at: Optional[str],
+        user_id: Optional[int],
+        file_id: Optional[str],
+        metadata_source_path: Optional[str],
+    ) -> RegisterDocumentRequest:
+        """Convert legacy register args into a semantic request.
+
+        Parses the optional ISO8601 ``uploaded_at`` string (supporting a
+        trailing ``Z``); a missing or unparsable value becomes ``None`` so the
+        handle applies its default timestamp.
+        """
+        uploaded_at_dt: Optional[datetime] = None
+        if uploaded_at:
+            try:
+                if uploaded_at.endswith("Z"):
+                    uploaded_at_dt = datetime.fromisoformat(
+                        uploaded_at.replace("Z", "+00:00")
+                    )
+                else:
+                    uploaded_at_dt = datetime.fromisoformat(uploaded_at)
+                if uploaded_at_dt.tzinfo is None:
+                    uploaded_at_dt = uploaded_at_dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                uploaded_at_dt = None
+
+        return RegisterDocumentRequest(
+            collection=collection,
+            file_id=file_id,
+            source_path=source_path,
+            metadata_source_path=metadata_source_path,
+            file_type=file_type,
+            doc_id=doc_id,
+            uploaded_at=uploaded_at_dt,
+            user_id=user_id,
+        )
+
     @contextmanager
     def _operation_context(
         self, *, operation_type: str, collection: str
@@ -109,22 +162,34 @@ class KBLegacyStepCompatibilityFacade:
         file_id: Optional[str] = None,
         metadata_source_path: Optional[str] = None,
     ) -> Dict[str, Any]:
-        from ..file.register_document import _register_document_public_impl
+        """Register a document row via the coordinator + collection handle.
+
+        Converts the legacy inputs into a semantic ``RegisterDocumentRequest``,
+        delegates to the coordinator (which opens the handle), and converts the
+        semantic response back into the legacy dict shape. The operation context
+        and document side-effect recording are preserved for rollback support.
+        """
+        # Preserve the legacy empty-collection contract before the coordinator
+        # normalizes the collection (which would raise a bare ValueError).
+        if not collection:
+            raise DocumentValidationError("Collection name cannot be empty")
+
+        request = self._build_register_request(
+            collection=collection,
+            source_path=source_path,
+            file_type=file_type,
+            doc_id=doc_id,
+            uploaded_at=uploaded_at,
+            user_id=user_id,
+            file_id=file_id,
+            metadata_source_path=metadata_source_path,
+        )
 
         with self._operation_context(
             operation_type="legacy_register_document", collection=collection
         ) as (operation, owns_operation):
-            with self._storage_context():
-                result = _register_document_public_impl(
-                    collection=collection,
-                    source_path=source_path,
-                    file_type=file_type,
-                    doc_id=doc_id,
-                    uploaded_at=uploaded_at,
-                    user_id=user_id,
-                    file_id=file_id,
-                    metadata_source_path=metadata_source_path,
-                )
+            response = self._active_coordinator().register_document_sync(request)
+            result: Dict[str, Any] = response.model_dump()
             self._record_document_side_effect(
                 operation,
                 collection=collection,
@@ -137,18 +202,26 @@ class KBLegacyStepCompatibilityFacade:
             return result
 
     def get_document(self, db_dir: str, collection: str, doc_id: str) -> Optional[Any]:
-        from ..file.register_document import _get_document_impl
+        """Load a document row via the handle (legacy raw-dict shape or None).
 
-        with self._storage_context():
-            return _get_document_impl(db_dir, collection, doc_id)
+        ``db_dir`` is accepted for backward compatibility and ignored. The
+        anonymous default scope reproduces the legacy ``get_document`` behavior.
+        """
+        detail = self._active_coordinator().load_document_sync(collection, doc_id)
+        return detail.to_legacy_dict() if detail is not None else None
 
     def list_documents(
         self, db_dir: str, collection: str, limit: int = 100
     ) -> list[Dict[str, Any]]:
-        from ..file.register_document import _list_documents_impl
+        """List document rows via the handle (legacy raw-dict list).
 
-        with self._storage_context():
-            return _list_documents_impl(db_dir, collection, limit)
+        ``db_dir`` is accepted for backward compatibility and ignored. Listing
+        uses admin scope to mirror the legacy file-level helper.
+        """
+        result = self._active_coordinator().list_document_records_sync(
+            collection, user_id=None, is_admin=True, limit=limit
+        )
+        return result.to_legacy_dicts()
 
     def parse_document(
         self,

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -541,6 +541,26 @@ class VectorIndexStore(ABC):
         """
 
     @abstractmethod
+    def delete_document_record(
+        self,
+        collection_name: str,
+        doc_id: str,
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> int:
+        """Delete only the ``documents`` table row(s) for a single document.
+
+        Row-only counterpart to :meth:`delete_document_data`: it must NOT
+        cascade into parse/chunk/embedding/version data. Implementations must
+        preserve document-scoped tenant safety (collection + doc_id, plus
+        user_id where the table supports it) and must be idempotent, returning
+        0 when the row or table is absent.
+
+        Returns:
+            Number of document rows deleted (0 if none matched).
+        """
+
+    @abstractmethod
     def aggregate_collection_stats(
         self,
         user_id: Optional[int],

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -861,6 +861,46 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         self.invalidate_table_cache()
         return counts
 
+    def delete_document_record(
+        self,
+        collection_name: str,
+        doc_id: str,
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> int:
+        """Delete only the ``documents`` table row(s) for a single document.
+
+        Row-only counterpart to :meth:`delete_document_data`; it does not
+        cascade into parses/chunks/embeddings. Reuses the cascade document
+        filter so tenant scoping stays identical. Idempotent: returns 0 when
+        the row or the ``documents`` table is absent.
+        """
+        from ..LanceDB.schema_manager import _safe_close_table
+        from ..version_management.cascade_cleaner import (
+            _build_document_filter,
+            _delete_rows_by_filters,
+        )
+
+        if "documents" not in self.list_table_names():
+            return 0
+
+        conn = self._get_connection()
+        filter_expr = _build_document_filter(
+            conn=conn,
+            table_name="documents",
+            collection=collection_name,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        table = conn.open_table("documents")
+        try:
+            deleted = _delete_rows_by_filters(table, [filter_expr])
+        finally:
+            _safe_close_table(table)
+        self.invalidate_table_cache("documents")
+        return deleted
+
     def delete_documents_data(
         self,
         collection_name: str,

--- a/tests/core/tools/core/RAG_tools/core/test_schemas_document_record_detail.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas_document_record_detail.py
@@ -1,0 +1,69 @@
+"""Tests for the lean handle-level document record schemas (#508).
+
+``DocumentRecordDetail`` / ``DocumentRecordListResult`` are the semantic types
+the collection handle returns for document-row reads. They must map losslessly
+back to the legacy file-level ``list[dict]`` shape (the full ``documents`` row).
+"""
+
+from datetime import datetime, timezone
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    DocumentRecordDetail,
+    DocumentRecordListResult,
+)
+
+FULL_ROW = {
+    "collection": "coll",
+    "doc_id": "doc-1",
+    "file_id": "file-9",
+    "source_path": "/uploads/user_7/report.txt",
+    "file_type": "txt",
+    "content_hash": "a" * 64,
+    "uploaded_at": datetime(2024, 1, 15, 10, 30, tzinfo=timezone.utc),
+    "title": None,
+    "language": None,
+    "user_id": 7,
+}
+
+
+class TestDocumentRecordDetail:
+    def test_from_row_to_legacy_dict_round_trip(self) -> None:
+        detail = DocumentRecordDetail.from_row(FULL_ROW)
+        assert detail.to_legacy_dict() == FULL_ROW
+
+    def test_from_row_normalizes_nan_and_nat_to_none(self) -> None:
+        nan = float("nan")
+        row = {
+            **FULL_ROW,
+            "file_id": nan,  # NaN sentinel from pandas object column
+            "title": nan,
+            "language": None,
+            "user_id": nan,  # int64 column upcast to float NaN when null
+        }
+        detail = DocumentRecordDetail.from_row(row)
+        assert detail.file_id is None
+        assert detail.title is None
+        assert detail.language is None
+        assert detail.user_id is None
+
+    def test_user_id_coerced_to_python_int(self) -> None:
+        detail = DocumentRecordDetail.from_row({**FULL_ROW, "user_id": 42})
+        assert detail.user_id == 42
+        assert isinstance(detail.user_id, int)
+
+
+class TestDocumentRecordListResult:
+    def test_to_legacy_dicts_preserves_order_and_count(self) -> None:
+        d1 = DocumentRecordDetail.from_row({**FULL_ROW, "doc_id": "d1"})
+        d2 = DocumentRecordDetail.from_row({**FULL_ROW, "doc_id": "d2"})
+        result = DocumentRecordListResult(documents=[d1, d2], total_count=2)
+
+        legacy = result.to_legacy_dicts()
+        assert legacy == [d1.to_legacy_dict(), d2.to_legacy_dict()]
+        assert [row["doc_id"] for row in legacy] == ["d1", "d2"]
+        assert result.total_count == 2
+
+    def test_empty_result(self) -> None:
+        result = DocumentRecordListResult(documents=[], total_count=0)
+        assert result.to_legacy_dicts() == []
+        assert result.total_count == 0

--- a/tests/core/tools/core/RAG_tools/file/test_document_lifecycle_characterization.py
+++ b/tests/core/tools/core/RAG_tools/file/test_document_lifecycle_characterization.py
@@ -1,0 +1,154 @@
+"""Characterization tests locking current document-row lifecycle behavior.
+
+These tests pin the *observable* behavior of the legacy document helpers
+(``register_document`` / ``get_document`` / ``list_documents``) BEFORE the
+#508 refactor moves that logic into ``KBCollectionHandle``. They act as the
+equivalence oracle for the handle implementation and, in particular, lock:
+
+* the exact ``documents`` table column set (lossless-mapping requirement), and
+* the raw-dict shape returned by ``get_document`` / ``list_documents``.
+
+Storage isolation + reset is provided by the autouse ``isolate_rag_storage``
+fixture in ``tests/conftest.py``.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+from xagent.core.tools.core.RAG_tools.file.register_document import (
+    get_document,
+    list_documents,
+    register_document,
+)
+from xagent.providers.vector_store.lancedb import get_connection_from_env
+
+# The full, current ``documents`` table schema (see LanceDB/schema_manager.py).
+DOCUMENT_COLUMNS = {
+    "collection",
+    "doc_id",
+    "file_id",
+    "source_path",
+    "file_type",
+    "content_hash",
+    "uploaded_at",
+    "title",
+    "language",
+    "user_id",
+}
+
+
+def _raw_documents_row(collection: str, doc_id: str) -> dict:
+    conn = get_connection_from_env()
+    table = conn.open_table("documents")
+    return (
+        table.search()
+        .where(f"collection = '{collection}' AND doc_id = '{doc_id}'")
+        .to_pandas()
+        .iloc[0]
+        .to_dict()
+    )
+
+
+class TestRegisteredRowSchema:
+    """Lock the persisted documents-row columns and field persistence."""
+
+    def test_persisted_row_has_exact_columns_and_values(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LANCEDB_DIR", str(tmp_path / "lancedb"))
+        src = tmp_path / "report.txt"
+        src.write_text("hello world")
+
+        response = register_document(
+            collection="coll",
+            source_path=str(src),
+            doc_id="doc-1",
+            user_id=7,
+            file_id="file-9",
+        )
+
+        assert response["doc_id"] == "doc-1"
+        assert response["created"] is True
+        assert len(response["content_hash"]) == 64
+
+        row = _raw_documents_row("coll", "doc-1")
+        # Lossless-mapping oracle: exactly these columns, nothing more/less.
+        assert set(row.keys()) == DOCUMENT_COLUMNS
+
+        assert row["collection"] == "coll"
+        assert row["doc_id"] == "doc-1"
+        assert row["file_id"] == "file-9"
+        assert row["source_path"] == str(src)
+        assert row["file_type"] == "txt"  # auto-detected from extension
+        assert row["content_hash"] == response["content_hash"]
+        assert row["user_id"] == 7
+        assert not pd.isna(row["uploaded_at"])
+        # title / language are written as None and stay null.
+        assert row["title"] is None or pd.isna(row["title"])
+        assert row["language"] is None or pd.isna(row["language"])
+
+
+class TestGetDocument:
+    """Lock get_document's behavior under its (anonymous) default scope.
+
+    The public ``get_document(db_dir, collection, doc_id)`` exposes no user
+    scope, so it always runs as unauthenticated non-admin. Per the user-access
+    rules (``UserPermissions.get_user_filter``) that scope can see *no* rows,
+    so the call returns ``None`` even for an existing document. This helper has
+    no production callers; the behavior is locked so the handle reproduces it.
+    """
+
+    def test_existing_document_under_anonymous_scope_returns_none(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LANCEDB_DIR", str(tmp_path / "lancedb"))
+        src = tmp_path / "a.md"
+        src.write_text("# title")
+
+        register_document(collection="coll", source_path=str(src), doc_id="doc-a")
+
+        # Row exists (admin-visible), but anonymous default scope sees nothing.
+        assert get_document(str(tmp_path / "lancedb"), "coll", "doc-a") is None
+
+    def test_missing_document_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("LANCEDB_DIR", str(tmp_path / "lancedb"))
+        src = tmp_path / "a.txt"
+        src.write_text("x")
+        register_document(collection="coll", source_path=str(src), doc_id="exists")
+
+        assert get_document(str(tmp_path / "lancedb"), "coll", "nope") is None
+
+
+class TestListDocuments:
+    """Lock list_documents (admin scope) shape, collection filter, and limit."""
+
+    def _register(self, tmp_path: Path, name: str, collection: str, doc_id: str):
+        src = tmp_path / name
+        src.write_text(f"content of {name}")
+        register_document(collection=collection, source_path=str(src), doc_id=doc_id)
+
+    def test_shape_filter_and_limit(self, tmp_path: Path, monkeypatch) -> None:
+        db_dir = tmp_path / "lancedb"
+        monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+
+        self._register(tmp_path, "a1.txt", "coll_a", "a1")
+        self._register(tmp_path, "a2.txt", "coll_a", "a2")
+        self._register(tmp_path, "b1.txt", "coll_b", "b1")
+
+        rows_a = list_documents(str(db_dir), collection="coll_a", limit=100)
+        assert len(rows_a) == 2
+        for row in rows_a:
+            assert set(row.keys()) == DOCUMENT_COLUMNS
+            assert row["collection"] == "coll_a"
+        assert {row["doc_id"] for row in rows_a} == {"a1", "a2"}
+
+        limited = list_documents(str(db_dir), collection="coll_a", limit=1)
+        assert len(limited) == 1
+
+    def test_empty_collection_returns_empty_list(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        db_dir = tmp_path / "lancedb"
+        monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+        assert list_documents(str(db_dir), collection="none", limit=10) == []

--- a/tests/core/tools/core/RAG_tools/file/test_register_document.py
+++ b/tests/core/tools/core/RAG_tools/file/test_register_document.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +15,9 @@ from xagent.core.tools.core.RAG_tools.core.exceptions import (
 from xagent.core.tools.core.RAG_tools.file.register_document import (
     list_documents,
     register_document,
+)
+from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+    LanceDBVectorIndexStore,
 )
 from xagent.providers.vector_store.lancedb import get_connection_from_env
 
@@ -262,11 +265,14 @@ class TestRegisterDocument:
         ):
             register_document(collection="", source_path="/tmp/test.txt")
 
-    @patch("xagent.core.tools.core.RAG_tools.file.register_document.compute_file_hash")
+    @patch("xagent.core.tools.core.RAG_tools.kb.collection_handle.compute_file_hash")
     def test_register_document_hash_computation_error(
         self, mock_hash, tmp_path: Path, monkeypatch
     ) -> None:
-        """Test handling hash computation errors."""
+        """Test handling hash computation errors.
+
+        The hash computation now lives in the collection handle; patch it there.
+        """
         # Setup environment variable
         db_dir = tmp_path / "lancedb"
         monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
@@ -282,23 +288,24 @@ class TestRegisterDocument:
         with pytest.raises(HashComputationError):
             register_document(collection="test_collection", source_path=str(test_file))
 
-    @patch(
-        "xagent.core.tools.core.RAG_tools.file.register_document.get_vector_index_store"
+    @patch.object(
+        LanceDBVectorIndexStore,
+        "count_rows_or_zero",
+        side_effect=ConfigurationError("LANCEDB_DIR not configured"),
     )
     def test_register_document_configuration_error(
-        self, mock_get_store, tmp_path: Path
+        self, _mock_count, tmp_path: Path, monkeypatch
     ) -> None:
-        """Test handling configuration errors."""
-        # Setup test file
+        """Test handling configuration errors.
+
+        The handle performs the existence check on the bound vector store; a
+        ConfigurationError from the store must propagate unchanged.
+        """
+        db_dir = tmp_path / "lancedb"
+        monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
+
         test_file = tmp_path / "config_error_test.txt"
         test_file.write_text("Test content")
-
-        # Mock database connection to raise configuration error
-        mock_store = MagicMock()
-        mock_store.count_rows_or_zero.side_effect = ConfigurationError(
-            "LANCEDB_DIR not configured"
-        )
-        mock_get_store.return_value = mock_store
 
         # Should propagate ConfigurationError
         with pytest.raises(ConfigurationError):
@@ -324,13 +331,19 @@ class TestRegisterDocument:
         ):
             register_document(collection=collection, source_path=str(unsupported_file))
 
-    @patch(
-        "xagent.core.tools.core.RAG_tools.file.register_document.get_vector_index_store"
+    @patch.object(
+        LanceDBVectorIndexStore,
+        "count_rows_or_zero",
+        side_effect=Exception("Table access failed"),
     )
     def test_register_document_database_operation_error(
-        self, mock_get_store, tmp_path: Path, monkeypatch
+        self, _mock_count, tmp_path: Path, monkeypatch
     ) -> None:
-        """Test handling database operation errors."""
+        """Test handling database operation errors.
+
+        A generic store failure during the handle's existence check must be
+        wrapped as DatabaseOperationError.
+        """
         # Setup environment variable
         db_dir = tmp_path / "lancedb"
         monkeypatch.setenv("LANCEDB_DIR", str(db_dir))
@@ -338,11 +351,6 @@ class TestRegisterDocument:
         # Setup test file
         test_file = tmp_path / "db_error_test.txt"
         test_file.write_text("Test content")
-
-        # Mock vector store to raise an error
-        mock_store = MagicMock()
-        mock_store.count_rows_or_zero.side_effect = Exception("Table access failed")
-        mock_get_store.return_value = mock_store
 
         # Should propagate DatabaseOperationError
         with pytest.raises(DatabaseOperationError, match="Table access failed"):

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
@@ -9,6 +9,7 @@ Storage isolation/reset is provided by the autouse ``isolate_rag_storage``
 fixture in ``tests/conftest.py``.
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -239,3 +240,38 @@ class TestHandleListDocuments:
         assert result.total_count == 0
         assert result.documents == []
         assert result.to_legacy_dicts() == []
+
+
+class TestHandleDeleteDocumentRecord:
+    def test_deletes_row_only_and_is_idempotent(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        _register(handle, tmp_path / "a.txt", "del")
+
+        # A parse row for the same doc proves the handle delete does not cascade.
+        store = get_vector_index_store()
+        store.upsert_parses(
+            [
+                {
+                    "collection": "coll",
+                    "doc_id": "del",
+                    "parse_hash": "h1",
+                    "parser": "p",
+                    "created_at": datetime.now(timezone.utc),
+                    "params_json": "{}",
+                    "parsed_content": "x",
+                    "user_id": None,
+                }
+            ]
+        )
+
+        assert handle.delete_document_record("del", is_admin=True) == 1
+        assert handle.load_document("del", is_admin=True) is None
+        # Parse row is untouched (row-only delete, no cascade).
+        assert (
+            store.count_rows(
+                "parses", {"collection": "coll", "doc_id": "del"}, is_admin=True
+            )
+            == 1
+        )
+        # Idempotent: deleting again returns 0.
+        assert handle.delete_document_record("del", is_admin=True) == 0

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
@@ -141,6 +141,35 @@ class TestHandleRegisterDocument:
                 )
             )
 
+    def test_register_persists_into_context_collection_not_request(
+        self, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "a.txt"
+        src.write_text("hello")
+        handle = make_handle("coll_a")
+
+        # The request names a different collection; the collection-scoped handle
+        # must ignore it and persist into its bound context collection.
+        handle.register_document(
+            RegisterDocumentRequest(
+                collection="coll_b", source_path=str(src), doc_id="doc-x"
+            )
+        )
+
+        store = get_vector_index_store()
+        assert (
+            store.count_rows(
+                "documents", {"collection": "coll_a", "doc_id": "doc-x"}, is_admin=True
+            )
+            == 1
+        )
+        assert (
+            store.count_rows(
+                "documents", {"collection": "coll_b", "doc_id": "doc-x"}, is_admin=True
+            )
+            == 0
+        )
+
 
 def _register(handle: LanceDBCollectionHandle, src: Path, doc_id: str, **kwargs):
     src.write_text(kwargs.pop("content", f"content of {doc_id}"))
@@ -379,3 +408,21 @@ class TestHandleRollback:
         )
         assert again.doc_id == first.doc_id
         assert again.created is True
+
+    def test_restore_rejects_snapshot_from_other_collection(
+        self, tmp_path: Path
+    ) -> None:
+        from xagent.core.tools.core.RAG_tools.core.exceptions import (
+            DocumentValidationError,
+        )
+
+        source = make_handle("coll_a")
+        _register(source, tmp_path / "a.txt", "doc-1", user_id=7)
+        snapshot = source.snapshot_document("doc-1", is_admin=True)
+        assert snapshot is not None
+
+        # A handle bound to a different collection must refuse the snapshot so
+        # restore cannot write outside its resolved collection.
+        other = make_handle("coll_b")
+        with pytest.raises(DocumentValidationError, match="cannot restore a snapshot"):
+            other.restore_document(snapshot)

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
@@ -275,3 +275,107 @@ class TestHandleDeleteDocumentRecord:
         )
         # Idempotent: deleting again returns 0.
         assert handle.delete_document_record("del", is_admin=True) == 0
+
+
+class TestHandleRollback:
+    def test_new_document_rollback_is_idempotent_and_row_only(
+        self, tmp_path: Path
+    ) -> None:
+        handle = make_handle("coll")
+        response = _register(handle, tmp_path / "a.txt", "new-doc", user_id=7)
+        assert response.created is True
+
+        store = get_vector_index_store()
+        store.upsert_parses(
+            [
+                {
+                    "collection": "coll",
+                    "doc_id": "new-doc",
+                    "parse_hash": "h1",
+                    "parser": "p",
+                    "created_at": datetime.now(timezone.utc),
+                    "params_json": "{}",
+                    "parsed_content": "x",
+                    "user_id": None,
+                }
+            ]
+        )
+
+        # Rollback of a newly created document removes only the document row.
+        assert handle.delete_created_document("new-doc", user_id=7, is_admin=True) == 1
+        assert handle.load_document("new-doc", is_admin=True) is None
+        assert (
+            store.count_rows(
+                "parses", {"collection": "coll", "doc_id": "new-doc"}, is_admin=True
+            )
+            == 1
+        )
+        # Idempotent.
+        assert handle.delete_created_document("new-doc", user_id=7, is_admin=True) == 0
+
+    def test_existing_document_replacement_rollback_preserves_fields(
+        self, tmp_path: Path
+    ) -> None:
+        handle = make_handle("coll")
+        _register(
+            handle,
+            tmp_path / "orig.txt",
+            "doc-1",
+            user_id=7,
+            file_id="f1",
+            content="original content",
+        )
+
+        snapshot = handle.snapshot_document("doc-1", is_admin=True)
+        assert snapshot is not None
+
+        # Overwrite the existing row with a different file/owner.
+        _register(
+            handle,
+            tmp_path / "changed.md",
+            "doc-1",
+            user_id=9,
+            file_id="f2",
+            content="changed content",
+        )
+        overwritten = handle.load_document("doc-1", is_admin=True)
+        assert overwritten is not None
+        assert overwritten.file_type == "md"
+        assert overwritten.file_id == "f2"
+        assert overwritten.user_id == 9
+
+        # Restoring the snapshot brings every field back.
+        handle.restore_document(snapshot)
+        restored = handle.load_document("doc-1", is_admin=True)
+        assert restored is not None
+        assert restored.collection == "coll"
+        assert restored.doc_id == "doc-1"
+        assert restored.file_id == "f1"
+        assert restored.user_id == 7
+        assert restored.file_type == "txt"
+        assert restored.source_path == snapshot.source_path
+        assert restored.content_hash == snapshot.content_hash
+        assert restored.title == snapshot.title
+        assert restored.language == snapshot.language
+        assert restored.uploaded_at is not None
+
+    def test_duplicate_registration_idempotent_after_rollback(
+        self, tmp_path: Path
+    ) -> None:
+        handle = make_handle("my_kb")
+        src = tmp_path / "report.docx"
+        src.write_text("content")
+
+        first = handle.register_document(
+            RegisterDocumentRequest(collection="my_kb", source_path=str(src))
+        )
+        assert first.created is True
+
+        assert handle.delete_created_document(first.doc_id, is_admin=True) == 1
+
+        # Re-registering after rollback yields the same deterministic doc_id.
+        again = handle.register_document(
+            RegisterDocumentRequest(collection="my_kb", source_path=str(src))
+        )
+        assert again.doc_id == first.doc_id
+        assert again.created is True

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
@@ -139,3 +139,103 @@ class TestHandleRegisterDocument:
                     collection="coll", source_path="/no/such/file.txt"
                 )
             )
+
+
+def _register(handle: LanceDBCollectionHandle, src: Path, doc_id: str, **kwargs):
+    src.write_text(kwargs.pop("content", f"content of {doc_id}"))
+    return handle.register_document(
+        RegisterDocumentRequest(
+            collection=handle.context.collection,
+            source_path=str(src),
+            doc_id=doc_id,
+            **kwargs,
+        )
+    )
+
+
+class TestHandleLoadDocument:
+    def test_admin_scope_returns_detail(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        _register(handle, tmp_path / "a.txt", "doc-1", user_id=7, file_id="f9")
+
+        detail = handle.load_document("doc-1", user_id=None, is_admin=True)
+
+        assert detail is not None
+        assert detail.collection == "coll"
+        assert detail.doc_id == "doc-1"
+        assert detail.file_type == "txt"
+        assert detail.user_id == 7
+        assert detail.content_hash is not None
+        assert len(detail.content_hash) == 64
+        # Lossless legacy shape: full 10-column row dict.
+        assert set(detail.to_legacy_dict().keys()) == {
+            "collection",
+            "doc_id",
+            "file_id",
+            "source_path",
+            "file_type",
+            "content_hash",
+            "uploaded_at",
+            "title",
+            "language",
+            "user_id",
+        }
+
+    def test_anonymous_scope_returns_none(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        _register(handle, tmp_path / "a.txt", "doc-1")  # user_id=None
+
+        # Default (anonymous) scope sees no rows -> None (matches legacy
+        # get_document behavior locked by the characterization oracle).
+        assert handle.load_document("doc-1") is None
+
+    def test_missing_returns_none(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        _register(handle, tmp_path / "a.txt", "exists")
+        assert handle.load_document("nope", is_admin=True) is None
+
+
+class TestHandleListDocuments:
+    def test_returns_result_and_maps_to_legacy(self, tmp_path: Path) -> None:
+        handle = make_handle("coll_a")
+        _register(handle, tmp_path / "a1.txt", "a1")
+        _register(handle, tmp_path / "a2.txt", "a2")
+        # A doc in a different collection must not leak in.
+        other = make_handle("coll_b")
+        _register(other, tmp_path / "b1.txt", "b1")
+
+        result = handle.list_documents(is_admin=True, limit=100)
+
+        assert result.total_count == 2
+        legacy = result.to_legacy_dicts()
+        assert {row["doc_id"] for row in legacy} == {"a1", "a2"}
+        for row in legacy:
+            assert row["collection"] == "coll_a"
+            assert set(row.keys()) == {
+                "collection",
+                "doc_id",
+                "file_id",
+                "source_path",
+                "file_type",
+                "content_hash",
+                "uploaded_at",
+                "title",
+                "language",
+                "user_id",
+            }
+
+    def test_limit_is_honored(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        _register(handle, tmp_path / "a1.txt", "a1")
+        _register(handle, tmp_path / "a2.txt", "a2")
+
+        result = handle.list_documents(is_admin=True, limit=1)
+        assert result.total_count == 1
+        assert len(result.documents) == 1
+
+    def test_empty_collection_returns_empty_result(self, tmp_path: Path) -> None:
+        handle = make_handle("coll")
+        result = handle.list_documents(is_admin=True, limit=10)
+        assert result.total_count == 0
+        assert result.documents == []
+        assert result.to_legacy_dicts() == []

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle.py
@@ -1,0 +1,141 @@
+"""Tests for the collection handle document-row lifecycle (#508).
+
+The abstract ``KBCollectionHandle`` owns collection-scoped document-row
+operations; ``LanceDBCollectionHandle`` is the first implementation. These
+tests assert equivalence with the behavior locked by the file-level
+characterization oracle.
+
+Storage isolation/reset is provided by the autouse ``isolate_rag_storage``
+fixture in ``tests/conftest.py``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import RegisterDocumentRequest
+from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+    KBCollectionHandle,
+    LanceDBCollectionHandle,
+)
+from xagent.core.tools.core.RAG_tools.kb.models import (
+    KBAccessMode,
+    KBBackendCapabilities,
+    KBCollectionContext,
+    KBStorageBackend,
+    KBUserScope,
+)
+from xagent.core.tools.core.RAG_tools.storage.factory import (
+    get_metadata_store,
+    get_vector_index_store,
+)
+from xagent.core.tools.core.RAG_tools.utils.string_utils import (
+    generate_deterministic_doc_id,
+)
+
+
+def make_handle(collection: str = "coll") -> LanceDBCollectionHandle:
+    """Build a LanceDB-backed handle bound to the current test stores."""
+    context = KBCollectionContext(
+        collection=collection,
+        user_scope=KBUserScope(user_id=None, is_admin=True),
+        access_mode=KBAccessMode.WRITE,
+        allow_create=True,
+        hide_missing=True,
+        metadata_store=get_metadata_store(),
+        vector_index_store=get_vector_index_store(),
+        backend=KBStorageBackend.LANCEDB,
+        capabilities=KBBackendCapabilities.lancedb(),
+        collection_info=None,
+    )
+    return LanceDBCollectionHandle(context)
+
+
+class TestHandleAbstractness:
+    def test_base_is_abstract_and_lancedb_implements_it(self) -> None:
+        assert issubclass(LanceDBCollectionHandle, KBCollectionHandle)
+        with pytest.raises(TypeError):
+            KBCollectionHandle()  # type: ignore[abstract]
+
+
+class TestHandleRegisterDocument:
+    def test_register_new_document_matches_oracle(self, tmp_path: Path) -> None:
+        src = tmp_path / "report.txt"
+        src.write_text("hello world")
+        handle = make_handle("coll")
+
+        response = handle.register_document(
+            RegisterDocumentRequest(
+                collection="coll",
+                source_path=str(src),
+                doc_id="doc-1",
+                user_id=7,
+                file_id="file-9",
+            )
+        )
+
+        assert response.doc_id == "doc-1"
+        assert response.created is True
+        assert len(response.content_hash) == 64
+
+        store = get_vector_index_store()
+        assert (
+            store.count_rows(
+                "documents", {"collection": "coll", "doc_id": "doc-1"}, is_admin=True
+            )
+            == 1
+        )
+
+    def test_deterministic_doc_id_and_idempotency(self, tmp_path: Path) -> None:
+        src = tmp_path / "report.docx"
+        src.write_text("content")
+        handle = make_handle("my_kb")
+
+        first = handle.register_document(
+            RegisterDocumentRequest(collection="my_kb", source_path=str(src))
+        )
+        second = handle.register_document(
+            RegisterDocumentRequest(collection="my_kb", source_path=str(src))
+        )
+
+        # Deterministic doc_id derived from (collection, source_path).
+        assert first.doc_id == generate_deterministic_doc_id("my_kb", str(src))
+        assert first.doc_id == second.doc_id
+        assert first.created is True
+        assert second.created is False  # idempotent re-register is an update
+        assert first.content_hash == second.content_hash
+
+    def test_auto_file_type_detection(self, tmp_path: Path) -> None:
+        src = tmp_path / "notes.md"
+        src.write_text("# Title")
+        handle = make_handle("coll")
+
+        response = handle.register_document(
+            RegisterDocumentRequest(
+                collection="coll", source_path=str(src), doc_id="md-doc"
+            )
+        )
+
+        store = get_vector_index_store()
+        for batch in store.iter_batches(
+            table_name="documents",
+            filters={"collection": "coll", "doc_id": "md-doc"},
+            is_admin=True,
+        ):
+            row = batch.to_pandas().iloc[0]
+            assert row["file_type"] == "md"
+            assert row["content_hash"] == response.content_hash
+            break
+
+    def test_missing_source_path_raises(self, tmp_path: Path) -> None:
+        from xagent.core.tools.core.RAG_tools.core.exceptions import (
+            DocumentValidationError,
+        )
+
+        handle = make_handle("coll")
+        with pytest.raises(DocumentValidationError, match="Source path does not exist"):
+            handle.register_document(
+                RegisterDocumentRequest(
+                    collection="coll", source_path="/no/such/file.txt"
+                )
+            )

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_document_lifecycle.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_document_lifecycle.py
@@ -1,0 +1,79 @@
+"""Tests for coordinator document-row delegation + sync wrappers (#508).
+
+The coordinator opens a collection handle (Option A: via ``get_context``, which
+resolves the backend from collection metadata) and delegates document-row
+operations to it. Sync wrappers bridge the async coordinator for legacy callers.
+
+Storage/coordinator reset is handled by the autouse ``isolate_rag_storage``
+fixture in ``tests/conftest.py``.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from xagent.core.tools.core.RAG_tools.core.schemas import RegisterDocumentRequest
+from xagent.core.tools.core.RAG_tools.kb.coordinator import get_kb_coordinator
+from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import LanceDBMetadataStore
+
+
+def test_register_load_list_delete_sync(tmp_path: Path) -> None:
+    coord = get_kb_coordinator()
+    src = tmp_path / "a.txt"
+    src.write_text("hello world")
+
+    response = coord.register_document_sync(
+        RegisterDocumentRequest(
+            collection="coll", source_path=str(src), doc_id="doc-1", user_id=7
+        )
+    )
+    assert response.created is True
+    assert response.doc_id == "doc-1"
+
+    detail = coord.load_document_sync("coll", "doc-1", is_admin=True)
+    assert detail is not None
+    assert detail.doc_id == "doc-1"
+    assert detail.user_id == 7
+
+    listing = coord.list_document_records_sync("coll", is_admin=True, limit=100)
+    assert listing.total_count == 1
+    assert listing.documents[0].doc_id == "doc-1"
+
+    assert coord.delete_document_record_sync("coll", "doc-1", is_admin=True) == 1
+    assert coord.load_document_sync("coll", "doc-1", is_admin=True) is None
+
+
+def test_register_into_missing_collection_is_tolerated(tmp_path: Path) -> None:
+    """hide_missing tolerance: registering into a never-created collection works."""
+    coord = get_kb_coordinator()
+    src = tmp_path / "a.txt"
+    src.write_text("x")
+
+    response = coord.register_document_sync(
+        RegisterDocumentRequest(
+            collection="never_created", source_path=str(src), doc_id="d1"
+        )
+    )
+    assert response.created is True
+
+
+def test_document_ops_route_through_get_context(tmp_path: Path) -> None:
+    """Locks Option A: each op resolves context via metadata get_collection."""
+    coord = get_kb_coordinator()
+    src = tmp_path / "a.txt"
+    src.write_text("x")
+
+    calls: list[str] = []
+    original = LanceDBMetadataStore.get_collection
+
+    async def spy(self, collection_name):  # type: ignore[no-untyped-def]
+        calls.append(collection_name)
+        return await original(self, collection_name)
+
+    with patch.object(LanceDBMetadataStore, "get_collection", spy):
+        coord.register_document_sync(
+            RegisterDocumentRequest(
+                collection="coll", source_path=str(src), doc_id="d1"
+            )
+        )
+
+    assert "coll" in calls

--- a/tests/core/tools/core/RAG_tools/storage/test_delete_document_record.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_delete_document_record.py
@@ -1,0 +1,122 @@
+"""Tests for the row-only ``delete_document_record`` store primitive (#508).
+
+This primitive deletes ONLY the ``documents`` table row for a document. It must
+not cascade into parse/chunk/embedding data (that stays with the cascade path),
+must be idempotent, and must preserve document-scoped tenant safety.
+
+Storage isolation/reset is provided by the autouse ``isolate_rag_storage``
+fixture in ``tests/conftest.py``.
+"""
+
+from datetime import datetime, timezone
+
+from xagent.core.tools.core.RAG_tools.storage.factory import get_vector_index_store
+
+
+def _doc_row(collection: str, doc_id: str, user_id=None) -> dict:
+    return {
+        "collection": collection,
+        "doc_id": doc_id,
+        "file_id": None,
+        "source_path": f"/uploads/{doc_id}.txt",
+        "file_type": "txt",
+        "content_hash": "a" * 64,
+        "uploaded_at": datetime.now(timezone.utc),
+        "title": None,
+        "language": None,
+        "user_id": user_id,
+    }
+
+
+def _parse_row(collection: str, doc_id: str) -> dict:
+    return {
+        "collection": collection,
+        "doc_id": doc_id,
+        "parse_hash": "parsehash1",
+        "parser": "test_parser",
+        "created_at": datetime.now(timezone.utc),
+        "params_json": "{}",
+        "parsed_content": "parsed text",
+        "user_id": None,
+    }
+
+
+def test_deletes_only_documents_row_no_cascade() -> None:
+    store = get_vector_index_store()
+    store.upsert_documents([_doc_row("coll", "keep"), _doc_row("coll", "del")])
+    store.upsert_parses([_parse_row("coll", "del")])
+
+    # Sanity baseline.
+    assert store.count_rows("documents", {"collection": "coll"}, is_admin=True) == 2
+    assert (
+        store.count_rows(
+            "parses", {"collection": "coll", "doc_id": "del"}, is_admin=True
+        )
+        == 1
+    )
+
+    deleted = store.delete_document_record("coll", "del", user_id=None, is_admin=True)
+
+    assert deleted == 1
+    # documents row gone for the target, the other survives.
+    assert (
+        store.count_rows(
+            "documents", {"collection": "coll", "doc_id": "del"}, is_admin=True
+        )
+        == 0
+    )
+    assert (
+        store.count_rows(
+            "documents", {"collection": "coll", "doc_id": "keep"}, is_admin=True
+        )
+        == 1
+    )
+    # parse row for the deleted doc is untouched (no cascade in this primitive).
+    assert (
+        store.count_rows(
+            "parses", {"collection": "coll", "doc_id": "del"}, is_admin=True
+        )
+        == 1
+    )
+
+
+def test_idempotent_and_missing_returns_zero() -> None:
+    store = get_vector_index_store()
+    store.upsert_documents([_doc_row("coll", "d1")])
+
+    assert store.delete_document_record("coll", "d1", user_id=None, is_admin=True) == 1
+    # Second delete: row already gone -> 0, no error.
+    assert store.delete_document_record("coll", "d1", user_id=None, is_admin=True) == 0
+    # Never-existed doc -> 0.
+    assert (
+        store.delete_document_record("coll", "nope", user_id=None, is_admin=True) == 0
+    )
+
+
+def test_missing_documents_table_returns_zero() -> None:
+    store = get_vector_index_store()
+    # No documents table has been created in this fresh store.
+    assert store.delete_document_record("coll", "d1", user_id=None, is_admin=True) == 0
+
+
+def test_user_scoping_blocks_other_tenant() -> None:
+    store = get_vector_index_store()
+    store.upsert_documents([_doc_row("coll", "owned", user_id=5)])
+
+    # A different non-admin user cannot delete another tenant's row.
+    assert store.delete_document_record("coll", "owned", user_id=6, is_admin=False) == 0
+    assert (
+        store.count_rows(
+            "documents", {"collection": "coll", "doc_id": "owned"}, is_admin=True
+        )
+        == 1
+    )
+
+    # The owner can delete their own row.
+    assert store.delete_document_record("coll", "owned", user_id=5, is_admin=False) == 1
+    assert (
+        store.count_rows(
+            "documents", {"collection": "coll", "doc_id": "owned"}, is_admin=True
+        )
+        == 0
+    )


### PR DESCRIPTION
## Summary

Implements #508 (H01), the first handle-replacement step of the epic #494 Phase 2. It moves the collection-scoped **document-row lifecycle** out of the file-level helpers into a new `KBCollectionHandle` abstraction, routed through `KBCoordinator`. Public contracts and observable behavior are preserved.

## What changed

- **New abstraction.** Adds an abstract `KBCollectionHandle` (the collection-scoped backend data-plane boundary) with a first `LanceDBCollectionHandle` implementation in `kb/collection_handle.py`.
- **Lean result types.** Adds handle-owned `DocumentRecordDetail` / `DocumentRecordListResult` to `core/schemas.py`. They mirror the full 10-column `documents` row and map losslessly back to the legacy raw-dict shape.
- **Row-only delete primitive.** Adds `delete_document_record` to `storage/contracts.py` and `storage/lancedb_stores.py`. It deletes only the `documents` row (no cascade into parse/chunk/embedding/version data), reuses the existing audited document tenant-filter, and is idempotent.
- **Coordinator delegation.** `kb/coordinator.py` gains `register_document` / `load_document` / `list_document_records` / `delete_document_record` (async + sync wrappers) that resolve the collection context and delegate to the handle.
- **Legacy rewire.** The file-level helpers `register_document` / `get_document` / `list_documents` (`file/register_document.py`) now route through the coordinator + handle via `kb/legacy_step_compatibility.py`, keeping their public signatures and return shapes. Dead private impls were removed.
- **Rollback mechanics.** Adds handle-level compensation methods `snapshot_document` / `restore_document` / `delete_created_document`. These are document-plane mechanics only; wiring them into the live operation-rollback path is left to a later Phase 2 step (#514).

## Approach

Faithful port: document operations resolve a collection context through the coordinator (`get_context` / `open_collection`) and delegate to the handle. This accepts a small per-call cost (an extra metadata read and an async thread-hop from sync surfaces) in exchange for routing every document operation through the single coordinator boundary, as the epic intends.

## Behavior preservation

Verified against the pre-refactor implementation:

- the register existence check runs under admin scope;
- `get_document` runs under the anonymous default scope (always returns `None`); and
- `list_documents` runs under admin scope so legacy rows remain visible.

The file-level `get_document` / `list_documents` have no production callers (the only production consumer of this module is `register_document`, whose `{doc_id, created, content_hash}` result is unchanged). Null normalization (`NaN`/`NaT` to `None`, `user_id` to `int`) in `DocumentRecordDetail.from_row` is therefore an internal-only detail.

## Tests

TDD, characterization-first. The oracle is pinned against current behavior before the move, then kept green after it:

- `file/test_document_lifecycle_characterization.py` — locks pre-refactor behavior and the exact 10-column row schema
- `core/test_schemas_document_record_detail.py`
- `storage/test_delete_document_record.py`
- `kb/test_collection_handle.py`
- `kb/test_coordinator_document_lifecycle.py`

All #508 suites and the adjacent register-path suites (multitenancy, metadata propagation, chunk, parse, search) pass. The pre-commit gate (ruff check/format, mypy, isort, codespell) is clean on all changed files.

Closes #508.
