### PR TITLE
fix: hide SDK tasks from chat history

### DIFF
--- a/src/xagent/migrations/versions/20260624_backfill_sdk_task_visibility.py
+++ b/src/xagent/migrations/versions/20260624_backfill_sdk_task_visibility.py
@@ -1,0 +1,49 @@
+"""backfill sdk task visibility
+
+Revision ID: 20260624_backfill_sdk_task_visibility
+Revises: 20260616_add_agent_triggers
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260624_backfill_sdk_task_visibility"
+down_revision: Union[str, tuple[str, str], None] = "20260616_add_agent_triggers"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "tasks" not in inspector.get_table_names():
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("tasks")}
+    if not {"source", "is_visible"}.issubset(existing_columns):
+        return
+
+    tasks = sa.table(
+        "tasks",
+        sa.column("source", sa.String(length=20)),
+        sa.column("is_visible", sa.Boolean()),
+    )
+    bind.execute(
+        tasks.update()
+        .where(
+            tasks.c.source == "sdk",
+            tasks.c.is_visible.is_(True),
+        )
+        .values(is_visible=False)
+    )
+
+
+def downgrade() -> None:
+    # Data migration is intentionally not reversed: after upgrade, hiding SDK
+    # tasks is the product invariant and user-created visible tasks are
+    # distinguished by source != "sdk".
+    pass

--- a/src/xagent/migrations/versions/20260624_backfill_sdk_task_visibility.py
+++ b/src/xagent/migrations/versions/20260624_backfill_sdk_task_visibility.py
@@ -6,15 +6,15 @@ Create Date: 2026-06-24 00:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260624_backfill_sdk_task_visibility"
-down_revision: Union[str, tuple[str, str], None] = "20260616_add_agent_triggers"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | tuple[str, str] | None = "20260616_add_agent_triggers"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -75,8 +75,8 @@ async def create_chat_task(
          (404 not 403, so the existence of unrelated agents isn't
          leaked via error code).
       2. Persists a new :class:`Task` row owned by the agent's user,
-         with ``source='sdk'`` and ``input`` set to the user message.
-         Also persists the first user message to
+         with ``source='sdk'``, ``is_visible=False``, and ``input`` set
+         to the user message. Also persists the first user message to
          ``task_chat_messages`` so the existing background execution
          path can consume it without special-casing this entry point.
       3. Schedules background execution via
@@ -131,8 +131,11 @@ async def create_chat_task(
 
     # Create the Task row with SDK-specific fields populated.
     # ``source='sdk'`` lets adoption metrics queries split SDK traffic
-    # from web/widget; ``input`` records this turn's user message so
-    # GET endpoint can return it without going through task_chat_messages.
+    # from web/widget; ``is_visible=False`` keeps SDK/REST runs out of
+    # Web UI discovery surfaces while preserving exact task-id access
+    # for SDK polling and audit views; ``input`` records this turn's
+    # user message so GET endpoint can return it without going through
+    # task_chat_messages.
     task = Task(
         user_id=agent.user_id,
         title=title,
@@ -141,6 +144,7 @@ async def create_chat_task(
         agent_id=agent.id,
         input=request.message.content,
         source="sdk",
+        is_visible=False,
     )
     db.add(task)
     db.commit()

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -16,15 +16,11 @@ class TestTryUpgradeDb:
         try_upgrade_db(engine)
 
         columns = inspect(engine).get_columns("alembic_version")
-        version_num = next(
-            column for column in columns if column["name"] == "version_num"
-        )
+        version_num = next(column for column in columns if column["name"] == "version_num")
         assert version_num["type"].length == 255
 
         with engine.begin() as conn:
-            version = conn.execute(
-                text("SELECT version_num FROM alembic_version")
-            ).scalar()
+            version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar()
 
         script = ScriptDirectory.from_config(create_alembic_config(engine))
         assert version == script.get_current_head()
@@ -34,12 +30,7 @@ class TestTryUpgradeDb:
         cfg = create_alembic_config(engine)
 
         with engine.begin() as conn:
-            conn.execute(
-                text(
-                    "CREATE TABLE alembic_version "
-                    "(version_num VARCHAR(255) NOT NULL)"
-                )
-            )
+            conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)"))
             conn.execute(
                 text(
                     "INSERT INTO alembic_version (version_num) "
@@ -66,18 +57,14 @@ class TestTryUpgradeDb:
             cfg.attributes["connection"] = conn
             command.upgrade(cfg, "head")
 
-            rows = conn.execute(
-                text("SELECT id, is_visible FROM tasks ORDER BY id")
-            ).all()
+            rows = conn.execute(text("SELECT id, is_visible FROM tasks ORDER BY id")).all()
 
         assert rows == [(1, 0), (2, 1), (3, 0)]
 
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")
     @patch("xagent.db.migration.get_alembic_revision")
-    def test_successful_upgrade(
-        self, mock_get_revision, mock_create_config, mock_upgrade
-    ):
+    def test_successful_upgrade(self, mock_get_revision, mock_create_config, mock_upgrade):
         engine = MagicMock()
         mock_get_revision.return_value = "abc123"
         mock_config = mock_create_config.return_value
@@ -125,9 +112,7 @@ class TestTryUpgradeDb:
         mock_get_revision.return_value = None
         mock_is_empty.return_value = False  # Database has tables but no revision
 
-        with pytest.raises(
-            RuntimeError, match="Database exists without alembic revision"
-        ):
+        with pytest.raises(RuntimeError, match="Database exists without alembic revision"):
             try_upgrade_db(engine)
 
     @patch("xagent.db.migration.command.upgrade")
@@ -164,9 +149,9 @@ class TestTryUpgradeDb:
     @patch("xagent.db.migration.get_alembic_revision")
     def test_logs_error_on_failure(self, mock_get_revision, mock_logger):
         engine = Mock()
-        mock_get_revision.side_effect = Exception("DB error")
+        mock_get_revision.side_effect = RuntimeError("DB error")
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="DB error"):
             try_upgrade_db(engine)
 
         mock_logger.error.assert_called_once()

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -16,11 +16,15 @@ class TestTryUpgradeDb:
         try_upgrade_db(engine)
 
         columns = inspect(engine).get_columns("alembic_version")
-        version_num = next(column for column in columns if column["name"] == "version_num")
+        version_num = next(
+            column for column in columns if column["name"] == "version_num"
+        )
         assert version_num["type"].length == 255
 
         with engine.begin() as conn:
-            version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar()
+            version = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
 
         script = ScriptDirectory.from_config(create_alembic_config(engine))
         assert version == script.get_current_head()
@@ -30,7 +34,9 @@ class TestTryUpgradeDb:
         cfg = create_alembic_config(engine)
 
         with engine.begin() as conn:
-            conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)"))
+            conn.execute(
+                text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+            )
             conn.execute(
                 text(
                     "INSERT INTO alembic_version (version_num) "
@@ -57,14 +63,18 @@ class TestTryUpgradeDb:
             cfg.attributes["connection"] = conn
             command.upgrade(cfg, "head")
 
-            rows = conn.execute(text("SELECT id, is_visible FROM tasks ORDER BY id")).all()
+            rows = conn.execute(
+                text("SELECT id, is_visible FROM tasks ORDER BY id")
+            ).all()
 
         assert rows == [(1, 0), (2, 1), (3, 0)]
 
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")
     @patch("xagent.db.migration.get_alembic_revision")
-    def test_successful_upgrade(self, mock_get_revision, mock_create_config, mock_upgrade):
+    def test_successful_upgrade(
+        self, mock_get_revision, mock_create_config, mock_upgrade
+    ):
         engine = MagicMock()
         mock_get_revision.return_value = "abc123"
         mock_config = mock_create_config.return_value
@@ -112,7 +122,9 @@ class TestTryUpgradeDb:
         mock_get_revision.return_value = None
         mock_is_empty.return_value = False  # Database has tables but no revision
 
-        with pytest.raises(RuntimeError, match="Database exists without alembic revision"):
+        with pytest.raises(
+            RuntimeError, match="Database exists without alembic revision"
+        ):
             try_upgrade_db(engine)
 
     @patch("xagent.db.migration.command.upgrade")

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from alembic import command
 from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 
@@ -27,6 +28,49 @@ class TestTryUpgradeDb:
 
         script = ScriptDirectory.from_config(create_alembic_config(engine))
         assert version == script.get_current_head()
+
+    def test_upgrade_backfills_legacy_sdk_tasks_as_hidden(self):
+        engine = create_engine("sqlite:///:memory:")
+        cfg = create_alembic_config(engine)
+
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE alembic_version "
+                    "(version_num VARCHAR(255) NOT NULL)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO alembic_version (version_num) "
+                    "VALUES ('20260616_add_agent_triggers')"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TABLE tasks ("
+                    "id INTEGER PRIMARY KEY, "
+                    "source VARCHAR(20), "
+                    "is_visible BOOLEAN NOT NULL)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO tasks (id, source, is_visible) VALUES "
+                    "(1, 'sdk', 1), "
+                    "(2, 'internal', 1), "
+                    "(3, 'sdk', 0)"
+                )
+            )
+
+            cfg.attributes["connection"] = conn
+            command.upgrade(cfg, "head")
+
+            rows = conn.execute(
+                text("SELECT id, is_visible FROM tasks ORDER BY id")
+            ).all()
+
+        assert rows == [(1, 0), (2, 1), (3, 0)]
 
     @patch("xagent.db.migration.command.upgrade")
     @patch("xagent.db.migration.create_alembic_config")

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -136,7 +136,9 @@ def test_create_task_happy_path(mock_start_task):
         # task_chat_messages: one user-role message written
         from xagent.web.models.chat_message import TaskChatMessage
 
-        msgs = db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).all()
+        msgs = (
+            db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).all()
+        )
         assert len(msgs) == 1
         assert msgs[0].role == "user"
         assert msgs[0].content == "first user message"
@@ -285,9 +287,9 @@ def test_create_task_cross_user_agent_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
-        "full_key"
-    ]
+    bob_key = client.post(
+        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
+    ).json()["full_key"]
 
     # Bob's key + Alice's agent_id in body -> 404
     resp = client.post(
@@ -610,9 +612,9 @@ def test_append_message_to_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
-        "full_key"
-    ]
+    bob_key = client.post(
+        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
+    ).json()["full_key"]
 
     resp = client.post(
         f"/v1/chat/tasks/{alice_task_id}/messages",
@@ -742,9 +744,9 @@ def test_get_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
-        "full_key"
-    ]
+    bob_key = client.post(
+        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
+    ).json()["full_key"]
 
     resp = client.get(f"/v1/chat/tasks/{alice_task_id}", headers=_bearer(bob_key))
     assert resp.status_code == 404
@@ -919,9 +921,9 @@ def test_get_steps_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
-        "full_key"
-    ]
+    bob_key = client.post(
+        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
+    ).json()["full_key"]
 
     resp = client.get(f"/v1/chat/tasks/{alice_task_id}/steps", headers=_bearer(bob_key))
     assert resp.status_code == 404
@@ -985,8 +987,12 @@ def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_tas
             "xagent.web.api.v1.tasks.map_trace_events_to_public_steps",
             wraps=_step_mapping.map_trace_events_to_public_steps,
         ) as mapper:
-            first = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
-            second = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
+            first = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
+            second = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
 
             assert first.status_code == 200, first.text
             assert second.status_code == 200, second.text
@@ -1000,7 +1006,9 @@ def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_tas
                 timestamp=base.replace(second=1),
                 data={"content": "new"},
             )
-            third = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
+            third = client.get(
+                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+            )
 
             assert third.status_code == 200, third.text
             assert mapper.call_count == 2
@@ -1089,7 +1097,9 @@ def test_get_steps_returns_404_for_non_sdk_source(mock_start_task):
     agent_id, full_key = _create_agent_with_key()
     internal_task_id = _insert_internal_task(agent_id)
 
-    resp = client.get(f"/v1/chat/tasks/{internal_task_id}/steps", headers=_bearer(full_key))
+    resp = client.get(
+        f"/v1/chat/tasks/{internal_task_id}/steps", headers=_bearer(full_key)
+    )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "task_not_found"
 

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -97,8 +97,9 @@ def mock_start_task():
 
 
 def test_create_task_happy_path(mock_start_task):
-    """Returns 202 + task_id, writes Task with source='sdk' + input,
-    persists first user message, kicks off background.
+    """Returns 202 + task_id, writes hidden SDK Task + input,
+    persists first user message, kicks off background, and leaves the
+    task readable through the SDK API surface.
     """
     agent_id, full_key = _create_agent_with_key()
 
