### PR TITLE
fix(tools): scope custom API selection to connectors

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -30,6 +30,10 @@ logger = logging.getLogger(__name__)
 MAX_AGENT_NAME_LENGTH = 200
 
 
+def _assignable_tool_categories() -> list[str]:
+    return [cat.value for cat in ToolCategory if cat is not ToolCategory.OTHER]
+
+
 class _DelegatedAgentDatabaseTraceHandler:
     """Persist child-agent traces without broadcasting them to the parent UI."""
 
@@ -475,10 +479,9 @@ class ListToolCategoriesTool(AbstractBaseTool):
         raise NotImplementedError("Only supports async execution.")
 
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        from .base import ToolCategory
-
-        available_categories = [cat.value for cat in ToolCategory]
-        return ListToolCategoriesResult(categories=available_categories).model_dump()
+        return ListToolCategoriesResult(
+            categories=_assignable_tool_categories()
+        ).model_dump()
 
 
 class CreateAgentTool(AbstractBaseTool):
@@ -525,11 +528,6 @@ class CreateAgentTool(AbstractBaseTool):
     @property
     def description(self) -> str:
         """Tool description."""
-        # Get available tool categories
-        from .base import ToolCategory
-
-        available_categories = [cat.value for cat in ToolCategory]
-
         # Get available skills (from builtin skills directory)
         import os
 
@@ -544,7 +542,7 @@ class CreateAgentTool(AbstractBaseTool):
                     available_skills.append(skill_dir)
 
         skills_list = ", ".join(available_skills) if available_skills else "none"
