### PR TITLE
fix(deepseek): disable thinking by default

### DIFF
--- a/src/xagent/core/model/chat/basic/deepseek.py
+++ b/src/xagent/core/model/chat/basic/deepseek.py
@@ -114,7 +114,7 @@ class DeepSeekLLM(OpenAILLM):
                 extra_body["thinking"] = {"type": "enabled"}
             else:
                 extra_body["thinking"] = {"type": "disabled"}
-        elif tools or response_format or output_config:
+        else:
             extra_body["thinking"] = {"type": "disabled"}
 
         return extra_body

--- a/tests/core/model/chat/basic/test_deepseek.py
+++ b/tests/core/model/chat/basic/test_deepseek.py
@@ -88,6 +88,72 @@ class TestDeepSeekLLM:
         assert "enable_thinking" not in call_kwargs["extra_body"]
 
     @pytest.mark.asyncio
+    async def test_chat_disables_thinking_by_default(
+        self, llm, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_chat_completion
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        await llm.chat([{"role": "user", "content": "Hello"}])
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_disables_thinking_by_default(self, llm, mocker):
+        async def stream():
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content=None,
+                            content="Hello",
+                            tool_calls=None,
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+                model_dump=lambda: {"id": "content"},
+            )
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content=None,
+                            content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+                model_dump=lambda: {"id": "end"},
+            )
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = stream()
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat([{"role": "user", "content": "Hello"}])
+        ]
+
+        assert [chunk.delta for chunk in chunks if chunk.type == ChunkType.TOKEN] == [
+            "Hello"
+        ]
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+
+    @pytest.mark.asyncio
     async def test_tool_calls_disable_thinking_by_default(
         self, llm, mock_tool_call_completion, mocker
     ):


### PR DESCRIPTION
## Summary

- Disable DeepSeek thinking mode by default for every DeepSeek request.
- Preserve explicit caller opt-in via `thinking={"type": "enabled"}`.
- Add coverage for plain chat and stream chat requests with no tools.

## Details

Previously, DeepSeek only sent `thinking: disabled` by default when a request included tools, `response_format`, or `output_config`. Plain follow-up calls without tools omitted the `thinking` payload,
allowing DeepSeek’s API default to enable thinking mode.

Now `DeepSeekLLM` always sends:

```python
extra_body={"thinking": {"type": "disabled"}}
```
unless the caller explicitly enables thinking.
