### PR TITLE
fix: retry OpenRouter tool choice fallback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           - langchain-openai
           - langchain-community
           - numexpr
-          - numpy
+          - numpy==1.26.4
           - html2text
           - rich
           - prompt_toolkit

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -64,6 +64,51 @@ def _should_retry_without_thinking(
     )
 
 
+def _should_retry_with_relaxed_tool_choice(
+    exc: Exception,
+    *,
+    tools: list[dict[str, Any]] | None,
+    tool_choice: str | dict[str, Any] | None,
+) -> bool:
+    if not tools or tool_choice in (None, "auto", "none"):
+        return False
+
+    # Deliberate OpenRouter compatibility bridge: official provider routing can
+    # reject strict tool_choice values before selecting an endpoint. This
+    # degrades forced tool use to "auto" instead of failing the whole agent run.
+    # Replace string matching with typed provider errors when available.
+    exc_msg = str(exc).lower()
+    return "no endpoints found" in exc_msg and "tool_choice" in exc_msg
+
+
+def _next_retry_state(
+    exc: Exception,
+    *,
+    tools: list[dict[str, Any]] | None,
+    thinking: dict[str, Any] | None,
+    tool_choice: str | dict[str, Any] | None,
+) -> tuple[str | dict[str, Any] | None, dict[str, Any] | None, str, str] | None:
+    if _should_retry_without_thinking(exc, thinking=thinking, tool_choice=tool_choice):
+        return (
+            tool_choice,
+            _DISABLE_DOWNSTREAM_THINKING,
+            "selected model rejected thinking with tool_choice; retrying without thinking",
+            "disable_thinking",
+        )
+
+    if _should_retry_with_relaxed_tool_choice(
+        exc, tools=tools, tool_choice=tool_choice
+    ):
+        return (
+            "auto",
+            thinking,
+            "selected OpenRouter endpoint rejected tool_choice; retrying with tool_choice=auto",
+            "relax_tool_choice",
+        )
+
+    return None
+
+
 class _NullStore:
     """Duck-typed CallStore that drops the decision log (degradation fallback)."""
 
@@ -189,7 +234,7 @@ class RouterLLM(BaseLLM):
     def supports_thinking_mode(self) -> bool:
         return "thinking_mode" in self._abilities
 