@@ -129,6 +130,7 @@ def test_create_task_happy_path(mock_start_task):
         assert task is not None
         assert task.agent_id == agent_id
         assert task.source == "sdk"
+        assert task.is_visible is False
         assert task.input == "first user message"
         assert task.status == TaskStatus.RUNNING
 
@@ -143,6 +145,10 @@ def test_create_task_happy_path(mock_start_task):
         assert msgs[0].content == "first user message"
     finally:
         db.close()
+
+    sdk_task = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert sdk_task.status_code == 200, sdk_task.text
+    assert sdk_task.json()["task_id"] == task_id
 
     # Background kickoff was called exactly once for this task. The
     # scheduler receives a ``TaskTurnPayload`` carrying both transcript

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -14,8 +14,7 @@ real :class:`TraceEvent` rows inserted directly into the test DB to
 drive the mapping.
 """
 
-from datetime import datetime, timezone
-from typing import Tuple
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,7 +36,7 @@ pytestmark = pytest.mark.usefixtures("_test_db")
 # ===== helpers =====
 
 
-def _create_agent_with_key() -> Tuple[int, str]:
+def _create_agent_with_key() -> tuple[int, str]:
     """Create one agent under the admin user + generate its API key.
 
     Returns: (agent_id, full_key)
@@ -137,9 +136,7 @@ def test_create_task_happy_path(mock_start_task):
         # task_chat_messages: one user-role message written
         from xagent.web.models.chat_message import TaskChatMessage
 
