### PR TITLE
ref: batch agent model lookups into a single query

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
@@ -27,25 +27,22 @@ def resolve_agent_model_llms(
 
     from .....web.models.model import Model as DBModel
 
-    model_ids = [
-        coerced_model_id
+    model_ids_by_key = {
+        model_key: coerced_model_id
         for model_key in AGENT_MODEL_KEYS
         if (coerced_model_id := _coerce_model_db_id(agent_models.get(model_key)))
         is not None
-    ]
+    }
+    model_ids = list(model_ids_by_key.values())
     if not model_ids:
         return None, None, None, None
 
     models_by_id: dict[Any, Any] = {}
     for model in db.query(DBModel).filter(DBModel.id.in_(model_ids)).all():
         models_by_id[model.id] = model
-        models_by_id[str(model.id)] = model
 
     resolved_llms = {}
-    for model_key in AGENT_MODEL_KEYS:
-        model_id = agent_models.get(model_key)
-        if not model_id:
-            continue
+    for model_key, model_id in model_ids_by_key.items():
         model = models_by_id.get(model_id)
         if model:
             resolved_llms[model_key] = storage.get_llm_by_name_with_access(

--- a/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
@@ -1,0 +1,49 @@
+"""Model resolution helpers for delegated agent tools."""
+
+from typing import Any, Mapping
+
+AGENT_MODEL_KEYS = ("general", "small_fast", "visual", "compact")
+
+
+def resolve_agent_model_llms(
+    db: Any,
+    storage: Any,
+    agent_models: Mapping[str, Any] | None,
+    user_id: int,
+) -> tuple[Any | None, Any | None, Any | None, Any | None]:
+    """Resolve delegated-agent model slots with one database lookup."""
+    if not agent_models:
+        return None, None, None, None
+
+    from .....web.models.model import Model as DBModel
+
+    model_ids = [
+        agent_models[model_key]
+        for model_key in AGENT_MODEL_KEYS
+        if agent_models.get(model_key)
+    ]
+    if not model_ids:
+        return None, None, None, None
+
+    models_by_id: dict[Any, Any] = {}
+    for model in db.query(DBModel).filter(DBModel.id.in_(model_ids)).all():
+        models_by_id[model.id] = model
+        models_by_id[str(model.id)] = model
+
+    resolved_llms = {}
+    for model_key in AGENT_MODEL_KEYS:
+        model_id = agent_models.get(model_key)
+        if not model_id:
+            continue
+        model = models_by_id.get(model_id)
+        if model:
+            resolved_llms[model_key] = storage.get_llm_by_name_with_access(
+                str(model.model_id), user_id
+            )
+
+    return (
+        resolved_llms.get("general"),
+        resolved_llms.get("small_fast"),
+        resolved_llms.get("visual"),
+        resolved_llms.get("compact"),
+    )

--- a/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_model_resolution.py
@@ -1,8 +1,18 @@
 """Model resolution helpers for delegated agent tools."""
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 AGENT_MODEL_KEYS = ("general", "small_fast", "visual", "compact")
+
+
+def _coerce_model_db_id(raw_model_id: Any) -> int | None:
+    if raw_model_id in (None, "") or isinstance(raw_model_id, bool):
+        return None
+    try:
+        return int(raw_model_id)
+    except (TypeError, ValueError):
+        return None
 
 
 def resolve_agent_model_llms(
@@ -12,15 +22,16 @@ def resolve_agent_model_llms(
     user_id: int,
 ) -> tuple[Any | None, Any | None, Any | None, Any | None]:
     """Resolve delegated-agent model slots with one database lookup."""
-    if not agent_models:
+    if not agent_models or not isinstance(agent_models, Mapping):
         return None, None, None, None
 
     from .....web.models.model import Model as DBModel
 
     model_ids = [
-        agent_models[model_key]
+        coerced_model_id
         for model_key in AGENT_MODEL_KEYS
-        if agent_models.get(model_key)
+        if (coerced_model_id := _coerce_model_db_id(agent_models.get(model_key)))
+        is not None
     ]
     if not model_ids:
         return None, None, None, None

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1691,51 +1691,13 @@ class AgentTool(AbstractBaseTool):
             compact_llm = None
 
             if agent.models:
-                from .....web.models.model import Model as DBModel
+                from .agent_model_resolution import resolve_agent_model_llms
 
-                if agent.models.get("general"):
-                    general_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["general"])
-                        .first()
+                default_llm, fast_llm, vision_llm, compact_llm = (
+                    resolve_agent_model_llms(
+                        self._db, storage, agent.models, self._user_id
                     )
-                    if general_model:
-                        default_llm = storage.get_llm_by_name_with_access(
-                            str(general_model.model_id), self._user_id
-                        )
-
-                if agent.models.get("small_fast"):
-                    fast_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["small_fast"])
-                        .first()
-                    )
-                    if fast_model:
-                        fast_llm = storage.get_llm_by_name_with_access(
-                            str(fast_model.model_id), self._user_id
-                        )
-
-                if agent.models.get("visual"):
-                    visual_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["visual"])
-                        .first()
-                    )
-                    if visual_model:
-                        vision_llm = storage.get_llm_by_name_with_access(
-                            str(visual_model.model_id), self._user_id
-                        )
-
-                if agent.models.get("compact"):
-                    compact_model = (
-                        self._db.query(DBModel)
-                        .filter(DBModel.id == agent.models["compact"])
-                        .first()
-                    )
-                    if compact_model:
-                        compact_llm = storage.get_llm_by_name_with_access(
-                            str(compact_model.model_id), self._user_id
-                        )
+                )
 
             if not default_llm:
                 error_msg = f"Error: No valid model configured for agent {agent.name}"

