### PR TITLE
feat(react): in-turn tool concurrency for the ReAct pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,10 @@ repos:
           - langchain-openai
           - langchain-community
           - numexpr
+          # Pin to the project's resolved numpy (uv.lock). Unpinned, the mypy
+          # hook env pulls the latest numpy, whose newer stubs use PEP 695
+          # `type` syntax that fails under python_version = 3.11 and aborts the
+          # whole mypy run before it reaches project code.
           - numpy==1.26.4
           - html2text
           - rich

--- a/example.env
+++ b/example.env
@@ -175,6 +175,13 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # Requires installing the optional extra: pip install "xagent[waf-crawl]"
 # XAGENT_WEB_CRAWL_TLS_IMPERSONATE="auto"
 
+# In-turn tool concurrency: run independent, concurrency-safe tool calls from a
+# single ReAct turn in parallel instead of one-by-one. Default off (serial).
+# XAGENT_TOOL_PARALLEL_ENABLED="false"
+# Max concurrent tool calls per turn batch (kept low to limit API rate-limit
+# pressure). Invalid/non-positive values fall back to the default.
+# XAGENT_TOOL_MAX_CONCURRENCY="3"
+
 # Zhipu Web Search (recommended for Chinese users, get key at https://open.bigmodel.cn/)
 ZHIPU_API_KEY=""
 

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -199,6 +199,11 @@ export function processTraceEvents(
   taskStatus?: string,
 ): ProcessedStep[] {
     const stepsMap = new Map<string, ProcessedStep>();
+    // Steps that ever had more than one tool in flight at once. Their step-level
+    // output scalar is meaningless (whichever tool finishes last would clobber
+    // it), so once a step is flagged concurrent we stop writing step.output and
+    // rely on the per-action outputs instead.
+    const concurrentSteps = new Set<string>();
     let currentReactStepId: string | null = null;
     const orderedEvents = events
       .map((event, index) => {
@@ -520,10 +525,20 @@ export function processTraceEvents(
           // except if there's an 'error' field handled elsewhere.
         }
 
-        // Don't clobber the step-level output scalar when multiple tools are in
-        // flight (the per-action output below is the authoritative value).
-        const toolActionCount = step.actions.filter(a => a.type === 'tool').length;
-        if (toolActionCount <= 1) {
+        // Detect *actual* concurrency, not just multiple tools in the step: at
+        // the moment a tool ends it is still marked 'running' (its status is set
+        // below), so >1 running tool here means siblings overlapped it. Counting
+        // total tool actions instead would wrongly suppress step.output for
+        // tools that merely ran sequentially within the same step. Once a step
+        // is concurrent the scalar is unreliable, so keep the per-action outputs
+        // authoritative and stop writing step.output for it.
+        const runningTools = step.actions.filter(
+          a => a.type === 'tool' && a.status === 'running'
+        );
+        if (runningTools.length > 1) {
+          concurrentSteps.add(stepId);
+        }
+        if (!concurrentSteps.has(stepId)) {
           step.output = output;
         }
         const artifacts =

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -109,6 +109,7 @@ interface StepAction {
     assistant_content?: string;
     error?: any;
     tool_calls?: any;
+    tool_call_id?: string;
     sandboxed?: boolean;
     inline?: boolean;
   };
@@ -190,9 +191,13 @@ const isAgentProgressEvent = (event: TraceEvent): boolean => (
 );
 
 // Process trace events into steps
-function useProcessedSteps(events: TraceEvent[], taskStatus?: string): ProcessedStep[] {
-  const { t } = useI18n();
-  return useMemo(() => {
+// Pure reducer over trace events -> ordered steps. Exported for unit testing
+// (e.g. tool_call_id attribution under in-turn tool concurrency).
+export function processTraceEvents(
+  events: TraceEvent[],
+  t: (key: string, vars?: Record<string, string | number>) => string,
+  taskStatus?: string,
+): ProcessedStep[] {
     const stepsMap = new Map<string, ProcessedStep>();
     let currentReactStepId: string | null = null;
     const orderedEvents = events
@@ -211,6 +216,26 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
       for (let i = step.actions.length - 1; i >= 0; i--) {
         if (step.actions[i].type === type && step.actions[i].status === 'running') {
           return step.actions[i];
+        }
+      }
+      return null;
+    };
+
+    // Match a running tool action by its tool_call_id. With concurrent tool
+    // execution several same-named tools can be in flight at once, so pairing
+    // by "last running tool" mis-attributes results; the id makes it exact.
+    // Returns null when the id is absent so callers can fall back to
+    // findLastRunningAction (legacy / single-tool events).
+    const findRunningToolByCallId = (step: ProcessedStep, toolCallId?: string) => {
+      if (!toolCallId) return null;
+      for (let i = step.actions.length - 1; i >= 0; i--) {
+        const action = step.actions[i];
+        if (
+          action.type === 'tool' &&
+          action.status === 'running' &&
+          action.data?.tool_call_id === toolCallId
+        ) {
+          return action;
         }
       }
       return null;
@@ -428,6 +453,7 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
         }
         // Support both data.response.tool_name and data.tool_name
         const toolName = event.data?.response?.tool_name || event.data?.tool_name || t('traceEventRenderer.unknownTool');
+        const toolCallId = event.data?.tool_call_id as string | undefined;
         const assistantContent = event.data?.response?.assistant_content || event.data?.assistant_content;
 
         if (typeof assistantContent === 'string' && assistantContent.trim()) {
@@ -461,6 +487,7 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
             tool: toolName,
             args: toolArgs,
             code: step.code,
+            tool_call_id: toolCallId,
             sandboxed: !!event.data?.sandboxed
           }
         });
@@ -493,7 +520,12 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
           // except if there's an 'error' field handled elsewhere.
         }
 
-        step.output = output;
+        // Don't clobber the step-level output scalar when multiple tools are in
+        // flight (the per-action output below is the authoritative value).
+        const toolActionCount = step.actions.filter(a => a.type === 'tool').length;
+        if (toolActionCount <= 1) {
+          step.output = output;
+        }
         const artifacts =
           typeof result === 'object' &&
             result !== null &&
@@ -501,7 +533,10 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
             ? result.artifacts
             : undefined;
 
-        const action = findLastRunningAction(step, 'tool');
+        const endToolCallId = event.data?.tool_call_id as string | undefined;
+        const action =
+          findRunningToolByCallId(step, endToolCallId) ||
+          findLastRunningAction(step, 'tool');
         if (action) {
           action.status = 'completed';
           action.data.output = output;
@@ -582,7 +617,9 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
 
         // If no running action found, or type mismatch, try to find the last action of corresponding type
         if (event.event_type === 'tool_execution_failed') {
-          const lastTool = findLastRunningAction(step, 'tool');
+          const lastTool =
+            findRunningToolByCallId(step, errorData.tool_call_id as string | undefined) ||
+            findLastRunningAction(step, 'tool');
           if (lastTool) runningAction = lastTool;
         } else if (event.event_type === 'llm_call_failed') {
           const lastLlm = findLastRunningAction(step, 'llm');
@@ -640,7 +677,14 @@ function useProcessedSteps(events: TraceEvent[], taskStatus?: string): Processed
     }
 
     return steps;
-  }, [events, taskStatus, t]);
+}
+
+function useProcessedSteps(events: TraceEvent[], taskStatus?: string): ProcessedStep[] {
+  const { t } = useI18n();
+  return useMemo(
+    () => processTraceEvents(events, t, taskStatus),
+    [events, taskStatus, t],
+  );
 }
 
 

--- a/frontend/src/components/chat/trace-event-processing.test.ts
+++ b/frontend/src/components/chat/trace-event-processing.test.ts
@@ -116,6 +116,79 @@ describe("processTraceEvents tool_call_id attribution", () => {
     expect(b?.data.output).toBe("RESULT_B")
   })
 
+  it("updates step.output for sequential tools within one step", () => {
+    // Two tools run one-after-another (never overlapping). step.output must
+    // track the latest tool's output, exactly as it did before concurrency was
+    // introduced — counting total tool actions would wrongly freeze it.
+    const events = [
+      stepStart,
+      ev("tool_execution_start", {
+        tool_name: "calculator",
+        tool_call_id: "A",
+        tool_args: { expression: "1+1" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "calculator",
+        tool_call_id: "A",
+        result: { output: "RESULT_A" },
+      }),
+      ev("tool_execution_start", {
+        tool_name: "calculator",
+        tool_call_id: "B",
+        tool_args: { expression: "2+2" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "calculator",
+        tool_call_id: "B",
+        result: { output: "RESULT_B" },
+      }),
+    ]
+
+    const steps = processTraceEvents(events as never, t)
+    expect(steps[0].output).toBe("RESULT_B")
+  })
+
+  it("does not clobber step.output when tools run concurrently", () => {
+    // Both tools are in flight at once, so the step-level scalar is ambiguous;
+    // the processor leaves it unset and the per-action outputs carry the data.
+    const events = [
+      stepStart,
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        tool_args: { query: "a" },
+      }),
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        tool_args: { query: "b" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        result: { output: "RESULT_A" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        result: { output: "RESULT_B" },
+      }),
+    ]
+
+    const steps = processTraceEvents(events as never, t)
+    // step.output is left at its initial value, not clobbered by whichever
+    // concurrent tool happened to finish last.
+    expect(steps[0].output).not.toBe("RESULT_A")
+    expect(steps[0].output).not.toBe("RESULT_B")
+    const toolActions = steps[0].actions.filter((a) => a.type === "tool")
+    expect(toolActions.find((x) => x.data.tool_call_id === "A")?.data.output).toBe(
+      "RESULT_A"
+    )
+    expect(toolActions.find((x) => x.data.tool_call_id === "B")?.data.output).toBe(
+      "RESULT_B"
+    )
+  })
+
   it("falls back to last running tool when tool_call_id is absent (legacy)", () => {
     const events = [
       stepStart,

--- a/frontend/src/components/chat/trace-event-processing.test.ts
+++ b/frontend/src/components/chat/trace-event-processing.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Inc.7 (frontend) — tool-event attribution by tool_call_id.
+ *
+ * With in-turn tool concurrency, a single step can have several same-named tool
+ * actions in flight. The processor must attribute each tool_execution_end /
+ * _failed to the action with the matching tool_call_id, not to the
+ * "last running tool" (which mis-attributes output/status the moment completion
+ * order differs from reverse-start order).
+ */
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({ openFilePreview: vi.fn(), dispatch: vi.fn() }),
+}))
+vi.mock("@/lib/api-wrapper", () => ({ apiRequest: vi.fn() }))
+// These pull in heavy/optional deps (e.g. pptxviewjs) not needed for the
+// pure reducer under test.
+vi.mock("@/components/file/docx-preview-renderer", () => ({
+  DocxPreviewRenderer: () => null,
+}))
+vi.mock("@/components/file/excel-preview-renderer", () => ({
+  ExcelPreviewRenderer: () => null,
+}))
+vi.mock("@/components/file/pptx-preview-renderer", () => ({
+  PptxPreviewRenderer: () => null,
+}))
+
+import { processTraceEvents } from "./TraceEventRenderer"
+
+const t = (key: string, vars?: Record<string, string | number>) =>
+  vars?.tool ? `${key}:${vars.tool}` : key
+
+const ev = (event_type: string, data: Record<string, unknown>) => ({
+  event_type,
+  step_id: "step-1",
+  data,
+})
+
+const stepStart = ev("dag_step_start", { step_name: "Search" })
+
+describe("processTraceEvents tool_call_id attribution", () => {
+  it("attributes concurrent same-name tool results by tool_call_id", () => {
+    const events = [
+      stepStart,
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        tool_args: { query: "a" },
+      }),
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        tool_args: { query: "b" },
+      }),
+      // First-started finishes first: this is the order that breaks LIFO.
+      ev("tool_execution_end", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        result: { output: "RESULT_A" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        result: { output: "RESULT_B" },
+      }),
+    ]
+
+    const steps = processTraceEvents(events as never, t)
+    const toolActions = steps[0].actions.filter((a) => a.type === "tool")
+    const a = toolActions.find((x) => x.data.tool_call_id === "A")
+    const b = toolActions.find((x) => x.data.tool_call_id === "B")
+
+    expect(a?.data.output).toBe("RESULT_A")
+    expect(b?.data.output).toBe("RESULT_B")
+    expect(a?.status).toBe("completed")
+    expect(b?.status).toBe("completed")
+  })
+
+  it("attributes a concurrent tool failure by tool_call_id", () => {
+    const events = [
+      stepStart,
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        tool_args: { query: "a" },
+      }),
+      ev("tool_execution_start", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        tool_args: { query: "b" },
+      }),
+      ev("tool_execution_failed", {
+        tool_name: "web_search",
+        tool_call_id: "A",
+        error: "boom-A",
+      }),
+      ev("tool_execution_end", {
+        tool_name: "web_search",
+        tool_call_id: "B",
+        result: { output: "RESULT_B" },
+      }),
+    ]
+
+    const steps = processTraceEvents(events as never, t)
+    const toolActions = steps[0].actions.filter((a) => a.type === "tool")
+    const a = toolActions.find((x) => x.data.tool_call_id === "A")
+    const b = toolActions.find((x) => x.data.tool_call_id === "B")
+
+    expect(a?.status).toBe("failed")
+    expect(a?.data.error).toBe("boom-A")
+    expect(b?.status).toBe("completed")
+    expect(b?.data.output).toBe("RESULT_B")
+  })
+
+  it("falls back to last running tool when tool_call_id is absent (legacy)", () => {
+    const events = [
+      stepStart,
+      ev("tool_execution_start", {
+        tool_name: "calculator",
+        tool_args: { expression: "1+1" },
+      }),
+      ev("tool_execution_end", {
+        tool_name: "calculator",
+        result: { output: "2" },
+      }),
+    ]
+
+    const steps = processTraceEvents(events as never, t)
+    const toolActions = steps[0].actions.filter((a) => a.type === "tool")
+    expect(toolActions).toHaveLength(1)
+    expect(toolActions[0].status).toBe("completed")
+    expect(toolActions[0].data.output).toBe("2")
+  })
+})

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -60,6 +60,8 @@ SANDBOX_HOST_STORAGE_ROOT = "XAGENT_SANDBOX_HOST_STORAGE_ROOT"
 BOXLITE_HOME_DIR = "BOXLITE_HOME_DIR"
 WEB_SEARCH_PROVIDER = "XAGENT_WEB_SEARCH_PROVIDER"
 WEB_CRAWL_TLS_IMPERSONATE = "XAGENT_WEB_CRAWL_TLS_IMPERSONATE"
+TOOL_PARALLEL_ENABLED = "XAGENT_TOOL_PARALLEL_ENABLED"
+TOOL_MAX_CONCURRENCY = "XAGENT_TOOL_MAX_CONCURRENCY"
 REDIS_URL = "XAGENT_REDIS_URL"
 HOT_PATH_CACHE_ENABLED = "XAGENT_HOT_PATH_CACHE_ENABLED"
 HOT_PATH_CACHE_TTL_SECONDS = "XAGENT_HOT_PATH_CACHE_TTL_SECONDS"
@@ -340,6 +342,35 @@ def get_hot_path_task_cache_ttl_seconds() -> int:
 def get_celery_enabled() -> bool:
     """Return whether durable background jobs should be enqueued to Celery."""
     return _get_bool_env(CELERY_ENABLED, False)
