### PR TITLE
feat(tool): add Meta MCP tool and related tests

### DIFF
--- a/example.env
+++ b/example.env
@@ -217,6 +217,21 @@ LINKEDIN_CLIENT_SECRET=""
 # Example: http://localhost:8000/api/auth/linkedin/callback
 LINKEDIN_REDIRECT_URI=""
 
+# ===========================================
+# Meta OAuth Configuration (Optional)
+# ===========================================
+# Required for Facebook Pages and Instagram integrations in MCP
+# Create credentials at https://developers.facebook.com/apps/
+META_CLIENT_ID=""
+META_CLIENT_SECRET=""
+# Redirect URI for Meta OAuth callback
+# Example: http://localhost:8000/api/auth/meta/callback
+META_REDIRECT_URI=""
+# Optional Facebook Login for Business configuration ID. When set, Meta OAuth
+# uses config_id instead of a raw scope list, which is required by some Meta app
+# configurations for Pages and Instagram permissions.
+META_CONFIG_ID=""
+
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
 # - LanceDB storage path: <project_root>/memory_store/

--- a/src/xagent/migrations/versions/20260627_seed_meta_connectors.py
+++ b/src/xagent/migrations/versions/20260627_seed_meta_connectors.py
@@ -1,0 +1,186 @@
+"""seed built-in Meta connector registry data
+
+Revision ID: 20260627_seed_meta_connectors
+Revises: 20260624_add_mcp_concurrency_config
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260627_seed_meta_connectors"
+down_revision: Union[str, None] = "20260624_add_mcp_concurrency_config"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+META_APP_IDS = ("facebook", "instagram")
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _meta_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "meta",
+        "name": "Meta",
+        "client_id": os.environ.get("META_CLIENT_ID", ""),
+        "client_secret": os.environ.get("META_CLIENT_SECRET", ""),
+        "auth_url": "https://www.facebook.com/v25.0/dialog/oauth",
+        "token_url": "https://graph.facebook.com/v25.0/oauth/access_token",
+        "redirect_uri": os.environ.get("META_REDIRECT_URI", ""),
+        "userinfo_url": "https://graph.facebook.com/v25.0/me?fields=id,email",
+        "user_id_path": "id",
+        "email_path": "email",
+        "default_scopes": ["public_profile"],
+    }
+
+
+def _meta_app_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "app_id": "facebook",
+            "name": "Facebook Pages",
+            "description": "Connect to Facebook Pages to discover managed pages and publish page posts.",
+            "icon": "https://www.google.com/s2/favicons?domain=facebook.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "meta",
+            "category": "Marketing",
+            "oauth_scopes": [
+                "pages_show_list",
+                "pages_read_engagement",
+                "pages_manage_posts",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "uv",
+                "args": ["run", "python", "-m", "xagent.web.tools.mcp.facebook"],
+                "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "instagram",
+            "name": "Instagram",
+            "description": "Connect to Instagram professional accounts through Meta Graph API.",
+            "icon": "https://www.google.com/s2/favicons?domain=instagram.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "meta",
+            "category": "Marketing",
+            "oauth_scopes": [
+                "pages_show_list",
+                "pages_read_engagement",
+                "instagram_basic",
+                "instagram_content_publish",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "uv",
+                "args": ["run", "python", "-m", "xagent.web.tools.mcp.instagram"],
+                "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+            },
+        },
+    ]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+        )
+        if "meta" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_meta_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        app_rows_to_insert = [
+            _filter_row(row, app_columns)
+            for row in _meta_app_rows()
+            if row["app_id"] not in existing_app_ids
+        ]
+        if app_rows_to_insert:
+            bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), app_rows_to_insert)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id.in_(META_APP_IDS)
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_meta_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "meta")
+        ).scalar_one()
+        if remaining_meta_apps:
+            return
+
+    bind.execute(
+        sa.delete(OAUTH_PROVIDERS_TABLE).where(
+            OAUTH_PROVIDERS_TABLE.c.provider_name == "meta"
+        )
+    )

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -143,8 +143,16 @@ def _exchange_meta_long_lived_token(
         },
         timeout=10.0,
     )
-    long_lived_token_data = response.json()
-    if response.status_code != 200 or "error" in long_lived_token_data:
+    try:
+        long_lived_token_data = response.json()
+    except ValueError:
+        return token_data
+
+    if (
+        response.status_code != 200
+        or not isinstance(long_lived_token_data, dict)
+        or "error" in long_lived_token_data
+    ):
         return token_data
 
     return {**token_data, **long_lived_token_data}
@@ -1304,12 +1312,12 @@ def generic_oauth_callback(
             )
             db.add(oauth_account)
 
-            oauth_account.access_token = access_token
+            setattr(oauth_account, "access_token", access_token)
             setattr(oauth_account, "token_type", token_data.get("token_type", "Bearer"))
             setattr(oauth_account, "scope", token_data.get("scope", ""))
             setattr(oauth_account, "email", email)
             if "refresh_token" in token_data:
-                oauth_account.refresh_token = token_data.get("refresh_token")
+                setattr(oauth_account, "refresh_token", token_data.get("refresh_token"))
             if "expires_in" in token_data:
                 setattr(
                     oauth_account,

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -133,19 +133,19 @@ def _exchange_meta_long_lived_token(
     if not access_token:
         return token_data
 
-    response = requests.get(
-        token_url,
-        params={
-            "grant_type": "fb_exchange_token",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "fb_exchange_token": access_token,
-        },
-        timeout=10.0,
-    )
     try:
+        response = requests.get(
+            token_url,
+            params={
+                "grant_type": "fb_exchange_token",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "fb_exchange_token": access_token,
+            },
+            timeout=10.0,
+        )
         long_lived_token_data = response.json()
-    except ValueError:
+    except (requests.RequestException, ValueError):
         return token_data
 
     if (

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -114,9 +114,7 @@ def _oauth_scope_separator(provider: str) -> str:
 
 
 def _meta_login_config_id() -> str:
-    return os.environ.get("META_CONFIG_ID") or os.environ.get(
-        "META_LOGIN_CONFIG_ID", ""
-    )
+    return os.environ.get("META_CONFIG_ID", "")
 
 
 def _exchange_meta_long_lived_token(
@@ -1077,16 +1075,15 @@ def generic_oauth_login(
     }
     state = create_access_token(data=state_payload, expires_delta=timedelta(minutes=10))
 
-    scopes = _merge_oauth_scopes(db_provider.default_scopes or [], None)
+    app_scopes: list[str] | None = None
     from ..mcp_apps import get_app_by_id
 
     if app_id:
         app_info = get_app_by_id(db, app_id)
         if app_info and "oauth_scopes" in app_info:
-            scopes = _merge_oauth_scopes(
-                db_provider.default_scopes or [], app_info["oauth_scopes"]
-            )
+            app_scopes = app_info["oauth_scopes"]
 
+    scopes = _merge_oauth_scopes(db_provider.default_scopes or [], app_scopes)
     scope_str = _oauth_scope_separator(provider).join(scopes)
 
     from urllib.parse import urlencode

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -91,6 +91,7 @@ def _oauth_provider_config_error(
 def _merge_oauth_scopes(
     default_scopes: list[str] | None, app_scopes: list[str] | None
 ) -> list[str]:
+    """Preserve provider default order and sort app scopes for deterministic URLs."""
     scopes: list[str] = []
     seen: set[str] = set()
 
@@ -143,7 +144,11 @@ def _exchange_meta_long_lived_token(
             timeout=10.0,
         )
         long_lived_token_data = response.json()
-    except (requests.RequestException, ValueError):
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning(
+            "Meta long-lived token exchange failed; using short-lived token: %s",
+            exc,
+        )
         return token_data
 
     if (
@@ -151,6 +156,21 @@ def _exchange_meta_long_lived_token(
         or not isinstance(long_lived_token_data, dict)
         or "error" in long_lived_token_data
     ):
+        reason_parts = []
+        if response.status_code != 200:
+            reason_parts.append(f"status={response.status_code}")
+        if not isinstance(long_lived_token_data, dict):
+            reason_parts.append(f"body_type={type(long_lived_token_data).__name__}")
+        else:
+            error = long_lived_token_data.get("error")
+            if error:
+                reason_parts.append(f"error={error}")
+        reason = ", ".join(reason_parts) or "unknown reason"
+        logger.warning(
+            "Meta long-lived token exchange returned unusable response; "
+            "using short-lived token: %s",
+            reason,
+        )
         return token_data
 
     return {**token_data, **long_lived_token_data}

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -88,6 +88,68 @@ def _oauth_provider_config_error(
     )
 
 
+def _merge_oauth_scopes(
+    default_scopes: list[str] | None, app_scopes: list[str] | None
+) -> list[str]:
+    scopes: list[str] = []
+    seen: set[str] = set()
+
+    for scope in default_scopes or []:
+        if scope and scope not in seen:
+            scopes.append(scope)
+            seen.add(scope)
+
+    for scope in sorted(app_scopes or []):
+        if scope and scope not in seen:
+            scopes.append(scope)
+            seen.add(scope)
+
+    return scopes
+
+
+def _oauth_scope_separator(provider: str) -> str:
+    if provider.lower() == "meta":
+        return ","
+    return " "
+
+
+def _meta_login_config_id() -> str:
+    return os.environ.get("META_CONFIG_ID") or os.environ.get(
+        "META_LOGIN_CONFIG_ID", ""
+    )
+
+
+def _exchange_meta_long_lived_token(
+    provider: str,
+    token_url: str,
+    token_data: dict[str, Any],
+    client_id: str,
+    client_secret: str,
+) -> dict[str, Any]:
+    if provider.lower() != "meta":
+        return token_data
+
+    access_token = token_data.get("access_token")
+    if not access_token:
+        return token_data
+
+    response = requests.get(
+        token_url,
+        params={
+            "grant_type": "fb_exchange_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "fb_exchange_token": access_token,
+        },
+        timeout=10.0,
+    )
+    long_lived_token_data = response.json()
+    if response.status_code != 200 or "error" in long_lived_token_data:
+        return token_data
+
+    return {**token_data, **long_lived_token_data}
+
+
 def create_access_token(
     data: Dict[str, Any], expires_delta: Optional[timedelta] = None
 ) -> str:
@@ -1007,15 +1069,17 @@ def generic_oauth_login(
     }
     state = create_access_token(data=state_payload, expires_delta=timedelta(minutes=10))
 
-    scopes = db_provider.default_scopes or []
+    scopes = _merge_oauth_scopes(db_provider.default_scopes or [], None)
     from ..mcp_apps import get_app_by_id
 
     if app_id:
         app_info = get_app_by_id(db, app_id)
         if app_info and "oauth_scopes" in app_info:
-            scopes = list(set(scopes + app_info["oauth_scopes"]))
+            scopes = _merge_oauth_scopes(
+                db_provider.default_scopes or [], app_info["oauth_scopes"]
+            )
 
-    scope_str = " ".join(scopes)
+    scope_str = _oauth_scope_separator(provider).join(scopes)
 
     from urllib.parse import urlencode
 
@@ -1031,7 +1095,10 @@ def generic_oauth_login(
         params["prompt"] = "consent"
     if provider.lower() == "zoom":
         params["prompt"] = "login"
-    if scope_str:
+    meta_config_id = _meta_login_config_id() if provider.lower() == "meta" else ""
+    if meta_config_id:
+        params["config_id"] = meta_config_id
+    elif scope_str:
         params["scope"] = scope_str
 
     separator = "&" if "?" in auth_url else "?"
@@ -1207,6 +1274,9 @@ def generic_oauth_callback(
                 status_code=400,
             )
 
+        token_data = _exchange_meta_long_lived_token(
+            provider, token_url, token_data, client_id, client_secret
+        )
         access_token = token_data.get("access_token")
 
         provider_user_id = None

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -80,6 +80,19 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "email_path": "userPrincipalName",
             "default_scopes": ["User.Read"],
         },
+        {
+            "provider_name": "meta",
+            "name": "Meta",
+            "client_id": os.environ.get("META_CLIENT_ID", ""),
+            "client_secret": os.environ.get("META_CLIENT_SECRET", ""),
+            "auth_url": "https://www.facebook.com/v25.0/dialog/oauth",
+            "token_url": "https://graph.facebook.com/v25.0/oauth/access_token",
+            "redirect_uri": os.environ.get("META_REDIRECT_URI", ""),
+            "userinfo_url": "https://graph.facebook.com/v25.0/me?fields=id,email",
+            "user_id_path": "id",
+            "email_path": "email",
+            "default_scopes": ["public_profile"],
+        },
     ]
 
 
@@ -212,6 +225,47 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "uv",
                 "args": ["run", "python", "-m", "xagent.web.tools.mcp.onedrive"],
                 "env_mapping": {"AUTH_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "facebook",
+            "name": "Facebook Pages",
+            "description": "Connect to Facebook Pages to discover managed pages and publish page posts.",
+            "icon": "https://www.google.com/s2/favicons?domain=facebook.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "meta",
+            "category": "Marketing",
+            "oauth_scopes": [
+                "pages_show_list",
+                "pages_read_engagement",
+                "pages_manage_posts",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "uv",
+                "args": ["run", "python", "-m", "xagent.web.tools.mcp.facebook"],
+                "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "instagram",
+            "name": "Instagram",
+            "description": "Connect to Instagram professional accounts through Meta Graph API.",
+            "icon": "https://www.google.com/s2/favicons?domain=instagram.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "meta",
+            "category": "Marketing",
+            "oauth_scopes": [
+                "pages_show_list",
+                "pages_read_engagement",
+                "instagram_basic",
+                "instagram_content_publish",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "uv",
+                "args": ["run", "python", "-m", "xagent.web.tools.mcp.instagram"],
+                "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
             },
         },
     ]

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -42,12 +42,6 @@ async def refresh_oauth_token_if_needed(
     if expires_at > now + timedelta(minutes=5):
         return True  # Token is still valid
 
-    if not oauth_account.refresh_token:
-        logger.warning(
-            f"Token expired for {provider_name} but no refresh_token available."
-        )
-        return False
-
     logger.info(f"Token expired for {provider_name}, attempting to refresh...")
     try:
         from ...core.utils.encryption import decrypt_value
@@ -68,6 +62,44 @@ async def refresh_oauth_token_if_needed(
         if not client_id or not client_secret:
             logger.warning(
                 f"{provider_name} OAuth not configured (missing CLIENT_ID or SECRET)."
+            )
+            return False
+
+        if provider_name == "meta":
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    provider_config.token_url,
+                    params={
+                        "grant_type": "fb_exchange_token",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "fb_exchange_token": oauth_account.access_token,
+                    },
+                    timeout=10.0,
+                )
+
+            if response.status_code == 200:
+                data = response.json()
+                if "access_token" in data:
+                    oauth_account.access_token = data["access_token"]
+                    if "expires_in" in data:
+                        oauth_account.expires_at = datetime.now(
+                            timezone.utc
+                        ) + timedelta(seconds=int(data["expires_in"]))
+                    db.commit()
+                    logger.info(
+                        f"Successfully refreshed {provider_name} token for user {oauth_account.user_id}"
+                    )
+                    return True
+            else:
+                logger.error(
+                    f"Failed to refresh {provider_name} token: {response.text}"
+                )
+            return False
+
+        if not oauth_account.refresh_token:
+            logger.warning(
+                f"Token expired for {provider_name} but no refresh_token available."
             )
             return False
 

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -158,7 +158,9 @@ def _list_pages_with_tokens() -> list[dict[str, Any]]:
         "/me/accounts",
         params={"fields": "id,name,category,tasks,access_token"},
     )
-    pages = result.get("data", []) if isinstance(result, dict) else []
+    pages = result.get("data") if isinstance(result, dict) else None
+    if not isinstance(pages, list):
+        return []
     return [page for page in pages if isinstance(page, dict)]
 
 

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -7,13 +7,13 @@ from mcp.server.fastmcp import FastMCP
 from . import meta_graph
 from .meta_graph import (
     GraphAPIError,
-    bounded_limit as _bounded_limit,
-    error_response as _error,
-    graph_error_response as _graph_error,
-    graph_request as _graph_request,
-    is_public_image_url as _is_public_image_url,
-    success_response as _success,
 )
+from .meta_graph import bounded_limit as _bounded_limit
+from .meta_graph import error_response as _error
+from .meta_graph import graph_error_response as _graph_error
+from .meta_graph import graph_request as _graph_request
+from .meta_graph import is_public_image_url as _is_public_image_url
+from .meta_graph import success_response as _success
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -1,12 +1,19 @@
-import json
 import logging
-import os
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
-import requests
 from mcp.server.fastmcp import FastMCP
 
+from . import meta_graph
+from .meta_graph import (
+    GraphAPIError,
+    bounded_limit as _bounded_limit,
+    error_response as _error,
+    graph_error_response as _graph_error,
+    graph_request as _graph_request,
+    is_public_image_url as _is_public_image_url,
+    success_response as _success,
+)
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -15,133 +22,7 @@ logger = logging.getLogger("facebook-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("facebook-mcp")
-
-GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
-DEFAULT_TIMEOUT_SECONDS = 30
-MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
-
-
-class GraphAPIError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        details: Any = None,
-        sensitive_values: set[str] | None = None,
-    ):
-        super().__init__(message)
-        self.details = details
-        self.sensitive_values = sensitive_values or set()
-
-
-def _success(**payload: Any) -> str:
-    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
-
-
-def _redact_secrets(value: Any, sensitive_values: set[str] | None = None) -> Any:
-    tokens = {token for token in sensitive_values or set() if token}
-    env_token = os.environ.get("META_ACCESS_TOKEN")
-    if env_token:
-        tokens.add(env_token)
-
-    if isinstance(value, dict):
-        return {
-            key: _redact_secrets(item, sensitive_values=tokens)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_secrets(item, sensitive_values=tokens) for item in value]
-    if isinstance(value, str):
-        redacted = value
-        for token in tokens:
-            redacted = redacted.replace(token, "[redacted]")
-        return redacted
-    return value
-
-
-def _error(
-    message: str,
-    *,
-    details: Any = None,
-    sensitive_values: set[str] | None = None,
-) -> str:
-    payload: dict[str, Any] = {
-        "status": "error",
-        "message": _redact_secrets(message, sensitive_values=sensitive_values),
-    }
-    if details is not None:
-        payload["details"] = _redact_secrets(details, sensitive_values=sensitive_values)
-    return json.dumps(payload, ensure_ascii=False)
-
-
-def _graph_error(e: GraphAPIError) -> str:
-    return _error(str(e), details=e.details, sensitive_values=e.sensitive_values)
-
-
-def _user_token() -> str:
-    token = os.environ.get("META_ACCESS_TOKEN")
-    if not token:
-        raise ValueError("META_ACCESS_TOKEN environment variable is missing")
-    return token
-
-
-def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-    }
-    if form:
-        headers["Content-Type"] = "application/x-www-form-urlencoded"
-    return headers
-
-
-def _response_error_text(response: Any) -> str:
-    response_text = str(getattr(response, "text", "")).strip()
-    if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
-        return response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
-    return response_text
-
-
-def _graph_request(
-    method: str,
-    path: str,
-    *,
-    token: str | None = None,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
-) -> Any:
-    request_token = token or _user_token()
-    response = requests.request(
-        method=method,
-        url=f"{GRAPH_BASE_URL}{path}",
-        headers=_graph_headers(request_token, form=method.upper() != "GET"),
-        params=params,
-        data=data,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
-
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as exc:
-        details = _response_json(response)
-        message = str(exc)
-        response_text = _response_error_text(response)
-        if response_text:
-            message = f"{message} - {response_text}"
-        sensitive_values = {request_token, os.environ.get("META_ACCESS_TOKEN", "")}
-        raise GraphAPIError(
-            message, details=details, sensitive_values=sensitive_values
-        ) from exc
-
-    if response.status_code == 204 or not response.content:
-        return {}
-    return response.json()
-
-
-def _response_json(response: Any) -> Any:
-    try:
-        return response.json()
-    except Exception:
-        return None
+requests = meta_graph.requests
 
 
 def _page_path(page_id: str, suffix: str) -> str:
@@ -181,15 +62,6 @@ def _page_access_token(page_id: str) -> str:
                 return str(token)
             raise ValueError(f"Page {page_id} did not include an access token")
     raise ValueError(f"Page {page_id} is not accessible to the connected user")
-
-
-def _bounded_limit(limit: int, maximum: int = 100) -> int:
-    return max(1, min(int(limit), maximum))
-
-
-def _is_public_image_url(image_url: str) -> bool:
-    parsed = urlparse(image_url)
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -18,6 +18,7 @@ mcp = FastMCP("facebook-mcp")
 
 GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
 DEFAULT_TIMEOUT_SECONDS = 30
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
 
 
 class GraphAPIError(RuntimeError):
@@ -93,6 +94,13 @@ def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
     return headers
 
 
+def _response_error_text(response: Any) -> str:
+    response_text = str(getattr(response, "text", "")).strip()
+    if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+        return response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    return response_text
+
+
 def _graph_request(
     method: str,
     path: str,
@@ -116,7 +124,7 @@ def _graph_request(
     except requests.HTTPError as exc:
         details = _response_json(response)
         message = str(exc)
-        response_text = response.text.strip()
+        response_text = _response_error_text(response)
         if response_text:
             message = f"{message} - {response_text}"
         sensitive_values = {request_token, os.environ.get("META_ACCESS_TOKEN", "")}

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -1,0 +1,303 @@
+import json
+import logging
+import os
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("facebook-mcp")
+
+setup_proxy_env()
+
+mcp = FastMCP("facebook-mcp")
+
+GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+class GraphAPIError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        details: Any = None,
+        sensitive_values: set[str] | None = None,
+    ):
+        super().__init__(message)
+        self.details = details
+        self.sensitive_values = sensitive_values or set()
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _redact_secrets(value: Any, sensitive_values: set[str] | None = None) -> Any:
+    tokens = {token for token in sensitive_values or set() if token}
+    env_token = os.environ.get("META_ACCESS_TOKEN")
+    if env_token:
+        tokens.add(env_token)
+
+    if isinstance(value, dict):
+        return {
+            key: _redact_secrets(item, sensitive_values=tokens)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(item, sensitive_values=tokens) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for token in tokens:
+            redacted = redacted.replace(token, "[redacted]")
+        return redacted
+    return value
+
+
+def _error(
+    message: str,
+    *,
+    details: Any = None,
+    sensitive_values: set[str] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "status": "error",
+        "message": _redact_secrets(message, sensitive_values=sensitive_values),
+    }
+    if details is not None:
+        payload["details"] = _redact_secrets(details, sensitive_values=sensitive_values)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _graph_error(e: GraphAPIError) -> str:
+    return _error(str(e), details=e.details, sensitive_values=e.sensitive_values)
+
+
+def _user_token() -> str:
+    token = os.environ.get("META_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("META_ACCESS_TOKEN environment variable is missing")
+    return token
+
+
+def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if form:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    return headers
+
+
+def _graph_request(
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    params: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    request_token = token or _user_token()
+    response = requests.request(
+        method=method,
+        url=f"{GRAPH_BASE_URL}{path}",
+        headers=_graph_headers(request_token, form=method.upper() != "GET"),
+        params=params,
+        data=data,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        details = _response_json(response)
+        message = str(exc)
+        response_text = response.text.strip()
+        if response_text:
+            message = f"{message} - {response_text}"
+        sensitive_values = {request_token, os.environ.get("META_ACCESS_TOKEN", "")}
+        raise GraphAPIError(
+            message, details=details, sensitive_values=sensitive_values
+        ) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _response_json(response: Any) -> Any:
+    try:
+        return response.json()
+    except Exception:
+        return None
+
+
+def _page_path(page_id: str, suffix: str) -> str:
+    if not page_id.strip():
+        raise ValueError("page_id is required")
+    return f"/{quote(page_id.strip(), safe='')}/{suffix}"
+
+
+def _normalize_page(page: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": page.get("id"),
+        "name": page.get("name"),
+        "category": page.get("category"),
+        "tasks": page.get("tasks", []),
+        "has_access_token": bool(page.get("access_token")),
+    }
+
+
+def _list_pages_with_tokens() -> list[dict[str, Any]]:
+    result = _graph_request(
+        "GET",
+        "/me/accounts",
+        params={"fields": "id,name,category,tasks,access_token"},
+    )
+    pages = result.get("data", []) if isinstance(result, dict) else []
+    return [page for page in pages if isinstance(page, dict)]
+
+
+def _page_access_token(page_id: str) -> str:
+    pages = _list_pages_with_tokens()
+    for page in pages:
+        if str(page.get("id")) == str(page_id):
+            token = page.get("access_token")
+            if token:
+                return str(token)
+            raise ValueError(f"Page {page_id} did not include an access token")
+    raise ValueError(f"Page {page_id} is not accessible to the connected user")
+
+
+def _bounded_limit(limit: int, maximum: int = 100) -> int:
+    return max(1, min(int(limit), maximum))
+
+
+def _is_public_image_url(image_url: str) -> bool:
+    parsed = urlparse(image_url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+@mcp.tool()
+def facebook_auth_status() -> str:
+    """Check whether the injected Meta access token is usable."""
+    try:
+        me = _graph_request("GET", "/me", params={"fields": "id,name,email"})
+        return _success(
+            authenticated=True,
+            user={
+                "id": me.get("id"),
+                "name": me.get("name"),
+                "email": me.get("email"),
+            },
+        )
+    except GraphAPIError as e:
+        logger.error("Error checking Facebook auth status: %s", e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error checking Facebook auth status: %s", e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def facebook_list_pages() -> str:
+    """List Facebook Pages accessible to the connected Meta account."""
+    try:
+        pages = [_normalize_page(page) for page in _list_pages_with_tokens()]
+        return _success(pages=pages)
+    except GraphAPIError as e:
+        logger.error("Error listing Facebook Pages: %s", e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error listing Facebook Pages: %s", e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def facebook_list_page_posts(page_id: str, limit: int = 10) -> str:
+    """List recent posts for a Facebook Page by page_id."""
+    try:
+        page_token = _page_access_token(page_id)
+        result = _graph_request(
+            "GET",
+            _page_path(page_id, "feed"),
+            token=page_token,
+            params={
+                "fields": "id,message,created_time,permalink_url,full_picture,status_type",
+                "limit": _bounded_limit(limit),
+            },
+        )
+        return _success(
+            posts=result.get("data", []),
+            next_link=result.get("paging", {}).get("next"),
+        )
+    except GraphAPIError as e:
+        logger.error("Error listing Facebook Page posts for %s: %s", page_id, e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error listing Facebook Page posts for %s: %s", page_id, e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def facebook_publish_text_post(page_id: str, message: str) -> str:
+    """Publish a text post to a Facebook Page by page_id."""
+    try:
+        if not message.strip():
+            raise ValueError("message is required")
+        page_token = _page_access_token(page_id)
+        result = _graph_request(
+            "POST",
+            _page_path(page_id, "feed"),
+            token=page_token,
+            data={"message": message},
+        )
+        return _success(post_id=result.get("id"))
+    except GraphAPIError as e:
+        logger.error("Error publishing Facebook Page text post for %s: %s", page_id, e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error publishing Facebook Page text post for %s: %s", page_id, e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def facebook_publish_image_post(
+    page_id: str,
+    image_url: str,
+    caption: str | None = None,
+    published: bool = True,
+) -> str:
+    """Publish an image post to a Facebook Page using a public image URL."""
+    try:
+        if not _is_public_image_url(image_url):
+            raise ValueError("image_url must be a public http or https URL")
+        page_token = _page_access_token(page_id)
+        data = {
+            "url": image_url,
+            "published": "true" if published else "false",
+        }
+        if caption:
+            data["caption"] = caption
+
+        result = _graph_request(
+            "POST",
+            _page_path(page_id, "photos"),
+            token=page_token,
+            data=data,
+        )
+        return _success(photo_id=result.get("id"), post_id=result.get("post_id"))
+    except GraphAPIError as e:
+        logger.error("Error publishing Facebook Page image post for %s: %s", page_id, e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error publishing Facebook Page image post for %s: %s", page_id, e)
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/facebook.py
+++ b/src/xagent/web/tools/mcp/facebook.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("facebook-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("facebook-mcp")
-requests = meta_graph.requests
+requests = meta_graph.requests  # exposed for test monkeypatching
 
 
 def _page_path(page_id: str, suffix: str) -> str:

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -197,7 +197,9 @@ def _list_pages_with_instagram_accounts() -> list[dict[str, Any]]:
         "/me/accounts",
         params={"fields": LINKED_ACCOUNT_FIELDS},
     )
-    pages = result.get("data", []) if isinstance(result, dict) else []
+    pages = result.get("data") if isinstance(result, dict) else None
+    if not isinstance(pages, list):
+        return []
     accounts: list[dict[str, Any]] = []
     for page in pages:
         if not isinstance(page, dict):

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -7,13 +7,13 @@ from mcp.server.fastmcp import FastMCP
 from . import meta_graph
 from .meta_graph import (
     GraphAPIError,
-    bounded_limit as _bounded_limit,
-    error_response as _error,
-    graph_error_response as _graph_error,
-    graph_request as _graph_request,
-    is_public_image_url as _is_public_image_url,
-    success_response as _success,
 )
+from .meta_graph import bounded_limit as _bounded_limit
+from .meta_graph import error_response as _error
+from .meta_graph import graph_error_response as _graph_error
+from .meta_graph import graph_request as _graph_request
+from .meta_graph import is_public_image_url as _is_public_image_url
+from .meta_graph import success_response as _success
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -1,0 +1,334 @@
+import json
+import logging
+import os
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("instagram-mcp")
+
+setup_proxy_env()
+
+mcp = FastMCP("instagram-mcp")
+
+GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+LINKED_ACCOUNT_FIELDS = (
+    "id,name,category,tasks,access_token,"
+    "instagram_business_account{id,username,name,profile_picture_url}"
+)
+PROFILE_FIELDS = (
+    "id,username,name,biography,profile_picture_url,followers_count,"
+    "follows_count,media_count,website"
+)
+MEDIA_FIELDS = (
+    "id,caption,media_type,media_url,permalink,timestamp,username,thumbnail_url"
+)
+
+
+class GraphAPIError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        details: Any = None,
+        sensitive_values: set[str] | None = None,
+    ):
+        super().__init__(message)
+        self.details = details
+        self.sensitive_values = sensitive_values or set()
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _redact_secrets(value: Any, sensitive_values: set[str] | None = None) -> Any:
+    tokens = {token for token in sensitive_values or set() if token}
+    env_token = os.environ.get("META_ACCESS_TOKEN")
+    if env_token:
+        tokens.add(env_token)
+
+    if isinstance(value, dict):
+        return {
+            key: _redact_secrets(item, sensitive_values=tokens)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(item, sensitive_values=tokens) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for token in tokens:
+            redacted = redacted.replace(token, "[redacted]")
+        return redacted
+    return value
+
+
+def _error(
+    message: str,
+    *,
+    details: Any = None,
+    sensitive_values: set[str] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "status": "error",
+        "message": _redact_secrets(message, sensitive_values=sensitive_values),
+    }
+    if details is not None:
+        payload["details"] = _redact_secrets(details, sensitive_values=sensitive_values)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _graph_error(e: GraphAPIError) -> str:
+    return _error(str(e), details=e.details, sensitive_values=e.sensitive_values)
+
+
+def _user_token() -> str:
+    token = os.environ.get("META_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("META_ACCESS_TOKEN environment variable is missing")
+    return token
+
+
+def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if form:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    return headers
+
+
+def _graph_request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    request_token = _user_token()
+    response = requests.request(
+        method=method,
+        url=f"{GRAPH_BASE_URL}{path}",
+        headers=_graph_headers(request_token, form=method.upper() != "GET"),
+        params=params,
+        data=data,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        details = _response_json(response)
+        message = str(exc)
+        response_text = response.text.strip()
+        if response_text:
+            message = f"{message} - {response_text}"
+        raise GraphAPIError(
+            message,
+            details=details,
+            sensitive_values={request_token},
+        ) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _response_json(response: Any) -> Any:
+    try:
+        return response.json()
+    except Exception:
+        return None
+
+
+def _graph_path(object_id: str, suffix: str | None = None) -> str:
+    if not object_id.strip():
+        raise ValueError("object id is required")
+    path = f"/{quote(object_id.strip(), safe='')}"
+    if suffix:
+        path = f"{path}/{suffix}"
+    return path
+
+
+def _bounded_limit(limit: int, maximum: int = 100) -> int:
+    return max(1, min(int(limit), maximum))
+
+
+def _is_public_image_url(image_url: str) -> bool:
+    parsed = urlparse(image_url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _page_summary(page: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": page.get("id"),
+        "name": page.get("name"),
+        "category": page.get("category"),
+        "tasks": page.get("tasks", []),
+        "has_access_token": bool(page.get("access_token")),
+    }
+
+
+def _linked_account(page: dict[str, Any]) -> dict[str, Any] | None:
+    instagram_account = page.get("instagram_business_account")
+    if not isinstance(instagram_account, dict):
+        return None
+    return {
+        "page": _page_summary(page),
+        "instagram_account": {
+            "id": instagram_account.get("id"),
+            "username": instagram_account.get("username"),
+            "name": instagram_account.get("name"),
+            "profile_picture_url": instagram_account.get("profile_picture_url"),
+        },
+    }
+
+
+def _list_pages_with_instagram_accounts() -> list[dict[str, Any]]:
+    result = _graph_request(
+        "GET",
+        "/me/accounts",
+        params={"fields": LINKED_ACCOUNT_FIELDS},
+    )
+    pages = result.get("data", []) if isinstance(result, dict) else []
+    accounts: list[dict[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, dict):
+            continue
+        account = _linked_account(page)
+        if account:
+            accounts.append(account)
+    return accounts
+
+
+@mcp.tool()
+def instagram_auth_status() -> str:
+    """Check whether the injected Meta access token is usable."""
+    try:
+        me = _graph_request("GET", "/me", params={"fields": "id,name,email"})
+        return _success(
+            authenticated=True,
+            user={
+                "id": me.get("id"),
+                "name": me.get("name"),
+                "email": me.get("email"),
+            },
+        )
+    except GraphAPIError as e:
+        logger.error("Error checking Instagram auth status: %s", e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error checking Instagram auth status: %s", e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def instagram_list_linked_accounts() -> str:
+    """List Facebook Pages that have linked Instagram professional accounts."""
+    try:
+        return _success(accounts=_list_pages_with_instagram_accounts())
+    except GraphAPIError as e:
+        logger.error("Error listing Instagram linked accounts: %s", e)
+        return _graph_error(e)
+    except Exception as e:
+        logger.error("Error listing Instagram linked accounts: %s", e)
+        return _error(str(e))
+
+
+@mcp.tool()
+def instagram_get_profile(instagram_account_id: str) -> str:
+    """Get profile information for an Instagram professional account."""
+    try:
+        profile = _graph_request(
+            "GET",
+            _graph_path(instagram_account_id),
+            params={"fields": PROFILE_FIELDS},
+        )
+        return _success(profile=profile)
+    except GraphAPIError as e:
+        logger.error(
+            "Error getting Instagram profile for %s: %s", instagram_account_id, e
+        )
+        return _graph_error(e)
+    except Exception as e:
+        logger.error(
+            "Error getting Instagram profile for %s: %s", instagram_account_id, e
+        )
+        return _error(str(e))
+
+
+@mcp.tool()
+def instagram_list_media(instagram_account_id: str, limit: int = 10) -> str:
+    """List recent media for an Instagram professional account."""
+    try:
+        result = _graph_request(
+            "GET",
+            _graph_path(instagram_account_id, "media"),
+            params={"fields": MEDIA_FIELDS, "limit": _bounded_limit(limit)},
+        )
+        return _success(
+            media=result.get("data", []),
+            next_link=result.get("paging", {}).get("next"),
+        )
+    except GraphAPIError as e:
+        logger.error(
+            "Error listing Instagram media for %s: %s", instagram_account_id, e
+        )
+        return _graph_error(e)
+    except Exception as e:
+        logger.error(
+            "Error listing Instagram media for %s: %s", instagram_account_id, e
+        )
+        return _error(str(e))
+
+
+@mcp.tool()
+def instagram_publish_image(
+    instagram_account_id: str,
+    image_url: str,
+    caption: str | None = None,
+) -> str:
+    """Create and publish an Instagram image media container from a public image URL."""
+    try:
+        if not _is_public_image_url(image_url):
+            raise ValueError("image_url must be a public http or https URL")
+        data = {"image_url": image_url}
+        if caption:
+            data["caption"] = caption
+
+        container = _graph_request(
+            "POST",
+            _graph_path(instagram_account_id, "media"),
+            data=data,
+        )
+        container_id = container.get("id")
+        if not container_id:
+            raise ValueError("Instagram media container response did not include id")
+
+        published = _graph_request(
+            "POST",
+            _graph_path(instagram_account_id, "media_publish"),
+            data={"creation_id": str(container_id)},
+        )
+        return _success(container_id=container_id, media_id=published.get("id"))
+    except GraphAPIError as e:
+        logger.error(
+            "Error publishing Instagram image for %s: %s", instagram_account_id, e
+        )
+        return _graph_error(e)
+    except Exception as e:
+        logger.error(
+            "Error publishing Instagram image for %s: %s", instagram_account_id, e
+        )
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -18,6 +18,7 @@ mcp = FastMCP("instagram-mcp")
 
 GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
 DEFAULT_TIMEOUT_SECONDS = 30
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
 
 LINKED_ACCOUNT_FIELDS = (
     "id,name,category,tasks,access_token,"
@@ -105,6 +106,13 @@ def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
     return headers
 
 
+def _response_error_text(response: Any) -> str:
+    response_text = str(getattr(response, "text", "")).strip()
+    if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+        return response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    return response_text
+
+
 def _graph_request(
     method: str,
     path: str,
@@ -127,7 +135,7 @@ def _graph_request(
     except requests.HTTPError as exc:
         details = _response_json(response)
         message = str(exc)
-        response_text = response.text.strip()
+        response_text = _response_error_text(response)
         if response_text:
             message = f"{message} - {response_text}"
         raise GraphAPIError(

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -1,12 +1,19 @@
-import json
 import logging
-import os
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
-import requests
 from mcp.server.fastmcp import FastMCP
 
+from . import meta_graph
+from .meta_graph import (
+    GraphAPIError,
+    bounded_limit as _bounded_limit,
+    error_response as _error,
+    graph_error_response as _graph_error,
+    graph_request as _graph_request,
+    is_public_image_url as _is_public_image_url,
+    success_response as _success,
+)
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -15,10 +22,7 @@ logger = logging.getLogger("instagram-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("instagram-mcp")
-
-GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
-DEFAULT_TIMEOUT_SECONDS = 30
-MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+requests = meta_graph.requests
 
 LINKED_ACCOUNT_FIELDS = (
     "id,name,category,tasks,access_token,"
@@ -33,129 +37,6 @@ MEDIA_FIELDS = (
 )
 
 
-class GraphAPIError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        details: Any = None,
-        sensitive_values: set[str] | None = None,
-    ):
-        super().__init__(message)
-        self.details = details
-        self.sensitive_values = sensitive_values or set()
-
-
-def _success(**payload: Any) -> str:
-    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
-
-
-def _redact_secrets(value: Any, sensitive_values: set[str] | None = None) -> Any:
-    tokens = {token for token in sensitive_values or set() if token}
-    env_token = os.environ.get("META_ACCESS_TOKEN")
-    if env_token:
-        tokens.add(env_token)
-
-    if isinstance(value, dict):
-        return {
-            key: _redact_secrets(item, sensitive_values=tokens)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_secrets(item, sensitive_values=tokens) for item in value]
-    if isinstance(value, str):
-        redacted = value
-        for token in tokens:
-            redacted = redacted.replace(token, "[redacted]")
-        return redacted
-    return value
-
-
-def _error(
-    message: str,
-    *,
-    details: Any = None,
-    sensitive_values: set[str] | None = None,
-) -> str:
-    payload: dict[str, Any] = {
-        "status": "error",
-        "message": _redact_secrets(message, sensitive_values=sensitive_values),
-    }
-    if details is not None:
-        payload["details"] = _redact_secrets(details, sensitive_values=sensitive_values)
-    return json.dumps(payload, ensure_ascii=False)
-
-
-def _graph_error(e: GraphAPIError) -> str:
-    return _error(str(e), details=e.details, sensitive_values=e.sensitive_values)
-
-
-def _user_token() -> str:
-    token = os.environ.get("META_ACCESS_TOKEN")
-    if not token:
-        raise ValueError("META_ACCESS_TOKEN environment variable is missing")
-    return token
-
-
-def _graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-    }
-    if form:
-        headers["Content-Type"] = "application/x-www-form-urlencoded"
-    return headers
-
-
-def _response_error_text(response: Any) -> str:
-    response_text = str(getattr(response, "text", "")).strip()
-    if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
-        return response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
-    return response_text
-
-
-def _graph_request(
-    method: str,
-    path: str,
-    *,
-    params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
-) -> Any:
-    request_token = _user_token()
-    response = requests.request(
-        method=method,
-        url=f"{GRAPH_BASE_URL}{path}",
-        headers=_graph_headers(request_token, form=method.upper() != "GET"),
-        params=params,
-        data=data,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
-
-    try:
-        response.raise_for_status()
-    except requests.HTTPError as exc:
-        details = _response_json(response)
-        message = str(exc)
-        response_text = _response_error_text(response)
-        if response_text:
-            message = f"{message} - {response_text}"
-        raise GraphAPIError(
-            message,
-            details=details,
-            sensitive_values={request_token},
-        ) from exc
-
-    if response.status_code == 204 or not response.content:
-        return {}
-    return response.json()
-
-
-def _response_json(response: Any) -> Any:
-    try:
-        return response.json()
-    except Exception:
-        return None
-
-
 def _graph_path(object_id: str, suffix: str | None = None) -> str:
     if not object_id.strip():
         raise ValueError("object id is required")
@@ -163,15 +44,6 @@ def _graph_path(object_id: str, suffix: str | None = None) -> str:
     if suffix:
         path = f"{path}/{suffix}"
     return path
-
-
-def _bounded_limit(limit: int, maximum: int = 100) -> int:
-    return max(1, min(int(limit), maximum))
-
-
-def _is_public_image_url(image_url: str) -> bool:
-    parsed = urlparse(image_url)
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
 def _page_summary(page: dict[str, Any]) -> dict[str, Any]:

--- a/src/xagent/web/tools/mcp/instagram.py
+++ b/src/xagent/web/tools/mcp/instagram.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("instagram-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("instagram-mcp")
-requests = meta_graph.requests
+requests = meta_graph.requests  # exposed for test monkeypatching
 
 LINKED_ACCOUNT_FIELDS = (
     "id,name,category,tasks,access_token,"

--- a/src/xagent/web/tools/mcp/meta_graph.py
+++ b/src/xagent/web/tools/mcp/meta_graph.py
@@ -1,0 +1,144 @@
+import json
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+GRAPH_BASE_URL = "https://graph.facebook.com/v25.0"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+
+
+class GraphAPIError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        details: Any = None,
+        sensitive_values: set[str] | None = None,
+    ):
+        super().__init__(message)
+        self.details = details
+        self.sensitive_values = sensitive_values or set()
+
+
+def success_response(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def redact_secrets(value: Any, sensitive_values: set[str] | None = None) -> Any:
+    tokens = {token for token in sensitive_values or set() if token}
+    env_token = os.environ.get("META_ACCESS_TOKEN")
+    if env_token:
+        tokens.add(env_token)
+
+    if isinstance(value, dict):
+        return {
+            key: redact_secrets(item, sensitive_values=tokens)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_secrets(item, sensitive_values=tokens) for item in value]
+    if isinstance(value, str):
+        redacted = value
+        for token in tokens:
+            redacted = redacted.replace(token, "[redacted]")
+        return redacted
+    return value
+
+
+def error_response(
+    message: str,
+    *,
+    details: Any = None,
+    sensitive_values: set[str] | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "status": "error",
+        "message": redact_secrets(message, sensitive_values=sensitive_values),
+    }
+    if details is not None:
+        payload["details"] = redact_secrets(details, sensitive_values=sensitive_values)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def graph_error_response(e: GraphAPIError) -> str:
+    return error_response(
+        str(e), details=e.details, sensitive_values=e.sensitive_values
+    )
+
+
+def user_token() -> str:
+    token = os.environ.get("META_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("META_ACCESS_TOKEN environment variable is missing")
+    return token
+
+
+def graph_headers(token: str, *, form: bool = False) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if form:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    return headers
+
+
+def response_error_text(response: Any) -> str:
+    response_text = str(getattr(response, "text", "")).strip()
+    if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+        return response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    return response_text
+
+
+def graph_request(
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    params: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    request_token = token or user_token()
+    response = requests.request(
+        method=method,
+        url=f"{GRAPH_BASE_URL}{path}",
+        headers=graph_headers(request_token, form=method.upper() != "GET"),
+        params=params,
+        data=data,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        details = response_json(response)
+        message = str(exc)
+        response_text = response_error_text(response)
+        if response_text:
+            message = f"{message} - {response_text}"
+        sensitive_values = {request_token, os.environ.get("META_ACCESS_TOKEN", "")}
+        raise GraphAPIError(
+            message, details=details, sensitive_values=sensitive_values
+        ) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def response_json(response: Any) -> Any:
+    try:
+        return response.json()
+    except Exception:
+        return None
+
+
+def bounded_limit(limit: int, maximum: int = 100) -> int:
+    return max(1, min(int(limit), maximum))
+
+
+def is_public_image_url(image_url: str) -> bool:
+    parsed = urlparse(image_url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/tests/alembic/test_20260627_seed_meta_connectors.py
+++ b/tests/alembic/test_20260627_seed_meta_connectors.py
@@ -1,0 +1,95 @@
+"""Tests for the Meta connector registry seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260627_seed_meta_connectors.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_meta_connectors_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    context = MigrationContext.configure(connection)
+    return Operations(context)
+
+
+def test_upgrade_inserts_meta_provider_and_public_apps(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE oauth_providers (
+                    id INTEGER PRIMARY KEY,
+                    provider_name VARCHAR(50) UNIQUE NOT NULL,
+                    name VARCHAR(100) NOT NULL,
+                    client_id VARCHAR(500) NOT NULL,
+                    client_secret VARCHAR(500) NOT NULL,
+                    auth_url VARCHAR(1000) NOT NULL,
+                    token_url VARCHAR(1000) NOT NULL,
+                    redirect_uri VARCHAR(1000),
+                    userinfo_url VARCHAR(1000),
+                    user_id_path VARCHAR(100),
+                    email_path VARCHAR(100),
+                    default_scopes JSON
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    app_id VARCHAR(100) UNIQUE NOT NULL,
+                    name VARCHAR(200) NOT NULL,
+                    description TEXT,
+                    icon VARCHAR(1000),
+                    transport VARCHAR(50) NOT NULL,
+                    provider_name VARCHAR(50),
+                    category VARCHAR(100),
+                    oauth_scopes JSON,
+                    is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                    launch_config JSON
+                )
+                """
+            )
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+        providers = connection.execute(
+            text("SELECT provider_name, name FROM oauth_providers")
+        ).fetchall()
+        apps = connection.execute(
+            text("SELECT app_id, provider_name, category FROM public_mcp_apps")
+        ).fetchall()
+
+    assert providers == [("meta", "Meta")]
+    assert {
+        (row.app_id, row.provider_name, row.category)
+        for row in apps
+        if row.app_id in {"facebook", "instagram"}
+    } == {
+        ("facebook", "meta", "Marketing"),
+        ("instagram", "meta", "Marketing"),
+    }

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -458,7 +458,7 @@ def test_init_db_seeds_builtin_oauth_and_microsoft_graph_public_apps() -> None:
     db = next(get_db())
     try:
         provider_names = {row.provider_name for row in db.query(OAuthProvider).all()}
-        assert {"google", "linkedin", "microsoft"}.issubset(provider_names)
+        assert {"google", "linkedin", "microsoft", "meta"}.issubset(provider_names)
 
         microsoft_provider = (
             db.query(OAuthProvider)
@@ -467,6 +467,13 @@ def test_init_db_seeds_builtin_oauth_and_microsoft_graph_public_apps() -> None:
         )
         assert microsoft_provider is not None
         assert microsoft_provider.default_scopes == ["User.Read"]
+        meta_provider = (
+            db.query(OAuthProvider)
+            .filter(OAuthProvider.provider_name == "meta")
+            .first()
+        )
+        assert meta_provider is not None
+        assert meta_provider.default_scopes == ["public_profile"]
 
         app_ids = {row.app_id for row in db.query(PublicMCPApp).all()}
         assert {
@@ -477,6 +484,8 @@ def test_init_db_seeds_builtin_oauth_and_microsoft_graph_public_apps() -> None:
             "teams",
             "outlook",
             "onedrive",
+            "facebook",
+            "instagram",
         }.issubset(app_ids)
 
         teams_app = (
@@ -487,6 +496,12 @@ def test_init_db_seeds_builtin_oauth_and_microsoft_graph_public_apps() -> None:
         )
         onedrive_app = (
             db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "onedrive").first()
+        )
+        facebook_app = (
+            db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "facebook").first()
+        )
+        instagram_app = (
+            db.query(PublicMCPApp).filter(PublicMCPApp.app_id == "instagram").first()
         )
 
         assert teams_app is not None
@@ -526,6 +541,35 @@ def test_init_db_seeds_builtin_oauth_and_microsoft_graph_public_apps() -> None:
             "command": "uv",
             "args": ["run", "python", "-m", "xagent.web.tools.mcp.onedrive"],
             "env_mapping": {"AUTH_TOKEN": "access_token"},
+        }
+
+        assert facebook_app is not None
+        assert facebook_app.provider_name == "meta"
+        assert facebook_app.category == "Marketing"
+        assert facebook_app.oauth_scopes == [
+            "pages_show_list",
+            "pages_read_engagement",
+            "pages_manage_posts",
+        ]
+        assert facebook_app.launch_config == {
+            "command": "uv",
+            "args": ["run", "python", "-m", "xagent.web.tools.mcp.facebook"],
+            "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+        }
+
+        assert instagram_app is not None
+        assert instagram_app.provider_name == "meta"
+        assert instagram_app.category == "Marketing"
+        assert instagram_app.oauth_scopes == [
+            "pages_show_list",
+            "pages_read_engagement",
+            "instagram_basic",
+            "instagram_content_publish",
+        ]
+        assert instagram_app.launch_config == {
+            "command": "uv",
+            "args": ["run", "python", "-m", "xagent.web.tools.mcp.instagram"],
+            "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
         }
     finally:
         db.close()

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -22,6 +22,7 @@ from xagent.web.api.auth import (
     create_access_token,
     generic_oauth_login,
 )
+from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
 
@@ -184,6 +185,84 @@ def test_non_zoom_provider_does_not_set_prompt_login(db_session):
     )
     qs = parse_qs(urlparse(_location(resp)).query)
     assert "prompt" not in qs
+
+
+def test_meta_login_uses_comma_separated_scopes_from_selected_app(db_session):
+    db, user = db_session
+    token = _token_for(user)
+    db.add(
+        PublicMCPApp(
+            app_id="facebook",
+            name="Facebook Pages",
+            description="Facebook connector",
+            transport="oauth",
+            provider_name="meta",
+            category="Marketing",
+            oauth_scopes=["pages_show_list", "pages_manage_posts"],
+            is_visible_in_connector=True,
+            launch_config={},
+        )
+    )
+    db.commit()
+
+    provider = _provider(
+        auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+        default_scopes=["public_profile"],
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="meta",
+        token=token,
+        app_id="facebook",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert qs["scope"] == ["public_profile,pages_manage_posts,pages_show_list"]
+
+
+def test_meta_login_uses_config_id_without_scope_when_configured(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.setenv("META_CONFIG_ID", "1234567890")
+    db.add(
+        PublicMCPApp(
+            app_id="instagram",
+            name="Instagram",
+            description="Instagram connector",
+            transport="oauth",
+            provider_name="meta",
+            category="Marketing",
+            oauth_scopes=["instagram_basic", "instagram_content_publish"],
+            is_visible_in_connector=True,
+            launch_config={},
+        )
+    )
+    db.commit()
+
+    provider = _provider(
+        auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+        default_scopes=["public_profile"],
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="meta",
+        token=token,
+        app_id="instagram",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert qs["config_id"] == ["1234567890"]
+    assert "scope" not in qs
 
 
 def test_login_uses_env_client_id_when_provider_client_id_is_empty(

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -269,6 +269,34 @@ def test_meta_login_uses_config_id_without_scope_when_configured(
     assert "scope" not in qs
 
 
+def test_meta_login_ignores_undocumented_legacy_config_id_alias(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.delenv("META_CONFIG_ID", raising=False)
+    monkeypatch.setenv("META_LOGIN_CONFIG_ID", "legacy-config-id")
+
+    provider = _provider(
+        auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+        default_scopes=["public_profile"],
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="meta",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert "config_id" not in qs
+    assert qs["scope"] == ["public_profile"]
+
+
 def test_login_uses_env_client_id_when_provider_client_id_is_empty(
     db_session, monkeypatch
 ):

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -187,9 +187,13 @@ def test_non_zoom_provider_does_not_set_prompt_login(db_session):
     assert "prompt" not in qs
 
 
-def test_meta_login_uses_comma_separated_scopes_from_selected_app(db_session):
+def test_meta_login_uses_comma_separated_scopes_from_selected_app(
+    db_session, monkeypatch
+):
     db, user = db_session
     token = _token_for(user)
+    monkeypatch.delenv("META_CONFIG_ID", raising=False)
+    monkeypatch.delenv("META_LOGIN_CONFIG_ID", raising=False)
     db.add(
         PublicMCPApp(
             app_id="facebook",

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -22,8 +22,8 @@ from xagent.web.api.auth import (
     create_access_token,
     generic_oauth_login,
 )
-from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 
 # ---------- helpers ---------------------------------------------------------

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -163,7 +164,7 @@ def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(
 
 
 def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_is_not_json(
-    db_session, monkeypatch
+    db_session, monkeypatch, caplog
 ):
     db, user = db_session
     state = create_access_token(
@@ -200,6 +201,7 @@ def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_is_not_js
         return MockResponse({"id": "meta-user-1", "email": "alice@example.com"})
 
     monkeypatch.setattr(auth_api.requests, "get", Mock(side_effect=get))
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
 
     response = generic_oauth_callback("meta", request, db, _meta_provider())
 
@@ -211,10 +213,12 @@ def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_is_not_js
     )
     assert oauth_account.access_token == "short-token"
     assert oauth_account.provider_user_id == "meta-user-1"
+    assert "Meta long-lived token exchange failed" in caplog.text
+    assert "response body is not JSON" in caplog.text
 
 
 def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_fails(
-    db_session, monkeypatch
+    db_session, monkeypatch, caplog
 ):
     db, user = db_session
     state = create_access_token(
@@ -251,6 +255,7 @@ def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_fails(
         return MockResponse({"id": "meta-user-1", "email": "alice@example.com"})
 
     monkeypatch.setattr(auth_api.requests, "get", Mock(side_effect=get))
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
 
     response = generic_oauth_callback("meta", request, db, _meta_provider())
 
@@ -262,6 +267,40 @@ def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_fails(
     )
     assert oauth_account.access_token == "short-token"
     assert oauth_account.provider_user_id == "meta-user-1"
+    assert "Meta long-lived token exchange failed" in caplog.text
+    assert "meta token exchange timed out" in caplog.text
+
+
+def test_meta_long_lived_token_exchange_logs_rejected_response(monkeypatch, caplog):
+    token_data = {
+        "access_token": "short-token",
+        "token_type": "bearer",
+        "expires_in": 3600,
+    }
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"error": {"message": "invalid short token"}},
+                status_code=400,
+            )
+        ),
+    )
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
+
+    result = auth_api._exchange_meta_long_lived_token(
+        "meta",
+        "https://graph.facebook.com/v25.0/oauth/access_token",
+        token_data,
+        "meta-client-id",
+        "meta-client-secret",
+    )
+
+    assert result == token_data
+    assert "Meta long-lived token exchange returned unusable response" in caplog.text
+    assert "status=400" in caplog.text
+    assert "invalid short token" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -30,6 +30,11 @@ class MockResponse:
         return self._json_data
 
 
+class NonJsonResponse(MockResponse):
+    def json(self):
+        raise ValueError("response body is not JSON")
+
+
 @pytest.fixture()
 def db_session(tmp_path):
     db_path = tmp_path / "test.db"
@@ -155,6 +160,57 @@ def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(
         .one()
     )
     assert user_mcp.is_active is True
+
+
+def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_is_not_json(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "meta",
+            "app_id": "facebook",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "short-code", "state": state})
+
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "short-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                }
+            )
+        ),
+    )
+
+    def get(url, **kwargs):
+        if url.endswith("/oauth/access_token"):
+            return NonJsonResponse(status_code=502, text="<html>bad gateway</html>")
+
+        assert url == "https://graph.facebook.com/v25.0/me?fields=id,email"
+        assert kwargs["headers"] == {"Authorization": "Bearer short-token"}
+        return MockResponse({"id": "meta-user-1", "email": "alice@example.com"})
+
+    monkeypatch.setattr(auth_api.requests, "get", Mock(side_effect=get))
+
+    response = generic_oauth_callback("meta", request, db, _meta_provider())
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "facebook")
+        .one()
+    )
+    assert oauth_account.access_token == "short-token"
+    assert oauth_account.provider_user_id == "meta-user-1"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -213,6 +213,57 @@ def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_is_not_js
     assert oauth_account.provider_user_id == "meta-user-1"
 
 
+def test_meta_callback_uses_short_lived_token_when_long_lived_exchange_fails(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "meta",
+            "app_id": "facebook",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "short-code", "state": state})
+
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "short-token",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                }
+            )
+        ),
+    )
+
+    def get(url, **kwargs):
+        if url.endswith("/oauth/access_token"):
+            raise auth_api.requests.RequestException("meta token exchange timed out")
+
+        assert url == "https://graph.facebook.com/v25.0/me?fields=id,email"
+        assert kwargs["headers"] == {"Authorization": "Bearer short-token"}
+        return MockResponse({"id": "meta-user-1", "email": "alice@example.com"})
+
+    monkeypatch.setattr(auth_api.requests, "get", Mock(side_effect=get))
+
+    response = generic_oauth_callback("meta", request, db, _meta_provider())
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "facebook")
+        .one()
+    )
+    assert oauth_account.access_token == "short-token"
+    assert oauth_account.provider_user_id == "meta-user-1"
+
+
 @pytest.mark.asyncio
 async def test_meta_expired_token_refresh_uses_fb_exchange_token(
     db_session, monkeypatch

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.oauth_provider import OAuthProvider
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="facebook",
+            name="Facebook Pages",
+            description="Facebook connector",
+            transport="oauth",
+            provider_name="meta",
+            category="Marketing",
+            oauth_scopes=["pages_show_list", "pages_manage_posts"],
+            is_visible_in_connector=True,
+            launch_config={
+                "command": "uv",
+                "args": ["run", "python", "-m", "xagent.web.tools.mcp.facebook"],
+                "env_mapping": {"META_ACCESS_TOKEN": "access_token"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _meta_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="meta",
+        client_id=encrypt_value("meta-client-id"),
+        client_secret=encrypt_value("meta-client-secret"),
+        token_url="https://graph.facebook.com/v25.0/oauth/access_token",
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+        userinfo_url="https://graph.facebook.com/v25.0/me?fields=id,email",
+        user_id_path="id",
+        email_path="email",
+        default_scopes=["public_profile"],
+    )
+
+
+def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "meta",
+            "app_id": "facebook",
+            "redirect": "https://app.example.com/tools",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "short-code", "state": state})
+
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "short-token",
+                "token_type": "bearer",
+                "expires_in": 3600,
+            }
+        )
+    )
+
+    def get(url, **kwargs):
+        if url.endswith("/oauth/access_token"):
+            assert kwargs["params"] == {
+                "grant_type": "fb_exchange_token",
+                "client_id": "meta-client-id",
+                "client_secret": "meta-client-secret",
+                "fb_exchange_token": "short-token",
+            }
+            return MockResponse(
+                {
+                    "access_token": "long-token",
+                    "token_type": "bearer",
+                    "expires_in": 5184000,
+                }
+            )
+
+        assert url == "https://graph.facebook.com/v25.0/me?fields=id,email"
+        assert kwargs["headers"] == {"Authorization": "Bearer long-token"}
+        return MockResponse({"id": "meta-user-1", "email": "alice@example.com"})
+
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(auth_api.requests, "get", Mock(side_effect=get))
+
+    response = generic_oauth_callback("meta", request, db, _meta_provider())
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "facebook")
+        .one()
+    )
+    assert oauth_account.access_token == "long-token"
+    assert oauth_account.provider_user_id == "meta-user-1"
+    assert oauth_account.email == "alice@example.com"
+    assert oauth_account.expires_at is not None
+
+    server = db.query(MCPServer).filter(MCPServer.name == "Facebook Pages").one()
+    assert server.transport == "oauth"
+    assert server.auth == {"app_id": "facebook", "provider": "meta"}
+    user_mcp = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert user_mcp.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_meta_expired_token_refresh_uses_fb_exchange_token(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="meta",
+            name="Meta",
+            client_id=encrypt_value("meta-client-id"),
+            client_secret=encrypt_value("meta-client-secret"),
+            auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+            token_url="https://graph.facebook.com/v25.0/oauth/access_token",
+            redirect_uri="https://app.example.com/api/auth/meta/callback",
+            userinfo_url="https://graph.facebook.com/v25.0/me?fields=id,email",
+            user_id_path="id",
+            email_path="email",
+            default_scopes=["public_profile"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="facebook",
+        access_token="old-long-token",
+        refresh_token=None,
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="meta-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-long-token",
+                    "token_type": "bearer",
+                    "expires_in": 5184000,
+                }
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "meta")
+        is True
+    )
+
+    assert oauth_account.access_token == "new-long-token"
+    assert oauth_account.expires_at is not None
+    assert captured_requests == [
+        (
+            "https://graph.facebook.com/v25.0/oauth/access_token",
+            {
+                "params": {
+                    "grant_type": "fb_exchange_token",
+                    "client_id": "meta-client-id",
+                    "client_secret": "meta-client-secret",
+                    "fb_exchange_token": "old-long-token",
+                },
+                "timeout": 10.0,
+            },
+        )
+    ]

--- a/tests/web/tools/test_facebook_mcp.py
+++ b/tests/web/tools/test_facebook_mcp.py
@@ -237,6 +237,22 @@ def test_graph_api_errors_are_structured_and_redact_tokens(monkeypatch):
     assert result["details"]["error"]["code"] == 190
 
 
+def test_graph_api_error_message_truncates_large_response_text(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    long_response_text = "x" * 1200
+    monkeypatch.setattr(
+        facebook.requests,
+        "request",
+        Mock(return_value=MockResponse(text=long_response_text, status_code=502)),
+    )
+
+    result = _payload(facebook.facebook_auth_status())
+
+    assert result["status"] == "error"
+    assert "... [truncated]" in result["message"]
+    assert "x" * 1001 not in result["message"]
+
+
 def test_page_token_is_redacted_from_publish_errors(monkeypatch):
     monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
 

--- a/tests/web/tools/test_facebook_mcp.py
+++ b/tests/web/tools/test_facebook_mcp.py
@@ -95,6 +95,19 @@ def test_list_pages_hides_page_access_tokens(monkeypatch):
     }
 
 
+def test_list_pages_treats_non_list_data_as_empty(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(
+        facebook.requests,
+        "request",
+        Mock(return_value=MockResponse({"data": None})),
+    )
+
+    result = _payload(facebook.facebook_list_pages())
+
+    assert result == {"status": "success", "pages": []}
+
+
 def test_list_page_posts_uses_page_access_token(monkeypatch):
     monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
 

--- a/tests/web/tools/test_facebook_mcp.py
+++ b/tests/web/tools/test_facebook_mcp.py
@@ -1,0 +1,270 @@
+import json
+from unittest.mock import Mock
+
+import requests
+
+from xagent.web.tools.mcp import facebook
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data or {}
+        self.text = text
+        self.status_code = status_code
+        self.content = text.encode("utf-8") if text else b"{}"
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self
+            raise error
+
+
+def _payload(result: str):
+    return json.loads(result)
+
+
+def test_auth_status_uses_injected_meta_token(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse({"id": "user-1", "name": "Alice Meta"})
+    )
+    monkeypatch.setattr(facebook.requests, "request", mock_request)
+
+    result = _payload(facebook.facebook_auth_status())
+
+    assert result == {
+        "status": "success",
+        "authenticated": True,
+        "user": {"id": "user-1", "name": "Alice Meta", "email": None},
+    }
+    mock_request.assert_called_once_with(
+        method="GET",
+        url="https://graph.facebook.com/v25.0/me",
+        headers={
+            "Authorization": "Bearer user-token",
+            "Accept": "application/json",
+        },
+        params={"fields": "id,name,email"},
+        data=None,
+        timeout=30,
+    )
+
+
+def test_list_pages_hides_page_access_tokens(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse(
+            {
+                "data": [
+                    {
+                        "id": "page-1",
+                        "name": "Launch Page",
+                        "category": "Software",
+                        "tasks": ["CREATE_CONTENT"],
+                        "access_token": "page-token",
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(facebook.requests, "request", mock_request)
+
+    result = _payload(facebook.facebook_list_pages())
+
+    assert result == {
+        "status": "success",
+        "pages": [
+            {
+                "id": "page-1",
+                "name": "Launch Page",
+                "category": "Software",
+                "tasks": ["CREATE_CONTENT"],
+                "has_access_token": True,
+            }
+        ],
+    }
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://graph.facebook.com/v25.0/me/accounts"
+    )
+    assert mock_request.call_args.kwargs["params"] == {
+        "fields": "id,name,category,tasks,access_token"
+    }
+
+
+def test_list_page_posts_uses_page_access_token(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        if url.endswith("/me/accounts"):
+            return MockResponse(
+                {
+                    "data": [
+                        {
+                            "id": "page-1",
+                            "name": "Launch Page",
+                            "access_token": "page-token",
+                        }
+                    ]
+                }
+            )
+        assert method == "GET"
+        assert url == "https://graph.facebook.com/v25.0/page-1/feed"
+        assert kwargs["headers"]["Authorization"] == "Bearer page-token"
+        assert kwargs["params"] == {
+            "fields": "id,message,created_time,permalink_url,full_picture,status_type",
+            "limit": 5,
+        }
+        return MockResponse(
+            {
+                "data": [{"id": "post-1", "message": "hello"}],
+                "paging": {"next": "https://graph.facebook.com/next"},
+            }
+        )
+
+    monkeypatch.setattr(facebook.requests, "request", Mock(side_effect=request))
+
+    result = _payload(facebook.facebook_list_page_posts("page-1", limit=5))
+
+    assert result == {
+        "status": "success",
+        "posts": [{"id": "post-1", "message": "hello"}],
+        "next_link": "https://graph.facebook.com/next",
+    }
+
+
+def test_publish_text_post_uses_page_access_token_and_message_payload(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        if url.endswith("/me/accounts"):
+            return MockResponse(
+                {"data": [{"id": "page-1", "access_token": "page-token"}]}
+            )
+        assert method == "POST"
+        assert url == "https://graph.facebook.com/v25.0/page-1/feed"
+        assert kwargs["headers"] == {
+            "Authorization": "Bearer page-token",
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        assert kwargs["data"] == {"message": "Launch update"}
+        return MockResponse({"id": "page-1_post-1"})
+
+    monkeypatch.setattr(facebook.requests, "request", Mock(side_effect=request))
+
+    result = _payload(facebook.facebook_publish_text_post("page-1", "Launch update"))
+
+    assert result == {
+        "status": "success",
+        "post_id": "page-1_post-1",
+    }
+
+
+def test_publish_image_post_uses_public_url_payload(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        if url.endswith("/me/accounts"):
+            return MockResponse(
+                {"data": [{"id": "page-1", "access_token": "page-token"}]}
+            )
+        assert method == "POST"
+        assert url == "https://graph.facebook.com/v25.0/page-1/photos"
+        assert kwargs["headers"]["Authorization"] == "Bearer page-token"
+        assert kwargs["data"] == {
+            "url": "https://example.com/image.png",
+            "published": "true",
+            "caption": "Launch visual",
+        }
+        return MockResponse({"id": "photo-1", "post_id": "page-1_post-1"})
+
+    monkeypatch.setattr(facebook.requests, "request", Mock(side_effect=request))
+
+    result = _payload(
+        facebook.facebook_publish_image_post(
+            "page-1", "https://example.com/image.png", caption="Launch visual"
+        )
+    )
+
+    assert result == {
+        "status": "success",
+        "photo_id": "photo-1",
+        "post_id": "page-1_post-1",
+    }
+
+
+def test_graph_api_errors_are_structured_and_redact_tokens(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(
+        facebook.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "error": {
+                        "message": "Bad OAuth token user-token",
+                        "code": 190,
+                    }
+                },
+                text='{"error":{"message":"Bad OAuth token user-token","code":190}}',
+                status_code=400,
+            )
+        ),
+    )
+
+    result = _payload(facebook.facebook_auth_status())
+
+    assert result["status"] == "error"
+    assert "user-token" not in json.dumps(result)
+    assert "[redacted]" in json.dumps(result)
+    assert result["details"]["error"]["code"] == 190
+
+
+def test_page_token_is_redacted_from_publish_errors(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        if url.endswith("/me/accounts"):
+            return MockResponse(
+                {"data": [{"id": "page-1", "access_token": "page-token"}]}
+            )
+        return MockResponse(
+            {
+                "error": {
+                    "message": "Bad Page token page-token",
+                    "code": 190,
+                }
+            },
+            text='{"error":{"message":"Bad Page token page-token","code":190}}',
+            status_code=400,
+        )
+
+    monkeypatch.setattr(facebook.requests, "request", Mock(side_effect=request))
+
+    result = _payload(facebook.facebook_publish_text_post("page-1", "Launch update"))
+
+    serialized = json.dumps(result)
+    assert result["status"] == "error"
+    assert "page-token" not in serialized
+    assert "[redacted]" in serialized
+    assert result["details"]["error"]["code"] == 190
+
+
+def test_publish_image_post_rejects_non_public_url(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock()
+    monkeypatch.setattr(facebook.requests, "request", mock_request)
+
+    result = _payload(
+        facebook.facebook_publish_image_post("page-1", "/tmp/local-image.png")
+    )
+
+    assert result == {
+        "status": "error",
+        "message": "image_url must be a public http or https URL",
+    }
+    mock_request.assert_not_called()

--- a/tests/web/tools/test_instagram_mcp.py
+++ b/tests/web/tools/test_instagram_mcp.py
@@ -118,6 +118,19 @@ def test_list_linked_accounts_returns_pages_with_instagram_accounts(monkeypatch)
     assert "page-token" not in json.dumps(result)
 
 
+def test_list_linked_accounts_treats_non_list_data_as_empty(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(
+        instagram.requests,
+        "request",
+        Mock(return_value=MockResponse({"data": None})),
+    )
+
+    result = _payload(instagram.instagram_list_linked_accounts())
+
+    assert result == {"status": "success", "accounts": []}
+
+
 def test_get_profile_reads_selected_instagram_account(monkeypatch):
     monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
     mock_request = Mock(

--- a/tests/web/tools/test_instagram_mcp.py
+++ b/tests/web/tools/test_instagram_mcp.py
@@ -1,0 +1,263 @@
+import json
+from unittest.mock import Mock
+
+import requests
+
+from xagent.web.tools.mcp import instagram
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data or {}
+        self.text = text
+        self.status_code = status_code
+        self.content = text.encode("utf-8") if text else b"{}"
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self
+            raise error
+
+
+def _payload(result: str):
+    return json.loads(result)
+
+
+def test_auth_status_uses_injected_meta_token(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse({"id": "user-1", "name": "Alice Meta"})
+    )
+    monkeypatch.setattr(instagram.requests, "request", mock_request)
+
+    result = _payload(instagram.instagram_auth_status())
+
+    assert result == {
+        "status": "success",
+        "authenticated": True,
+        "user": {"id": "user-1", "name": "Alice Meta", "email": None},
+    }
+    mock_request.assert_called_once_with(
+        method="GET",
+        url="https://graph.facebook.com/v25.0/me",
+        headers={
+            "Authorization": "Bearer user-token",
+            "Accept": "application/json",
+        },
+        params={"fields": "id,name,email"},
+        data=None,
+        timeout=30,
+    )
+
+
+def test_list_linked_accounts_returns_pages_with_instagram_accounts(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse(
+            {
+                "data": [
+                    {
+                        "id": "page-1",
+                        "name": "Launch Page",
+                        "category": "Software",
+                        "tasks": ["CREATE_CONTENT"],
+                        "access_token": "page-token",
+                        "instagram_business_account": {
+                            "id": "ig-1",
+                            "username": "launch",
+                            "name": "Launch",
+                            "profile_picture_url": "https://example.com/avatar.jpg",
+                        },
+                    },
+                    {
+                        "id": "page-2",
+                        "name": "No Instagram",
+                        "access_token": "page-token-2",
+                    },
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(instagram.requests, "request", mock_request)
+
+    result = _payload(instagram.instagram_list_linked_accounts())
+
+    assert result == {
+        "status": "success",
+        "accounts": [
+            {
+                "page": {
+                    "id": "page-1",
+                    "name": "Launch Page",
+                    "category": "Software",
+                    "tasks": ["CREATE_CONTENT"],
+                    "has_access_token": True,
+                },
+                "instagram_account": {
+                    "id": "ig-1",
+                    "username": "launch",
+                    "name": "Launch",
+                    "profile_picture_url": "https://example.com/avatar.jpg",
+                },
+            }
+        ],
+    }
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://graph.facebook.com/v25.0/me/accounts"
+    )
+    assert mock_request.call_args.kwargs["params"] == {
+        "fields": (
+            "id,name,category,tasks,access_token,"
+            "instagram_business_account{id,username,name,profile_picture_url}"
+        )
+    }
+    assert "page-token" not in json.dumps(result)
+
+
+def test_get_profile_reads_selected_instagram_account(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse(
+            {
+                "id": "ig-1",
+                "username": "launch",
+                "name": "Launch",
+                "biography": "Build notes",
+                "followers_count": 10,
+                "media_count": 2,
+            }
+        )
+    )
+    monkeypatch.setattr(instagram.requests, "request", mock_request)
+
+    result = _payload(instagram.instagram_get_profile("ig-1"))
+
+    assert result["status"] == "success"
+    assert result["profile"]["username"] == "launch"
+    mock_request.assert_called_once_with(
+        method="GET",
+        url="https://graph.facebook.com/v25.0/ig-1",
+        headers={
+            "Authorization": "Bearer user-token",
+            "Accept": "application/json",
+        },
+        params={
+            "fields": (
+                "id,username,name,biography,profile_picture_url,followers_count,"
+                "follows_count,media_count,website"
+            )
+        },
+        data=None,
+        timeout=30,
+    )
+
+
+def test_list_media_reads_recent_instagram_media(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock(
+        return_value=MockResponse(
+            {
+                "data": [{"id": "media-1", "caption": "hello"}],
+                "paging": {"next": "https://graph.facebook.com/next"},
+            }
+        )
+    )
+    monkeypatch.setattr(instagram.requests, "request", mock_request)
+
+    result = _payload(instagram.instagram_list_media("ig-1", limit=5))
+
+    assert result == {
+        "status": "success",
+        "media": [{"id": "media-1", "caption": "hello"}],
+        "next_link": "https://graph.facebook.com/next",
+    }
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://graph.facebook.com/v25.0/ig-1/media"
+    )
+    assert mock_request.call_args.kwargs["params"] == {
+        "fields": (
+            "id,caption,media_type,media_url,permalink,timestamp,username,thumbnail_url"
+        ),
+        "limit": 5,
+    }
+
+
+def test_publish_image_creates_container_then_publishes(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        if url == "https://graph.facebook.com/v25.0/ig-1/media":
+            assert method == "POST"
+            assert kwargs["headers"] == {
+                "Authorization": "Bearer user-token",
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
+            assert kwargs["data"] == {
+                "image_url": "https://example.com/image.png",
+                "caption": "Launch visual",
+            }
+            return MockResponse({"id": "container-1"})
+        assert url == "https://graph.facebook.com/v25.0/ig-1/media_publish"
+        assert method == "POST"
+        assert kwargs["data"] == {"creation_id": "container-1"}
+        return MockResponse({"id": "media-1"})
+
+    monkeypatch.setattr(instagram.requests, "request", Mock(side_effect=request))
+
+    result = _payload(
+        instagram.instagram_publish_image(
+            "ig-1", "https://example.com/image.png", caption="Launch visual"
+        )
+    )
+
+    assert result == {
+        "status": "success",
+        "container_id": "container-1",
+        "media_id": "media-1",
+    }
+
+
+def test_publish_image_rejects_non_public_url(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    mock_request = Mock()
+    monkeypatch.setattr(instagram.requests, "request", mock_request)
+
+    result = _payload(instagram.instagram_publish_image("ig-1", "/tmp/image.png"))
+
+    assert result == {
+        "status": "error",
+        "message": "image_url must be a public http or https URL",
+    }
+    mock_request.assert_not_called()
+
+
+def test_graph_api_errors_are_structured_and_redact_tokens(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    monkeypatch.setattr(
+        instagram.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "error": {
+                        "message": "Bad OAuth token user-token",
+                        "code": 190,
+                    }
+                },
+                text='{"error":{"message":"Bad OAuth token user-token","code":190}}',
+                status_code=400,
+            )
+        ),
+    )
+
+    result = _payload(instagram.instagram_auth_status())
+
+    assert result["status"] == "error"
+    assert "user-token" not in json.dumps(result)
+    assert "[redacted]" in json.dumps(result)
+    assert result["details"]["error"]["code"] == 190

--- a/tests/web/tools/test_instagram_mcp.py
+++ b/tests/web/tools/test_instagram_mcp.py
@@ -274,3 +274,19 @@ def test_graph_api_errors_are_structured_and_redact_tokens(monkeypatch):
     assert "user-token" not in json.dumps(result)
     assert "[redacted]" in json.dumps(result)
     assert result["details"]["error"]["code"] == 190
+
+
+def test_graph_api_error_message_truncates_large_response_text(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+    long_response_text = "x" * 1200
+    monkeypatch.setattr(
+        instagram.requests,
+        "request",
+        Mock(return_value=MockResponse(text=long_response_text, status_code=502)),
+    )
+
+    result = _payload(instagram.instagram_auth_status())
+
+    assert result["status"] == "error"
+    assert "... [truncated]" in result["message"]
+    assert "x" * 1001 not in result["message"]

--- a/tests/web/tools/test_meta_graph.py
+++ b/tests/web/tools/test_meta_graph.py
@@ -1,0 +1,58 @@
+import json
+
+import requests
+
+from xagent.web.tools.mcp import meta_graph
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data or {}
+        self.text = text
+        self.status_code = status_code
+        self.content = text.encode("utf-8") if text else b"{}"
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self
+            raise error
+
+
+def test_graph_request_redacts_env_and_request_tokens(monkeypatch):
+    monkeypatch.setenv("META_ACCESS_TOKEN", "user-token")
+
+    def request(method, url, **kwargs):
+        assert method == "GET"
+        assert url == "https://graph.facebook.com/v25.0/page-1/feed"
+        assert kwargs["headers"]["Authorization"] == "Bearer page-token"
+        return MockResponse(
+            {"error": {"message": "Bad Page token page-token user-token"}},
+            text="Bad Page token page-token user-token",
+            status_code=400,
+        )
+
+    monkeypatch.setattr(meta_graph.requests, "request", request)
+
+    try:
+        meta_graph.graph_request("GET", "/page-1/feed", token="page-token")
+    except meta_graph.GraphAPIError as exc:
+        result = json.loads(meta_graph.graph_error_response(exc))
+    else:
+        raise AssertionError("expected GraphAPIError")
+
+    serialized = json.dumps(result)
+    assert "page-token" not in serialized
+    assert "user-token" not in serialized
+    assert "[redacted]" in serialized
+
+
+def test_response_error_text_truncates_large_body():
+    response = MockResponse(text="x" * 1200, status_code=502)
+
+    assert meta_graph.response_error_text(response) == (
+        "x" * meta_graph.MAX_ERROR_RESPONSE_TEXT_CHARS + "... [truncated]"
+    )


### PR DESCRIPTION
This pull request adds built-in support for Meta (Facebook and Instagram) OAuth integration, including configuration, database seeding, and authentication logic. It introduces new environment variables, database migration scripts, and updates the OAuth login and token refresh flows to handle Meta-specific requirements such as long-lived token exchange and config-based login. 

The most important changes are:

**Meta OAuth Integration and Configuration**
* Added new Meta OAuth environment variables (`META_CLIENT_ID`, `META_CLIENT_SECRET`, `META_REDIRECT_URI`, `META_CONFIG_ID`) to `example.env` for Facebook Pages and Instagram integrations.
* Updated `src/xagent/web/builtin_mcp_registry.py` to include Meta as a built-in OAuth provider and added Facebook Pages and Instagram as built-in MCP apps. 

**Database Migration**
* Added Alembic migration script `20260627_seed_meta_connectors.py` to seed the Meta OAuth provider and corresponding MCP apps (Facebook Pages, Instagram) in the database.

**OAuth Login and Callback Enhancements**
* Refactored `src/xagent/web/api/auth.py` to:
    - Merge default and app-specific scopes correctly and use the appropriate scope separator for Meta (comma instead of space).
    - Support Meta's config-based login by passing `config_id` if set.
    - Exchange short-lived for long-lived Meta access tokens after OAuth callback. 

**Token Refresh Logic**
* Updated the token refresh logic in `src/xagent/web/tools/config.py` to handle Meta's long-lived token exchange flow, which does not use refresh tokens. 