### PR TITLE
fix(build): load agent preview images via authenticated file preview

### DIFF
--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import React from "react"
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
@@ -51,9 +51,13 @@ vi.mock("@/components/file/excel-preview-renderer", () => ({
 }))
 
 vi.mock("@/components/file/pptx-preview-renderer", () => ({
-  PptxPreviewRenderer: ({ base64Content }: { base64Content: string }) => (
-    <div data-testid="pptx-preview">{base64Content}</div>
-  ),
+  PptxPreviewRenderer: ({
+    base64Content,
+    fileId,
+  }: {
+    base64Content?: string
+    fileId?: string
+  }) => <div data-testid="pptx-preview">{base64Content ?? fileId ?? ""}</div>,
 }))
 
 import { TraceEventRenderer } from "./TraceEventRenderer"
@@ -70,6 +74,11 @@ describe("TraceEventRenderer", () => {
   })
 
   it("renders image artifacts inline from tool results", async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["image-bytes"], { type: "image/png" }),
+    })
+
     render(
       <TraceEventRenderer
         events={[
@@ -116,21 +125,17 @@ describe("TraceEventRenderer", () => {
       }),
     )
 
-    const image = screen.getByAltText("generated_image.png")
-    expect(image).toHaveAttribute(
-      "src",
-      "http://api.local/api/files/public/preview/582e7b79-4de9-4905-b73b-7d5a70ad64fe",
+    const image = await screen.findByAltText("generated_image.png")
+    await waitFor(() => {
+      expect(image.getAttribute("src")).toMatch(/^blob:/)
+    })
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "http://api.local/api/files/preview/582e7b79-4de9-4905-b73b-7d5a70ad64fe",
+      expect.objectContaining({ cache: "no-cache" }),
     )
   })
 
   it("renders pptx artifacts inline through PptxPreviewRenderer", async () => {
-    // Arbitrary sentinel bytes; base64 encodes to "AQI=". See
-    // inline-file-preview.test.tsx for why we avoid "PK" here.
-    apiRequestMock.mockResolvedValue({
-      ok: true,
-      arrayBuffer: async () => new Uint8Array([0x01, 0x02]).buffer,
-    })
-
     render(
       <TraceEventRenderer
         events={[
@@ -177,14 +182,12 @@ describe("TraceEventRenderer", () => {
       }),
     )
 
-    // Browsers can't render raw .pptx in an iframe, and the backend's
-    // /api/files/public/preview endpoint now returns the raw bytes, so
-    // we mirror the docx/xlsx path: fetch + base64 + canvas render
-    // via pptxviewjs.
-    expect(await screen.findByTestId("pptx-preview")).toHaveTextContent("AQI=")
-    expect(apiRequestMock).toHaveBeenCalledWith(
+    // Managed fileId path: mount PptxPreviewRenderer immediately and let it
+    // probe the PDF endpoint first instead of eagerly downloading raw bytes.
+    expect(await screen.findByTestId("pptx-preview")).toHaveTextContent("slides-file-id")
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
       "http://api.local/api/files/public/preview/slides-file-id",
-      expect.objectContaining({ cache: "no-cache" }),
+      expect.anything(),
     )
   })
 

--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getInlineFileDownloadUrl,
   getInlineFilePreviewKind,
+  getInlineFilePreviewMimeType,
   getInlineFilePreviewUrl,
   getPreviewUrlTrust,
   resolveInlineFileId,
@@ -222,5 +223,19 @@ describe('inline-file-preview-utils', () => {
 
   it('returns legacy paths unchanged when the first segment is not a uuid', () => {
     expect(resolveInlineFileId('output/screenshot.png')).toBe('output/screenshot.png')
+  })
+
+  it('maps preview kinds to default OOXML mime types', () => {
+    expect(getInlineFilePreviewMimeType('presentation')).toBe(
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+    )
+    expect(getInlineFilePreviewMimeType('document')).toBe(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+    expect(getInlineFilePreviewMimeType('spreadsheet')).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    )
+    expect(getInlineFilePreviewMimeType('image')).toBeUndefined()
+    expect(getInlineFilePreviewMimeType('file')).toBeUndefined()
   })
 })

--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -214,6 +214,12 @@ describe('inline-file-preview-utils', () => {
     ).toBe('550e8400-e29b-41d4-a716-446655440000')
   })
 
+  it('extracts bare uuid from paths with leading slashes', () => {
+    expect(
+      resolveInlineFileId('/550e8400-e29b-41d4-a716-446655440000/linkedin.png')
+    ).toBe('550e8400-e29b-41d4-a716-446655440000')
+  })
+
   it('returns legacy paths unchanged when the first segment is not a uuid', () => {
     expect(resolveInlineFileId('output/screenshot.png')).toBe('output/screenshot.png')
   })

--- a/frontend/src/components/file/inline-file-preview-utils.test.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.test.ts
@@ -5,6 +5,7 @@ import {
   getInlineFilePreviewKind,
   getInlineFilePreviewUrl,
   getPreviewUrlTrust,
+  resolveInlineFileId,
 } from './inline-file-preview-utils'
 
 describe('inline-file-preview-utils', () => {
@@ -205,5 +206,15 @@ describe('inline-file-preview-utils', () => {
 
   it('returns an empty string when no file id or preview URL is available', () => {
     expect(getInlineFileDownloadUrl({ filename: 'anon.bin' }, 'http://api.local')).toBe('')
+  })
+
+  it('extracts bare uuid from file paths that include a filename suffix', () => {
+    expect(
+      resolveInlineFileId('550e8400-e29b-41d4-a716-446655440000/linkedin.png')
+    ).toBe('550e8400-e29b-41d4-a716-446655440000')
+  })
+
+  it('returns legacy paths unchanged when the first segment is not a uuid', () => {
+    expect(resolveInlineFileId('output/screenshot.png')).toBe('output/screenshot.png')
   })
 })

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -199,6 +199,6 @@ export const UUID_PATTERN =
 
 /** When file refs use ``file:<uuid>/<filename>``, API routes expect the bare UUID. */
 export const resolveInlineFileId = (filePath: string): string => {
-  const firstSegment = filePath.split('/')[0]
+  const firstSegment = filePath.split('/').find(Boolean) || ''
   return UUID_PATTERN.test(firstSegment) ? firstSegment : filePath
 }

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -45,6 +45,23 @@ const SPREADSHEET_MIME_TYPES = new Set<string>([
   'text/csv',
 ])
 
+/** Default OOXML mime types for inline preview kinds (images vary by file). */
+export const INLINE_FILE_PREVIEW_MIME_BY_KIND: Partial<
+  Record<PreviewableInlineFileKind, string>
+> = {
+  presentation:
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  document: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  spreadsheet: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+}
+
+export const getInlineFilePreviewMimeType = (
+  kind: InlineFilePreviewKind
+): string | undefined => {
+  if (kind === 'file' || kind === 'image') return undefined
+  return INLINE_FILE_PREVIEW_MIME_BY_KIND[kind]
+}
+
 export const isPreviewableInlineFileKind = (
   kind: InlineFilePreviewKind
 ): kind is PreviewableInlineFileKind =>

--- a/frontend/src/components/file/inline-file-preview-utils.ts
+++ b/frontend/src/components/file/inline-file-preview-utils.ts
@@ -196,3 +196,9 @@ export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
 
 export const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/** When file refs use ``file:<uuid>/<filename>``, API routes expect the bare UUID. */
+export const resolveInlineFileId = (filePath: string): string => {
+  const firstSegment = filePath.split('/')[0]
+  return UUID_PATTERN.test(firstSegment) ? firstSegment : filePath
+}

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -101,17 +101,96 @@ describe('InlineFilePreview', () => {
     })
   })
 
-  it('renders image previews from file ids', () => {
+  it('loads image previews through authenticated preview when file id is present', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
+
     render(
       <InlineFilePreview
         source={{ type: 'image', fileId: 'image-file-id', filename: 'plot.png' }}
       />
     )
 
-    expect(screen.getByAltText('plot.png')).toHaveAttribute(
-      'src',
-      'http://api.local/api/files/public/preview/image-file-id'
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/image-file-id',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+
+    const image = await screen.findByAltText('plot.png')
+    expect(image.getAttribute('src')).toMatch(/^blob:/)
+  })
+
+  it('passes resolved file id to onFileClick for uuid paths with filename suffix', () => {
+    const handleFileClick = vi.fn()
+
+    render(
+      <InlineFilePreview
+        source={{
+          type: 'presentation',
+          fileId: '550e8400-e29b-41d4-a716-446655440000/slides.pptx',
+          filename: 'slides.pptx',
+        }}
+        onFileClick={handleFileClick}
+      />
     )
+
+    fireEvent.click(screen.getByText('Open'))
+
+    expect(handleFileClick).toHaveBeenCalledWith(
+      '550e8400-e29b-41d4-a716-446655440000',
+      'slides.pptx'
+    )
+  })
+
+  it('does not request public preview before authenticated image fallback', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
+
+    render(
+      <InlineFilePreview
+        source={{
+          type: 'image',
+          fileId: '550e8400-e29b-41d4-a716-446655440000',
+          filename: 'plot.png',
+        }}
+      />
+    )
+
+    expect(screen.queryByAltText('plot.png')).not.toBeInTheDocument()
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      'http://api.local/api/files/public/preview/550e8400-e29b-41d4-a716-446655440000',
+      expect.anything()
+    )
+
+    await waitFor(() => {
+      expect(screen.getByAltText('plot.png').getAttribute('src')).toMatch(/^blob:/)
+    })
+  })
+
+  it('renders image previews from file ids', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: false,
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'image', fileId: 'image-file-id', filename: 'plot.png' }}
+      />
+    )
+
+    const image = await screen.findByAltText('plot.png')
+    await waitFor(() => {
+      expect(image).toHaveAttribute(
+        'src',
+        'http://api.local/api/files/public/preview/image-file-id'
+      )
+    })
   })
 
   it('mounts PptxPreviewRenderer immediately with fileId without eager byte fetch', () => {

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -77,6 +77,30 @@ describe('InlineFilePreview', () => {
     })
   })
 