-        msgs = (
-            db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).all()
-        )
+        msgs = db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).all()
         assert len(msgs) == 1
         assert msgs[0].role == "user"
         assert msgs[0].content == "first user message"
@@ -288,9 +285,9 @@ def test_create_task_cross_user_agent_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(
-        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
-    ).json()["full_key"]
+    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
+        "full_key"
+    ]
 
     # Bob's key + Alice's agent_id in body -> 404
     resp = client.post(
@@ -613,9 +610,9 @@ def test_append_message_to_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(
-        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
-    ).json()["full_key"]
+    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
+        "full_key"
+    ]
 
     resp = client.post(
         f"/v1/chat/tasks/{alice_task_id}/messages",
@@ -745,9 +742,9 @@ def test_get_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(
-        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
-    ).json()["full_key"]
+    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
+        "full_key"
+    ]
 
     resp = client.get(f"/v1/chat/tasks/{alice_task_id}", headers=_bearer(bob_key))
     assert resp.status_code == 404
@@ -798,7 +795,7 @@ def test_get_steps_returns_mapped_steps_in_order(mock_start_task):
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
 
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
 
     # Public step 1: thinking phase=action (react_action_start/end)
     _insert_trace_event(
@@ -922,9 +919,9 @@ def test_get_steps_other_agents_task_returns_404(mock_start_task):
         },
     ).json()
     bob_agent_id = bob_agent["id"]
