### PR TITLE
fix(kb): harden embedding chunk read and batch env parsing

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -71,6 +71,22 @@ def _safe_int_value(value: Any, default: int = 0) -> int:
         return default
 
 
+def _int_env(name: str, default: int) -> int:
+    """Read an integer environment variable, falling back to ``default``.
+
+    A missing variable, or one set to a non-numeric value, yields ``default``
+    instead of raising, so a malformed operator override cannot crash an
+    embedding write.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def _safe_optional_str(value: Any) -> str | None:
     """Return the string value or ``None`` for ``None``/NaN sentinels."""
     if value is None:
@@ -1164,7 +1180,12 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 index = _safe_int_value(chunk_dict.get("index"), default=0)
 
                 page_number_value = chunk_dict.get("page_number")
-                if page_number_value is not None:
+                # A missing page number can arrive as None or as a pandas/LanceDB
+                # NaN sentinel (NaN != NaN); both mean "no page", not page 1.
+                if (
+                    page_number_value is not None
+                    and page_number_value == page_number_value
+                ):
                     page_num = _safe_int_value(page_number_value, default=1)
                     page_number = page_num if page_num > 0 else None
                 else:
@@ -1291,12 +1312,10 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 f"Multiple vector dimensions found for model {model}: {unique_dims}"
             )
 
-        original_batch_size = int(
-            os.getenv("LANCEDB_BATCH_SIZE", str(DEFAULT_LANCEDB_BATCH_SIZE))
-        )
+        original_batch_size = _int_env("LANCEDB_BATCH_SIZE", DEFAULT_LANCEDB_BATCH_SIZE)
         batch_size = original_batch_size
         batch_timestamp = pd.Timestamp.now(tz="UTC")
-        max_spill_retries = int(os.getenv("LANCEDB_MAX_SPILL_RETRIES", "3"))
+        max_spill_retries = _int_env("LANCEDB_MAX_SPILL_RETRIES", 3)
         spill_retry_count = 0
 
         upserted_count = 0

--- a/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -1350,6 +1350,8 @@ class LanceDBCollectionHandle(KBCollectionHandle):
                 current_idx = end_idx
                 spill_retry_count = 0
             except Exception as batch_error:  # noqa: BLE001 - spill-retry then re-raise
+                # TODO: brittle string match; replace with a typed lancedb spill
+                # exception if/when one is exposed (cf. is_non_recoverable_merge_error).
                 if "Spill has sent an error" in str(batch_error):
                     spill_retry_count += 1
                     if spill_retry_count <= max_spill_retries:

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_handle_embedding.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_handle_embedding.py
@@ -224,6 +224,37 @@ class TestHandleReadChunksNeedingEmbedding:
         assert result.pending_count == 1
         assert to_model_tag("other_model") == "other_model"
 
+    def test_nan_page_number_normalized_to_none(self) -> None:
+        # A missing page number can surface as a pandas/LanceDB NaN sentinel; it
+        # must normalize to None, not be coerced to page 1.
+        from unittest.mock import MagicMock
+
+        handle, store = _mock_store_handle("coll")
+        store.count_rows_or_zero.side_effect = [1, 0]  # 1 chunk, 0 embeddings
+        batch = MagicMock()
+        batch.to_pylist.return_value = [
+            {
+                "doc_id": "d1",
+                "chunk_id": "c0",
+                "parse_hash": "h1",
+                "index": 0,
+                "text": "t",
+                "chunk_hash": "ch-c0",
+                "page_number": float("nan"),
+                "section": None,
+                "anchor": None,
+                "json_path": None,
+                "metadata": None,
+            }
+        ]
+        store.iter_batches.return_value = [batch]
+
+        result = handle.read_chunks_needing_embedding(
+            "d1", "h1", "test_model", is_admin=True
+        )
+        assert result.pending_count == 1
+        assert result.chunks[0].page_number is None
+
 
 def _embedding(
     doc_id: str,
@@ -534,6 +565,19 @@ class TestHandleWriteEmbeddingsMechanics:
         assert result.upsert_count == 3
         # 3 embeddings in batches of 2 -> two upsert calls.
         assert store.upsert_embeddings.call_count == 2
+
+    def test_invalid_int_env_falls_back_to_defaults(self, monkeypatch) -> None:
+        # A malformed integer override must fall back to the default instead of
+        # crashing the write with a ValueError.
+        monkeypatch.setenv("LANCEDB_BATCH_SIZE", "not-a-number")
+        monkeypatch.setenv("LANCEDB_MAX_SPILL_RETRIES", "")
+        handle, store = _mock_store_handle()
+        result = handle.write_embeddings(
+            [_embedding("d1", "c0", "h1", "m1", vector=[0.1, 0.2])],
+            create_index=False,
+        )
+        assert result.upsert_count == 1
+        store.upsert_embeddings.assert_called_once()
 
     def test_spill_error_reduces_batch_and_retries(self, monkeypatch) -> None:
         monkeypatch.setenv("LANCEDB_BATCH_SIZE", "100")


### PR DESCRIPTION
## Summary

Two small robustness fixes in the embedding lifecycle, surfaced by automated review on #658. Both behaviors were carried over verbatim from the legacy `vector_manager.py`, so they were left untouched in #658 (a behavior-preserving refactor) and are addressed here instead.

> **Stacked on #658.** This branch builds on `ref/kb-h03-embedding-lifecycle`; the diff includes #658's commits until that PR merges. Review/merge after #658.

## Changes (`kb/collection_handle.py`)

- **`read_chunks_needing_embedding`**: a missing `page_number` can arrive as a pandas/LanceDB `NaN` sentinel. The old `is not None` guard let `NaN` through and coerced it to page `1`; it now normalizes `NaN` to `None` (matching a genuinely missing page).
- **`_process_model_embeddings`**: `LANCEDB_BATCH_SIZE` / `LANCEDB_MAX_SPILL_RETRIES` were parsed with a bare `int()`, which raised `ValueError` and crashed the write if an operator set a non-numeric value. Parsing now goes through a small `_int_env` helper that falls back to the default on missing/invalid input.

## Tests

- `test_nan_page_number_normalized_to_none` — NaN `page_number` → `None`.
- `test_invalid_int_env_falls_back_to_defaults` — malformed batch-size/spill-retry env vars fall back to defaults instead of crashing.

`ruff`, `mypy`, and the full pre-commit hook set pass; the #510 characterization suite stays green (these edge cases were not previously exercised).