+  it('extracts uuid from file paths that include a filename suffix', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
+
+    render(
+      <InlineFilePreview
+        source={{
+          type: 'image',
+          fileId: '550e8400-e29b-41d4-a716-446655440000/linkedin.png',
+          filename: 'linkedin.png',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/550e8400-e29b-41d4-a716-446655440000',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+  })
+
   it('renders image previews from file ids', () => {
     render(
       <InlineFilePreview

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -397,6 +397,73 @@ describe('InlineFilePreview', () => {
     )
   })
 
+  it('uses authenticated preview for images with fileId even when previewUrl is set', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
+
+    render(
+      <InlineFilePreview
+        source={{
+          type: 'image',
+          fileId: 'image-file-id',
+          previewUrl: 'https://cdn.example.com/plot.png',
+          filename: 'plot.png',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/image-file-id',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+
+    const image = await screen.findByAltText('plot.png')
+    expect(image.getAttribute('src')).toMatch(/^blob:/)
+  })
+
+  it('revokes blob URLs when unmounting during authenticated image fetch', async () => {
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL')
+    let resolveBlob: ((blob: Blob) => void) | undefined
+
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: () =>
+        new Promise<Blob>((resolve) => {
+          resolveBlob = resolve
+        }),
+    })
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{
+          type: 'image',
+          fileId: 'image-file-id',
+          filename: 'plot.png',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalled()
+    })
+
+    unmount()
+    resolveBlob?.(new Blob(['image-bytes'], { type: 'image/png' }))
+
+    await waitFor(() => {
+      expect(createObjectUrlSpy).not.toHaveBeenCalled()
+    })
+    expect(revokeObjectUrlSpy).not.toHaveBeenCalled()
+
+    createObjectUrlSpy.mockRestore()
+    revokeObjectUrlSpy.mockRestore()
+  })
+
   it('does not automatically render cross-origin image preview URLs', () => {
     render(
       <InlineFilePreview

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import React from 'react'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
@@ -45,6 +45,36 @@ describe('InlineFilePreview', () => {
 
   afterEach(() => {
     cleanup()
+  })
+
+  it('falls back to authenticated preview for uuid image file ids', async () => {
+    const blob = new Blob(['image-bytes'], { type: 'image/png' })
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => blob,
+    })
+
+    render(
+      <InlineFilePreview
+        source={{
+          type: 'image',
+          fileId: '550e8400-e29b-41d4-a716-446655440000',
+          filename: 'linkedin-visual.png',
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/550e8400-e29b-41d4-a716-446655440000',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+
+    const image = screen.getByAltText('linkedin-visual.png')
+    await waitFor(() => {
+      expect(image.getAttribute('src')).toMatch(/^blob:/)
+    })
   })
 
   it('renders image previews from file ids', () => {

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -107,6 +107,7 @@ function InlineImagePreview({
     return (
       <div
         aria-label={filename}
+        data-inline-file-preview-wrapper
         className={cn(
           'flex min-h-[8rem] items-center justify-center text-muted-foreground',
           imageClassName || 'max-w-full rounded-lg border border-border/50 bg-muted/20'

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -13,6 +13,7 @@ import {
   getInlineFilePreviewUrl,
   getPreviewUrlTrust,
   isPreviewableInlineFileKind,
+  resolveInlineFileId,
   type InlineFilePreviewSource,
 } from './inline-file-preview-utils'
 
@@ -234,11 +235,14 @@ export function InlineFilePreview({
   loadErrorText = DEFAULT_LOAD_ERROR_TEXT,
 }: InlineFilePreviewProps) {
   const apiUrl = getApiUrl()
-  const kind = getInlineFilePreviewKind(source)
-  const previewUrl = getInlineFilePreviewUrl(source, apiUrl)
-  const downloadUrl = getInlineFileDownloadUrl(source, apiUrl)
-  const previewUrlTrust = getPreviewUrlTrust(source, apiUrl)
-  const filename = fileNameFromSource(source)
+  const resolvedSource = source.fileId
+    ? { ...source, fileId: resolveInlineFileId(source.fileId) }
+    : source
+  const kind = getInlineFilePreviewKind(resolvedSource)
+  const previewUrl = getInlineFilePreviewUrl(resolvedSource, apiUrl)
+  const downloadUrl = getInlineFileDownloadUrl(resolvedSource, apiUrl)
+  const previewUrlTrust = getPreviewUrlTrust(resolvedSource, apiUrl)
+  const filename = fileNameFromSource(resolvedSource)
   const canOpenFilePreview = Boolean(onFileClick && source.fileId)
 
   const handleOpenPreview = (event: React.MouseEvent<HTMLElement>) => {
@@ -264,7 +268,7 @@ export function InlineFilePreview({
   if (kind === 'image') {
     return (
       <InlineImagePreview
-        source={source}
+        source={resolvedSource}
         previewUrl={previewUrl}
         filename={filename}
         imageClassName={imageClassName}
@@ -314,7 +318,7 @@ export function InlineFilePreview({
           kind={kind}
           previewUrl={previewUrl}
           loadErrorText={loadErrorText}
-          fileId={source.fileId}
+          fileId={resolvedSource.fileId}
         />
       </div>
     </div>

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -46,7 +46,7 @@ function InlineImagePreview({
   onFileClick?: (filePath: string, fileName: string) => void
 }) {
   const apiUrl = getApiUrl()
-  const shouldFallback = Boolean(source.fileId && !source.previewUrl)
+  const shouldFallback = Boolean(source.fileId)
   const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
 
   useEffect(() => {
@@ -68,17 +68,15 @@ function InlineImagePreview({
             },
           }
         )
+        if (isCancelled) return
         if (!response.ok) {
-          if (!isCancelled) {
-            setResolvedUrl(previewUrl)
-          }
+          setResolvedUrl(previewUrl)
           return
         }
         const blob = await response.blob()
+        if (isCancelled) return
         objectUrl = URL.createObjectURL(blob)
-        if (!isCancelled) {
-          setResolvedUrl(objectUrl)
-        }
+        setResolvedUrl(objectUrl)
       } catch {
         if (!isCancelled) {
           setResolvedUrl(previewUrl)

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -70,6 +70,10 @@ function InlineImagePreview({
         )
         if (isCancelled) return
         if (!response.ok) {
+          // Last-resort fallback: try the public preview URL when the
+          // authenticated route fails. On Agent Builder surfaces that
+          // route may also require auth, but a spinner with no recovery
+          // path is worse than attempting the anonymous endpoint.
           setResolvedUrl(previewUrl)
           return
         }
@@ -79,6 +83,7 @@ function InlineImagePreview({
         setResolvedUrl(objectUrl)
       } catch {
         if (!isCancelled) {
+          // See comment above: public preview is best-effort after auth errors.
           setResolvedUrl(previewUrl)
         }
       }

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -46,19 +46,20 @@ function InlineImagePreview({
   onFileClick?: (filePath: string, fileName: string) => void
 }) {
   const apiUrl = getApiUrl()
-  const [resolvedUrl, setResolvedUrl] = useState(previewUrl)
+  const shouldFallback = Boolean(source.fileId && !source.previewUrl)
+  const [resolvedUrl, setResolvedUrl] = useState(shouldFallback ? '' : previewUrl)
 
   useEffect(() => {
     let objectUrl: string | null = null
     let isCancelled = false
 
-    setResolvedUrl(previewUrl)
+    setResolvedUrl(shouldFallback ? '' : previewUrl)
 
     const runFallback = async () => {
-      if (!source.fileId || source.previewUrl) return
+      if (!shouldFallback) return
       try {
         const response = await apiRequest(
-          `${apiUrl}/api/files/preview/${encodeURIComponent(source.fileId)}`,
+          `${apiUrl}/api/files/preview/${encodeURIComponent(source.fileId!)}`,
           {
             cache: 'no-cache',
             headers: {
@@ -67,14 +68,21 @@ function InlineImagePreview({
             },
           }
         )
-        if (!response.ok) return
+        if (!response.ok) {
+          if (!isCancelled) {
+            setResolvedUrl(previewUrl)
+          }
+          return
+        }
         const blob = await response.blob()
         objectUrl = URL.createObjectURL(blob)
         if (!isCancelled) {
           setResolvedUrl(objectUrl)
         }
       } catch {
-        return
+        if (!isCancelled) {
+          setResolvedUrl(previewUrl)
+        }
       }
     }
 
@@ -84,12 +92,26 @@ function InlineImagePreview({
       isCancelled = true
       if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [apiUrl, previewUrl, source.fileId, source.previewUrl])
+  }, [apiUrl, previewUrl, shouldFallback, source.fileId])
 
   const handleClick = (event: React.MouseEvent<HTMLImageElement>) => {
     if (!onFileClick || !source.fileId) return
     event.preventDefault()
     onFileClick(source.fileId, filename)
+  }
+
+  if (!resolvedUrl) {
+    return (
+      <div
+        aria-label={filename}
+        className={cn(
+          'flex min-h-[8rem] items-center justify-center text-muted-foreground',
+          imageClassName || 'max-w-full rounded-lg border border-border/50 bg-muted/20'
+        )}
+      >
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    )
   }
 
   return (
@@ -243,12 +265,12 @@ export function InlineFilePreview({
   const downloadUrl = getInlineFileDownloadUrl(resolvedSource, apiUrl)
   const previewUrlTrust = getPreviewUrlTrust(resolvedSource, apiUrl)
   const filename = fileNameFromSource(resolvedSource)
-  const canOpenFilePreview = Boolean(onFileClick && source.fileId)
+  const canOpenFilePreview = Boolean(onFileClick && resolvedSource.fileId)
 
   const handleOpenPreview = (event: React.MouseEvent<HTMLElement>) => {
-    if (!onFileClick || !source.fileId) return
+    if (!onFileClick || !resolvedSource.fileId) return
     event.preventDefault()
-    onFileClick(source.fileId, filename)
+    onFileClick(resolvedSource.fileId, filename)
   }
 
   if (!previewUrl) return null

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -14,7 +14,6 @@ import {
   getPreviewUrlTrust,
   isPreviewableInlineFileKind,
   type InlineFilePreviewSource,
-  UUID_PATTERN,
 } from './inline-file-preview-utils'
 
 type InlineFilePreviewProps = {
@@ -55,7 +54,7 @@ function InlineImagePreview({
     setResolvedUrl(previewUrl)
 
     const runFallback = async () => {
-      if (!source.fileId || source.previewUrl || UUID_PATTERN.test(source.fileId)) return
+      if (!source.fileId || source.previewUrl) return
       try {
         const response = await apiRequest(
           `${apiUrl}/api/files/preview/${encodeURIComponent(source.fileId)}`,

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -226,7 +226,7 @@ describe('MarkdownRenderer', () => {
       )
     })
 
-    const image = screen.getByAltText('linkedin.png')
+    const image = screen.getByAltText('LinkedIn visual')
     await waitFor(() => {
       expect(image.getAttribute('src')).toMatch(/^blob:/)
     })

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -10,6 +10,8 @@ vi.mock('@/lib/utils', () => ({
   getApiUrl: () => 'http://api.local',
   getFilePublicPreviewUrl: (fileId: string, apiUrl = 'http://api.local') =>
     `${apiUrl}/api/files/public/preview/${encodeURIComponent(fileId)}`,
+  getFilePublicDownloadUrl: (fileId: string, apiUrl = 'http://api.local') =>
+    `${apiUrl}/api/files/public/download/${encodeURIComponent(fileId)}`,
 }))
 
 vi.mock('@/lib/api-wrapper', () => ({
@@ -29,9 +31,13 @@ vi.mock('@/components/file/excel-preview-renderer', () => ({
 }))
 
 vi.mock('@/components/file/pptx-preview-renderer', () => ({
-  PptxPreviewRenderer: ({ base64Content }: { base64Content: string }) => (
-    <div data-testid="pptx-preview">{base64Content}</div>
-  ),
+  PptxPreviewRenderer: ({
+    base64Content,
+    fileId,
+  }: {
+    base64Content?: string
+    fileId?: string
+  }) => <div data-testid="pptx-preview">{base64Content ?? fileId ?? ''}</div>,
 }))
 
 vi.mock('@/contexts/i18n-context', () => ({
@@ -99,24 +105,17 @@ describe('MarkdownRenderer', () => {
   })
 
   it('renders pptx file links as inline previews', async () => {
-    // Arbitrary sentinel bytes; base64 encodes to "AQI=". See
-    // inline-file-preview.test.tsx for why we avoid "PK" here.
-    apiRequestMock.mockResolvedValue({
-      ok: true,
-      arrayBuffer: async () => new Uint8Array([0x01, 0x02]).buffer,
-    })
-
     const content = '[example_presentation.pptx](file:99fb81ab-b995-4976-be18-21b02f748768)'
     render(<MarkdownRenderer content={content} />)
 
-    // Browsers can't render raw .pptx in an iframe, and the backend's
-    // /api/files/public/preview endpoint now returns the raw bytes, so
-    // pptx inline previews are funnelled through PptxPreviewRenderer
-    // (canvas-based, pptxviewjs) — same fetch+base64 pattern as docx/xlsx.
-    expect(await screen.findByTestId('pptx-preview')).toHaveTextContent('AQI=')
-    expect(apiRequestMock).toHaveBeenCalledWith(
+    // Managed fileId path: mount PptxPreviewRenderer immediately and let it
+    // probe the PDF endpoint first instead of eagerly downloading raw bytes.
+    expect(await screen.findByTestId('pptx-preview')).toHaveTextContent(
+      '99fb81ab-b995-4976-be18-21b02f748768'
+    )
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
       'http://api.local/api/files/public/preview/99fb81ab-b995-4976-be18-21b02f748768',
-      expect.objectContaining({ cache: 'no-cache' })
+      expect.anything()
     )
     expect(screen.queryByText('example_presentation.pptx')?.tagName.toLowerCase()).not.toBe('a')
   })

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -91,6 +91,20 @@ describe('MarkdownRenderer', () => {
     expect(mathElements.length).toBe(0)
   })
 
+  it('passes resolved file id to onFileClick for non-previewable file links', () => {
+    const handleFileClick = vi.fn()
+    const content = '[archive.zip](file:550e8400-e29b-41d4-a716-446655440000/archive.zip)'
+
+    render(<MarkdownRenderer content={content} onFileClick={handleFileClick} />)
+
+    fireEvent.click(screen.getByText('archive.zip'))
+
+    expect(handleFileClick).toHaveBeenCalledWith(
+      '550e8400-e29b-41d4-a716-446655440000',
+      'archive.zip'
+    )
+  })
+
   it('handles file: links with onFileClick callback', () => {
     const handleFileClick = vi.fn()
     const content = '[open file](file:/tmp/test.txt)'

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -195,11 +195,25 @@ describe('MarkdownRenderer', () => {
     })
   })
 
-  it('renders file links as image previews when the path has an image extension', () => {
+  it('renders file links as image previews when the path has an image extension', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
     const content = '[LinkedIn visual](file:550e8400-e29b-41d4-a716-446655440000/linkedin.png)'
     render(<MarkdownRenderer content={content} />)
 
-    expect(screen.getByAltText('linkedin.png')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/550e8400-e29b-41d4-a716-446655440000',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
+    })
+
+    const image = screen.getByAltText('linkedin.png')
+    await waitFor(() => {
+      expect(image.getAttribute('src')).toMatch(/^blob:/)
+    })
   })
 
   it('uses authenticated preview fallback for uuid file: images', async () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -195,6 +195,22 @@ describe('MarkdownRenderer', () => {
     })
   })
 
+  it('prefers link label over generic file id when determining preview kind', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([65, 66]).buffer,
+    })
+    const content = '[report.docx](file:doc-file-id)'
+
+    render(<MarkdownRenderer content={content} />)
+
+    expect(await screen.findByTestId('docx-preview')).toHaveTextContent('QUI=')
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'http://api.local/api/files/public/preview/doc-file-id',
+      expect.objectContaining({ cache: 'no-cache' })
+    )
+  })
+
   it('renders file links as image previews when the path has an image extension', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -195,15 +195,31 @@ describe('MarkdownRenderer', () => {
     })
   })
 
-  it('does not run authenticated fallback for uuid file: images', async () => {
+  it('renders file links as image previews when the path has an image extension', () => {
+    const content = '[LinkedIn visual](file:550e8400-e29b-41d4-a716-446655440000/linkedin.png)'
+    render(<MarkdownRenderer content={content} />)
+
+    expect(screen.getByAltText('linkedin.png')).toBeInTheDocument()
+  })
+
+  it('uses authenticated preview fallback for uuid file: images', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+    })
     const content = '![uuid image](file:550e8400-e29b-41d4-a716-446655440000)'
     render(<MarkdownRenderer content={content} />)
 
     await waitFor(() => {
-      const image = screen.getByAltText('uuid image')
-      expect(image).toBeInTheDocument()
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        'http://api.local/api/files/preview/550e8400-e29b-41d4-a716-446655440000',
+        expect.objectContaining({ cache: 'no-cache' })
+      )
     })
 
-    expect(apiRequestMock).not.toHaveBeenCalled()
+    const image = screen.getByAltText('uuid image')
+    await waitFor(() => {
+      expect(image.getAttribute('src')).toMatch(/^blob:/)
+    })
   })
 })

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -212,7 +212,7 @@ function resolvePreviewableFileLink({
 }): { previewKind: PreviewableInlineFileKind; displayFilename: string } | null {
   const pathKind = getInlineFilePreviewKind({ filename: fileNameFromPath })
   if (isPreviewableInlineFileKind(pathKind)) {
-    return { previewKind: pathKind, displayFilename: fileNameFromPath }
+    return { previewKind: pathKind, displayFilename: fileName }
   }
 
   const labelKind = getInlineFilePreviewKind({ filename: fileName })
@@ -271,7 +271,11 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
                 source={{
                   fileId,
                   filename: preview.displayFilename,
-                  type: preview.previewKind === 'image' ? 'image' : undefined,
+                  type: preview.previewKind,
+                  mimeType:
+                    preview.previewKind === 'presentation'
+                      ? 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+                      : undefined,
                 }}
                 openLabel={t('files.previewDialog.buttons.open')}
                 loadErrorText={t('files.previewDialog.errors.loadFailed')}

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -234,6 +234,10 @@ function containsPreviewFileLinkNode(node: any): boolean {
     const label = title || hastText(node)
     if (resolvePreviewableFileLink({ fileNameFromPath, fileName: label })) return true
   }
+  const src = node.properties?.src
+  if (typeof src === 'string' && src.startsWith('file:')) {
+    return true
+  }
   if (!Array.isArray(node.children)) return false
   return node.children.some(containsPreviewFileLinkNode)
 }
@@ -286,7 +290,7 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
             if (onFileClick) {
               e.preventDefault()
               const fallbackTitle = title || linkText || fileNameFromPath
-              onFileClick(filePath, fallbackTitle)
+              onFileClick(fileId, fallbackTitle)
             }
           }
 

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -11,6 +11,7 @@ import { InlineFilePreview } from '@/components/file/inline-file-preview'
 import {
   getInlineFilePreviewKind,
   isPreviewableInlineFileKind,
+  resolveInlineFileId,
 } from '@/components/file/inline-file-preview-utils'
 import { getApiUrl } from '@/lib/utils'
 
@@ -243,12 +244,13 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
           const fileName = title || linkText || fileNameFromPath
           const previewFilename = fileNameFromPath || fileName
           const previewKind = getInlineFilePreviewKind({ filename: previewFilename })
+          const fileId = resolveInlineFileId(filePath)
 
           if (isPreviewableInlineFileKind(previewKind)) {
             return (
               <InlineFilePreview
                 source={{
-                  fileId: filePath,
+                  fileId,
                   filename: previewFilename,
                   type: previewKind === 'image' ? 'image' : undefined,
                 }}
@@ -312,11 +314,12 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
       img({ node: _node, src, alt, title, ...props }) {
         if (src && src.startsWith('file:')) {
           const filePath = src.replace(/^file:/, '')
-          const fileName = title || alt || filePath.split('/').pop() || filePath
+          const fileNameFromPath = filePath.split('/').pop() || filePath
+          const fileName = title || alt || fileNameFromPath
           return (
             <InlineFilePreview
               source={{
-                fileId: filePath,
+                fileId: resolveInlineFileId(filePath),
                 filename: fileName,
                 type: 'image',
               }}

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -191,9 +191,12 @@ function containsPreviewFileLinkNode(node: any): boolean {
   if (!node) return false
   const href = node.properties?.href
   if (typeof href === 'string' && href.startsWith('file:')) {
+    const filePath = href.replace(/^file:/, '')
+    const fileNameFromPath = filePath.split('/').pop() || filePath
     const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
     const label = title || hastText(node)
-    if (isPreviewableInlineFileKind(getInlineFilePreviewKind({ filename: label }))) return true
+    const previewFilename = fileNameFromPath || label
+    if (isPreviewableInlineFileKind(getInlineFilePreviewKind({ filename: previewFilename }))) return true
   }
   if (!Array.isArray(node.children)) return false
   return node.children.some(containsPreviewFileLinkNode)
@@ -238,13 +241,16 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
           const fileNameFromPath = filePath.split('/').pop() || filePath
           const linkText = nodeText(children).trim()
           const fileName = title || linkText || fileNameFromPath
+          const previewFilename = fileNameFromPath || fileName
+          const previewKind = getInlineFilePreviewKind({ filename: previewFilename })
 
-          if (isPreviewableInlineFileKind(getInlineFilePreviewKind({ filename: fileName }))) {
+          if (isPreviewableInlineFileKind(previewKind)) {
             return (
               <InlineFilePreview
                 source={{
                   fileId: filePath,
-                  filename: fileName,
+                  filename: previewFilename,
+                  type: previewKind === 'image' ? 'image' : undefined,
                 }}
                 openLabel={t('files.previewDialog.buttons.open')}
                 loadErrorText={t('files.previewDialog.errors.loadFailed')}

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@/contexts/i18n-context'
 import { InlineFilePreview } from '@/components/file/inline-file-preview'
 import {
   getInlineFilePreviewKind,
+  getInlineFilePreviewMimeType,
   isPreviewableInlineFileKind,
   resolveInlineFileId,
   type PreviewableInlineFileKind,
@@ -272,10 +273,7 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
                   fileId,
                   filename: preview.displayFilename,
                   type: preview.previewKind,
-                  mimeType:
-                    preview.previewKind === 'presentation'
-                      ? 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
-                      : undefined,
+                  mimeType: getInlineFilePreviewMimeType(preview.previewKind),
                 }}
                 openLabel={t('files.previewDialog.buttons.open')}
                 loadErrorText={t('files.previewDialog.errors.loadFailed')}

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -12,6 +12,7 @@ import {
   getInlineFilePreviewKind,
   isPreviewableInlineFileKind,
   resolveInlineFileId,
+  type PreviewableInlineFileKind,
 } from '@/components/file/inline-file-preview-utils'
 import { getApiUrl } from '@/lib/utils'
 
@@ -188,21 +189,6 @@ function hastText(node: any): string {
   return node.children.map(hastText).join('')
 }
 
-function containsPreviewFileLinkNode(node: any): boolean {
-  if (!node) return false
-  const href = node.properties?.href
-  if (typeof href === 'string' && href.startsWith('file:')) {
-    const filePath = href.replace(/^file:/, '')
-    const fileNameFromPath = filePath.split('/').pop() || filePath
-    const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
-    const label = title || hastText(node)
-    const previewFilename = fileNameFromPath || label
-    if (isPreviewableInlineFileKind(getInlineFilePreviewKind({ filename: previewFilename }))) return true
-  }
-  if (!Array.isArray(node.children)) return false
-  return node.children.some(containsPreviewFileLinkNode)
-}
-
 const nodeText = (children: React.ReactNode): string => {
   return React.Children.toArray(children)
     .map((child) => {
@@ -215,6 +201,40 @@ const nodeText = (children: React.ReactNode): string => {
       return ''
     })
     .join('')
+}
+
+function resolvePreviewableFileLink({
+  fileNameFromPath,
+  fileName,
+}: {
+  fileNameFromPath: string
+  fileName: string
+}): { previewKind: PreviewableInlineFileKind; displayFilename: string } | null {
+  const pathKind = getInlineFilePreviewKind({ filename: fileNameFromPath })
+  if (isPreviewableInlineFileKind(pathKind)) {
+    return { previewKind: pathKind, displayFilename: fileNameFromPath }
+  }
+
+  const labelKind = getInlineFilePreviewKind({ filename: fileName })
+  if (isPreviewableInlineFileKind(labelKind)) {
+    return { previewKind: labelKind, displayFilename: fileName }
+  }
+
+  return null
+}
+
+function containsPreviewFileLinkNode(node: any): boolean {
+  if (!node) return false
+  const href = node.properties?.href
+  if (typeof href === 'string' && href.startsWith('file:')) {
+    const filePath = href.replace(/^file:/, '')
+    const fileNameFromPath = filePath.split('/').pop() || filePath
+    const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
+    const label = title || hastText(node)
+    if (resolvePreviewableFileLink({ fileNameFromPath, fileName: label })) return true
+  }
+  if (!Array.isArray(node.children)) return false
+  return node.children.some(containsPreviewFileLinkNode)
 }
 
 export function MarkdownRenderer({ content, className = '', onFileClick, onAgentClick }: MarkdownRendererProps) {
@@ -242,17 +262,16 @@ export function MarkdownRenderer({ content, className = '', onFileClick, onAgent
           const fileNameFromPath = filePath.split('/').pop() || filePath
           const linkText = nodeText(children).trim()
           const fileName = title || linkText || fileNameFromPath
-          const previewFilename = fileNameFromPath || fileName
-          const previewKind = getInlineFilePreviewKind({ filename: previewFilename })
+          const preview = resolvePreviewableFileLink({ fileNameFromPath, fileName })
           const fileId = resolveInlineFileId(filePath)
 
-          if (isPreviewableInlineFileKind(previewKind)) {
+          if (preview) {
             return (
               <InlineFilePreview
                 source={{
                   fileId,
-                  filename: previewFilename,
-                  type: previewKind === 'image' ? 'image' : undefined,
+                  filename: preview.displayFilename,
+                  type: preview.previewKind === 'image' ? 'image' : undefined,
                 }}
                 openLabel={t('files.previewDialog.buttons.open')}
                 loadErrorText={t('files.previewDialog.errors.loadFailed')}

--- a/frontend/src/vitest.setup.ts
+++ b/frontend/src/vitest.setup.ts
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest"
-import { beforeEach } from "vitest"
+import { beforeEach, vi } from "vitest"
+
+// jsdom does not implement blob URL APIs; InlineFilePreview authenticated image
+// previews rely on them in tests that assert blob: src values or spy on revoke.
+URL.createObjectURL = vi.fn(
+  (blob: Blob) => `blob:mock-${blob.size}`
+) as typeof URL.createObjectURL
+URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL
 
 class ResizeObserverMock {
   observe() {}


### PR DESCRIPTION
## Summary

Fixes broken inline image previews in Agent Builder preview and chat when assistant messages reference generated artifacts via `file:<uuid>` markdown.

- Always load inline `file:` images through the authenticated `/api/files/preview/{fileId}` endpoint (blob URL), instead of relying solely on `/api/files/public/preview` without a public access token.
- Detect image file links from the path extension when the link label is generic (e.g. `[LinkedIn visual](file:.../image.png)`).

## Problem

When an agent generates an image and embeds it in markdown like:

```md
![蓝色渐变抽象背景](file:550e8400-e29b-41d4-a716-446655440000)