-    async def _run_non_streaming_with_thinking_retry(
+    async def _run_non_streaming_with_provider_retry(
         self,
         method: Callable[..., Any],
         messages: list[dict[str, Any]],
@@ -203,42 +248,42 @@ class RouterLLM(BaseLLM):
         output_config: dict[str, Any] | None,
         kwargs: dict[str, Any],
     ) -> str | dict[str, Any]:
-        try:
-            result = await method(
-                messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
-                thinking=thinking,
-                output_config=output_config,
-                **kwargs,
-            )
-            return cast(str | dict[str, Any], result)
-        except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
-            if not _should_retry_without_thinking(
-                exc, thinking=thinking, tool_choice=tool_choice
-            ):
-                raise
-            logger.info(
-                "selected model rejected thinking with tool_choice; retrying without thinking"
-            )
-            # Auto routing dispatches selected slugs through OpenRouterLLM
-            # (injected resolver or fallback), whose disabled-thinking hook emits
-            # the provider-specific reasoning payload.
-            result = await method(
-                messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
-                thinking=_DISABLE_DOWNSTREAM_THINKING,
-                output_config=output_config,
-                **kwargs,
-            )
-            return cast(str | dict[str, Any], result)
+        current_tool_choice = tool_choice
+        current_thinking = thinking
+        attempted_retry_actions: set[str] = set()
+
+        while True:
+            try:
+                result = await method(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    response_format=response_format,
+                    thinking=current_thinking,
+                    output_config=output_config,
+                    **kwargs,
+                )
+                return cast(str | dict[str, Any], result)
+            except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
+                retry_state = _next_retry_state(
+                    exc,
+                    tools=tools,
+                    thinking=current_thinking,
+                    tool_choice=current_tool_choice,
+                )
+                if retry_state is None:
+                    raise
+
+                next_tool_choice, next_thinking, log_message, action_key = retry_state
+                if action_key in attempted_retry_actions:
+                    raise
+
+                attempted_retry_actions.add(action_key)
+                logger.info(log_message)
+                current_tool_choice = next_tool_choice
+                current_thinking = next_thinking
 
     async def chat(
         self,
@@ -253,7 +298,7 @@ class RouterLLM(BaseLLM):
         **kwargs: Any,
     ) -> str | dict[str, Any]:
         llm = await self._resolve(messages)
-        return await self._run_non_streaming_with_thinking_retry(
+        return await self._run_non_streaming_with_provider_retry(
             llm.chat,
             messages,
             temperature=temperature,
@@ -279,7 +324,7 @@ class RouterLLM(BaseLLM):
         **kwargs: Any,
     ) -> str | dict[str, Any]:
         llm = await self._resolve(messages)
-        return await self._run_non_streaming_with_thinking_retry(
+        return await self._run_non_streaming_with_provider_retry(
             llm.vision_chat,
             messages,
             temperature=temperature,
@@ -306,42 +351,47 @@ class RouterLLM(BaseLLM):
     ) -> AsyncIterator[StreamChunk]:
         llm = await self._resolve(messages)
         has_yielded = False
-        try:
-            async for chunk in llm.stream_chat(
-                messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
-                thinking=thinking,
-                output_config=output_config,
-                **kwargs,
-            ):
-                has_yielded = True
-                yield chunk
-        except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
-            if has_yielded or not _should_retry_without_thinking(
-                exc, thinking=thinking, tool_choice=tool_choice
-            ):
-                raise
-            logger.info(
-                "selected model rejected thinking with tool_choice; retrying stream without thinking"
-            )
-            # See _run_non_streaming_with_thinking_retry: OpenRouterLLM owns the
-            # provider-specific disabled-reasoning payload.
-            async for chunk in llm.stream_chat(
-                messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
-                thinking=_DISABLE_DOWNSTREAM_THINKING,
-                output_config=output_config,
-                **kwargs,
-            ):
-                yield chunk
+        current_tool_choice = tool_choice
+        current_thinking = thinking
+        attempted_retry_actions: set[str] = set()
+
+        while True:
+            try:
+                async for chunk in llm.stream_chat(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    response_format=response_format,
+                    thinking=current_thinking,
+                    output_config=output_config,
+                    **kwargs,
+                ):
+                    has_yielded = True
+                    yield chunk
+                return
+            except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
+                if has_yielded:
+                    raise
+
+                retry_state = _next_retry_state(
+                    exc,
+                    tools=tools,
+                    thinking=current_thinking,
+                    tool_choice=current_tool_choice,
+                )
+                if retry_state is None:
+                    raise
+
+                next_tool_choice, next_thinking, log_message, action_key = retry_state
+                if action_key in attempted_retry_actions:
+                    raise
+
+                attempted_retry_actions.add(action_key)
+                logger.info(log_message)
+                current_tool_choice = next_tool_choice
+                current_thinking = next_thinking
 
     # ---- Routing ------------------------------------------------------------
     async def _resolve(self, messages: list[dict[str, Any]]) -> BaseLLM:

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -1,0 +1,253 @@
+"""Tests for RouterLLM provider compatibility retries."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+import pytest
+
+from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.basic.router import RouterLLM
+from xagent.core.model.chat.types import ChunkType, StreamChunk
+
+_OPENROUTER_TOOL_CHOICE_ERROR = (
+    "OpenAI API error (404): Error code: 404 - {'error': {'message': "
+    "\"No endpoints found that support the provided 'tool_choice' value.\"}}"
+)
+_THINKING_TOOL_CHOICE_ERROR = (
+    "OpenAI bad request (400): Thinking mode does not support this tool_choice"
+)
+
+
+def _tool_schema() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "answer",
+            "description": "Answer the user",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+class _ToolChoiceRetryLLM(BaseLLM):
+    def __init__(self) -> None:
+        self.chat_tool_choices: list[str | dict[str, Any] | None] = []
+        self.stream_tool_choices: list[str | dict[str, Any] | None] = []
+
+    @property
+    def abilities(self) -> list[str]:
+        return ["chat", "tool_calling"]
+
+    @property
+    def model_name(self) -> str:
+        return "z-ai/glm-5.2"
+
+    @property
+    def supports_thinking_mode(self) -> bool:
+        return False
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any]:
+        del messages, temperature, max_tokens, tools, response_format
+        del thinking, output_config, kwargs
+        self.chat_tool_choices.append(tool_choice)
+        if tool_choice == "required":
+            raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+        return "ok"
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, str]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        del messages, temperature, max_tokens, tools, response_format
+        del thinking, output_config, kwargs
+        self.stream_tool_choices.append(tool_choice)
+        if tool_choice == "required":
+            raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
+
+
+class _ScriptedChatLLM(BaseLLM):
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = list(errors)
+        self.tool_choices: list[str | dict[str, Any] | None] = []
+        self.thinking_values: list[dict[str, Any] | None] = []
+
+    @property
+    def abilities(self) -> list[str]:
+        return ["chat", "tool_calling"]
+
+    @property
+    def model_name(self) -> str:
+        return "z-ai/glm-5.2"
+
+    @property
+    def supports_thinking_mode(self) -> bool:
+        return False
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any]:
+        del messages, temperature, max_tokens, tools, response_format
+        del output_config, kwargs
+        self.tool_choices.append(tool_choice)
+        self.thinking_values.append(thinking)
+        if self.errors:
+            raise RuntimeError(self.errors.pop(0))
+        return "ok"
+
+
+async def _select_glm(_prompt: str) -> str:
+    return "z-ai/glm-5.2"
+
+
+@pytest.mark.asyncio
+async def test_router_chat_relaxes_required_tool_choice_on_openrouter_endpoint_error(
+    monkeypatch,
+):
+    llm = _ToolChoiceRetryLLM()
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+
+    async def select_model(_prompt: str) -> str:
+        return "z-ai/glm-5.2"
+
+    monkeypatch.setattr(router, "_select_model", select_model)
+
+    result = await router.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=[_tool_schema()],
+        tool_choice="required",
+    )
+
+    assert result == "ok"
+    assert llm.chat_tool_choices == ["required", "auto"]
+
+
+@pytest.mark.asyncio
+async def test_router_stream_relaxes_required_tool_choice_before_first_chunk(
+    monkeypatch,
+):
+    llm = _ToolChoiceRetryLLM()
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+
+    async def select_model(_prompt: str) -> str:
+        return "z-ai/glm-5.2"
+
+    monkeypatch.setattr(router, "_select_model", select_model)
+
+    chunks = [
+        chunk
+        async for chunk in router.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert llm.stream_tool_choices == ["required", "auto"]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_does_not_relax_auto_tool_choice_on_openrouter_error(
+    monkeypatch,
+):
+    llm = _ScriptedChatLLM([_OPENROUTER_TOOL_CHOICE_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="No endpoints found"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="auto",
+        )
+
+    assert llm.tool_choices == ["auto"]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_propagates_non_matching_errors_without_retry(monkeypatch):
+    llm = _ScriptedChatLLM(["different provider error"])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="different provider error"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+        )
+
+    assert llm.tool_choices == ["required"]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_does_not_retry_same_action_twice(monkeypatch):
+    llm = _ScriptedChatLLM([_THINKING_TOOL_CHOICE_ERROR, _THINKING_TOOL_CHOICE_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
+        await router.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=[_tool_schema()],
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+
+    assert llm.tool_choices == ["required", "required"]
+    assert llm.thinking_values == [
+        {"type": "disabled", "enable": False},
+        {"type": "disabled", "enable": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_chat_can_chain_thinking_and_tool_choice_retries(monkeypatch):
+    llm = _ScriptedChatLLM([_THINKING_TOOL_CHOICE_ERROR, _OPENROUTER_TOOL_CHOICE_ERROR])
+    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+    monkeypatch.setattr(router, "_select_model", _select_glm)
+
+    result = await router.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=[_tool_schema()],
+        tool_choice="required",
+        thinking={"type": "enabled", "enable": True},
+    )
+
+    assert result == "ok"
+    assert llm.tool_choices == ["required", "required", "auto"]
+    assert llm.thinking_values == [
+        {"type": "enabled", "enable": True},
+        {"type": "disabled", "enable": False},
+        {"type": "disabled", "enable": False},
+    ]


### PR DESCRIPTION
## Summary
- retry RouterLLM calls with `tool_choice=auto` when OpenRouter reports no endpoint supports the provided `tool_choice`
- keep the existing thinking/tool_choice compatibility retry inside RouterLLM
- add focused chat and streaming tests for the OpenRouter tool_choice downgrade path
- pin the pre-commit mypy hook's numpy dependency to the project version to avoid CI-only stub syntax drift

## Root cause
OpenRouter official-provider routing can select endpoints such as `z-ai/glm-5.2` that reject `tool_choice=required`, returning a 404 before any stream chunks are emitted. RouterLLM previously only retried thinking/tool_choice conflicts and propagated this endpoint-routing error.

CI also exposed a separate dependency-drift issue: the isolated pre-commit mypy hook installed an unpinned latest numpy stub package while the project mypy target is Python 3.11, so CI failed parsing Python 3.12-only stub syntax.

## Validation
- `pytest tests/core/model/chat/basic/test_router.py tests/core/model/test_router_provider_config.py tests/core/model/chat/basic/test_openrouter.py`
- `PRE_COMMIT_HOME=$(mktemp -d) pre-commit run mypy --all-files`
- PR checks on `69b98696`: all passing