### PR TITLE
feat: add embed_origin parameter for iframe authentication

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -117,11 +117,31 @@
   if (agentId) {
     iframeUrl += '&agent_id=' + agentId;
   }
-  // Pass the embedding page's origin: fetches inside the iframe carry the
-  // iframe's own origin, so the backend needs this to check allowed_domains.
-  iframeUrl += '&embed_origin=' + encodeURIComponent(window.location.origin);
-  iframe.src = iframeUrl;
   panel.appendChild(iframe);
+
+  function loadIframe(ticket) {
+    iframe.src = ticket
+      ? iframeUrl + '&embed_ticket=' + encodeURIComponent(ticket)
+      : iframeUrl;
+  }
+
+  // Request a short-lived embed ticket from the top-level page. This fetch
+  // carries the embedding page's real, browser-enforced Origin header, which
+  // the backend validates against allowed_domains before signing the ticket.
+  // Fetches inside the iframe carry the iframe's own origin instead, so the
+  // ticket is how the validated embedding origin reaches the auth call.
+  if (agentId) {
+    fetch(host + '/api/widget/embed-ticket', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent_id: parseInt(agentId, 10) })
+    })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (data) { loadIframe(data && data.ticket); })
+      .catch(function () { loadIframe(null); });
+  } else {
+    loadIframe(null);
+  }
 
   // FAB
   var fab = document.createElement('button');

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -115,7 +115,7 @@
   iframe.className = 'xagent-widget-iframe';
   var iframeUrl = host + '/widget/chat/' + token + '?guest_id=' + guestId;
   if (agentId) {
-    iframeUrl += '&agent_id=' + agentId;
+    iframeUrl += '&agent_id=' + encodeURIComponent(agentId);
   }
   panel.appendChild(iframe);
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -130,15 +130,28 @@
   // the backend validates against allowed_domains before signing the ticket.
   // Fetches inside the iframe carry the iframe's own origin instead, so the
   // ticket is how the validated embedding origin reaches the auth call.
-  if (agentId) {
+  var numericAgentId = parseInt(agentId, 10);
+  if (agentId && isNaN(numericAgentId)) {
+    console.error('Xagent Widget: data-agent-id must be numeric, got "' + agentId + '".');
+    loadIframe(null);
+  } else if (agentId) {
     fetch(host + '/api/widget/embed-ticket', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agent_id: parseInt(agentId, 10) })
+      body: JSON.stringify({ agent_id: numericAgentId })
     })
-      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (res) {
+        if (!res.ok) {
+          console.warn('Xagent Widget: embed ticket request failed (HTTP ' + res.status + '); loading widget without a ticket. If this page is not in the agent\'s allowed domains, authentication will fail.');
+          return null;
+        }
+        return res.json();
+      })
       .then(function (data) { loadIframe(data && data.ticket); })
-      .catch(function () { loadIframe(null); });
+      .catch(function (err) {
+        console.warn('Xagent Widget: embed ticket request failed (' + err + '); loading widget without a ticket.');
+        loadIframe(null);
+      });
   } else {
     loadIframe(null);
   }

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -117,6 +117,9 @@
   if (agentId) {
     iframeUrl += '&agent_id=' + agentId;
   }
+  // Pass the embedding page's origin: fetches inside the iframe carry the
+  // iframe's own origin, so the backend needs this to check allowed_domains.
+  iframeUrl += '&embed_origin=' + encodeURIComponent(window.location.origin);
   iframe.src = iframeUrl;
   panel.appendChild(iframe);
 

--- a/frontend/src/app/widget/chat/[token]/page-client.tsx
+++ b/frontend/src/app/widget/chat/[token]/page-client.tsx
@@ -15,6 +15,7 @@ function WidgetChatInner() {
       routeToken={token}
       guestId={searchParams.get("guest_id")}
       searchAgentId={searchParams.get("agent_id") ? parseInt(searchParams.get("agent_id") as string, 10) : null}
+      embedOrigin={searchParams.get("embed_origin")}
     />
   )
 }

