### PR TITLE
fix: route deploy snippets through configurable API target

### DIFF
--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -14,7 +14,7 @@ import { toast } from "@/components/ui/sonner"
 import { getApiUrl } from "@/lib/utils"
 import { copyToClipboard } from "@/lib/clipboard"
 import { apiRequest } from "@/lib/api-wrapper"
-type ApiSnippetTab = "curl" | "python"
+import { formatAgentApiSnippets, type ApiSnippetTab } from "@/lib/api-snippet-format"
 
 export interface Agent {
   id: number
@@ -70,23 +70,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
 
   const agentId = deployAgent?.id ?? 0
   const apiSnippets: Record<ApiSnippetTab, string> = useMemo(() => {
-    const apiBase =
-      getApiUrl() || (typeof window !== "undefined" ? window.location.origin : "")
-    return {
-      curl: `curl -X POST ${apiBase}/v1/chat/tasks \\
-  -H "Authorization: Bearer YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "agent_id": ${agentId},
-    "message": { "role": "user", "content": "Hello" }
-  }'`,
-      python: `# pip install "xagent-sdk @ git+https://github.com/xorbitsai/xagent-sdk@v0.3.0#subdirectory=python"
-from xagent_sdk import AgentClient
-
-with AgentClient(api_key="YOUR_API_KEY", base_url="${apiBase}") as agent:
-    result = agent.tasks.run(agent_id=${agentId}, message="Hello")
-    print(result.output)`,
-    }
+    return formatAgentApiSnippets(agentId)
   }, [agentId])
 
   useEffect(() => {

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -17,6 +17,7 @@ import { apiRequest } from "@/lib/api-wrapper"
 import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
 import { formatAgentApiSnippets, type ApiSnippetTab } from "@/lib/api-snippet-format"
 import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
+import { getBrowserLocationOrigin } from "@/lib/browser-location"
 
 export interface Agent {
   id: number
@@ -65,7 +66,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
   const [isLoadingShareLink, setIsLoadingShareLink] = useState(false)
   const [shareLink, setShareLink] = useState<ShareLinkResponse | null>(null)
   const [newDomain, setNewDomain] = useState("")
-  const appOrigin = typeof window !== "undefined" ? window.location.origin : getApiUrl()
+  const [appOrigin, setAppOrigin] = useState("")
   const isPublished = deployAgent?.status === "published"
   const shareEnabled = shareLink?.share_enabled ?? deployAgent?.share_enabled ?? false
   const shareUrl = shareLink?.share_token ? `${appOrigin}/share/${shareLink.share_token}` : ""
@@ -80,6 +81,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
 
   useEffect(() => {
     setApiSnippetTarget(getApiSnippetTarget())
+    setAppOrigin(getBrowserLocationOrigin() || getApiUrl())
   }, [])
 
   useEffect(() => {

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -14,7 +14,9 @@ import { toast } from "@/components/ui/sonner"
 import { getApiUrl } from "@/lib/utils"
 import { copyToClipboard } from "@/lib/clipboard"
 import { apiRequest } from "@/lib/api-wrapper"
+import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
 import { formatAgentApiSnippets, type ApiSnippetTab } from "@/lib/api-snippet-format"
+import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export interface Agent {
   id: number
@@ -69,9 +71,16 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
   const shareUrl = shareLink?.share_token ? `${appOrigin}/share/${shareLink.share_token}` : ""
 
   const agentId = deployAgent?.id ?? 0
+  const [apiSnippetTarget, setApiSnippetTarget] = useState<ApiSnippetTarget>({
+    baseUrl: "",
+  })
   const apiSnippets: Record<ApiSnippetTab, string> = useMemo(() => {
-    return formatAgentApiSnippets(agentId)
-  }, [agentId])
+    return formatAgentApiSnippets(agentId, apiSnippetTarget)
+  }, [agentId, apiSnippetTarget])
+
+  useEffect(() => {
+    setApiSnippetTarget(getApiSnippetTarget())
+  }, [])
 
   useEffect(() => {
     setShareLink(null)

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -81,7 +81,7 @@ export function DeployAgentDialog({ deployAgent, onClose, onUpdate, onManageApiK
 
   useEffect(() => {
     setApiSnippetTarget(getApiSnippetTarget())
-    setAppOrigin(getBrowserLocationOrigin() || getApiUrl())
+    setAppOrigin(getBrowserLocationOrigin())
   }, [])
 
   useEffect(() => {

--- a/frontend/src/lib/api-snippet-base-url.test.ts
+++ b/frontend/src/lib/api-snippet-base-url.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getApiUrlMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: getApiUrlMock,
+}))
+
+import { getApiSnippetTarget } from "./api-snippet-base-url"
+
+describe("getApiSnippetTarget", () => {
+  beforeEach(() => {
+    getApiUrlMock.mockReset()
+  })
+
+  it("uses the configured API URL when present", () => {
+    getApiUrlMock.mockReturnValue("https://api.example.test")
+
+    expect(getApiSnippetTarget()).toEqual({
+      baseUrl: "https://api.example.test",
+    })
+  })
+
+  it("falls back to the browser origin for same-origin deployments", () => {
+    getApiUrlMock.mockReturnValue("")
+
+    expect(getApiSnippetTarget()).toEqual({
+      baseUrl: window.location.origin,
+    })
+  })
+})

--- a/frontend/src/lib/api-snippet-base-url.test.ts
+++ b/frontend/src/lib/api-snippet-base-url.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const getApiUrlMock = vi.hoisted(() => vi.fn())
+const browserOriginMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/utils", () => ({
   getApiUrl: getApiUrlMock,
+}))
+
+vi.mock("@/lib/browser-location", () => ({
+  getBrowserLocationOrigin: browserOriginMock,
 }))
 
 import { getApiSnippetTarget } from "./api-snippet-base-url"
@@ -11,6 +16,8 @@ import { getApiSnippetTarget } from "./api-snippet-base-url"
 describe("getApiSnippetTarget", () => {
   beforeEach(() => {
     getApiUrlMock.mockReset()
+    browserOriginMock.mockReset()
+    browserOriginMock.mockReturnValue(window.location.origin)
   })
 
   afterEach(() => {
@@ -43,7 +50,7 @@ describe("getApiSnippetTarget", () => {
 
   it("returns an empty string when no base URL is available", () => {
     getApiUrlMock.mockReturnValue("")
-    vi.stubGlobal("window", undefined)
+    browserOriginMock.mockReturnValue("")
 
     expect(getApiSnippetTarget()).toEqual({
       baseUrl: "",
@@ -52,7 +59,7 @@ describe("getApiSnippetTarget", () => {
 
   it("returns an empty string when a relative API URL has no browser origin", () => {
     getApiUrlMock.mockReturnValue("/api")
-    vi.stubGlobal("window", undefined)
+    browserOriginMock.mockReturnValue("")
 
     expect(getApiSnippetTarget()).toEqual({
       baseUrl: "",

--- a/frontend/src/lib/api-snippet-base-url.test.ts
+++ b/frontend/src/lib/api-snippet-base-url.test.ts
@@ -25,6 +25,14 @@ describe("getApiSnippetTarget", () => {
     })
   })
 
+  it("resolves relative API URLs against the browser origin", () => {
+    getApiUrlMock.mockReturnValue("/api")
+
+    expect(getApiSnippetTarget()).toEqual({
+      baseUrl: `${window.location.origin}/api`,
+    })
+  })
+
   it("falls back to the browser origin for same-origin deployments", () => {
     getApiUrlMock.mockReturnValue("")
 
@@ -35,6 +43,15 @@ describe("getApiSnippetTarget", () => {
 
   it("returns an empty string when no base URL is available", () => {
     getApiUrlMock.mockReturnValue("")
+    vi.stubGlobal("window", undefined)
+
+    expect(getApiSnippetTarget()).toEqual({
+      baseUrl: "",
+    })
+  })
+
+  it("returns an empty string when a relative API URL has no browser origin", () => {
+    getApiUrlMock.mockReturnValue("/api")
     vi.stubGlobal("window", undefined)
 
     expect(getApiSnippetTarget()).toEqual({

--- a/frontend/src/lib/api-snippet-base-url.test.ts
+++ b/frontend/src/lib/api-snippet-base-url.test.ts
@@ -33,10 +33,12 @@ describe("getApiSnippetTarget", () => {
     })
   })
 
-  it("throws when no base URL is available", () => {
+  it("returns an empty string when no base URL is available", () => {
     getApiUrlMock.mockReturnValue("")
     vi.stubGlobal("window", undefined)
 
-    expect(() => getApiSnippetTarget()).toThrow("Unable to determine API snippet base URL")
+    expect(getApiSnippetTarget()).toEqual({
+      baseUrl: "",
+    })
   })
 })

--- a/frontend/src/lib/api-snippet-base-url.test.ts
+++ b/frontend/src/lib/api-snippet-base-url.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const getApiUrlMock = vi.hoisted(() => vi.fn())
 
@@ -13,8 +13,12 @@ describe("getApiSnippetTarget", () => {
     getApiUrlMock.mockReset()
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it("uses the configured API URL when present", () => {
-    getApiUrlMock.mockReturnValue("https://api.example.test")
+    getApiUrlMock.mockReturnValue(" https://api.example.test/ ")
 
     expect(getApiSnippetTarget()).toEqual({
       baseUrl: "https://api.example.test",
@@ -27,5 +31,12 @@ describe("getApiSnippetTarget", () => {
     expect(getApiSnippetTarget()).toEqual({
       baseUrl: window.location.origin,
     })
+  })
+
+  it("throws when no base URL is available", () => {
+    getApiUrlMock.mockReturnValue("")
+    vi.stubGlobal("window", undefined)
+
+    expect(() => getApiSnippetTarget()).toThrow("Unable to determine API snippet base URL")
   })
 })

--- a/frontend/src/lib/api-snippet-base-url.ts
+++ b/frontend/src/lib/api-snippet-base-url.ts
@@ -1,9 +1,9 @@
+import { getBrowserLocationOrigin } from "@/lib/browser-location"
 import { getApiUrl } from "@/lib/utils"
 import { resolveApiSnippetBaseUrl, type ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export function getApiSnippetTarget(): ApiSnippetTarget {
-  const browserOrigin =
-    typeof window !== "undefined" ? window.location?.origin ?? "" : ""
+  const browserOrigin = getBrowserLocationOrigin()
   const candidate = getApiUrl() || browserOrigin
   return { baseUrl: resolveApiSnippetBaseUrl(candidate, browserOrigin) }
 }

--- a/frontend/src/lib/api-snippet-base-url.ts
+++ b/frontend/src/lib/api-snippet-base-url.ts
@@ -1,11 +1,8 @@
 import { getApiUrl } from "@/lib/utils"
-
-export interface ApiSnippetTarget {
-  baseUrl: string
-}
+import { normalizeApiSnippetBaseUrl, type ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export function getApiSnippetTarget(): ApiSnippetTarget {
-  const baseUrl =
+  const candidate =
     getApiUrl() || (typeof window !== "undefined" ? window.location.origin : "")
-  return { baseUrl }
+  return { baseUrl: normalizeApiSnippetBaseUrl(candidate) }
 }

--- a/frontend/src/lib/api-snippet-base-url.ts
+++ b/frontend/src/lib/api-snippet-base-url.ts
@@ -1,0 +1,11 @@
+import { getApiUrl } from "@/lib/utils"
+
+export interface ApiSnippetTarget {
+  baseUrl: string
+}
+
+export function getApiSnippetTarget(): ApiSnippetTarget {
+  const baseUrl =
+    getApiUrl() || (typeof window !== "undefined" ? window.location.origin : "")
+  return { baseUrl }
+}

--- a/frontend/src/lib/api-snippet-base-url.ts
+++ b/frontend/src/lib/api-snippet-base-url.ts
@@ -1,8 +1,9 @@
 import { getApiUrl } from "@/lib/utils"
-import { normalizeApiSnippetBaseUrl, type ApiSnippetTarget } from "@/lib/api-snippet-target"
+import { resolveApiSnippetBaseUrl, type ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export function getApiSnippetTarget(): ApiSnippetTarget {
-  const candidate =
-    getApiUrl() || (typeof window !== "undefined" ? window.location.origin : "")
-  return { baseUrl: normalizeApiSnippetBaseUrl(candidate) }
+  const browserOrigin =
+    typeof window !== "undefined" ? window.location?.origin ?? "" : ""
+  const candidate = getApiUrl() || browserOrigin
+  return { baseUrl: resolveApiSnippetBaseUrl(candidate, browserOrigin) }
 }

--- a/frontend/src/lib/api-snippet-format.test.ts
+++ b/frontend/src/lib/api-snippet-format.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { formatAgentApiSnippets } from "./api-snippet-format"
+
+describe("formatAgentApiSnippets", () => {
+  it("formats runtime snippets with the regional base_url", () => {
+    const snippets = formatAgentApiSnippets(42, {
+      baseUrl: "https://sg.cloud.xagent.co",
+    })
+
+    expect(snippets.curl).toContain("https://sg.cloud.xagent.co/v1/chat/tasks")
+    expect(snippets.python).toContain("from xagent_sdk import AgentClient")
+    expect(snippets.python).toContain('base_url="https://sg.cloud.xagent.co"')
+    expect(snippets.python).not.toContain("Region")
+    expect(snippets.python).not.toContain("region=")
+  })
+
+  it("formats runtime snippets with an explicit fallback base_url", () => {
+    const snippets = formatAgentApiSnippets(42, {
+      baseUrl: "https://api.example.test",
+    })
+
+    expect(snippets.curl).toContain("https://api.example.test/v1/chat/tasks")
+    expect(snippets.python).toContain('base_url="https://api.example.test"')
+    expect(snippets.python).not.toContain("Region")
+  })
+})

--- a/frontend/src/lib/api-snippet-format.test.ts
+++ b/frontend/src/lib/api-snippet-format.test.ts
@@ -24,4 +24,13 @@ describe("formatAgentApiSnippets", () => {
     expect(snippets.python).toContain('base_url="https://api.example.test"')
     expect(snippets.python).not.toContain("Region")
   })
+
+  it("uses a placeholder when the base URL is empty", () => {
+    const snippets = formatAgentApiSnippets(42, {
+      baseUrl: "",
+    })
+
+    expect(snippets.curl).toContain("YOUR_API_BASE_URL/v1/chat/tasks")
+    expect(snippets.python).toContain('base_url="YOUR_API_BASE_URL"')
+  })
 })

--- a/frontend/src/lib/api-snippet-format.ts
+++ b/frontend/src/lib/api-snippet-format.ts
@@ -1,11 +1,10 @@
-import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
 import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export type ApiSnippetTab = "curl" | "python"
 
 export function formatAgentApiSnippets(
   agentId: number,
-  apiTarget: ApiSnippetTarget = getApiSnippetTarget(),
+  apiTarget: ApiSnippetTarget,
 ): Record<ApiSnippetTab, string> {
   const baseUrl = apiTarget.baseUrl || "YOUR_API_BASE_URL"
 

--- a/frontend/src/lib/api-snippet-format.ts
+++ b/frontend/src/lib/api-snippet-format.ts
@@ -7,8 +7,10 @@ export function formatAgentApiSnippets(
   agentId: number,
   apiTarget: ApiSnippetTarget = getApiSnippetTarget(),
 ): Record<ApiSnippetTab, string> {
+  const baseUrl = apiTarget.baseUrl || "YOUR_API_BASE_URL"
+
   return {
-    curl: `curl -X POST ${apiTarget.baseUrl}/v1/chat/tasks \\
+    curl: `curl -X POST ${baseUrl}/v1/chat/tasks \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -18,7 +20,7 @@ export function formatAgentApiSnippets(
     python: `# pip install "xagent-sdk @ git+https://github.com/xorbitsai/xagent-sdk@v0.3.1#subdirectory=python"
 from xagent_sdk import AgentClient
 
-with AgentClient(api_key="YOUR_API_KEY", base_url="${apiTarget.baseUrl}") as agent:
+with AgentClient(api_key="YOUR_API_KEY", base_url="${baseUrl}") as agent:
     result = agent.tasks.run(agent_id=${agentId}, message="Hello")
     print(result.output)`,
   }

--- a/frontend/src/lib/api-snippet-format.ts
+++ b/frontend/src/lib/api-snippet-format.ts
@@ -1,0 +1,24 @@
+import { getApiSnippetTarget, type ApiSnippetTarget } from "@/lib/api-snippet-base-url"
+
+export type ApiSnippetTab = "curl" | "python"
+
+export function formatAgentApiSnippets(
+  agentId: number,
+  apiTarget: ApiSnippetTarget = getApiSnippetTarget(),
+): Record<ApiSnippetTab, string> {
+  return {
+    curl: `curl -X POST ${apiTarget.baseUrl}/v1/chat/tasks \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "agent_id": ${agentId},
+    "message": { "role": "user", "content": "Hello" }
+  }'`,
+    python: `# pip install "xagent-sdk @ git+https://github.com/xorbitsai/xagent-sdk@v0.3.1#subdirectory=python"
+from xagent_sdk import AgentClient
+
+with AgentClient(api_key="YOUR_API_KEY", base_url="${apiTarget.baseUrl}") as agent:
+    result = agent.tasks.run(agent_id=${agentId}, message="Hello")
+    print(result.output)`,
+  }
+}

--- a/frontend/src/lib/api-snippet-format.ts
+++ b/frontend/src/lib/api-snippet-format.ts
@@ -1,4 +1,5 @@
-import { getApiSnippetTarget, type ApiSnippetTarget } from "@/lib/api-snippet-base-url"
+import { getApiSnippetTarget } from "@/lib/api-snippet-base-url"
+import type { ApiSnippetTarget } from "@/lib/api-snippet-target"
 
 export type ApiSnippetTab = "curl" | "python"
 

--- a/frontend/src/lib/api-snippet-target.test.ts
+++ b/frontend/src/lib/api-snippet-target.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { normalizeApiSnippetBaseUrl } from "./api-snippet-target"
+import {
+  normalizeApiSnippetBaseUrl,
+  resolveApiSnippetBaseUrl,
+} from "./api-snippet-target"
 
 describe("normalizeApiSnippetBaseUrl", () => {
   it("trims whitespace and trailing slashes", () => {
@@ -11,5 +14,23 @@ describe("normalizeApiSnippetBaseUrl", () => {
 
   it("handles empty base URLs gracefully", () => {
     expect(normalizeApiSnippetBaseUrl(" / ")).toBe("")
+  })
+})
+
+describe("resolveApiSnippetBaseUrl", () => {
+  it("keeps absolute HTTP URLs", () => {
+    expect(resolveApiSnippetBaseUrl(" https://api.example.test/// ")).toBe(
+      "https://api.example.test"
+    )
+  })
+
+  it("resolves relative URLs against an absolute browser origin", () => {
+    expect(resolveApiSnippetBaseUrl("/api", "https://app.example.test")).toBe(
+      "https://app.example.test/api"
+    )
+  })
+
+  it("returns an empty string when a relative URL has no usable origin", () => {
+    expect(resolveApiSnippetBaseUrl("/api", "")).toBe("")
   })
 })

--- a/frontend/src/lib/api-snippet-target.test.ts
+++ b/frontend/src/lib/api-snippet-target.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeApiSnippetBaseUrl } from "./api-snippet-target"
+
+describe("normalizeApiSnippetBaseUrl", () => {
+  it("trims whitespace and trailing slashes", () => {
+    expect(normalizeApiSnippetBaseUrl(" https://api.example.test/// ")).toBe(
+      "https://api.example.test"
+    )
+  })
+
+  it("rejects empty base URLs", () => {
+    expect(() => normalizeApiSnippetBaseUrl(" / ")).toThrow(
+      "Unable to determine API snippet base URL"
+    )
+  })
+})

--- a/frontend/src/lib/api-snippet-target.test.ts
+++ b/frontend/src/lib/api-snippet-target.test.ts
@@ -13,7 +13,11 @@ describe("normalizeApiSnippetBaseUrl", () => {
   })
 
   it("handles empty base URLs gracefully", () => {
-    expect(normalizeApiSnippetBaseUrl(" / ")).toBe("")
+    expect(normalizeApiSnippetBaseUrl("   ")).toBe("")
+  })
+
+  it("preserves a single slash representing the root path", () => {
+    expect(normalizeApiSnippetBaseUrl(" / ")).toBe("/")
   })
 })
 
@@ -27,6 +31,12 @@ describe("resolveApiSnippetBaseUrl", () => {
   it("resolves relative URLs against an absolute browser origin", () => {
     expect(resolveApiSnippetBaseUrl("/api", "https://app.example.test")).toBe(
       "https://app.example.test/api"
+    )
+  })
+
+  it("resolves the root path against an absolute browser origin", () => {
+    expect(resolveApiSnippetBaseUrl("/", "https://app.example.test")).toBe(
+      "https://app.example.test"
     )
   })
 

--- a/frontend/src/lib/api-snippet-target.test.ts
+++ b/frontend/src/lib/api-snippet-target.test.ts
@@ -9,9 +9,7 @@ describe("normalizeApiSnippetBaseUrl", () => {
     )
   })
 
-  it("rejects empty base URLs", () => {
-    expect(() => normalizeApiSnippetBaseUrl(" / ")).toThrow(
-      "Unable to determine API snippet base URL"
-    )
+  it("handles empty base URLs gracefully", () => {
+    expect(normalizeApiSnippetBaseUrl(" / ")).toBe("")
   })
 })

--- a/frontend/src/lib/api-snippet-target.test.ts
+++ b/frontend/src/lib/api-snippet-target.test.ts
@@ -43,4 +43,10 @@ describe("resolveApiSnippetBaseUrl", () => {
   it("returns an empty string when a relative URL has no usable origin", () => {
     expect(resolveApiSnippetBaseUrl("/api", "")).toBe("")
   })
+
+  it("rejects non-HTTP absolute URLs after URL resolution", () => {
+    expect(resolveApiSnippetBaseUrl("javascript:alert(1)", "https://app.example.test")).toBe("")
+    expect(resolveApiSnippetBaseUrl("ftp://api.example.test", "https://app.example.test")).toBe("")
+    expect(resolveApiSnippetBaseUrl("ws://api.example.test", "https://app.example.test")).toBe("")
+  })
 })

--- a/frontend/src/lib/api-snippet-target.ts
+++ b/frontend/src/lib/api-snippet-target.ts
@@ -5,3 +5,36 @@ export interface ApiSnippetTarget {
 export function normalizeApiSnippetBaseUrl(rawBaseUrl: string): string {
   return rawBaseUrl.trim().replace(/\/+$/, "")
 }
+
+export function resolveApiSnippetBaseUrl(
+  rawBaseUrl: string,
+  browserOrigin = "",
+): string {
+  const candidate = normalizeApiSnippetBaseUrl(rawBaseUrl)
+  if (!candidate) {
+    return ""
+  }
+  if (isHttpUrl(candidate)) {
+    return candidate
+  }
+
+  const origin = normalizeApiSnippetBaseUrl(browserOrigin)
+  if (!isHttpUrl(origin)) {
+    return ""
+  }
+
+  try {
+    return normalizeApiSnippetBaseUrl(new URL(candidate, `${origin}/`).toString())
+  } catch {
+    return ""
+  }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/lib/api-snippet-target.ts
+++ b/frontend/src/lib/api-snippet-target.ts
@@ -1,0 +1,11 @@
+export interface ApiSnippetTarget {
+  baseUrl: string
+}
+
+export function normalizeApiSnippetBaseUrl(rawBaseUrl: string): string {
+  const baseUrl = rawBaseUrl.trim().replace(/\/+$/, "")
+  if (!baseUrl) {
+    throw new Error("Unable to determine API snippet base URL")
+  }
+  return baseUrl
+}

--- a/frontend/src/lib/api-snippet-target.ts
+++ b/frontend/src/lib/api-snippet-target.ts
@@ -28,7 +28,10 @@ export function resolveApiSnippetBaseUrl(
   }
 
   try {
-    return normalizeApiSnippetBaseUrl(new URL(candidate, `${origin}/`).toString())
+    const resolved = normalizeApiSnippetBaseUrl(
+      new URL(candidate, `${origin}/`).toString()
+    )
+    return isHttpUrl(resolved) ? resolved : ""
   } catch {
     return ""
   }

--- a/frontend/src/lib/api-snippet-target.ts
+++ b/frontend/src/lib/api-snippet-target.ts
@@ -3,7 +3,11 @@ export interface ApiSnippetTarget {
 }
 
 export function normalizeApiSnippetBaseUrl(rawBaseUrl: string): string {
-  return rawBaseUrl.trim().replace(/\/+$/, "")
+  const trimmed = rawBaseUrl.trim()
+  if (trimmed === "/") {
+    return "/"
+  }
+  return trimmed.replace(/\/+$/, "")
 }
 
 export function resolveApiSnippetBaseUrl(

--- a/frontend/src/lib/api-snippet-target.ts
+++ b/frontend/src/lib/api-snippet-target.ts
@@ -3,9 +3,5 @@ export interface ApiSnippetTarget {
 }
 
 export function normalizeApiSnippetBaseUrl(rawBaseUrl: string): string {
-  const baseUrl = rawBaseUrl.trim().replace(/\/+$/, "")
-  if (!baseUrl) {
-    throw new Error("Unable to determine API snippet base URL")
-  }
-  return baseUrl
+  return rawBaseUrl.trim().replace(/\/+$/, "")
 }

--- a/frontend/src/lib/browser-location.test.ts
+++ b/frontend/src/lib/browser-location.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getBrowserLocationHostname,
+  getBrowserLocationOrigin,
+} from "./browser-location"
+
+describe("browser location helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("reads browser origin and hostname when available", () => {
+    expect(getBrowserLocationOrigin()).toBe(window.location.origin)
+    expect(getBrowserLocationHostname()).toBe(window.location.hostname)
+  })
+
+  it("returns empty strings when window is unavailable", () => {
+    vi.stubGlobal("window", undefined)
+
+    expect(getBrowserLocationOrigin()).toBe("")
+    expect(getBrowserLocationHostname()).toBe("")
+  })
+
+  it("returns empty strings when location access throws", () => {
+    vi.stubGlobal("window", {
+      get location() {
+        throw new DOMException("Blocked", "SecurityError")
+      },
+    })
+
+    expect(getBrowserLocationOrigin()).toBe("")
+    expect(getBrowserLocationHostname()).toBe("")
+  })
+})

--- a/frontend/src/lib/browser-location.ts
+++ b/frontend/src/lib/browser-location.ts
@@ -1,0 +1,23 @@
+export function getBrowserLocationOrigin(): string {
+  if (typeof window === "undefined") {
+    return ""
+  }
+
+  try {
+    return window.location?.origin ?? ""
+  } catch {
+    return ""
+  }
+}
+
+export function getBrowserLocationHostname(): string {
+  if (typeof window === "undefined") {
+    return ""
+  }
+
+  try {
+    return window.location?.hostname ?? ""
+  } catch {
+    return ""
+  }
+}


### PR DESCRIPTION
## Summary
- route deploy dialog API snippets through an explicit snippet target helper
- keep snippet base URL resolution browser-safe for SSR, same-origin, relative API URL, and invalid-scheme fallbacks
- keep cURL/Python snippet formatting pure and driven by an explicit runtime API target

## Validation
- npm run test:run -- --pool=forks --minWorkers=1 --maxWorkers=1 src/lib/browser-location.test.ts src/lib/api-snippet-target.test.ts src/lib/api-snippet-base-url.test.ts src/lib/api-snippet-format.test.ts
- npm run type-check
- npm run lint -- src/components/build/deploy-agent-dialog.tsx src/lib/browser-location.ts src/lib/browser-location.test.ts src/lib/api-snippet-target.ts src/lib/api-snippet-target.test.ts src/lib/api-snippet-base-url.ts src/lib/api-snippet-base-url.test.ts src/lib/api-snippet-format.ts src/lib/api-snippet-format.test.ts