+
+
+def get_tool_parallel_enabled() -> bool:
+    """Whether independent tool calls in a ReAct turn run concurrently.
+
+    Priority:
+        1. XAGENT_TOOL_PARALLEL_ENABLED environment variable
+        2. Default ``False`` (serial; byte-for-byte equivalent to before)
+
+    Returns:
+        True if concurrency-safe tool calls in a turn should run as a batch.
+    """
+    return _get_bool_env(TOOL_PARALLEL_ENABLED, False)
+
+
+def get_tool_max_concurrency() -> int:
+    """Maximum concurrent tool calls per ReAct turn batch (Semaphore bound).
+
+    Priority:
+        1. XAGENT_TOOL_MAX_CONCURRENCY environment variable
+        2. Default ``3`` (kept low to limit API rate-limit pressure;
+           per-API throttling is tracked separately)
+
+    Invalid or non-positive values fall back to the default.
+
+    Returns:
+        The per-batch concurrency cap (>= 1).
+    """
+    return _get_positive_int_env(TOOL_MAX_CONCURRENCY, 3)
 
 
 def get_celery_broker_url() -> str | None:

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -248,10 +248,14 @@ class AgentExecutionAdapter:
         if self.config.pattern == "auto":
             return (
                 AutoPattern(
+                    react_pattern=ReActPattern(
+                        tool_parallel_enabled=self.config.tool_parallel_enabled,
+                        tool_max_concurrency=self.config.tool_max_concurrency,
+                    ),
                     dag_pattern=DAGPattern(
                         LLMPlanGenerator(),
                         max_concurrency=self.config.dag_max_concurrency,
-                    )
+                    ),
                 ),
                 "agent_auto",
             )

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from ...config import get_tool_max_concurrency, get_tool_parallel_enabled
 from .agent import Agent
 from .pattern import AutoPattern, DAGPattern, LLMPlanGenerator, ReActPattern
 from .registry import ExecutionRegistry
@@ -28,6 +29,8 @@ class AgentExecutionConfig:
     service_id: str | None = None
     registry: ExecutionRegistry | None = None
     dag_max_concurrency: int = 4
+    tool_parallel_enabled: bool = field(default_factory=get_tool_parallel_enabled)
+    tool_max_concurrency: int = field(default_factory=get_tool_max_concurrency)
     outbound_message_handler: Any | None = None
     conversation_history: list[dict[str, Any]] = field(default_factory=list)
     execution_context_messages: list[dict[str, Any]] = field(default_factory=list)
@@ -254,10 +257,21 @@ class AgentExecutionAdapter:
             )
         if self.config.pattern == "single_call":
             return (
-                ReActPattern(max_iterations=2, finalize_after_tool_result=True),
+                ReActPattern(
+                    max_iterations=2,
+                    finalize_after_tool_result=True,
+                    tool_parallel_enabled=self.config.tool_parallel_enabled,
+                    tool_max_concurrency=self.config.tool_max_concurrency,
+                ),
                 "agent_single_call",
             )
-        return ReActPattern(), "agent_react"
+        return (
+            ReActPattern(
+                tool_parallel_enabled=self.config.tool_parallel_enabled,
+                tool_max_concurrency=self.config.tool_max_concurrency,
+            ),
+            "agent_react",
+        )
 
     def _initial_messages(self) -> list[dict[str, Any]]:
         return [

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1,3 +1,31 @@
+"""ReAct execution pattern for the agent runtime.
+
+In-turn tool concurrency (off by default; gated by ``tool_parallel_enabled``)
+lets consecutive concurrency-safe tool calls in a single turn run as a bounded
+concurrent batch instead of strictly serially. The implementation preserves
+these invariants — referenced as I1–I6 in the code below — so that enabling the
+flag never changes observable results, only latency:
+
+- I1 (ordered backfill): tool results are written to the context in the model's
+  original tool-call order, regardless of which tool finishes first.
+- I2 (one result per call): every ``tool_call_id`` gets exactly one result,
+  including failures.
+- I3 (ledger order): ``tool_ledger`` insertion order matches input order after a
+  batch, because the consecutive-count walks read it in reverse insertion order.
+- I4 (control short-circuit): a control tool (final_answer / send_message /
+  ask_user_question) owns its segment and ends the turn's tool execution; later
+  tool calls in the same turn do not run.
+- I5 (interrupt / resume): an interrupt is honored at a segment boundary with
+  the remaining calls left pending; a crash mid-batch leaves the whole segment
+  pending so resume re-runs it (safe because batched tools are read-only).
+- I6 (trace pairing): tool trace spans pair START with END/ERROR by
+  ``tool_call_id`` rather than tool name, so concurrent same-name calls do not
+  cross-attribute (see ``tracing/langfuse/handler.py``).
+
+When ``tool_parallel_enabled`` is False every segment is a single serial call,
+making the loop byte-for-byte equivalent to the pre-concurrency behavior.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -1209,6 +1237,16 @@ class ReActPattern(AgentPattern):
             if not self._tool_is_concurrency_safe(name, tools):
                 break
             segment.append(tool_call)
+            # Cap a batch at the concurrency width. The loop re-checks the
+            # interrupt before each segment, so a mid-turn interrupt is honored
+            # after at most one wave instead of after every safe call the model
+            # emitted. Tradeoff: a run longer than the width is split into
+            # successive gather() barriers rather than one continuously
+            # pipelined batch, so under skewed tool latencies a straggler in one
+            # wave can briefly idle the next wave's slots. Acceptable for v1;
+            # decouple batch size from the semaphore if profiling shows it costs.
+            if len(segment) >= self.tool_max_concurrency:
+                break
         # A lone safe tool degrades to serial: no gather/Semaphore overhead and
         # byte-for-byte identical behavior to the current serial path.
         if len(segment) == 1:
@@ -1873,44 +1911,63 @@ class ReActPattern(AgentPattern):
         tool_call = self._with_tool_call_content(tool_call)
         tool_call = self._with_runtime_step(tool_call, runtime)
         self._record_tool_call(tool_call, status="running")
-        await runtime.on_tool_start(tool_call=tool_call)
+        recorded_terminal = False
         try:
-            result = await self._execute_tool(tool_call, tools)
-        except Exception as exc:  # noqa: BLE001
-            error_result = {
-                "success": False,
-                "error": str(exc),
-                "tool_name": tool_call["name"],
-            }
-            await runtime.on_tool_error(
-                tool_call=tool_call, error=exc, result=error_result
-            )
-            self._record_tool_call(
-                tool_call,
-                status="failed",
-                result=error_result,
-                error=str(exc),
-            )
-            return error_result
+            await runtime.on_tool_start(tool_call=tool_call)
+            try:
+                result = await self._execute_tool(tool_call, tools)
+            except Exception as exc:  # noqa: BLE001
+                error_result = {
+                    "success": False,
+                    "error": str(exc),
+                    "tool_name": tool_call["name"],
+                }
+                await runtime.on_tool_error(
+                    tool_call=tool_call, error=exc, result=error_result
+                )
+                self._record_tool_call(
+                    tool_call,
+                    status="failed",
+                    result=error_result,
+                    error=str(exc),
+                )
+                recorded_terminal = True
+                return error_result
 
-        if not self._tool_result_success(result):
-            error_message = str(result.get("error") or result.get("message") or result)
-            await runtime.on_tool_error(
-                tool_call=tool_call,
-                error=RuntimeError(error_message),
-                result=result,
-            )
-            self._record_tool_call(
-                tool_call,
-                status="failed",
-                result=result,
-                error=error_message,
-            )
+            if not self._tool_result_success(result):
+                error_message = str(
+                    result.get("error") or result.get("message") or result
+                )
+                await runtime.on_tool_error(
+                    tool_call=tool_call,
+                    error=RuntimeError(error_message),
+                    result=result,
+                )
+                self._record_tool_call(
+                    tool_call,
+                    status="failed",
+                    result=result,
+                    error=error_message,
+                )
+                recorded_terminal = True
+                return result
+
+            self._record_tool_call(tool_call, status="completed", result=result)
+            recorded_terminal = True
+            await runtime.on_tool_end(tool_call=tool_call, result=result)
             return result
-
-        self._record_tool_call(tool_call, status="completed", result=result)
-        await runtime.on_tool_end(tool_call=tool_call, result=result)
-        return result
+        finally:
+            # An infra callback (on_tool_start) can raise before any terminal
+            # record is written. Never leave the ledger stuck at "running": the
+            # consecutive-count walks skip non-terminal records, which would
+            # undercount repeated-tool-decision triggers. The exception still
+            # propagates (serial path) or is captured by the batch gather.
+            if not recorded_terminal:
+                self._record_tool_call(
+                    tool_call,
+                    status="failed",
+                    error="tool execution aborted before completion",
+                )
 
     def _with_runtime_step(
         self, tool_call: dict[str, Any], runtime: PatternRuntime

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1911,6 +1911,15 @@ class ReActPattern(AgentPattern):
         tools: list[Any],
         runtime: PatternRuntime,
     ) -> Any:
+        # Stamp a stable id on the *original* dict before the _with_* transforms
+        # (which may return a copy). _record_tool_call only computes a fallback
+        # key locally; without writing it back, the key drifts between the
+        # running/completed writes as the ledger grows, and the still-id-less
+        # dict that _backfill_result / _reorder_ledger_for_batch read desyncs
+        # from the ledger (I2/I3). No await runs before the first record below,
+        # so concurrent batch members get distinct fallback ids.
+        if not tool_call.get("id"):
+            tool_call["id"] = f"tool_call_{len(self.tool_ledger)}"
         tool_call = self._with_tool_call_content(tool_call)
         tool_call = self._with_runtime_step(tool_call, runtime)
         self._record_tool_call(tool_call, status="running")

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1264,7 +1264,29 @@ class ReActPattern(AgentPattern):
 
         for tool_call, result in zip(batch, results):
             self._backfill_result(tool_call, result, context)
+        self._reorder_ledger_for_batch(batch)
         return results
+
+    def _reorder_ledger_for_batch(self, batch: list[dict[str, Any]]) -> None:
+        """Reassert input order for this batch's ledger records (I3).
+
+        Concurrent execution can interleave ``_record_tool_call`` writes, so the
+        batch's records may land out of order in the insertion-ordered ledger.
+        ``_consecutive_*_count`` walk the ledger in reverse insertion order, so
+        we pop this batch's records and re-insert them at the tail in the
+        original tool-call order. Records keep their latest (final) state; only
+        their relative position is restored.
+        """
+        ids = [str(tool_call.get("id") or "") for tool_call in batch]
+        records = {
+            tool_id: self.tool_ledger.pop(tool_id)
+            for tool_id in ids
+            if tool_id in self.tool_ledger
+        }
+        for tool_id in ids:
+            record = records.get(tool_id)
+            if record is not None:
+                self.tool_ledger[tool_id] = record
 
     async def _execute_pending_tool_calls(
         self,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1209,6 +1209,63 @@ class ReActPattern(AgentPattern):
             return segment, "serial"
         return segment, "concurrent"
 
+    def _backfill_result(
+        self, tool_call: dict[str, Any], result: Any, context: Any
+    ) -> None:
+        """Record one tool result into the context and drop its cached content.
+
+        Shared by the serial and concurrent paths so message-history ordering
+        is produced the same way regardless of execution mode.
+        """
+        context.add_tool_result(
+            tool_name=tool_call["name"],
+            result=result,
+            tool_call_id=tool_call.get("id"),
+        )
+        self._forget_tool_call_content(tool_call)
+
+    async def _run_concurrent_batch(
+        self,
+        batch: list[dict[str, Any]],
+        tools: list[Any],
+        runtime: PatternRuntime,
+        context: Any,
+    ) -> list[Any]:
+        """Run a segment of concurrency-safe tool calls and back-fill in order.
+
+        Tools run under a Semaphore via ``asyncio.gather`` (results stay aligned
+        to ``batch`` regardless of completion order, satisfying I1). Results are
+        back-filled serially in the main coroutine after all tools finish, so
+        message-history order is deterministic (I1) and every call gets exactly
+        one result (I2). ``_execute_tool_safely`` already turns tool exceptions
+        into error dicts; ``return_exceptions=True`` is a belt-and-suspenders
+        guard against unexpected failures in the execution unit itself.
+        """
+        semaphore = asyncio.Semaphore(self.tool_max_concurrency)
+
+        async def _guarded(tool_call: dict[str, Any]) -> Any:
+            async with semaphore:
+                return await self._execute_tool_safely(tool_call, tools, runtime)
+
+        raw_results = await asyncio.gather(
+            *(_guarded(tool_call) for tool_call in batch),
+            return_exceptions=True,
+        )
+
+        results: list[Any] = []
+        for tool_call, result in zip(batch, raw_results):
+            if isinstance(result, BaseException):
+                result = {
+                    "success": False,
+                    "error": str(result),
+                    "tool_name": tool_call["name"],
+                }
+            results.append(result)
+
+        for tool_call, result in zip(batch, results):
+            self._backfill_result(tool_call, result, context)
+        return results
+
     async def _execute_pending_tool_calls(
         self,
         *,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1282,8 +1282,9 @@ class ReActPattern(AgentPattern):
         back-filled serially in the main coroutine after all tools finish, so
         message-history order is deterministic (I1) and every call gets exactly
         one result (I2). ``_execute_tool_safely`` already turns tool exceptions
-        into error dicts; ``return_exceptions=True`` is a belt-and-suspenders
-        guard against unexpected failures in the execution unit itself.
+        into error dicts, so any real exception captured by
+        ``return_exceptions=True`` is an infra-callback/unexpected failure and is
+        re-raised to halt the turn exactly like the serial path (I5).
         """
         semaphore = asyncio.Semaphore(self.tool_max_concurrency)
 
@@ -1296,20 +1297,22 @@ class ReActPattern(AgentPattern):
             return_exceptions=True,
         )
 
-        results: list[Any] = []
-        for tool_call, result in zip(batch, raw_results):
+        # Tool-level failures are already converted to error dicts inside
+        # _execute_tool_safely, so anything coming back as a real exception is an
+        # infra-callback failure (on_tool_start/on_tool_end) or an unexpected
+        # bug. The serial path lets those propagate and halt the turn; re-raise
+        # here so the concurrent path behaves identically instead of
+        # mis-reporting infrastructure breakage to the model as a tool failure.
+        # Re-raising before backfill leaves the whole (idempotent) segment
+        # pending, so resume re-runs it cleanly (I5).
+        for result in raw_results:
             if isinstance(result, BaseException):
-                result = {
-                    "success": False,
-                    "error": str(result),
-                    "tool_name": tool_call["name"],
-                }
-            results.append(result)
+                raise result
 
-        for tool_call, result in zip(batch, results):
+        for tool_call, result in zip(batch, raw_results):
             self._backfill_result(tool_call, result, context)
         self._reorder_ledger_for_batch(batch)