--- a/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
+++ b/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
@@ -22,6 +22,26 @@ def _create_session() -> tuple[Session, str]:
     return session_local(), temp_db.name
 
 
+def test_resolve_agent_model_llms_ignores_non_mapping_model_config() -> None:
+    db, db_path = _create_session()
+    try:
+        storage = Mock()
+
+        assert resolve_agent_model_llms(db, storage, ["not", "a", "mapping"], 42) == (
+            None,
+            None,
+            None,
+            None,
+        )
+        storage.get_llm_by_name_with_access.assert_not_called()
+    finally:
+        db.close()
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
 def test_resolve_agent_model_llms_batches_configured_model_lookup() -> None:
     db, db_path = _create_session()
     try:
@@ -94,6 +114,78 @@ def test_resolve_agent_model_llms_batches_configured_model_lookup() -> None:
         ]
         assert len(model_selects) == 1
         assert " IN " in model_selects[0].upper()
+    finally:
+        db.close()
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+def test_resolve_agent_model_llms_normalizes_string_ids_for_batch_query() -> None:
+    db, db_path = _create_session()
+    try:
+        models: dict[str, Model] = {}
+        for role in ("general", "small_fast", "visual", "compact"):
+            model = Model(
+                model_id=f"{role}-model-id",
+                category="llm",
+                model_provider="openai",
+                model_name=f"{role}-model",
+                api_key="test-api-key",
+                base_url="https://api.openai.com/v1",
+                temperature=0.7,
+                abilities=["chat"],
+            )
+            db.add(model)
+            models[role] = model
+        db.commit()
+        for model in models.values():
+            db.refresh(model)
+
+        model_select_params: list[tuple[object, ...]] = []
+        engine = db.get_bind()
+
+        def capture_model_select_params(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, context, executemany
+            normalized = " ".join(statement.lower().split())
+            if normalized.startswith("select") and "from models" in normalized:
+                model_select_params.append(tuple(parameters))
+
+        llms_by_model_id = {
+            model.model_id: Mock(name=f"{role}_llm") for role, model in models.items()
+        }
+        storage = Mock()
+        storage.get_llm_by_name_with_access.side_effect = lambda model_id, user_id: (
+            llms_by_model_id[model_id]
+        )
+
+        event.listen(engine, "before_cursor_execute", capture_model_select_params)
+        try:
+            resolved = resolve_agent_model_llms(
+                db,
+                storage,
+                {role: str(model.id) for role, model in models.items()},
+                user_id=42,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_model_select_params)
+
+        assert resolved == (
+            llms_by_model_id["general-model-id"],
+            llms_by_model_id["small_fast-model-id"],
+            llms_by_model_id["visual-model-id"],
+            llms_by_model_id["compact-model-id"],
+        )
+        assert len(model_select_params) == 1
+        assert all(isinstance(param, int) for param in model_select_params[0])
     finally:
         db.close()
         try:

--- a/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
+++ b/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+from unittest.mock import Mock
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.core.tools.adapters.vibe.agent_model_resolution import (
+    resolve_agent_model_llms,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model
+
+
+def _create_session() -> tuple[Session, str]:
+    temp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_db.close()
+    db_url = f"sqlite:///{temp_db.name}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return session_local(), temp_db.name
+
+
+def test_resolve_agent_model_llms_batches_configured_model_lookup() -> None:
+    db, db_path = _create_session()
+    try:
+        models: dict[str, Model] = {}
+        for role in ("general", "small_fast", "visual", "compact"):
+            model = Model(
+                model_id=f"{role}-model-id",
+                category="llm",
+                model_provider="openai",
+                model_name=f"{role}-model",
+                api_key="test-api-key",
+                base_url="https://api.openai.com/v1",
+                temperature=0.7,
+                abilities=["chat"],
+            )
+            db.add(model)
+            models[role] = model
+        db.commit()
+        for model in models.values():
+            db.refresh(model)
+
+        model_selects: list[str] = []
+        engine = db.get_bind()
+
+        def capture_model_selects(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            normalized = " ".join(statement.lower().split())
+            if normalized.startswith("select") and "from models" in normalized:
+                model_selects.append(statement)
+
+        llms_by_model_id = {
+            model.model_id: Mock(name=f"{role}_llm") for role, model in models.items()
+        }
+        storage = Mock()
+        storage.get_llm_by_name_with_access.side_effect = lambda model_id, user_id: (
+            llms_by_model_id[model_id]
+        )
+
+        event.listen(engine, "before_cursor_execute", capture_model_selects)
+        try:
+            resolved = resolve_agent_model_llms(
+                db,
+                storage,
+                {role: model.id for role, model in models.items()},
+                user_id=42,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_model_selects)
+
+        assert resolved == (
+            llms_by_model_id["general-model-id"],
+            llms_by_model_id["small_fast-model-id"],
+            llms_by_model_id["visual-model-id"],
+            llms_by_model_id["compact-model-id"],
+        )
+        assert [
+            call.args for call in storage.get_llm_by_name_with_access.call_args_list
+        ] == [
+            (models["general"].model_id, 42),
+            (models["small_fast"].model_id, 42),
+            (models["visual"].model_id, 42),
+            (models["compact"].model_id, 42),
+        ]
+        assert len(model_selects) == 1
+        assert " IN " in model_selects[0].upper()
+    finally:
+        db.close()
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass

--- a/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
+++ b/tests/core/tools/adapters/vibe/test_agent_model_resolution.py
@@ -168,11 +168,13 @@ def test_resolve_agent_model_llms_normalizes_string_ids_for_batch_query() -> Non
         )
 
         event.listen(engine, "before_cursor_execute", capture_model_select_params)
+        agent_models = {role: str(model.id) for role, model in models.items()}
+        agent_models["general"] = f"00{models['general'].id}"
         try:
             resolved = resolve_agent_model_llms(
                 db,
                 storage,
-                {role: str(model.id) for role, model in models.items()},
+                agent_models,
                 user_id=42,
             )
         finally:
@@ -186,6 +188,120 @@ def test_resolve_agent_model_llms_normalizes_string_ids_for_batch_query() -> Non
         )
         assert len(model_select_params) == 1
         assert all(isinstance(param, int) for param in model_select_params[0])
+    finally:
+        db.close()
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+def test_resolve_agent_model_llms_skips_invalid_and_falsy_ids_without_query() -> None:
+    db, db_path = _create_session()
+    try:
+        model_select_params: list[tuple[object, ...]] = []
+        engine = db.get_bind()
+
+        def capture_model_select_params(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, context, executemany
+            normalized = " ".join(statement.lower().split())
+            if normalized.startswith("select") and "from models" in normalized:
+                model_select_params.append(tuple(parameters))
+
+        storage = Mock()
+        event.listen(engine, "before_cursor_execute", capture_model_select_params)
+        try:
+            resolved = resolve_agent_model_llms(
+                db,
+                storage,
+                {
+                    "general": None,
+                    "small_fast": "",
+                    "visual": True,
+                    "compact": "not-a-model-id",
+                },
+                user_id=42,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_model_select_params)
+
+        assert resolved == (None, None, None, None)
+        assert model_select_params == []
+        storage.get_llm_by_name_with_access.assert_not_called()
+    finally:
+        db.close()
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+
+
+def test_resolve_agent_model_llms_handles_stale_and_partial_model_config() -> None:
+    db, db_path = _create_session()
+    try:
+        model = Model(
+            model_id="general-model-id",
+            category="llm",
+            model_provider="openai",
+            model_name="general-model",
+            api_key="test-api-key",
+            base_url="https://api.openai.com/v1",
+            temperature=0.7,
+            abilities=["chat"],
+        )
+        db.add(model)
+        db.commit()
+        db.refresh(model)
+
+        model_select_params: list[tuple[object, ...]] = []
+        engine = db.get_bind()
+
+        def capture_model_select_params(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, context, executemany
+            normalized = " ".join(statement.lower().split())
+            if normalized.startswith("select") and "from models" in normalized:
+                model_select_params.append(tuple(parameters))
+
+        general_llm = Mock(name="general_llm")
+        storage = Mock()
+        storage.get_llm_by_name_with_access.return_value = general_llm
+        stale_model_id = model.id + 1000
+
+        event.listen(engine, "before_cursor_execute", capture_model_select_params)
+        try:
+            resolved = resolve_agent_model_llms(
+                db,
+                storage,
+                {
+                    "general": model.id,
+                    "small_fast": stale_model_id,
+                },
+                user_id=42,
+            )
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_model_select_params)
+
+        assert resolved == (general_llm, None, None, None)
+        assert len(model_select_params) == 1
+        assert set(model_select_params[0]) == {model.id, stale_model_id}
+        storage.get_llm_by_name_with_access.assert_called_once_with(
+            model.model_id,
+            42,
+        )
     finally:
         db.close()
         try:


### PR DESCRIPTION
This pull request refactors the way agent model resolution is handled for delegated agent tools, consolidating repeated logic into a single helper function and adding comprehensive tests. The main goal is to ensure that all required agent models are resolved efficiently with a single database query, improving maintainability and performance.

**Agent model resolution improvements:**

* Introduced a new helper function `resolve_agent_model_llms` in `agent_model_resolution.py` to batch-resolve all relevant agent models (`general`, `small_fast`, `visual`, `compact`) in one database lookup, replacing repetitive per-model queries.
* Refactored `run_json_async` in `agent_tool.py` to use the new `resolve_agent_model_llms` function, simplifying the code and ensuring more efficient model resolution.

**Testing enhancements:**

* Added a new test module `test_agent_model_resolution.py` to verify that `resolve_agent_model_llms` correctly batches lookups and returns the expected LLMs, including checks for query efficiency and correct storage access.