### PR TITLE
fix(docker): include xrouter-llm in backend-image and all extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ all = [
   "curl_cffi>=0.14.0",
   "chromadb",
   "pymilvus>=2.6.9,<3.0.0",
+  "xrouter-llm>=0.1.1",
+  "sentence-transformers>=3.0.0",
 ]
 
 [dependency-groups]
@@ -155,6 +157,8 @@ backend-image = [
   "pymilvus>=2.6.9,<3.0.0",
   "torch",
   "torchvision",
+  "xrouter-llm>=0.1.1",
+  "sentence-transformers>=3.0.0",
 ]
 
 # Development tools (linting, formatting)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
 # does not declare its bundled predictor runtime deps, so keep them explicit
 # here until upstream does.
 router = [
-  "xrouter-llm>=0.1.1",
+  "xrouter-llm>=0.1.2",
   "sentence-transformers>=3.0.0",
   "torch>=2.0.0",
 ]
@@ -136,7 +136,7 @@ all = [
   "curl_cffi>=0.14.0",
   "chromadb",
   "pymilvus>=2.6.9,<3.0.0",
-  "xrouter-llm>=0.1.1",
+  "xrouter-llm>=0.1.2",
   "sentence-transformers>=3.0.0",
 ]
 
@@ -157,7 +157,7 @@ backend-image = [
   "pymilvus>=2.6.9,<3.0.0",
   "torch",
   "torchvision",
-  "xrouter-llm>=0.1.1",
+  "xrouter-llm>=0.1.2",
   "sentence-transformers>=3.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -7485,8 +7485,10 @@ all = [
     { name = "pypdf2" },
     { name = "python-docx" },
     { name = "python-pptx" },
+    { name = "sentence-transformers" },
     { name = "typer" },
     { name = "unstructured" },
+    { name = "xrouter-llm" },
 ]
 browser = [
     { name = "playwright" },
@@ -7537,12 +7539,14 @@ backend-image = [
     { name = "pypdf2" },
     { name = "python-docx" },
     { name = "python-pptx" },
+    { name = "sentence-transformers" },
     { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "typer" },
     { name = "unstructured" },
+    { name = "xrouter-llm" },
 ]
 dev = [
     { name = "chromadb" },
@@ -7671,6 +7675,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "s3fs", specifier = ">=2026.2.0" },
+    { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'router'", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
@@ -7683,6 +7688,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "xinference-client", specifier = ">=2.3.0" },
+    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.1.1" },
     { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.1" },
     { name = "zai-sdk", specifier = ">=0.0.3.2" },
 ]
@@ -7701,10 +7707,12 @@ backend-image = [
     { name = "pypdf2", specifier = ">=3.0.1" },
     { name = "python-docx", specifier = ">=1.1.0" },
     { name = "python-pptx", specifier = ">=0.6.0" },
+    { name = "sentence-transformers", specifier = ">=3.0.0" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "unstructured", specifier = ">=0.15.0" },
+    { name = "xrouter-llm", specifier = ">=0.1.1" },
 ]
 dev = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -7688,8 +7688,8 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "xinference-client", specifier = ">=2.3.0" },
-    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.1.1" },
-    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.1" },
+    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.1.2" },
+    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.2" },
     { name = "zai-sdk", specifier = ">=0.0.3.2" },
 ]
 provides-extras = ["ai-document", "all", "browser", "chromadb", "document-processing", "duckdb", "milvus", "postgresql", "router", "waf-crawl"]
@@ -7712,7 +7712,7 @@ backend-image = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "unstructured", specifier = ">=0.15.0" },
-    { name = "xrouter-llm", specifier = ">=0.1.1" },
+    { name = "xrouter-llm", specifier = ">=0.1.2" },
 ]
 dev = [
     { name = "chromadb" },
@@ -7815,7 +7815,7 @@ wheels = [
 
 [[package]]
 name = "xrouter-llm"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -7826,9 +7826,9 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/7b/ecafb589320a4b4183bb7394e67c894b2ab809126b70e45ae3cfe2ea687f/xrouter_llm-0.1.1.tar.gz", hash = "sha256:63c769b8911cb159e47e38519c84397d4f96906a72180eaef48cd4bd6168a102", size = 110328, upload-time = "2026-06-20T17:20:13.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/36/63ccf8f0db5c0bdb8bcd04eae05e07ec7d013c2ec9854dd0e3c720cf74df/xrouter_llm-0.1.2.tar.gz", hash = "sha256:0d3b184f749505fc80b0049ee9a466d7472171145dad98977a778e4effd3d7c9", size = 1506669, upload-time = "2026-06-23T13:41:34.143Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/75/094eb6c4633781ec12bf39ccb2364b9ee452c36a1d03068ac462ad30f492/xrouter_llm-0.1.1-py3-none-any.whl", hash = "sha256:d549ce76bb593aa01baab865347904277e073ea719b28f31fd900a4b0015dc35", size = 112760, upload-time = "2026-06-20T17:20:11.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/77/f4082e25dad8d123bd85173735e66dd547c34a43c39aa87e43713fbe83bd/xrouter_llm-0.1.2-py3-none-any.whl", hash = "sha256:df1b5c2f36c091b27f3e97355ba154c2bb0c5cfecac52b6ca3ec5e867041ada8", size = 116349, upload-time = "2026-06-23T13:41:32.776Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`xrouter-llm` (and its runtime dep `sentence-transformers`) were only listed under `[project.optional-dependencies].router` in `pyproject.toml`. The `Dockerfile.backend` runs:

```
uv sync --group backend-image
```

…which installs the `backend-image` dependency-group but **never activates the `router` extra**, so the published image ships without the in-process LLM router. Any attempt to use the OpenRouter `auto` model fails at runtime with an `ImportError`.

## Fix

- Add `xrouter-llm>=0.1.1` and `sentence-transformers>=3.0.0` to the `backend-image` dependency-group (alongside `torch`/`torchvision` that are already there).
- Back-fill the same two packages into the `all` optional-extra so `pip install xagent[all]` gets the router as well.
- Regenerate `uv.lock` to reflect the new entries.

## Test plan

- [ ] Build `Dockerfile.backend` and verify `python -c "from xrouter_llm import load_benchmark_profiles"` succeeds inside the image.
- [ ] Confirm `uv sync --group backend-image` on a clean env installs `xrouter-llm` and `sentence-transformers`.