### PR TITLE
test(kb): cover numpy-vector and None-text in version-candidate listing

### DIFF
--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -7,6 +7,7 @@ import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -282,6 +283,52 @@ class TestListCandidates:
                     candidate["stats"]["upsert_count"] == 1
                 )  # Each parse_hash has 1 row
                 assert candidate["stats"]["vector_dim"] == 3
+
+    def test_embed_candidates_numpy_vector(self):
+        """Regression for #709/#708: a numpy-ndarray ``vector`` column must not
+        crash candidate listing. The pre-#708 ``if vector:`` check raised
+        ``ValueError: truth value of an array ... is ambiguous`` on np.ndarray.
+        """
+        mock_conn = MagicMock(spec=["table_names", "open_table"])
+        mock_conn.table_names.return_value = ["embeddings_bge_large"]
+
+        mock_table = MagicMock()
+        mock_data = pd.DataFrame(
+            [
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "model": "BAAI/bge-large-zh-v1.5",
+                    "parse_hash": "parse_hash1",
+                    "vector": np.array([0.1, 0.2, 0.3]),  # numpy, not list
+                    "created_at": datetime.now(),
+                },
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "model": "BAAI/bge-large-zh-v1.5",
+                    "parse_hash": "parse_hash2",
+                    "vector": np.array([0.4, 0.5, 0.6]),  # numpy, not list
+                    "created_at": datetime.now(),
+                },
+            ]
+        )
+        # Force the to_pandas fallback (where vector columns come back as
+        # np.ndarray); to_arrow/to_list raise as in the sibling tests.
+        mock_where = mock_table.search.return_value.where.return_value
+        mock_where.to_arrow.side_effect = AttributeError("to_arrow not available")
+        mock_where.to_list.side_effect = AttributeError("to_list not available")
+        mock_where.to_pandas.return_value = mock_data
+        mock_conn.open_table.return_value = mock_table
+
+        with self._patch_get_connection_from_env(mock_conn):
+            result = list_candidates(
+                "test_collection", "test_doc", StepType.EMBED, model_tag="bge_large"
+            )
+
+        assert len(result["candidates"]) == 2
+        for candidate in result["candidates"]:
+            assert candidate["stats"]["vector_dim"] == 3
 
     def test_state_filter(self):
         """Test that state filter works correctly."""

--- a/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
+++ b/tests/core/tools/core/RAG_tools/version_management/test_list_candidates.py
@@ -227,6 +227,62 @@ class TestListCandidates:
             assert candidate1["technical_id"] == "parse_hash1"
             assert candidate1["stats"]["chunks_count"] == 2
 
+    def test_chunk_candidates_none_text(self):
+        """Regression for #709/#708: a chunk row whose ``text`` value is None
+        must not crash. The pre-#708 ``len(row.get("text", ""))`` raised
+        ``TypeError: object of type 'NoneType' has no len()`` (get() only
+        substitutes the default when the key is *absent*, not when it is None).
+        Also verifies avg_length treats the None row as length 0.
+        """
+        mock_conn = MagicMock(spec=["table_names", "open_table"])
+        mock_conn.table_names.return_value = ["chunks"]
+
+        mock_table = MagicMock()
+        base = datetime.now()
+        mock_data = pd.DataFrame(
+            [
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "parse_hash": "parse_hash1",
+                    "chunk_id": "chunk1",
+                    "text": "0123456789",  # len 10
+                    "created_at": base + timedelta(milliseconds=2),
+                },
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "parse_hash": "parse_hash1",
+                    "chunk_id": "chunk2",
+                    "text": None,  # len treated as 0 -> avg (10+0)/2 = 5
+                    "created_at": base + timedelta(milliseconds=1),
+                },
+                {
+                    "collection": "test_collection",
+                    "doc_id": "test_doc",
+                    "parse_hash": "parse_hash2",
+                    "chunk_id": "chunk3",
+                    "text": "0123456789",  # len 10 -> avg 10
+                    "created_at": base,
+                },
+            ]
+        )
+        mock_where = mock_table.search.return_value.where.return_value
+        mock_where.to_arrow.side_effect = AttributeError("to_arrow not available")
+        mock_where.to_list.side_effect = AttributeError("to_list not available")
+        mock_where.to_pandas.return_value = mock_data
+        mock_conn.open_table.return_value = mock_table
+
+        with self._patch_get_connection_from_env(mock_conn):
+            result = list_candidates("test_collection", "test_doc", StepType.CHUNK)
+
+        assert len(result["candidates"]) == 2  # grouped by parse_hash
+        by_hash = {c["technical_id"]: c for c in result["candidates"]}
+        assert by_hash["parse_hash1"]["stats"]["chunks_count"] == 2
+        assert by_hash["parse_hash1"]["stats"]["avg_length"] == 5
+        assert by_hash["parse_hash2"]["stats"]["chunks_count"] == 1
+        assert by_hash["parse_hash2"]["stats"]["avg_length"] == 10
+
     def test_embed_candidates_with_data(self):
         """Test list_candidates returns embed candidates when data exists."""
         mock_conn = MagicMock(spec=["table_names", "open_table"])


### PR DESCRIPTION
## What

Adds two regression tests to `test_list_candidates.py` covering the
version-candidate listing path:

- `test_embed_candidates_numpy_vector` — a numpy `ndarray` vector column.
- `test_chunk_candidates_none_text` — a present-but-`None` `text` column
  value (also asserts `avg_length` math).

## Why

Both crashes described in #709 were already fixed on the live store path by
PR #708 (`_vis_get_embed_candidates` / `_vis_get_chunk_candidates` in
`storage/lancedb_stores.py`), but that fix shipped with **no test coverage** —
the existing tests feed Python lists and non-null text, which is exactly why
both bugs stayed latent. These tests fail on the pre-#708 code
(`ValueError` / `TypeError`) and pass on current code, so they guard the fix
against future regressions in the `query_to_list` / candidate logic.

This PR contains **no production-code change**.

## Scope note

The identical legacy copy in `version_management/list_candidates.py`
(`_get_chunk_candidates` / `_get_embed_candidates`) is still buggy but is
**dead code in production** (reachable only via the never-taken
`coordinator is None` fallback in `KBVersionCompatibilityFacade`). Its
removal is tracked separately under the `#494` refactor (see linked
follow-up issue) and is intentionally out of scope here.

Closes #709