-        return results
+        return list(raw_results)
 
     def _reorder_ledger_for_batch(self, batch: list[dict[str, Any]]) -> None:
         """Reassert input order for this batch's ledger records (I3).

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -600,6 +600,8 @@ class ReActPattern(AgentPattern):
             "current_iteration": self.current_iteration,
             "max_iterations": self.max_iterations,
             "finalize_after_tool_result": self.finalize_after_tool_result,
+            "tool_parallel_enabled": self.tool_parallel_enabled,
+            "tool_max_concurrency": self.tool_max_concurrency,
             "repeated_tool_decision_after_consecutive_tool_calls": (
                 self.repeated_tool_decision_after_consecutive_tool_calls
             ),
@@ -629,6 +631,10 @@ class ReActPattern(AgentPattern):
         self.finalize_after_tool_result = bool(
             state.get("finalize_after_tool_result", self.finalize_after_tool_result)
         )
+        if "tool_parallel_enabled" in state:
+            self.tool_parallel_enabled = bool(state["tool_parallel_enabled"])
+        if "tool_max_concurrency" in state:
+            self.tool_max_concurrency = max(1, int(state["tool_max_concurrency"]))
         if "repeated_tool_decision_after_consecutive_tool_calls" in state:
             raw_threshold = state["repeated_tool_decision_after_consecutive_tool_calls"]
             self.repeated_tool_decision_after_consecutive_tool_calls = (

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1306,55 +1306,88 @@ class ReActPattern(AgentPattern):
             if interrupted is not None:
                 return interrupted
 
-            tool_call = self.pending_tool_calls[0]
-            control_result = await self._handle_control_tool(
-                tool_call,
-                context,
-                llm,
-                runtime,
-            )
-            if control_result is not None:
+            segment, kind = self._next_segment(self.pending_tool_calls, tools)
+
+            if kind == "control":
+                tool_call = segment[0]
+                control_result = await self._handle_control_tool(
+                    tool_call,
+                    context,
+                    llm,
+                    runtime,
+                )
                 self.pending_tool_calls = self.pending_tool_calls[1:]
                 self._forget_tool_call_content(tool_call)
                 await runtime.checkpoint(
-                    str(control_result.get("status", "control_tool")),
+                    str(control_result.get("status", "control_tool"))
+                    if control_result is not None
+                    else "control_tool",
                     context=context,
                     pattern=self,
                     metadata={"tool_call": tool_call},
                 )
-                if control_result.get("status") == "completed":
-                    self.pending_tool_calls = []
-                    return control_result
-                if control_result.get("status") == "waiting_for_user":
-                    return control_result
+                if control_result is not None:
+                    if control_result.get("status") == "completed":
+                        self.pending_tool_calls = []
+                        return control_result
+                    if control_result.get("status") == "waiting_for_user":
+                        return control_result
                 continue
 
-            await runtime.checkpoint(
-                "before_tool",
-                context=context,
-                pattern=self,
-                metadata={"tool_call": tool_call},
-            )
-            result = await self._execute_tool_safely(tool_call, tools, runtime)
-            context.add_tool_result(
-                tool_name=tool_call["name"],
-                result=result,
-                tool_call_id=tool_call.get("id"),
-            )
-            self.pending_tool_calls = self.pending_tool_calls[1:]
-            self._forget_tool_call_content(tool_call)
-            await runtime.checkpoint(
-                "after_tool",
-                context=context,
-                pattern=self,
-                metadata={"tool_call": tool_call},
-            )
+            if kind == "serial":
+                tool_call = segment[0]
+                await runtime.checkpoint(
+                    "before_tool",
+                    context=context,
+                    pattern=self,
+                    metadata={"tool_call": tool_call},
+                )
+                result = await self._execute_tool_safely(tool_call, tools, runtime)
+                self._backfill_result(tool_call, result, context)
+                self.pending_tool_calls = self.pending_tool_calls[1:]
+                await runtime.checkpoint(
+                    "after_tool",
+                    context=context,
+                    pattern=self,
+                    metadata={"tool_call": tool_call},
+                )
+                results = [result]
+            else:  # kind == "concurrent"
+                await runtime.checkpoint(
+                    "before_tool_batch",
+                    context=context,
+                    pattern=self,
+                    metadata={"tool_calls": segment},
+                )
+                results = await self._run_concurrent_batch(
+                    segment, tools, runtime, context
+                )
+                self.pending_tool_calls = self.pending_tool_calls[len(segment) :]
+                await runtime.checkpoint(
+                    "after_tool_batch",
+                    context=context,
+                    pattern=self,
+                    metadata={"tool_calls": segment},
+                )
+                # In-flight tools are not cancellable, so an interrupt that
+                # arrives during the batch is honored here, at the segment
+                # boundary. The completed (read-only, concurrency-safe) results
+                # are already recorded, which is correct for resume.
+                interrupted = await self._interrupt_if_requested(
+                    runtime=runtime,
+                    context=context,
+                    label="after_tool_batch",
+                )
+                if interrupted is not None:
+                    return interrupted
+
+            # Evaluate repeated-tool-decision once per segment, on its last call.
             requested_decision = await self._request_repeated_tool_decision_if_needed(
-                tool_call=tool_call,
+                tool_call=segment[-1],
                 context=context,
                 runtime=runtime,
             )
-            if self._tool_result_success(result):
+            if any(self._tool_result_success(result) for result in results):
                 successful_tool_result = True
             if requested_decision:
                 successful_tool_result = False

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -148,12 +148,19 @@ class ReActPattern(AgentPattern):
         repeated_tool_decision_after_consecutive_work_tool_calls: int | None = (
             DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_WORK_TOOL_CALLS
         ),
+        tool_parallel_enabled: bool = False,
+        tool_max_concurrency: int = 3,
     ) -> None:
         self.llm = llm
         self.max_iterations = max_iterations
         self.tool_choice = tool_choice
         self.reasoning_mode = ReActReasoningMode(reasoning_mode)
         self.finalize_after_tool_result = finalize_after_tool_result
+        # In-turn tool concurrency (default off). When enabled, consecutive
+        # concurrency-safe tool calls in a single turn run as a concurrent
+        # batch bounded by ``tool_max_concurrency``.
+        self.tool_parallel_enabled = tool_parallel_enabled
+        self.tool_max_concurrency = max(1, int(tool_max_concurrency))
         self.repeated_tool_decision_after_consecutive_tool_calls = (
             repeated_tool_decision_after_consecutive_tool_calls
         )
@@ -1153,6 +1160,54 @@ class ReActPattern(AgentPattern):
             }
 
         return None
+
+    def _tool_is_concurrency_safe(self, name: str, tools: list[Any]) -> bool:
+        """Whether ``name`` may run concurrently with other safe tools.
+
+        Conservative: unknown tools and tools without the metadata flag are
+        treated as not safe.
+        """
+        try:
+            tool = self._find_tool(name, tools)
+        except ValueError:
+            return False
+        metadata = getattr(tool, "metadata", None)
+        return bool(getattr(metadata, "concurrency_safe", False))
+
+    def _next_segment(
+        self, pending: list[dict[str, Any]], tools: list[Any]
+    ) -> tuple[list[dict[str, Any]], str]:
+        """Slice the next consecutive segment off the front of ``pending``.
+
+        Returns ``(segment, kind)`` where ``kind`` is one of:
+        - ``"control"``: a single control tool (final_answer / send_message /
+          ask_user_question), which always owns its segment;
+        - ``"serial"``: a single tool executed on its own (a non-safe tool, any
+          tool when the parallel flag is off, or a lone safe tool);
+        - ``"concurrent"``: two or more consecutive concurrency-safe tools.
+        """
+        control_tool_names = self._control_tool_names()
+        first = pending[0]
+        if first["name"] in control_tool_names:
+            return [first], "control"
+        if not self.tool_parallel_enabled:
+            return [first], "serial"
+        if not self._tool_is_concurrency_safe(first["name"], tools):
+            return [first], "serial"
+
+        segment: list[dict[str, Any]] = []
+        for tool_call in pending:
+            name = tool_call["name"]
+            if name in control_tool_names:
+                break
+            if not self._tool_is_concurrency_safe(name, tools):
+                break
+            segment.append(tool_call)
+        # A lone safe tool degrades to serial: no gather/Semaphore overhead and
+        # byte-for-byte identical behavior to the current serial path.
+        if len(segment) == 1:
+            return segment, "serial"
+        return segment, "concurrent"
 
     async def _execute_pending_tool_calls(
         self,

--- a/src/xagent/core/storage/manager.py
+++ b/src/xagent/core/storage/manager.py
@@ -17,6 +17,7 @@ from ...config import (
     get_default_sqlite_db_path,
 )
 from ...config import get_storage_root as get_config_storage_root
+from ...db.sqlite import apply_sqlite_concurrency_pragmas
 
 __all__ = [
     "StorageRootManager",
@@ -133,6 +134,9 @@ def create_db_session() -> Session:
     connect_args = {"check_same_thread": False} if "sqlite" in database_url else {}
     # Create database engine
     engine = create_engine(database_url, connect_args=connect_args)
+    # WAL + busy_timeout so concurrent writes wait for the lock instead of
+    # failing with "database is locked" (no-op on non-SQLite engines).
+    apply_sqlite_concurrency_pragmas(engine)
     # Create session factory
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -51,6 +51,16 @@ class ToolMetadata(BaseModel):
     # Optional logical group used by generic agent-control heuristics that
     # should treat related tools as one repeated action stream.
     decision_group: Optional[str] = None
+    # Concurrent-execution semantics (consumed by the ReAct in-turn scheduler).
+    # ``read_only`` is the stronger declaration: the tool is guaranteed not to
+    # write the filesystem / DB / any shared state. ``concurrency_safe`` is the
+    # only field the scheduler reads: it is safe to run this tool concurrently
+    # with other concurrency-safe tools in the same turn (idempotent, no
+    # process-global side effects, independent of other tools' results in the
+    # same turn). ``read_only`` implies ``concurrency_safe`` (enforced where the
+    # metadata is constructed).
+    read_only: bool = False
+    concurrency_safe: bool = False
 
 
 @runtime_checkable
@@ -98,6 +108,12 @@ class AbstractBaseTool(ABC, Tool):
             category=getattr(self, "category", ToolCategory.OTHER),
             source_server=getattr(self, "source_server", None),
             decision_group=getattr(self, "decision_group", None),
+            read_only=getattr(self, "read_only", False),
+            # read_only implies concurrency_safe; fall back to the explicit flag.
+            concurrency_safe=(
+                getattr(self, "concurrency_safe", False)
+                or getattr(self, "read_only", False)
+            ),
         )
 
     @abstractmethod

--- a/src/xagent/core/tools/adapters/vibe/exa_web_search.py
+++ b/src/xagent/core/tools/adapters/vibe/exa_web_search.py
@@ -61,6 +61,7 @@ class ExaWebSearchTool(AbstractBaseTool):
     """Framework wrapper for the Exa AI-powered web search tool."""
 
     category = ToolCategory.WEB_SEARCH
+    read_only = True  # read-only HTTP search ⇒ concurrency-safe
 
     def __init__(self, api_key: str | None = None) -> None:
         self._visibility = ToolVisibility.PUBLIC

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -32,6 +32,7 @@ class FetchWebContentTool(AbstractBaseTool):
     """Tool for reading a specific webpage after search discovers a URL."""
 
     category = ToolCategory.WEB_SEARCH
+    read_only = True  # read-only HTTP GET ⇒ concurrency-safe
 
     def __init__(self) -> None:
         self._visibility = ToolVisibility.PUBLIC

--- a/src/xagent/core/tools/adapters/vibe/file_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_tool.py
@@ -42,6 +42,7 @@ read_file_tool = FileTool(
         "context; use start_line/end_line to inspect a specific 1-based "
         "inclusive line range instead of repeating the same full-file read."
     ),
+    read_only=True,
 )
 write_file_tool = FileTool(
     write_file, name="write_file", description="Write content to file"
@@ -51,25 +52,40 @@ append_file_tool = FileTool(
 )
 delete_file_tool = FileTool(delete_file, name="delete_file", description="Delete file")
 list_files_tool = FileTool(
-    list_files, name="list_files", description="List files in directory"
+    list_files,
+    name="list_files",
+    description="List files in directory",
+    read_only=True,
 )
 create_directory_tool = FileTool(
     create_directory, name="create_directory", description="Create directory"
 )
 file_exists_tool = FileTool(
-    file_exists, name="file_exists", description="Check if file exists"
+    file_exists,
+    name="file_exists",
+    description="Check if file exists",
+    read_only=True,
 )
 get_file_info_tool = FileTool(
-    get_file_info, name="get_file_info", description="Get detailed file information"
+    get_file_info,
+    name="get_file_info",
+    description="Get detailed file information",
+    read_only=True,
 )
 read_json_file_tool = FileTool(
-    read_json_file, name="read_json_file", description="Read JSON file"
+    read_json_file,
+    name="read_json_file",
+    description="Read JSON file",
+    read_only=True,
 )
 write_json_file_tool = FileTool(
     write_json_file, name="write_json_file", description="Write JSON file"
 )
 read_csv_file_tool = FileTool(
-    read_csv_file, name="read_csv_file", description="Read CSV file"
+    read_csv_file,
+    name="read_csv_file",
+    description="Read CSV file",
+    read_only=True,
 )
 write_csv_file_tool = FileTool(
     write_csv_file, name="write_csv_file", description="Write CSV file"

--- a/src/xagent/core/tools/adapters/vibe/function.py
+++ b/src/xagent/core/tools/adapters/vibe/function.py
@@ -32,6 +32,8 @@ class FunctionTool(AbstractBaseTool):
         tags: Optional[list[str]] = None,
         visibility: Optional[ToolVisibility] = None,
         allow_users: Optional[list[str]] = None,
+        read_only: bool = False,
+        concurrency_safe: bool = False,
     ):
         self.func = func
         self._name = name or func.__name__
@@ -41,6 +43,9 @@ class FunctionTool(AbstractBaseTool):
         self._tags = tags or []
         self._visibility = visibility or ToolVisibility.PRIVATE
         self._allow_users = allow_users
+        # Concurrent-execution semantics (read by AbstractBaseTool.metadata).
+        self.read_only = read_only
+        self.concurrency_safe = concurrency_safe
 
         self._args_type = self._build_args_model()
         self._return_type = self._build_return_model()

--- a/src/xagent/core/tools/adapters/vibe/tavily_web_search.py
+++ b/src/xagent/core/tools/adapters/vibe/tavily_web_search.py
@@ -35,6 +35,7 @@ class TavilyWebSearchTool(AbstractBaseTool):
     """Framework wrapper for the Tavily web search tool."""
 
     category = ToolCategory.WEB_SEARCH
+    read_only = True  # read-only HTTP search ⇒ concurrency-safe
 
     def __init__(self, api_key: str | None = None) -> None:
         self._visibility = ToolVisibility.PUBLIC

--- a/src/xagent/core/tools/adapters/vibe/web_search.py
+++ b/src/xagent/core/tools/adapters/vibe/web_search.py
@@ -36,6 +36,7 @@ class WebSearchResult(BaseModel):
 
 class WebSearchTool(AbstractBaseTool):
     category = ToolCategory.WEB_SEARCH
+    read_only = True  # read-only HTTP search ⇒ concurrency-safe
     """Framework wrapper for the pure web search tool"""
 
     def __init__(self, api_key: str | None = None, cse_id: str | None = None) -> None:

--- a/src/xagent/core/tools/adapters/vibe/zhipu_web_search.py
+++ b/src/xagent/core/tools/adapters/vibe/zhipu_web_search.py
@@ -55,6 +55,7 @@ class ZhipuWebSearchTool(AbstractBaseTool):
     """Framework wrapper for the Zhipu web search tool."""
 
     category = ToolCategory.WEB_SEARCH
+    read_only = True  # read-only HTTP search ⇒ concurrency-safe
 
     def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
         self._visibility = ToolVisibility.PUBLIC

--- a/src/xagent/core/tracing/langfuse/handler.py
+++ b/src/xagent/core/tracing/langfuse/handler.py
@@ -467,8 +467,15 @@ class LangfuseTraceHandler(TraceHandler):
         }
 
     def _action_key(self, event: TraceEvent, data: Any) -> str:
+        category = event.event_type.category.value
+        # Prefer tool_call_id so concurrent same-step / same-name tool calls
+        # each map to a unique key (single-element list), giving exact START
+        # <-> END/ERROR pairing instead of last-in-wins (LIFO) mis-attribution.
+        # Falls back to tool_name for legacy / external events that omit it.
+        if isinstance(data, dict) and data.get("tool_call_id"):
+            return f"{event.step_id}:{category}:{data['tool_call_id']}"
         tool_name = data.get("tool_name") if isinstance(data, dict) else None
-        return f"{event.step_id}:{event.event_type.category.value}:{tool_name or ''}"
+        return f"{event.step_id}:{category}:{tool_name or ''}"
 
     def _error_message(self, data: Any) -> Optional[str]:
         if isinstance(data, dict):

--- a/src/xagent/db/sqlite.py
+++ b/src/xagent/db/sqlite.py
@@ -40,7 +40,29 @@ def apply_sqlite_concurrency_pragmas(
     def _set_sqlite_pragmas(dbapi_connection, _connection_record):  # type: ignore[no-untyped-def]
         cursor = dbapi_connection.cursor()
         try:
-            cursor.execute("PRAGMA journal_mode=WAL")
-            cursor.execute(f"PRAGMA busy_timeout={timeout_ms}")
+            _apply_concurrency_pragmas(cursor, timeout_ms)
         finally:
             cursor.close()
+
+
+def _apply_concurrency_pragmas(cursor, timeout_ms: int) -> None:  # type: ignore[no-untyped-def]
+    """Set the WAL + busy_timeout pragmas, best-effort.
+
+    A connect hook that raises breaks every connection, so a pragma failure must
+    never propagate. On a read-only database (or a directory where the -wal/-shm
+    sidecars cannot be created) ``PRAGMA journal_mode=WAL`` raises; we log and
+    continue. ``busy_timeout`` is connection-local (no disk write) and is set
+    independently so it still applies when WAL is unavailable.
+    """
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Could not enable SQLite WAL journal_mode (the database or its "
+            "directory may be read-only); continuing without it: %s",
+            exc,
+        )
+    try:
+        cursor.execute(f"PRAGMA busy_timeout={timeout_ms}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not set SQLite busy_timeout: %s", exc)

--- a/src/xagent/db/sqlite.py
+++ b/src/xagent/db/sqlite.py
@@ -1,0 +1,46 @@
+"""SQLite engine hardening for concurrent access.
+
+Enables WAL journaling (concurrent readers alongside a single writer) and a
+``busy_timeout`` (a writer waits for the lock instead of failing immediately
+with "database is locked") on SQLite engines. This lets the shared engine
+tolerate the concurrent writes that in-turn tool concurrency can produce.
+
+No effect on non-SQLite engines (e.g. Postgres handles this with MVCC and
+row-level locks).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import Engine, event
+
+logger = logging.getLogger(__name__)
+
+# 5s gives concurrent writers room to wait out a short-lived write lock without
+# unbounded blocking.
+DEFAULT_BUSY_TIMEOUT_MS = 5000
+
+
+def apply_sqlite_concurrency_pragmas(
+    engine: Engine, *, busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS
+) -> None:
+    """Register a connect hook that sets WAL + busy_timeout on SQLite engines.
+
+    Args:
+        engine: The SQLAlchemy engine to harden. Non-SQLite engines are ignored.
+        busy_timeout_ms: How long (ms) a blocked writer waits for the lock.
+    """
+    if engine.dialect.name != "sqlite":
+        return
+
+    timeout_ms = max(0, int(busy_timeout_ms))
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragmas(dbapi_connection, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute(f"PRAGMA busy_timeout={timeout_ms}")
+        finally:
+            cursor.close()

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
 
 from ...config import get_database_url
+from ...db.sqlite import apply_sqlite_concurrency_pragmas
 
 _SessionLocal: sessionmaker[Session] | None = None
 
@@ -90,6 +91,10 @@ def init_db(db_url: str | None = None) -> None:
             connect_args={"check_same_thread": False},
             poolclass=NullPool,  # SQLite doesn't need connection pooling
         )