-    bob_key = client.post(
-        f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers
-    ).json()["full_key"]
+    bob_key = client.post(f"/api/agents/{bob_agent_id}/api-key", headers=bob_headers).json()[
+        "full_key"
+    ]
 
     resp = client.get(f"/v1/chat/tasks/{alice_task_id}/steps", headers=_bearer(bob_key))
     assert resp.status_code == 404
@@ -952,7 +949,7 @@ def test_get_steps_ignores_worker_build_trace_events(mock_start_task):
         task_id=task_id,
         event_type="tool_execution_start",
         event_id="worker-trace-1",
-        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
         step_id="worker-step",
         build_id="agent_123_abcd1234",
         data={
@@ -971,7 +968,7 @@ def test_get_steps_ignores_worker_build_trace_events(mock_start_task):
 def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_task):
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     _insert_trace_event(
         task_id=task_id,
         event_type="ai_message",
@@ -988,12 +985,8 @@ def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_tas
             "xagent.web.api.v1.tasks.map_trace_events_to_public_steps",
             wraps=_step_mapping.map_trace_events_to_public_steps,
         ) as mapper:
-            first = client.get(
-                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
-            )
-            second = client.get(
-                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
-            )
+            first = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
+            second = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
 
             assert first.status_code == 200, first.text
             assert second.status_code == 200, second.text
