### PR TITLE
feat:Implement concurrent sandbox execution with lease management

### DIFF
--- a/example.env
+++ b/example.env
@@ -390,6 +390,11 @@ ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 # Sandbox memory limit in MB (default: 512)
 # SANDBOX_MEMORY=""
 
+# Max concurrent worker sandboxes per user/task lifecycle. This only affects
+# sandboxed tools that explicitly opt into concurrency-safe execution.
+# Invalid/non-positive values fall back to the default.
+# XAGENT_SANDBOX_MAX_CONCURRENCY="3"
+
 # ===========================================
 # Sandbox Volume Mount Configuration
 # ===========================================

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -57,6 +57,7 @@ SANDBOX_ENV = "SANDBOX_ENV"
 SANDBOX_VOLUMES = "SANDBOX_VOLUMES"
 SANDBOX_HOST_PROJECT_ROOT = "XAGENT_SANDBOX_HOST_PROJECT_ROOT"
 SANDBOX_HOST_STORAGE_ROOT = "XAGENT_SANDBOX_HOST_STORAGE_ROOT"
+SANDBOX_MAX_CONCURRENCY = "XAGENT_SANDBOX_MAX_CONCURRENCY"
 BOXLITE_HOME_DIR = "BOXLITE_HOME_DIR"
 WEB_SEARCH_PROVIDER = "XAGENT_WEB_SEARCH_PROVIDER"
 WEB_CRAWL_TLS_IMPERSONATE = "XAGENT_WEB_CRAWL_TLS_IMPERSONATE"
@@ -875,6 +876,21 @@ def get_sandbox_image() -> str:
         Sandbox image name
     """
     return os.getenv(SANDBOX_IMAGE, "xprobe/xagent-sandbox:latest")
+
+
+def get_sandbox_max_concurrency() -> int:
+    """Maximum concurrent worker sandboxes per lifecycle.
+
+    Priority:
+        1. XAGENT_SANDBOX_MAX_CONCURRENCY environment variable
+        2. Default ``3`` to match the default tool batch width
+
+    Invalid or non-positive values fall back to the default.
+
+    Returns:
+        The per-lifecycle sandbox worker cap (>= 1).
+    """
+    return _get_positive_int_env(SANDBOX_MAX_CONCURRENCY, 3)
 
 
 def get_lancedb_path() -> Path:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -356,7 +356,8 @@ class ToolFactory:
                     create_workspace_in_sandbox,
                 )
 
-                await create_workspace_in_sandbox(sandbox, workspace)
+                setup_sandbox = getattr(sandbox, "primary_sandbox", sandbox)
+                await create_workspace_in_sandbox(setup_sandbox, workspace)
             tools = await ToolFactory._wrap_sandbox_tools(tools, sandbox)
 
         # Apply output filtering to all tools

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -12,7 +12,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Mapping, Optional, Type
+from typing import Any, Mapping, Optional, Type, cast
 
 import cloudpickle  # type: ignore[import-untyped]
 from pydantic import BaseModel
@@ -393,7 +393,7 @@ class SandboxedToolWrapper(AbstractBaseTool):
         """Get the sandbox for exec test"""
         async with self._lease_sandbox() as sandbox:
             await self._ensure_dependencies(sandbox)
-            return sandbox
+            return cast(Sandbox, sandbox)
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         """Synchronous execution (calls async version via asyncio.run)"""

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -42,6 +42,29 @@ SANDBOX_BASE_DEPENDENCIES = [
 ]
 
 
+class _StaticSandboxLease:
+    """Async context manager that exposes one fixed sandbox."""
+
+    def __init__(self, sandbox: Sandbox) -> None:
+        self._sandbox = sandbox
+
+    async def __aenter__(self) -> Sandbox:
+        return self._sandbox
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        return None
+
+
+def _is_sandbox_lease_provider(value: Any) -> bool:
+    """Return whether an object is a real sandbox lease provider."""
+    return callable(getattr(type(value), "lease", None))
+
+
 class SandboxDependencyManager:
     """Track incremental dependency installation per sandbox."""
 
@@ -213,14 +236,14 @@ class SandboxedToolWrapper(AbstractBaseTool):
     def __init__(
         self,
         target_tool: AbstractBaseTool,
-        sandbox: Sandbox,
+        sandbox: Any,
     ):
         """
         Initialize sandboxed tool wrapper
 
         Args:
             target_tool: Target tool to wrap
-            sandbox: Sandbox instance
+            sandbox: Sandbox instance or lease provider
         """
         self._target = target_tool
         self._sandbox = sandbox
@@ -292,11 +315,21 @@ class SandboxedToolWrapper(AbstractBaseTool):
 
         return env
 
-    async def _ensure_dependencies(self) -> None:
+    def _lease_sandbox(self) -> Any:
+        """Lease the sandbox that should execute this tool call."""
+        if _is_sandbox_lease_provider(self._sandbox):
+            return self._sandbox.lease(concurrency_safe=self.metadata.concurrency_safe)
+        return _StaticSandboxLease(self._sandbox)
+
+    async def _ensure_dependencies(self, sandbox: Sandbox | None = None) -> None:
         """Ensure dependencies are installed in the sandbox."""
-        await SandboxDependencyManager.ensure_requirements(
-            self._sandbox, self._requirements
-        )
+        if sandbox is None:
+            sandbox = (
+                self._sandbox.primary_sandbox
+                if _is_sandbox_lease_provider(self._sandbox)
+                else self._sandbox
+            )
+        await SandboxDependencyManager.ensure_requirements(sandbox, self._requirements)
 
     def _resolve_execution_spec(self) -> tuple[dict[str, str], Any]:
         """
@@ -358,8 +391,9 @@ class SandboxedToolWrapper(AbstractBaseTool):
 
     async def get_sandbox_for_test(self) -> Sandbox:
         """Get the sandbox for exec test"""
-        await self._ensure_dependencies()
-        return self._sandbox
+        async with self._lease_sandbox() as sandbox:
+            await self._ensure_dependencies(sandbox)
+            return sandbox
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         """Synchronous execution (calls async version via asyncio.run)"""
@@ -372,54 +406,57 @@ class SandboxedToolWrapper(AbstractBaseTool):
         result_file = f"/tmp/xagent_result_{uuid.uuid4().hex}.json"
 
         try:
-            # Ensure dependencies are installed
-            await self._ensure_dependencies()
+            async with self._lease_sandbox() as sandbox:
+                # Ensure dependencies are installed
+                await self._ensure_dependencies(sandbox)
 