+        # WAL + busy_timeout so concurrent writes (e.g. concurrent tool
+        # execution) wait for the lock instead of failing with "database is
+        # locked".
+        apply_sqlite_concurrency_pragmas(_engine)
     else:
         _engine = create_engine(
             database_url,

--- a/tests/core/agent/concurrency_harness.py
+++ b/tests/core/agent/concurrency_harness.py
@@ -1,0 +1,308 @@
+"""Reusable test harness for ReAct in-turn tool-concurrency development.
+
+Shared by the concurrency increments (segmentation, concurrent batch, ledger
+ordering, segment-loop integration, resume). Provides controllable fakes so
+order/concurrency assertions are deterministic:
+
+- ``FakeTool`` — minimal tool face with a configurable ``execute`` (delay/gate/
+  raises/result) plus concurrency-safety metadata; records its own calls and,
+  via a shared ``ConcurrencyTracker``, the live concurrency peak.
+- ``ConcurrencyTracker`` — tracks active/peak overlap and enter/leave order to
+  prove a batch ran concurrently (not serially) and respected the Semaphore cap.
+- ``RecordingContext`` — drop-in for ``ExecutionContext`` message methods that
+  records ``add_tool_result`` calls in order with their ``tool_call_id`` (I1/I2).
+- ``FakeRuntime`` — stubs the ``PatternRuntime`` surface ReAct touches
+  (checkpoint / on_tool_* / should_interrupt / interrupt_reason) and records the
+  call sequence for checkpoint/span assertions.
+- ``make_tool_call`` / ``make_react`` — small constructors for tool-call dicts
+  and a minimal ``ReActPattern`` wired with the concurrency knobs.
+
+This is test-support code (no production logic); it is exercised by
+``test_concurrency_harness.py``'s sanity test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from typing import Any
+
+from xagent.core.agent import ReActPattern
+
+_tool_call_ids = itertools.count(1)
+
+
+class ConcurrencyTracker:
+    """Records live concurrency so tests can assert real parallelism + cap.
+
+    ``enter`` is called before a fake tool awaits its delay/gate, so when N
+    tools run concurrently the active count reaches N (and ``peak`` records it)
+    before any of them leaves. A purely serial run never exceeds 1.
+    """
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+        self.enter_order: list[str] = []
+        self.leave_order: list[str] = []
+
+    def enter(self, name: str) -> None:
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        self.enter_order.append(name)
+
+    def leave(self, name: str) -> None:
+        self.active -= 1
+        self.leave_order.append(name)
+
+
+class FakeToolMetadata:
+    """Lightweight stand-in for ``ToolMetadata``.
+
+    Carries only what the scheduler reads (``name`` / ``concurrency_safe`` /
+    ``read_only`` / ``category`` / ``decision_group``). ``concurrency_safe`` is
+    implied by ``read_only`` to mirror the production implication rule.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        concurrency_safe: bool = False,
+        read_only: bool = False,
+        category: str = "basic",
+        decision_group: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        self.name = name
+        self.description = description or f"Fake tool {name}"
+        self.read_only = bool(read_only)
+        self.concurrency_safe = bool(concurrency_safe) or bool(read_only)
+        self.category = category
+        self.decision_group = decision_group
+
+
+class FakeTool:
+    """Controllable fake tool for concurrency and ordering tests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        concurrency_safe: bool = False,
+        read_only: bool = False,
+        delay: float = 0.0,
+        gate: asyncio.Event | None = None,
+        raises: BaseException | None = None,
+        result: Any = None,
+        decision_group: str | None = None,
+        tracker: ConcurrencyTracker | None = None,
+    ) -> None:
+        self.metadata = FakeToolMetadata(
+            name,
+            concurrency_safe=concurrency_safe,
+            read_only=read_only,
+            decision_group=decision_group,
+        )
+        self._delay = delay
+        self._gate = gate
+        self._raises = raises
+        self._result = result
+        self.tracker = tracker
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def name(self) -> str:
+        return self.metadata.name
+
+    async def execute(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        tracker = self.tracker
+        if tracker is not None:
+            tracker.enter(self.metadata.name)
+        try:
+            if self._gate is not None:
+                await self._gate.wait()
+            elif self._delay:
+                await asyncio.sleep(self._delay)
+            if self._raises is not None:
+                raise self._raises
+            if self._result is not None:
+                return self._result
+            return {"success": True, "tool": self.metadata.name, "args": dict(kwargs)}
+        finally:
+            if tracker is not None:
+                tracker.leave(self.metadata.name)
+
+
+class _RecordedMessage:
+    __slots__ = ("role", "content", "tool_call_id", "metadata")
+
+    def __init__(
+        self,
+        role: str,
+        content: Any,
+        tool_call_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.role = role
+        self.content = content
+        self.tool_call_id = tool_call_id
+        self.metadata = metadata or {}
+
+
+class RecordingContext:
+    """Records message-producing calls in order (drop-in for ExecutionContext).
+
+    ``tool_results`` preserves the exact order and ``tool_call_id`` of every
+    ``add_tool_result`` call, which is what the ordered-backfill (I1) and
+    pairing (I2) assertions inspect.
+    """
+
+    def __init__(self, execution_id: str | None = "task-test") -> None:
+        self.execution_id = execution_id
+        self.messages: list[_RecordedMessage] = []
+        self.tool_results: list[dict[str, Any]] = []
+
+    def add_tool_result(
+        self,
+        tool_name: str,
+        result: Any,
+        tool_call_id: str | None = None,
+    ) -> _RecordedMessage:
+        self.tool_results.append(
+            {
+                "tool_name": tool_name,
+                "result": result,
+                "tool_call_id": tool_call_id,
+            }
+        )
+        message = _RecordedMessage("tool", result, tool_call_id=tool_call_id)
+        self.messages.append(message)
+        return message
+
+    def add_assistant_message(self, content: str, **kwargs: Any) -> _RecordedMessage:
+        message = _RecordedMessage("assistant", content, metadata=dict(kwargs))
+        self.messages.append(message)
+        return message
+
+    def add_system_message(self, content: str, **kwargs: Any) -> _RecordedMessage:
+        message = _RecordedMessage("system", content, metadata=dict(kwargs))
+        self.messages.append(message)
+        return message
+
+
+class FakeRuntime:
+    """Stubs the PatternRuntime surface ReAct touches and records the sequence.
+
+    ``events`` is an ordered log of ``(kind, payload)`` tuples so tests can
+    assert checkpoint sequencing and per-call span pairing. ``should_interrupt``
+    is driven by ``interrupt_at``: a set of labels/statuses (or the literal
+    ``True`` for always) used by interrupt tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        execution_id: str | None = "task-test",
+        interrupt: bool = False,
+        interrupt_reason: str | None = None,
+    ) -> None:
+        self.execution_id = execution_id
+        self.active_react_step_id: str | None = None
+        self._interrupt = interrupt
+        self.interrupt_reason = interrupt_reason
+        self.events: list[tuple[str, Any]] = []
+
+    @staticmethod
+    def _tool_call_id(tool_call: dict[str, Any]) -> str | None:
+        value = tool_call.get("id")
+        return str(value) if value is not None else None
+
+    async def should_interrupt(self) -> bool:
+        return bool(self._interrupt)
+
+    def request_interrupt(self, reason: str | None = None) -> None:
+        self._interrupt = True
+        self.interrupt_reason = reason
+
+    async def checkpoint(
+        self,
+        status: str,
+        *,
+        context: Any = None,
+        pattern: Any = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.events.append(("checkpoint", {"status": status, "metadata": metadata}))
+
+    async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
+        self.events.append(
+            (
+                "on_tool_start",
+                {
+                    "tool_name": tool_call.get("name"),
+                    "tool_call_id": self._tool_call_id(tool_call),
+                },
+            )
+        )
+
+    async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
+        self.events.append(
+            (
+                "on_tool_end",
+                {
+                    "tool_name": tool_call.get("name"),
+                    "tool_call_id": self._tool_call_id(tool_call),
+                    "result": result,
+                },
+            )
+        )
+
+    async def on_tool_error(
+        self, *, tool_call: dict[str, Any], error: BaseException, result: Any
+    ) -> None:
+        self.events.append(
+            (
+                "on_tool_error",
+                {
+                    "tool_name": tool_call.get("name"),
+                    "tool_call_id": self._tool_call_id(tool_call),
+                    "error": str(error),
+                    "result": result,
+                },
+            )
+        )
+
+    def events_of(self, kind: str) -> list[Any]:
+        return [payload for event_kind, payload in self.events if event_kind == kind]
+
+
+def make_tool_call(
+    name: str,
+    args: dict[str, Any] | None = None,
+    id: str | None = None,
+) -> dict[str, Any]:
+    """Build a normalized tool-call dict; auto-assigns a unique id if omitted."""
+    return {
+        "name": name,
+        "args": dict(args or {}),
+        "id": id if id is not None else f"call_{next(_tool_call_ids)}",
+    }
+
+
+def make_react(
+    *,
+    parallel: bool = False,
+    max_concurrency: int = 3,
+    **kwargs: Any,
+) -> ReActPattern:
+    """Construct a minimal ReActPattern wired with the concurrency knobs.
+
+    The concurrency attributes are set defensively via ``setattr`` so the
+    harness works both before Inc.2 introduces them on ``__init__`` and after.
+    """
+    pattern = ReActPattern(**kwargs)
+    setattr(pattern, "tool_parallel_enabled", parallel)
+    setattr(pattern, "tool_max_concurrency", max_concurrency)
+    return pattern

--- a/tests/core/agent/concurrency_harness.py
+++ b/tests/core/agent/concurrency_harness.py
@@ -222,6 +222,9 @@ class FakeRuntime:
     async def should_interrupt(self) -> bool:
         return bool(self._interrupt)
 
+    async def send_message(self, **kwargs: Any) -> None:
+        self.events.append(("send_message", dict(kwargs)))
+
     def request_interrupt(self, reason: str | None = None) -> None:
         self._interrupt = True
         self.interrupt_reason = reason

--- a/tests/core/agent/test_concurrency_harness.py
+++ b/tests/core/agent/test_concurrency_harness.py
@@ -1,0 +1,130 @@
+"""Inc.0 sanity test: the concurrency harness imports and behaves as designed.
+
+This is the acceptance gate for the test scaffolding (design §9 Inc.0): it does
+not exercise any production concurrency path, only that the fakes are wired
+correctly and reusable by later increments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from tests.core.agent.concurrency_harness import (
+    ConcurrencyTracker,
+    FakeRuntime,
+    FakeTool,
+    RecordingContext,
+    make_react,
+    make_tool_call,
+)
+
+
+def test_make_tool_call_assigns_unique_ids() -> None:
+    a = make_tool_call("calculator", {"expression": "1+1"})
+    b = make_tool_call("calculator", {"expression": "2+2"})
+    assert a["name"] == "calculator"
+    assert a["args"] == {"expression": "1+1"}
+    assert a["id"] and b["id"] and a["id"] != b["id"]
+
+    explicit = make_tool_call("web_search", id="fixed")
+    assert explicit["id"] == "fixed"
+
+
+def test_fake_tool_metadata_implication() -> None:
+    read_only = FakeTool("web_search", read_only=True)
+    assert read_only.metadata.read_only is True
+    assert read_only.metadata.concurrency_safe is True
+
+    safe = FakeTool("calculator", concurrency_safe=True)
+    assert safe.metadata.read_only is False
+    assert safe.metadata.concurrency_safe is True
+
+    unsafe = FakeTool("write_file")
+    assert unsafe.metadata.concurrency_safe is False
+
+
+async def test_fake_tool_execute_returns_default_envelope() -> None:
+    tool = FakeTool("calculator", concurrency_safe=True)
+    result = await tool.execute(expression="1+1")
+    assert result == {
+        "success": True,
+        "tool": "calculator",
+        "args": {"expression": "1+1"},
+    }
+    assert tool.calls == [{"expression": "1+1"}]
+
+
+async def test_fake_tool_raises_is_propagated() -> None:
+    boom = RuntimeError("boom")
+    tool = FakeTool("broken", raises=boom)
+    try:
+        await tool.execute()
+    except RuntimeError as exc:
+        assert exc is boom
+    else:  # pragma: no cover - defensive
+        raise AssertionError("FakeTool(raises=...) should have raised")
+
+
+async def test_concurrency_tracker_observes_real_overlap() -> None:
+    tracker = ConcurrencyTracker()
+    gate = asyncio.Event()
+    tools = [
+        FakeTool(f"t{i}", concurrency_safe=True, gate=gate, tracker=tracker)
+        for i in range(3)
+    ]
+
+    async def run(tool: FakeTool) -> None:
+        await tool.execute()
+
+    tasks = [asyncio.create_task(run(tool)) for tool in tools]
+    # Let all three enter (and block on the gate) before any can leave.
+    while tracker.active < 3:
+        await asyncio.sleep(0)
+    assert tracker.peak == 3
+    gate.set()
+    await asyncio.gather(*tasks)
+    assert tracker.active == 0
+    assert len(tracker.leave_order) == 3
+
+
+def test_recording_context_preserves_order_and_ids() -> None:
+    context = RecordingContext()
+    context.add_tool_result(tool_name="a", result={"ok": 1}, tool_call_id="id-a")
+    context.add_tool_result(tool_name="b", result={"ok": 2}, tool_call_id="id-b")
+    context.add_assistant_message("done")
+
+    assert [r["tool_call_id"] for r in context.tool_results] == ["id-a", "id-b"]
+    assert [r["tool_name"] for r in context.tool_results] == ["a", "b"]
+    assert context.messages[-1].role == "assistant"
+    assert context.messages[-1].content == "done"
+
+
+async def test_fake_runtime_records_event_sequence() -> None:
+    runtime = FakeRuntime()
+    assert await runtime.should_interrupt() is False
+
+    tool_call = make_tool_call("calculator", id="cc-1")
+    await runtime.on_tool_start(tool_call=tool_call)
+    await runtime.checkpoint("before_tool", metadata={"tool_call": tool_call})
+    await runtime.on_tool_end(tool_call=tool_call, result={"success": True})
+
+    kinds = [kind for kind, _ in runtime.events]
+    assert kinds == ["on_tool_start", "checkpoint", "on_tool_end"]
+    assert runtime.events_of("on_tool_start")[0]["tool_call_id"] == "cc-1"
+
+
+async def test_fake_runtime_interrupt_flag() -> None:
+    runtime = FakeRuntime(interrupt=True, interrupt_reason="stop")
+    assert await runtime.should_interrupt() is True
+    assert runtime.interrupt_reason == "stop"
+
+
+def test_make_react_sets_concurrency_knobs() -> None:
+    serial = make_react()
+    assert serial.tool_parallel_enabled is False
+    assert serial.tool_max_concurrency == 3
+
+    parallel = make_react(parallel=True, max_concurrency=2, max_iterations=5)
+    assert parallel.tool_parallel_enabled is True
+    assert parallel.tool_max_concurrency == 2
+    assert parallel.max_iterations == 5

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -682,6 +682,32 @@ def test_execution_adapter_routes_auto_to_auto() -> None:
     assert pattern.dag_pattern.max_concurrency == 4
 
 
+def test_execution_adapter_passes_tool_concurrency_to_react_children() -> None:
+    # The tool-concurrency config must reach the ReAct child on every route that
+    # can run ReAct: single_call, react, and auto. auto is the default for
+    # standalone non-v1 tasks, so it is the common path for enabling the feature;
+    # it previously built a default ReActPattern() and silently dropped the
+    # config (regression guard).
+    def build_react_child(pattern: str) -> Any:
+        adapter = AgentExecutionAdapter(
+            AgentExecutionConfig(
+                name=pattern,
+                pattern=pattern,
+                llm=FakeLLM([]),
+                tool_parallel_enabled=True,
+                tool_max_concurrency=7,
+                skill_manager=NoSkillManager(),
+            )
+        )
+        built, _ = adapter._build_pattern()
+        return built.react_pattern if pattern == "auto" else built
+
+    for pattern in ("single_call", "react", "auto"):
+        react = build_react_child(pattern)
+        assert react.tool_parallel_enabled is True, pattern
+        assert react.tool_max_concurrency == 7, pattern
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_executes_auto_final_answer() -> None:
     llm = FakeLLM(

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -127,3 +127,92 @@ async def test_exception_isolation_within_batch() -> None:
     assert results[1]["success"] is False
     assert "kaboom" in results[1]["error"]
     assert results[2]["success"] is True
+
+
+# --- Inc.4: tool_ledger ordering after a concurrent batch (I3) -------------
+
+
+def test_reorder_ledger_for_batch_restores_input_order() -> None:
+    # Simulate interleaved completion writing batch records out of order, with
+    # a pre-existing record before the batch that must keep its position.
+    pattern = make_react(parallel=True)
+    pattern._record_tool_call(
+        make_tool_call("earlier", id="e0"), status="completed", result={"success": True}
+    )
+    batch = [
+        make_tool_call("s1", id="b1"),
+        make_tool_call("s2", id="b2"),
+        make_tool_call("s3", id="b3"),
+    ]
+    for tool_call in (batch[2], batch[0], batch[1]):  # scrambled order
+        pattern._record_tool_call(
+            tool_call, status="completed", result={"success": True}
+        )
+    assert list(pattern.tool_ledger.keys()) == ["e0", "b3", "b1", "b2"]
+
+    pattern._reorder_ledger_for_batch(batch)
+
+    assert list(pattern.tool_ledger.keys()) == ["e0", "b1", "b2", "b3"]
+
+
+async def test_concurrent_batch_keeps_ledger_in_input_order() -> None:
+    names = ["s1", "s2", "s3"]
+    tracker = ConcurrencyTracker()
+    gates = {name: asyncio.Event() for name in names}
+    tools = [
+        FakeTool(name, concurrency_safe=True, gate=gates[name], tracker=tracker)
+        for name in names
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    task = asyncio.create_task(
+        pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+    )
+    while tracker.active < 3:
+        await asyncio.sleep(0)
+    for index, name in enumerate(["s3", "s2", "s1"], start=1):  # reverse completion
+        gates[name].set()
+        while len(tracker.leave_order) < index:
+            await asyncio.sleep(0)
+    await task
+
+    assert [tc["id"] for tc in batch] == list(pattern.tool_ledger.keys())
+
+
+async def test_concurrent_batch_updates_consecutive_group_count() -> None:
+    group = "search"
+    names = ["s1", "s2", "s3"]
+    tools = [
+        FakeTool(name, concurrency_safe=True, decision_group=group) for name in names
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    pattern._tool_decision_groups_by_name = pattern._tool_decision_groups_for_tools(
+        tools
+    )
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    assert pattern._consecutive_successful_tool_group_count(group) == 3
+
+
+async def test_concurrent_batch_with_failure_counts_work_calls() -> None:
+    tools = [
+        FakeTool("s1", concurrency_safe=True),
+        FakeTool("boom", concurrency_safe=True, raises=RuntimeError("x")),
+        FakeTool("s3", concurrency_safe=True),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    pattern._tool_decision_groups_by_name = pattern._tool_decision_groups_for_tools(
+        tools
+    )
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in ["s1", "boom", "s3"]]
+
+    await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    # completed + failed both count as work calls.
+    assert pattern._consecutive_work_tool_call_count() == 3

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -150,6 +150,39 @@ async def test_infra_callback_failure_marks_ledger_terminal() -> None:
     assert pattern.tool_ledger[call["id"]].status == "failed"
 
 
+async def test_concurrent_batch_assigns_ids_to_id_less_calls() -> None:
+    # A tool call without an id must get a stable one stamped on the *original*
+    # dict before _execute_tool_safely's _with_* transforms run. _record_tool_call
+    # only generates a fallback key internally; if it is not written back, the
+    # key drifts between the running/completed writes (len(tool_ledger) grows in
+    # between) and never matches the still-id-less dict that _backfill_result and
+    # _reorder_ledger_for_batch read, desyncing the ledger from the context
+    # (I2/I3).
+    tools = [
+        FakeTool("s1", concurrency_safe=True),
+        FakeTool("s2", concurrency_safe=True),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=2)
+    runtime = FakeRuntime()
+    # An active ReAct step makes _with_runtime_step return a *copy*, so stamping
+    # the id after the transform (rather than before) would miss the original
+    # batch dict that backfill/reorder iterate over.
+    runtime.active_react_step_id = "step-x"
+    context = RecordingContext()
+    batch = [make_tool_call("s1", id=""), make_tool_call("s2", id="")]
+
+    await pattern._run_concurrent_batch(batch, tools, runtime, context)
+
+    # Exactly one terminal record per call (no orphan stuck at "running").
+    assert len(pattern.tool_ledger) == 2
+    assert all(record.status == "completed" for record in pattern.tool_ledger.values())
+    # Context tool_call_ids are non-empty and match the ledger keys in input
+    # order (I2 + I3).
+    ctx_ids = [r["tool_call_id"] for r in context.tool_results]
+    assert all(ctx_ids)
+    assert ctx_ids == list(pattern.tool_ledger.keys())
+
+
 async def test_concurrent_batch_propagates_infra_callback_failure() -> None:
     # An infra callback failure (on_tool_start) is a real exception, not a tool
     # failure. The serial path lets it propagate and halt the turn; the

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from tests.core.agent.concurrency_harness import (
     ConcurrencyTracker,
     FakeRuntime,
@@ -127,6 +129,52 @@ async def test_exception_isolation_within_batch() -> None:
     assert results[1]["success"] is False
     assert "kaboom" in results[1]["error"]
     assert results[2]["success"] is True
+
+
+async def test_infra_callback_failure_marks_ledger_terminal() -> None:
+    # If an infra callback (on_tool_start) raises after the "running" record is
+    # written, the ledger must reach a terminal state. The consecutive-count
+    # walks only count {completed, failed}, so a record stuck at "running" would
+    # be silently skipped and undercount the repeated-tool-decision triggers.
+    class _BoomOnStart(FakeRuntime):
+        async def on_tool_start(self, *, tool_call: dict) -> None:
+            raise RuntimeError("trace backend down")
+
+    tools = [FakeTool("s1", concurrency_safe=True)]
+    pattern = make_react(parallel=True)
+    call = make_tool_call("s1")
+
+    with pytest.raises(RuntimeError, match="trace backend down"):
+        await pattern._execute_tool_safely(call, tools, _BoomOnStart())
+
+    assert pattern.tool_ledger[call["id"]].status == "failed"
+
+
+async def test_concurrent_batch_isolates_infra_callback_failure() -> None:
+    # An infra callback failure for one call becomes that call's error result
+    # (gather swallows it) and a terminal ledger record, while its siblings
+    # complete normally.
+    class _BoomOnFirst(FakeRuntime):
+        async def on_tool_start(self, *, tool_call: dict) -> None:
+            if tool_call["name"] == "boom":
+                raise RuntimeError("trace down")
+            await super().on_tool_start(tool_call=tool_call)
+
+    tools = [
+        FakeTool("s1", concurrency_safe=True),
+        FakeTool("boom", concurrency_safe=True),
+        FakeTool("s3", concurrency_safe=True),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in ["s1", "boom", "s3"]]
+
+    results = await pattern._run_concurrent_batch(batch, tools, _BoomOnFirst(), context)
+
+    assert results[1]["success"] is False
+    assert pattern.tool_ledger[batch[1]["id"]].status == "failed"
+    assert pattern.tool_ledger[batch[0]["id"]].status == "completed"
+    assert pattern.tool_ledger[batch[2]["id"]].status == "completed"
 
 
 # --- Inc.4: tool_ledger ordering after a concurrent batch (I3) -------------

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -1,0 +1,129 @@
+"""Inc.3 — concurrent batch execution + ordered backfill (design §4.2.2, §5.5).
+
+``_run_concurrent_batch`` runs a segment of concurrency-safe tool calls under a
+Semaphore via ``asyncio.gather`` and back-fills their results into the context
+in the original tool-call order. Invariants pinned here:
+
+- I1: ``add_tool_result`` order == input order, even when tools finish out of
+  order.
+- I2: every ``tool_call_id`` gets exactly one result (including failures).
+- real concurrency: the batch overlaps (peak == batch size) rather than running
+  serially, and the Semaphore caps the peak.
+- exception isolation: one failing tool yields an error result for that call
+  while the rest succeed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from tests.core.agent.concurrency_harness import (
+    ConcurrencyTracker,
+    FakeRuntime,
+    FakeTool,
+    RecordingContext,
+    make_react,
+    make_tool_call,
+)
+
+
+async def test_ordered_backfill_despite_out_of_order_completion() -> None:
+    names = ["s1", "s2", "s3"]
+    tracker = ConcurrencyTracker()
+    gates = {name: asyncio.Event() for name in names}
+    tools = [
+        FakeTool(name, concurrency_safe=True, gate=gates[name], tracker=tracker)
+        for name in names
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    runtime = FakeRuntime()
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    task = asyncio.create_task(
+        pattern._run_concurrent_batch(batch, tools, runtime, context)
+    )
+    # Wait until all three are in-flight, then release them in REVERSE order so
+    # completion order is the opposite of input order.
+    while tracker.active < 3:
+        await asyncio.sleep(0)
+    for index, name in enumerate(["s3", "s2", "s1"], start=1):
+        gates[name].set()
+        while len(tracker.leave_order) < index:
+            await asyncio.sleep(0)
+    await task
+
+    # Completion was reverse, but backfill preserves input order (I1).
+    assert tracker.leave_order == ["s3", "s2", "s1"]
+    assert [r["tool_name"] for r in context.tool_results] == names
+    assert [r["tool_call_id"] for r in context.tool_results] == [
+        tc["id"] for tc in batch
+    ]
+
+
+async def test_every_tool_call_id_gets_exactly_one_result() -> None:
+    names = ["s1", "s2", "s3"]
+    tools = [FakeTool(name, concurrency_safe=True) for name in names]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    ids = [r["tool_call_id"] for r in context.tool_results]
+    assert sorted(ids) == sorted(tc["id"] for tc in batch)
+    assert len(ids) == len(set(ids)) == 3
+
+
+async def test_batch_runs_concurrently() -> None:
+    names = ["s1", "s2", "s3"]
+    tracker = ConcurrencyTracker()
+    tools = [
+        FakeTool(name, concurrency_safe=True, delay=0.02, tracker=tracker)
+        for name in names
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    # All three overlapped (a serial run would never exceed 1).
+    assert tracker.peak == 3
+
+
+async def test_semaphore_caps_concurrency() -> None:
+    names = ["s1", "s2", "s3", "s4"]
+    tracker = ConcurrencyTracker()
+    tools = [
+        FakeTool(name, concurrency_safe=True, delay=0.02, tracker=tracker)
+        for name in names
+    ]
+    pattern = make_react(parallel=True, max_concurrency=2)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in names]
+
+    await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    assert tracker.peak <= 2
+    assert len(context.tool_results) == 4
+
+
+async def test_exception_isolation_within_batch() -> None:
+    tools = [
+        FakeTool("s1", concurrency_safe=True),
+        FakeTool("boom", concurrency_safe=True, raises=RuntimeError("kaboom")),
+        FakeTool("s3", concurrency_safe=True),
+    ]
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(name) for name in ["s1", "boom", "s3"]]
+
+    results = await pattern._run_concurrent_batch(batch, tools, FakeRuntime(), context)
+
+    # All three back-filled in order; the middle one is an error result.
+    assert [r["tool_name"] for r in context.tool_results] == ["s1", "boom", "s3"]
+    assert results[0]["success"] is True
+    assert results[1]["success"] is False
+    assert "kaboom" in results[1]["error"]
+    assert results[2]["success"] is True

--- a/tests/core/agent/test_react_concurrent_batch.py
+++ b/tests/core/agent/test_react_concurrent_batch.py
@@ -150,10 +150,13 @@ async def test_infra_callback_failure_marks_ledger_terminal() -> None:
     assert pattern.tool_ledger[call["id"]].status == "failed"
 
 
-async def test_concurrent_batch_isolates_infra_callback_failure() -> None:
-    # An infra callback failure for one call becomes that call's error result
-    # (gather swallows it) and a terminal ledger record, while its siblings
-    # complete normally.
+async def test_concurrent_batch_propagates_infra_callback_failure() -> None:
+    # An infra callback failure (on_tool_start) is a real exception, not a tool
+    # failure. The serial path lets it propagate and halt the turn; the
+    # concurrent path must do the same instead of mis-reporting infrastructure
+    # breakage to the model as a tool-failure result. The exception is re-raised
+    # before backfill, so nothing is committed to the context and the whole
+    # (idempotent) segment stays pending for a clean re-run on resume.
     class _BoomOnFirst(FakeRuntime):
         async def on_tool_start(self, *, tool_call: dict) -> None:
             if tool_call["name"] == "boom":
@@ -169,12 +172,13 @@ async def test_concurrent_batch_isolates_infra_callback_failure() -> None:
     context = RecordingContext()
     batch = [make_tool_call(name) for name in ["s1", "boom", "s3"]]
 
-    results = await pattern._run_concurrent_batch(batch, tools, _BoomOnFirst(), context)
+    with pytest.raises(RuntimeError, match="trace down"):
+        await pattern._run_concurrent_batch(batch, tools, _BoomOnFirst(), context)
 
-    assert results[1]["success"] is False
+    # Nothing was back-filled (the turn halts; the segment re-runs on resume)...
+    assert context.tool_results == []
+    # ...but the failing call still reaches a terminal ledger state (I3 walk).
     assert pattern.tool_ledger[batch[1]["id"]].status == "failed"
-    assert pattern.tool_ledger[batch[0]["id"]].status == "completed"
-    assert pattern.tool_ledger[batch[2]["id"]].status == "completed"
 
 
 # --- Inc.4: tool_ledger ordering after a concurrent batch (I3) -------------

--- a/tests/core/agent/test_react_real_tool_concurrency.py
+++ b/tests/core/agent/test_react_real_tool_concurrency.py
@@ -1,0 +1,177 @@
+"""Inc.1 follow-up — the real safe-set tools actually parallelize.
+
+The unit tests elsewhere prove the scheduler's ordering/isolation invariants
+with ``FakeTool``. This module instead drives the *real* production tool classes
+that are marked ``read_only`` / ``concurrency_safe`` through the real
+``ReActPattern`` concurrent path, to guard against two regressions the fakes
+cannot catch:
+
+1. A real tool loses its ``concurrency_safe`` metadata (so the scheduler would
+   silently fall back to serial) — covered by the segmentation assertions.
+2. A real tool's ``run_json_async`` wrapper serializes the batch even though the
+   scheduler offered it concurrency (e.g. a future refactor adds blocking work
+   around the awaited I/O seam) — covered by the barrier-overlap assertions.
+
+Scope boundary (intentional): the barrier is patched in at each tool's awaited
+I/O seam (``fetch_web_content`` / ``*Core.search``), so these tests verify the
+scheduler plus the tool's own async wrapper overlap. They do *not* exercise the
+production HTTP client itself (which is replaced) — keeping each tool's network
+layer non-blocking remains that tool's responsibility, and is asserted only
+indirectly via ``run_json_async`` being a coroutine function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.exa_web_search import ExaWebSearchTool
+from xagent.core.tools.adapters.vibe.fetch_web_content import FetchWebContentTool
+from xagent.core.tools.adapters.vibe.tavily_web_search import TavilyWebSearchTool
+from xagent.core.tools.adapters.vibe.web_search import WebSearchTool
+from xagent.core.tools.adapters.vibe.zhipu_web_search import ZhipuWebSearchTool
+
+from tests.core.agent.concurrency_harness import (
+    ConcurrencyTracker,
+    FakeRuntime,
+    RecordingContext,
+    make_react,
+    make_tool_call,
+)
+
+# How long a batched I/O seam waits to rendezvous with its sibling before giving
+# up. A serialized batch never rendezvouses, so it trips this instead of hanging.
+_RENDEZVOUS_TIMEOUT = 3.0
+
+
+class _FetchStub:
+    """Stand-in for ``WebContentFetchResult`` (only ``as_dict`` is consumed)."""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"success": True, "url": "https://example.com", "content": "ok"}
+
+
+@dataclass
+class _RealToolCase:
+    label: str
+    tool_factory: Callable[[], Any]
+    # Dotted path of the awaited I/O seam to replace with the barrier.
+    seam: str
+    # Value the patched seam returns once both callers rendezvous.
+    seam_return: Any
+    args: dict[str, Any]
+
+
+_CASES = [
+    _RealToolCase(
+        label="fetch_web_content",
+        tool_factory=FetchWebContentTool,
+        seam="xagent.core.tools.adapters.vibe.fetch_web_content.fetch_web_content",
+        seam_return=_FetchStub(),
+        args={"url": "https://example.com"},
+    ),
+    _RealToolCase(
+        label="web_search",
+        tool_factory=WebSearchTool,
+        seam="xagent.core.tools.adapters.vibe.web_search.WebSearchCore.search",
+        seam_return=[],
+        args={"query": "x"},
+    ),
+    _RealToolCase(
+        label="zhipu_web_search",
+        tool_factory=ZhipuWebSearchTool,
+        seam="xagent.core.tools.adapters.vibe.zhipu_web_search.ZhipuWebSearchCore.search",
+        # Zhipu wraps the response through ``normalize_results``; an empty dict
+        # normalizes to an empty result list.
+        seam_return={},
+        args={"query": "x"},
+    ),
+    _RealToolCase(
+        label="exa_web_search",
+        tool_factory=ExaWebSearchTool,
+        seam="xagent.core.tools.adapters.vibe.exa_web_search.ExaWebSearchCore.search",
+        seam_return=[],
+        args={"query": "x"},
+    ),
+    _RealToolCase(
+        label="tavily_web_search",
+        tool_factory=TavilyWebSearchTool,
+        seam="xagent.core.tools.adapters.vibe.tavily_web_search.TavilyWebSearchCore.search",
+        seam_return=[],
+        args={"query": "x"},
+    ),
+]
+
+_CASE_IDS = [case.label for case in _CASES]
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_real_safe_tool_is_batched_as_concurrent(case: _RealToolCase) -> None:
+    """Two calls to a real safe tool are recognized as a concurrent segment."""
+    tool = case.tool_factory()
+    pattern = make_react(parallel=True, max_concurrency=3)
+    # The registered tool name can differ from the test label (e.g. the Google
+    # and Tavily backends both expose "web_search"); drive the scheduler with
+    # the real name so ``_find_tool`` resolves the metadata.
+    batch = [make_tool_call(tool.name, case.args) for _ in range(2)]
+
+    segment, kind = pattern._next_segment(batch, [tool])
+
+    assert kind == "concurrent"
+    assert len(segment) == 2
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_real_safe_tool_exposes_async_executor(case: _RealToolCase) -> None:
+    """The real tool's executor is a coroutine function (yields to the loop)."""
+    tool = case.tool_factory()
+    assert inspect.iscoroutinefunction(tool.run_json_async)
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+async def test_real_safe_tool_runs_concurrently(
+    case: _RealToolCase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real tool's async path overlaps under the concurrent scheduler.
+
+    A two-party barrier sits at the tool's awaited I/O seam: it only releases
+    once both calls are in flight, so a passing run proves real overlap (peak
+    concurrency == 2) and ordered, one-result-per-call backfill. A serialized
+    run never reaches the barrier together and trips ``_RENDEZVOUS_TIMEOUT``,
+    surfacing as timed-out (failed) results rather than a hang.
+    """
+    tracker = ConcurrencyTracker()
+    barrier = asyncio.Barrier(2)
+
+    async def _seam(*_args: Any, **_kwargs: Any) -> Any:
+        tracker.enter(case.label)
+        try:
+            await asyncio.wait_for(barrier.wait(), timeout=_RENDEZVOUS_TIMEOUT)
+        finally:
+            tracker.leave(case.label)
+        return case.seam_return
+
+    monkeypatch.setattr(case.seam, _seam)
+
+    tool = case.tool_factory()
+    pattern = make_react(parallel=True, max_concurrency=3)
+    context = RecordingContext()
+    batch = [make_tool_call(tool.name, case.args) for _ in range(2)]
+
+    results = await asyncio.wait_for(
+        pattern._run_concurrent_batch(batch, [tool], FakeRuntime(), context),
+        timeout=_RENDEZVOUS_TIMEOUT * 2,
+    )
+
+    # Real overlap: both calls were in flight at once.
+    assert tracker.peak == 2
+    # I1/I2: one result per call, in input order, none of them a seam timeout.
+    assert len(results) == 2
+    assert all(pattern._tool_result_success(result) for result in results)
+    assert [r["tool_call_id"] for r in context.tool_results] == [
+        tc["id"] for tc in batch
+    ]

--- a/tests/core/agent/test_react_real_tool_concurrency.py
+++ b/tests/core/agent/test_react_real_tool_concurrency.py
@@ -29,12 +29,6 @@ from typing import Any, Callable
 
 import pytest
 
-from xagent.core.tools.adapters.vibe.exa_web_search import ExaWebSearchTool
-from xagent.core.tools.adapters.vibe.fetch_web_content import FetchWebContentTool
-from xagent.core.tools.adapters.vibe.tavily_web_search import TavilyWebSearchTool
-from xagent.core.tools.adapters.vibe.web_search import WebSearchTool
-from xagent.core.tools.adapters.vibe.zhipu_web_search import ZhipuWebSearchTool
-
 from tests.core.agent.concurrency_harness import (
     ConcurrencyTracker,
     FakeRuntime,
@@ -42,6 +36,11 @@ from tests.core.agent.concurrency_harness import (
     make_react,
     make_tool_call,
 )
+from xagent.core.tools.adapters.vibe.exa_web_search import ExaWebSearchTool
+from xagent.core.tools.adapters.vibe.fetch_web_content import FetchWebContentTool
+from xagent.core.tools.adapters.vibe.tavily_web_search import TavilyWebSearchTool
+from xagent.core.tools.adapters.vibe.web_search import WebSearchTool
+from xagent.core.tools.adapters.vibe.zhipu_web_search import ZhipuWebSearchTool
 
 # How long a batched I/O seam waits to rendezvous with its sibling before giving
 # up. A serialized batch never rendezvouses, so it trips this instead of hanging.

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -118,6 +118,33 @@ async def test_interrupt_before_batch_preserves_pending() -> None:
     assert [tc["name"] for tc in pattern.pending_tool_calls] == ["s1", "s2"]
 
 
+async def test_interrupt_after_capped_batch_preserves_remaining() -> None:
+    # The batch cap (= max_concurrency) turns a long safe run into multiple
+    # batches, so an interrupt requested after the first batch leaves the rest
+    # pending. Without the cap all four would run as one uninterruptible batch.
+    class _InterruptAfterFirstBatch(FakeRuntime):
+        async def should_interrupt(self) -> bool:
+            return len(self.events_of("on_tool_end")) >= 2
+
+    tools = [FakeTool(name, read_only=True) for name in ("s1", "s2", "s3", "s4")]
+    pattern = _make_pattern(max_concurrency=2)
+    pattern.pending_tool_calls = [
+        make_tool_call(name) for name in ("s1", "s2", "s3", "s4")
+    ]
+    context = RecordingContext()
+    runtime = _InterruptAfterFirstBatch()
+
+    result = await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    assert result is not None
+    assert result.get("status") == "interrupted"
+    # Only the first capped batch ran; the remainder is preserved for resume.
+    assert [r["tool_name"] for r in context.tool_results] == ["s1", "s2"]
+    assert [tc["name"] for tc in pattern.pending_tool_calls] == ["s3", "s4"]
+
+
 async def test_concurrent_batch_then_unsafe_serial_preserves_order() -> None:
     tools = [
         FakeTool("s1", read_only=True),

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -16,6 +16,8 @@ behavior:
 
 from __future__ import annotations
 
+import pytest
+
 from tests.core.agent.concurrency_harness import (
     FakeRuntime,
     FakeTool,
@@ -165,3 +167,39 @@ async def test_flag_off_runs_everything_serially() -> None:
     assert statuses.count("before_tool") == 2
     assert statuses.count("after_tool") == 2
     assert [r["tool_name"] for r in context.tool_results] == ["s1", "s2"]
+
+
+# --- Inc.6: checkpoint / resume of the concurrency knobs --------------------
+
+
+def test_get_state_load_state_round_trips_concurrency_fields() -> None:
+    pattern = make_react(parallel=True, max_concurrency=5)
+    state = pattern.get_state()
+    assert state["tool_parallel_enabled"] is True
+    assert state["tool_max_concurrency"] == 5
+
+    restored = make_react(parallel=False, max_concurrency=1)
+    restored.load_state(state)
+    assert restored.tool_parallel_enabled is True
+    assert restored.tool_max_concurrency == 5
+
+
+async def test_crash_during_batch_keeps_segment_pending_for_resume() -> None:
+    # If the process dies mid-batch (before backfill/dequeue), the whole segment
+    # must remain pending so resume re-executes it (concurrency-safe tools are
+    # idempotent). Backfill is where the crash is simulated.
+    class ExplodingContext(RecordingContext):
+        def add_tool_result(self, *args, **kwargs):
+            raise RuntimeError("crash during backfill")
+
+    tools = [FakeTool("s1", read_only=True), FakeTool("s2", read_only=True)]
+    pattern = _make_pattern()
+    pattern.pending_tool_calls = [make_tool_call("s1"), make_tool_call("s2")]
+
+    with pytest.raises(RuntimeError, match="crash during backfill"):
+        await pattern._execute_pending_tool_calls(
+            context=ExplodingContext(), tools=tools, llm=None, runtime=FakeRuntime()
+        )
+
+    # Segment was not dequeued -> available for re-execution on resume.
+    assert [tc["name"] for tc in pattern.pending_tool_calls] == ["s1", "s2"]

--- a/tests/core/agent/test_react_segment_loop.py
+++ b/tests/core/agent/test_react_segment_loop.py
@@ -1,0 +1,167 @@
+"""Inc.5 — segment loop integrated into _execute_pending_tool_calls (§4.2.3).
+
+Drives _execute_pending_tool_calls directly with fakes to pin the integrated
+behavior:
+- I4: concurrency-safe tools before a control tool run as a batch, then the
+  control tool short-circuits (final_answer -> completed; ask_user_question ->
+  waiting_for_user); later tools do not run.
+- I5 (interrupt half): an interrupt at the segment boundary stops the loop with
+  pending_tool_calls preserved.
+- mixed S/U ordering: a concurrent batch, then a serial unsafe tool, results
+  back-filled in input order.
+- batch checkpoints: before_tool_batch / after_tool_batch are emitted for a
+  concurrent segment; before_tool / after_tool for a serial one.
+- repeated-tool-decision is evaluated once per segment.
+"""
+
+from __future__ import annotations
+
+from tests.core.agent.concurrency_harness import (
+    FakeRuntime,
+    FakeTool,
+    RecordingContext,
+    make_react,
+    make_tool_call,
+)
+
+
+def _checkpoint_statuses(runtime: FakeRuntime) -> list[str]:
+    return [payload["status"] for payload in runtime.events_of("checkpoint")]
+
+
+def _make_pattern(**kwargs):
+    # Disable repeated-tool-decision thresholds so it never fires unless a test
+    # opts in; set task_text so final_answer's memory step is a no-op.
+    pattern = make_react(
+        parallel=True,
+        repeated_tool_decision_after_consecutive_tool_calls=None,
+        repeated_tool_decision_after_consecutive_work_tool_calls=None,
+        **kwargs,
+    )
+    pattern.task_text = "t"
+    return pattern
+
+
+async def test_concurrent_batch_then_final_answer_short_circuits() -> None:
+    tools = [FakeTool("s1", read_only=True), FakeTool("s2", read_only=True)]
+    pattern = _make_pattern()
+    pattern.pending_tool_calls = [
+        make_tool_call("s1"),
+        make_tool_call("s2"),
+        make_tool_call("final_answer", {"answer": "done"}),
+    ]
+    context = RecordingContext()
+    runtime = FakeRuntime()
+
+    result = await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    assert result is not None
+    assert result.get("status") == "completed"
+    assert pattern.pending_tool_calls == []
+    # s1, s2 ran (in order) then final_answer recorded its answer.
+    assert [r["tool_name"] for r in context.tool_results] == [
+        "s1",
+        "s2",
+        "final_answer",
+    ]
+    statuses = _checkpoint_statuses(runtime)
+    assert "before_tool_batch" in statuses
+    assert "after_tool_batch" in statuses
+
+
+async def test_serial_then_ask_user_waits() -> None:
+    # A lone safe tool degrades to serial; ask_user_question then waits.
+    tools = [FakeTool("s1", read_only=True)]
+    pattern = _make_pattern()
+    pattern.pending_tool_calls = [
+        make_tool_call("s1"),
+        make_tool_call("ask_user_question", {"message": "which?"}),
+        make_tool_call("s2"),  # must NOT run after waiting_for_user
+    ]
+    context = RecordingContext()
+    runtime = FakeRuntime()
+
+    result = await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    assert result is not None
+    assert result.get("status") == "waiting_for_user"
+    assert [r["tool_name"] for r in context.tool_results] == [
+        "s1",
+        "ask_user_question",
+    ]
+    statuses = _checkpoint_statuses(runtime)
+    assert "before_tool" in statuses  # serial path used for the lone safe tool
+
+
+async def test_interrupt_before_batch_preserves_pending() -> None:
+    tools = [FakeTool("s1", read_only=True), FakeTool("s2", read_only=True)]
+    pattern = _make_pattern()
+    pending = [make_tool_call("s1"), make_tool_call("s2")]
+    pattern.pending_tool_calls = list(pending)
+    context = RecordingContext()
+    runtime = FakeRuntime(interrupt=True, interrupt_reason="stop")
+
+    result = await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    assert result is not None
+    assert result.get("status") == "interrupted"
+    # Nothing executed; the whole batch is still pending for resume.
+    assert context.tool_results == []
+    assert [tc["name"] for tc in pattern.pending_tool_calls] == ["s1", "s2"]
+
+
+async def test_concurrent_batch_then_unsafe_serial_preserves_order() -> None:
+    tools = [
+        FakeTool("s1", read_only=True),
+        FakeTool("s2", read_only=True),
+        FakeTool("u1", concurrency_safe=False),
+    ]
+    pattern = _make_pattern()
+    pattern.pending_tool_calls = [
+        make_tool_call("s1"),
+        make_tool_call("s2"),
+        make_tool_call("u1"),
+    ]
+    context = RecordingContext()
+    runtime = FakeRuntime()
+
+    result = await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    assert result is None  # no control tool, loop drains pending
+    assert pattern.pending_tool_calls == []
+    assert [r["tool_name"] for r in context.tool_results] == ["s1", "s2", "u1"]
+    statuses = _checkpoint_statuses(runtime)
+    assert "before_tool_batch" in statuses  # s1+s2 batch
+    assert "before_tool" in statuses  # u1 serial
+
+
+async def test_flag_off_runs_everything_serially() -> None:
+    # With the flag off, two safe tools each run as their own serial segment.
+    tools = [FakeTool("s1", read_only=True), FakeTool("s2", read_only=True)]
+    pattern = make_react(
+        parallel=False,
+        repeated_tool_decision_after_consecutive_tool_calls=None,
+        repeated_tool_decision_after_consecutive_work_tool_calls=None,
+    )
+    pattern.task_text = "t"
+    pattern.pending_tool_calls = [make_tool_call("s1"), make_tool_call("s2")]
+    context = RecordingContext()
+    runtime = FakeRuntime()
+
+    await pattern._execute_pending_tool_calls(
+        context=context, tools=tools, llm=None, runtime=runtime
+    )
+
+    statuses = _checkpoint_statuses(runtime)
+    assert "before_tool_batch" not in statuses
+    assert statuses.count("before_tool") == 2
+    assert statuses.count("after_tool") == 2
+    assert [r["tool_name"] for r in context.tool_results] == ["s1", "s2"]

--- a/tests/core/agent/test_react_tool_segmentation.py
+++ b/tests/core/agent/test_react_tool_segmentation.py
@@ -91,6 +91,27 @@ def test_three_consecutive_safe_tools_merge() -> None:
     ]
 
 
+def test_concurrent_batch_capped_at_max_concurrency() -> None:
+    # A batch never grows past the concurrency width, so a mid-turn interrupt is
+    # honored after at most one wave. With max_concurrency=2 the trailing lone
+    # safe tool falls into its own (serial) segment.
+    pattern = make_react(parallel=True, max_concurrency=2)
+    assert _segments(pattern, ["s1", "s2", "s3"]) == [
+        ("concurrent", ["s1", "s2"]),
+        ("serial", ["s3"]),
+    ]
+
+
+def test_capping_splits_long_run_into_multiple_concurrent_batches() -> None:
+    # Six consecutive safe tools at max_concurrency=3 split into two concurrent
+    # batches of three; each batch boundary is an interrupt checkpoint.
+    pattern = make_react(parallel=True, max_concurrency=3)
+    assert _segments(pattern, ["s1", "s2", "s3", "s1", "s2", "s3"]) == [
+        ("concurrent", ["s1", "s2", "s3"]),
+        ("concurrent", ["s1", "s2", "s3"]),
+    ]
+
+
 def test_unsafe_tool_breaks_the_concurrent_batch() -> None:
     pattern = make_react(parallel=True)
     assert _segments(pattern, ["s1", "u1", "s2", "s3"]) == [

--- a/tests/core/agent/test_react_tool_segmentation.py
+++ b/tests/core/agent/test_react_tool_segmentation.py
@@ -1,0 +1,129 @@
+"""Inc.2 — ReAct tool-call segmentation (design §4.2.1).
+
+``_next_segment`` is the pure partitioning function that slices a turn's
+pending tool calls into consecutive segments:
+- control tools (final_answer / send_message / ask_user_question) own a segment;
+- non-concurrency-safe tools run serially, one per segment;
+- consecutive concurrency-safe tools merge into one concurrent batch;
+- a concurrent batch of length 1 degrades to a serial segment.
+
+When the parallel flag is off, every segment is a single serial call (current
+behavior, byte-for-byte). This increment only covers the function; it is not
+yet wired into the execution loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.core.agent.concurrency_harness import (
+    FakeTool,
+    make_react,
+    make_tool_call,
+)
+
+# Tool catalog: name -> concurrency_safe
+_SAFE_TOOLS = ["s1", "s2", "s3"]
+_UNSAFE_TOOLS = ["u1", "u2"]
+_CONTROL_TOOLS = ["final_answer", "send_message", "ask_user_question"]
+
+
+def _build_tools() -> list[FakeTool]:
+    tools: list[FakeTool] = []
+    for name in _SAFE_TOOLS:
+        tools.append(FakeTool(name, concurrency_safe=True))
+    for name in _UNSAFE_TOOLS:
+        tools.append(FakeTool(name, concurrency_safe=False))
+    return tools
+
+
+def _segments(pattern, names: list[str]) -> list[tuple[str, list[str]]]:
+    """Drive _next_segment like the loop would, returning (kind, names) list."""
+    tools = _build_tools()
+    pending = [make_tool_call(name) for name in names]
+    out: list[tuple[str, list[str]]] = []
+    guard = 0
+    while pending:
+        guard += 1
+        assert guard < 100, "segmentation did not make progress"
+        segment, kind = pattern._next_segment(pending, tools)
+        assert segment, "segment must be non-empty"
+        out.append((kind, [tc["name"] for tc in segment]))
+        pending = pending[len(segment) :]
+    return out
+
+
+def test_two_safe_tools_form_one_concurrent_segment() -> None:
+    pattern = make_react(parallel=True)
+    assert _segments(pattern, ["s1", "s2"]) == [("concurrent", ["s1", "s2"])]
+
+
+def test_single_safe_tool_degrades_to_serial() -> None:
+    pattern = make_react(parallel=True)
+    assert _segments(pattern, ["s1"]) == [("serial", ["s1"])]
+
+
+def test_mixed_sequence_partitions_into_expected_segments() -> None:
+    pattern = make_react(parallel=True)
+    # [S S U S C] -> concurrent[S,S], serial[U], serial[S], control[C]
+    assert _segments(pattern, ["s1", "s2", "u1", "s3", "final_answer"]) == [
+        ("concurrent", ["s1", "s2"]),
+        ("serial", ["u1"]),
+        ("serial", ["s3"]),
+        ("control", ["final_answer"]),
+    ]
+
+
+def test_control_tool_always_owns_its_segment() -> None:
+    pattern = make_react(parallel=True)
+    # [S C S] -> the lone S degrades to serial, control owns its own segment.
+    assert _segments(pattern, ["s1", "send_message", "s2"]) == [
+        ("serial", ["s1"]),
+        ("control", ["send_message"]),
+        ("serial", ["s2"]),
+    ]
+
+
+def test_three_consecutive_safe_tools_merge() -> None:
+    pattern = make_react(parallel=True)
+    assert _segments(pattern, ["s1", "s2", "s3"]) == [
+        ("concurrent", ["s1", "s2", "s3"])
+    ]
+
+
+def test_unsafe_tool_breaks_the_concurrent_batch() -> None:
+    pattern = make_react(parallel=True)
+    assert _segments(pattern, ["s1", "u1", "s2", "s3"]) == [
+        ("serial", ["s1"]),
+        ("serial", ["u1"]),
+        ("concurrent", ["s2", "s3"]),
+    ]
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        ["s1", "s2"],
+        ["s1", "s2", "s3"],
+        ["s1", "u1", "s2", "final_answer"],
+    ],
+)
+def test_flag_off_makes_everything_serial_length_one(names: list[str]) -> None:
+    pattern = make_react(parallel=False)
+    segments = _segments(pattern, names)
+    assert len(segments) == len(names)
+    for (kind, seg_names), original in zip(segments, names):
+        assert len(seg_names) == 1
+        assert seg_names[0] == original
+        # control tools still classify as control even with the flag off.
+        expected = "control" if original in _CONTROL_TOOLS else "serial"
+        assert kind == expected
+
+
+def test_unknown_tool_treated_as_not_concurrency_safe() -> None:
+    pattern = make_react(parallel=True)
+    # 'mystery' is not in the tool catalog -> conservative serial.
+    assert _segments(pattern, ["mystery", "s1", "s2"]) == [
+        ("serial", ["mystery"]),
+        ("concurrent", ["s1", "s2"]),
+    ]

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1191,3 +1191,41 @@ class TestGetMaxTracePayloadBytes:
     def test_negative_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv(MAX_TRACE_PAYLOAD_BYTES, "-100")
         assert get_max_trace_payload_bytes() == 50_000