@@ -1007,9 +1000,7 @@ def test_get_steps_cache_reuses_mapping_until_trace_event_changes(mock_start_tas
                 timestamp=base.replace(second=1),
                 data={"content": "new"},
             )
-            third = client.get(
-                f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
-            )
+            third = client.get(f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key))
 
             assert third.status_code == 200, third.text
             assert mapper.call_count == 2
@@ -1098,9 +1089,7 @@ def test_get_steps_returns_404_for_non_sdk_source(mock_start_task):
     agent_id, full_key = _create_agent_with_key()
     internal_task_id = _insert_internal_task(agent_id)
 
-    resp = client.get(
-        f"/v1/chat/tasks/{internal_task_id}/steps", headers=_bearer(full_key)
-    )
+    resp = client.get(f"/v1/chat/tasks/{internal_task_id}/steps", headers=_bearer(full_key))
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "task_not_found"
 

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -613,14 +613,15 @@ def test_get_tasks_hides_invisible_tasks_by_default(test_db, user1_headers):
             description="normal",
             status=TaskStatus.PENDING,
         )
-        preview_task = Task(
+        sdk_task = Task(
             user_id=user.id,
-            title="preview task",
-            description="preview",
+            title="sdk task",
+            description="sdk",
             status=TaskStatus.PENDING,
+            source="sdk",
             is_visible=False,
         )
-        db.add_all([normal_task, preview_task])
+        db.add_all([normal_task, sdk_task])
         db.commit()
 
         default_response = client.get("/api/chat/tasks", headers=user1_headers)
@@ -636,7 +637,7 @@ def test_get_tasks_hides_invisible_tasks_by_default(test_db, user1_headers):
         assert include_response.status_code == 200
         assert {task["title"] for task in include_response.json()["tasks"]} == {
             "normal task",
-            "preview task",
+            "sdk task",
         }
     finally:
         db.close()

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -101,9 +101,7 @@ def user1_headers(test_db):
     )
     assert response.status_code == 200
 
-    login = client.post(
-        "/api/auth/login", json={"username": "user1", "password": "password123"}
-    )
+    login = client.post("/api/auth/login", json={"username": "user1", "password": "password123"})
     assert login.status_code == 200
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
@@ -122,9 +120,7 @@ def user2_headers(test_db):
     )
     assert response.status_code == 200
 
