### PR TITLE
feat: add OAuth app metadata handling and validation for MCP

### DIFF
--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -36,6 +36,7 @@ import { KnowledgeBaseCreationDialog } from "@/components/kb/knowledge-base-crea
 import { toast } from "@/components/ui/sonner"
 import { cn } from "@/lib/utils"
 import { getBrandingFromEnv } from "@/lib/branding"
+import { findMatchingMcpApp, findMatchingMcpServer, mcpNameMatches } from "@/lib/mcp-lookup"
 import { BuildFilePreviewSheet } from "./build-file-preview-sheet"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { AgentTriggersDialog } from "./agent-triggers-dialog"
@@ -104,7 +105,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const MAX_INSTRUCTIONS_LENGTH = 8192;
   const { state, setTaskId, sendMessage, dispatch, closeFilePreview } = useApp()
   const { t, locale } = useI18n()
-  const { apps: officialApps, getAppIcon } = useMcpApps()
+  const { apps: officialApps, getAppIcon, refresh: refreshMcpApps } = useMcpApps()
   const router = useRouter()
   const searchParams = useSearchParams()
   const templateId = searchParams.get("template")
@@ -595,7 +596,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
               if (!connName) return;
 
               // Find the actual server object to use its exact name, to avoid case mismatches
-              const server = mcpServers.find(s => s.name.toLowerCase() === connName.toLowerCase() || s.app_id?.toLowerCase() === connName.toLowerCase().replace(/\s+/g, '-'))
+              const server = findMatchingMcpServer(mcpServers, connName)
               const finalName = server ? server.name : connName;
               if (!connectedMcpApps.includes(finalName)) {
                 connectedMcpApps.push(finalName)
@@ -911,7 +912,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
     // Add selected MCP servers back into tool_categories
     selectedMcpServers.forEach(server => {
-      finalToolCategories.push(`mcp:${server}`)
+      const connectedServer = findMatchingMcpServer(mcpServers, server)
+      const connectedApp = findMatchingMcpApp(officialApps, server)
+      finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.name || server}`)
     })
 
     setIsCreating(true)
@@ -1144,8 +1147,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const templateMissingMcp = Boolean(
     isTemplateBuildFlow &&
     templateRequirements?.requiredMcpServers.some((serverName) => {
-      const isSelected = selectedMcpServers.some((name) => name.toLowerCase() === serverName.toLowerCase())
-      const isConnected = mcpServers.some((server) => server.name.toLowerCase() === serverName.toLowerCase())
+      const isSelected = selectedMcpServers.some((name) => mcpNameMatches(name, serverName))
+      const connectedServer = findMatchingMcpServer(mcpServers, serverName)
+      const connectedApp = findMatchingMcpApp(officialApps, serverName)
+      const isConnected = Boolean(connectedServer || connectedApp?.is_connected)
       return !isSelected || !isConnected
     })
   )
@@ -1878,21 +1883,24 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           </div>
           <div className="flex flex-col gap-2">
             {selectedMcpServers.map((serverName, index) => {
-              const isConnected = mcpServers.some((s: any) => s.name === serverName)
-              const isSupported = officialApps.some((app: any) => app.name.toLowerCase() === serverName.toLowerCase() || app.id.toLowerCase() === serverName.toLowerCase())
+              const connectedServer = findMatchingMcpServer(mcpServers, serverName)
+              const matchingApp = findMatchingMcpApp(officialApps, serverName)
+              const isConnected = Boolean(connectedServer || matchingApp?.is_connected)
+              const isSupported = Boolean(matchingApp)
 
               let statusDesc = ""
 
-              if (isConnected) {
-                const server = mcpServers.find((s: any) => s.name === serverName)
-                statusDesc = server?.description || ""
+              if (connectedServer) {
+                statusDesc = connectedServer.description || ""
+              } else if (matchingApp?.is_connected) {
+                statusDesc = matchingApp.description || ""
               } else if (isSupported) {
                 statusDesc = t("tools.mcp.notConnected")
               } else {
                 statusDesc = t("tools.mcp.notSupported")
               }
 
-              const server = { name: serverName, description: statusDesc }
+              const server = { name: connectedServer?.name || matchingApp?.name || serverName, description: statusDesc }
               const icon = getAppIcon(server.name)
               return (
                 <div key={index} className={cn("flex items-center gap-3 p-2 rounded-md border", !isConnected && "opacity-50 bg-muted/50")}>
@@ -1920,7 +1928,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                       variant="ghost"
                       size="sm"
                       className="h-8 w-8 p-0 text-red-500 hover:text-red-600 hover:bg-red-50"
-                      onClick={() => setSelectedMcpServers(prev => prev.filter(name => name !== server.name))}
+                      onClick={() => setSelectedMcpServers(prev => prev.filter(name => !mcpNameMatches(name, serverName)))}
                     >
                       <X className="h-4 w-4" />
                     </Button>
@@ -2150,6 +2158,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           setSelectedMcpServers(selectedApps)
         }}
         onSuccess={() => {
+          refreshMcpApps().catch(console.error)
           apiRequest(`${getApiUrl()}/api/mcp/servers`)
             .then(res => res.json())
             .then(data => setMcpServers(data || []))

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -110,6 +110,8 @@ export function ConnectMcpDialog({
     config: {} as Record<string, any>
   })
 
+  const isAppConnected = (app: AppIntegration) => Boolean(app.is_connected)
+
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
     return () => clearTimeout(timer)
@@ -631,7 +633,7 @@ export function ConnectMcpDialog({
                 ) : (
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     {apps.map(app => {
-                      const isGloballyConnected = app.is_connected || globalMcpServers.some(s => s.name.toLowerCase() === app.id.toLowerCase() || s.name.toLowerCase() === app.name.toLowerCase())
+                      const isGloballyConnected = isAppConnected(app)
                       const isSelected = localSelectedServers.includes(app.id) || localSelectedServers.includes(app.name)
                       const isLoading = loadingApp === app.id
                       return (
@@ -819,7 +821,7 @@ export function ConnectMcpDialog({
           }
           return selectedApp;
         })()}
-        isGloballyConnected={selectedApp ? (selectedApp.is_connected || globalMcpServers.some(s => s.name.toLowerCase() === selectedApp.id.toLowerCase() || s.name.toLowerCase() === selectedApp.name.toLowerCase())) : false}
+        isGloballyConnected={selectedApp ? isAppConnected(selectedApp) : false}
         onSuccess={() => {
           if (onSuccess) onSuccess();
           loadApps();

--- a/frontend/src/contexts/mcp-apps-context.tsx
+++ b/frontend/src/contexts/mcp-apps-context.tsx
@@ -15,6 +15,9 @@ interface McpApp {
   transport: string
   provider: string
   category: string
+  is_connected?: boolean
+  server_id?: number
+  connected_account?: string
 }
 
 interface McpAppsContextType {

--- a/frontend/src/lib/mcp-lookup.test.ts
+++ b/frontend/src/lib/mcp-lookup.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { findMatchingMcpApp, findMatchingMcpServer, mcpNameMatches } from "./mcp-lookup"
+
+describe("MCP lookup helpers", () => {
+  it("matches saved app ids to connected server names", () => {
+    const server = findMatchingMcpServer(
+      [{ name: "Outlook", app_id: "outlook" }],
+      "outlook"
+    )
+
+    expect(server?.name).toBe("Outlook")
+  })
+
+  it("matches slug ids to display names", () => {
+    const app = findMatchingMcpApp(
+      [{ id: "google-drive", name: "Google Drive" }],
+      "Google Drive"
+    )
+
+    expect(app?.id).toBe("google-drive")
+    expect(mcpNameMatches("google-drive", "Google Drive")).toBe(true)
+  })
+})

--- a/frontend/src/lib/mcp-lookup.ts
+++ b/frontend/src/lib/mcp-lookup.ts
@@ -1,0 +1,54 @@
+export interface McpLookupReference {
+  name?: unknown
+  id?: unknown
+  app_id?: unknown
+}
+
+const normalizeMcpLookupValue = (value: unknown): string => {
+  return String(value ?? "").trim().toLowerCase()
+}
+
+const getMcpLookupKeys = (...values: unknown[]): Set<string> => {
+  const keys = new Set<string>()
+
+  values.forEach((value) => {
+    const normalized = normalizeMcpLookupValue(value)
+    if (!normalized) return
+
+    keys.add(normalized)
+    keys.add(normalized.replace(/\s+/g, "-"))
+  })
+
+  return keys
+}
+
+const hasSharedMcpLookupKey = (left: Set<string>, right: Set<string>): boolean => {
+  for (const key of left) {
+    if (right.has(key)) return true
+  }
+  return false
+}
+
+export const mcpNameMatches = (left: unknown, right: unknown): boolean => {
+  return hasSharedMcpLookupKey(getMcpLookupKeys(left), getMcpLookupKeys(right))
+}
+
+export const findMatchingMcpServer = <T extends McpLookupReference>(
+  servers: T[],
+  serverName: string
+): T | undefined => {
+  const targetKeys = getMcpLookupKeys(serverName)
+  return servers.find((server) =>
+    hasSharedMcpLookupKey(getMcpLookupKeys(server.name, server.app_id), targetKeys)
+  )
+}
+
+export const findMatchingMcpApp = <T extends McpLookupReference>(
+  apps: T[],
+  serverName: string
+): T | undefined => {
+  const targetKeys = getMcpLookupKeys(serverName)
+  return apps.find((app) =>
+    hasSharedMcpLookupKey(getMcpLookupKeys(app.name, app.id), targetKeys)
+  )
+}

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1061,7 +1061,7 @@ def _ensure_user_mcp_server(
                 "server before connecting the official OAuth app."
             )
 
-        auth = server.auth if isinstance(server.auth, dict) else {}
+        auth: dict[str, Any] = server.auth if isinstance(server.auth, dict) else {}
         expected_app_id = str(app_info["id"])
         existing_app_id = auth.get("app_id")
         if existing_app_id and str(existing_app_id) != expected_app_id:
@@ -1083,7 +1083,7 @@ def _ensure_user_mcp_server(
             )
 
         auth.update(_oauth_auth_metadata())
-        server.auth = auth
+        cast(Any, server).auth = auth
         server.description = app_info.get("description") or server.description
 
     mcp_server = db.query(MCPServer).filter(MCPServer.name == app_info["name"]).first()

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -45,6 +45,48 @@ SETUP_COMPLETED_SETTING_KEY = "setup_completed"
 EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
+def _oauth_env_name(provider: str, suffix: str) -> str:
+    return f"{provider.upper()}_{suffix}"
+
+
+def _resolve_oauth_secret(
+    provider: str, encrypted_value: Optional[str], env_suffix: str
+) -> str:
+    from ...core.utils.encryption import decrypt_value
+
+    value = decrypt_value(encrypted_value or "")
+    if value:
+        return value
+    return os.environ.get(_oauth_env_name(provider, env_suffix), "")
+
+
+def _resolve_oauth_redirect_uri(provider: str, db_provider: Any) -> str:
+    if getattr(db_provider, "redirect_uri", None):
+        return str(db_provider.redirect_uri)
+    return os.environ.get(
+        _oauth_env_name(provider, "REDIRECT_URI"),
+        f"http://localhost:8000/api/auth/{provider}/callback",
+    )
+
+
+def _oauth_provider_config_error(
+    provider: str, missing_env_names: list[str]
+) -> HTMLResponse:
+    import html
+
+    escaped_provider = html.escape(provider)
+    escaped_missing = html.escape(", ".join(missing_env_names))
+    return HTMLResponse(
+        content=(
+            "<h1>Error: OAuth provider not configured</h1>"
+            f"<p>Missing {escaped_missing} for provider {escaped_provider}.</p>"
+            "<p>Configure the provider in admin settings or set the corresponding "
+            "environment variables and restart the backend.</p>"
+        ),
+        status_code=500,
+    )
+
+
 def create_access_token(
     data: Dict[str, Any], expires_delta: Optional[timedelta] = None
 ) -> str:
@@ -931,19 +973,14 @@ def generic_oauth_login(
             content="<h1>Error: Provider not configured</h1>", status_code=500
         )
 
-    from ...core.utils.encryption import decrypt_value
-
-    client_id = decrypt_value(db_provider.client_id)
+    client_id = _resolve_oauth_secret(provider, db_provider.client_id, "CLIENT_ID")
+    if not client_id:
+        return _oauth_provider_config_error(
+            provider, [_oauth_env_name(provider, "CLIENT_ID")]
+        )
     auth_url = db_provider.auth_url
 
-    redirect_uri = None
-    if getattr(db_provider, "redirect_uri", None):
-        redirect_uri = db_provider.redirect_uri
-    if not redirect_uri:
-        redirect_uri = os.environ.get(
-            f"{provider.upper()}_REDIRECT_URI",
-            f"http://localhost:8000/api/auth/{provider}/callback",
-        )
+    redirect_uri = _resolve_oauth_redirect_uri(provider, db_provider)
 
     user_id = None
     if token:
@@ -1130,21 +1167,21 @@ def generic_oauth_callback(
             content="<h1>Error: Provider not configured</h1>", status_code=500
         )
 
-    from ...core.utils.encryption import decrypt_value
-
-    client_id = decrypt_value(db_provider.client_id)
-    client_secret = decrypt_value(db_provider.client_secret)
+    client_id = _resolve_oauth_secret(provider, db_provider.client_id, "CLIENT_ID")
+    client_secret = _resolve_oauth_secret(
+        provider, db_provider.client_secret, "CLIENT_SECRET"
+    )
+    missing_config = []
+    if not client_id:
+        missing_config.append(_oauth_env_name(provider, "CLIENT_ID"))
+    if not client_secret:
+        missing_config.append(_oauth_env_name(provider, "CLIENT_SECRET"))
+    if missing_config:
+        return _oauth_provider_config_error(provider, missing_config)
     token_url = db_provider.token_url
     userinfo_url = db_provider.userinfo_url
 
-    redirect_uri = None
-    if getattr(db_provider, "redirect_uri", None):
-        redirect_uri = db_provider.redirect_uri
-    if not redirect_uri:
-        redirect_uri = os.environ.get(
-            f"{provider.upper()}_REDIRECT_URI",
-            f"http://localhost:8000/api/auth/{provider}/callback",
-        )
+    redirect_uri = _resolve_oauth_redirect_uri(provider, db_provider)
 
     try:
         data = {

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -54,9 +54,10 @@ def _resolve_oauth_secret(
 ) -> str:
     from ...core.utils.encryption import decrypt_value
 
-    value = decrypt_value(encrypted_value or "")
-    if value:
-        return value
+    if encrypted_value:
+        value = decrypt_value(encrypted_value)
+        if value:
+            return value
     return os.environ.get(_oauth_env_name(provider, env_suffix), "")
 
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1009,6 +1009,46 @@ def _ensure_user_mcp_server(
 
     from ..models.mcp import MCPServer, UserMCPServer
 
+    def _oauth_auth_metadata() -> dict[str, str]:
+        metadata = {"app_id": str(app_info["id"])}
+        provider = app_info.get("provider")
+        if provider:
+            metadata["provider"] = str(provider)
+        return metadata
+
+    def _ensure_server_matches_oauth_app(server: MCPServer) -> None:
+        if server.transport != "oauth":
+            raise ValueError(
+                f"OAuth app '{app_info['name']}' conflicts with an existing MCP server "
+                f"using transport '{server.transport}'. Delete or rename that custom "
+                "server before connecting the official OAuth app."
+            )
+
+        auth = server.auth if isinstance(server.auth, dict) else {}
+        expected_app_id = str(app_info["id"])
+        existing_app_id = auth.get("app_id")
+        if existing_app_id and str(existing_app_id) != expected_app_id:
+            raise ValueError(
+                f"OAuth app '{app_info['name']}' conflicts with MCP server metadata "
+                f"for app '{existing_app_id}'."
+            )
+
+        expected_provider = app_info.get("provider")
+        existing_provider = auth.get("provider")
+        if (
+            expected_provider
+            and existing_provider
+            and str(existing_provider) != str(expected_provider)
+        ):
+            raise ValueError(
+                f"OAuth app '{app_info['name']}' conflicts with MCP server provider "
+                f"'{existing_provider}'."
+            )
+
+        auth.update(_oauth_auth_metadata())
+        server.auth = auth
+        server.description = app_info.get("description") or server.description
+
     mcp_server = db.query(MCPServer).filter(MCPServer.name == app_info["name"]).first()
     if not mcp_server:
         mcp_server = MCPServer(
@@ -1016,6 +1056,7 @@ def _ensure_user_mcp_server(
             description=app_info["description"],
             managed="external",
             transport="oauth",
+            auth=_oauth_auth_metadata(),
         )
         db.add(mcp_server)
         try:
@@ -1027,6 +1068,8 @@ def _ensure_user_mcp_server(
             )
             if not mcp_server:
                 raise
+
+    _ensure_server_matches_oauth_app(mcp_server)
 
     user_mcp = (
         db.query(UserMCPServer)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -9,7 +9,7 @@ import json
 import logging
 import shlex
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -518,7 +518,7 @@ def _connected_oauth_server_for_app(
         return None, None
 
     email = getattr(oauth_account, "email", None)
-    return server.id, str(email) if email else None
+    return cast(int, server.id), str(email) if email else None
 
 
 @mcp_router.get("/apps", response_model=List[dict])
@@ -533,12 +533,15 @@ def list_mcp_apps(
     """Get the list of available MCP applications in the library."""
 
     # Query connected servers for the current user
-    user_mcps = (
-        db.query(MCPServer, UserMCPServer)
-        .join(UserMCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
-        .filter(UserMCPServer.user_id == current_user.id)
-        .all()
-    )
+    user_mcps = [
+        (server, user_mcp)
+        for server, user_mcp in (
+            db.query(MCPServer, UserMCPServer)
+            .join(UserMCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
+            .filter(UserMCPServer.user_id == current_user.id)
+            .all()
+        )
+    ]
 
     # Also fetch user oauth accounts to get the connected email
     from ..models.user_oauth import UserOAuth

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -434,8 +434,17 @@ def _enrich_oauth_server_info(
 def _normalize_app_key(value: object) -> Optional[str]:
     if value is None:
         return None
-    normalized = str(value).strip().lower()
+    normalized = "-".join(str(value).strip().lower().split())
     return normalized or None
+
+
+def _app_lookup_keys(*values: object) -> list[str]:
+    keys = []
+    for value in values:
+        key = _normalize_app_key(value)
+        if key and key not in keys:
+            keys.append(key)
+    return keys
 
 
 def _oauth_account_can_connect(oauth_account: object) -> bool:
@@ -457,12 +466,8 @@ def _oauth_account_can_connect(oauth_account: object) -> bool:
     return expires_at > now
 
 
-def _oauth_keys_for_app(app: dict) -> set[str]:
-    keys = {
-        _normalize_app_key(app.get("id")),
-        _normalize_app_key(app.get("provider")),
-    }
-    return {key for key in keys if key}
+def _oauth_keys_for_app(app: dict) -> list[str]:
+    return _app_lookup_keys(app.get("id"), app.get("provider"))
 
 
 def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
@@ -491,29 +496,22 @@ def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
 
 
 def _connected_oauth_server_for_app(
-    app: dict, user_mcps: list[tuple[MCPServer, UserMCPServer]], oauth_accounts: list
+    app: dict,
+    oauth_server_lookup: dict[str, list[MCPServer]],
+    oauth_account_lookup: dict[str, object],
 ) -> tuple[Optional[int], Optional[str]]:
-    oauth_keys = _oauth_keys_for_app(app)
     oauth_account = next(
         (
-            account
-            for account in oauth_accounts
-            if _normalize_app_key(getattr(account, "provider", None)) in oauth_keys
-            and _oauth_account_can_connect(account)
+            oauth_account_lookup[key]
+            for key in _oauth_keys_for_app(app)
+            if key in oauth_account_lookup
         ),
         None,
     )
     if not oauth_account:
         return None, None
 
-    server = next(
-        (
-            server
-            for server, user_mcp in user_mcps
-            if user_mcp.is_active and _is_oauth_server_for_app(server, app)
-        ),
-        None,
-    )
+    server = _lookup_oauth_server_for_app(app, oauth_server_lookup)
     if not server:
         return None, None
 
@@ -521,26 +519,86 @@ def _connected_oauth_server_for_app(
     return cast(int, server.id), str(email) if email else None
 
 
+def _build_oauth_account_lookup(oauth_accounts: list[object]) -> dict[str, object]:
+    lookup: dict[str, object] = {}
+    for account in oauth_accounts:
+        key = _normalize_app_key(getattr(account, "provider", None))
+        if key and key not in lookup and _oauth_account_can_connect(account):
+            lookup[key] = account
+    return lookup
+
+
+def _oauth_server_lookup_keys(server: MCPServer) -> list[str]:
+    auth = getattr(server, "auth", None)
+    if isinstance(auth, dict):
+        auth_app_id = _normalize_app_key(auth.get("app_id"))
+        if auth_app_id:
+            return [auth_app_id]
+
+        auth_provider = _normalize_app_key(auth.get("provider"))
+        if auth_provider:
+            return [auth_provider]
+
+    return _app_lookup_keys(server.name)
+
+
+def _build_active_oauth_server_lookup(
+    user_mcps: list[tuple[MCPServer, UserMCPServer]],
+) -> dict[str, list[MCPServer]]:
+    lookup: dict[str, list[MCPServer]] = {}
+    for server, user_mcp in user_mcps:
+        if not user_mcp.is_active or _normalize_app_key(server.transport) != "oauth":
+            continue
+        for key in _oauth_server_lookup_keys(server):
+            lookup.setdefault(key, []).append(server)
+    return lookup
+
+
+def _lookup_oauth_server_for_app(
+    app: dict, oauth_server_lookup: dict[str, list[MCPServer]]
+) -> Optional[MCPServer]:
+    seen_servers: set[int] = set()
+    for key in _app_lookup_keys(app.get("id"), app.get("provider"), app.get("name")):
+        for server in oauth_server_lookup.get(key, []):
+            marker = id(server)
+            if marker in seen_servers:
+                continue
+            seen_servers.add(marker)
+            if _is_oauth_server_for_app(server, app):
+                return server
+    return None
+
+
+def _build_active_non_oauth_server_lookup(
+    user_mcps: list[tuple[MCPServer, UserMCPServer]],
+) -> dict[tuple[str, str], MCPServer]:
+    lookup: dict[tuple[str, str], MCPServer] = {}
+    for server, user_mcp in user_mcps:
+        transport = _normalize_app_key(server.transport)
+        server_name = _normalize_app_key(server.name)
+        if (
+            not user_mcp.is_active
+            or not transport
+            or transport == "oauth"
+            or not server_name
+        ):
+            continue
+        lookup.setdefault((transport, server_name), server)
+    return lookup
+
+
 def _connected_non_oauth_server_for_app(
-    app: dict, user_mcps: list[tuple[MCPServer, UserMCPServer]]
+    app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
 ) -> Optional[int]:
     app_transport = _normalize_app_key(app.get("transport"))
     if not app_transport or app_transport == "oauth":
         return None
 
-    app_keys = {
-        _normalize_app_key(app.get("id")),
-        _normalize_app_key(app.get("name")),
-    }
-    app_keys = {key for key in app_keys if key}
-
     server = next(
         (
-            server
-            for server, user_mcp in user_mcps
-            if user_mcp.is_active
-            and _normalize_app_key(server.transport) == app_transport
-            and _normalize_app_key(server.name) in app_keys
+            non_oauth_server_lookup[(app_transport, app_key)]
+            for app_key in _app_lookup_keys(app.get("id"), app.get("name"))
+            if (app_transport, app_key) in non_oauth_server_lookup
         ),
         None,
     )
@@ -583,15 +641,20 @@ def list_mcp_apps(
     library_apps = (
         get_all_mcp_apps(db) if location in ["remote", "local", "all"] else []
     )
+    oauth_account_lookup = _build_oauth_account_lookup(list(oauth_accounts))
+    oauth_server_lookup = _build_active_oauth_server_lookup(user_mcps)
+    non_oauth_server_lookup = _build_active_non_oauth_server_lookup(user_mcps)
 
     if location in ["remote", "all"]:
         for app in library_apps:
             if app.get("transport") == "oauth":
                 server_id, connected_account = _connected_oauth_server_for_app(
-                    app, user_mcps, oauth_accounts
+                    app, oauth_server_lookup, oauth_account_lookup
                 )
             else:
-                server_id = _connected_non_oauth_server_for_app(app, user_mcps)
+                server_id = _connected_non_oauth_server_for_app(
+                    app, non_oauth_server_lookup
+                )
                 connected_account = None
             is_connected = server_id is not None
             is_visible_in_connector = app.get("is_visible_in_connector", True)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -450,7 +450,10 @@ def _oauth_account_can_connect(oauth_account: object) -> bool:
     if getattr(oauth_account, "refresh_token", None):
         return True
 
-    now = datetime.now(timezone.utc if expires_at.tzinfo else None)
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
     return expires_at > now
 
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -521,6 +521,35 @@ def _connected_oauth_server_for_app(
     return cast(int, server.id), str(email) if email else None
 
 
+def _connected_non_oauth_server_for_app(
+    app: dict, user_mcps: list[tuple[MCPServer, UserMCPServer]]
+) -> Optional[int]:
+    app_transport = _normalize_app_key(app.get("transport"))
+    if not app_transport or app_transport == "oauth":
+        return None
+
+    app_keys = {
+        _normalize_app_key(app.get("id")),
+        _normalize_app_key(app.get("name")),
+    }
+    app_keys = {key for key in app_keys if key}
+
+    server = next(
+        (
+            server
+            for server, user_mcp in user_mcps
+            if user_mcp.is_active
+            and _normalize_app_key(server.transport) == app_transport
+            and _normalize_app_key(server.name) in app_keys
+        ),
+        None,
+    )
+    if not server:
+        return None
+
+    return cast(int, server.id)
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -557,11 +586,13 @@ def list_mcp_apps(
 
     if location in ["remote", "all"]:
         for app in library_apps:
-            server_id, connected_account = (
-                _connected_oauth_server_for_app(app, user_mcps, oauth_accounts)
-                if app.get("transport") == "oauth"
-                else (None, None)
-            )
+            if app.get("transport") == "oauth":
+                server_id, connected_account = _connected_oauth_server_for_app(
+                    app, user_mcps, oauth_accounts
+                )
+            else:
+                server_id = _connected_non_oauth_server_for_app(app, user_mcps)
+                connected_account = None
             is_connected = server_id is not None
             is_visible_in_connector = app.get("is_visible_in_connector", True)
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -8,7 +8,7 @@ in the web application.
 import json
 import logging
 import shlex
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -431,6 +431,93 @@ def _enrich_oauth_server_info(
     return app_id, provider, connected_account
 
 
+def _normalize_app_key(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    return normalized or None
+
+
+def _oauth_account_can_connect(oauth_account: object) -> bool:
+    access_token = getattr(oauth_account, "access_token", None)
+    if not access_token:
+        return False
+
+    expires_at = getattr(oauth_account, "expires_at", None)
+    if not isinstance(expires_at, datetime):
+        return True
+
+    if getattr(oauth_account, "refresh_token", None):
+        return True
+
+    now = datetime.now(timezone.utc if expires_at.tzinfo else None)
+    return expires_at > now
+
+
+def _oauth_keys_for_app(app: dict) -> set[str]:
+    keys = {
+        _normalize_app_key(app.get("id")),
+        _normalize_app_key(app.get("provider")),
+    }
+    return {key for key in keys if key}
+
+
+def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
+    if server.transport != "oauth":
+        return False
+
+    app_id = _normalize_app_key(app.get("id"))
+    app_name = _normalize_app_key(app.get("name"))
+    provider = _normalize_app_key(app.get("provider"))
+    server_name = _normalize_app_key(server.name)
+
+    auth = getattr(server, "auth", None)
+    if isinstance(auth, dict):
+        auth_app_id = _normalize_app_key(auth.get("app_id"))
+        auth_provider = _normalize_app_key(auth.get("provider"))
+
+        if auth_app_id and auth_app_id != app_id:
+            return False
+        if auth_provider and provider and auth_provider != provider:
+            return False
+        if auth_app_id or auth_provider:
+            return True
+
+    # Legacy OAuth server rows created before app metadata was stored in auth.
+    return bool(server_name and server_name in {app_id, app_name})
+
+
+def _connected_oauth_server_for_app(
+    app: dict, user_mcps: list[tuple[MCPServer, UserMCPServer]], oauth_accounts: list
+) -> tuple[Optional[int], Optional[str]]:
+    oauth_keys = _oauth_keys_for_app(app)
+    oauth_account = next(
+        (
+            account
+            for account in oauth_accounts
+            if _normalize_app_key(getattr(account, "provider", None)) in oauth_keys
+            and _oauth_account_can_connect(account)
+        ),
+        None,
+    )
+    if not oauth_account:
+        return None, None
+
+    server = next(
+        (
+            server
+            for server, user_mcp in user_mcps
+            if user_mcp.is_active and _is_oauth_server_for_app(server, app)
+        ),
+        None,
+    )
+    if not server:
+        return None, None
+
+    email = getattr(oauth_account, "email", None)
+    return server.id, str(email) if email else None
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -456,14 +543,6 @@ def list_mcp_apps(
     oauth_accounts = (
         db.query(UserOAuth).filter(UserOAuth.user_id == current_user.id).all()
     )
-    oauth_emails = {
-        str(oauth.provider): str(oauth.email) for oauth in oauth_accounts if oauth.email
-    }
-
-    # Try to map connected names to emails
-    connected_apps = {}
-    for server, _ in user_mcps:
-        connected_apps[server.name.lower()] = server.id
 
     results = []
     library_apps = (
@@ -472,10 +551,12 @@ def list_mcp_apps(
 
     if location in ["remote", "all"]:
         for app in library_apps:
-            is_connected = (
-                app["name"].lower() in connected_apps
-                or app["id"].lower() in connected_apps
+            server_id, connected_account = (
+                _connected_oauth_server_for_app(app, user_mcps, oauth_accounts)
+                if app.get("transport") == "oauth"
+                else (None, None)
             )
+            is_connected = server_id is not None
             is_visible_in_connector = app.get("is_visible_in_connector", True)
 
             # Strong hide mode: hidden public apps are removed from the
@@ -499,21 +580,10 @@ def list_mcp_apps(
             app_copy["is_connected"] = is_connected
 
             if is_connected:
-                # Find the server id
-                server_id = connected_apps.get(
-                    app["name"].lower()
-                ) or connected_apps.get(app["id"].lower())
                 app_copy["server_id"] = server_id
 
-                # Find connected email
-                provider = app.get("provider")
-                app_id = app.get("id")
-                # Check for email in both provider and app_id keys
-                email = oauth_emails.get(str(app_id)) if app_id else None
-                if not email and provider:
-                    email = oauth_emails.get(str(provider))
-                if email:
-                    app_copy["connected_account"] = email
+                if connected_account:
+                    app_copy["connected_account"] = connected_account
 
             if status == "verified" and not app_copy["is_connected"]:
                 continue

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -1,11 +1,14 @@
 import os
 import tempfile
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xagent.web.api.admin_mcp import admin_mcp_router
+import xagent.web.api.mcp as mcp_api
 from xagent.web.api.auth import _ensure_user_mcp_server, auth_router
 from xagent.web.api.mcp import mcp_router
 from xagent.web.models.database import Base, get_db, get_engine
@@ -148,6 +151,27 @@ def _connect_custom_stdio_mcp_for_user(username: str, server_name: str) -> None:
         db.commit()
     finally:
         db.close()
+
+
+def test_oauth_account_can_connect_with_sqlite_naive_utc_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is timezone.utc:
+                return cls(2026, 1, 1, 8, 0, tzinfo=timezone.utc)
+            return cls(2026, 1, 1, 16, 0)
+
+    monkeypatch.setattr(mcp_api, "datetime", FixedDateTime)
+
+    oauth_account = SimpleNamespace(
+        access_token="access-token",
+        refresh_token=None,
+        expires_at=FixedDateTime(2026, 1, 1, 9, 0),
+    )
+
+    assert mcp_api._oauth_account_can_connect(oauth_account) is True
 
 
 def test_hidden_public_mcp_app_is_excluded_from_remote_connector_list() -> None:

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -1,11 +1,12 @@
 import os
 import tempfile
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from xagent.web.api.admin_mcp import admin_mcp_router
-from xagent.web.api.auth import auth_router
+from xagent.web.api.auth import _ensure_user_mcp_server, auth_router
 from xagent.web.api.mcp import mcp_router
 from xagent.web.models.database import Base, get_db, get_engine
 from xagent.web.models.mcp import MCPServer, UserMCPServer
@@ -117,6 +118,38 @@ def _connect_app_for_user(username: str, server_name: str) -> None:
         db.close()
 
 
+def _connect_custom_stdio_mcp_for_user(username: str, server_name: str) -> None:
+    db = next(get_db())
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        assert user is not None
+
+        server = MCPServer(
+            name=server_name,
+            description="custom stdio connector",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@floriscornel/teams-mcp@latest"],
+        )
+        db.add(server)
+        db.flush()
+
+        db.add(
+            UserMCPServer(
+                user_id=user.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
 def test_hidden_public_mcp_app_is_excluded_from_remote_connector_list() -> None:
     temp_dir = _setup_test_db()
     try:
@@ -143,6 +176,87 @@ def test_hidden_public_mcp_app_is_excluded_from_remote_connector_list() -> None:
         app_ids = {app["id"] for app in response.json()}
         assert "visible-app" in app_ids
         assert "hidden-app" not in app_ids
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_custom_stdio_mcp_with_same_name_does_not_mark_builtin_oauth_app_connected() -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "username": "regular",
+                "email": "regular@example.com",
+                "password": "password123",
+            },
+        )
+        assert register_response.status_code == 200
+        regular_headers = _login("regular", "password123")
+
+        _connect_custom_stdio_mcp_for_user("regular", "Teams")
+
+        response = client.get(
+            "/api/mcp/apps?location=remote&search=teams",
+            headers=regular_headers,
+        )
+        assert response.status_code == 200
+
+        teams_app = next(app for app in response.json() if app["id"] == "teams")
+        assert teams_app["is_connected"] is False
+        assert "server_id" not in teams_app
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_oauth_connection_does_not_reuse_same_name_custom_stdio_mcp() -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "username": "regular",
+                "email": "regular@example.com",
+                "password": "password123",
+            },
+        )
+        assert register_response.status_code == 200
+        _connect_custom_stdio_mcp_for_user("regular", "Teams")
+
+        db = next(get_db())
+        try:
+            user = db.query(User).filter(User.username == "regular").first()
+            assert user is not None
+
+            with pytest.raises(ValueError, match="conflicts with an existing MCP server"):
+                _ensure_user_mcp_server(
+                    db,
+                    str(user.id),
+                    {
+                        "id": "teams",
+                        "name": "Teams",
+                        "description": "Connect to Microsoft Teams.",
+                        "provider": "microsoft",
+                    },
+                )
+        finally:
+            db.close()
     finally:
         Base.metadata.drop_all(bind=get_engine())
         try:

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -70,7 +70,11 @@ def _login(username: str, password: str) -> dict[str, str]:
 
 
 def _create_public_app(
-    headers: dict[str, str], app_id: str, name: str, is_visible_in_connector: bool
+    headers: dict[str, str],
+    app_id: str,
+    name: str,
+    is_visible_in_connector: bool,
+    transport: str = "oauth",
 ) -> None:
     response = client.post(
         "/api/admin/mcp/apps",
@@ -80,7 +84,7 @@ def _create_public_app(
             "name": name,
             "description": f"{name} description",
             "icon": "",
-            "transport": "oauth",
+            "transport": transport,
             "provider_name": None,
             "category": "Communication",
             "oauth_scopes": [],
@@ -151,6 +155,51 @@ def _connect_custom_stdio_mcp_for_user(username: str, server_name: str) -> None:
         db.commit()
     finally:
         db.close()
+
+
+def test_connected_non_oauth_public_app_is_marked_connected() -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "username": "regular",
+                "email": "regular@example.com",
+                "password": "password123",
+            },
+        )
+        assert register_response.status_code == 200
+        regular_headers = _login("regular", "password123")
+
+        _create_public_app(
+            admin_headers,
+            "public-stdio",
+            "Public Stdio",
+            True,
+            transport="stdio",
+        )
+        _connect_custom_stdio_mcp_for_user("regular", "Public Stdio")
+
+        response = client.get(
+            "/api/mcp/apps?location=remote&search=public",
+            headers=regular_headers,
+        )
+        assert response.status_code == 200
+
+        public_app = next(app for app in response.json() if app["id"] == "public-stdio")
+        assert public_app["is_connected"] is True
+        assert isinstance(public_app["server_id"], int)
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
 
 
 def test_oauth_account_can_connect_with_sqlite_naive_utc_expiry(

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -16,6 +16,7 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
 
 
 def override_get_db():
@@ -157,6 +158,26 @@ def _connect_custom_stdio_mcp_for_user(username: str, server_name: str) -> None:
         db.close()
 
 
+def _connect_oauth_account_for_user(username: str, provider: str) -> None:
+    db = next(get_db())
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        assert user is not None
+
+        db.add(
+            UserOAuth(
+                user_id=user.id,
+                provider=provider,
+                access_token="access-token",
+                provider_user_id=f"{provider}-user",
+                email=f"{provider}@example.com",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
 def test_connected_non_oauth_public_app_is_marked_connected() -> None:
     temp_dir = _setup_test_db()
     try:
@@ -192,6 +213,94 @@ def test_connected_non_oauth_public_app_is_marked_connected() -> None:
         public_app = next(app for app in response.json() if app["id"] == "public-stdio")
         assert public_app["is_connected"] is True
         assert isinstance(public_app["server_id"], int)
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_non_oauth_public_app_matches_space_hyphen_name_variant() -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "username": "regular",
+                "email": "regular@example.com",
+                "password": "password123",
+            },
+        )
+        assert register_response.status_code == 200
+        regular_headers = _login("regular", "password123")
+
+        _create_public_app(
+            admin_headers,
+            "space-hyphen",
+            "Different Display Name",
+            True,
+            transport="stdio",
+        )
+        _connect_custom_stdio_mcp_for_user("regular", "Space Hyphen")
+
+        response = client.get(
+            "/api/mcp/apps?location=remote&search=different",
+            headers=regular_headers,
+        )
+        assert response.status_code == 200
+
+        public_app = next(app for app in response.json() if app["id"] == "space-hyphen")
+        assert public_app["is_connected"] is True
+        assert isinstance(public_app["server_id"], int)
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_remote_connector_builds_oauth_connectability_once_per_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "username": "regular",
+                "email": "regular@example.com",
+                "password": "password123",
+            },
+        )
+        assert register_response.status_code == 200
+        regular_headers = _login("regular", "password123")
+        _connect_oauth_account_for_user("regular", "microsoft")
+
+        checked_providers: list[str] = []
+
+        def count_connectability_check(oauth_account: object) -> bool:
+            checked_providers.append(str(getattr(oauth_account, "provider")))
+            return True
+
+        monkeypatch.setattr(
+            mcp_api, "_oauth_account_can_connect", count_connectability_check
+        )
+
+        response = client.get("/api/mcp/apps?location=remote", headers=regular_headers)
+        assert response.status_code == 200
+
+        assert checked_providers == ["microsoft"]
     finally:
         Base.metadata.drop_all(bind=get_engine())
         try:

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -7,8 +7,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from xagent.web.api.admin_mcp import admin_mcp_router
 import xagent.web.api.mcp as mcp_api
+from xagent.web.api.admin_mcp import admin_mcp_router
 from xagent.web.api.auth import _ensure_user_mcp_server, auth_router
 from xagent.web.api.mcp import mcp_router
 from xagent.web.models.database import Base, get_db, get_engine
@@ -210,7 +210,9 @@ def test_hidden_public_mcp_app_is_excluded_from_remote_connector_list() -> None:
             pass
 
 
-def test_custom_stdio_mcp_with_same_name_does_not_mark_builtin_oauth_app_connected() -> None:
+def test_custom_stdio_mcp_with_same_name_does_not_mark_builtin_oauth_app_connected() -> (
+    None
+):
     temp_dir = _setup_test_db()
     try:
         _setup_admin()
@@ -268,7 +270,9 @@ def test_oauth_connection_does_not_reuse_same_name_custom_stdio_mcp() -> None:
             user = db.query(User).filter(User.username == "regular").first()
             assert user is not None
 
-            with pytest.raises(ValueError, match="conflicts with an existing MCP server"):
+            with pytest.raises(
+                ValueError, match="conflicts with an existing MCP server"
+            ):
                 _ensure_user_mcp_server(
                     db,
                     str(user.id),

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -17,7 +17,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.utils.encryption import encrypt_value
-from xagent.web.api.auth import create_access_token, generic_oauth_login
+from xagent.web.api.auth import (
+    _resolve_oauth_secret,
+    create_access_token,
+    generic_oauth_login,
+)
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
 
@@ -207,6 +211,26 @@ def test_login_uses_env_client_id_when_provider_client_id_is_empty(
     qs = parse_qs(urlparse(_location(resp)).query)
 
     assert qs["client_id"] == ["env-client-id"]
+
+
+@pytest.mark.parametrize("encrypted_value", [None, ""])
+def test_resolve_oauth_secret_uses_env_without_decrypting_empty_values(
+    encrypted_value, monkeypatch
+):
+    from xagent.core.utils import encryption
+
+    def fail_on_empty_decrypt(value: str) -> str:
+        if not value:
+            raise ValueError("empty values should not be decrypted")
+        return "db-secret"
+
+    monkeypatch.setattr(encryption, "decrypt_value", fail_on_empty_decrypt)
+    monkeypatch.setenv("MICROSOFT_CLIENT_SECRET", "env-secret")
+
+    assert (
+        _resolve_oauth_secret("microsoft", encrypted_value, "CLIENT_SECRET")
+        == "env-secret"
+    )
 
 
 def test_login_fails_locally_when_client_id_is_missing(db_session, monkeypatch):

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -52,10 +52,15 @@ def _token_for(user: User) -> str:
     )
 
 
-def _provider(auth_url: str, default_scopes=None, redirect_uri=None):
+def _provider(
+    auth_url: str,
+    default_scopes=None,
+    redirect_uri=None,
+    client_id: str = "test-client-id",
+):
     """A duck-typed stand-in for the OAuthProvider ORM row."""
     return SimpleNamespace(
-        client_id=encrypt_value("test-client-id"),
+        client_id=encrypt_value(client_id),
         auth_url=auth_url,
         redirect_uri=redirect_uri,
         default_scopes=default_scopes or [],
@@ -175,3 +180,55 @@ def test_non_zoom_provider_does_not_set_prompt_login(db_session):
     )
     qs = parse_qs(urlparse(_location(resp)).query)
     assert "prompt" not in qs
+
+
+def test_login_uses_env_client_id_when_provider_client_id_is_empty(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.setenv("MICROSOFT_CLIENT_ID", "env-client-id")
+
+    provider = _provider(
+        auth_url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        default_scopes=["User.Read"],
+        redirect_uri="https://app.example.com/cb",
+        client_id="",
+    )
+
+    resp = generic_oauth_login(
+        provider="microsoft",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert qs["client_id"] == ["env-client-id"]
+
+
+def test_login_fails_locally_when_client_id_is_missing(db_session, monkeypatch):
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.delenv("MICROSOFT_CLIENT_ID", raising=False)
+
+    provider = _provider(
+        auth_url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        default_scopes=["User.Read"],
+        redirect_uri="https://app.example.com/cb",
+        client_id="",
+    )
+
+    resp = generic_oauth_login(
+        provider="microsoft",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+
+    assert resp.status_code == 500
+    assert "MICROSOFT_CLIENT_ID" in resp.body.decode()


### PR DESCRIPTION
This pull request introduces significant improvements to the way MCP (Managed Connector Platform) apps and servers are matched, selected, and managed in the frontend, along with enhancements to OAuth provider configuration handling in the backend. The changes focus on making MCP name matching more robust, improving user experience with MCP server selection, and ensuring better error handling and validation for OAuth integrations.

**Frontend improvements for MCP app/server matching and selection:**

- **Robust MCP name matching and lookup:**
  - Introduced new utility functions (`findMatchingMcpServer`, `findMatchingMcpApp`, and `mcpNameMatches` in `mcp-lookup.ts`) that normalize and compare MCP server and app names/IDs, making matching more reliable and less error-prone. This logic is now used throughout the agent builder and MCP connection dialogs. 
  - Added unit tests for these lookup helpers to ensure correctness.

- **Improved MCP server selection and status display:**
  - Updated MCP server selection logic in the agent builder to use the new matching functions, preventing case/format mismatches and improving the accuracy of connection/support status. 
  - Ensured MCP app connection status is determined using a new `is_connected` field, and that MCP app lists refresh after successful connections.

**Backend improvements for OAuth provider handling:**

- **Centralized and robust OAuth provider configuration:**
  - Refactored OAuth configuration logic into helper functions (`_resolve_oauth_secret`, `_resolve_oauth_redirect_uri`, and related error helpers), improving maintainability and error messaging when required environment variables or secrets are missing. 
  - Enhanced error responses to clearly indicate which configuration values are missing for OAuth providers. 
 
- **Stronger validation for MCP OAuth server/app consistency:**
  - Added stricter checks to ensure that OAuth MCP servers are correctly matched to official app metadata, preventing conflicts with custom servers or mismatched app/provider IDs. 

**Other:**

- Updated `datetime` import to use `timezone` in `mcp.py` for better timezone handling.

These changes collectively make MCP app/server selection more reliable and user-friendly, and ensure OAuth integrations are correctly configured and validated, reducing the risk of misconfiguration and improving the overall developer and user experience.