+
+
+class TestToolConcurrencyConfig:
+    """Config for in-turn tool concurrency (design §7)."""
+
+    def test_parallel_enabled_default_is_false(self, monkeypatch):
+        from xagent.config import get_tool_parallel_enabled
+
+        monkeypatch.delenv("XAGENT_TOOL_PARALLEL_ENABLED", raising=False)
+        assert get_tool_parallel_enabled() is False
+
+    def test_parallel_enabled_env_override(self, monkeypatch):
+        from xagent.config import get_tool_parallel_enabled
+
+        monkeypatch.setenv("XAGENT_TOOL_PARALLEL_ENABLED", "true")
+        assert get_tool_parallel_enabled() is True
+        monkeypatch.setenv("XAGENT_TOOL_PARALLEL_ENABLED", "0")
+        assert get_tool_parallel_enabled() is False
+
+    def test_max_concurrency_default_is_three(self, monkeypatch):
+        from xagent.config import get_tool_max_concurrency
+
+        monkeypatch.delenv("XAGENT_TOOL_MAX_CONCURRENCY", raising=False)
+        assert get_tool_max_concurrency() == 3
+
+    def test_max_concurrency_env_override(self, monkeypatch):
+        from xagent.config import get_tool_max_concurrency
+
+        monkeypatch.setenv("XAGENT_TOOL_MAX_CONCURRENCY", "8")
+        assert get_tool_max_concurrency() == 8
+
+    def test_max_concurrency_invalid_falls_back_to_default(self, monkeypatch):
+        from xagent.config import get_tool_max_concurrency
+
+        monkeypatch.setenv("XAGENT_TOOL_MAX_CONCURRENCY", "not-a-number")
+        assert get_tool_max_concurrency() == 3
+        monkeypatch.setenv("XAGENT_TOOL_MAX_CONCURRENCY", "0")
+        assert get_tool_max_concurrency() == 3