-    login = client.post(
-        "/api/auth/login", json={"username": "user2", "password": "password123"}
-    )
+    login = client.post("/api/auth/login", json={"username": "user2", "password": "password123"})
     assert login.status_code == 200
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
@@ -243,8 +239,7 @@ def test_runtime_config_preserves_task_llm_when_agent_model_is_unavailable():
             return_value=fake_agent_builder_config,
         ) as load_cfg_mock,
         patch(
-            "xagent.web.services.llm_utils.UserAwareModelStorage."
-            "resolve_llms_from_names",
+            "xagent.web.services.llm_utils.UserAwareModelStorage.resolve_llms_from_names",
             return_value=(task_llm, None, None, None),
         ),
         patch(
@@ -304,8 +299,7 @@ def test_runtime_config_uses_accessible_agent_model_over_task_baseline():
             return_value=fake_agent_builder_config,
         ),
         patch(
-            "xagent.web.services.llm_utils.UserAwareModelStorage."
-            "resolve_llms_from_names",
+            "xagent.web.services.llm_utils.UserAwareModelStorage.resolve_llms_from_names",
             return_value=(task_llm, None, None, None),
         ),
         patch(
@@ -345,11 +339,7 @@ def test_pick_default_llm_warns_with_agent_context_when_builder_config_present(c
         )
 
     assert chosen is default_llm
-    matched = [
-        rec
-        for rec in caplog.records
-        if "falling back to default LLM" in rec.getMessage()
-    ]
+    matched = [rec for rec in caplog.records if "falling back to default LLM" in rec.getMessage()]
     assert len(matched) == 1
     message = matched[0].getMessage()
     assert "task_id=42" in message
@@ -378,11 +368,7 @@ def test_pick_default_llm_falls_back_to_saved_model_ids_when_descriptors_missing
             user_id=3,
         )
 
-    matched = [
-        rec
-        for rec in caplog.records
-        if "falling back to default LLM" in rec.getMessage()
-    ]
+    matched = [rec for rec in caplog.records if "falling back to default LLM" in rec.getMessage()]
     assert len(matched) == 1
     message = matched[0].getMessage()
     assert "agent_saved_models=" in message
@@ -405,11 +391,7 @@ def test_pick_default_llm_warns_with_task_only_message_when_no_builder_config(ca
         )
 
     assert chosen is default_llm
-    matched = [
-        rec
-        for rec in caplog.records
-        if "no valid LLM configuration" in rec.getMessage()
-    ]
+    matched = [rec for rec in caplog.records if "no valid LLM configuration" in rec.getMessage()]
     assert len(matched) == 1
     assert "Task 42" in matched[0].getMessage()
     assert "default-llm" in matched[0].getMessage()
@@ -475,9 +457,7 @@ def test_task_create_allows_shared_model_ids(
 ):
     """When admin shares a model, other users can use it in task creation (Mode B two-step)."""
     # Admin creates and shares a model
-    admin_login = client.post(
-        "/api/auth/login", json={"username": "admin", "password": "admin123"}
-    )
+    admin_login = client.post("/api/auth/login", json={"username": "admin", "password": "admin123"})
     assert admin_login.status_code == 200
     admin_headers = {"Authorization": f"Bearer {admin_login.json()['access_token']}"}
 
@@ -626,9 +606,7 @@ def test_get_tasks_hides_invisible_tasks_by_default(test_db, user1_headers):
 
         default_response = client.get("/api/chat/tasks", headers=user1_headers)
         assert default_response.status_code == 200