-            # Execute script in sandbox
-            logger.debug(f"Executing tool {self._target.name} in sandbox")
-            command = self._build_execution_command(args, result_file)
-            result = await self._sandbox.exec(
-                command[0], *command[1:], env=self._build_execution_env()
-            )
-
-            # Check execution result
-            if result.exit_code != 0:
-                error_msg = result.stderr or result.error_message or "Unknown error"
-                logger.error(f"Tool execution failed: {error_msg}")
-                raise RuntimeError(f"Tool execution failed: {error_msg}")
-
-            # Read output from result file
-            output = ""
-            try:
-                read_result = await self._sandbox.exec("cat", result_file)
-                if read_result.exit_code != 0:
-                    logger.error(f"Failed to read result file: {read_result.stderr}")
-                    raise RuntimeError(
-                        f"Failed to read result file: {read_result.stderr}"
-                    )
-
-                output = read_result.stdout.strip()
-
-                # Handle empty output
-                if not output:
-                    return None
-
-                return json.loads(output)
-            except json.JSONDecodeError as e:
-                logger.error(
-                    f"Failed to parse tool output from {result_file}. Raw output:\n{output}"
+                # Execute script in sandbox
+                logger.debug(f"Executing tool {self._target.name} in sandbox")
+                command = self._build_execution_command(args, result_file)
+                result = await sandbox.exec(
+                    command[0], *command[1:], env=self._build_execution_env()
                 )
-                raise RuntimeError(f"Failed to parse tool output: {e}")
+
+                # Check execution result
+                if result.exit_code != 0:
+                    error_msg = result.stderr or result.error_message or "Unknown error"
+                    logger.error(f"Tool execution failed: {error_msg}")
+                    raise RuntimeError(f"Tool execution failed: {error_msg}")
+
+                # Read output from result file
+                output = ""
+                try:
+                    read_result = await sandbox.exec("cat", result_file)
+                    if read_result.exit_code != 0:
+                        logger.error(
+                            f"Failed to read result file: {read_result.stderr}"
+                        )
+                        raise RuntimeError(
+                            f"Failed to read result file: {read_result.stderr}"
+                        )
+
+                    output = read_result.stdout.strip()
+
+                    # Handle empty output
+                    if not output:
+                        return None
+
+                    return json.loads(output)
+                except json.JSONDecodeError as e:
+                    logger.error(
+                        f"Failed to parse tool output from {result_file}. Raw output:\n{output}"
+                    )
+                    raise RuntimeError(f"Failed to parse tool output: {e}")
+                finally:
+                    # Clean up result file
+                    try:
+                        await sandbox.exec("rm", "-f", result_file)
+                    except Exception:
+                        pass
 
         except Exception as e:
             logger.error(f"Error executing tool in sandbox: {e}", exc_info=True)
             raise
-        finally:
-            # Clean up result file
-            try:
-                await self._sandbox.exec("rm", "-f", result_file)
-            except Exception:
-                pass
 
 
 async def create_sandboxed_tool(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -584,6 +584,7 @@ class AgentServiceManager:
         # task_id-keyed cache must not silently hand back an instance built
         # under a different user (e.g. once built with the wrong identity).
         self._agent_owner_ids: Dict[int, Optional[int]] = {}
+        self._agent_sandbox_keys: Dict[int, str] = {}
         self._sandboxes: Dict[str, Any] = {}  # lifecycle scope -> Sandbox instance
         self._sandbox_active_tasks: Dict[str, int] = {}
         self._sandbox_active_tasks_lock = asyncio.Lock()
@@ -598,6 +599,12 @@ class AgentServiceManager:
         except (TypeError, ValueError):
             return None
 
+        sandbox_key = self._agent_sandbox_keys.get(task_key)
+        if sandbox_key is not None:
+            if sandbox_key not in self._sandboxes:
+                return None
+            return sandbox_key
+
         owner_id = self._agent_owner_ids.get(task_key)
         if owner_id is None:
             return None
@@ -608,21 +615,92 @@ class AgentServiceManager:
         return sandbox_key
 
     async def _acquire_sandbox_task(self, task_id: Optional[str]) -> Optional[str]:
-        sandbox_key = self._sandbox_key_for_task(task_id)
-        if sandbox_key is None:
-            return None
-
         async with self._sandbox_active_tasks_lock:
+            sandbox_key = self._sandbox_key_for_task(task_id)
+            if sandbox_key is None:
+                return None
             self._sandbox_active_tasks[sandbox_key] = (
                 self._sandbox_active_tasks.get(sandbox_key, 0) + 1
             )
         return sandbox_key
 
+    def _evict_agents_for_sandbox(self, sandbox_key: str) -> None:
+        """Drop cached AgentService objects that were built with this sandbox."""
+        task_ids = {
+            task_key
+            for task_key, agent_sandbox_key in self._agent_sandbox_keys.items()
+            if agent_sandbox_key == sandbox_key
+        }
+
+        if sandbox_key.startswith("user:"):
+            try:
+                owner_id = int(sandbox_key.split(":", 1)[1])
+            except ValueError:
+                owner_id = None
+            if owner_id is not None:
+                for task_key, agent_owner_id in self._agent_owner_ids.items():
+                    if agent_owner_id != owner_id:
+                        continue
+                    agent_sandbox_key = self._agent_sandbox_keys.get(task_key)
+                    if agent_sandbox_key is None or agent_sandbox_key == sandbox_key:
+                        task_ids.add(task_key)
+
+        for task_key in task_ids:
+            self._agents.pop(task_key, None)
+            self._agent_owner_ids.pop(task_key, None)
+            self._agent_sandbox_keys.pop(task_key, None)
+            logger.info(
+                "Evicted cached AgentService for task %s after releasing sandbox %s",
+                task_key,
+                sandbox_key,
+            )
+
+    async def _get_or_create_task_sandbox(
+        self,
+        *,
+        task_id: int,
+        workspace_owner_id: int,
+        workspace_config: Mapping[str, Any],
+    ) -> Any | None:
+        sandbox_key = f"user:{workspace_owner_id}"
+
+        async with self._sandbox_active_tasks_lock:
+            sandbox = self._sandboxes.get(sandbox_key)
+            if sandbox is not None:
+                self._agent_sandbox_keys[task_id] = sandbox_key
+                return sandbox
+
+            from ..sandbox_manager import get_sandbox_manager
+
+            sandbox_mgr = get_sandbox_manager()
+            if not sandbox_mgr:
+                self._agent_sandbox_keys.pop(task_id, None)
+                return None
+
+            try:
+                sandbox = await sandbox_mgr.create_lease_provider(
+                    "user",
+                    str(workspace_owner_id),
+                    workspace_config=workspace_config,
+                )
+            except Exception as e:
+                self._agent_sandbox_keys.pop(task_id, None)
+                logger.warning(
+                    "Sandbox creation failed for workspace owner %s, "
+                    "falling back to local execution: %s",
+                    workspace_owner_id,
+                    e,
+                )
+                return None
+
+            self._sandboxes[sandbox_key] = sandbox
+            self._agent_sandbox_keys[task_id] = sandbox_key
+            return sandbox
+
     async def _release_sandbox_task(self, sandbox_key: Optional[str]) -> None:
         if sandbox_key is None:
             return
 
-        provider = None
         async with self._sandbox_active_tasks_lock:
             active_count = self._sandbox_active_tasks.get(sandbox_key, 0)
             if active_count > 1:
@@ -630,20 +708,23 @@ class AgentServiceManager:
                 return
 
             self._sandbox_active_tasks.pop(sandbox_key, None)
-            provider = self._sandboxes.get(sandbox_key)
+            provider = self._sandboxes.pop(sandbox_key, None)
+            self._evict_agents_for_sandbox(sandbox_key)
 
-        cleanup_workers = getattr(provider, "cleanup_worker_sandboxes", None)
-        if cleanup_workers is None:
-            return
+            # Keep the lifecycle lock through cleanup so a new provider cannot
+            # create same-named worker sandboxes while the old provider deletes.
+            cleanup_workers = getattr(provider, "cleanup_worker_sandboxes", None)
+            if cleanup_workers is None:
+                return
 
-        try:
-            await cleanup_workers()
-        except Exception as exc:
-            logger.warning(
-                "Failed to cleanup sandbox workers for %s: %s",
-                sandbox_key,
-                exc,
-            )
+            try:
+                await cleanup_workers()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to cleanup sandbox workers for %s: %s",
+                    sandbox_key,
+                    exc,
+                )
 
     def _get_task_llm_ids(self, task: Task, db: Session) -> List[Optional[str]]:
         """Return internal model_id identifiers for a task (never provider model_name)."""
@@ -1044,25 +1125,11 @@ class AgentServiceManager:
             "allowed_external_dirs": _build_allowed_external_dirs(workspace_owner_id),
         }
 
-        sandbox_key = f"user:{workspace_owner_id}"
-        sandbox = self._sandboxes.get(sandbox_key)
-        if sandbox is None:
-            from ..sandbox_manager import get_sandbox_manager
-
-            sandbox_mgr = get_sandbox_manager()
-            if sandbox_mgr:
-                try:
-                    sandbox = await sandbox_mgr.create_lease_provider(
-                        "user",
-                        str(workspace_owner_id),
-                        workspace_config=sandbox_workspace_config,
-                    )
-                    self._sandboxes[sandbox_key] = sandbox
-                except Exception as e:
-                    logger.warning(
-                        f"Sandbox creation failed for workspace owner {workspace_owner_id}, "
-                        f"falling back to local execution: {e}"
-                    )
+        sandbox = await self._get_or_create_task_sandbox(
+            task_id=task_id,
+            workspace_owner_id=workspace_owner_id,
+            workspace_config=sandbox_workspace_config,
+        )
 
         return await create_default_tools(
             db,
@@ -1184,6 +1251,7 @@ class AgentServiceManager:
                 )
             del self._agents[task_id]
             self._agent_owner_ids.pop(task_id, None)
+            self._agent_sandbox_keys.pop(task_id, None)
 
         if task_id not in self._agents:
             # Check if task exists in database
@@ -1275,6 +1343,7 @@ class AgentServiceManager:
                             )
                             del self._agents[task_id]
                             self._agent_owner_ids.pop(task_id, None)
+                            self._agent_sandbox_keys.pop(task_id, None)
                         # Continue with normal agent creation
 
             # Create tracer with all necessary handlers
@@ -1509,27 +1578,11 @@ class AgentServiceManager:
                     ),
                 }
 