--- a/tests/core/test_sqlite_pragmas.py
+++ b/tests/core/test_sqlite_pragmas.py
@@ -9,6 +9,8 @@ the engine tolerate that contention. Postgres is unaffected.
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import create_engine
 
 
@@ -38,6 +40,31 @@ def test_apply_pragmas_default_busy_timeout(tmp_path) -> None:
 
     assert busy_timeout and busy_timeout > 0
     engine.dispose()
+
+
+def test_apply_pragmas_swallows_pragma_failures(caplog) -> None:
+    # A read-only database/directory makes ``PRAGMA journal_mode=WAL`` raise (the
+    # -wal/-shm sidecars cannot be created). The connect hook must degrade with a
+    # warning instead of crashing every connection, and still attempt the
+    # connection-local busy_timeout.
+    from xagent.db.sqlite import _apply_concurrency_pragmas
+
+    class _FailWALCursor:
+        def __init__(self) -> None:
+            self.executed: list[str] = []
+
+        def execute(self, sql: str) -> None:
+            self.executed.append(sql)
+            if "journal_mode" in sql:
+                raise RuntimeError("attempt to write a readonly database")
+
+    cursor = _FailWALCursor()
+    with caplog.at_level(logging.WARNING):
+        _apply_concurrency_pragmas(cursor, 5000)  # must not raise
+
+    assert any("journal_mode" in sql for sql in cursor.executed)
+    assert any("busy_timeout=5000" in sql for sql in cursor.executed)
+    assert any("WAL" in record.message for record in caplog.records)
 
 
 def test_apply_pragmas_noop_for_non_sqlite() -> None:

--- a/tests/core/test_sqlite_pragmas.py
+++ b/tests/core/test_sqlite_pragmas.py
@@ -1,0 +1,50 @@
+"""Inc.7 — SQLite concurrency hardening (design §5.5-B1, issue #639).
+
+Concurrent tool execution can drive concurrent writes through the shared
+engine. On SQLite the default rollback journal + no busy timeout surfaces as
+"database is locked". Enabling WAL (concurrent readers + one writer) and a
+busy_timeout (writers wait for the lock instead of failing immediately) makes
+the engine tolerate that contention. Postgres is unaffected.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+
+
+def test_apply_pragmas_enables_wal_and_busy_timeout(tmp_path) -> None:
+    from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'wal.db'}")
+    apply_sqlite_concurrency_pragmas(engine, busy_timeout_ms=4000)
+
+    with engine.connect() as conn:
+        journal_mode = conn.exec_driver_sql("PRAGMA journal_mode").scalar()
+        busy_timeout = conn.exec_driver_sql("PRAGMA busy_timeout").scalar()
+
+    assert str(journal_mode).lower() == "wal"
+    assert busy_timeout == 4000
+    engine.dispose()
+
+
+def test_apply_pragmas_default_busy_timeout(tmp_path) -> None:
+    from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'default.db'}")
+    apply_sqlite_concurrency_pragmas(engine)
+
+    with engine.connect() as conn:
+        busy_timeout = conn.exec_driver_sql("PRAGMA busy_timeout").scalar()
+
+    assert busy_timeout and busy_timeout > 0
+    engine.dispose()
+
+
+def test_apply_pragmas_noop_for_non_sqlite() -> None:
+    from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+
+    # create_engine does not connect, so no Postgres server is required; the
+    # helper must return without registering a connect hook or raising.
+    engine = create_engine("postgresql://user:pass@localhost:5432/db")
+    apply_sqlite_concurrency_pragmas(engine)
+    engine.dispose()

--- a/tests/core/tools/adapters/vibe/test_tool_metadata_concurrency.py
+++ b/tests/core/tools/adapters/vibe/test_tool_metadata_concurrency.py
@@ -1,0 +1,134 @@
+"""Inc.1 — tool concurrency-safety metadata (design §3).
+
+Pins the contract that drives the ReAct concurrent scheduler:
+- ``ToolMetadata`` carries ``read_only`` / ``concurrency_safe`` (default False).
+- ``read_only=True`` implies ``concurrency_safe=True``.
+- A tool may opt into ``concurrency_safe`` without being ``read_only``.
+- The fields flow through the tool wrappers unchanged.
+- The v1 minimal safe set (read-only web/file tools) is concurrency-safe while
+  writing / process-stateful tools are not.
+
+``calculator`` from the original design table is intentionally NOT sampled here:
+the core ``calculator`` function is not wired into the vibe tool layer in this
+codebase, so there is no tool object to classify. The realized v1 safe set is
+web search + read-only web fetch + read-only file tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Type
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from tests.core.tools.adapters.sandboxed_tool.conftest import FakeBaseTool
+from xagent.core.tools.adapters.vibe.base import ToolMetadata
+from xagent.core.tools.adapters.vibe.fetch_web_content import FetchWebContentTool
+from xagent.core.tools.adapters.vibe.file_tool import (
+    read_file_tool,
+    write_file_tool,
+)
+from xagent.core.tools.adapters.vibe.function import FunctionTool
+from xagent.core.tools.adapters.vibe.output_filter_wrapper import (
+    OutputFilteredToolWrapper,
+)
+from xagent.core.tools.adapters.vibe.python_executor import PythonExecutorTool
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandbox_config import (
+    sandbox_config,
+)
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
+    SandboxedToolWrapper,
+)
+from xagent.core.tools.adapters.vibe.web_search import WebSearchTool
+
+
+def _noop(x: int = 0) -> dict[str, Any]:
+    """A trivial function for FunctionTool-based tests."""
+    return {"x": x}
+
+
+def test_tool_metadata_defaults_are_not_concurrency_safe() -> None:
+    metadata = ToolMetadata(name="anything")
+    assert metadata.read_only is False
+    assert metadata.concurrency_safe is False
+
+
+def test_read_only_implies_concurrency_safe_on_function_tool() -> None:
+    tool = FunctionTool(_noop, name="ro", read_only=True)
+    assert tool.metadata.read_only is True
+    assert tool.metadata.concurrency_safe is True
+
+
+def test_read_only_implies_concurrency_safe_on_class_attribute() -> None:
+    class ReadOnlyTool(FakeBaseTool):
+        read_only = True
+
+        @property
+        def name(self) -> str:
+            return "class_attr_ro"
+
+    assert ReadOnlyTool().metadata.concurrency_safe is True
+
+
+def test_concurrency_safe_can_be_declared_without_read_only() -> None:
+    tool = FunctionTool(_noop, name="cs", concurrency_safe=True)
+    assert tool.metadata.read_only is False
+    assert tool.metadata.concurrency_safe is True
+
+
+def test_default_function_tool_is_not_concurrency_safe() -> None:
+    tool = FunctionTool(_noop, name="plain")
+    assert tool.metadata.read_only is False
+    assert tool.metadata.concurrency_safe is False
+
+
+def test_output_filter_wrapper_passthrough() -> None:
+    safe = FunctionTool(_noop, name="ro", read_only=True)
+    unsafe = FunctionTool(_noop, name="plain")
+
+    wrapped_safe = OutputFilteredToolWrapper(safe, 1000, 50, 5)
+    wrapped_unsafe = OutputFilteredToolWrapper(unsafe, 1000, 50, 5)
+
+    assert wrapped_safe.metadata.concurrency_safe is True
+    assert wrapped_unsafe.metadata.concurrency_safe is False
+
+
+def test_sandboxed_wrapper_passthrough() -> None:
+    @sandbox_config()
+    class SandboxReadOnlyTool(FakeBaseTool):
+        read_only = True
+
+        def args_type(self) -> Type[BaseModel]:
+            return BaseModel
+
+        def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+            return {}
+
+        async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+            return {}
+
+        @property
+        def name(self) -> str:
+            return "sandbox_ro"
+
+    # The sandbox is irrelevant to metadata delegation; a stub suffices.
+    wrapped = SandboxedToolWrapper(SandboxReadOnlyTool(), MagicMock())
+    assert wrapped.metadata.concurrency_safe is True
+
+
+def test_builtin_read_only_tools_are_concurrency_safe() -> None:
+    assert WebSearchTool().metadata.concurrency_safe is True
+    assert FetchWebContentTool().metadata.concurrency_safe is True
+    assert read_file_tool.metadata.concurrency_safe is True
+
+
+def test_builtin_writing_or_stateful_tools_are_not_concurrency_safe() -> None:
+    assert write_file_tool.metadata.concurrency_safe is False
+    assert PythonExecutorTool().metadata.concurrency_safe is False
+
+
+def test_abstract_base_tool_metadata_exposes_concurrency_fields() -> None:
+    # The metadata object must always carry the fields (even when False) so the
+    # scheduler can read them uniformly across every tool.
+    assert "read_only" in PythonExecutorTool().metadata.model_dump()
+    assert "concurrency_safe" in PythonExecutorTool().metadata.model_dump()

