### PR TITLE
refactor(tools): isolate db session per tool call for safe concurrency

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -15,6 +15,11 @@ from .....web.services.model_service import (
     _get_visible_user_ids,
     _is_model_visible_to_user,
 )
+
+# ``WebToolConfig`` is referenced as a module-level name in ``run_json_async``
+# so the nested sub-agent's config is constructed via the module attribute
+# (which also keeps it patchable in tests).
+from .....web.tools.config import WebToolConfig
 from ....tracing import create_agent_tracer
 from ....utils.type_check import ensure_list
 from ...core.document_search import find_missing_knowledge_bases
@@ -1216,8 +1221,8 @@ class ListAgentsTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """List all agents for the current user."""
-        from .db_session import tool_session_scope
         from .....web.models.agent import Agent
+        from .db_session import tool_session_scope
 
         try:
             status_filter = args.get("status_filter", "").strip().lower()
@@ -1314,7 +1319,7 @@ class AgentTool(AbstractBaseTool):
         agent_id: int,
         agent_name: str,
         agent_description: str,
-        db: Any,
+        session_factory: Any,
         user_id: int,
         task_id: Optional[str] = None,
         workspace_base_dir: Optional[str] = None,
@@ -1339,7 +1344,8 @@ class AgentTool(AbstractBaseTool):
             agent_id: The database ID of the published agent
             agent_name: Name of the agent
             agent_description: Description of what this agent does
-            db: Database session for loading agent config and models
+            session_factory: Session factory minting short-lived DB sessions
+                for loading agent config and models
             user_id: User ID for model access
             task_id: Task ID for workspace isolation
             workspace_base_dir: Base directory for workspace files
@@ -1364,7 +1370,7 @@ class AgentTool(AbstractBaseTool):
         self._tool_name = tool_name
         self._tool_description = tool_description
         self._extra_system_prompt = extra_system_prompt
-        self._db = db
+        self._session_factory = session_factory
         self._user_id = user_id
         self._task_id = task_id or f"agent_tool_{agent_id}"
         self._parent_task_id = parent_task_id or task_id
@@ -1550,7 +1556,7 @@ class AgentTool(AbstractBaseTool):
         return Path(workspace.resolve_path(raw, default_dir=default_dir))
 
     def _parent_owned_file_outputs(
-        self, file_outputs: Any, workspace: Any
+        self, file_outputs: Any, workspace: Any, db: Any
     ) -> Optional[list[dict[str, Any]]]:
         if not isinstance(file_outputs, list):
             return None