--- a/frontend/src/app/widget/chat/[token]/page-client.tsx
+++ b/frontend/src/app/widget/chat/[token]/page-client.tsx
@@ -15,7 +15,7 @@ function WidgetChatInner() {
       routeToken={token}
       guestId={searchParams.get("guest_id")}
       searchAgentId={searchParams.get("agent_id") ? parseInt(searchParams.get("agent_id") as string, 10) : null}
-      embedOrigin={searchParams.get("embed_origin")}
+      embedTicket={searchParams.get("embed_ticket")}
     />
   )
 }

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -19,6 +19,7 @@ interface PublicAgentChatPageProps {
   routeToken: string
   guestId?: string | null
   searchAgentId?: number | null
+  embedOrigin?: string | null
 }
 
 type PublicAuthResult = {
@@ -259,6 +260,7 @@ export function PublicAgentChatPage({
   routeToken,
   guestId,
   searchAgentId = null,
+  embedOrigin = null,
 }: PublicAgentChatPageProps) {
   const { t } = useI18n()
   const normalizedGuestId = authMode === "widget" ? (guestId || "anonymous") : null
@@ -272,7 +274,11 @@ export function PublicAgentChatPage({
         const authPath = authMode === "share" ? "/api/share/auth" : "/api/widget/auth"
         const authPayload = authMode === "share"
           ? { share_token: routeToken }
-          : { guest_id: normalizedGuestId, agent_id: searchAgentId }
+          : {
+              guest_id: normalizedGuestId,
+              agent_id: searchAgentId,
+              embed_origin: embedOrigin || undefined,
+            }
 
         const authResponse = await fetch(`${getApiUrl()}${authPath}`, {
           method: "POST",
@@ -300,7 +306,7 @@ export function PublicAgentChatPage({
 
     initPublicChat()
     return () => setPublicAccessToken(null)
-  }, [authMode, normalizedGuestId, routeToken, searchAgentId, t])
+  }, [authMode, embedOrigin, normalizedGuestId, routeToken, searchAgentId, t])
 
   const publicAccessToken = authResult?.access_token ?? ""
 

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -19,7 +19,7 @@ interface PublicAgentChatPageProps {
   routeToken: string
   guestId?: string | null
   searchAgentId?: number | null
-  embedOrigin?: string | null
+  embedTicket?: string | null
 }
 
 type PublicAuthResult = {
@@ -260,7 +260,7 @@ export function PublicAgentChatPage({
   routeToken,
   guestId,
   searchAgentId = null,
-  embedOrigin = null,
+  embedTicket = null,
 }: PublicAgentChatPageProps) {
   const { t } = useI18n()
   const normalizedGuestId = authMode === "widget" ? (guestId || "anonymous") : null
@@ -277,7 +277,7 @@ export function PublicAgentChatPage({
           : {
               guest_id: normalizedGuestId,
               agent_id: searchAgentId,
-              embed_origin: embedOrigin || undefined,
+              embed_ticket: embedTicket || undefined,
             }
 
         const authResponse = await fetch(`${getApiUrl()}${authPath}`, {
@@ -306,7 +306,7 @@ export function PublicAgentChatPage({
 
     initPublicChat()
     return () => setPublicAccessToken(null)
-  }, [authMode, embedOrigin, normalizedGuestId, routeToken, searchAgentId, t])
+  }, [authMode, embedTicket, normalizedGuestId, routeToken, searchAgentId, t])
 
   const publicAccessToken = authResult?.access_token ?? ""
 

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -1,6 +1,8 @@
 """Web Widget API route handlers."""
 
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from fastapi import (
     APIRouter,
@@ -13,9 +15,11 @@ from fastapi import (
     UploadFile,
     WebSocket,
 )
+from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from ..models.agent import Agent, is_workforce_generated_manager_agent
 from ..models.database import get_db
 from ..models.user import User
@@ -32,14 +36,98 @@ from .public_chat_access import (
 
 widget_router = APIRouter(prefix="/api/widget", tags=["widget"])
 
+EMBED_TICKET_TYPE = "widget_embed_ticket"
+EMBED_TICKET_TTL_SECONDS = 60
+
 
 class WidgetAuthRequest(BaseModel):
     guest_id: str
     agent_id: Optional[int] = None
-    embed_origin: Optional[str] = None
+    embed_ticket: Optional[str] = None
+
+
+class EmbedTicketRequest(BaseModel):
+    agent_id: int
+
+
+class EmbedTicketResponse(BaseModel):
+    ticket: str
 
 
 WidgetAuthResponse = PublicChatAuthResponse
+
+
+def _origin_to_domain(origin: str) -> str:
+    """Extract a lowercased host[:port] from an origin/referer value."""
+    if not origin:
+        return ""
+    parsed = urlparse(origin)
+    return (parsed.netloc or parsed.path).lower()
+
+
+def _domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
+    """Check a domain against the agent allowlist (case-insensitive,
+    supports "*" and subdomain suffix matches)."""
+    for domain in allowed_domains:
+        normalized_domain = domain.strip().lower()
+        if (
+            normalized_domain == "*"
+            or normalized_domain == origin_domain
+            or (origin_domain and origin_domain.endswith("." + normalized_domain))
+        ):
+            return True
+    return False
+
+
+def _get_widget_enabled_agent(db: Session, agent_id: int) -> Agent:
+    """Load a widget-enabled agent or raise the matching HTTP error."""
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if agent is None or is_workforce_generated_manager_agent(agent):
+        raise HTTPException(
+            status_code=401, detail="Widget owner not found or invalid agent_id"
+        )
+    if not agent.widget_enabled:
+        raise HTTPException(status_code=403, detail="Widget is disabled for this agent")
+    return agent
+
+
+@widget_router.post("/embed-ticket", response_model=EmbedTicketResponse)
+async def issue_widget_embed_ticket(
+    request: EmbedTicketRequest,
+    req: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    """Issue a short-lived signed embed ticket to the embedding page.
+
+    This endpoint is called by widget.js from the top-level embedding page,
+    so the browser-enforced Origin header carries the real embedding site —
+    unlike fetches from inside the widget iframe, whose Origin is the xagent
+    host itself. The signed ticket is the only way that validated origin is
+    trusted downstream; the widget never self-reports its parent's origin.
+    """
+    agent = _get_widget_enabled_agent(db, request.agent_id)
+
+    allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
+    origin = req.headers.get("origin") or req.headers.get("referer", "")
+    origin_domain = _origin_to_domain(origin)
+
+    if not _domain_allowed(origin_domain, allowed_domains):
+        raise HTTPException(
+            status_code=403, detail=f"Domain not allowed: {origin_domain}"
+        )
+
+    expire = datetime.now(timezone.utc) + timedelta(seconds=EMBED_TICKET_TTL_SECONDS)
+    ticket = jwt.encode(
+        {
+            "type": EMBED_TICKET_TYPE,
+            "agent_id": int(agent.id),
+            "embed_origin": origin_domain,
+            "exp": expire,
+        },
+        JWT_SECRET_KEY,
+        algorithm=JWT_ALGORITHM,
+    )
+    return EmbedTicketResponse(ticket=ticket)
 
 
 @widget_router.post("/auth", response_model=WidgetAuthResponse)
@@ -55,61 +143,53 @@ async def authenticate_widget(
     agent = None
 
     # Authenticate via agent_id directly (since web widget channel is deprecated)
+    origin_domain = ""
     if agent_id:
-        candidate_agent = db.query(Agent).filter(Agent.id == agent_id).first()
-        if candidate_agent and not is_workforce_generated_manager_agent(
-            candidate_agent
-        ):
-            agent = candidate_agent
-        if agent:
-            if not agent.widget_enabled:
-                raise HTTPException(
-                    status_code=403, detail="Widget is disabled for this agent"
+        agent = _get_widget_enabled_agent(db, agent_id)
+
+        allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
+
+        if request.embed_ticket:
+            # The auth fetch runs inside the widget iframe, so its
+            # Origin/Referer headers reflect the xagent host, not the
+            # embedding site. The embedding page's origin is instead carried
+            # by the backend-signed embed ticket issued by /embed-ticket,
+            # where it was validated against the browser-enforced Origin
+            # header. A client-supplied origin value is never trusted here.
+            try:
+                claims = jwt.decode(
+                    request.embed_ticket,
+                    JWT_SECRET_KEY,
+                    algorithms=[JWT_ALGORITHM],
                 )
-
-            # Check allowed domains
-            allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
-
-            # The auth fetch runs inside the widget iframe, so the browser's
-            # Origin/Referer headers reflect the xagent host itself, not the
-            # embedding site. widget.js forwards the embedding page's origin
-            # as embed_origin; prefer it, falling back to headers for older
-            # cached embeds and direct page visits.
-            origin = request.embed_origin or (
-                req.headers.get("origin") or req.headers.get("referer", "")
-            )
-
-            from urllib.parse import urlparse
-
-            origin_domain = ""
-
-            if origin:
-                parsed = urlparse(origin)
-                origin_domain = (parsed.netloc or parsed.path).lower()
-
-            # Check if origin matches any allowed domain. Domains are
-            # case-insensitive, so compare both sides lowercased regardless of
-            # how the entry was stored.
-            is_allowed = False
-            for domain in allowed_domains:
-                normalized_domain = domain.strip().lower()
-                if (
-                    normalized_domain == "*"
-                    or normalized_domain == origin_domain
-                    or (
-                        origin_domain
-                        and origin_domain.endswith("." + normalized_domain)
-                    )
-                ):
-                    is_allowed = True
-                    break
-
-            if not is_allowed:
+            except JWTError:
+                raise HTTPException(
+                    status_code=403, detail="Invalid or expired embed ticket"
+                )
+            if (
+                claims.get("type") != EMBED_TICKET_TYPE
+                or claims.get("agent_id") != agent_id
+            ):
+                raise HTTPException(
+                    status_code=403, detail="Invalid or expired embed ticket"
+                )
+            origin_domain = str(claims.get("embed_origin") or "")
+            # Re-check so tickets die immediately if the allowlist shrinks.
+            if not _domain_allowed(origin_domain, allowed_domains):
+                raise HTTPException(
+                    status_code=403, detail=f"Domain not allowed: {origin_domain}"
+                )
+        else:
+            # No ticket: direct page visits (not embedded via widget.js).
+            # Fall back to the request's own Origin/Referer headers.
+            origin = req.headers.get("origin") or req.headers.get("referer", "")
+            origin_domain = _origin_to_domain(origin)
+            if not _domain_allowed(origin_domain, allowed_domains):
                 raise HTTPException(
                     status_code=403, detail=f"Domain not allowed: {origin_domain}"
                 )
 
-            user = db.query(User).filter(User.id == agent.user_id).first()
+        user = db.query(User).filter(User.id == agent.user_id).first()
 
     if not user:
         raise HTTPException(
@@ -133,6 +213,8 @@ async def authenticate_widget(
             "guest_id": request.guest_id,
             "auth_mode": "widget",
             "widget_agent_id": int(agent.id) if agent else None,
+            # Validated embedding origin, kept for downstream re-validation.
+            "embed_origin": origin_domain,
         }
     )
 

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -36,6 +36,7 @@ widget_router = APIRouter(prefix="/api/widget", tags=["widget"])
 class WidgetAuthRequest(BaseModel):
     guest_id: str
     agent_id: Optional[int] = None
+    embed_origin: Optional[str] = None
 
 
 WidgetAuthResponse = PublicChatAuthResponse
@@ -69,21 +70,22 @@ async def authenticate_widget(
             # Check allowed domains
             allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
 
-            # Use X-Forwarded-Host if available, then Host, then Origin/Referer
-            # This is important when widget is loaded via iframe
-            origin = req.headers.get("origin") or req.headers.get("referer", "")
+            # The auth fetch runs inside the widget iframe, so the browser's
+            # Origin/Referer headers reflect the xagent host itself, not the
+            # embedding site. widget.js forwards the embedding page's origin
+            # as embed_origin; prefer it, falling back to headers for older
+            # cached embeds and direct page visits.
+            origin = request.embed_origin or (
+                req.headers.get("origin") or req.headers.get("referer", "")
+            )
 
             from urllib.parse import urlparse
 
             origin_domain = ""
 
-            # Try origin/referer
             if origin:
                 parsed = urlparse(origin)
                 origin_domain = (parsed.netloc or parsed.path).lower()
-
-            # If origin_domain is localhost:3000 but host is localhost:8001
-            # Next.js might be rewriting the request. Let's use the origin_domain.
 
             # Check if origin matches any allowed domain. Domains are
             # case-insensitive, so compare both sides lowercased regardless of

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -16,7 +16,7 @@ from fastapi import (
     WebSocket,
 )
 from jose import JWTError, jwt
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
@@ -41,9 +41,11 @@ EMBED_TICKET_TTL_SECONDS = 60
 
 
 class WidgetAuthRequest(BaseModel):
-    guest_id: str
+    guest_id: str = Field(max_length=256)
     agent_id: Optional[int] = None
-    embed_ticket: Optional[str] = None
+    # A signed embed ticket is a compact JWT; cap it to reject pathological
+    # payloads, matching the length limits on sibling request models.
+    embed_ticket: Optional[str] = Field(default=None, max_length=4096)
 
 
 class EmbedTicketRequest(BaseModel):

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -118,6 +118,10 @@ async def issue_widget_embed_ticket(
             status_code=403, detail=f"Domain not allowed: {origin_domain}"
         )
 
+    # The ticket has no jti/nonce and is intentionally replayable within its
+    # short TTL: it only re-certifies "this origin is allowed", which /auth
+    # independently re-checks against the live allowlist on every use, and the
+    # guest tokens it mints are low-privilege. Replay-within-TTL is accepted.
     expire = datetime.now(timezone.utc) + timedelta(seconds=EMBED_TICKET_TTL_SECONDS)
     ticket = jwt.encode(
         {
@@ -215,8 +219,6 @@ async def authenticate_widget(
             "guest_id": request.guest_id,
             "auth_mode": "widget",
             "widget_agent_id": int(agent.id) if agent else None,
-            # Validated embedding origin, kept for downstream re-validation.
-            "embed_origin": origin_domain,
         }
     )
 

--- a/src/xagent/web/api/widget.py
+++ b/src/xagent/web/api/widget.py
@@ -1,6 +1,6 @@
 """Web Widget API route handlers."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -24,6 +24,7 @@ from ..models.agent import Agent, is_workforce_generated_manager_agent
 from ..models.database import get_db
 from ..models.user import User
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
+from .auth import create_access_token
 from .public_chat_access import (
     PublicChatAccessContext,
     PublicChatAuthResponse,
@@ -81,6 +82,14 @@ def _domain_allowed(origin_domain: str, allowed_domains: list[str]) -> bool:
     return False
 
 
+def _require_domain_allowed(origin_domain: str, allowed_domains: list[str]) -> None:
+    """Raise 403 unless the domain passes the agent allowlist."""
+    if not _domain_allowed(origin_domain, allowed_domains):
+        raise HTTPException(
+            status_code=403, detail=f"Domain not allowed: {origin_domain}"
+        )
+
+
 def _get_widget_enabled_agent(db: Session, agent_id: int) -> Agent:
     """Load a widget-enabled agent or raise the matching HTTP error."""
     agent = db.query(Agent).filter(Agent.id == agent_id).first()
@@ -112,26 +121,19 @@ async def issue_widget_embed_ticket(
     allowed_domains: list[str] = agent.allowed_domains or []  # type: ignore
     origin = req.headers.get("origin") or req.headers.get("referer", "")
     origin_domain = _origin_to_domain(origin)
-
-    if not _domain_allowed(origin_domain, allowed_domains):
-        raise HTTPException(
-            status_code=403, detail=f"Domain not allowed: {origin_domain}"
-        )
+    _require_domain_allowed(origin_domain, allowed_domains)
 
     # The ticket has no jti/nonce and is intentionally replayable within its
     # short TTL: it only re-certifies "this origin is allowed", which /auth
     # independently re-checks against the live allowlist on every use, and the
     # guest tokens it mints are low-privilege. Replay-within-TTL is accepted.
-    expire = datetime.now(timezone.utc) + timedelta(seconds=EMBED_TICKET_TTL_SECONDS)
-    ticket = jwt.encode(
+    ticket = create_access_token(
         {
             "type": EMBED_TICKET_TYPE,
             "agent_id": int(agent.id),
             "embed_origin": origin_domain,
-            "exp": expire,
         },
-        JWT_SECRET_KEY,
-        algorithm=JWT_ALGORITHM,
+        expires_delta=timedelta(seconds=EMBED_TICKET_TTL_SECONDS),
     )
     return EmbedTicketResponse(ticket=ticket)
 
@@ -181,19 +183,13 @@ async def authenticate_widget(
                 )
             origin_domain = str(claims.get("embed_origin") or "")
             # Re-check so tickets die immediately if the allowlist shrinks.
-            if not _domain_allowed(origin_domain, allowed_domains):
-                raise HTTPException(
-                    status_code=403, detail=f"Domain not allowed: {origin_domain}"
-                )
+            _require_domain_allowed(origin_domain, allowed_domains)
         else:
             # No ticket: direct page visits (not embedded via widget.js).
             # Fall back to the request's own Origin/Referer headers.
             origin = req.headers.get("origin") or req.headers.get("referer", "")
             origin_domain = _origin_to_domain(origin)
-            if not _domain_allowed(origin_domain, allowed_domains):
-                raise HTTPException(
-                    status_code=403, detail=f"Domain not allowed: {origin_domain}"
-                )
+            _require_domain_allowed(origin_domain, allowed_domains)
 
         user = db.query(User).filter(User.id == agent.user_id).first()
 

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -587,6 +587,44 @@ def test_widget_auth_falls_back_to_origin_header_without_embed_ticket() -> None:
     assert response.status_code == 200, response.text
 
 
+def test_widget_embed_ticket_matches_domain_regardless_of_scheme() -> None:
+    """allowed_domains matches on host[:port] only; the scheme is not part
+    of the comparison, so an http origin matches an entry with no scheme."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Scheme Agnostic Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    response = _issue_embed_ticket(agent_id, "http://trusted-site.com")
+
+    assert response.status_code == 200, response.text
+
+
+def test_widget_auth_rejects_when_ticket_and_origin_both_absent() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="No Origin Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: "
+
+
 def test_widget_public_tokens_cannot_create_tasks_for_other_agents() -> None:
     _admin_headers()
     owner_id = _user_id("admin")

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -1,11 +1,15 @@
 """Integration tests for agent management endpoints."""
 
 import io
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
+from jose import jwt as jose_jwt
 
 from xagent.config import get_uploads_dir
+from xagent.web.api.widget import EMBED_TICKET_TYPE
+from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.agent import Agent, AgentOrigin, AgentStatus
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
@@ -367,19 +371,78 @@ def test_widget_auth_matches_allowed_domains_case_insensitively() -> None:
     assert response.status_code == 200, response.text
 
 
-def test_widget_auth_prefers_embed_origin_over_iframe_origin_header() -> None:
+def _issue_embed_ticket(agent_id: int, origin: str) -> Any:
+    return client.post(
+        "/api/widget/embed-ticket",
+        json={"agent_id": agent_id},
+        headers={"origin": origin},
+    )
+
+
+def test_widget_embed_ticket_flow_validates_embedding_origin() -> None:
     _admin_headers()
     owner_id = _user_id("admin")
     agent_id = _create_agent_row(
         user_id=owner_id,
-        name="Embed Origin Widget Agent",
+        name="Embed Ticket Widget Agent",
         status=AgentStatus.PUBLISHED,
         widget_enabled=True,
         allowed_domains=["trusted-site.com"],
     )
 
-    # The auth fetch runs inside the widget iframe, so the Origin header is
-    # the xagent host's own origin; embed_origin carries the embedding page.
+    # widget.js requests the ticket from the top-level embedding page, so
+    # the browser-enforced Origin header carries the real embedding site.
+    ticket_response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+    assert ticket_response.status_code == 200, ticket_response.text
+    ticket = ticket_response.json()["ticket"]
+
+    # The auth fetch runs inside the iframe: its Origin is the xagent host,
+    # which is NOT in allowed_domains — the ticket alone must carry trust.
+    auth_response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+        headers={"origin": "https://xagent-host.example"},
+    )
+    assert auth_response.status_code == 200, auth_response.text
+
+    claims = jose_jwt.decode(
+        auth_response.json()["access_token"],
+        JWT_SECRET_KEY,
+        algorithms=[JWT_ALGORITHM],
+    )
+    assert claims["embed_origin"] == "trusted-site.com"
+
+
+def test_widget_embed_ticket_rejected_for_disallowed_origin() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Embed Ticket Rejection Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    response = _issue_embed_ticket(agent_id, "https://evil-attacker.com")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
+
+
+def test_widget_auth_ignores_client_supplied_embed_origin() -> None:
+    """A browser-JS attacker must not pass by self-reporting an allowed
+    origin in the request body (the pre-ticket design's flaw)."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Self Reported Origin Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
     response = client.post(
         "/api/widget/auth",
         json={
@@ -387,21 +450,79 @@ def test_widget_auth_prefers_embed_origin_over_iframe_origin_header() -> None:
             "guest_id": "guest-1",
             "embed_origin": "https://trusted-site.com",
         },
-        headers={"origin": "https://xagent-host.example"},
+        headers={"origin": "https://evil-attacker.com"},
     )
 
-    assert response.status_code == 200, response.text
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
 
 
-def test_widget_auth_rejects_disallowed_embed_origin_despite_allowed_header() -> None:
+def test_widget_auth_rejects_tampered_or_mismatched_ticket() -> None:
     _admin_headers()
     owner_id = _user_id("admin")
     agent_id = _create_agent_row(
         user_id=owner_id,
-        name="Embed Origin Rejection Widget Agent",
+        name="Tampered Ticket Widget Agent",
         status=AgentStatus.PUBLISHED,
         widget_enabled=True,
         allowed_domains=["trusted-site.com"],
+    )
+    other_agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Other Ticket Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    # Garbage ticket: fails signature verification.
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "agent_id": agent_id,
+            "guest_id": "guest-1",
+            "embed_ticket": "not-a-real-ticket",
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid or expired embed ticket"
+
+    # Valid ticket, but issued for a different agent.
+    other_ticket = _issue_embed_ticket(
+        other_agent_id, "https://trusted-site.com"
+    ).json()["ticket"]
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "agent_id": agent_id,
+            "guest_id": "guest-1",
+            "embed_ticket": other_ticket,
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid or expired embed ticket"
+
+
+def test_widget_auth_rejects_expired_embed_ticket() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Expired Ticket Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    expired_ticket = jose_jwt.encode(
+        {
+            "type": EMBED_TICKET_TYPE,
+            "agent_id": agent_id,
+            "embed_origin": "trusted-site.com",
+            "exp": datetime.now(timezone.utc) - timedelta(seconds=1),
+        },
+        JWT_SECRET_KEY,
+        algorithm=JWT_ALGORITHM,
     )
 
     response = client.post(
@@ -409,16 +530,44 @@ def test_widget_auth_rejects_disallowed_embed_origin_despite_allowed_header() ->
         json={
             "agent_id": agent_id,
             "guest_id": "guest-1",
-            "embed_origin": "https://evil-attacker.com",
+            "embed_ticket": expired_ticket,
         },
-        headers={"origin": "https://trusted-site.com"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid or expired embed ticket"
+
+
+def test_widget_auth_rechecks_ticket_origin_against_current_allowlist() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Shrinking Allowlist Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
     )
 
+    ticket = _issue_embed_ticket(agent_id, "https://trusted-site.com").json()["ticket"]
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).first()
+        assert agent is not None
+        agent.allowed_domains = ["another-site.com"]
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1", "embed_ticket": ticket},
+    )
     assert response.status_code == 403
-    assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
+    assert response.json()["detail"] == "Domain not allowed: trusted-site.com"
 
 
-def test_widget_auth_falls_back_to_origin_header_without_embed_origin() -> None:
+def test_widget_auth_falls_back_to_origin_header_without_embed_ticket() -> None:
     _admin_headers()
     owner_id = _user_id("admin")
     agent_id = _create_agent_row(

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -367,6 +367,77 @@ def test_widget_auth_matches_allowed_domains_case_insensitively() -> None:
     assert response.status_code == 200, response.text
 
 
+def test_widget_auth_prefers_embed_origin_over_iframe_origin_header() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Embed Origin Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    # The auth fetch runs inside the widget iframe, so the Origin header is
+    # the xagent host's own origin; embed_origin carries the embedding page.
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "agent_id": agent_id,
+            "guest_id": "guest-1",
+            "embed_origin": "https://trusted-site.com",
+        },
+        headers={"origin": "https://xagent-host.example"},
+    )
+
+    assert response.status_code == 200, response.text
+
+
+def test_widget_auth_rejects_disallowed_embed_origin_despite_allowed_header() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Embed Origin Rejection Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "agent_id": agent_id,
+            "guest_id": "guest-1",
+            "embed_origin": "https://evil-attacker.com",
+        },
+        headers={"origin": "https://trusted-site.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Domain not allowed: evil-attacker.com"
+
+
+def test_widget_auth_falls_back_to_origin_header_without_embed_origin() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Header Fallback Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={"agent_id": agent_id, "guest_id": "guest-1"},
+        headers={"origin": "https://trusted-site.com"},
+    )
+
+    assert response.status_code == 200, response.text
+
+
 def test_widget_public_tokens_cannot_create_tasks_for_other_agents() -> None:
     _admin_headers()
     owner_id = _user_id("admin")

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -396,6 +396,12 @@ def test_widget_embed_ticket_flow_validates_embedding_origin() -> None:
     assert ticket_response.status_code == 200, ticket_response.text
     ticket = ticket_response.json()["ticket"]
 
+    # The backend signs the validated embedding origin into the ticket, not
+    # a caller-supplied value.
+    ticket_claims = jose_jwt.decode(ticket, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+    assert ticket_claims["type"] == EMBED_TICKET_TYPE
+    assert ticket_claims["embed_origin"] == "trusted-site.com"
+
     # The auth fetch runs inside the iframe: its Origin is the xagent host,
     # which is NOT in allowed_domains — the ticket alone must carry trust.
     auth_response = client.post(
@@ -404,13 +410,6 @@ def test_widget_embed_ticket_flow_validates_embedding_origin() -> None:
         headers={"origin": "https://xagent-host.example"},
     )
     assert auth_response.status_code == 200, auth_response.text
-
-    claims = jose_jwt.decode(
-        auth_response.json()["access_token"],
-        JWT_SECRET_KEY,
-        algorithms=[JWT_ALGORITHM],
-    )
-    assert claims["embed_origin"] == "trusted-site.com"
 
 
 def test_widget_embed_ticket_rejected_for_disallowed_origin() -> None:

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -536,6 +536,43 @@ def test_widget_auth_rejects_expired_embed_ticket() -> None:
     assert response.json()["detail"] == "Invalid or expired embed ticket"
 
 
+def test_widget_auth_rejects_valid_signed_token_of_wrong_type() -> None:
+    """All token classes share one signing key, so the type claim is the only
+    thing separating them. A validly-signed guest access token with the right
+    agent_id must not be replayable as an embed ticket."""
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Wrong Type Ticket Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    wrong_type_ticket = jose_jwt.encode(
+        {
+            "type": "widget",
+            "agent_id": agent_id,
+            "embed_origin": "trusted-site.com",
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        },
+        JWT_SECRET_KEY,
+        algorithm=JWT_ALGORITHM,
+    )
+
+    response = client.post(
+        "/api/widget/auth",
+        json={
+            "agent_id": agent_id,
+            "guest_id": "guest-1",
+            "embed_ticket": wrong_type_ticket,
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid or expired embed ticket"
+
+
 def test_widget_auth_rechecks_ticket_origin_against_current_allowlist() -> None:
     _admin_headers()
     owner_id = _user_id("admin")
@@ -622,6 +659,81 @@ def test_widget_auth_rejects_when_ticket_and_origin_both_absent() -> None:
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Domain not allowed: "
+
+
+def test_widget_embed_ticket_wildcard_allows_any_origin() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Wildcard Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["*"],
+    )
+
+    response = _issue_embed_ticket(agent_id, "https://anything-goes.example")
+
+    assert response.status_code == 200, response.text
+
+
+def test_widget_embed_ticket_matches_subdomain_of_allowed_entry() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Subdomain Widget Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=True,
+        allowed_domains=["trusted-site.com"],
+    )
+
+    allowed = _issue_embed_ticket(agent_id, "https://app.trusted-site.com")
+    assert allowed.status_code == 200, allowed.text
+
+    # A domain that merely ends with the allowed string but is not a subdomain
+    # (no dot boundary) must not match.
+    spoofed = _issue_embed_ticket(agent_id, "https://eviltrusted-site.com")
+    assert spoofed.status_code == 403
+    assert spoofed.json()["detail"] == "Domain not allowed: eviltrusted-site.com"
+
+
+def test_embed_ticket_endpoint_rejects_unknown_agent() -> None:
+    _admin_headers()
+    response = _issue_embed_ticket(999999, "https://trusted-site.com")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Widget owner not found or invalid agent_id"
+
+
+def test_embed_ticket_endpoint_rejects_generated_manager_agent() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    manager_id = _create_agent_row(
+        user_id=owner_id,
+        name="Generated Manager Ticket Agent",
+        status=AgentStatus.PUBLISHED,
+        origin=AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+        widget_enabled=True,
+        allowed_domains=["*"],
+    )
+    response = _issue_embed_ticket(manager_id, "https://trusted-site.com")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Widget owner not found or invalid agent_id"
+
+
+def test_embed_ticket_endpoint_rejects_widget_disabled_agent() -> None:
+    _admin_headers()
+    owner_id = _user_id("admin")
+    agent_id = _create_agent_row(
+        user_id=owner_id,
+        name="Widget Disabled Ticket Agent",
+        status=AgentStatus.PUBLISHED,
+        widget_enabled=False,
+        allowed_domains=["trusted-site.com"],
+    )
+    response = _issue_embed_ticket(agent_id, "https://trusted-site.com")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Widget is disabled for this agent"
 
 
 def test_widget_public_tokens_cannot_create_tasks_for_other_agents() -> None:


### PR DESCRIPTION
This pull request improves the security and reliability of widget authentication by ensuring that the embedding page's origin is explicitly passed and validated when authenticating widget requests. This helps prevent unauthorized domains from embedding the widget, even if the iframe's own origin or headers could be spoofed. The changes affect both the frontend and backend, and include new tests to verify the correct behavior.

Key changes:

**Frontend: Pass embedding page origin**

* [`frontend/public/widget.js`](diffhunk://#diff-f27aa7db713286ef73cfb8a2d8e4d52ce3c7c140b6892fd878fdda588b398952R120-R122): Adds the embedding page's origin as `embed_origin` to the iframe URL so it can be sent to the backend during authentication.
* `frontend/src/app/widget/chat/[token]/page-client.tsx`, `frontend/src/components/widget/public-agent-chat-page.tsx`: Passes `embed_origin` through the React component props and includes it in the authentication payload. ([frontend/src/app/widget/chat/[token]/page-client.tsxR18](diffhunk://#diff-6910399d1f280defae4047ee7b4a01f034ae854af0aa9409e44a682494471554R18), [[1]](diffhunk://#diff-d020836d3be13e2a2074a27aa84194a5417956d33a483e02b3b701a5358c399cR22) [[2]](diffhunk://#diff-d020836d3be13e2a2074a27aa84194a5417956d33a483e02b3b701a5358c399cR263) [[3]](diffhunk://#diff-d020836d3be13e2a2074a27aa84194a5417956d33a483e02b3b701a5358c399cL275-R281) [[4]](diffhunk://#diff-d020836d3be13e2a2074a27aa84194a5417956d33a483e02b3b701a5358c399cL303-R309)

**Backend: Prefer `embed_origin` for domain validation**

* [`src/xagent/web/api/widget.py`](diffhunk://#diff-a24eff2c525a3493865d363d4f1be70376709fe91832e3d88103f6b82c4412d5R39): Updates the authentication logic to prefer the `embed_origin` field from the request body over the Origin/Referer headers when checking allowed domains. Also updates the request schema to include `embed_origin`. [[1]](diffhunk://#diff-a24eff2c525a3493865d363d4f1be70376709fe91832e3d88103f6b82c4412d5R39) [[2]](diffhunk://#diff-a24eff2c525a3493865d363d4f1be70376709fe91832e3d88103f6b82c4412d5L72-L87)

**Testing: Add tests for embed origin behavior**

* [`tests/web/api/test_agents_management.py`](diffhunk://#diff-7a2362424f8a78a302e0d947894ebde1ea92c2fa4a65d1e64192116da453d269R370-R440): Adds tests to ensure that `embed_origin` is preferred over headers, that disallowed origins are correctly rejected, and that the system falls back to the Origin header if `embed_origin` is not provided.…d validation