--- a/tests/web/test_langfuse_handler_concurrency.py
+++ b/tests/web/test_langfuse_handler_concurrency.py
@@ -1,0 +1,278 @@
+"""Inc.1.5 — Langfuse action-span pairing under in-turn tool concurrency.
+
+When several tool calls in the same ReAct turn share a step_id and tool name
+(e.g. three concurrent ``web_search`` calls), the handler must pair each
+START with its own END/ERROR by ``tool_call_id`` — not by "last observation
+pushed for this name" (LIFO), which mis-attributes output/duration/status the
+moment completion order differs from reverse-start order.
+
+This is the prerequisite fix that must land before tool concurrency is enabled
+(design §5.4). It introduces no concurrency itself; it drives the handler with
+interleaved events directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.utils.mock_helpers import create_langfuse_mock
+from xagent.core.agent.trace import (
+    TraceAction,
+    TraceCategory,
+    TraceEventType,
+    TraceScope,
+    Tracer,
+    trace_action_end,
+    trace_action_start,
+)
+from xagent.core.tracing.langfuse import create_langfuse_trace_handler
+
+
+def _make_observation(mocker, span_id: str) -> Any:
+    observation = mocker.Mock()
+    observation.trace_id = "trace-concurrency"
+    observation.id = span_id
+    return observation
+
+
+def _enable_langfuse_env(monkeypatch) -> None:
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "test-public")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://langfuse.example")
+
+
+async def _trace_tool_error(
+    tracer: Tracer,
+    task_id: str,
+    step_id: str,
+    data: dict[str, Any],
+) -> None:
+    """Emit a per-tool ACTION/ERROR/TOOL event, as runtime.on_tool_error does."""
+    await tracer.trace_event(
+        TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.TOOL),
+        task_id=task_id,
+        step_id=step_id,
+        data=data,
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_name_concurrent_tools_pair_by_tool_call_id(
+    mocker, monkeypatch, langfuse_client_reset
+):
+    _enable_langfuse_env(monkeypatch)
+    _, mock_langfuse = create_langfuse_mock(mocker)
+    root = _make_observation(mocker, "root")
+    obs_a = _make_observation(mocker, "obs-a")
+    obs_b = _make_observation(mocker, "obs-b")
+    mock_langfuse.start_observation.return_value = root
+    # First START (call A) gets obs_a, second START (call B) gets obs_b.
+    root.start_observation.side_effect = [obs_a, obs_b]
+
+    handler = create_langfuse_trace_handler(task_id="task-1")
+    assert handler is not None
+    tracer = Tracer()
+    tracer.add_handler(handler)
+
+    # Two same-name tool calls start; the first-started one completes first
+    # (FIFO completion), which is exactly what LIFO pairing gets wrong.
+    await trace_action_start(
+        tracer,
+        "task-1",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_call_id": "A", "tool_args": {"q": "a"}},
+    )
+    await trace_action_start(
+        tracer,
+        "task-1",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_call_id": "B", "tool_args": {"q": "b"}},
+    )
+    await trace_action_end(
+        tracer,
+        "task-1",
+        "step-1",
+        TraceCategory.TOOL,
+        data={
+            "tool_name": "web_search",
+            "tool_call_id": "A",
+            "result": "RES_A",
+            "success": True,
+        },
+    )
+    await trace_action_end(
+        tracer,
+        "task-1",
+        "step-1",
+        TraceCategory.TOOL,
+        data={
+            "tool_name": "web_search",
+            "tool_call_id": "B",
+            "result": "RES_B",
+            "success": True,
+        },
+    )
+
+    assert obs_a.update.call_args.kwargs["output"]["result"] == "RES_A"
+    assert obs_b.update.call_args.kwargs["output"]["result"] == "RES_B"
+    obs_a.end.assert_called_once()
+    obs_b.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_error_pairs_by_tool_call_id(
+    mocker, monkeypatch, langfuse_client_reset
+):
+    _enable_langfuse_env(monkeypatch)
+    _, mock_langfuse = create_langfuse_mock(mocker)
+    root = _make_observation(mocker, "root")
+    obs_a = _make_observation(mocker, "obs-a")
+    obs_b = _make_observation(mocker, "obs-b")
+    mock_langfuse.start_observation.return_value = root
+    root.start_observation.side_effect = [obs_a, obs_b]
+
+    handler = create_langfuse_trace_handler(task_id="task-2")
+    assert handler is not None
+    tracer = Tracer()
+    tracer.add_handler(handler)
+
+    # A errors while B is still running, then B ends normally.
+    await trace_action_start(
+        tracer,
+        "task-2",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_call_id": "A", "tool_args": {"q": "a"}},
+    )
+    await trace_action_start(
+        tracer,
+        "task-2",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_call_id": "B", "tool_args": {"q": "b"}},
+    )
+    await _trace_tool_error(
+        tracer,
+        "task-2",
+        "step-1",
+        data={
+            "tool_name": "web_search",
+            "tool_call_id": "A",
+            "error_message": "boom-A",
+            "success": False,
+        },
+    )
+    await trace_action_end(
+        tracer,
+        "task-2",
+        "step-1",
+        TraceCategory.TOOL,
+        data={
+            "tool_name": "web_search",
+            "tool_call_id": "B",
+            "result": "RES_B",
+            "success": True,
+        },
+    )
+
+    # A's observation is the one flagged ERROR with A's message.
+    assert obs_a.update.call_args.kwargs["level"] == "ERROR"
+    assert obs_a.update.call_args.kwargs["status_message"] == "boom-A"
+    obs_a.end.assert_called_once()
+    # B's observation ends normally with B's result.
+    assert obs_b.update.call_args.kwargs.get("level") != "ERROR"
+    assert obs_b.update.call_args.kwargs["output"]["result"] == "RES_B"
+    obs_b.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_single_tool_without_tool_call_id_still_pairs(
+    mocker, monkeypatch, langfuse_client_reset
+):
+    # Backward compatibility: events without tool_call_id (legacy / external)
+    # still degrade to name-based pairing for a single in-flight call.
+    _enable_langfuse_env(monkeypatch)
+    _, mock_langfuse = create_langfuse_mock(mocker)
+    root = _make_observation(mocker, "root")
+    obs = _make_observation(mocker, "obs")
+    mock_langfuse.start_observation.return_value = root
+    root.start_observation.side_effect = [obs]
+
+    handler = create_langfuse_trace_handler(task_id="task-3")
+    assert handler is not None
+    tracer = Tracer()
+    tracer.add_handler(handler)
+
+    await trace_action_start(
+        tracer,
+        "task-3",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "calculator", "tool_args": {"expression": "1+1"}},
+    )
+    await trace_action_end(
+        tracer,
+        "task-3",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "calculator", "result": "2", "success": True},
+    )
+
+    assert obs.update.call_args.kwargs["output"]["result"] == "2"
+    obs.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_same_name_tools_in_different_steps_remain_independent(
+    mocker, monkeypatch, langfuse_client_reset
+):
+    # DAG step-level concurrency (already supported): same tool name in
+    # different steps must stay independent. Guards against regression.
+    _enable_langfuse_env(monkeypatch)
+    _, mock_langfuse = create_langfuse_mock(mocker)
+    root = _make_observation(mocker, "root")
+    obs_s1 = _make_observation(mocker, "obs-s1")
+    obs_s2 = _make_observation(mocker, "obs-s2")
+    mock_langfuse.start_observation.return_value = root
+    root.start_observation.side_effect = [obs_s1, obs_s2]
+
+    handler = create_langfuse_trace_handler(task_id="task-4")
+    assert handler is not None
+    tracer = Tracer()
+    tracer.add_handler(handler)
+
+    await trace_action_start(
+        tracer,
+        "task-4",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_args": {"q": "s1"}},
+    )
+    await trace_action_start(
+        tracer,
+        "task-4",
+        "step-2",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "tool_args": {"q": "s2"}},
+    )
+    await trace_action_end(
+        tracer,
+        "task-4",
+        "step-1",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "result": "RES_S1", "success": True},
+    )
+    await trace_action_end(
+        tracer,
+        "task-4",
+        "step-2",
+        TraceCategory.TOOL,
+        data={"tool_name": "web_search", "result": "RES_S2", "success": True},
+    )
+
+    assert obs_s1.update.call_args.kwargs["output"]["result"] == "RES_S1"
+    assert obs_s2.update.call_args.kwargs["output"]["result"] == "RES_S2"

--- a/tests/web/test_langfuse_handler_concurrency.py
+++ b/tests/web/test_langfuse_handler_concurrency.py
@@ -22,8 +22,8 @@ from xagent.core.agent.trace import (
     TraceAction,
     TraceCategory,
     TraceEventType,
-    TraceScope,
     Tracer,
+    TraceScope,
     trace_action_end,
     trace_action_start,
 )


### PR DESCRIPTION
## Summary

Implements in-turn tool concurrency for the ReAct pattern (issue #639). Within a single model turn, consecutive concurrency-safe tool calls now run as a bounded concurrent batch instead of strictly serially, while preserving result ordering, the tool ledger, interrupt/resume semantics, and tracing.

The feature is gated behind a config flag (`tool_parallel_enabled`) and a width knob (`tool_max_concurrency`). **With the flag off, the segment loop is byte-for-byte equivalent to the prior serial behavior.**

## How it works

`_execute_pending_tool_calls` partitions a turn's pending tool calls into consecutive segments via `_next_segment`:

- **control** tools (`final_answer` / `send_message` / `ask_user_question`) own their own segment and short-circuit the loop;
- **non-concurrency-safe** tools run serially, one per segment;
- consecutive **concurrency-safe** tools merge into one concurrent batch, capped at `tool_max_concurrency`;
- a concurrent batch of length 1 degrades to the serial path (no `gather`/`Semaphore` overhead).

A concurrent batch runs under `asyncio.Semaphore(tool_max_concurrency)` + `asyncio.gather(return_exceptions=True)`, then results are back-filled into the context in original tool-call order and the tool ledger is reordered to match.

## Invariants pinned by tests (I1–I6)

- **I1** ordered backfill == input order, even on out-of-order completion
- **I2** every `tool_call_id` gets exactly one result (including failures)
- **I3** `tool_ledger` keeps input insertion order after a batch
- **I4** a control tool short-circuits the segment loop
- **I5** interrupt at a segment boundary / crash mid-batch keeps the segment pending for resume
- **I6** Langfuse trace spans pair by `tool_call_id`

## Tool metadata

Adds `read_only` / `concurrency_safe` flags to the vibe tool base, with the implication `read_only ⇒ concurrency_safe` and a conservative default (unknown tools are treated as not safe). The web-search and fetch tools are marked `read_only`.

## Supporting changes

- **SQLite**: WAL mode + `busy_timeout` pragmas so concurrent tool writes don't trip `database is locked`.
- **Frontend**: attribute tool trace events by `tool_call_id` so concurrently-running tools render under the correct trace.
- **Batch cap**: a concurrent batch is capped at the concurrency width so a mid-turn interrupt is honored after at most one wave (tradeoff documented in code).
- **Terminal ledger guarantee**: `try/finally` in `_execute_tool_safely` ensures a record never sticks at `running` if an infra callback raises, so consecutive-count walks don't undercount.

## Testing

New suites under `tests/core/agent/` (segmentation, concurrent batch, segment loop, real-tool concurrency via barrier), plus tool-metadata, SQLite pragma, config, and Langfuse handler concurrency tests. Real production safe-set tools are driven through the real concurrent path with a two-party barrier to prove they actually overlap (not just the fakes).

All Python pre-commit hooks pass (ruff, ruff format, mypy, isort, codespell).

Closes #639