-        assert [task["title"] for task in default_response.json()["tasks"]] == [
-            "normal task"
-        ]
+        assert [task["title"] for task in default_response.json()["tasks"]] == ["normal task"]
 
         include_response = client.get(
             "/api/chat/tasks?include_hidden=true",
@@ -730,9 +708,7 @@ def test_task_create_skips_stale_user_default(test_db, user1_headers):
         db.close()
 
 
-def test_task_create_rejects_agent_id_from_another_user(
-    test_db, user1_headers, user2_headers
-):
+def test_task_create_rejects_agent_id_from_another_user(test_db, user1_headers, user2_headers):
     from xagent.web.models.agent import Agent, AgentStatus
     from xagent.web.models.database import get_db
     from xagent.web.models.user import User
@@ -822,9 +798,7 @@ def test_task_create_rejects_generated_workforce_manager_agent(
         db.close()
 
 
-def test_task_create_allows_policy_visible_published_agent(
-    test_db, user1_headers, user2_headers
-):
+def test_task_create_allows_policy_visible_published_agent(test_db, user1_headers, user2_headers):
     from xagent.web.models.agent import Agent, AgentStatus
     from xagent.web.models.database import get_db
     from xagent.web.models.task import Task
@@ -928,7 +902,7 @@ def test_delete_task_removes_trace_blobs_and_task_owned_rows(test_db, user1_head
                     build_id=None,
                     event_id="vibe-event",
                     event_type="dag_execute_end",
-                    timestamp=datetime.now(timezone.utc),
+                    timestamp=datetime.now(UTC),
                     data={"ok": True},
                 ),
                 TraceEvent(
@@ -936,7 +910,7 @@ def test_delete_task_removes_trace_blobs_and_task_owned_rows(test_db, user1_head
                     build_id="builder-session",
                     event_id="build-event",
                     event_type="agent_message",
-                    timestamp=datetime.now(timezone.utc),
+                    timestamp=datetime.now(UTC),
                     data={"ok": True},
                 ),
                 TraceMessageBlob(
@@ -991,9 +965,7 @@ def test_delete_task_removes_trace_blobs_and_task_owned_rows(test_db, user1_head
         db.close()
 
 
-def test_delete_task_keeps_cross_user_access_denied(
-    test_db, user1_headers, user2_headers
-):
+def test_delete_task_keeps_cross_user_access_denied(test_db, user1_headers, user2_headers):
     from xagent.web.models.database import get_db
     from xagent.web.models.task import Task
     from xagent.web.models.user import User

--- a/tests/web/test_chat_task_model_ids.py
+++ b/tests/web/test_chat_task_model_ids.py
@@ -101,7 +101,9 @@ def user1_headers(test_db):
     )
     assert response.status_code == 200
 
-    login = client.post("/api/auth/login", json={"username": "user1", "password": "password123"})
+    login = client.post(
+        "/api/auth/login", json={"username": "user1", "password": "password123"}
+    )
     assert login.status_code == 200
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
@@ -120,7 +122,9 @@ def user2_headers(test_db):
     )
     assert response.status_code == 200
 
-    login = client.post("/api/auth/login", json={"username": "user2", "password": "password123"})
+    login = client.post(
+        "/api/auth/login", json={"username": "user2", "password": "password123"}
+    )
     assert login.status_code == 200
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
@@ -339,7 +343,11 @@ def test_pick_default_llm_warns_with_agent_context_when_builder_config_present(c
         )
 
     assert chosen is default_llm
-    matched = [rec for rec in caplog.records if "falling back to default LLM" in rec.getMessage()]
+    matched = [
+        rec
+        for rec in caplog.records
+        if "falling back to default LLM" in rec.getMessage()
+    ]
     assert len(matched) == 1
     message = matched[0].getMessage()
     assert "task_id=42" in message
@@ -368,7 +376,11 @@ def test_pick_default_llm_falls_back_to_saved_model_ids_when_descriptors_missing
             user_id=3,
         )
 
-    matched = [rec for rec in caplog.records if "falling back to default LLM" in rec.getMessage()]
+    matched = [
+        rec
+        for rec in caplog.records
+        if "falling back to default LLM" in rec.getMessage()
+    ]
     assert len(matched) == 1
     message = matched[0].getMessage()
     assert "agent_saved_models=" in message
@@ -391,7 +403,11 @@ def test_pick_default_llm_warns_with_task_only_message_when_no_builder_config(ca
         )
 
     assert chosen is default_llm
-    matched = [rec for rec in caplog.records if "no valid LLM configuration" in rec.getMessage()]
+    matched = [
+        rec
+        for rec in caplog.records
+        if "no valid LLM configuration" in rec.getMessage()
+    ]
     assert len(matched) == 1
     assert "Task 42" in matched[0].getMessage()
     assert "default-llm" in matched[0].getMessage()
@@ -457,7 +473,9 @@ def test_task_create_allows_shared_model_ids(
 ):
     """When admin shares a model, other users can use it in task creation (Mode B two-step)."""
     # Admin creates and shares a model
-    admin_login = client.post("/api/auth/login", json={"username": "admin", "password": "admin123"})
+    admin_login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin123"}
+    )
     assert admin_login.status_code == 200
     admin_headers = {"Authorization": f"Bearer {admin_login.json()['access_token']}"}
 
@@ -606,7 +624,9 @@ def test_get_tasks_hides_invisible_tasks_by_default(test_db, user1_headers):
 
         default_response = client.get("/api/chat/tasks", headers=user1_headers)
         assert default_response.status_code == 200
-        assert [task["title"] for task in default_response.json()["tasks"]] == ["normal task"]
+        assert [task["title"] for task in default_response.json()["tasks"]] == [
+            "normal task"
+        ]
 
         include_response = client.get(
             "/api/chat/tasks?include_hidden=true",
@@ -708,7 +728,9 @@ def test_task_create_skips_stale_user_default(test_db, user1_headers):
         db.close()
 
 
-def test_task_create_rejects_agent_id_from_another_user(test_db, user1_headers, user2_headers):
+def test_task_create_rejects_agent_id_from_another_user(
+    test_db, user1_headers, user2_headers
+):
     from xagent.web.models.agent import Agent, AgentStatus
     from xagent.web.models.database import get_db
     from xagent.web.models.user import User
@@ -798,7 +820,9 @@ def test_task_create_rejects_generated_workforce_manager_agent(
         db.close()
 
 
-def test_task_create_allows_policy_visible_published_agent(test_db, user1_headers, user2_headers):
+def test_task_create_allows_policy_visible_published_agent(
+    test_db, user1_headers, user2_headers
+):
     from xagent.web.models.agent import Agent, AgentStatus
     from xagent.web.models.database import get_db
     from xagent.web.models.task import Task
@@ -965,7 +989,9 @@ def test_delete_task_removes_trace_blobs_and_task_owned_rows(test_db, user1_head
         db.close()
 
 
-def test_delete_task_keeps_cross_user_access_denied(test_db, user1_headers, user2_headers):
+def test_delete_task_keeps_cross_user_access_denied(
+    test_db, user1_headers, user2_headers
+):
     from xagent.web.models.database import get_db
     from xagent.web.models.task import Task
     from xagent.web.models.user import User


### PR DESCRIPTION
## Summary
- hide SDK/REST-created tasks from the default web chat history by setting `is_visible=false` at `/v1/chat/tasks` creation
- backfill existing `source="sdk"` tasks so previously created SDK/REST conversations are hidden from default web history as well
- keep SDK task records available through exact task-id SDK reads and hidden/audit task listings
- add regression coverage for SDK task visibility, chat-history filtering, and the backfill migration

## Root Cause
SDK task creation populated `source="sdk"` but left `is_visible` at its default `true`, so API-triggered conversations appeared in the frontend task history. Existing SDK task rows had the same persisted visibility issue.

## Validation
- `git diff --check`
- `uv run pytest tests/migration/test_migration.py`
- `uv run pytest tests/migration/test_migration.py::TestTryUpgradeDb::test_upgrade_backfills_legacy_sdk_tasks_as_hidden tests/web/api/v1/test_tasks.py tests/web/test_chat_task_model_ids.py`
- local backend/frontend E2E: SDK task is absent from `/api/chat/tasks`, present with `include_hidden=true`, and hidden from the `/task` UI while a visible web task still appears.