### PR TITLE
fix(kb): recover parse method from parser column for candidate semantic_id

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -2415,8 +2415,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             return []
         parse_candidates: List[Dict[str, Any]] = []
         for row in result:
-            parse_method = row.get("parse_method", "unknown")
             parser = row.get("parser", "unknown")
+            parse_method = self._vis_method_from_parser(parser)
             merged_params: Dict[str, Any] = {
                 "parse_method": parse_method,
                 "parser": parser,

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -2389,6 +2389,23 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         else:
             return f"{step_type_str}_{hash_prefix}"
 
+    @staticmethod
+    def _vis_method_from_parser(parser: Any) -> str:
+        """Recover the real parse method from the ``parser`` column value.
+
+        The ``parses`` table has no top-level ``parse_method`` column; the
+        method is only carried by the ``parser`` column as
+        ``local:{method}@v1.0.0`` (written by ``parse_document`` and
+        ``KBCollectionHandle.write_parse``). This reverse-parse therefore
+        depends on that write-side format — if the ``parser`` string format
+        changes, update this helper. Any non-conforming value yields
+        ``"unknown"``.
+        """
+        if not isinstance(parser, str) or not parser.startswith("local:"):
+            return "unknown"
+        method = parser[len("local:"):].split("@", 1)[0]
+        return method or "unknown"
+
     def _vis_get_parse_candidates(
         self, connection: Any, filters: Dict[str, Any]
     ) -> List[Dict[str, Any]]:

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -2403,7 +2403,7 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         """
         if not isinstance(parser, str) or not parser.startswith("local:"):
             return "unknown"
-        method = parser[len("local:"):].split("@", 1)[0]
+        method = parser[len("local:") :].split("@", 1)[0]
         return method or "unknown"
 
     def _vis_get_parse_candidates(

--- a/src/xagent/core/tools/core/RAG_tools/version_management/list_candidates.py
+++ b/src/xagent/core/tools/core/RAG_tools/version_management/list_candidates.py
@@ -136,6 +136,12 @@ def _get_parse_candidates(
         return []
     parse_candidates: List[Dict[str, Any]] = []
     for row in result:
+        # NOTE: This legacy path shares the same latent bug as #705 (the parses
+        # table has no top-level parse_method column, so this resolves to
+        # "unknown"). It is intentionally left unfixed because it is unreachable:
+        # the only callers are the KBVersionCompatibilityFacade fallbacks
+        # (coordinator is None), and the facade is always constructed with a
+        # coordinator. The live path is LanceDBVectorIndexStore._vis_get_parse_candidates.
         params = {
             "parse_method": row.get("parse_method", "unknown"),
             "parser": row.get("parser", "unknown"),

--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -127,7 +127,8 @@ class TestListCandidates:
         mock_conn.table_names.return_value = ["parses"]
         mock_table = MagicMock()
 
-        # Mock pandas result
+        # Real `parses` schema has NO top-level parse_method column; the method
+        # is carried only by the `parser` column as local:{method}@v1.0.0.
         now = datetime.now()
         mock_data = pd.DataFrame(
             [
@@ -135,16 +136,16 @@ class TestListCandidates:
                     "collection": "test_collection",
                     "doc_id": "test_doc",
                     "parse_hash": "hash1",
-                    "parse_method": "unstructured",
-                    "parser": "local:UnstructuredParser@v1",
+                    "parser": "local:unstructured@v1.0.0",
+                    "params_json": "{}",
                     "created_at": now + timedelta(milliseconds=1),
                 },
                 {
                     "collection": "test_collection",
                     "doc_id": "test_doc",
                     "parse_hash": "hash2",
-                    "parse_method": "pypdf",
-                    "parser": "local:PyPDFParser@v1",
+                    "parser": "local:pypdf@v1.0.0",
+                    "params_json": "{}",
                     "created_at": now,
                 },
             ]
@@ -164,11 +165,46 @@ class TestListCandidates:
             assert result["returned_count"] == 2
             assert result["step_type"] == "parse"
 
-            # Check first candidate (should be hash1 as it's newer)
+            # hash1 is newer -> first; method recovered from the parser column.
             candidate1 = result["candidates"][0]
             assert candidate1["technical_id"] == "hash1"
             assert candidate1["state"] == "candidate"
-            assert "parse_unstructured" in candidate1["semantic_id"]
+            assert candidate1["semantic_id"] == "parse_unstructured_hash1"
+            assert candidate1["stats"]["parse_method"] == "unstructured"
+
+    def test_parse_candidates_method_from_parser_column(self):
+        """Characterization: with no top-level parse_method column and an empty
+        params_json, the method must still be recovered from the parser column,
+        so semantic_id reflects the real method instead of parse_unknown_*.
+        """
+        mock_conn = MagicMock(spec=["table_names", "open_table"])
+        mock_conn.table_names.return_value = ["parses"]
+        mock_table = MagicMock()
+
+        mock_data = pd.DataFrame(
+            [
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "parse_hash": "abcd1234ef",
+                    "parser": "local:pypdf@v1.0.0",
+                    "params_json": "{}",  # method is NOT in params_json
+                    "created_at": datetime.now(),
+                }
+            ]
+        )
+        mock_where = mock_table.search.return_value.where.return_value
+        mock_where.to_arrow.side_effect = AttributeError("to_arrow not available")
+        mock_where.to_list.side_effect = AttributeError("to_list not available")
+        mock_where.to_pandas.return_value = mock_data
+        mock_conn.open_table.return_value = mock_table
+
+        with self._patch_get_connection_from_env(mock_conn):
+            result = list_candidates("test_collection", "test_doc", StepType.PARSE)
+
+            candidate = result["candidates"][0]
+            assert candidate["semantic_id"] == "parse_pypdf_abcd1234"
+            assert candidate["stats"]["parse_method"] == "pypdf"
 
     def test_chunk_candidates_with_data(self):
         """Test list_candidates returns chunk candidates when data exists."""

--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -518,3 +518,26 @@ class TestListCandidates:
             assert result["total_count"] == 0
             assert result["returned_count"] == 0
             assert result["step_type"] == "parse"
+
+
+@pytest.mark.parametrize(
+    "parser,expected",
+    [
+        ("local:pypdf@v1.0.0", "pypdf"),
+        ("local:unstructured@v1.0.0", "unstructured"),
+        ("local:default@v1.0.0", "default"),
+        ("local:pypdf", "pypdf"),            # missing version segment, still recovers
+        ("local:@v1.0.0", "unknown"),        # empty method
+        ("unknown", "unknown"),              # current row.get("parser", "unknown") default
+        ("remote:something@v1", "unknown"),  # non-local prefix
+        ("", "unknown"),
+        (None, "unknown"),
+        (123, "unknown"),                    # non-str
+    ],
+)
+def test_vis_method_from_parser(parser, expected):
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        LanceDBVectorIndexStore,
+    )
+
+    assert LanceDBVectorIndexStore._vis_method_from_parser(parser) == expected

--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -560,13 +560,13 @@ class TestListCandidates:
         ("local:pypdf@v1.0.0", "pypdf"),
         ("local:unstructured@v1.0.0", "unstructured"),
         ("local:default@v1.0.0", "default"),
-        ("local:pypdf", "pypdf"),            # missing version segment, still recovers
-        ("local:@v1.0.0", "unknown"),        # empty method
-        ("unknown", "unknown"),              # current row.get("parser", "unknown") default
+        ("local:pypdf", "pypdf"),  # missing version segment, still recovers
+        ("local:@v1.0.0", "unknown"),  # empty method
+        ("unknown", "unknown"),  # current row.get("parser", "unknown") default
         ("remote:something@v1", "unknown"),  # non-local prefix
         ("", "unknown"),
         (None, "unknown"),
-        (123, "unknown"),                    # non-str
+        (123, "unknown"),  # non-str
     ],
 )
 def test_vis_method_from_parser(parser, expected):

--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -332,8 +332,7 @@ class TestListCandidates:
                     "collection": "test_collection",
                     "doc_id": "test_doc",
                     "parse_hash": "hash1",
-                    "parse_method": "unstructured",
-                    "parser": "local:UnstructuredParser@v1",
+                    "parser": "local:unstructured@v1.0.0",
                     "created_at": datetime.now(),
                 }
             ]
@@ -368,8 +367,7 @@ class TestListCandidates:
                     "collection": "test_collection",
                     "doc_id": "test_doc",
                     "parse_hash": f"hash{i}",
-                    "parse_method": "unstructured",
-                    "parser": "local:UnstructuredParser@v1",
+                    "parser": "local:unstructured@v1.0.0",
                     "created_at": datetime.now(),
                 }
                 for i in range(5)


### PR DESCRIPTION
## Summary
- The `parses` table has no top-level `parse_method` column, so `_vis_get_parse_candidates` always fell back to `"unknown"`, producing degenerate `semantic_id`s like `parse_unknown_{hash8}` on real data instead of `parse_{method}_{hash8}`.
- Adds `LanceDBVectorIndexStore._vis_method_from_parser`, which reverse-parses the real method from the `parser` column (`local:{method}@v1.0.0`, the only column that actually carries it), and wires it into `_vis_get_parse_candidates`. Read-path only — no schema, write-path, or chunk/embed changes.
- The unreachable legacy fallback in `list_candidates.py` (`_get_parse_candidates`) shares the same latent bug but is never invoked (the coordinator is always constructed), so it is left as-is with an explanatory comment rather than being fixed.

## Behavior change
- Parse-candidate `semantic_id` generation changes from `parse_unknown_*` to `parse_{method}_*` on real data.
- Existing `main_pointers` rows promoted during the buggy period keep their stale `parse_unknown_*` semantic_id label. This is intentionally **not backfilled**: `technical_id` (the hash) is the primary, stable match key and is checked first; `list_candidates` does not compare candidates against the stored pointer; `restore` round-trips the stored value without comparison. The only narrow residual risk is a client that cached an old `parse_unknown_*` string and resubmits it as `selected_id` — not a concern for the current UI, which lists candidates fresh each time.
- Scope is parse-only. `chunk` has the same class of bug but isn't fixable read-path-only (no column carries strategy/size) — tracked separately in #710. `embed` is unaffected since embeddings have a real top-level `model` column.

## Test plan
- [x] `python -m pytest tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py -q` — 21/21 passed
- [x] `python -m pytest tests/core/tools/core/RAG_tools/version_management/ tests/core/tools/core/RAG_tools/storage/ -q` — 206/206 passed, no regressions
- [x] New parametrized unit test for `_vis_method_from_parser` covering all edge cases (non-str, non-`local:` prefix, empty method, missing version segment, etc.)
- [x] New characterization test (`test_parse_candidates_method_from_parser_column`) seeding an empty `params_json` and no top-level `parse_method` column, asserting the method is recovered solely from `parser`

Closes #705