### PR TITLE
fix: stop Preview thinking animation after response completes

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -96,7 +96,7 @@ function GeneratingIndicator({ latestTitle, taskStatus, errorMessage }: { latest
   return (
     <div className="py-3 text-sm leading-relaxed text-muted-foreground flex items-center">
       <span>{displayTitle}</span>
-      {!["failed", "paused", "waiting_for_user"].includes(taskStatus || "") && (
+      {!["failed", "paused", "waiting_for_user", "completed"].includes(taskStatus || "") && (
         <span className="ml-1 inline-flex items-end gap-1">
           <span className="dot" />
           <span className="dot" />

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -321,6 +321,60 @@ describe("TaskConversationPanel", () => {
     expect(processMessages[1]).toHaveAttribute("data-process-status", "completed")
   })
 
+  it("keeps late react_task_end events in the same thinking group after the assistant result", () => {
+    appState.messages = [
+      {
+        id: "msg-user",
+        role: "user",
+        content: "Hello",
+        timestamp: "1000",
+      },
+      {
+        id: "msg-result",
+        role: "assistant",
+        content: "Hi there",
+        timestamp: "3000",
+        isResult: true,
+        status: "completed",
+      },
+    ] as any
+    appState.traceEvents = [
+      {
+        event_id: "react-start",
+        event_type: "react_task_start",
+        step_id: "step-1",
+        timestamp: 2000,
+        data: {},
+      },
+      {
+        event_id: "react-end",
+        event_type: "react_task_end",
+        step_id: "step-1",
+        timestamp: 4000,
+        data: {},
+      },
+    ] as any
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "running",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as any
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const processMessages = screen
+      .getAllByTestId("chat-message")
+      .filter((message) => message.getAttribute("data-trace-count") !== "0")
+
+    expect(processMessages).toHaveLength(1)
+    expect(processMessages[0]).toHaveAttribute("data-trace-count", "2")
+    expect(processMessages[0]).toHaveAttribute("data-process-status", "completed")
+    expect(processMessages[0]).toHaveAttribute("data-show-empty-status", "false")
+  })
+
   it("does not apply current task status to a previous turn when the new turn has no trace yet", () => {
     appState.messages = [
       {

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -16,7 +16,8 @@ import { useApp } from "@/contexts/app-context-chat"
 import { useI18n } from "@/contexts/i18n-context"
 import { apiRequest } from "@/lib/api-wrapper"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
-import { getProcessGroupIndex } from "@/lib/task-timeline"
+import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
+import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
 import { cn } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
@@ -73,13 +74,6 @@ const toTimestampMs = (timestamp: unknown): number => {
 
   return time < 100000000000 ? time * 1000 : time
 }
-
-const getLastUserMessageIndex = (messages: Array<{ role?: string }>): number =>
-  messages.reduce(
-    (latestIndex, message, index) =>
-      message.role === "user" ? index : latestIndex,
-    -1
-  )
 
 const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   if (currentTask?.status !== "waiting_for_user") {
@@ -249,10 +243,13 @@ export function TaskConversationPanel({
       return items
     }
 
+    const userTurnAnchors = getUserTimelineAnchors(sortedMessages)
+    const userTurnCount = userTurnAnchors.length
+
     const processGroups = new Map<number, TimelineProcessEvent[]>()
     processEvents.forEach((event) => {
       const eventTime = toTimestampMs(event.timestamp)
-      const groupIndex = getProcessGroupIndex(sortedMessages, eventTime)
+      const groupIndex = getProcessGroupIndex(userTurnAnchors, eventTime)
       const group = processGroups.get(groupIndex) || []
       group.push(event)
       processGroups.set(groupIndex, group)
@@ -261,7 +258,6 @@ export function TaskConversationPanel({
     const groupEntries = Array.from(processGroups.entries()).sort((a, b) => a[0] - b[0])
     const latestGroupIndex =
       groupEntries.length > 0 ? groupEntries[groupEntries.length - 1][0] : -1
-    const lastUserMessageIndex = getLastUserMessageIndex(sortedMessages)
 
     groupEntries.forEach(([groupIndex, events]) => {
       if (events.length === 0) {
@@ -275,12 +271,15 @@ export function TaskConversationPanel({
       const shouldShowEmptyStatus =
         !hasFinalAssistantMessage &&
         groupIndex === latestGroupIndex &&
-        groupIndex >= sortedMessages.length
-      const isCurrentTurnGroup = groupIndex > lastUserMessageIndex
-      const processStatus =
-        groupIndex === latestGroupIndex && isCurrentTurnGroup
-          ? state.currentTask?.status
-          : undefined
+        groupIndex >= userTurnCount
+      const isCurrentTurnGroup =
+        groupIndex >= userTurnCount && groupIndex === latestGroupIndex
+      const processStatus = isCurrentTurnGroup
+        ? resolveTraceProcessStatus({
+            processStatus: state.currentTask?.status,
+            traceEvents: events,
+          })
+        : resolveTraceProcessStatus({ traceEvents: events })
 
       items.push({
         id: `process-${groupIndex}-${firstEvent?.event_id || groupTimestamp}`,
@@ -315,14 +314,15 @@ export function TaskConversationPanel({
     }
 
     const sortedMessages = [...messageItems].sort((a, b) => a.timestamp - b.timestamp)
-    const lastUserMessageIndex = getLastUserMessageIndex(sortedMessages)
-    if (lastUserMessageIndex < 0) {
+    const userTurnAnchors = getUserTimelineAnchors(sortedMessages)
+    const userTurnCount = userTurnAnchors.length
+    if (userTurnCount === 0) {
       return state.traceEvents
     }
 
     return state.traceEvents.filter((event: any) => {
       const eventTime = toTimestampMs(event?.timestamp)
-      return getProcessGroupIndex(sortedMessages, eventTime) > lastUserMessageIndex
+      return getProcessGroupIndex(userTurnAnchors, eventTime) >= userTurnCount
     })
   }, [messageItems, state.traceEvents])
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1286,9 +1286,11 @@ export function AppProvider({
           dispatch({ type: "SET_PROCESSING", payload: true })
         } else if (message.type === "final_answer_end") {
           dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
+          dispatch({ type: "TRIGGER_TASK_UPDATE" })
           dispatch({ type: "SET_PROCESSING", payload: false })
         } else if (message.type === "final_answer_error") {
           dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
+          dispatch({ type: "TRIGGER_TASK_UPDATE" })
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
       }
@@ -1532,9 +1534,11 @@ export function AppProvider({
               dispatch({ type: "SET_PROCESSING", payload: true })
             } else if (eventType === "final_answer_end") {
               dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
+              dispatch({ type: "TRIGGER_TASK_UPDATE" })
               dispatch({ type: "SET_PROCESSING", payload: false })
             } else if (eventType === "final_answer_error") {
               dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
+              dispatch({ type: "TRIGGER_TASK_UPDATE" })
               dispatch({ type: "SET_PROCESSING", payload: false })
             }
           }

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1284,6 +1284,12 @@ export function AppProvider({
         dispatch({ type: "UPSERT_STREAMING_FINAL_ANSWER", payload })
         if (message.type === "final_answer_start") {
           dispatch({ type: "SET_PROCESSING", payload: true })
+        } else if (message.type === "final_answer_end") {
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
+          dispatch({ type: "SET_PROCESSING", payload: false })
+        } else if (message.type === "final_answer_error") {
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
+          dispatch({ type: "SET_PROCESSING", payload: false })
         }
       }
       return
@@ -1524,6 +1530,12 @@ export function AppProvider({
             dispatch({ type: "UPSERT_STREAMING_FINAL_ANSWER", payload })
             if (eventType === "final_answer_start") {
               dispatch({ type: "SET_PROCESSING", payload: true })
+            } else if (eventType === "final_answer_end") {
+              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
+              dispatch({ type: "SET_PROCESSING", payload: false })
+            } else if (eventType === "final_answer_error") {
+              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
+              dispatch({ type: "SET_PROCESSING", payload: false })
             }
           }
 

--- a/frontend/src/lib/task-timeline.test.ts
+++ b/frontend/src/lib/task-timeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getProcessGroupIndex } from "./task-timeline";
+import { getProcessGroupIndex, getUserTimelineAnchors } from "./task-timeline";
 
 describe("getProcessGroupIndex", () => {
   it("places same-time process events after the user message that triggered them", () => {
@@ -36,5 +36,15 @@ describe("getProcessGroupIndex", () => {
     expect(getProcessGroupIndex(messages, 500)).toBe(0);
     expect(getProcessGroupIndex(messages, 1500)).toBe(1);
     expect(getProcessGroupIndex(messages, 2500)).toBe(2);
+  });
+
+  it("keeps late trace events in the same turn when grouping by user anchors only", () => {
+    const userAnchors = getUserTimelineAnchors([
+      { role: "user", timestamp: 1000 },
+      { role: "assistant", timestamp: 3000 },
+    ]);
+
+    expect(getProcessGroupIndex(userAnchors, 1500)).toBe(1);
+    expect(getProcessGroupIndex(userAnchors, 4000)).toBe(1);
   });
 });

--- a/frontend/src/lib/task-timeline.ts
+++ b/frontend/src/lib/task-timeline.ts
@@ -3,6 +3,13 @@ export type TimelineAnchor = {
   role?: string;
 };
 
+/** User messages delimit execution turns; assistant result messages should not split trace groups. */
+export function getUserTimelineAnchors(
+  sortedMessages: TimelineAnchor[],
+): TimelineAnchor[] {
+  return sortedMessages.filter((message) => message.role === "user");
+}
+
 export function getProcessGroupIndex(
   sortedMessages: TimelineAnchor[],
   eventTime: number

--- a/frontend/src/lib/trace-process-status.test.ts
+++ b/frontend/src/lib/trace-process-status.test.ts
@@ -111,4 +111,22 @@ describe("trace process status", () => {
       })
     ).toBe("completed")
   })
+
+  it("prefers explicit failed status over inferred completed trace status", () => {
+    expect(
+      resolveTraceProcessStatus({
+        processStatus: "failed",
+        traceEvents: [
+          {
+            event_type: "react_task_start",
+            data: {},
+          },
+          {
+            event_type: "react_task_end",
+            data: {},
+          },
+        ],
+      })
+    ).toBe("failed")
+  })
 })

--- a/frontend/src/lib/trace-process-status.test.ts
+++ b/frontend/src/lib/trace-process-status.test.ts
@@ -76,4 +76,39 @@ describe("trace process status", () => {
       })
     ).toBe("completed")
   })
+
+  it("infers a completed process from react_task_end events", () => {
+    expect(
+      resolveTraceProcessStatus({
+        traceEvents: [
+          {
+            event_type: "react_task_start",
+            data: {},
+          },
+          {
+            event_type: "react_task_end",
+            data: {},
+          },
+        ],
+      })
+    ).toBe("completed")
+  })
+
+  it("prefers terminal trace status over a still-running task status", () => {
+    expect(
+      resolveTraceProcessStatus({
+        processStatus: "running",
+        traceEvents: [
+          {
+            event_type: "react_task_start",
+            data: {},
+          },
+          {
+            event_type: "react_task_end",
+            data: {},
+          },
+        ],
+      })
+    ).toBe("completed")
+  })
 })

--- a/frontend/src/lib/trace-process-status.ts
+++ b/frontend/src/lib/trace-process-status.ts
@@ -98,11 +98,11 @@ export const resolveTraceProcessStatus = ({
     normalizeTraceProcessStatus(taskStatus)
   const inferred = getTraceProcessStatusFromEvents(traceEvents)
 
-  if (inferred && isStoppedTraceProcessStatus(inferred)) {
-    return inferred
-  }
   if (explicit && isStoppedTraceProcessStatus(explicit)) {
     return explicit
+  }
+  if (inferred && isStoppedTraceProcessStatus(inferred)) {
+    return inferred
   }
   return explicit || inferred
 }

--- a/frontend/src/lib/trace-process-status.ts
+++ b/frontend/src/lib/trace-process-status.ts
@@ -18,6 +18,13 @@ const TERMINAL_FAILURE_EVENTS = new Set([
   "task_failed_react",
 ])
 
+const TERMINAL_SUCCESS_EVENTS = new Set([
+  "react_task_end",
+  "task_end_react",
+  "task_completion",
+  "dag_execute_end",
+])
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object" ? (value as Record<string, unknown>) : null
 
@@ -68,6 +75,10 @@ export const getTraceProcessStatusFromEvents = (
     if (TERMINAL_FAILURE_EVENTS.has(eventType)) {
       return "failed"
     }
+
+    if (TERMINAL_SUCCESS_EVENTS.has(eventType)) {
+      return "completed"
+    }
   }
 
   return undefined
@@ -81,7 +92,17 @@ export const resolveTraceProcessStatus = ({
   processStatus?: unknown
   taskStatus?: unknown
   traceEvents?: TraceProcessEvent[]
-}): TraceProcessStatus | undefined =>
-  normalizeTraceProcessStatus(processStatus) ||
-  normalizeTraceProcessStatus(taskStatus) ||
-  getTraceProcessStatusFromEvents(traceEvents)
+}): TraceProcessStatus | undefined => {
+  const explicit =
+    normalizeTraceProcessStatus(processStatus) ||
+    normalizeTraceProcessStatus(taskStatus)
+  const inferred = getTraceProcessStatusFromEvents(traceEvents)
+
+  if (inferred && isStoppedTraceProcessStatus(inferred)) {
+    return inferred
+  }
+  if (explicit && isStoppedTraceProcessStatus(explicit)) {
+    return explicit
+  }
+  return explicit || inferred
+}


### PR DESCRIPTION
## Summary

Fixes Preview UI issue where the **Thinking** animation stays in progress after the assistant response has already finished (notably on the first preview call).

**Root cause:** Trace events were grouped using assistant result messages as timeline anchors. When `react_task_end` arrived after the result message, it was split into a separate process group, so the thinking step never received its completion event.

**Changes:**
- Group trace events by **user message turns** only, so late `react_task_end` events stay with the active thinking step
- Infer `completed` status from terminal trace events (`react_task_end`, `task_completion`, etc.), even when task status is still `running`
- Stop processing and mark the task completed/failed when final-answer streaming ends
- Hide the loading dots in `GeneratingIndicator` when status is `completed`

## Test plan

- [ ] Open **Agent Builder → Preview**, send the **first** message, and confirm Thinking switches to the **completed** icon after the reply finishes
- [ ] Send a **second** message and verify process grouping still works across turns
- [ ] Run frontend tests:
  ```bash
  cd frontend
  npx vitest --run src/lib/task-timeline.test.ts src/lib/trace-process-status.test.ts src/components/task/task-conversation-panel.test.tsx