-                # Get or create owner sandbox for run task tools
-                sandbox_key = f"user:{workspace_owner_id}"
-                sandbox = self._sandboxes.get(sandbox_key)
-                if sandbox is None:
-                    from ..sandbox_manager import get_sandbox_manager
-
-                    sandbox_mgr = get_sandbox_manager()
-                    if sandbox_mgr:
-                        try:
-                            sandbox = await sandbox_mgr.create_lease_provider(
-                                "user",
-                                str(workspace_owner_id),
-                                workspace_config=sandbox_workspace_config,
-                            )
-                            self._sandboxes[sandbox_key] = sandbox
-                        except Exception as e:
-                            # Graceful degradation: tools will run locally without sandbox
-                            logger.warning(
-                                f"Sandbox creation failed for workspace owner {workspace_owner_id}, "
-                                f"falling back to local execution: {e}"
-                            )
+                sandbox = await self._get_or_create_task_sandbox(
+                    task_id=task_id,
+                    workspace_owner_id=workspace_owner_id,
+                    workspace_config=sandbox_workspace_config,
+                )
 
                 tool_selection_spec = _build_tool_selection_spec_for_task(
                     agent_config, workforce_runtime, task_id=task_id
@@ -1725,6 +1778,7 @@ class AgentServiceManager:
 
             del self._agents[task_id]
             self._agent_owner_ids.pop(task_id, None)
+            self._agent_sandbox_keys.pop(task_id, None)
             logger.info(f"Removed AgentService for task {task_id}")
         else:
             # If agent is not in memory, clean up workspace directory directly

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -995,7 +995,7 @@ class AgentServiceManager:
             sandbox_mgr = get_sandbox_manager()
             if sandbox_mgr:
                 try:
-                    sandbox = await sandbox_mgr.get_or_create_sandbox(
+                    sandbox = await sandbox_mgr.create_lease_provider(
                         "user",
                         str(workspace_owner_id),
                         workspace_config=sandbox_workspace_config,
@@ -1461,7 +1461,7 @@ class AgentServiceManager:
                     sandbox_mgr = get_sandbox_manager()
                     if sandbox_mgr:
                         try:
-                            sandbox = await sandbox_mgr.get_or_create_sandbox(
+                            sandbox = await sandbox_mgr.create_lease_provider(
                                 "user",
                                 str(workspace_owner_id),
                                 workspace_config=sandbox_workspace_config,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -585,8 +585,65 @@ class AgentServiceManager:
         # under a different user (e.g. once built with the wrong identity).
         self._agent_owner_ids: Dict[int, Optional[int]] = {}
         self._sandboxes: Dict[str, Any] = {}  # lifecycle scope -> Sandbox instance
+        self._sandbox_active_tasks: Dict[str, int] = {}
+        self._sandbox_active_tasks_lock = asyncio.Lock()
         self._default_llm = create_default_llm()
         self.request = request
+
+    def _sandbox_key_for_task(self, task_id: Optional[str]) -> Optional[str]:
+        if task_id is None:
+            return None
+        try:
+            task_key = int(task_id)
+        except (TypeError, ValueError):
+            return None
+
+        owner_id = self._agent_owner_ids.get(task_key)
+        if owner_id is None:
+            return None
+
+        sandbox_key = f"user:{owner_id}"
+        if sandbox_key not in self._sandboxes:
+            return None
+        return sandbox_key
+
+    async def _acquire_sandbox_task(self, task_id: Optional[str]) -> Optional[str]:
+        sandbox_key = self._sandbox_key_for_task(task_id)
+        if sandbox_key is None:
+            return None
+
+        async with self._sandbox_active_tasks_lock:
+            self._sandbox_active_tasks[sandbox_key] = (
+                self._sandbox_active_tasks.get(sandbox_key, 0) + 1
+            )
+        return sandbox_key
+
+    async def _release_sandbox_task(self, sandbox_key: Optional[str]) -> None:
+        if sandbox_key is None:
+            return
+
+        provider = None
+        async with self._sandbox_active_tasks_lock:
+            active_count = self._sandbox_active_tasks.get(sandbox_key, 0)
+            if active_count > 1:
+                self._sandbox_active_tasks[sandbox_key] = active_count - 1
+                return
+
+            self._sandbox_active_tasks.pop(sandbox_key, None)
+            provider = self._sandboxes.get(sandbox_key)
+
+        cleanup_workers = getattr(provider, "cleanup_worker_sandboxes", None)
+        if cleanup_workers is None:
+            return
+
+        try:
+            await cleanup_workers()
+        except Exception as exc:
+            logger.warning(
+                "Failed to cleanup sandbox workers for %s: %s",
+                sandbox_key,
+                exc,
+            )
 
     def _get_task_llm_ids(self, task: Task, db: Session) -> List[Optional[str]]:
         """Return internal model_id identifiers for a task (never provider model_name)."""
@@ -1707,6 +1764,7 @@ class AgentServiceManager:
         lease_stop_event = None
         lease_heartbeat_task = None
         result: Dict[str, Any] | None = None
+        sandbox_task_key = None
         if db_session and tracker_task_id:
             lease = acquire_task_lease(db_session, int(tracker_task_id))
             if lease is None:
@@ -1749,6 +1807,7 @@ class AgentServiceManager:
                 )
                 tracker = None
 
+        sandbox_task_key = await self._acquire_sandbox_task(tracker_task_id)
         try:
             logger.info(
                 f"=== About to execute task: task_id={task_id}, has_db_session={db_session is not None} ==="
@@ -1795,6 +1854,7 @@ class AgentServiceManager:
                     logger.error(
                         f"Failed to complete token tracking for task {tracker_task_id}: {e}"
                     )
+            await self._release_sandbox_task(sandbox_task_key)
 
     def _cleanup_workspace_directory(
         self, task_id: int, user_id: Optional[int] = None

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -84,6 +84,14 @@ chat_router = APIRouter(prefix="/api/chat", tags=["chat"])
 _TERMINAL_CACHE_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
 
 
+@dataclass
+class _SandboxLifecycleLock:
+    """Per-sandbox lifecycle lock with waiter/holder tracking."""
+
+    lock: asyncio.Lock
+    ref_count: int = 0
+
+
 def _build_task_agent_config(
     request_agent_config: Optional[Dict[str, Any]],
     selected_file_ids: list[str],
@@ -588,8 +596,51 @@ class AgentServiceManager:
         self._sandboxes: Dict[str, Any] = {}  # lifecycle scope -> Sandbox instance
         self._sandbox_active_tasks: Dict[str, int] = {}
         self._sandbox_active_tasks_lock = asyncio.Lock()
+        self._sandbox_lifecycle_locks: Dict[str, _SandboxLifecycleLock] = {}
         self._default_llm = create_default_llm()
         self.request = request
+
+    async def _acquire_sandbox_lifecycle_lock(
+        self, sandbox_key: str
+    ) -> _SandboxLifecycleLock:
+        async with self._sandbox_active_tasks_lock:
+            lifecycle_lock = self._sandbox_lifecycle_locks.get(sandbox_key)
+            if lifecycle_lock is None:
+                lifecycle_lock = _SandboxLifecycleLock(lock=asyncio.Lock())
+                self._sandbox_lifecycle_locks[sandbox_key] = lifecycle_lock
+            lifecycle_lock.ref_count += 1
+
+        try:
+            await lifecycle_lock.lock.acquire()
+        except BaseException:
+            async with self._sandbox_active_tasks_lock:
+                lifecycle_lock.ref_count -= 1
+                self._drop_sandbox_lifecycle_lock_if_unused_locked(
+                    sandbox_key, lifecycle_lock
+                )
+            raise
+
+        return lifecycle_lock
+
+    async def _release_sandbox_lifecycle_lock(
+        self, sandbox_key: str, lifecycle_lock: _SandboxLifecycleLock
+    ) -> None:
+        lifecycle_lock.lock.release()
+        async with self._sandbox_active_tasks_lock:
+            lifecycle_lock.ref_count -= 1
+            self._drop_sandbox_lifecycle_lock_if_unused_locked(
+                sandbox_key, lifecycle_lock
+            )
+
+    def _drop_sandbox_lifecycle_lock_if_unused_locked(
+        self, sandbox_key: str, lifecycle_lock: _SandboxLifecycleLock
+    ) -> None:
+        if lifecycle_lock.ref_count > 0:
+            return
+        if sandbox_key in self._sandboxes or sandbox_key in self._sandbox_active_tasks:
+            return
+        if self._sandbox_lifecycle_locks.get(sandbox_key) is lifecycle_lock:
+            self._sandbox_lifecycle_locks.pop(sandbox_key, None)
 
     def _sandbox_key_for_task(self, task_id: Optional[str]) -> Optional[str]:
         if task_id is None:
@@ -664,17 +715,20 @@ class AgentServiceManager:
     ) -> Any | None:
         sandbox_key = f"user:{workspace_owner_id}"
 
-        async with self._sandbox_active_tasks_lock:
-            sandbox = self._sandboxes.get(sandbox_key)
-            if sandbox is not None:
-                self._agent_sandbox_keys[task_id] = sandbox_key
-                return sandbox
+        lifecycle_lock = await self._acquire_sandbox_lifecycle_lock(sandbox_key)
+        try:
+            async with self._sandbox_active_tasks_lock:
+                sandbox = self._sandboxes.get(sandbox_key)
+                if sandbox is not None:
+                    self._agent_sandbox_keys[task_id] = sandbox_key
+                    return sandbox
 
             from ..sandbox_manager import get_sandbox_manager
 
             sandbox_mgr = get_sandbox_manager()
             if not sandbox_mgr:
-                self._agent_sandbox_keys.pop(task_id, None)
+                async with self._sandbox_active_tasks_lock:
+                    self._agent_sandbox_keys.pop(task_id, None)
                 return None
 
             try:
@@ -684,7 +738,8 @@ class AgentServiceManager:
                     workspace_config=workspace_config,
                 )
             except Exception as e:
-                self._agent_sandbox_keys.pop(task_id, None)
+                async with self._sandbox_active_tasks_lock:
+                    self._agent_sandbox_keys.pop(task_id, None)
                 logger.warning(
                     "Sandbox creation failed for workspace owner %s, "
                     "falling back to local execution: %s",
@@ -693,26 +748,32 @@ class AgentServiceManager:
                 )
                 return None
 
-            self._sandboxes[sandbox_key] = sandbox
-            self._agent_sandbox_keys[task_id] = sandbox_key
+            async with self._sandbox_active_tasks_lock:
+                self._sandboxes[sandbox_key] = sandbox
+                self._agent_sandbox_keys[task_id] = sandbox_key
             return sandbox
+        finally:
+            await self._release_sandbox_lifecycle_lock(sandbox_key, lifecycle_lock)
 
     async def _release_sandbox_task(self, sandbox_key: Optional[str]) -> None:
         if sandbox_key is None:
             return
 
-        async with self._sandbox_active_tasks_lock:
-            active_count = self._sandbox_active_tasks.get(sandbox_key, 0)
-            if active_count > 1:
-                self._sandbox_active_tasks[sandbox_key] = active_count - 1
-                return
+        lifecycle_lock = await self._acquire_sandbox_lifecycle_lock(sandbox_key)
+        try:
+            async with self._sandbox_active_tasks_lock:
+                active_count = self._sandbox_active_tasks.get(sandbox_key, 0)
+                if active_count > 1:
+                    self._sandbox_active_tasks[sandbox_key] = active_count - 1
+                    return
 
-            self._sandbox_active_tasks.pop(sandbox_key, None)
-            provider = self._sandboxes.pop(sandbox_key, None)
-            self._evict_agents_for_sandbox(sandbox_key)
+                self._sandbox_active_tasks.pop(sandbox_key, None)
+                provider = self._sandboxes.pop(sandbox_key, None)
+                self._evict_agents_for_sandbox(sandbox_key)
 
-            # Keep the lifecycle lock through cleanup so a new provider cannot
-            # create same-named worker sandboxes while the old provider deletes.
+            # Keep the per-sandbox lifecycle lock through cleanup so a new
+            # provider cannot create same-named worker sandboxes while the old
+            # provider deletes them. Other sandbox keys can proceed.
             cleanup_workers = getattr(provider, "cleanup_worker_sandboxes", None)
             if cleanup_workers is None:
                 return
@@ -725,6 +786,8 @@ class AgentServiceManager:
                     sandbox_key,
                     exc,
                 )
+        finally:
+            await self._release_sandbox_lifecycle_lock(sandbox_key, lifecycle_lock)
 
     def _get_task_llm_ids(self, task: Task, db: Session) -> List[Optional[str]]:
         """Return internal model_id identifiers for a task (never provider model_name)."""

--- a/src/xagent/web/sandbox_manager.py
+++ b/src/xagent/web/sandbox_manager.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 
 from ..config import (
     get_boxlite_home_dir,
+    get_sandbox_max_concurrency,
     get_sandbox_cpus,
     get_sandbox_env,
     get_sandbox_host_storage_root,
@@ -28,6 +29,102 @@ from ..sandbox import SandboxService
 from ..sandbox.base import Sandbox, SandboxConfig, SandboxTemplate
 
 logger = logging.getLogger(__name__)
+
+
+class SandboxLease:
+    """Async context manager for one leased sandbox execution slot."""
+
+    def __init__(
+        self,
+        provider: "SandboxLeaseProvider",
+        *,
+        concurrency_safe: bool,
+    ) -> None:
+        self._provider = provider
+        self._concurrency_safe = concurrency_safe
+        self._slot: int | None = None
+        self._sandbox: Sandbox | None = None
+
+    async def __aenter__(self) -> Sandbox:
+        if not self._concurrency_safe:
+            self._sandbox = self._provider.primary_sandbox
+            return self._sandbox
+
+        self._slot = await self._provider.acquire_worker_slot()
+        try:
+            self._sandbox = await self._provider.get_worker_sandbox(self._slot)
+            return self._sandbox
+        except Exception:
+            await self._provider.release_worker_slot(self._slot)
+            self._slot = None
+            raise
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        if self._slot is not None:
+            await self._provider.release_worker_slot(self._slot)
+            self._slot = None
+        self._sandbox = None
+
+
+class SandboxLeaseProvider:
+    """Lease primary or worker sandboxes for sandboxed tool execution."""
+
+    def __init__(
+        self,
+        *,
+        manager: "SandboxManager",
+        lifecycle_type: str,
+        lifecycle_id: str,
+        primary_sandbox: Sandbox,
+        workspace_config: Mapping[str, Any] | None,
+        max_concurrency: int,
+    ) -> None:
+        self._manager = manager
+        self._lifecycle_type = lifecycle_type
+        self._lifecycle_id = lifecycle_id
+        self._workspace_config = workspace_config
+        self._available_slots: asyncio.Queue[int] = asyncio.Queue()
+        self._worker_locks: dict[int, asyncio.Lock] = {}
+        self._workers: dict[int, Sandbox] = {}
+        self.primary_sandbox = primary_sandbox
+        for slot in range(max(1, max_concurrency)):
+            self._available_slots.put_nowait(slot)
+
+    def lease(self, *, concurrency_safe: bool) -> SandboxLease:
+        """Return an async context manager for the requested execution mode."""
+        return SandboxLease(self, concurrency_safe=concurrency_safe)
+
+    async def acquire_worker_slot(self) -> int:
+        """Reserve one worker slot, waiting when all workers are busy."""
+        return await self._available_slots.get()
+
+    async def release_worker_slot(self, slot: int) -> None:
+        """Return a worker slot to the provider."""
+        self._available_slots.put_nowait(slot)
+
+    async def get_worker_sandbox(self, slot: int) -> Sandbox:
+        """Get or lazily create a worker sandbox for a slot."""
+        if slot in self._workers:
+            return self._workers[slot]
+
+        if slot not in self._worker_locks:
+            self._worker_locks[slot] = asyncio.Lock()
+
+        async with self._worker_locks[slot]:
+            if slot in self._workers:
+                return self._workers[slot]
+            worker = await self._manager.get_or_create_sandbox(
+                self._lifecycle_type,
+                f"{self._lifecycle_id}::worker::{slot}",
+                workspace_config=self._workspace_config,
+            )
+            self._workers[slot] = worker
+            return worker
 
 
 class SandboxPathMapper:
@@ -358,6 +455,28 @@ class SandboxManager:
             self._config_cache[sandbox_name] = config
             return sandbox
 
+    async def create_lease_provider(
+        self,
+        lifecycle_type: str,
+        lifecycle_id: str,
+        *,
+        workspace_config: Mapping[str, Any] | None = None,
+    ) -> SandboxLeaseProvider:
+        """Create a lease provider for primary and worker sandboxes."""
+        primary = await self.get_or_create_sandbox(
+            lifecycle_type,
+            lifecycle_id,
+            workspace_config=workspace_config,
+        )
+        return SandboxLeaseProvider(
+            manager=self,
+            lifecycle_type=lifecycle_type,
+            lifecycle_id=lifecycle_id,
+            primary_sandbox=primary,
+            workspace_config=workspace_config,
+            max_concurrency=get_sandbox_max_concurrency(),
+        )
+
     async def delete_sandbox(self, lifecycle_type: str, lifecycle_id: str) -> None:
         """
         Delete sandbox.
@@ -367,17 +486,26 @@ class SandboxManager:
             lifecycle_id: e.g. task_id|user_id
         """
         sandbox_name = self.make_sandbox_name(lifecycle_type, lifecycle_id)
-        try:
-            await self._service.delete(sandbox_name)
-            logger.debug(f"Sandbox deleted: {sandbox_name}")
-        except Exception as e:
-            logger.error(f"Failed to delete sandbox {sandbox_name}: {e}")
-        finally:
-            # Always evict from cache — even on failure the instance
-            # may be in an unknown state and should be recreated.
-            self._cache.pop(sandbox_name, None)
-            self._config_cache.pop(sandbox_name, None)
-            self._locks.pop(sandbox_name, None)
+        worker_prefix = f"{sandbox_name}::worker::"
+        sandbox_names = {
+            name
+            for name in self._cache
+            if name == sandbox_name or name.startswith(worker_prefix)
+        }
+        sandbox_names.add(sandbox_name)
+
+        for name in sorted(sandbox_names):
+            try:
+                await self._service.delete(name)
+                logger.debug(f"Sandbox deleted: {name}")
+            except Exception as e:
+                logger.error(f"Failed to delete sandbox {name}: {e}")
+            finally:
+                # Always evict from cache — even on failure the instance
+                # may be in an unknown state and should be recreated.
+                self._cache.pop(name, None)
+                self._config_cache.pop(name, None)
+                self._locks.pop(name, None)
 
     async def warmup(self) -> None:
         """

--- a/src/xagent/web/sandbox_manager.py
+++ b/src/xagent/web/sandbox_manager.py
@@ -12,11 +12,11 @@ from typing import Any, Optional
 
 from ..config import (
     get_boxlite_home_dir,
-    get_sandbox_max_concurrency,
     get_sandbox_cpus,
     get_sandbox_env,
     get_sandbox_host_storage_root,
     get_sandbox_image,
+    get_sandbox_max_concurrency,
     get_sandbox_memory,
     get_sandbox_volumes,
     get_storage_root,

--- a/src/xagent/web/sandbox_manager.py
+++ b/src/xagent/web/sandbox_manager.py
@@ -30,6 +30,8 @@ from ..sandbox.base import Sandbox, SandboxConfig, SandboxTemplate
 
 logger = logging.getLogger(__name__)
 
+_WORKER_LIFECYCLE_MARKER = "::worker::"
+
 
 class SandboxLease:
     """Async context manager for one leased sandbox execution slot."""
@@ -125,6 +127,14 @@ class SandboxLeaseProvider:
             )
             self._workers[slot] = worker
             return worker
+
+    async def cleanup_worker_sandboxes(self) -> None:
+        """Delete worker sandboxes while keeping the primary sandbox cached."""
+        await self._manager.delete_worker_sandboxes(
+            self._lifecycle_type,
+            self._lifecycle_id,
+        )
+        self._workers.clear()
 
 
 class SandboxPathMapper:
@@ -232,6 +242,18 @@ class SandboxManager:
             raise ValueError(f"Invalid sandbox name format: {name!r}")
         return parts[0], parts[1]
 
+    @staticmethod
+    def _base_lifecycle_id(lifecycle_id: str) -> str:
+        """Return the owner lifecycle id for primary and worker sandboxes."""
+        return lifecycle_id.split(_WORKER_LIFECYCLE_MARKER, 1)[0]
+
+    @classmethod
+    def _worker_sandbox_prefix(cls, lifecycle_type: str, lifecycle_id: str) -> str:
+        return (
+            cls.make_sandbox_name(lifecycle_type, lifecycle_id)
+            + _WORKER_LIFECYCLE_MARKER
+        )
+
     def _get_sandbox_image_and_config(self) -> tuple[str, SandboxConfig]:
         """Get sandbox image and configuration from centralized config module."""
         image = get_sandbox_image()
@@ -285,7 +307,8 @@ class SandboxManager:
             for raw_dir in workspace_config.get("allowed_external_dirs") or []:
                 paths.append((Path(str(raw_dir)), False))
         elif lifecycle_type == "user":
-            paths.append((get_uploads_dir() / f"user_{lifecycle_id}", True))
+            owner_lifecycle_id = SandboxManager._base_lifecycle_id(lifecycle_id)
+            paths.append((get_uploads_dir() / f"user_{owner_lifecycle_id}", True))
 
         return paths
 
@@ -485,15 +508,61 @@ class SandboxManager:
             lifecycle_type: e.g. task|user
             lifecycle_id: e.g. task_id|user_id
         """
+        sandbox_names = await self._find_lifecycle_sandbox_names(
+            lifecycle_type,
+            lifecycle_id,
+            include_primary=True,
+            include_workers=True,
+        )
+        await self._delete_sandbox_names(sandbox_names)
+
+    async def delete_worker_sandboxes(
+        self, lifecycle_type: str, lifecycle_id: str
+    ) -> None:
+        """Delete worker sandboxes for a lifecycle while preserving the primary."""
+        sandbox_names = await self._find_lifecycle_sandbox_names(
+            lifecycle_type,
+            lifecycle_id,
+            include_primary=False,
+            include_workers=True,
+        )
+        await self._delete_sandbox_names(sandbox_names)
+
+    async def _find_lifecycle_sandbox_names(
+        self,
+        lifecycle_type: str,
+        lifecycle_id: str,
+        *,
+        include_primary: bool,
+        include_workers: bool,
+    ) -> set[str]:
         sandbox_name = self.make_sandbox_name(lifecycle_type, lifecycle_id)
-        worker_prefix = f"{sandbox_name}::worker::"
+        worker_prefix = self._worker_sandbox_prefix(lifecycle_type, lifecycle_id)
         sandbox_names = {
             name
             for name in self._cache
-            if name == sandbox_name or name.startswith(worker_prefix)
+            if (include_primary and name == sandbox_name)
+            or (include_workers and name.startswith(worker_prefix))
         }
-        sandbox_names.add(sandbox_name)
+        if include_primary:
+            sandbox_names.add(sandbox_name)
 
+        try:
+            listed_sandboxes = await self._service.list_sandboxes()
+        except Exception as exc:
+            logger.warning("Failed to list sandboxes for cleanup: %s", exc)
+            return sandbox_names
+
+        for sb in listed_sandboxes or []:
+            name = sb.name
+            if include_primary and name == sandbox_name:
+                sandbox_names.add(name)
+            elif include_workers and name.startswith(worker_prefix):
+                sandbox_names.add(name)
+
+        return sandbox_names
+
+    async def _delete_sandbox_names(self, sandbox_names: set[str]) -> None:
         for name in sorted(sandbox_names):
             try:
                 await self._service.delete(name)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1229,3 +1229,27 @@ class TestToolConcurrencyConfig:
         assert get_tool_max_concurrency() == 3
         monkeypatch.setenv("XAGENT_TOOL_MAX_CONCURRENCY", "0")
         assert get_tool_max_concurrency() == 3
+
+
+class TestSandboxConcurrencyConfig:
+    """Config for sandbox worker concurrency."""
+
+    def test_sandbox_max_concurrency_default_is_three(self, monkeypatch):
+        from xagent.config import get_sandbox_max_concurrency
+
+        monkeypatch.delenv("XAGENT_SANDBOX_MAX_CONCURRENCY", raising=False)
+        assert get_sandbox_max_concurrency() == 3
+
+    def test_sandbox_max_concurrency_env_override(self, monkeypatch):
+        from xagent.config import get_sandbox_max_concurrency
+
+        monkeypatch.setenv("XAGENT_SANDBOX_MAX_CONCURRENCY", "5")
+        assert get_sandbox_max_concurrency() == 5
+
+    def test_sandbox_max_concurrency_invalid_falls_back_to_default(self, monkeypatch):
+        from xagent.config import get_sandbox_max_concurrency
+
+        monkeypatch.setenv("XAGENT_SANDBOX_MAX_CONCURRENCY", "not-a-number")
+        assert get_sandbox_max_concurrency() == 3
+        monkeypatch.setenv("XAGENT_SANDBOX_MAX_CONCURRENCY", "0")
+        assert get_sandbox_max_concurrency() == 3

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_tool_lease_provider.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_tool_lease_provider.py
@@ -1,0 +1,118 @@
+"""Unit tests for SandboxedToolWrapper sandbox lease selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.core.tools.adapters.sandboxed_tool.conftest import FakeBaseTool
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandbox_config import (
+    sandbox_config,
+)
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
+    SandboxedToolWrapper,
+)
+
+
+@dataclass
+class FakeExecResult:
+    exit_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+    error_message: str = ""
+
+
+class FakeSandbox:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.exec_calls: list[tuple[str, tuple[str, ...]]] = []
+
+    async def exec(self, command: str, *args: str, env: dict[str, str] | None = None):
+        self.exec_calls.append((command, args))
+        if command == "cat":
+            return FakeExecResult(stdout=f'{{"sandbox": "{self.name}"}}')
+        return FakeExecResult()
+
+
+class FakeLease:
+    def __init__(self, sandbox: FakeSandbox) -> None:
+        self._sandbox = sandbox
+
+    async def __aenter__(self) -> FakeSandbox:
+        return self._sandbox
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        return None
+
+
+class FakeLeaseProvider:
+    def __init__(self, *, primary: FakeSandbox, worker: FakeSandbox) -> None:
+        self.primary = primary
+        self.worker = worker
+        self.lease_calls: list[bool] = []
+
+    def lease(self, *, concurrency_safe: bool) -> FakeLease:
+        self.lease_calls.append(concurrency_safe)
+        return FakeLease(self.worker if concurrency_safe else self.primary)
+
+
+@sandbox_config()
+class UnsafeSandboxTool(FakeBaseTool):
+    @property
+    def name(self) -> str:
+        return "unsafe_sandbox_tool"
+
+
+@sandbox_config()
+class SafeSandboxTool(FakeBaseTool):
+    concurrency_safe = True
+
+    @property
+    def name(self) -> str:
+        return "safe_sandbox_tool"
+
+
+@pytest.mark.asyncio
+async def test_safe_tool_executes_through_worker_sandbox() -> None:
+    primary = FakeSandbox("primary")
+    worker = FakeSandbox("worker")
+    provider = FakeLeaseProvider(primary=primary, worker=worker)
+    wrapper = SandboxedToolWrapper(SafeSandboxTool(), provider)
+
+    with patch(
+        "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper."
+        "SandboxDependencyManager.ensure_requirements",
+        new=AsyncMock(),
+    ) as ensure_requirements:
+        result = await wrapper.run_json_async({"code": "print('ok')"})
+
+    assert result == {"sandbox": "worker"}
+    assert provider.lease_calls == [True]
+    ensure_requirements.assert_awaited_once()
+    assert ensure_requirements.await_args.args[0] is worker
+    assert primary.exec_calls == []
+    assert [call[0] for call in worker.exec_calls] == ["python", "cat", "rm"]
+
+
+@pytest.mark.asyncio
+async def test_unsafe_tool_executes_through_primary_sandbox() -> None:
+    primary = FakeSandbox("primary")
+    worker = FakeSandbox("worker")
+    provider = FakeLeaseProvider(primary=primary, worker=worker)
+    wrapper = SandboxedToolWrapper(UnsafeSandboxTool(), provider)
+
+    with patch(
+        "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper."
+        "SandboxDependencyManager.ensure_requirements",
+        new=AsyncMock(),
+    ) as ensure_requirements:
+        result = await wrapper.run_json_async({"code": "print('ok')"})
+
+    assert result == {"sandbox": "primary"}
+    assert provider.lease_calls == [False]
+    ensure_requirements.assert_awaited_once()
+    assert ensure_requirements.await_args.args[0] is primary
+    assert [call[0] for call in primary.exec_calls] == ["python", "cat", "rm"]
+    assert worker.exec_calls == []

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -29,6 +29,109 @@ class _FakeAgentService:
 
 
 @pytest.mark.asyncio
+async def test_worker_cleanup_does_not_block_other_users() -> None:
+    """Slow worker cleanup for one user must not serialize other users."""
+    manager = AgentServiceManager()
+    provider = AsyncMock()
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+
+    async def slow_cleanup() -> None:
+        cleanup_started.set()
+        await cleanup_release.wait()
+
+    provider.cleanup_worker_sandboxes.side_effect = slow_cleanup
+    manager._sandboxes["user:7"] = provider
+    manager._sandbox_active_tasks["user:7"] = 1
+    manager._sandboxes["user:8"] = AsyncMock()
+    manager._agent_owner_ids[2] = 8
+    manager._agent_sandbox_keys[2] = "user:8"
+
+    release_task = asyncio.create_task(manager._release_sandbox_task("user:7"))
+    await cleanup_started.wait()
+
+    try:
+        sandbox_key = await asyncio.wait_for(
+            manager._acquire_sandbox_task("2"),
+            timeout=0.05,
+        )
+    finally:
+        cleanup_release.set()
+        await release_task
+
+    assert sandbox_key == "user:8"
+    assert manager._sandbox_active_tasks["user:8"] == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_cleanup_removes_sandbox_lifecycle_lock_entry() -> None:
+    """Lifecycle lock entries should not leak after a provider is removed."""
+    manager = AgentServiceManager()
+    provider = AsyncMock()
+    manager._sandboxes["user:7"] = provider
+    manager._sandbox_active_tasks["user:7"] = 1
+
+    await manager._release_sandbox_task("user:7")
+
+    assert "user:7" not in manager._sandbox_lifecycle_locks
+
+
+@pytest.mark.asyncio
+async def test_worker_cleanup_blocks_same_user_provider_recreate(monkeypatch) -> None:
+    """The same user must not recreate same-named workers during cleanup."""
+    manager = AgentServiceManager()
+    old_provider = AsyncMock()
+    new_provider = AsyncMock()
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+    create_called = asyncio.Event()
+
+    async def slow_cleanup() -> None:
+        cleanup_started.set()
+        await cleanup_release.wait()
+
+    async def create_provider(*_args, **_kwargs):
+        create_called.set()
+        return new_provider
+
+    sandbox_mgr = AsyncMock()
+    sandbox_mgr.create_lease_provider.side_effect = create_provider
+    monkeypatch.setattr(
+        "xagent.web.sandbox_manager.get_sandbox_manager",
+        lambda: sandbox_mgr,
+    )
+
+    old_provider.cleanup_worker_sandboxes.side_effect = slow_cleanup
+    manager._sandboxes["user:7"] = old_provider
+    manager._sandbox_active_tasks["user:7"] = 1
+
+    release_task = asyncio.create_task(manager._release_sandbox_task("user:7"))
+    await cleanup_started.wait()
+
+    create_task = asyncio.create_task(
+        manager._get_or_create_task_sandbox(
+            task_id=3,
+            workspace_owner_id=7,
+            workspace_config={},
+        )
+    )
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(create_called.wait(), timeout=0.05)
+
+        cleanup_release.set()
+        sandbox = await asyncio.wait_for(create_task, timeout=0.5)
+        await release_task
+    finally:
+        cleanup_release.set()
+        await asyncio.gather(release_task, create_task, return_exceptions=True)
+
+    assert sandbox is new_provider
+    sandbox_mgr.create_lease_provider.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_execute_task_releases_sandbox_workers_after_task() -> None:
     """Terminal task execution should release cached worker sandboxes."""
     manager = AgentServiceManager()

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -33,17 +33,51 @@ async def test_execute_task_releases_sandbox_workers_after_task() -> None:
     """Terminal task execution should release cached worker sandboxes."""
     manager = AgentServiceManager()
     provider = AsyncMock()
+    agent_service = _FakeAgentService()
     manager._sandboxes["user:7"] = provider
+    manager._agents[1] = agent_service
     manager._agent_owner_ids[1] = 7
+    manager._agent_sandbox_keys[1] = "user:7"
 
     result = await manager.execute_task(
-        agent_service=_FakeAgentService(),
+        agent_service=agent_service,
         task="run",
         task_id="1",
     )
 
     assert result == {"success": True}
+    assert "user:7" not in manager._sandboxes
     provider.cleanup_worker_sandboxes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_evicts_agents_for_released_sandbox_provider() -> None:
+    """Cached agents must not retain a provider after its sandbox is released."""
+    manager = AgentServiceManager()
+    provider = AsyncMock()
+    agent_service = _FakeAgentService()
+    other_agent_service = _FakeAgentService()
+    manager._sandboxes["user:7"] = provider
+    manager._agents[1] = agent_service
+    manager._agents[2] = other_agent_service
+    manager._agent_owner_ids[1] = 7
+    manager._agent_owner_ids[2] = 7
+    manager._agent_sandbox_keys[1] = "user:7"
+    manager._agent_sandbox_keys[2] = "user:7"
+
+    await manager.execute_task(
+        agent_service=agent_service,
+        task="run",
+        task_id="1",
+    )
+
+    assert "user:7" not in manager._sandboxes
+    assert 1 not in manager._agents
+    assert 2 not in manager._agents
+    assert 1 not in manager._agent_owner_ids
+    assert 2 not in manager._agent_owner_ids
+    assert 1 not in manager._agent_sandbox_keys
+    assert 2 not in manager._agent_sandbox_keys
 
 
 @pytest.mark.asyncio
@@ -51,20 +85,28 @@ async def test_execute_task_keeps_workers_until_last_same_user_task_finishes() -
     """One task finishing must not delete workers still shared by another task."""
     manager = AgentServiceManager()
     provider = AsyncMock()
+    first_agent_service = _FakeAgentService()
+    second_agent_service = _FakeAgentService()
     manager._sandboxes["user:7"] = provider
+    manager._agents[1] = first_agent_service
+    manager._agents[2] = second_agent_service
     manager._agent_owner_ids[1] = 7
     manager._agent_owner_ids[2] = 7
+    manager._agent_sandbox_keys[1] = "user:7"
+    manager._agent_sandbox_keys[2] = "user:7"
 
     first_started = asyncio.Event()
     first_release = asyncio.Event()
     second_started = asyncio.Event()
     second_release = asyncio.Event()
+    first_agent_service.started = first_started
+    first_agent_service.release = first_release
+    second_agent_service.started = second_started
+    second_agent_service.release = second_release
 
     first_task = asyncio.create_task(
         manager.execute_task(
-            agent_service=_FakeAgentService(
-                started=first_started, release=first_release
-            ),
+            agent_service=first_agent_service,
             task="first",
             task_id="1",
         )
@@ -73,9 +115,7 @@ async def test_execute_task_keeps_workers_until_last_same_user_task_finishes() -
 
     second_task = asyncio.create_task(
         manager.execute_task(
-            agent_service=_FakeAgentService(
-                started=second_started, release=second_release
-            ),
+            agent_service=second_agent_service,
             task="second",
             task_id="2",
         )
@@ -84,8 +124,14 @@ async def test_execute_task_keeps_workers_until_last_same_user_task_finishes() -
 
     first_release.set()
     await first_task
+    assert "user:7" in manager._sandboxes
+    assert 1 in manager._agents
+    assert 2 in manager._agents
     provider.cleanup_worker_sandboxes.assert_not_awaited()
 
     second_release.set()
     await second_task
+    assert "user:7" not in manager._sandboxes
+    assert 1 not in manager._agents
+    assert 2 not in manager._agents
     provider.cleanup_worker_sandboxes.assert_awaited_once()

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -1,0 +1,91 @@
+"""Tests for task-scoped sandbox worker cleanup in AgentServiceManager."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+
+
+class _FakeAgentService:
+    def __init__(
+        self,
+        *,
+        result: dict | None = None,
+        started: asyncio.Event | None = None,
+        release: asyncio.Event | None = None,
+    ) -> None:
+        self.result = result or {"success": True}
+        self.started = started
+        self.release = release
+
+    async def execute_task(self, **_kwargs):
+        if self.started is not None:
+            self.started.set()
+        if self.release is not None:
+            await self.release.wait()
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_execute_task_releases_sandbox_workers_after_task() -> None:
+    """Terminal task execution should release cached worker sandboxes."""
+    manager = AgentServiceManager()
+    provider = AsyncMock()
+    manager._sandboxes["user:7"] = provider
+    manager._agent_owner_ids[1] = 7
+
+    result = await manager.execute_task(
+        agent_service=_FakeAgentService(),
+        task="run",
+        task_id="1",
+    )
+
+    assert result == {"success": True}
+    provider.cleanup_worker_sandboxes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_keeps_workers_until_last_same_user_task_finishes() -> None:
+    """One task finishing must not delete workers still shared by another task."""
+    manager = AgentServiceManager()
+    provider = AsyncMock()
+    manager._sandboxes["user:7"] = provider
+    manager._agent_owner_ids[1] = 7
+    manager._agent_owner_ids[2] = 7
+
+    first_started = asyncio.Event()
+    first_release = asyncio.Event()
+    second_started = asyncio.Event()
+    second_release = asyncio.Event()
+
+    first_task = asyncio.create_task(
+        manager.execute_task(
+            agent_service=_FakeAgentService(
+                started=first_started, release=first_release
+            ),
+            task="first",
+            task_id="1",
+        )
+    )
+    await first_started.wait()
+
+    second_task = asyncio.create_task(
+        manager.execute_task(
+            agent_service=_FakeAgentService(
+                started=second_started, release=second_release
+            ),
+            task="second",
+            task_id="2",
+        )
+    )
+    await second_started.wait()
+
+    first_release.set()
+    await first_task
+    provider.cleanup_worker_sandboxes.assert_not_awaited()
+
+    second_release.set()
+    await second_task
+    provider.cleanup_worker_sandboxes.assert_awaited_once()

--- a/tests/web/test_sandbox_manager.py
+++ b/tests/web/test_sandbox_manager.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from xagent.sandbox.base import SandboxConfig, SandboxInfo, SandboxTemplate
 from xagent.web.sandbox_manager import (
     SandboxManager,
     _create_boxlite_service,
@@ -13,6 +14,15 @@ from xagent.web.sandbox_manager import (
     _create_sandbox_service,
     get_sandbox_manager,
 )
+
+
+def _sandbox_info(name: str, state: str = "running") -> SandboxInfo:
+    return SandboxInfo(
+        name=name,
+        state=state,
+        template=SandboxTemplate(type="image", image="img:v1"),
+        config=SandboxConfig(),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -731,6 +741,31 @@ class TestSandboxLeaseProvider:
         assert "user::42" not in manager._cache
         assert "user::42::worker::0" not in manager._cache
         assert "user::42::worker::1" not in manager._cache
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_removes_persisted_worker_sandboxes(self):
+        """Delete should include worker sandboxes discovered from the service."""
+        service = AsyncMock()
+        service.delete = AsyncMock()
+        service.list_sandboxes = AsyncMock(
+            return_value=[
+                _sandbox_info("user::42"),
+                _sandbox_info("user::42::worker::0"),
+                _sandbox_info("user::42::worker::1"),
+                _sandbox_info("user::420::worker::0"),
+                _sandbox_info("tools::42::worker::0"),
+            ]
+        )
+        manager = SandboxManager(service)
+
+        await manager.delete_sandbox("user", "42")
+
+        deleted_names = {call.args[0] for call in service.delete.await_args_list}
+        assert deleted_names == {
+            "user::42",
+            "user::42::worker::0",
+            "user::42::worker::1",
+        }
 
 
 class TestSandboxManagerWarmup:

--- a/tests/web/test_sandbox_manager.py
+++ b/tests/web/test_sandbox_manager.py
@@ -576,6 +576,163 @@ class TestSandboxLifecycleConfig:
         assert service.get_or_create.await_args_list[1].args[0] == "build_preview::42"
 
 
+class TestSandboxLeaseProvider:
+    """Test leasing primary and worker sandboxes for tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_lease_returns_primary_sandbox(self, tmp_path):
+        """Tools that are not concurrency-safe should keep the existing behavior."""
+
+        async def get_or_create(name, *args, **kwargs):
+            sandbox = MagicMock()
+            sandbox.name = name
+            return sandbox
+
+        service = AsyncMock()
+        service.get_or_create = AsyncMock(side_effect=get_or_create)
+        manager = SandboxManager(service)
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "xagent.web.sandbox_manager.build_code_mount_volumes",
+                return_value=[("/repo/src", "/app/src", "ro")],
+            ),
+        ):
+            provider = await manager.create_lease_provider(
+                "user",
+                "42",
+                workspace_config={"base_dir": str(tmp_path / "user_42")},
+            )
+            async with provider.lease(concurrency_safe=False) as sandbox:
+                assert sandbox.name == "user::42"
+
+        assert service.get_or_create.await_count == 1
+        assert service.get_or_create.await_args_list[0].args[0] == "user::42"
+
+    @pytest.mark.asyncio
+    async def test_safe_concurrent_leases_use_distinct_workers(self, tmp_path):
+        """Concurrent safe leases should execute on separate worker sandboxes."""
+
+        async def get_or_create(name, *args, **kwargs):
+            sandbox = MagicMock()
+            sandbox.name = name
+            return sandbox
+
+        service = AsyncMock()
+        service.get_or_create = AsyncMock(side_effect=get_or_create)
+        manager = SandboxManager(service)
+
+        with (
+            patch.dict(
+                "os.environ", {"XAGENT_SANDBOX_MAX_CONCURRENCY": "2"}, clear=True
+            ),
+            patch(
+                "xagent.web.sandbox_manager.build_code_mount_volumes",
+                return_value=[("/repo/src", "/app/src", "ro")],
+            ),
+        ):
+            provider = await manager.create_lease_provider(
+                "user",
+                "42",
+                workspace_config={"base_dir": str(tmp_path / "user_42")},
+            )
+            async with provider.lease(concurrency_safe=True) as first:
+                async with provider.lease(concurrency_safe=True) as second:
+                    assert first.name == "user::42::worker::0"
+                    assert second.name == "user::42::worker::1"
+
+        assert service.get_or_create.await_args_list[0].args[0] == "user::42"
+        assert service.get_or_create.await_args_list[1].args[0] == (
+            "user::42::worker::0"
+        )
+        assert service.get_or_create.await_args_list[2].args[0] == (
+            "user::42::worker::1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_worker_sandboxes_reuse_primary_workspace_config(self, tmp_path):
+        """Worker sandboxes should mount the same workspace roots as the primary."""
+
+        async def get_or_create(name, *args, **kwargs):
+            sandbox = MagicMock()
+            sandbox.name = name
+            return sandbox
+
+        service = AsyncMock()
+        service.get_or_create = AsyncMock(side_effect=get_or_create)
+        manager = SandboxManager(service)
+        workspace_dir = tmp_path / "user_42"
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "xagent.web.sandbox_manager.build_code_mount_volumes",
+                return_value=[("/repo/src", "/app/src", "ro")],
+            ),
+        ):
+            provider = await manager.create_lease_provider(
+                "user",
+                "42",
+                workspace_config={"base_dir": str(workspace_dir)},
+            )
+            async with provider.lease(concurrency_safe=True):
+                pass
+
+        primary_config = service.get_or_create.await_args_list[0].kwargs["config"]
+        worker_config = service.get_or_create.await_args_list[1].kwargs["config"]
+        assert primary_config.volumes == worker_config.volumes
+        assert any(
+            volume[0] == str(workspace_dir) and volume[2] == "rw"
+            for volume in worker_config.volumes
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_removes_cached_worker_sandboxes(self, tmp_path):
+        """Deleting a lifecycle sandbox should delete its worker sandboxes too."""
+
+        async def get_or_create(name, *args, **kwargs):
+            sandbox = MagicMock()
+            sandbox.name = name
+            return sandbox
+
+        service = AsyncMock()
+        service.get_or_create = AsyncMock(side_effect=get_or_create)
+        service.delete = AsyncMock()
+        manager = SandboxManager(service)
+
+        with (
+            patch.dict(
+                "os.environ", {"XAGENT_SANDBOX_MAX_CONCURRENCY": "2"}, clear=True
+            ),
+            patch(
+                "xagent.web.sandbox_manager.build_code_mount_volumes",
+                return_value=[("/repo/src", "/app/src", "ro")],
+            ),
+        ):
+            provider = await manager.create_lease_provider(
+                "user",
+                "42",
+                workspace_config={"base_dir": str(tmp_path / "user_42")},
+            )
+            async with provider.lease(concurrency_safe=True):
+                pass
+            async with provider.lease(concurrency_safe=True):
+                pass
+
+            await manager.delete_sandbox("user", "42")
+
+        deleted_names = {call.args[0] for call in service.delete.await_args_list}
+        assert deleted_names == {
+            "user::42",
+            "user::42::worker::0",
+            "user::42::worker::1",
+        }
+        assert "user::42" not in manager._cache
+        assert "user::42::worker::0" not in manager._cache
+        assert "user::42::worker::1" not in manager._cache
+
+
 class TestSandboxManagerWarmup:
     """Test sandbox warmup functionality."""
 

--- a/tests/web/test_sandbox_manager_cleanup.py
+++ b/tests/web/test_sandbox_manager_cleanup.py
@@ -358,6 +358,46 @@ async def test_cleanup_stops_when_config_matches(
 
 
 @pytest.mark.asyncio
+async def test_cleanup_stops_worker_when_base_user_config_matches(
+    manager: SandboxManager, service: AsyncMock, tmp_path: Path
+):
+    """Worker sandbox cleanup should compare against the owner workspace."""
+    uploads = tmp_path / "uploads"
+    user_dir = uploads / "user_6"
+    user_dir.mkdir(parents=True)
+    resolved = str(user_dir.resolve())
+
+    code_volumes = build_code_mount_volumes()
+    sb = _make_sb_info(
+        "user::6::worker::0",
+        image="img:v1",
+        cpus=1,
+        memory=512,
+        volumes=code_volumes + [(resolved, resolved, "rw")],
+    )
+
+    mock_box = AsyncMock()
+    service.list_sandboxes.return_value = [sb]
+    service.get_or_create.return_value = mock_box
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"SANDBOX_IMAGE": "img:v1", "SANDBOX_CPUS": "1", "SANDBOX_MEMORY": "512"},
+            clear=True,
+        ),
+        patch("xagent.web.sandbox_manager.get_uploads_dir", return_value=uploads),
+    ):
+        await manager.cleanup()
+
+    service.delete.assert_not_awaited()
+    service.get_or_create.assert_awaited_once_with(
+        "user::6::worker::0", template=sb.template, config=sb.config
+    )
+    mock_box.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_deletes_on_multiple_changes(
     manager: SandboxManager, service: AsyncMock
 ):


### PR DESCRIPTION
This pull request introduces a new concurrency model for sandboxed tool execution, allowing tools that are concurrency-safe to run in parallel worker sandboxes, while unsafe tools are isolated in a primary sandbox. It adds lease management for sandbox slots, environment variable configuration for concurrency, and updates the codebase and tests to support and validate this behavior.

**Sandbox concurrency and lease management:**

* Introduced `SandboxLease` and `SandboxLeaseProvider` classes in `src/xagent/web/sandbox_manager.py` to manage leasing of primary and worker sandboxes for concurrent tool execution. This enables concurrency-safe tools to execute in parallel, with slot management and async context handling. (Febe1e87L31R31)
* Added a new environment variable `XAGENT_SANDBOX_MAX_CONCURRENCY` (with default 3) and corresponding getter `get_sandbox_max_concurrency()` in `src/xagent/config.py` to control the maximum number of concurrent worker sandboxes per lifecycle. 


**Sandboxed tool wrapper and execution changes:**

* Refactored `SandboxedToolWrapper` in `src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py` to support both static sandboxes and lease providers, selecting the appropriate sandbox based on the tool's concurrency safety. Tool execution and dependency installation now occur in the leased sandbox context. 

**API and sandbox manager integration:**

* Updated API endpoints in `src/xagent/web/api/chat.py` to use `create_lease_provider` instead of directly acquiring a sandbox, ensuring that the new concurrency model is used throughout tool lifecycle management. 
* Enhanced `delete_sandbox` in `src/xagent/web/sandbox_manager.py` to clean up all worker sandboxes associated with a lifecycle, not just the primary sandbox.

**Testing and configuration:**

* Added new unit tests in `tests/core/tools/adapters/sandboxed_tool/test_sandboxed_tool_lease_provider.py` to verify correct sandbox selection and lease behavior for concurrency-safe and unsafe tools.
* Added tests for sandbox concurrency environment variable handling in `tests/core/test_config.py`.

These changes collectively provide robust, configurable concurrent execution for sandboxed tools, improving both performance and safety.
This pull request introduces support for concurrent sandboxed tool execution by implementing a lease provider pattern and configurable concurrency limits. It refactors how sandboxes are managed and leased for tool execution, allowing multiple concurrent sandboxes per user or task lifecycle. The changes also ensure proper cleanup of worker sandboxes and improve the safety and scalability of tool execution.

**Sandbox concurrency and leasing:**

* Introduced `SandboxLeaseProvider` and `SandboxLease` classes in `src/xagent/web/sandbox_manager.py` to manage leasing of primary and worker sandboxes, supporting configurable concurrency for concurrency-safe tools.
* Added `XAGENT_SANDBOX_MAX_CONCURRENCY` environment variable (with default 3) to control max concurrent worker sandboxes per user/lifecycle, and corresponding config plumbing via `get_sandbox_max_concurrency`. 

**Refactoring tool execution to use leasing:**

* Updated `SandboxedToolWrapper` in `src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py` to lease sandboxes for each tool invocation, supporting both static and lease-provider patterns and ensuring dependencies are installed per sandbox. 

**Web API and sandbox manager integration:**

* Refactored the web API (`src/xagent/web/api/chat.py`) to use `create_lease_provider` instead of `get_or_create_sandbox` for user sandboxes, and added per-sandbox active task tracking and cleanup logic to ensure proper resource management. 
* Added methods to `SandboxManager` for creating lease providers and cleaning up worker sandboxes, and ensured workspace mount paths and sandbox naming are correct for worker sandboxes. 

These changes together enable safe, scalable concurrent execution of sandboxed tools, with robust resource management and configuration.