-        categories_list = ", ".join(available_categories)
+        categories_list = ", ".join(_assignable_tool_categories())
 
         return (
             "Create a new agent with specific capabilities during task execution. "
@@ -871,11 +869,6 @@ class UpdateAgentTool(AbstractBaseTool):
     @property
     def description(self) -> str:
         """Tool description."""
-        # Get available tool categories
-        from .base import ToolCategory
-
-        available_categories = [cat.value for cat in ToolCategory]
-
         # Get available skills (from builtin skills directory)
         import os
 
@@ -890,7 +883,7 @@ class UpdateAgentTool(AbstractBaseTool):
                     available_skills.append(skill_dir)
 
         skills_list = ", ".join(available_skills) if available_skills else "none"
-        categories_list = ", ".join(available_categories)
+        categories_list = ", ".join(_assignable_tool_categories())
 
         return (
             "Update an existing agent with specific capabilities during task execution. "

--- a/src/xagent/core/tools/adapters/vibe/custom_api_factory.py
+++ b/src/xagent/core/tools/adapters/vibe/custom_api_factory.py
@@ -19,10 +19,9 @@ logger = logging.getLogger(__name__)
 async def create_db_custom_api_tools(config: BaseToolConfig) -> Sequence[Tool]:
     """Create Custom API tools from database configurations.
 
-    Internal short-circuit via ``ToolSelectionSpec.includes_custom_api()``
-    (``"other" in categories or bool(mcp_servers)``): when the spec
-    selects neither the ``"other"`` category nor any ``mcp:<server>``
-    scope, this creator returns early WITHOUT calling
+    Internal short-circuit via ``ToolSelectionSpec.includes_custom_api()``:
+    when the spec selects no ``mcp:<server>`` connector scope, this creator
+    returns early WITHOUT calling
     ``config.get_custom_api_configs()`` — that call goes through the DB
     to enumerate the user's Custom API rows. The creator is registered
     bare (no ``categories=``), so the registry always dispatches it;

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -300,8 +300,10 @@ class ToolSelectionSpec(ABC):
                 # docstring). No built-in tool carries this category, so
                 # dropping it just prunes stale data -- except a legacy
                 # agent persisted with exactly ["other"] (no mcp_servers),
-                # which loses its only tool access. Warn so those agents
-                # are traceable instead of silently degraded.
+                # which loses its only tool access. Warn so this is
+                # visible in logs; from_raw() has no agent id, so
+                # per-agent traceability comes from the backfill
+                # migration's logging instead.
                 logger.warning(
                     "Dropping non-assignable 'other' tool category from "
                     "tool_categories=%r; if 'other' was the only entry, "

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -150,11 +150,10 @@ class ToolSelectionSpec(ABC):
     def includes_custom_api(self) -> bool:
         """Whether the Custom API creator should run.
 
-        In BY_CATEGORIES mode this also requires ``"other"`` in
-        :attr:`categories` because Custom API tools surface under
-        the ``other`` category; without it they cannot survive the
-        post-build name filter, so running the creator (and its
-        ``get_custom_api_configs()`` DB lookup) is wasted I/O.
+        In BY_CATEGORIES mode Custom API tools are connector-scoped:
+        only an explicit ``mcp:<server>`` selector should load the matching
+        Custom API wrapper. Plain ``"other"`` must not bulk-enable every
+        Custom API the user has configured.
         """
 
     @abstractmethod
@@ -230,7 +229,8 @@ class ToolSelectionSpec(ABC):
             filters to the worker tool names (or ``_SpecNone`` when there
             is no ``published_agent_ids``). Lets an unconfigured manager
             delegate only to its workers without inheriting the full set.
-          - Otherwise → ``_SpecByCategories``.
+          - Otherwise → ``_SpecByCategories`` after dropping non-assignable
+            entries such as ``"other"``; if nothing assignable remains, NONE.
 
         ``name_allowlist`` is a pure name-level filter (only meaningful in
         BY_CATEGORIES; ALL already includes everything, NONE rejects
@@ -271,7 +271,8 @@ class ToolSelectionSpec(ABC):
             return _SpecAll()
 
         # ``tool_categories`` mixes two orthogonal shapes:
-        #   - plain category names (``"basic"``, ``"file"``, ``"mcp"``)
+        #   - plain category names (``"basic"``, ``"file"``, ``"mcp"``);
+        #     ``"other"`` is an internal fallback, not an assignable category
         #   - ``"mcp:<server>"`` — a specific MCP server (or the
         #     Custom-API tool fronting it)
         #
@@ -291,21 +292,25 @@ class ToolSelectionSpec(ABC):
             if isinstance(entry, str) and entry.startswith("mcp:"):
                 server_name = normalize_mcp_server_name(entry.split(":", 1)[1])
                 derived_mcp_servers.add(server_name)
+            elif entry == "other":
+                continue
             else:
                 plain_cats.add(entry)
 
         final_mcp_servers = (
             frozenset(derived_mcp_servers) if derived_mcp_servers else None
         )
+        final_published_agent_ids = (
+            frozenset(published_agent_ids) if published_agent_ids is not None else None
+        )
+
+        if not plain_cats and not final_mcp_servers and not final_published_agent_ids:
+            return _SpecNone()
 
         return _SpecByCategories(
             categories=frozenset(plain_cats),
             mcp_servers=final_mcp_servers,
-            published_agent_ids=(
-                frozenset(published_agent_ids)
-                if published_agent_ids is not None
-                else None
-            ),
+            published_agent_ids=final_published_agent_ids,
             name_allowlist=names,
         )
 
@@ -523,14 +528,14 @@ class _SpecByCategories(ToolSelectionSpec):
         return "mcp" in self.categories or bool(self.mcp_servers)
 
     def includes_custom_api(self) -> bool:
-        # Custom API tools surface under the "other" category. A scoped
-        # mcp:<server> also fronts a Custom-API wrapper
-        # (api_<server>_call), so a server scope runs this creator too.
+        # Custom API tools are exposed through connector scope only. A plain
+        # "other" category used to bulk-load every Custom API for the user,
+        # which let agents call APIs unrelated to the configured connector.
         # Filter happens in the creator via ``config.get_custom_api_configs``
         # and ``compute_allowed_names``'s structured ``source_server`` match
         # -- there is no spec-level custom_api id list (ids can't be mapped to
         # tool names in the spec layer).
-        return "other" in self.categories or bool(self.mcp_servers)
+        return bool(self.mcp_servers)
 
     def includes_published_agent(self) -> bool:
         # Pure dispatch decision: whether the published-agent creator runs
@@ -561,8 +566,8 @@ class _SpecByCategories(ToolSelectionSpec):
         reconstruction):
 
           - a tool whose category ∈ ``categories`` is admitted (plain
-            ``"mcp"`` admits all MCP tools, ``"other"`` all Custom-API
-            tools, etc.);
+            ``"mcp"`` admits all MCP tools, etc.; DB-backed Custom API
+            tools are loaded only for scoped ``mcp:<server>`` connectors);
           - otherwise a tool whose ``metadata.source_server`` matches a
             scoped server in ``mcp_servers`` is admitted. ``source_server``
             is the normalized originating-server identity set once at

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -48,9 +48,12 @@ access; no Tool type import required.
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Set
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_mcp_server_name(name: str) -> str:
@@ -293,6 +296,19 @@ class ToolSelectionSpec(ABC):
                 server_name = normalize_mcp_server_name(entry.split(":", 1)[1])
                 derived_mcp_servers.add(server_name)
             elif entry == "other":
+                # Legacy-only entry, no longer assignable (see module
+                # docstring). No built-in tool carries this category, so
+                # dropping it just prunes stale data -- except a legacy
+                # agent persisted with exactly ["other"] (no mcp_servers),
+                # which loses its only tool access. Warn so those agents
+                # are traceable instead of silently degraded.
+                logger.warning(
+                    "Dropping non-assignable 'other' tool category from "
+                    "tool_categories=%r; if 'other' was the only entry, "
+                    "this agent now gets zero tools instead of its "
+                    "previous (leaky) Custom API access",
+                    tool_categories,
+                )
                 continue
             else:
                 plain_cats.add(entry)

--- a/src/xagent/migrations/versions/20260703_backfill_strip_other_tool_category.py
+++ b/src/xagent/migrations/versions/20260703_backfill_strip_other_tool_category.py
@@ -11,7 +11,7 @@ affected agent ids for traceability, instead of that data being
 re-detected and re-warned-about on every read forever.
 
 Revision ID: 20260703_backfill_strip_other_tool_category
-Revises: 20260629_add_gmail_watch_states
+Revises: 20260625_add_user_skills_tables
 Create Date: 2026-07-03 00:00:00.000000
 
 """
@@ -23,7 +23,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260703_backfill_strip_other_tool_category"
-down_revision: Union[str, None] = "20260629_add_gmail_watch_states"
+down_revision: Union[str, None] = "20260625_add_user_skills_tables"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260703_backfill_strip_other_tool_category.py
+++ b/src/xagent/migrations/versions/20260703_backfill_strip_other_tool_category.py
@@ -1,0 +1,74 @@
+"""strip legacy 'other' entries from persisted agent tool_categories
+
+'other' was demoted from an assignable tool category to an internal-only
+fallback (see ToolSelectionSpec.from_raw in
+src/xagent/core/tools/adapters/vibe/selection_spec.py) to close a leak
+where it bulk-enabled every configured Custom API tool. The runtime
+normalizer already strips 'other' on every read, so this migration does
+not change any agent's effective tool access -- it just removes the now
+provably-inert 'other' entries from the stored column and logs the
+affected agent ids for traceability, instead of that data being
+re-detected and re-warned-about on every read forever.
+
+Revision ID: 20260703_backfill_strip_other_tool_category
+Revises: 20260629_add_gmail_watch_states
+Create Date: 2026-07-03 00:00:00.000000
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260703_backfill_strip_other_tool_category"
+down_revision: Union[str, None] = "20260629_add_gmail_watch_states"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "agents" not in inspector.get_table_names():
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("agents")}
+    if "tool_categories" not in existing_columns:
+        return
+
+    agents = sa.table(
+        "agents",
+        sa.column("id", sa.Integer),
+        sa.column("tool_categories", sa.JSON),
+    )
+
+    affected_ids = []
+    rows = bind.execute(sa.select(agents.c.id, agents.c.tool_categories))
+    for row in rows.mappings():
+        categories = row["tool_categories"]
+        if not isinstance(categories, list) or "other" not in categories:
+            continue
+        affected_ids.append(row["id"])
+        bind.execute(
+            agents.update()
+            .where(agents.c.id == row["id"])
+            .values(tool_categories=[c for c in categories if c != "other"])
+        )
+
+    if affected_ids:
+        logger.warning(
+            "Stripped legacy 'other' tool_categories entry from %d agent(s): %r",
+            len(affected_ids),
+            affected_ids,
+        )
+
+
+def downgrade() -> None:
+    # Data migration is intentionally not reversed: 'other' was never a
+    # real tool grant (the runtime already ignored it), so there is
+    # nothing meaningful to restore.
+    pass

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -39,6 +39,10 @@ _AGENT_UPDATE_FIELDS = {
 }
 
 
+def clean_tool_categories(categories: Any) -> list[str]:
+    return [c for c in (ensure_list(categories) or []) if c != "other"]
+
+
 class AgentStore:
     """Owns Agent reads/writes that participate in hot-path cache policy."""
 
@@ -56,7 +60,7 @@ class AgentStore:
             "models": agent.models,
             "knowledge_bases": ensure_list(agent.knowledge_bases) or [],
             "skills": ensure_list(agent.skills) or [],
-            "tool_categories": ensure_list(agent.tool_categories) or [],
+            "tool_categories": clean_tool_categories(agent.tool_categories),
             "suggested_prompts": ensure_list(agent.suggested_prompts) or [],
             "logo_url": agent.logo_url,
             "status": agent.status.value,
@@ -226,7 +230,7 @@ class AgentStore:
             models=models,
             knowledge_bases=knowledge_bases or [],
             skills=skills or [],
-            tool_categories=tool_categories or [],
+            tool_categories=clean_tool_categories(tool_categories),
             suggested_prompts=suggested_prompts or [],
             origin=origin,
             status=status,
@@ -255,6 +259,8 @@ class AgentStore:
             )
 
         for field, value in updates.items():
+            if field == "tool_categories":
+                value = clean_tool_categories(value)
             setattr(agent, field, value)
 
         self.db.commit()

--- a/tests/alembic/test_20260703_backfill_strip_other_tool_category.py
+++ b/tests/alembic/test_20260703_backfill_strip_other_tool_category.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+
+
+def _load_migration_module():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src/xagent/migrations/versions/20260703_backfill_strip_other_tool_category.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_20260703_backfill_strip_other_tool_category", path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_strips_other_from_existing_agents() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    agents = sa.Table(
+        "agents",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("tool_categories", sa.JSON, nullable=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(
+            agents.insert(),
+            [
+                {"id": 1, "tool_categories": ["other"]},
+                {"id": 2, "tool_categories": ["basic", "other"]},
+                {"id": 3, "tool_categories": ["basic"]},
+                {"id": 4, "tool_categories": None},
+            ],
+        )
+
+        with patch.object(migration.op, "get_bind", return_value=conn):
+            migration.upgrade()
+
+        rows = conn.execute(
+            sa.select(agents.c.id, agents.c.tool_categories).order_by(agents.c.id)
+        ).all()
+
+    assert rows == [
+        (1, []),
+        (2, ["basic"]),
+        (3, ["basic"]),
+        (4, None),
+    ]

--- a/tests/alembic/test_20260703_backfill_strip_other_tool_category.py
+++ b/tests/alembic/test_20260703_backfill_strip_other_tool_category.py
@@ -55,3 +55,34 @@ def test_upgrade_strips_other_from_existing_agents() -> None:
         (3, ["basic"]),
         (4, None),
     ]
+
+
+def test_upgrade_is_noop_when_agents_table_missing() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as conn:
+        with patch.object(migration.op, "get_bind", return_value=conn):
+            migration.upgrade()  # must not raise
+
+
+def test_upgrade_is_noop_when_tool_categories_column_missing() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    agents = sa.Table(
+        "agents",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(agents.insert(), [{"id": 1}])
+
+        with patch.object(migration.op, "get_bind", return_value=conn):
+            migration.upgrade()  # must not raise
+
+        rows = conn.execute(sa.select(agents.c.id)).all()
+
+    assert rows == [(1,)]

--- a/tests/core/tools/adapters/vibe/test_custom_api_factory.py
+++ b/tests/core/tools/adapters/vibe/test_custom_api_factory.py
@@ -6,6 +6,7 @@ from xagent.core.tools.adapters.vibe.config import BaseToolConfig
 from xagent.core.tools.adapters.vibe.custom_api_factory import (
     create_db_custom_api_tools,
 )
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
 
 @pytest.mark.asyncio
@@ -25,6 +26,21 @@ async def test_create_db_custom_api_tools_no_configs():
 
     tools = await create_db_custom_api_tools(config)
     assert tools == []
+
+
+@pytest.mark.asyncio
+async def test_create_db_custom_api_tools_other_category_does_not_load_configs():
+    config = MagicMock()
+    config.get_tool_selection_spec.return_value = ToolSelectionSpec.from_raw(
+        tool_categories=["other"]
+    )
+    config.get_user_id.return_value = 1
+    config.get_custom_api_configs.return_value = []
+
+    tools = await create_db_custom_api_tools(config)
+
+    assert tools == []
+    config.get_custom_api_configs.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1693,13 +1693,15 @@ def test_from_raw_warns_when_dropping_other(caplog):
     with caplog.at_level("WARNING"):
         spec = ToolSelectionSpec.from_raw(tool_categories=["other"])
     assert spec.is_none()
-    assert any("other" in record.message for record in caplog.records)
+    assert any(repr(["other"]) in record.getMessage() for record in caplog.records)
 
     caplog.clear()
     with caplog.at_level("WARNING"):
         spec = ToolSelectionSpec.from_raw(tool_categories=["basic", "other"])
     assert spec.categories == frozenset({"basic"})
-    assert any("other" in record.message for record in caplog.records)
+    assert any(
+        repr(["basic", "other"]) in record.getMessage() for record in caplog.records
+    )
 
 
 def test_compute_allowed_names_mcp_server_does_not_broaden_to_all_mcp():

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1683,6 +1683,25 @@ def test_compute_allowed_names_plain_other_is_ignored():
     assert result == frozenset()
 
 
+def test_from_raw_warns_when_dropping_other(caplog):
+    """A legacy ``["other"]``-only agent silently loses Custom API
+    access (see module docstring / PR #716 review thread) -- warn so
+    it is traceable instead of a silent behavior change. Covers both
+    the degraded (zero-tools) case and a mixed case where the agent
+    keeps its other categories, so the warning is proven to fire in
+    both -- not just whichever one happens to trip the assertion."""
+    with caplog.at_level("WARNING"):
+        spec = ToolSelectionSpec.from_raw(tool_categories=["other"])
+    assert spec.is_none()
+    assert any("other" in record.message for record in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        spec = ToolSelectionSpec.from_raw(tool_categories=["basic", "other"])
+    assert spec.categories == frozenset({"basic"})
+    assert any("other" in record.message for record in caplog.records)
+
+
 def test_compute_allowed_names_mcp_server_does_not_broaden_to_all_mcp():
     """User picked only ``["mcp:Gmail"]`` — MUST stay narrow to
     Gmail's mcp tools, NOT broaden to every mcp tool."""

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -1249,7 +1249,7 @@ def test_name_allowlist_alone_does_not_trigger_published_dispatch():
     assert spec.includes_published_agent() is False
 
 
-# ----- P2 fix: includes_custom_api with category restriction -------------
+# ----- Custom API creator dispatch ---------------------------------------
 
 
 def test_by_categories_excludes_custom_api_when_other_missing():
@@ -1264,12 +1264,22 @@ def test_by_categories_excludes_custom_api_when_other_missing():
     assert spec.includes_custom_api() is False
 
 
-def test_by_categories_includes_custom_api_when_other_present():
-    """Mirror of the P2 fix: ``"other"`` IN categories means custom
-    API tools survive the filter; creator must run."""
+def test_by_categories_excludes_custom_api_when_other_present():
+    """Plain ``"other"`` must not bulk-enable every configured Custom API."""
     from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
 
     spec = _SpecByCategories(categories=frozenset({"other"}))
+    assert spec.includes_custom_api() is False
+
+
+def test_by_categories_includes_custom_api_when_mcp_server_scoped():
+    """A specific connector scope may load its matching Custom API wrapper."""
+    from xagent.core.tools.adapters.vibe.selection_spec import _SpecByCategories
+
+    spec = _SpecByCategories(
+        categories=frozenset(),
+        mcp_servers=frozenset({"onedrive"}),
+    )
     assert spec.includes_custom_api() is True
 
 
@@ -1660,9 +1670,8 @@ def test_compute_allowed_names_plain_mcp_admits_all_mcp_tools():
     assert result == frozenset({"mcp_gmail_send", "mcp_slack_post"})
 
 
-def test_compute_allowed_names_plain_other_admits_all_other_tools():
-    """User picked plain ``["other"]`` — MUST admit every other-
-    category tool."""
+def test_compute_allowed_names_plain_other_is_ignored():
+    """Plain ``other`` is not an assignable agent capability."""
     spec = ToolSelectionSpec.from_raw(tool_categories=["other"])
     result = spec.compute_allowed_names(
         [
@@ -1671,7 +1680,7 @@ def test_compute_allowed_names_plain_other_admits_all_other_tools():
             _mock_tool("calc", "basic"),
         ]
     )
-    assert result == frozenset({"api_custom_call", "api_legacy_call"})
+    assert result == frozenset()
 
 
 def test_compute_allowed_names_mcp_server_does_not_broaden_to_all_mcp():
@@ -1688,8 +1697,7 @@ def test_compute_allowed_names_mcp_server_does_not_broaden_to_all_mcp():
 
 
 def test_compute_allowed_names_mixed_plain_and_server_picks():
-    """``["mcp:Gmail", "other"]`` should pick only Gmail's mcp tools
-    plus every other-category tool."""
+    """``other`` is ignored even when mixed with a scoped connector."""
     spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Gmail", "other"])
     result = spec.compute_allowed_names(
         [
@@ -1699,7 +1707,7 @@ def test_compute_allowed_names_mixed_plain_and_server_picks():
             _mock_tool("calc", "basic"),
         ]
     )
-    assert result == frozenset({"mcp_gmail_send", "api_custom_call"})
+    assert result == frozenset({"mcp_gmail_send"})
 
 
 def test_compute_allowed_names_plain_mcp_wins_over_server_scope():

--- a/tests/core/tools/test_create_agent_tool.py
+++ b/tests/core/tools/test_create_agent_tool.py
@@ -14,6 +14,7 @@ from xagent.core.tools.adapters.vibe.agent_tool import (
     AgentTool,
     CreateAgentTool,
     ListAgentsTool,
+    ListToolCategoriesTool,
     UpdateAgentTool,
     _coerce_db_task_id,
     gen_agent_tool_name,
@@ -74,6 +75,30 @@ class TestCreateAgentTool:
             "same natural language as the current output language policy"
             in instructions_schema
         )
+
+    @pytest.mark.asyncio
+    async def test_assignable_tool_categories_hide_other(self) -> None:
+        categories = (await ListToolCategoriesTool().run_json_async({}))["categories"]
+        create_description = CreateAgentTool(
+            session_factory=None, user_id=1
+        ).description
+        update_description = UpdateAgentTool(
+            session_factory=None, user_id=1
+        ).description
+        create_categories_line = next(
+            line
+            for line in create_description.splitlines()
+            if "Available categories:" in line
+        )
+        update_categories_line = next(
+            line
+            for line in update_description.splitlines()
+            if "Available categories:" in line
+        )
+
+        assert "other" not in categories
+        assert "other" not in create_categories_line
+        assert "other" not in update_categories_line
 
     def test_coerce_db_task_id_accepts_only_db_task_formats(self) -> None:
         assert _coerce_db_task_id(12) == 12


### PR DESCRIPTION
## Summary

Fixes a tool-selection leak where agents with legacy `other` tool categories could load unrelated Custom API tools, even when only a specific connector such as OneDrive was configured.

## Root Cause

`tool_categories=["other"]` was treated as enabling Custom API tools globally. For agents that had stale or legacy `other` values saved, the runtime could query and load all user Custom API configs instead of only tools scoped to configured connectors.

## Changes

- Treat `other` as an internal fallback category, not an assignable runtime tool category.
- Only load Custom API tools when they are explicitly scoped through `mcp:<server>`.
- Clean `other` from agent tool categories at read/write boundaries.
- Hide `other` from agent category listing and create/update agent tool descriptions.
- Add focused tests covering legacy `other` values and connector-scoped Custom API loading.