@@ -1592,7 +1598,7 @@ class AgentTool(AbstractBaseTool):
             file_record = None
             if item_file_id:
                 file_record = (
-                    self._db.query(UploadedFile)
+                    db.query(UploadedFile)
                     .filter(
                         UploadedFile.file_id == item_file_id,
                         UploadedFile.user_id == self._user_id,
@@ -1621,7 +1627,7 @@ class AgentTool(AbstractBaseTool):
                     try:
                         registered_file_id = workspace.register_file(
                             str(resolved_path),
-                            db_session=self._db,
+                            db_session=db,
                         )
                     except (FileNotFoundError, ValueError):
                         logger.debug(
@@ -1632,7 +1638,7 @@ class AgentTool(AbstractBaseTool):
                         continue
 
                     file_record = (
-                        self._db.query(UploadedFile)
+                        db.query(UploadedFile)
                         .filter(
                             UploadedFile.file_id == registered_file_id,
                             UploadedFile.user_id == self._user_id,
@@ -1661,98 +1667,128 @@ class AgentTool(AbstractBaseTool):
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Execute the agent with the given task."""
         from .....web.models.agent import Agent
-        from .....web.tools.config import WebToolConfig
         from .....web.user_isolated_memory import UserContext
+        from .db_session import tool_session_scope
 
         execution_task_id: Optional[str] = None
         try:
-            # Load agent from database - support both PUBLISHED and DRAFT
-            agent = self._db.query(Agent).filter(
-                Agent.id == self._agent_id,
-                Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
-            )
-            agent = _apply_agent_visibility_filters(
-                agent,
-                Agent,
-                user_id=self._user_id,
-                allowed_agent_ids=self._target_allowed_agent_ids,
-                allow_cross_user_agent_ids=self._target_allow_cross_user_agent_ids,
-            )
-            agent = agent.first() if agent is not None else None
-
-            if not agent:
-                error_msg = f"Error: Agent {self._agent_id} not found"
-                await self._trace_delegation("error", error=error_msg)
-                return AgentToolResult(response=error_msg).model_dump(exclude_none=True)
-
-            # Generate unique task ID for this execution
-            execution_task_id = f"agent_{self._agent_id}_{uuid4().hex[:8]}"
-            await self._trace_delegation("start", execution_task_id=execution_task_id)
-
-            # Resolve models
             from .....core.agent.service import AgentService
             from .....core.memory.in_memory import InMemoryMemoryStore
             from .....web.services.llm_utils import UserAwareModelStorage
 
-            storage = UserAwareModelStorage(self._db)
+            # ---- Phase 1: load agent config + resolve models in a
+            # short-lived session that is CLOSED before the sub-agent runs.
+            # The sub-agent has its own ReAct/DAG loop that may issue
+            # concurrent tool calls; holding the parent session across it is
+            # the core hazard, so we capture everything Phase 2/3 needs into
+            # plain locals while the session is open and never touch the
+            # detached ORM instance afterwards.
             default_llm = None
             fast_llm = None
             vision_llm = None
             compact_llm = None
+            agent_name = ""
+            agent_instructions = None
+            agent_knowledge_bases = None
+            agent_skills = None
+            agent_tool_categories = None
 
-            if agent.models:
-                from .....web.models.model import Model as DBModel
+            with tool_session_scope(self._session_factory) as db:
+                # Load agent from database - support both PUBLISHED and DRAFT
+                agent = db.query(Agent).filter(
+                    Agent.id == self._agent_id,
+                    Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
+                )
+                agent = _apply_agent_visibility_filters(
+                    agent,
+                    Agent,
+                    user_id=self._user_id,
+                    allowed_agent_ids=self._target_allowed_agent_ids,
+                    allow_cross_user_agent_ids=self._target_allow_cross_user_agent_ids,
+                )
+                agent = agent.first() if agent is not None else None
 
-                if agent.models.get("general"):
-                    general_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["general"])
-                        .first()
+                if not agent:
+                    error_msg = f"Error: Agent {self._agent_id} not found"
+                    await self._trace_delegation("error", error=error_msg)
+                    return AgentToolResult(response=error_msg).model_dump(
+                        exclude_none=True
                     )
-                    if general_model:
-                        default_llm = storage.get_llm_by_name_with_access(
-                            str(general_model.model_id), self._user_id
-                        )
 
-                if agent.models.get("small_fast"):
-                    fast_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["small_fast"])
-                        .first()
-                    )
-                    if fast_model:
-                        fast_llm = storage.get_llm_by_name_with_access(
-                            str(fast_model.model_id), self._user_id
-                        )
+                # Generate unique task ID for this execution
+                execution_task_id = f"agent_{self._agent_id}_{uuid4().hex[:8]}"
+                await self._trace_delegation(
+                    "start", execution_task_id=execution_task_id
+                )
 
-                if agent.models.get("visual"):
-                    visual_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["visual"])
-                        .first()
-                    )
-                    if visual_model:
-                        vision_llm = storage.get_llm_by_name_with_access(
-                            str(visual_model.model_id), self._user_id
-                        )
+                # Capture agent fields as plain locals before the session
+                # closes (avoid detached-ORM access in Phase 2/3).
+                agent_name = agent.name
+                agent_instructions = agent.instructions
+                agent_knowledge_bases = agent.knowledge_bases
+                agent_skills = agent.skills
+                agent_tool_categories = agent.tool_categories
 
-                if agent.models.get("compact"):
-                    compact_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["compact"])
-                        .first()
-                    )
-                    if compact_model:
-                        compact_llm = storage.get_llm_by_name_with_access(
-                            str(compact_model.model_id), self._user_id
+                # Resolve models
+                storage = UserAwareModelStorage(db)
+
+                if agent.models:
+                    from .....web.models.model import Model as DBModel
+
+                    if agent.models.get("general"):
+                        general_model = (
+                            db.query(DBModel)
+                            .filter(DBModel.id == agent.models["general"])
+                            .first()
                         )
+                        if general_model:
+                            default_llm = storage.get_llm_by_name_with_access(
+                                str(general_model.model_id), self._user_id
+                            )
+
+                    if agent.models.get("small_fast"):
+                        fast_model = (
+                            db.query(DBModel)
+                            .filter(DBModel.id == agent.models["small_fast"])
+                            .first()
+                        )
+                        if fast_model:
+                            fast_llm = storage.get_llm_by_name_with_access(
+                                str(fast_model.model_id), self._user_id
+                            )
+
+                    if agent.models.get("visual"):
+                        visual_model = (
+                            db.query(DBModel)
+                            .filter(DBModel.id == agent.models["visual"])
+                            .first()
+                        )
+                        if visual_model:
+                            vision_llm = storage.get_llm_by_name_with_access(
+                                str(visual_model.model_id), self._user_id
+                            )
+
+                    if agent.models.get("compact"):
+                        compact_model = (
+                            db.query(DBModel)
+                            .filter(DBModel.id == agent.models["compact"])
+                            .first()
+                        )
+                        if compact_model:
+                            compact_llm = storage.get_llm_by_name_with_access(
+                                str(compact_model.model_id), self._user_id
+                            )
+            # ---- Phase 1 session closed here. ----
 
             if not default_llm:
-                error_msg = f"Error: No valid model configured for agent {agent.name}"
+                error_msg = f"Error: No valid model configured for agent {agent_name}"
                 await self._trace_delegation(
                     "error", execution_task_id=execution_task_id, error=error_msg
                 )
                 return AgentToolResult(response=error_msg).model_dump(exclude_none=True)
+
+            # ---- Phase 2: build the child config with the FACTORY (no live
+            # parent session) and run the sub-agent. ----
 
             # Create tool config with allowed collections, skills, and tools
             class MinimalRequest:
@@ -1770,18 +1806,19 @@ class AgentTool(AbstractBaseTool):
             )
 
             tool_selection_spec = ToolSelectionSpec.from_raw(
-                tool_categories=agent.tool_categories,
+                tool_categories=agent_tool_categories,
             )
 
             parent_db_task_id = _coerce_db_task_id(self._parent_task_id)
             tool_config = WebToolConfig(
-                db=self._db,
+                db=None,
+                db_factory=self._session_factory,
                 request=MinimalRequest(self._user_id),
                 user_id=self._user_id,
-                allowed_collections=agent.knowledge_bases
-                if agent.knowledge_bases is not None
+                allowed_collections=agent_knowledge_bases
+                if agent_knowledge_bases is not None
                 else None,
-                allowed_skills=agent.skills,
+                allowed_skills=agent_skills,
                 tool_selection_spec=tool_selection_spec,
                 # Keep MCP config loading aligned with the direct chat path.
                 # _SpecAll still admits MCP at the final filter layer for
@@ -1802,52 +1839,62 @@ class AgentTool(AbstractBaseTool):
                 },
             )
 
-            tracer = self._create_child_execution_tracer(
-                execution_task_id=execution_task_id,
-                agent_name=str(agent.name),
-                parent_db_task_id=parent_db_task_id,
-            )
-
-            # Create agent service
-            memory = InMemoryMemoryStore()
-            agent_service = AgentService(
-                name=agent.name,
-                llm=default_llm,
-                fast_llm=fast_llm,
-                vision_llm=vision_llm,
-                compact_llm=compact_llm,
-                memory=memory,
-                tool_config=tool_config,
-                use_dag_pattern=True,
-                id=execution_task_id,
-                enable_workspace=True,
-                workspace_base_dir=self._workspace_base_dir,
-                task_id=execution_task_id,
-                tracer=tracer,
-            )
-
-            # Build execution context
-            execution_context: dict[str, Any] = {}
-            system_prompts = []
-            if agent.instructions:
-                system_prompts.append(agent.instructions)
-            if self._extra_system_prompt:
-                system_prompts.append(self._extra_system_prompt)
-            if system_prompts:
-                execution_context["system_prompt"] = "\n\n".join(system_prompts)
-
-            # Execute task
-            with UserContext(self._user_id):
-                result = await agent_service.execute_task(
-                    task=args["task"],
-                    context=execution_context if execution_context else None,
-                    task_id=execution_task_id,
+            try:
+                tracer = self._create_child_execution_tracer(
+                    execution_task_id=execution_task_id,
+                    agent_name=str(agent_name),
+                    parent_db_task_id=parent_db_task_id,
                 )
 
+                # Create agent service
+                memory = InMemoryMemoryStore()
+                agent_service = AgentService(
+                    name=agent_name,
+                    llm=default_llm,
+                    fast_llm=fast_llm,
+                    vision_llm=vision_llm,
+                    compact_llm=compact_llm,
+                    memory=memory,
+                    tool_config=tool_config,
+                    use_dag_pattern=True,
+                    id=execution_task_id,
+                    enable_workspace=True,
+                    workspace_base_dir=self._workspace_base_dir,
+                    task_id=execution_task_id,
+                    tracer=tracer,
+                )
+
+                # Build execution context
+                execution_context: dict[str, Any] = {}
+                system_prompts = []
+                if agent_instructions:
+                    system_prompts.append(agent_instructions)
+                if self._extra_system_prompt:
+                    system_prompts.append(self._extra_system_prompt)
+                if system_prompts:
+                    execution_context["system_prompt"] = "\n\n".join(system_prompts)
+
+                # Execute task
+                with UserContext(self._user_id):
+                    result = await agent_service.execute_task(
+                        task=args["task"],
+                        context=execution_context if execution_context else None,
+                        task_id=execution_task_id,
+                    )
+            finally:
+                tool_config.close()
+
+            # ---- Phase 3: post-run file outputs in a fresh short-lived
+            # session. Registering delegated outputs only flushes into the
+            # session, so this owned session commits before closing to make
+            # the parent-owned file records durable (the parent session used
+            # to carry these to the request-level commit).
             output = result.get("output", "No response generated")
-            file_outputs = self._parent_owned_file_outputs(
-                result.get("file_outputs"), agent_service.workspace
-            )
+            with tool_session_scope(self._session_factory) as db:
+                file_outputs = self._parent_owned_file_outputs(
+                    result.get("file_outputs"), agent_service.workspace, db
+                )
+                db.commit()
             file_outputs = file_outputs if isinstance(file_outputs, list) else None
             logger.info(
                 f"Agent tool {self.name} executed successfully, output length: {len(output)}"
@@ -1873,7 +1920,7 @@ class AgentTool(AbstractBaseTool):
 
 
 def get_published_agents_tools(
-    db: Any,
+    session_factory: Any,
     user_id: int,
     task_id: Optional[str] = None,
     workspace_base_dir: Optional[str] = None,
@@ -1892,7 +1939,7 @@ def get_published_agents_tools(
     Get tools for published (and optionally draft) agents.
 
     Args:
-        db: Database session
+        session_factory: Session factory minting short-lived DB sessions
         user_id: User ID for model access
         task_id: Task ID for workspace isolation
         workspace_base_dir: Base directory for workspace files
@@ -1912,6 +1959,7 @@ def get_published_agents_tools(
     """
     from .....config import get_uploads_dir
     from .....web.models.agent import Agent, AgentStatus
+    from .db_session import tool_session_scope
 
     if workspace_base_dir is None:
         workspace_base_dir = str(get_uploads_dir())
@@ -1943,144 +1991,145 @@ def get_published_agents_tools(
         ]
 
     try:
-        if normalized_injected_agent_ids is not None:
-            if not normalized_injected_agent_ids:
-                return []
-            query = db.query(Agent).filter(
-                Agent.status.in_(["published"]),  # type: ignore[attr-defined]
-            )
-            query = _apply_agent_visibility_filters(
-                query,
-                Agent,
-                user_id=user_id,
-                allowed_agent_ids=normalized_injected_agent_ids,
-                allow_cross_user_agent_ids=allow_cross_user_agent_ids,
-            )
-            if query is None:
-                return []
-        elif not enable_global_agent_tools:
-            return []
-        elif include_draft:
-            # Include both PUBLISHED and DRAFT agents
-            query = db.query(Agent).filter(
-                Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
-            )
-            query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
-        else:
-            # Only PUBLISHED agents
-            query = db.query(Agent).filter(
-                Agent.status == "published",
-            )
-            query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
-
-        # Exclude the active delegation stack to prevent recursive self-calls.
-        if excluded_agent_ids:
-            query = query.filter(Agent.id.notin_(sorted(excluded_agent_ids)))
-
-        agents = query.all()
-
-        # If specific DRAFT agents should be included, add them
-        if draft_agent_ids_to_include:
-            normalized_draft_agent_ids = _normalize_agent_ids(
-                draft_agent_ids_to_include
-            )
-            normalized_draft_agent_ids = [
-                agent_id
-                for agent_id in (normalized_draft_agent_ids or [])
-                if agent_id not in excluded_agent_ids
-            ]
-            draft_agents = _apply_owned_agent_tool_filters(
-                db.query(Agent).filter(
-                    Agent.id.in_(normalized_draft_agent_ids),
-                    Agent.status == "draft",
-                ),
-                Agent,
-                user_id=user_id,
-            ).all()
-            # Merge without duplicates
-            existing_ids = {agent.id for agent in agents}
-            for draft_agent in draft_agents:
-                if draft_agent.id not in existing_ids:
-                    agents.append(draft_agent)
-
-        if normalized_injected_agent_ids is not None:
-            agent_types = "selected PUBLISHED"
-        else:
-            agent_types = "PUBLISHED and DRAFT" if include_draft else "PUBLISHED"
-        logger.info(
-            f"Found {len(agents)} {agent_types} agents (excluded: {sorted(excluded_agent_ids)})"
-        )
-
-        for agent in agents:
-            override = normalized_overrides.get(int(agent.id or 0), {})
-            # Build description
-            description = agent.description or f"Call {agent.name} agent"
-            if agent.instructions:
-                # Add brief instructions to description
-                instructions_preview = agent.instructions[:200]
-                if len(agent.instructions) > 200:
-                    instructions_preview += "..."
-                description += f". Instructions: {instructions_preview}"
-
-            # Add status indicator for draft agents
-            if agent.status == AgentStatus.DRAFT:
-                description = f"[DRAFT] {description}"
-
-            tool_name = _string_override(override, "tool_name")
-            tool_description = _string_override(
-                override, "description", "tool_description"
-            )
-            extra_system_prompt = _string_override(override, "extra_system_prompt")
-            delegation_allowed_agent_ids = (
-                _normalize_agent_ids(override.get("allowed_agent_ids"))
-                if "allowed_agent_ids" in override
-                else None
-            )
-            delegation_agent_tool_overrides = _normalize_agent_tool_overrides(
-                override.get("agent_tool_overrides")
-            )
-            delegation_enable_global_agent_tools = _truthy_bool(
-                override.get("enable_global_agent_tools"), True
-            )
-            delegation_allow_cross_user_agent_ids = _truthy_bool(
-                override.get("allow_cross_user_agent_ids"), False
-            )
-            runtime_metadata = {
-                key: override[key]
-                for key in (
-                    "workforce_run_id",
-                    "workforce_id",
-                    "workforce_name",
-                    "worker_member_id",
-                    "worker_alias",
+        with tool_session_scope(session_factory) as db:
+            if normalized_injected_agent_ids is not None:
+                if not normalized_injected_agent_ids:
+                    return []
+                query = db.query(Agent).filter(
+                    Agent.status.in_(["published"]),  # type: ignore[attr-defined]
                 )
-                if key in override
-            }
+                query = _apply_agent_visibility_filters(
+                    query,
+                    Agent,
+                    user_id=user_id,
+                    allowed_agent_ids=normalized_injected_agent_ids,
+                    allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+                )
+                if query is None:
+                    return []
+            elif not enable_global_agent_tools:
+                return []
+            elif include_draft:
+                # Include both PUBLISHED and DRAFT agents
+                query = db.query(Agent).filter(
+                    Agent.status.in_(["published", "draft"]),  # type: ignore[attr-defined]
+                )
+                query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
+            else:
+                # Only PUBLISHED agents
+                query = db.query(Agent).filter(
+                    Agent.status == "published",
+                )
+                query = _apply_owned_agent_tool_filters(query, Agent, user_id=user_id)
 
-            tool = AgentTool(
-                agent_id=agent.id,
-                agent_name=agent.name,
-                agent_description=tool_description or description,
-                db=db,
-                user_id=user_id,
-                task_id=task_id,
-                workspace_base_dir=workspace_base_dir,
-                tool_name=tool_name,
-                tool_description=tool_description,
-                extra_system_prompt=extra_system_prompt,
-                parent_task_id=parent_task_id,
-                parent_tracer=parent_tracer,
-                agent_call_stack=normalized_call_stack,
-                delegation_allowed_agent_ids=delegation_allowed_agent_ids,
-                agent_tool_overrides=delegation_agent_tool_overrides,
-                enable_global_agent_tools=delegation_enable_global_agent_tools,
-                delegation_allow_cross_user_agent_ids=delegation_allow_cross_user_agent_ids,
-                target_allowed_agent_ids=normalized_injected_agent_ids,
-                target_allow_cross_user_agent_ids=allow_cross_user_agent_ids,
-                runtime_metadata=runtime_metadata,
+            # Exclude the active delegation stack to prevent recursive self-calls.
+            if excluded_agent_ids:
+                query = query.filter(Agent.id.notin_(sorted(excluded_agent_ids)))
+
+            agents = query.all()
+
+            # If specific DRAFT agents should be included, add them
+            if draft_agent_ids_to_include:
+                normalized_draft_agent_ids = _normalize_agent_ids(
+                    draft_agent_ids_to_include
+                )
+                normalized_draft_agent_ids = [
+                    agent_id
+                    for agent_id in (normalized_draft_agent_ids or [])
+                    if agent_id not in excluded_agent_ids
+                ]
+                draft_agents = _apply_owned_agent_tool_filters(
+                    db.query(Agent).filter(
+                        Agent.id.in_(normalized_draft_agent_ids),
+                        Agent.status == "draft",
+                    ),
+                    Agent,
+                    user_id=user_id,
+                ).all()
+                # Merge without duplicates
+                existing_ids = {agent.id for agent in agents}
+                for draft_agent in draft_agents:
+                    if draft_agent.id not in existing_ids:
+                        agents.append(draft_agent)
+
+            if normalized_injected_agent_ids is not None:
+                agent_types = "selected PUBLISHED"
+            else:
+                agent_types = "PUBLISHED and DRAFT" if include_draft else "PUBLISHED"
+            logger.info(
+                f"Found {len(agents)} {agent_types} agents (excluded: {sorted(excluded_agent_ids)})"
             )
-            tools.append(tool)
-            logger.debug(f"Created agent tool: {tool.name}")
+
+            for agent in agents:
+                override = normalized_overrides.get(int(agent.id or 0), {})
+                # Build description
+                description = agent.description or f"Call {agent.name} agent"
+                if agent.instructions:
+                    # Add brief instructions to description
+                    instructions_preview = agent.instructions[:200]
+                    if len(agent.instructions) > 200:
+                        instructions_preview += "..."
+                    description += f". Instructions: {instructions_preview}"
+
+                # Add status indicator for draft agents
+                if agent.status == AgentStatus.DRAFT:
+                    description = f"[DRAFT] {description}"
+
+                tool_name = _string_override(override, "tool_name")
+                tool_description = _string_override(
+                    override, "description", "tool_description"
+                )
+                extra_system_prompt = _string_override(override, "extra_system_prompt")
+                delegation_allowed_agent_ids = (
+                    _normalize_agent_ids(override.get("allowed_agent_ids"))
+                    if "allowed_agent_ids" in override
+                    else None
+                )
+                delegation_agent_tool_overrides = _normalize_agent_tool_overrides(
+                    override.get("agent_tool_overrides")
+                )
+                delegation_enable_global_agent_tools = _truthy_bool(
+                    override.get("enable_global_agent_tools"), True
+                )
+                delegation_allow_cross_user_agent_ids = _truthy_bool(
+                    override.get("allow_cross_user_agent_ids"), False
+                )
+                runtime_metadata = {
+                    key: override[key]
+                    for key in (
+                        "workforce_run_id",
+                        "workforce_id",
+                        "workforce_name",
+                        "worker_member_id",
+                        "worker_alias",
+                    )
+                    if key in override
+                }
+
+                tool = AgentTool(
+                    agent_id=agent.id,
+                    agent_name=agent.name,
+                    agent_description=tool_description or description,
+                    session_factory=session_factory,
+                    user_id=user_id,
+                    task_id=task_id,
+                    workspace_base_dir=workspace_base_dir,
+                    tool_name=tool_name,
+                    tool_description=tool_description,
+                    extra_system_prompt=extra_system_prompt,
+                    parent_task_id=parent_task_id,
+                    parent_tracer=parent_tracer,
+                    agent_call_stack=normalized_call_stack,
+                    delegation_allowed_agent_ids=delegation_allowed_agent_ids,
+                    agent_tool_overrides=delegation_agent_tool_overrides,
+                    enable_global_agent_tools=delegation_enable_global_agent_tools,
+                    delegation_allow_cross_user_agent_ids=delegation_allow_cross_user_agent_ids,
+                    target_allowed_agent_ids=normalized_injected_agent_ids,
+                    target_allow_cross_user_agent_ids=allow_cross_user_agent_ids,
+                    runtime_metadata=runtime_metadata,
+                )
+                tools.append(tool)
+                logger.debug(f"Created agent tool: {tool.name}")
 
     except Exception as e:
         logger.error(f"Failed to load agents as tools: {e}", exc_info=True)
@@ -2119,7 +2168,7 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
         return []
 
     try:
-        db = config.get_db()
+        session_factory = config.get_session_factory()
         user_id = config.get_user_id()
         if not user_id:
             return []
@@ -2127,7 +2176,7 @@ async def create_agent_tools(config: "WebToolConfig") -> list[AbstractBaseTool]:
         excluded_agent_id = config.get_excluded_agent_id() if config else None
 
         return get_published_agents_tools(
-            db=db,
+            session_factory=session_factory,
             user_id=user_id,
             task_id=config.get_task_id(),
             workspace_base_dir=None,  # Will use get_uploads_dir() default

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1145,7 +1145,7 @@ class ListAgentsTool(AbstractBaseTool):
 
     def __init__(
         self,
-        db: Any,
+        session_factory: Any,
         user_id: int,
         task_id: Optional[str] = None,
         workspace_base_dir: Optional[str] = None,
@@ -1154,12 +1154,12 @@ class ListAgentsTool(AbstractBaseTool):
         Initialize the list agents tool.
 
         Args:
-            db: Database session for querying agents
+            session_factory: Callable that returns a new database session per call
             user_id: User ID for filtering user's agents
             task_id: Task ID for context
             workspace_base_dir: Base directory for workspace files
         """
-        self._db = db
+        self._session_factory = session_factory
         self._user_id = user_id
         self._task_id = task_id
         if workspace_base_dir is None:
@@ -1216,6 +1216,7 @@ class ListAgentsTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """List all agents for the current user."""
+        from .db_session import tool_session_scope
         from .....web.models.agent import Agent
 
         try:
@@ -1232,39 +1233,40 @@ class ListAgentsTool(AbstractBaseTool):
                     message=f"Error: Invalid status_filter '{status_filter}'. Must be 'draft', 'published', or 'archived'",
                 ).model_dump()
 
-            # Build query
-            query = _apply_owned_agent_tool_filters(
-                self._db.query(Agent),
-                Agent,
-                user_id=self._user_id,
-            )
-
-            # Apply status filter if provided
-            if status_filter:
-                query = query.filter(Agent.status == status_filter)
-
-            # Order by status (draft first) then by name
-            agents = query.order_by(Agent.status, Agent.name).all()
-
-            # Build agent info list
-            agent_infos = []
-            for agent in agents:
-                tool_name = gen_agent_tool_name(agent.id)
-                markdown_link = f"[{agent.name}](agent://{agent.id})"
-
-                agent_info = AgentInfo(
-                    agent_id=agent.id,
-                    name=agent.name,
-                    description=agent.description or "No description",
-                    status=agent.status.value,
-                    tool_name=tool_name,
-                    markdown_link=markdown_link,
-                    execution_mode=agent.execution_mode or "react",
-                    knowledge_bases=agent.knowledge_bases,
-                    tool_categories=agent.tool_categories,
-                    skills=agent.skills if agent.skills else None,
+            with tool_session_scope(self._session_factory) as db:
+                # Build query
+                query = _apply_owned_agent_tool_filters(
+                    db.query(Agent),
+                    Agent,
+                    user_id=self._user_id,
                 )
-                agent_infos.append(agent_info.model_dump())
+
+                # Apply status filter if provided
+                if status_filter:
+                    query = query.filter(Agent.status == status_filter)
+
+                # Order by status (draft first) then by name
+                agents = query.order_by(Agent.status, Agent.name).all()
+
+                # Build agent info list
+                agent_infos = []
+                for agent in agents:
+                    tool_name = gen_agent_tool_name(agent.id)
+                    markdown_link = f"[{agent.name}](agent://{agent.id})"
+
+                    agent_info = AgentInfo(
+                        agent_id=agent.id,
+                        name=agent.name,
+                        description=agent.description or "No description",
+                        status=agent.status.value,
+                        tool_name=tool_name,
+                        markdown_link=markdown_link,
+                        execution_mode=agent.execution_mode or "react",
+                        knowledge_bases=agent.knowledge_bases,
+                        tool_categories=agent.tool_categories,
+                        skills=agent.skills if agent.skills else None,
+                    )
+                    agent_infos.append(agent_info.model_dump())
 
             total_count = len(agent_infos)
             filter_msg = (
@@ -2217,13 +2219,13 @@ async def create_list_agents_tool(config: "WebToolConfig") -> list[AbstractBaseT
         return []
 
     try:
-        db = config.get_db()
+        factory = config.get_session_factory()
         user_id = config.get_user_id()
         if not user_id:
             return []
 
         tool = ListAgentsTool(
-            db=db,
+            session_factory=factory,
             user_id=user_id,
             task_id=config.get_task_id(),
             workspace_base_dir=None,  # Will use get_uploads_dir() default

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -635,9 +635,9 @@ class CreateAgentTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Create a new agent with the given configuration."""
-        from .db_session import tool_session_scope
         from .....web.models.agent import AgentStatus
         from .....web.models.user import UserDefaultModel, UserModel
+        from .db_session import tool_session_scope
 
         with tool_session_scope(self._session_factory) as db:
             try:
@@ -722,7 +722,9 @@ class CreateAgentTool(AbstractBaseTool):
                     visible_ids = _get_visible_user_ids(db, self._user_id)
                     admin_defaults = (
                         db.query(UserDefaultModel)
-                        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                        .join(
+                            UserModel, UserDefaultModel.model_id == UserModel.model_id
+                        )
                         .filter(
                             UserDefaultModel.config_type.in_(missing_types),
                             UserModel.is_shared.is_(True),
@@ -833,7 +835,7 @@ class UpdateAgentTool(AbstractBaseTool):
 
     def __init__(
         self,
-        db: Any,
+        session_factory: Any,
         user_id: int,
         task_id: Optional[str] = None,
         workspace_base_dir: Optional[str] = None,
@@ -842,12 +844,13 @@ class UpdateAgentTool(AbstractBaseTool):
         Initialize the update agent tool.
 
         Args:
-            db: Database session for updating the agent
+            session_factory: Callable that returns a new SQLAlchemy session; a
+                fresh session is opened per call and closed in ``finally``.
             user_id: User ID for ownership and access control
             task_id: Task ID for context
             workspace_base_dir: Base directory for workspace files
         """
-        self._db = db
+        self._session_factory = session_factory
         self._user_id = user_id
         self._task_id = task_id
         if workspace_base_dir is None:
@@ -932,199 +935,201 @@ class UpdateAgentTool(AbstractBaseTool):
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Update an existing agent with the given configuration."""
         from .....web.models.agent import Agent, AgentStatus
+        from .db_session import tool_session_scope
 
-        try:
-            agent_id = args.get("agent_id")
+        with tool_session_scope(self._session_factory) as db:
+            try:
+                agent_id = args.get("agent_id")
 
-            if not agent_id:
-                return UpdateAgentToolResult(
-                    agent_id=0,
-                    agent_name="",
-                    tool_name="",
-                    markdown_link="",
-                    status="error",
-                    message="Error: Agent ID is required",
-                ).model_dump()
+                if not agent_id:
+                    return UpdateAgentToolResult(
+                        agent_id=0,
+                        agent_name="",
+                        tool_name="",
+                        markdown_link="",
+                        status="error",
+                        message="Error: Agent ID is required",
+                    ).model_dump()
 
-            # Find the agent
-            query = self._db.query(Agent).filter(Agent.id == agent_id)
-            query = _apply_owned_agent_tool_filters(
-                query,
-                Agent,
-                user_id=self._user_id,
-            )
-            agent = query.first()
-
-            if not agent:
-                return UpdateAgentToolResult(
-                    agent_id=0,
-                    agent_name="",
-                    tool_name="",
-                    markdown_link="",
-                    status="error",
-                    message=f"Error: Agent with ID {agent_id} not found",
-                ).model_dump()
-
-            if agent.status == AgentStatus.ARCHIVED:
-                return UpdateAgentToolResult(
-                    agent_id=agent_id,
-                    agent_name=agent.name,
-                    tool_name=gen_agent_tool_name(agent.id),
-                    markdown_link=f"[{agent.name}](agent://{agent.id})",
-                    status="error",
-                    message=(
-                        "Error: Archived agents cannot be updated. "
-                        f"This agent is {agent.status.value.upper()}."
-                    ),
-                ).model_dump()
-
-            # Track changes
-            changes = []
-            updates: dict[str, Any] = {}
-
-            # Update name if provided
-            new_name = args.get("name", "").strip() if args.get("name") else None
-            if new_name:
-                # Check for duplicate name (exclude current agent)
-                existing = _apply_owned_agent_tool_filters(
-                    self._db.query(Agent).filter(
-                        Agent.name == new_name,
-                        Agent.id != agent_id,
-                    ),
+                # Find the agent
+                query = db.query(Agent).filter(Agent.id == agent_id)
+                query = _apply_owned_agent_tool_filters(
+                    query,
                     Agent,
                     user_id=self._user_id,
-                ).first()
-                if existing:
+                )
+                agent = query.first()
+
+                if not agent:
                     return UpdateAgentToolResult(
                         agent_id=0,
                         agent_name="",
                         tool_name="",
                         markdown_link="",
                         status="error",
-                        message=f"Error: Agent with name '{new_name}' already exists",
+                        message=f"Error: Agent with ID {agent_id} not found",
                     ).model_dump()
-                updates["name"] = new_name
-                changes.append(f"name → '{new_name}'")
 
-            # Update description if provided
-            new_description = (
-                args.get("description", "").strip() if args.get("description") else None
-            )
-            if new_description:
-                updates["description"] = new_description
-                changes.append("description updated")
-
-            # Update instructions if provided
-            new_instructions = (
-                args.get("instructions", "").strip()
-                if args.get("instructions")
-                else None
-            )
-            if new_instructions:
-                updates["instructions"] = new_instructions
-                changes.append("instructions updated")
-
-            # Update tool_categories if provided
-            new_tool_categories = ensure_list(args.get("tool_categories"))
-            if new_tool_categories is not None:
-                updates["tool_categories"] = new_tool_categories
-                changes.append(f"tool_categories → {new_tool_categories}")
-
-            # Update knowledge_bases if provided
-            new_knowledge_bases = ensure_list(args.get("knowledge_bases"))
-            if new_knowledge_bases is not None:
-                missing_kbs = await _missing_knowledge_bases_for_user(
-                    new_knowledge_bases, self._db, self._user_id
-                )
-                if missing_kbs:
+                if agent.status == AgentStatus.ARCHIVED:
                     return UpdateAgentToolResult(
-                        agent_id=0,
-                        agent_name="",
-                        tool_name="",
-                        markdown_link="",
+                        agent_id=agent_id,
+                        agent_name=agent.name,
+                        tool_name=gen_agent_tool_name(agent.id),
+                        markdown_link=f"[{agent.name}](agent://{agent.id})",
                         status="error",
                         message=(
-                            "Error: Knowledge base(s) not found or not visible to this user: "
-                            + ", ".join(missing_kbs)
+                            "Error: Archived agents cannot be updated. "
+                            f"This agent is {agent.status.value.upper()}."
                         ),
                     ).model_dump()
-                updates["knowledge_bases"] = new_knowledge_bases
-                changes.append(f"knowledge_bases → {new_knowledge_bases}")
 
-            # Update skills if provided
-            new_skills = ensure_list(args.get("skills"))
-            if new_skills is not None:
-                updates["skills"] = new_skills
-                changes.append(f"skills → {new_skills}")
+                # Track changes
+                changes = []
+                updates: dict[str, Any] = {}
 
-            # Update execution_mode if provided
-            new_execution_mode = args.get("execution_mode")
-            if new_execution_mode in ["flash", "balanced", "think", "auto"]:
-                updates["execution_mode"] = new_execution_mode
-                changes.append(f"execution_mode → {new_execution_mode}")
+                # Update name if provided
+                new_name = args.get("name", "").strip() if args.get("name") else None
+                if new_name:
+                    # Check for duplicate name (exclude current agent)
+                    existing = _apply_owned_agent_tool_filters(
+                        db.query(Agent).filter(
+                            Agent.name == new_name,
+                            Agent.id != agent_id,
+                        ),
+                        Agent,
+                        user_id=self._user_id,
+                    ).first()
+                    if existing:
+                        return UpdateAgentToolResult(
+                            agent_id=0,
+                            agent_name="",
+                            tool_name="",
+                            markdown_link="",
+                            status="error",
+                            message=f"Error: Agent with name '{new_name}' already exists",
+                        ).model_dump()
+                    updates["name"] = new_name
+                    changes.append(f"name → '{new_name}'")
 
-            # Check if there were any changes
-            if not changes:
+                # Update description if provided
+                new_description = (
+                    args.get("description", "").strip()
+                    if args.get("description")
+                    else None
+                )
+                if new_description:
+                    updates["description"] = new_description
+                    changes.append("description updated")
+
+                # Update instructions if provided
+                new_instructions = (
+                    args.get("instructions", "").strip()
+                    if args.get("instructions")
+                    else None
+                )
+                if new_instructions:
+                    updates["instructions"] = new_instructions
+                    changes.append("instructions updated")
+
+                # Update tool_categories if provided
+                new_tool_categories = ensure_list(args.get("tool_categories"))
+                if new_tool_categories is not None:
+                    updates["tool_categories"] = new_tool_categories
+                    changes.append(f"tool_categories → {new_tool_categories}")
+
+                # Update knowledge_bases if provided
+                new_knowledge_bases = ensure_list(args.get("knowledge_bases"))
+                if new_knowledge_bases is not None:
+                    missing_kbs = await _missing_knowledge_bases_for_user(
+                        new_knowledge_bases, db, self._user_id
+                    )
+                    if missing_kbs:
+                        return UpdateAgentToolResult(
+                            agent_id=0,
+                            agent_name="",
+                            tool_name="",
+                            markdown_link="",
+                            status="error",
+                            message=(
+                                "Error: Knowledge base(s) not found or not visible to this user: "
+                                + ", ".join(missing_kbs)
+                            ),
+                        ).model_dump()
+                    updates["knowledge_bases"] = new_knowledge_bases
+                    changes.append(f"knowledge_bases → {new_knowledge_bases}")
+
+                # Update skills if provided
+                new_skills = ensure_list(args.get("skills"))
+                if new_skills is not None:
+                    updates["skills"] = new_skills
+                    changes.append(f"skills → {new_skills}")
+
+                # Update execution_mode if provided
+                new_execution_mode = args.get("execution_mode")
+                if new_execution_mode in ["flash", "balanced", "think", "auto"]:
+                    updates["execution_mode"] = new_execution_mode
+                    changes.append(f"execution_mode → {new_execution_mode}")
+
+                # Check if there were any changes
+                if not changes:
+                    return UpdateAgentToolResult(
+                        agent_id=agent_id,
+                        agent_name=agent.name,
+                        tool_name=gen_agent_tool_name(agent.id),
+                        markdown_link=f"[{agent.name}](agent://{agent.id})",
+                        status="success",
+                        message=f"ℹ️ No updates were made to agent '{agent.name}' (ID: {agent_id}). "
+                        f"Status: {agent.status.value.upper()}. "
+                        f"All fields were the same or no values were provided.",
+                    ).model_dump()
+
+                agent = (
+                    AgentStore(db).update_agent_fields(self._user_id, agent_id, updates)
+                    or agent
+                )
+
+                # Generate the tool name and markdown link
+                agent_name = str(agent.name)
+                tool_name = gen_agent_tool_name(agent.id)
+                markdown_link = f"[{agent_name}](agent://{agent.id})"
+
+                logger.info(
+                    f"Updated {agent.status.value.upper()} agent '{agent_name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
+                )
+
                 return UpdateAgentToolResult(
-                    agent_id=agent_id,
-                    agent_name=agent.name,
-                    tool_name=gen_agent_tool_name(agent.id),
-                    markdown_link=f"[{agent.name}](agent://{agent.id})",
+                    agent_id=agent.id,
+                    agent_name=agent_name,
+                    tool_name=tool_name,
+                    markdown_link=markdown_link,
                     status="success",
-                    message=f"ℹ️ No updates were made to agent '{agent.name}' (ID: {agent_id}). "
-                    f"Status: {agent.status.value.upper()}. "
-                    f"All fields were the same or no values were provided.",
+                    message=(
+                        f"✅ Agent updated successfully\n\n"
+                        f"**Agent Details:**\n"
+                        f"- Agent ID: {agent.id}\n"
+                        f"- Agent Name: {agent.name}\n"
+                        f"- Tool Name: {tool_name}\n"
+                        f"- Status: {agent.status.value.upper()}\n\n"
+                        f"**Changes Applied:**\n"
+                        + "\n".join(f"- {change}" for change in changes)
+                        + f"\n\n**How to use this agent:**\n"
+                        f"Include this link in your response: {markdown_link}\n"
+                        f"Or use the tool: {tool_name}\n\n"
+                        f"*The agent keeps its current publication status and will reflect the updated changes on next execution.*"
+                    ),
                 ).model_dump()
 
-            agent = (
-                AgentStore(self._db).update_agent_fields(
-                    self._user_id, agent_id, updates
-                )
-                or agent
-            )
-
-            # Generate the tool name and markdown link
-            agent_name = str(agent.name)
-            tool_name = gen_agent_tool_name(agent.id)
-            markdown_link = f"[{agent_name}](agent://{agent.id})"
-
-            logger.info(
-                f"Updated {agent.status.value.upper()} agent '{agent_name}' (ID: {agent.id}) for user {self._user_id}: {', '.join(changes)}"
-            )
-
-            return UpdateAgentToolResult(
-                agent_id=agent.id,
-                agent_name=agent_name,
-                tool_name=tool_name,
-                markdown_link=markdown_link,
-                status="success",
-                message=(
-                    f"✅ Agent updated successfully\n\n"
-                    f"**Agent Details:**\n"
-                    f"- Agent ID: {agent.id}\n"
-                    f"- Agent Name: {agent.name}\n"
-                    f"- Tool Name: {tool_name}\n"
-                    f"- Status: {agent.status.value.upper()}\n\n"
-                    f"**Changes Applied:**\n"
-                    + "\n".join(f"- {change}" for change in changes)
-                    + f"\n\n**How to use this agent:**\n"
-                    f"Include this link in your response: {markdown_link}\n"
-                    f"Or use the tool: {tool_name}\n\n"
-                    f"*The agent keeps its current publication status and will reflect the updated changes on next execution.*"
-                ),
-            ).model_dump()
-
-        except Exception as e:
-            error_msg = f"Error updating agent: {str(e)}"
-            logger.error(error_msg, exc_info=True)
-            return UpdateAgentToolResult(
-                agent_id=0,
-                agent_name="",
-                tool_name="",
-                markdown_link="",
-                status="error",
-                message=error_msg,
-            ).model_dump()
+            except Exception as e:
+                error_msg = f"Error updating agent: {str(e)}"
+                logger.error(error_msg, exc_info=True)
+                return UpdateAgentToolResult(
+                    agent_id=0,
+                    agent_name="",
+                    tool_name="",
+                    markdown_link="",
+                    status="error",
+                    message=error_msg,
+                ).model_dump()
 
 
 class ListAgentsTool(AbstractBaseTool):
@@ -2187,13 +2192,13 @@ async def create_update_agent_tool(config: "WebToolConfig") -> list[AbstractBase
         return []
 
     try:
-        db = config.get_db()
+        factory = config.get_session_factory()
         user_id = config.get_user_id()
         if not user_id:
             return []
 
         tool = UpdateAgentTool(
-            db=db,
+            session_factory=factory,
             user_id=user_id,
             task_id=config.get_task_id(),
             workspace_base_dir=None,  # Will use get_uploads_dir() default

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2038,19 +2038,22 @@ def get_published_agents_tools(
                     for agent_id in (normalized_draft_agent_ids or [])
                     if agent_id not in excluded_agent_ids
                 ]
-                draft_agents = _apply_owned_agent_tool_filters(
-                    db.query(Agent).filter(
-                        Agent.id.in_(normalized_draft_agent_ids),
-                        Agent.status == "draft",
-                    ),
-                    Agent,
-                    user_id=user_id,
-                ).all()
-                # Merge without duplicates
-                existing_ids = {agent.id for agent in agents}
-                for draft_agent in draft_agents:
-                    if draft_agent.id not in existing_ids:
-                        agents.append(draft_agent)
+                # Skip the query entirely when nothing survives the exclusion
+                # filter, so we never issue an empty ``IN ()`` predicate.
+                if normalized_draft_agent_ids:
+                    draft_agents = _apply_owned_agent_tool_filters(
+                        db.query(Agent).filter(
+                            Agent.id.in_(normalized_draft_agent_ids),
+                            Agent.status == "draft",
+                        ),
+                        Agent,
+                        user_id=user_id,
+                    ).all()
+                    # Merge without duplicates
+                    existing_ids = {agent.id for agent in agents}
+                    for draft_agent in draft_agents:
+                        if draft_agent.id not in existing_ids:
+                            agents.append(draft_agent)
 
             if normalized_injected_agent_ids is not None:
                 agent_types = "selected PUBLISHED"

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -489,7 +489,7 @@ class CreateAgentTool(AbstractBaseTool):
 
     def __init__(
         self,
-        db: Any,
+        session_factory: Any,
         user_id: int,
         task_id: Optional[str] = None,
         workspace_base_dir: Optional[str] = None,
@@ -498,12 +498,13 @@ class CreateAgentTool(AbstractBaseTool):
         Initialize the create agent tool.
 
         Args:
-            db: Database session for saving the agent
+            session_factory: Callable that returns a new SQLAlchemy session; a
+                fresh session is opened per call and closed in ``finally``.
             user_id: User ID for ownership and model access
             task_id: Task ID for context
             workspace_base_dir: Base directory for workspace files
         """
-        self._db = db
+        self._session_factory = session_factory
         self._user_id = user_id
         self._task_id = task_id
         if workspace_base_dir is None:
@@ -596,7 +597,7 @@ class CreateAgentTool(AbstractBaseTool):
         return suffix.strip()[:MAX_AGENT_NAME_LENGTH]
 
     def _resolve_available_agent_name(
-        self, requested_name: str
+        self, requested_name: str, db: Any
     ) -> tuple[str, Optional[str]]:
         from .....web.models.agent import Agent
 
@@ -604,7 +605,7 @@ class CreateAgentTool(AbstractBaseTool):
 
         existing_names = {
             name
-            for (name,) in self._db.query(Agent.name)
+            for (name,) in db.query(Agent.name)
             .filter(Agent.user_id == self._user_id)
             .all()
         }
@@ -634,187 +635,189 @@ class CreateAgentTool(AbstractBaseTool):
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
         """Create a new agent with the given configuration."""
+        from .db_session import tool_session_scope
         from .....web.models.agent import AgentStatus
         from .....web.models.user import UserDefaultModel, UserModel
 
-        try:
-            agent_name = args.get("name", "").strip()
-            agent_description = args.get("description", "").strip()
-            instructions = args.get("instructions", "").strip()
+        with tool_session_scope(self._session_factory) as db:
+            try:
+                agent_name = args.get("name", "").strip()
+                agent_description = args.get("description", "").strip()
+                instructions = args.get("instructions", "").strip()
 
-            if not agent_name:
-                return CreateAgentToolResult(
-                    agent_id=0,
-                    agent_name="",
-                    tool_name="",
-                    markdown_link="",
-                    status="error",
-                    message="Error: Agent name is required",
-                ).model_dump()
+                if not agent_name:
+                    return CreateAgentToolResult(
+                        agent_id=0,
+                        agent_name="",
+                        tool_name="",
+                        markdown_link="",
+                        status="error",
+                        message="Error: Agent name is required",
+                    ).model_dump()
 
-            if not agent_description:
-                return CreateAgentToolResult(
-                    agent_id=0,
-                    agent_name="",
-                    tool_name="",
-                    markdown_link="",
-                    status="error",
-                    message="Error: Agent description is required. Please describe when to use this agent.",
-                ).model_dump()
+                if not agent_description:
+                    return CreateAgentToolResult(
+                        agent_id=0,
+                        agent_name="",
+                        tool_name="",
+                        markdown_link="",
+                        status="error",
+                        message="Error: Agent description is required. Please describe when to use this agent.",
+                    ).model_dump()
 
-            if not instructions:
-                return CreateAgentToolResult(
-                    agent_id=0,
-                    agent_name="",
-                    tool_name="",
-                    markdown_link="",
-                    status="error",
-                    message="Error: Agent instructions are required",
-                ).model_dump()
+                if not instructions:
+                    return CreateAgentToolResult(
+                        agent_id=0,
+                        agent_name="",
+                        tool_name="",
+                        markdown_link="",
+                        status="error",
+                        message="Error: Agent instructions are required",
+                    ).model_dump()
 
-            requested_agent_name = agent_name
-            agent_name, auto_renamed_from = self._resolve_available_agent_name(
-                requested_agent_name
-            )
-
-            # Get user's default model configuration
-            from .....web.models.model import Model as DBModel
-
-            user_defaults = (
-                self._db.query(UserDefaultModel)
-                .join(DBModel, UserDefaultModel.model_id == DBModel.id)
-                .filter(
-                    UserDefaultModel.user_id == self._user_id,
-                    DBModel.is_active,
+                requested_agent_name = agent_name
+                agent_name, auto_renamed_from = self._resolve_available_agent_name(
+                    requested_agent_name, db
                 )
-                .all()
-            )
 
-            # Prepare models configuration
-            models_config = {}
-            for default in user_defaults:
-                if default.config_type in [
-                    "general",
-                    "small_fast",
-                    "visual",
-                    "compact",
-                ]:
-                    if default.model:
-                        try:
-                            if not _is_model_visible_to_user(
-                                self._db, default.model.id, self._user_id
-                            ):
-                                continue
-                        except Exception:
-                            pass
-                    models_config[default.config_type] = default.model_id
+                # Get user's default model configuration
+                from .....web.models.model import Model as DBModel
 
-            missing_types = [
-                t
-                for t in ["general", "small_fast", "visual", "compact"]
-                if t not in models_config
-            ]
-            if missing_types:
-                # Fill missing with visible users' shared defaults
-                visible_ids = _get_visible_user_ids(self._db, self._user_id)
-                admin_defaults = (
-                    self._db.query(UserDefaultModel)
-                    .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                user_defaults = (
+                    db.query(UserDefaultModel)
+                    .join(DBModel, UserDefaultModel.model_id == DBModel.id)
                     .filter(
-                        UserDefaultModel.config_type.in_(missing_types),
-                        UserModel.is_shared.is_(True),
-                        UserDefaultModel.user_id.in_(visible_ids),
+                        UserDefaultModel.user_id == self._user_id,
+                        DBModel.is_active,
                     )
                     .all()
                 )
-                for admin_default in admin_defaults:
-                    if admin_default.config_type not in models_config:
-                        models_config[admin_default.config_type] = (
-                            admin_default.model_id
+
+                # Prepare models configuration
+                models_config = {}
+                for default in user_defaults:
+                    if default.config_type in [
+                        "general",
+                        "small_fast",
+                        "visual",
+                        "compact",
+                    ]:
+                        if default.model:
+                            try:
+                                if not _is_model_visible_to_user(
+                                    db, default.model.id, self._user_id
+                                ):
+                                    continue
+                            except Exception:
+                                pass
+                        models_config[default.config_type] = default.model_id
+
+                missing_types = [
+                    t
+                    for t in ["general", "small_fast", "visual", "compact"]
+                    if t not in models_config
+                ]
+                if missing_types:
+                    # Fill missing with visible users' shared defaults
+                    visible_ids = _get_visible_user_ids(db, self._user_id)
+                    admin_defaults = (
+                        db.query(UserDefaultModel)
+                        .join(UserModel, UserDefaultModel.model_id == UserModel.model_id)
+                        .filter(
+                            UserDefaultModel.config_type.in_(missing_types),
+                            UserModel.is_shared.is_(True),
+                            UserDefaultModel.user_id.in_(visible_ids),
                         )
+                        .all()
+                    )
+                    for admin_default in admin_defaults:
+                        if admin_default.config_type not in models_config:
+                            models_config[admin_default.config_type] = (
+                                admin_default.model_id
+                            )
 
-            execution_mode = args.get("execution_mode", "balanced")
-            if execution_mode not in ["flash", "balanced", "think", "auto"]:
-                execution_mode = "balanced"
+                execution_mode = args.get("execution_mode", "balanced")
+                if execution_mode not in ["flash", "balanced", "think", "auto"]:
+                    execution_mode = "balanced"
 
-            knowledge_bases = ensure_list(args.get("knowledge_bases"))
-            missing_kbs = await _missing_knowledge_bases_for_user(
-                knowledge_bases, self._db, self._user_id
-            )
-            if missing_kbs:
+                knowledge_bases = ensure_list(args.get("knowledge_bases"))
+                missing_kbs = await _missing_knowledge_bases_for_user(
+                    knowledge_bases, db, self._user_id
+                )
+                if missing_kbs:
+                    return CreateAgentToolResult(
+                        agent_id=0,
+                        agent_name="",
+                        tool_name="",
+                        markdown_link="",
+                        status="error",
+                        message=(
+                            "Error: Knowledge base(s) not found or not visible to this user: "
+                            + ", ".join(missing_kbs)
+                        ),
+                    ).model_dump()
+
+                agent = AgentStore(db).create_agent(
+                    user_id=self._user_id,
+                    name=agent_name,
+                    description=agent_description,
+                    instructions=instructions,
+                    execution_mode=execution_mode,
+                    models=models_config if models_config else None,
+                    knowledge_bases=knowledge_bases,
+                    skills=ensure_list(args.get("skills")),
+                    tool_categories=ensure_list(args.get("tool_categories")),
+                    status=AgentStatus.DRAFT,  # Create as DRAFT, not PUBLISHED
+                    suggested_prompts=[],
+                )
+
+                # Generate the tool name and markdown link
+                tool_name = gen_agent_tool_name(agent.id)
+                markdown_link = f"[{agent_name}](agent://{agent.id})"
+
+                rename_note = ""
+                if auto_renamed_from:
+                    rename_note = (
+                        f"**Auto-renamed:** Requested name '{auto_renamed_from}' was already in use, "
+                        f"so the agent was created as '{agent_name}'.\n\n"
+                    )
+
+                logger.info(
+                    f"Created DRAFT agent '{agent_name}' (ID: {agent.id}) for user {self._user_id}"
+                )
+
+                return CreateAgentToolResult(
+                    agent_id=agent.id,
+                    agent_name=agent_name,
+                    tool_name=tool_name,
+                    markdown_link=markdown_link,
+                    status="success",
+                    message=(
+                        f"✅ Agent created successfully\n\n"
+                        f"{rename_note}"
+                        f"**Agent Details:**\n"
+                        f"- Agent ID: {agent.id}\n"
+                        f"- Agent Name: {agent_name}\n"
+                        f"- Tool Name: {tool_name}\n"
+                        f"- Status: DRAFT (unpublished)\n\n"
+                        f"**How to use this agent:**\n"
+                        f"Include this link in your response: {markdown_link}\n"
+                        f"Or use the tool: {tool_name}\n\n"
+                        f"*The agent is ready to use and will be displayed as a clickable card.*"
+                    ),
+                ).model_dump()
+
+            except Exception as e:
+                error_msg = f"Error creating agent: {str(e)}"
+                logger.error(error_msg, exc_info=True)
                 return CreateAgentToolResult(
                     agent_id=0,
                     agent_name="",
                     tool_name="",
                     markdown_link="",
                     status="error",
-                    message=(
-                        "Error: Knowledge base(s) not found or not visible to this user: "
-                        + ", ".join(missing_kbs)
-                    ),
+                    message=error_msg,
                 ).model_dump()
-
-            agent = AgentStore(self._db).create_agent(
-                user_id=self._user_id,
-                name=agent_name,
-                description=agent_description,
-                instructions=instructions,
-                execution_mode=execution_mode,
-                models=models_config if models_config else None,
-                knowledge_bases=knowledge_bases,
-                skills=ensure_list(args.get("skills")),
-                tool_categories=ensure_list(args.get("tool_categories")),
-                status=AgentStatus.DRAFT,  # Create as DRAFT, not PUBLISHED
-                suggested_prompts=[],
-            )
-
-            # Generate the tool name and markdown link
-            tool_name = gen_agent_tool_name(agent.id)
-            markdown_link = f"[{agent_name}](agent://{agent.id})"
-
-            rename_note = ""
-            if auto_renamed_from:
-                rename_note = (
-                    f"**Auto-renamed:** Requested name '{auto_renamed_from}' was already in use, "
-                    f"so the agent was created as '{agent_name}'.\n\n"
-                )
-
-            logger.info(
-                f"Created DRAFT agent '{agent_name}' (ID: {agent.id}) for user {self._user_id}"
-            )
-
-            return CreateAgentToolResult(
-                agent_id=agent.id,
-                agent_name=agent_name,
-                tool_name=tool_name,
-                markdown_link=markdown_link,
-                status="success",
-                message=(
-                    f"✅ Agent created successfully\n\n"
-                    f"{rename_note}"
-                    f"**Agent Details:**\n"
-                    f"- Agent ID: {agent.id}\n"
-                    f"- Agent Name: {agent_name}\n"
-                    f"- Tool Name: {tool_name}\n"
-                    f"- Status: DRAFT (unpublished)\n\n"
-                    f"**How to use this agent:**\n"
-                    f"Include this link in your response: {markdown_link}\n"
-                    f"Or use the tool: {tool_name}\n\n"
-                    f"*The agent is ready to use and will be displayed as a clickable card.*"
-                ),
-            ).model_dump()
-
-        except Exception as e:
-            error_msg = f"Error creating agent: {str(e)}"
-            logger.error(error_msg, exc_info=True)
-            return CreateAgentToolResult(
-                agent_id=0,
-                agent_name="",
-                tool_name="",
-                markdown_link="",
-                status="error",
-                message=error_msg,
-            ).model_dump()
 
 
 class UpdateAgentTool(AbstractBaseTool):
@@ -2147,30 +2150,25 @@ async def create_create_agent_tool(config: "WebToolConfig") -> list[AbstractBase
         return []
 
     try:
-        db = config.get_db()
+        factory = config.get_session_factory()
         user_id = config.get_user_id()
         if not user_id:
             return []
 
         tool = CreateAgentTool(
-            db=db,
+            session_factory=factory,
             user_id=user_id,
             task_id=config.get_task_id(),
-            workspace_base_dir=None,  # Will use get_uploads_dir() default
         )
 
         list_skills_tool = ListAvailableSkillsTool(
-            db=db,
             user_id=user_id,
             task_id=config.get_task_id(),
-            workspace_base_dir=None,
         )
 
         list_categories_tool = ListToolCategoriesTool(
-            db=db,
             user_id=user_id,
             task_id=config.get_task_id(),
-            workspace_base_dir=None,
         )
 
         logger.debug(

--- a/src/xagent/core/tools/adapters/vibe/db_session.py
+++ b/src/xagent/core/tools/adapters/vibe/db_session.py
@@ -1,0 +1,22 @@
+"""Per-call SQLAlchemy session scope for DB-touching tools.
+
+A tool that holds a long-lived shared ``Session`` is unsafe under in-turn tool
+concurrency (one connection/cursor, a mutable identity map). This context
+manager mints a fresh ``Session`` from a factory for the duration of a single
+tool invocation and closes it in ``finally``. Commit/rollback stays the caller's
+responsibility — the scope only guarantees the session is closed.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator
+
+
+@contextmanager
+def tool_session_scope(session_factory: Callable[[], Any]) -> Iterator[Any]:
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -4584,13 +4584,13 @@ clarification questions as plain assistant text.
 
             # Create only the necessary tools directly (much faster than loading all tools)
             create_agent_tool = CreateAgentTool(
-                db=db,
+                session_factory=get_session_local(),
                 user_id=int(user.id),
                 task_id=builder_task_id,
                 workspace_base_dir=str(get_uploads_dir() / "builder_chat"),
             )
             update_agent_tool = UpdateAgentTool(
-                db=db,
+                session_factory=get_session_local(),
                 user_id=int(user.id),
                 task_id=builder_task_id,
                 workspace_base_dir=str(get_uploads_dir() / "builder_chat"),

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -153,7 +153,7 @@ class WebToolConfig(BaseToolConfig):
         # reads ``config.get_tool_selection_spec()``. ``None`` defaults
         # to the ``_SpecAll`` ALL-mode (build every default tool).
         self._tool_selection_spec = tool_selection_spec
-        self.db = db
+        self._live_db = db
         self._db_factory = db_factory
         self._lazy_db = None
         self.request = request
@@ -440,20 +440,30 @@ class WebToolConfig(BaseToolConfig):
 
         return get_session_local()
 
-    def get_db(self) -> Any:
-        """Get database session.
+    @property
+    def db(self) -> Any:
+        """Construction-time DB session.
 
-        Request path: returns the caller-owned request session verbatim.
-        Factory path (nested): lazily opens and caches one construction-time
-        session, closed by ``close()``.
+        Request path: the caller-owned live session, returned verbatim.
+        Factory path (nested child config): a lazily-opened, cached session
+        minted from the factory and closed by ``close()``.
+
+        Exposing this as a property keeps every DB-backed config loader that
+        reads ``self.db.query(...)`` working whether the config was built with
+        a live session or with only a factory — without each loader having to
+        route through ``get_db()`` explicitly.
         """
-        if self.db is not None:
-            return self.db
+        if self._live_db is not None:
+            return self._live_db
         if self._db_factory is not None:
             if self._lazy_db is None:
                 self._lazy_db = self._db_factory()
             return self._lazy_db
         return None
+
+    def get_db(self) -> Any:
+        """Get database session (see the :attr:`db` property)."""
+        return self.db
 
     def close(self) -> None:
         """Close the lazily-opened factory session, if any."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -124,6 +124,7 @@ class WebToolConfig(BaseToolConfig):
         self,
         db: Any,
         request: Any,
+        db_factory: Optional[Any] = None,
         user_id: Optional[int] = None,
         is_admin: Optional[bool] = None,
         user: Optional[Any] = None,
@@ -153,6 +154,8 @@ class WebToolConfig(BaseToolConfig):
         # to the ``_SpecAll`` ALL-mode (build every default tool).
         self._tool_selection_spec = tool_selection_spec
         self.db = db
+        self._db_factory = db_factory
+        self._lazy_db = None
         self.request = request
         self._user_id = (
             user_id if user_id is not None else self._get_user_id_from_request(request)
@@ -429,9 +432,34 @@ class WebToolConfig(BaseToolConfig):
         """Get current user ID for multi-tenancy."""
         return self._user_id
 
+    def get_session_factory(self) -> Any:
+        """Return the sessionmaker used to mint per-call tool sessions."""
+        if self._db_factory is not None:
+            return self._db_factory
+        from ..models.database import get_session_local
+
+        return get_session_local()
+
     def get_db(self) -> Any:
-        """Get database session."""
-        return self.db
+        """Get database session.
+
+        Request path: returns the caller-owned request session verbatim.
+        Factory path (nested): lazily opens and caches one construction-time
+        session, closed by ``close()``.
+        """
+        if self.db is not None:
+            return self.db
+        if self._db_factory is not None:
+            if self._lazy_db is None:
+                self._lazy_db = self._db_factory()
+            return self._lazy_db
+        return None
+
+    def close(self) -> None:
+        """Close the lazily-opened factory session, if any."""
+        if self._lazy_db is not None:
+            self._lazy_db.close()
+            self._lazy_db = None
 
     def is_admin(self) -> bool:
         """Whether current user is admin."""

--- a/tests/core/tools/adapters/vibe/test_db_session.py
+++ b/tests/core/tools/adapters/vibe/test_db_session.py
@@ -1,0 +1,40 @@
+import pytest
+
+from xagent.core.tools.adapters.vibe.db_session import tool_session_scope
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_scope_opens_one_session_and_closes_it() -> None:
+    made: list[_FakeSession] = []
+
+    def factory() -> _FakeSession:
+        s = _FakeSession()
+        made.append(s)
+        return s
+
+    with tool_session_scope(factory) as db:
+        assert db is made[0]
+        assert db.closed is False
+    assert len(made) == 1
+    assert made[0].closed is True
+
+
+def test_scope_closes_session_on_exception() -> None:
+    made: list[_FakeSession] = []
+
+    def factory() -> _FakeSession:
+        s = _FakeSession()
+        made.append(s)
+        return s
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with tool_session_scope(factory):
+            raise RuntimeError("boom")
+    assert made[0].closed is True

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -18,14 +18,14 @@ from xagent.web.models.user import User
 from xagent.web.tools.config import WebToolConfig
 
 
-def _create_session() -> tuple[Session, str]:
+def _create_session() -> tuple[Session, str, sessionmaker]:
     temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
     temp_db.close()
     db_url = f"sqlite:///{temp_db.name}"
     engine = create_engine(db_url)
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-    return SessionLocal(), temp_db.name
+    return SessionLocal(), temp_db.name, SessionLocal
 
 
 class _Request:
@@ -46,7 +46,7 @@ def test_delegation_config_defaults_are_noop() -> None:
 
 
 def test_web_delegation_config_defaults_are_noop() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         user = User(username="config-owner", password_hash="x", is_admin=False)
         db.add(user)
@@ -73,7 +73,7 @@ def test_web_delegation_config_defaults_are_noop() -> None:
 
 
 def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner", password_hash="x", is_admin=False)
         other_user = User(username="other", password_hash="x", is_admin=False)
@@ -90,7 +90,9 @@ def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
         db.add(published_agent)
         db.commit()
 
-        tools_for_other = get_published_agents_tools(db=db, user_id=2)
+        tools_for_other = get_published_agents_tools(
+            session_factory=SessionLocal, user_id=2
+        )
         tool_names = {tool.name for tool in tools_for_other}
 
         assert f"agent_{published_agent.id}" not in tool_names
@@ -105,7 +107,7 @@ def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:
 
 
 def test_owner_sees_only_own_published_agents_not_drafts() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner2", password_hash="x", is_admin=False)
         db.add(owner)
@@ -125,7 +127,9 @@ def test_owner_sees_only_own_published_agents_not_drafts() -> None:
         db.add_all([published_agent, draft_agent])
         db.commit()
 
-        tools_for_owner = get_published_agents_tools(db=db, user_id=1)
+        tools_for_owner = get_published_agents_tools(
+            session_factory=SessionLocal, user_id=1
+        )
         tool_names = {tool.name for tool in tools_for_owner}
 
         assert f"agent_{published_agent.id}" in tool_names
@@ -141,7 +145,7 @@ def test_owner_sees_only_own_published_agents_not_drafts() -> None:
 
 
 def test_published_agent_tool_name_is_id_based_for_non_ascii_names() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner_non_ascii", password_hash="x", is_admin=False)
         db.add(owner)
@@ -157,7 +161,9 @@ def test_published_agent_tool_name_is_id_based_for_non_ascii_names() -> None:
         db.commit()
         db.refresh(published_agent)
 
-        tools = get_published_agents_tools(db=db, user_id=owner.id)
+        tools = get_published_agents_tools(
+            session_factory=SessionLocal, user_id=owner.id
+        )
 
         assert {tool.name for tool in tools} == {f"agent_{published_agent.id}"}
     finally:
@@ -171,7 +177,7 @@ def test_published_agent_tool_name_is_id_based_for_non_ascii_names() -> None:
 
 
 def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner3", password_hash="x", is_admin=False)
         other_user = User(username="other3", password_hash="x", is_admin=False)
@@ -211,7 +217,7 @@ def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None
         db.commit()
 
         tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             allowed_agent_ids=[
                 selected_published.id,
@@ -236,7 +242,7 @@ def test_allowed_agent_ids_include_only_selected_published_user_agents() -> None
 
 
 def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner_cross", password_hash="x", is_admin=False)
         runner = User(username="runner_cross", password_hash="x", is_admin=False)
@@ -255,7 +261,7 @@ def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
         db.refresh(published_agent)
 
         blocked_tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=runner.id,
             allowed_agent_ids=[published_agent.id],
             enable_global_agent_tools=False,
@@ -265,7 +271,7 @@ def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
         }
 
         allowed_tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=runner.id,
             allowed_agent_ids=[published_agent.id],
             enable_global_agent_tools=False,
@@ -284,7 +290,7 @@ def test_allowed_agent_ids_can_cross_users_only_when_enabled() -> None:
 
 @pytest.mark.asyncio
 async def test_agent_tool_execution_enforces_owner_visibility() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="exec_owner", password_hash="x", is_admin=False)
         runner = User(username="exec_runner", password_hash="x", is_admin=False)
@@ -306,7 +312,7 @@ async def test_agent_tool_execution_enforces_owner_visibility() -> None:
             agent_id=published_agent.id,
             agent_name=published_agent.name,
             agent_description="Private worker",
-            db=db,
+            session_factory=SessionLocal,
             user_id=runner.id,
         )
 
@@ -325,7 +331,7 @@ async def test_agent_tool_execution_enforces_owner_visibility() -> None:
 
 @pytest.mark.asyncio
 async def test_agent_tool_execution_enforces_target_allowed_agent_ids() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="allow_owner", password_hash="x", is_admin=False)
         db.add(owner)
@@ -351,7 +357,7 @@ async def test_agent_tool_execution_enforces_target_allowed_agent_ids() -> None:
             agent_id=blocked_agent.id,
             agent_name=blocked_agent.name,
             agent_description="Blocked worker",
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             target_allowed_agent_ids=[allowed_agent.id],
         )
@@ -373,7 +379,7 @@ async def test_agent_tool_execution_enforces_target_allowed_agent_ids() -> None:
 async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist() -> (
     None
 ):
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="cross_owner", password_hash="x", is_admin=False)
         runner = User(username="cross_runner", password_hash="x", is_admin=False)
@@ -395,7 +401,7 @@ async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist
             agent_id=published_agent.id,
             agent_name=published_agent.name,
             agent_description="Cross user worker",
-            db=db,
+            session_factory=SessionLocal,
             user_id=runner.id,
             target_allowed_agent_ids=[published_agent.id],
         )
@@ -410,7 +416,7 @@ async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist
             agent_id=published_agent.id,
             agent_name=published_agent.name,
             agent_description="Cross user worker",
-            db=db,
+            session_factory=SessionLocal,
             user_id=runner.id,
             target_allowed_agent_ids=[published_agent.id],
             target_allow_cross_user_agent_ids=True,
@@ -435,7 +441,7 @@ async def test_agent_tool_execution_allows_cross_user_only_with_target_allowlist
 async def test_delegation_allowed_agent_ids_do_not_block_current_worker_execution() -> (
     None
 ):
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="nested_owner", password_hash="x", is_admin=False)
         db.add(owner)
@@ -452,7 +458,7 @@ async def test_delegation_allowed_agent_ids_do_not_block_current_worker_executio
         db.refresh(worker)
 
         tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             allowed_agent_ids=[worker.id],
             enable_global_agent_tools=False,
@@ -480,7 +486,7 @@ async def test_delegation_allowed_agent_ids_do_not_block_current_worker_executio
 
 
 def test_global_agent_tools_can_be_disabled_without_allowed_workers() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner4", password_hash="x", is_admin=False)
         db.add(owner)
@@ -496,7 +502,7 @@ def test_global_agent_tools_can_be_disabled_without_allowed_workers() -> None:
         db.commit()
 
         tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             enable_global_agent_tools=False,
         )
@@ -513,7 +519,7 @@ def test_global_agent_tools_can_be_disabled_without_allowed_workers() -> None:
 
 
 def test_agent_call_stack_prevents_recursive_agent_tools() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner5", password_hash="x", is_admin=False)
         db.add(owner)
@@ -536,7 +542,7 @@ def test_agent_call_stack_prevents_recursive_agent_tools() -> None:
         db.refresh(other_agent)
 
         tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             agent_call_stack=[active_agent.id],
         )
@@ -555,7 +561,7 @@ def test_agent_call_stack_prevents_recursive_agent_tools() -> None:
 
 
 def test_worker_overrides_inject_selected_agent_tool_metadata() -> None:
-    db, db_path = _create_session()
+    db, db_path, SessionLocal = _create_session()
     try:
         owner = User(username="owner6", password_hash="x", is_admin=False)
         db.add(owner)
@@ -578,7 +584,7 @@ def test_worker_overrides_inject_selected_agent_tool_metadata() -> None:
         db.refresh(worker)
 
         tools = get_published_agents_tools(
-            db=db,
+            session_factory=SessionLocal,
             user_id=owner.id,
             allowed_agent_ids=[worker.id],
             enable_global_agent_tools=False,

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+import tempfile
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import xagent.core.tools.adapters.vibe.agent_tool as mod
+from xagent.core.tools.adapters.vibe.agent_tool import AgentTool
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import UserAwareModelStorage
+
+
+class _Stop(Exception):
+    """Halt the run before the sub-agent executes."""
+
+
+def _create_factory() -> tuple[sessionmaker, str]:
+    temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_db.close()
+    db_url = f"sqlite:///{temp_db.name}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return SessionLocal, temp_db.name
+
+
+def test_agent_tool_does_not_share_a_live_session_with_child_config(monkeypatch):
+    """The child WebToolConfig must be built with a factory, never a live session."""
+    SessionLocal, db_path = _create_factory()
+    try:
+        seed = SessionLocal()
+        try:
+            user = User(username="iso_owner", password_hash="x", is_admin=False)
+            seed.add(user)
+            seed.commit()
+            seed.refresh(user)
+
+            model = Model(
+                model_id="general-model",
+                model_provider="openai",
+                model_name="General Model",
+                api_key="x",
+            )
+            seed.add(model)
+            seed.commit()
+            seed.refresh(model)
+
+            agent = Agent(
+                user_id=user.id,
+                name="Iso Worker",
+                status=AgentStatus.PUBLISHED,
+                models={"general": model.id},
+            )
+            seed.add(agent)
+            seed.commit()
+            seed.refresh(agent)
+
+            agent_id = agent.id
+            user_id = user.id
+        finally:
+            seed.close()
+
+        # Make model resolution succeed so we reach the WebToolConfig build.
+        monkeypatch.setattr(
+            UserAwareModelStorage,
+            "get_llm_by_name_with_access",
+            lambda self, model_id, uid: object(),
+        )
+
+        captured: dict = {}
+
+        def spy(*args, **kwargs):
+            captured["db"] = kwargs.get("db")
+            captured["db_factory"] = kwargs.get("db_factory")
+            raise _Stop()
+
+        monkeypatch.setattr(mod, "WebToolConfig", spy)
+
+        tool = AgentTool(
+            agent_id=agent_id,
+            agent_name="Iso Worker",
+            agent_description="d",
+            session_factory=SessionLocal,
+            user_id=user_id,
+            tool_name="t",
+            tool_description="d",
+        )
+
+        try:
+            asyncio.run(tool.run_json_async({"task": "hi"}))
+        except _Stop:
+            pass
+
+        assert captured["db"] is None
+        assert captured["db_factory"] is SessionLocal
+    finally:
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -171,7 +171,7 @@ class TestCreateAgentTool:
 
     @pytest.mark.asyncio
     async def test_agent_tool_rejects_generated_workforce_manager(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_generated_manager_run",
@@ -198,7 +198,7 @@ class TestCreateAgentTool:
                 agent_id=generated_manager.id,
                 agent_name=generated_manager.name,
                 agent_description=generated_manager.description or "",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
             )
 
@@ -222,7 +222,7 @@ class TestCreateAgentTool:
 
     @pytest.mark.asyncio
     async def test_agent_tool_applies_workforce_runtime_overrides(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser11", password_hash="x", is_admin=False)
             db.add(user)
@@ -280,7 +280,7 @@ class TestCreateAgentTool:
                 agent_id=agent.id,
                 agent_name=agent.name,
                 agent_description=agent.description or "",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
                 task_id="tool-session",
                 tool_name="call_workforce_worker_7_writer",
@@ -373,7 +373,7 @@ class TestCreateAgentTool:
     async def test_agent_tool_returns_parent_owned_file_refs_for_worker_outputs(
         self,
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="worker-output-user", password_hash="x", is_admin=False
@@ -444,7 +444,7 @@ class TestCreateAgentTool:
                     agent_id=agent.id,
                     agent_name=agent.name,
                     agent_description=agent.description or "",
-                    db=db,
+                    session_factory=SessionLocal,
                     user_id=user.id,
                     task_id="77",
                     parent_task_id="77",
@@ -541,7 +541,7 @@ class TestCreateAgentTool:
                 pass
 
     def test_agent_tool_rebinds_worker_owned_file_ids_to_parent_task(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="worker-owned-output-user",
@@ -585,7 +585,7 @@ class TestCreateAgentTool:
                     agent_id=1,
                     agent_name="File Worker",
                     agent_description="Writes files",
-                    db=db,
+                    session_factory=SessionLocal,
                     user_id=user.id,
                     task_id="77",
                     parent_task_id="77",
@@ -601,6 +601,7 @@ class TestCreateAgentTool:
                         }
                     ],
                     worker_workspace,
+                    db,
                 )
 
                 assert file_outputs is not None
@@ -635,13 +636,13 @@ class TestCreateAgentTool:
     def test_agent_tool_omits_workforce_file_outputs_without_parent_db_task_id(
         self,
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             tool = AgentTool(
                 agent_id=1,
                 agent_name="File Worker",
                 agent_description="Writes files",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=1,
                 task_id="agent_1_abcd1234",
                 parent_task_id="agent_1_abcd1234",
@@ -650,7 +651,10 @@ class TestCreateAgentTool:
 
             file_outputs = [{"file_path": "/tmp/worker-output.txt"}]
 
-            assert tool._parent_owned_file_outputs(file_outputs, workspace=None) == []
+            assert (
+                tool._parent_owned_file_outputs(file_outputs, workspace=None, db=db)
+                == []
+            )
         finally:
             db.close()
             try:
@@ -663,13 +667,13 @@ class TestCreateAgentTool:
     def test_agent_tool_preserves_non_workforce_file_outputs_without_parent_db_task_id(
         self,
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             tool = AgentTool(
                 agent_id=1,
                 agent_name="File Worker",
                 agent_description="Writes files",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=1,
                 task_id="agent_1_abcd1234",
                 parent_task_id="agent_1_abcd1234",
@@ -677,7 +681,7 @@ class TestCreateAgentTool:
             file_outputs = [{"file_path": "/tmp/legacy-output.txt"}]
 
             assert (
-                tool._parent_owned_file_outputs(file_outputs, workspace=None)
+                tool._parent_owned_file_outputs(file_outputs, workspace=None, db=db)
                 is file_outputs
             )
         finally:
@@ -693,7 +697,7 @@ class TestCreateAgentTool:
         self,
         tmp_path,
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             output_path = tmp_path / "report.txt"
             output_path.write_text("worker report", encoding="utf-8")
@@ -705,7 +709,7 @@ class TestCreateAgentTool:
                 agent_id=1,
                 agent_name="File Worker",
                 agent_description="Writes files",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=1,
                 task_id="77",
                 parent_task_id="77",
@@ -715,6 +719,7 @@ class TestCreateAgentTool:
                 tool._parent_owned_file_outputs(
                     [{"file_path": str(output_path), "filename": "report.txt"}],
                     workspace,
+                    db,
                 )
         finally:
             db.close()
@@ -1858,7 +1863,7 @@ class TestDraftAgentsInTools:
 
     def test_get_tools_with_draft_disabled(self) -> None:
         """Test that draft agents are excluded when include_draft=False."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser6", password_hash="x", is_admin=False)
             db.add(user)
@@ -1879,7 +1884,7 @@ class TestDraftAgentsInTools:
             db.commit()
 
             tools = get_published_agents_tools(
-                db=db, user_id=user.id, include_draft=False
+                session_factory=SessionLocal, user_id=user.id, include_draft=False
             )
             tool_names = {tool.name for tool in tools}
 
@@ -1897,7 +1902,7 @@ class TestDraftAgentsInTools:
 
     def test_get_tools_with_draft_enabled(self) -> None:
         """Test that draft agents are included when include_draft=True."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser7", password_hash="x", is_admin=False)
             db.add(user)
@@ -1918,7 +1923,7 @@ class TestDraftAgentsInTools:
             db.commit()
 
             tools = get_published_agents_tools(
-                db=db, user_id=user.id, include_draft=True
+                session_factory=SessionLocal, user_id=user.id, include_draft=True
             )
             tool_names = {tool.name for tool in tools}
 
@@ -1935,7 +1940,7 @@ class TestDraftAgentsInTools:
                 pass
 
     def test_generated_workforce_managers_are_hidden_from_agent_tools(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_generated_manager_tools",
@@ -1962,14 +1967,16 @@ class TestDraftAgentsInTools:
             db.refresh(reusable_agent)
             db.refresh(generated_manager)
 
-            tools = get_published_agents_tools(db=db, user_id=user.id)
+            tools = get_published_agents_tools(
+                session_factory=SessionLocal, user_id=user.id
+            )
             tool_names = {tool.name for tool in tools}
 
             assert f"agent_{reusable_agent.id}" in tool_names
             assert f"agent_{generated_manager.id}" not in tool_names
 
             explicitly_allowed_tools = get_published_agents_tools(
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
                 allowed_agent_ids=[generated_manager.id],
             )
@@ -1986,7 +1993,7 @@ class TestDraftAgentsInTools:
 
     def test_user_isolation_for_draft_agents(self) -> None:
         """Test that users cannot see other users' draft agents."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user1 = User(username="user1", password_hash="x", is_admin=False)
             user2 = User(username="user2", password_hash="x", is_admin=False)
@@ -2006,7 +2013,7 @@ class TestDraftAgentsInTools:
 
             # User2 should not see User1's draft agent
             tools_for_user2 = get_published_agents_tools(
-                db=db, user_id=user2.id, include_draft=True
+                session_factory=SessionLocal, user_id=user2.id, include_draft=True
             )
             tool_names = {tool.name for tool in tools_for_user2}
 
@@ -2075,7 +2082,9 @@ class TestCreateAndCallAgent:
                 verify_db = SessionLocal()
                 try:
                     tools = get_published_agents_tools(
-                        db=verify_db, user_id=user_id, include_draft=True
+                        session_factory=SessionLocal,
+                        user_id=user_id,
+                        include_draft=True,
                     )
                     tool_names = {tool.name for tool in tools}
                     assert f"agent_{agent_id}" in tool_names
@@ -2099,7 +2108,7 @@ class TestCreateAndCallAgent:
     async def test_agent_tool_injects_langfuse_tracer(
         self, mocker, monkeypatch, langfuse_client_reset
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "test-public")
             monkeypatch.setenv("LANGFUSE_SECRET_KEY", "test-secret")
@@ -2140,7 +2149,7 @@ class TestCreateAndCallAgent:
                 agent_id=agent.id,
                 agent_name=agent.name,
                 agent_description=agent.description or "",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
                 task_id="parent-task-1",
             )
@@ -2182,7 +2191,7 @@ class TestCreateAndCallAgent:
 
     @pytest.mark.asyncio
     async def test_agent_tool_keeps_mcp_tools_when_filtering_by_category(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser10", password_hash="x", is_admin=False)
             db.add(user)
@@ -2220,7 +2229,7 @@ class TestCreateAndCallAgent:
                 agent_id=agent.id,
                 agent_name=agent.name,
                 agent_description=agent.description or "",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
                 task_id="parent-task-mcp",
             )
@@ -2297,7 +2306,7 @@ class TestCreateAndCallAgent:
         ``include_mcp_tools=False`` -- so it does not pay MCP server init.
         Empty and NULL categories still build an ALL-mode selection spec
         for final filtering, but should not opt into MCP config loading."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="basicdeleg", password_hash="x", is_admin=False)
             db.add(user)
@@ -2335,7 +2344,7 @@ class TestCreateAndCallAgent:
                 agent_id=agent.id,
                 agent_name=agent.name,
                 agent_description=agent.description or "",
-                db=db,
+                session_factory=SessionLocal,
                 user_id=user.id,
                 task_id="parent-task-basic",
             )

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -155,7 +155,9 @@ class TestCreateAgentTool:
                     )
                     assert agent is not None
                     assert agent.status == AgentStatus.DRAFT
-                    assert agent.instructions == "You are a test agent for unit testing."
+                    assert (
+                        agent.instructions == "You are a test agent for unit testing."
+                    )
                 finally:
                     verify_db.close()
 
@@ -1043,7 +1045,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_success(self) -> None:
         """Test successful agent update."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_update", password_hash="x", is_admin=False)
             db.add(user)
@@ -1065,7 +1067,9 @@ class TestUpdateAgentTool:
             with patch(
                 "xagent.web.services.agent_store.invalidate_agent_cache"
             ) as mock_invalidate_agent_cache:
-                tool = UpdateAgentTool(db=db, user_id=user.id, task_id="test_task")
+                tool = UpdateAgentTool(
+                    session_factory=SessionLocal, user_id=user.id, task_id="test_task"
+                )
 
                 result = await tool.run_json_async(
                     {
@@ -1102,7 +1106,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_partial_update(self) -> None:
         """Test partial agent update (only some fields)."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_partial", password_hash="x", is_admin=False)
             db.add(user)
@@ -1120,7 +1124,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(existing_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             # Update only description, keep name and instructions
             result = await tool.run_json_async(
@@ -1150,14 +1154,14 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_not_found(self) -> None:
         """Test updating non-existent agent."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_notfound", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             result = await tool.run_json_async(
                 {
@@ -1180,7 +1184,7 @@ class TestUpdateAgentTool:
 
     @pytest.mark.asyncio
     async def test_update_agent_rejects_generated_workforce_manager(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_update_generated_manager",
@@ -1203,7 +1207,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(generated_manager)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             result = await tool.run_json_async(
                 {
@@ -1230,7 +1234,7 @@ class TestUpdateAgentTool:
     async def test_update_agent_name_conflict_ignores_generated_workforce_manager(
         self,
     ) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_update_generated_manager_name",
@@ -1256,7 +1260,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(visible_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             result = await tool.run_json_async(
                 {
@@ -1281,7 +1285,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_rejects_missing_knowledge_base(self) -> None:
         """Test that update_agent rejects knowledge bases that do not exist."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_update_missing_kb", password_hash="x")
             db.add(user)
@@ -1300,7 +1304,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(existing_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             with patch(
                 "xagent.core.tools.adapters.vibe.agent_tool.find_missing_knowledge_bases",
@@ -1330,7 +1334,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_published_agent_success_preserves_status(self) -> None:
         """Test that published agents can be updated and remain published."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_published", password_hash="x", is_admin=False
@@ -1350,7 +1354,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(published_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             result = await tool.run_json_async(
                 {
@@ -1382,7 +1386,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_archived_agent_rejected(self) -> None:
         """Test that archived agents cannot be updated."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_archived", password_hash="x", is_admin=False)
             db.add(user)
@@ -1400,7 +1404,7 @@ class TestUpdateAgentTool:
             db.commit()
             db.refresh(archived_agent)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             result = await tool.run_json_async(
                 {
@@ -1430,7 +1434,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_duplicate_name(self) -> None:
         """Test that duplicate names are rejected when updating."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_dup", password_hash="x", is_admin=False)
             db.add(user)
@@ -1453,7 +1457,7 @@ class TestUpdateAgentTool:
             db.refresh(agent1)
             db.refresh(agent2)
 
-            tool = UpdateAgentTool(db=db, user_id=user.id)
+            tool = UpdateAgentTool(session_factory=SessionLocal, user_id=user.id)
 
             # Try to rename agent2 to agent_one (duplicate)
             result = await tool.run_json_async(
@@ -1468,6 +1472,74 @@ class TestUpdateAgentTool:
 
         finally:
             db.close()
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    def test_update_agent_tool_opens_and_closes_session_per_call(self) -> None:
+        """UpdateAgentTool must open exactly one session per call and close it."""
+        import asyncio
+
+        db, db_path, SessionLocal = _create_session()
+        try:
+            # Seed one agent to update
+            user = User(
+                username="testuser_update_session_lifecycle",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            existing_agent = Agent(
+                user_id=user.id,
+                name="session_lifecycle_agent",
+                description="Agent for session lifecycle test",
+                instructions="Original instructions",
+                status=AgentStatus.DRAFT,
+            )
+            db.add(existing_agent)
+            db.commit()
+            db.refresh(existing_agent)
+            seeded_id = existing_agent.id
+            seeded_user_id = user.id
+            db.close()
+
+            opened: list = []
+            closed: list = []
+
+            def tracking_factory():
+                s = SessionLocal()
+                orig_close = s.close
+
+                # Session has no __slots__; instance attr shadows the method
+                def tracked_close():
+                    closed.append(s)
+                    orig_close()
+
+                s.close = tracked_close
+                opened.append(s)
+                return s
+
+            with patch("xagent.web.services.agent_store.invalidate_agent_cache"):
+                tool = UpdateAgentTool(
+                    session_factory=tracking_factory, user_id=seeded_user_id
+                )
+                result = asyncio.run(
+                    tool.run_json_async(
+                        {"agent_id": seeded_id, "name": "Renamed Agent"}
+                    )
+                )
+
+            assert result["status"] == "success"
+            assert len(opened) == 1, f"expected 1 session opened, got {len(opened)}"
+            assert closed == opened, "session was not closed after the call"
+
+        finally:
             try:
                 import os
 

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -1554,7 +1554,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_all_agents(self) -> None:
         """Test listing all agents."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_list", password_hash="x", is_admin=False)
             db.add(user)
@@ -1584,8 +1584,10 @@ class TestListAgentsTool:
             )
             db.add_all([draft_agent, published_agent, archived_agent])
             db.commit()
+            user_id = user.id
+            db.close()
 
-            tool = ListAgentsTool(db=db, user_id=user.id)
+            tool = ListAgentsTool(session_factory=SessionLocal, user_id=user_id)
 
             result = await tool.run_json_async({})
 
@@ -1600,7 +1602,6 @@ class TestListAgentsTool:
             assert "archived_agent" in agent_names
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1610,7 +1611,7 @@ class TestListAgentsTool:
 
     @pytest.mark.asyncio
     async def test_list_agents_hides_generated_workforce_managers(self) -> None:
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(
                 username="testuser_list_generated_manager",
@@ -1636,8 +1637,10 @@ class TestListAgentsTool:
             )
             db.add_all([regular_agent, generated_manager])
             db.commit()
+            user_id = user.id
+            db.close()
 
-            tool = ListAgentsTool(db=db, user_id=user.id)
+            tool = ListAgentsTool(session_factory=SessionLocal, user_id=user_id)
 
             result = await tool.run_json_async({})
 
@@ -1647,7 +1650,6 @@ class TestListAgentsTool:
             assert agent_names == {"reusable_agent"}
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1658,7 +1660,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_with_status_filter(self) -> None:
         """Test listing agents with status filter."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_filter", password_hash="x", is_admin=False)
             db.add(user)
@@ -1677,8 +1679,10 @@ class TestListAgentsTool:
             )
             db.add_all([draft_agent, published_agent])
             db.commit()
+            user_id = user.id
+            db.close()
 
-            tool = ListAgentsTool(db=db, user_id=user.id)
+            tool = ListAgentsTool(session_factory=SessionLocal, user_id=user_id)
 
             # List only draft agents
             result = await tool.run_json_async({"status_filter": "draft"})
@@ -1689,7 +1693,6 @@ class TestListAgentsTool:
             assert result["agents"][0]["status"] == "draft"
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1700,7 +1703,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_user_isolation(self) -> None:
         """Test that users can only see their own agents."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user1 = User(username="listuser1", password_hash="x", is_admin=False)
             user2 = User(username="listuser2", password_hash="x", is_admin=False)
@@ -1723,9 +1726,11 @@ class TestListAgentsTool:
             )
             db.add_all([user1_agent, user2_agent])
             db.commit()
+            user1_id = user1.id
+            db.close()
 
             # User1 should only see their own agents
-            tool = ListAgentsTool(db=db, user_id=user1.id)
+            tool = ListAgentsTool(session_factory=SessionLocal, user_id=user1_id)
             result = await tool.run_json_async({})
 
             assert result["status"] == "success"
@@ -1733,7 +1738,6 @@ class TestListAgentsTool:
             assert result["agents"][0]["name"] == "user1_agent"
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1744,14 +1748,16 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_invalid_status_filter(self) -> None:
         """Test that invalid status filter returns error."""
-        db, db_path, _ = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_invalid", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
-            tool = ListAgentsTool(db=db, user_id=user.id)
+            tool = ListAgentsTool(session_factory=SessionLocal, user_id=user_id)
 
             result = await tool.run_json_async({"status_filter": "invalid_status"})
 
@@ -1759,7 +1765,67 @@ class TestListAgentsTool:
             assert "invalid" in result["message"].lower()
 
         finally:
+            try:
+                import os
+
+                os.remove(db_path)
+            except OSError:
+                pass
+
+    def test_list_agents_tool_opens_and_closes_session_per_call(self) -> None:
+        """ListAgentsTool must open exactly one session per call and close it."""
+        import asyncio
+
+        db, db_path, SessionLocal = _create_session()
+        try:
+            user = User(
+                username="testuser_list_session_lifecycle",
+                password_hash="x",
+                is_admin=False,
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+
+            agent = Agent(
+                user_id=user.id,
+                name="session_lifecycle_list_agent",
+                description="Agent for list session lifecycle test",
+                instructions="Some instructions",
+                status=AgentStatus.DRAFT,
+            )
+            db.add(agent)
+            db.commit()
+            seeded_user_id = user.id
             db.close()
+
+            opened: list = []
+            closed: list = []
+
+            def tracking_factory():
+                s = SessionLocal()
+                orig_close = s.close
+
+                # Session has no __slots__; instance attr shadows the method
+                def tracked_close():
+                    closed.append(s)
+                    orig_close()
+
+                s.close = tracked_close
+                opened.append(s)
+                return s
+
+            tool = ListAgentsTool(
+                session_factory=tracking_factory, user_id=seeded_user_id
+            )
+            result = asyncio.run(tool.run_json_async({}))
+
+            assert result["status"] == "success"
+            assert result["total_count"] == 1
+            assert len(opened) == 1, f"expected 1 session opened, got {len(opened)}"
+            assert closed == opened, "session was not closed after the call"
+
+        finally:
             try:
                 import os
 

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -28,15 +29,21 @@ from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 
 
-def _create_session() -> tuple[Session, str]:
-    """Create a temporary database session for testing."""
+def _create_session() -> tuple[Session, str, Any]:
+    """Create a temporary database session for testing.
+
+    Returns:
+        (session, db_path, SessionLocal) — the open session, path to the
+        SQLite file (for cleanup), and the sessionmaker so callers can open
+        fresh sessions after the per-call session is closed.
+    """
     temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
     temp_db.close()
     db_url = f"sqlite:///{temp_db.name}"
     engine = create_engine(db_url)
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-    return SessionLocal(), temp_db.name
+    return SessionLocal(), temp_db.name, SessionLocal
 
 
 @pytest.fixture
@@ -48,7 +55,7 @@ class TestCreateAgentTool:
     """Test suite for CreateAgentTool."""
 
     def test_create_agent_tool_schema_anchors_persisted_text_language(self) -> None:
-        tool = CreateAgentTool(db=None, user_id=1)
+        tool = CreateAgentTool(session_factory=None, user_id=1)
 
         assert (
             "same natural language as the current output language policy"
@@ -82,13 +89,15 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_success(self) -> None:
         """Test successful agent creation."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             # Create test user
             user = User(username="testuser", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
             # Mock model storage to return default LLM
             mock_llm = Mock()
@@ -112,7 +121,9 @@ class TestCreateAgentTool:
                 mock_storage_class.return_value = mock_storage
 
                 # Create tool
-                tool = CreateAgentTool(db=db, user_id=user.id, task_id="test_task")
+                tool = CreateAgentTool(
+                    session_factory=SessionLocal, user_id=user_id, task_id="test_task"
+                )
 
                 # Execute tool
                 result = await tool.run_json_async(
@@ -131,21 +142,24 @@ class TestCreateAgentTool:
                 assert "test_agent" in result["markdown_link"]
                 assert "agent://" in result["markdown_link"]
                 mock_invalidate_agent_cache.assert_called_once_with(
-                    user.id, result["agent_id"]
+                    user_id, result["agent_id"]
                 )
 
-                # Verify agent was created in database
-                agent = (
-                    db.query(Agent)
-                    .filter(Agent.name == "test_agent", Agent.user_id == user.id)
-                    .first()
-                )
-                assert agent is not None
-                assert agent.status == AgentStatus.DRAFT
-                assert agent.instructions == "You are a test agent for unit testing."
+                # Verify agent was created in database (use a fresh session)
+                verify_db = SessionLocal()
+                try:
+                    agent = (
+                        verify_db.query(Agent)
+                        .filter(Agent.name == "test_agent", Agent.user_id == user_id)
+                        .first()
+                    )
+                    assert agent is not None
+                    assert agent.status == AgentStatus.DRAFT
+                    assert agent.instructions == "You are a test agent for unit testing."
+                finally:
+                    verify_db.close()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -155,7 +169,7 @@ class TestCreateAgentTool:
 
     @pytest.mark.asyncio
     async def test_agent_tool_rejects_generated_workforce_manager(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_generated_manager_run",
@@ -206,7 +220,7 @@ class TestCreateAgentTool:
 
     @pytest.mark.asyncio
     async def test_agent_tool_applies_workforce_runtime_overrides(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser11", password_hash="x", is_admin=False)
             db.add(user)
@@ -357,7 +371,7 @@ class TestCreateAgentTool:
     async def test_agent_tool_returns_parent_owned_file_refs_for_worker_outputs(
         self,
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="worker-output-user", password_hash="x", is_admin=False
@@ -525,7 +539,7 @@ class TestCreateAgentTool:
                 pass
 
     def test_agent_tool_rebinds_worker_owned_file_ids_to_parent_task(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="worker-owned-output-user",
@@ -619,7 +633,7 @@ class TestCreateAgentTool:
     def test_agent_tool_omits_workforce_file_outputs_without_parent_db_task_id(
         self,
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             tool = AgentTool(
                 agent_id=1,
@@ -647,7 +661,7 @@ class TestCreateAgentTool:
     def test_agent_tool_preserves_non_workforce_file_outputs_without_parent_db_task_id(
         self,
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             tool = AgentTool(
                 agent_id=1,
@@ -677,7 +691,7 @@ class TestCreateAgentTool:
         self,
         tmp_path,
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             output_path = tmp_path / "report.txt"
             output_path.write_text("worker report", encoding="utf-8")
@@ -712,12 +726,14 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_with_tool_filters(self) -> None:
         """Test agent creation with tool categories and skills filters."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser2", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
             mock_llm = Mock()
             mock_llm.model_id = "gpt-4"
@@ -734,7 +750,7 @@ class TestCreateAgentTool:
                 )
                 mock_storage_class.return_value = mock_storage
 
-                tool = CreateAgentTool(db=db, user_id=user.id)
+                tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
                 result = await tool.run_json_async(
                     {
@@ -748,14 +764,21 @@ class TestCreateAgentTool:
 
                 assert result["status"] == "success"
 
-                # Verify filters were saved
-                agent = db.query(Agent).filter(Agent.name == "filtered_agent").first()
-                assert agent is not None
-                assert agent.tool_categories == ["file", "knowledge"]
-                assert agent.skills == ["web_search"]
+                # Verify filters were saved (use a fresh session)
+                verify_db = SessionLocal()
+                try:
+                    agent = (
+                        verify_db.query(Agent)
+                        .filter(Agent.name == "filtered_agent")
+                        .first()
+                    )
+                    assert agent is not None
+                    assert agent.tool_categories == ["file", "knowledge"]
+                    assert agent.skills == ["web_search"]
+                finally:
+                    verify_db.close()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -766,7 +789,7 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_duplicate_name_auto_renames(self) -> None:
         """Test that duplicate agent names are auto-renamed and created."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser3", password_hash="x", is_admin=False)
             db.add(user)
@@ -781,6 +804,8 @@ class TestCreateAgentTool:
             )
             db.add(existing_agent)
             db.commit()
+            user_id = user.id
+            db.close()
 
             mock_llm = Mock()
             mock_llm.model_id = "gpt-4"
@@ -797,7 +822,7 @@ class TestCreateAgentTool:
                 )
                 mock_storage_class.return_value = mock_storage
 
-                tool = CreateAgentTool(db=db, user_id=user.id)
+                tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
                 result = await tool.run_json_async(
                     {
@@ -811,18 +836,21 @@ class TestCreateAgentTool:
                 assert result["agent_name"] == "duplicate_name Assistant"
                 assert "auto-renamed" in result["message"].lower()
 
-                created_agent = (
-                    db.query(Agent)
-                    .filter(
-                        Agent.user_id == user.id,
-                        Agent.name == "duplicate_name Assistant",
+                verify_db = SessionLocal()
+                try:
+                    created_agent = (
+                        verify_db.query(Agent)
+                        .filter(
+                            Agent.user_id == user_id,
+                            Agent.name == "duplicate_name Assistant",
+                        )
+                        .first()
                     )
-                    .first()
-                )
-                assert created_agent is not None
+                    assert created_agent is not None
+                finally:
+                    verify_db.close()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -833,14 +861,16 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_rejects_missing_knowledge_base(self) -> None:
         """Test that create_agent rejects knowledge bases that do not exist."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser_missing_kb", password_hash="x")
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
-            tool = CreateAgentTool(db=db, user_id=user.id)
+            tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
             with patch(
                 "xagent.core.tools.adapters.vibe.agent_tool.find_missing_knowledge_bases",
@@ -857,10 +887,16 @@ class TestCreateAgentTool:
 
             assert result["status"] == "error"
             assert "missing_kb" in result["message"]
-            assert db.query(Agent).filter(Agent.name == "kb_agent").first() is None
+            verify_db = SessionLocal()
+            try:
+                assert (
+                    verify_db.query(Agent).filter(Agent.name == "kb_agent").first()
+                    is None
+                )
+            finally:
+                verify_db.close()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -873,7 +909,7 @@ class TestCreateAgentTool:
         self,
     ) -> None:
         """Test that auto-rename skips occupied fallback names."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser3b", password_hash="x", is_admin=False)
             db.add(user)
@@ -895,6 +931,8 @@ class TestCreateAgentTool:
                 ]
             )
             db.commit()
+            user_id = user.id
+            db.close()
 
             mock_llm = Mock()
             mock_llm.model_id = "gpt-4"
@@ -911,7 +949,7 @@ class TestCreateAgentTool:
                 )
                 mock_storage_class.return_value = mock_storage
 
-                tool = CreateAgentTool(db=db, user_id=user.id)
+                tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
                 result = await tool.run_json_async(
                     {
@@ -925,7 +963,6 @@ class TestCreateAgentTool:
                 assert result["agent_name"] == "duplicate_name V2"
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -936,14 +973,16 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_missing_name(self) -> None:
         """Test that missing name returns error."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser4", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
-            tool = CreateAgentTool(db=db, user_id=user.id)
+            tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
             result = await tool.run_json_async(
                 {
@@ -957,7 +996,6 @@ class TestCreateAgentTool:
             assert "required" in result["message"].lower()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -968,14 +1006,16 @@ class TestCreateAgentTool:
     @pytest.mark.asyncio
     async def test_create_agent_missing_instructions(self) -> None:
         """Test that missing instructions returns error."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser5", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
-            tool = CreateAgentTool(db=db, user_id=user.id)
+            tool = CreateAgentTool(session_factory=SessionLocal, user_id=user_id)
 
             result = await tool.run_json_async(
                 {
@@ -989,7 +1029,6 @@ class TestCreateAgentTool:
             assert "required" in result["message"].lower()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1004,7 +1043,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_success(self) -> None:
         """Test successful agent update."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_update", password_hash="x", is_admin=False)
             db.add(user)
@@ -1063,7 +1102,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_partial_update(self) -> None:
         """Test partial agent update (only some fields)."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_partial", password_hash="x", is_admin=False)
             db.add(user)
@@ -1111,7 +1150,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_not_found(self) -> None:
         """Test updating non-existent agent."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_notfound", password_hash="x", is_admin=False)
             db.add(user)
@@ -1141,7 +1180,7 @@ class TestUpdateAgentTool:
 
     @pytest.mark.asyncio
     async def test_update_agent_rejects_generated_workforce_manager(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_update_generated_manager",
@@ -1191,7 +1230,7 @@ class TestUpdateAgentTool:
     async def test_update_agent_name_conflict_ignores_generated_workforce_manager(
         self,
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_update_generated_manager_name",
@@ -1242,7 +1281,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_rejects_missing_knowledge_base(self) -> None:
         """Test that update_agent rejects knowledge bases that do not exist."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_update_missing_kb", password_hash="x")
             db.add(user)
@@ -1291,7 +1330,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_published_agent_success_preserves_status(self) -> None:
         """Test that published agents can be updated and remain published."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_published", password_hash="x", is_admin=False
@@ -1343,7 +1382,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_archived_agent_rejected(self) -> None:
         """Test that archived agents cannot be updated."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_archived", password_hash="x", is_admin=False)
             db.add(user)
@@ -1391,7 +1430,7 @@ class TestUpdateAgentTool:
     @pytest.mark.asyncio
     async def test_update_agent_duplicate_name(self) -> None:
         """Test that duplicate names are rejected when updating."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_dup", password_hash="x", is_admin=False)
             db.add(user)
@@ -1443,7 +1482,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_all_agents(self) -> None:
         """Test listing all agents."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_list", password_hash="x", is_admin=False)
             db.add(user)
@@ -1499,7 +1538,7 @@ class TestListAgentsTool:
 
     @pytest.mark.asyncio
     async def test_list_agents_hides_generated_workforce_managers(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_list_generated_manager",
@@ -1547,7 +1586,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_with_status_filter(self) -> None:
         """Test listing agents with status filter."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_filter", password_hash="x", is_admin=False)
             db.add(user)
@@ -1589,7 +1628,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_user_isolation(self) -> None:
         """Test that users can only see their own agents."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user1 = User(username="listuser1", password_hash="x", is_admin=False)
             user2 = User(username="listuser2", password_hash="x", is_admin=False)
@@ -1633,7 +1672,7 @@ class TestListAgentsTool:
     @pytest.mark.asyncio
     async def test_list_agents_invalid_status_filter(self) -> None:
         """Test that invalid status filter returns error."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser_invalid", password_hash="x", is_admin=False)
             db.add(user)
@@ -1681,7 +1720,7 @@ class TestDraftAgentsInTools:
 
     def test_get_tools_with_draft_disabled(self) -> None:
         """Test that draft agents are excluded when include_draft=False."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser6", password_hash="x", is_admin=False)
             db.add(user)
@@ -1720,7 +1759,7 @@ class TestDraftAgentsInTools:
 
     def test_get_tools_with_draft_enabled(self) -> None:
         """Test that draft agents are included when include_draft=True."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser7", password_hash="x", is_admin=False)
             db.add(user)
@@ -1758,7 +1797,7 @@ class TestDraftAgentsInTools:
                 pass
 
     def test_generated_workforce_managers_are_hidden_from_agent_tools(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(
                 username="testuser_generated_manager_tools",
@@ -1809,7 +1848,7 @@ class TestDraftAgentsInTools:
 
     def test_user_isolation_for_draft_agents(self) -> None:
         """Test that users cannot see other users' draft agents."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user1 = User(username="user1", password_hash="x", is_admin=False)
             user2 = User(username="user2", password_hash="x", is_admin=False)
@@ -1851,12 +1890,14 @@ class TestCreateAndCallAgent:
     @pytest.mark.asyncio
     async def test_create_then_call_draft_agent(self) -> None:
         """Test creating a draft agent and then calling it."""
-        db, db_path = _create_session()
+        db, db_path, SessionLocal = _create_session()
         try:
             user = User(username="testuser8", password_hash="x", is_admin=False)
             db.add(user)
             db.commit()
             db.refresh(user)
+            user_id = user.id
+            db.close()
 
             # Mock LLM
             mock_llm = Mock()
@@ -1878,7 +1919,7 @@ class TestCreateAndCallAgent:
 
                 # Step 1: Create agent
                 create_tool = CreateAgentTool(
-                    db=db, user_id=user.id, task_id="test_task"
+                    session_factory=SessionLocal, user_id=user_id, task_id="test_task"
                 )
 
                 create_result = await create_tool.run_json_async(
@@ -1892,21 +1933,23 @@ class TestCreateAndCallAgent:
                 assert create_result["status"] == "success"
                 agent_id = create_result["agent_id"]
 
-                # Step 2: Verify agent is in tools list
-                tools = get_published_agents_tools(
-                    db=db, user_id=user.id, include_draft=True
-                )
-                tool_names = {tool.name for tool in tools}
+                # Step 2: Verify agent is in tools list (use a fresh session)
+                verify_db = SessionLocal()
+                try:
+                    tools = get_published_agents_tools(
+                        db=verify_db, user_id=user_id, include_draft=True
+                    )
+                    tool_names = {tool.name for tool in tools}
+                    assert f"agent_{agent_id}" in tool_names
 
-                assert f"agent_{agent_id}" in tool_names
-
-                # Step 3: Verify agent can be loaded
-                agent = db.query(Agent).filter(Agent.id == agent_id).first()
-                assert agent is not None
-                assert agent.status == AgentStatus.DRAFT
+                    # Step 3: Verify agent can be loaded
+                    agent = verify_db.query(Agent).filter(Agent.id == agent_id).first()
+                    assert agent is not None
+                    assert agent.status == AgentStatus.DRAFT
+                finally:
+                    verify_db.close()
 
         finally:
-            db.close()
             try:
                 import os
 
@@ -1918,7 +1961,7 @@ class TestCreateAndCallAgent:
     async def test_agent_tool_injects_langfuse_tracer(
         self, mocker, monkeypatch, langfuse_client_reset
     ) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "test-public")
             monkeypatch.setenv("LANGFUSE_SECRET_KEY", "test-secret")
@@ -2001,7 +2044,7 @@ class TestCreateAndCallAgent:
 
     @pytest.mark.asyncio
     async def test_agent_tool_keeps_mcp_tools_when_filtering_by_category(self) -> None:
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="testuser10", password_hash="x", is_admin=False)
             db.add(user)
@@ -2116,7 +2159,7 @@ class TestCreateAndCallAgent:
         ``include_mcp_tools=False`` -- so it does not pay MCP server init.
         Empty and NULL categories still build an ALL-mode selection spec
         for final filtering, but should not opt into MCP config loading."""
-        db, db_path = _create_session()
+        db, db_path, _ = _create_session()
         try:
             user = User(username="basicdeleg", password_hash="x", is_admin=False)
             db.add(user)

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -1,0 +1,33 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.tools.config import WebToolConfig
+
+
+def _factory():
+    engine = create_engine("sqlite://")  # in-memory, fresh
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def test_get_session_factory_prefers_injected_factory():
+    factory = _factory()
+    cfg = WebToolConfig(db=None, request=None, db_factory=factory)
+    assert cfg.get_session_factory() is factory
+
+
+def test_factory_built_get_db_is_lazy_and_closed_by_close():
+    factory = _factory()
+    cfg = WebToolConfig(db=None, request=None, db_factory=factory)
+    db1 = cfg.get_db()
+    db2 = cfg.get_db()
+    assert db1 is db2  # cached, single construction-time session
+    cfg.close()
+    # closing twice is safe
+    cfg.close()
+
+
+def test_live_db_path_unchanged():
+    sentinel = object()
+    cfg = WebToolConfig(db=sentinel, request=None)
+    assert cfg.get_db() is sentinel
+    cfg.close()  # must not raise; caller owns the request session

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -7,6 +9,37 @@ from xagent.web.tools.config import WebToolConfig
 def _factory():
     engine = create_engine("sqlite://")  # in-memory, fresh
     return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+class _Chain:
+    """Minimal chainable query stub: filter/join return self, terminals empty."""
+
+    def filter(self, *a, **k):
+        return self
+
+    def join(self, *a, **k):
+        return self
+
+    def all(self):
+        return []
+
+    def first(self):
+        return None
+
+
+class _TrackingSession:
+    """Records whether ``.query`` was driven (i.e. the session was used)."""
+
+    def __init__(self):
+        self.query_calls = 0
+        self.closed = False
+
+    def query(self, *a, **k):
+        self.query_calls += 1
+        return _Chain()
+
+    def close(self):
+        self.closed = True
 
 
 def test_get_session_factory_prefers_injected_factory():
@@ -31,3 +64,20 @@ def test_live_db_path_unchanged():
     cfg = WebToolConfig(db=sentinel, request=None)
     assert cfg.get_db() is sentinel
     cfg.close()  # must not raise; caller owns the request session
+
+
+def test_custom_api_loader_uses_factory_session():
+    # Factory-only (nested child) config: the loader must mint/reuse the lazy
+    # factory session via get_db(), not read the None live ``self.db`` and
+    # silently swallow ``None.query`` into an empty tool list.
+    sess = _TrackingSession()
+    cfg = WebToolConfig(db=None, request=None, db_factory=lambda: sess, user_id=1)
+    cfg.get_custom_api_configs()
+    assert sess.query_calls >= 1
+
+
+def test_mcp_loader_uses_factory_session():
+    sess = _TrackingSession()
+    cfg = WebToolConfig(db=None, request=None, db_factory=lambda: sess, user_id=1)
+    asyncio.run(cfg._load_mcp_server_configs())
+    assert sess.query_calls >= 1


### PR DESCRIPTION
## Summary

Isolate the SQLAlchemy `Session` per tool call for the DB-touching agent tools, so the tools no longer hold a long-lived task-scoped session. This is the **isolation-only enabler** for issue #640 — behavior stays identical (still serial); no `concurrency_safe` / `read_only` flips are made here (those follow in a separate PR together with in-turn concurrency tests).

A shared `Session` is unsafe under in-turn tool concurrency (#650): one connection/cursor and a mutable identity map. Once any two DB-touching tools land in the same concurrent segment they would drive the same session. This PR removes that coupling by minting a fresh session per `run_json_async` invocation.

## What changed

- **New `tool_session_scope(session_factory)` context manager** — opens a session from a factory, yields it, and closes it in `finally` (close-only; commit/rollback stays where it already is).
- **`WebToolConfig`** — new optional `db_factory` ctor param, `get_session_factory()`, a lazy factory-built `get_db()`, and an idempotent `close()`. The live request path (`self.db`) is unchanged.
- **The four agent tools** (`CreateAgentTool`, `UpdateAgentTool`, `ListAgentsTool`, `AgentTool`) and the sibling list-tools now take `session_factory` instead of `db`; `self._db` is gone. Each `run_json_async` wraps its DB work in `tool_session_scope`.
- **`AgentTool` is split into phases**: load agent config + resolve models in a short-lived session that is **closed before the sub-agent runs** (agent fields are captured as plain locals to avoid detached-ORM access), then the child `WebToolConfig` is built with the **factory** (not the parent's live session), and post-run file outputs are registered in a fresh session.

## Notes

- `AgentTool` post-run file-output registration issues an explicit `db.commit()` on its own short-lived session: `workspace.register_file` only `flush()`es when handed a caller session, relying on the caller to commit later — which the old shared task session used to do downstream. Documented as the single exception to the scope's close-only contract.
- No behavior change intended: existing create/update/list agent tests pass unchanged with per-call sessions.

## Testing

- New tests cover the per-call session lifecycle, `WebToolConfig` factory/lazy semantics, and the `AgentTool` load/run ordering (child config built with a factory, never the parent live session).
- `ruff`, `mypy`, `isort`, `codespell` all pass on the changed files.
- Full test failure set is identical to `main` (pre-existing environment/pollution failures only) — zero new failures.

Refs #640.
