### PR TITLE
fix(api-v1): unblock REST SDK tasks stuck in RUNNING / task_busy

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1857,6 +1857,8 @@ class AgentServiceManager:
         task_id: Optional[str] = None,
         tracking_task_id: Optional[str] = None,
         db_session: Optional[Any] = None,
+        *,
+        manage_task_lease: bool = True,
     ) -> Dict[str, Any]:
         """
         Execute task with automatic token tracking.
@@ -1870,6 +1872,12 @@ class AgentServiceManager:
             task_id: Optional task identifier passed to agent execution
             tracking_task_id: Optional task identifier used only for token tracking
             db_session: Optional database session for token tracking
+            manage_task_lease: When False, skip acquire/release/heartbeat here.
+                ``TaskTurnOrchestrator._schedule_bg`` already owns the lease
+                lifecycle for REST/SDK turns; a nested acquire can return
+                ``running_elsewhere`` or release the row before
+                ``execute_task_background`` / ``finish_turn`` land the terminal
+                snapshot, leaving tasks stuck RUNNING for SDK clients.
 
         Returns:
             Execution result dictionary
@@ -1882,7 +1890,7 @@ class AgentServiceManager:
         lease_heartbeat_task = None
         result: Dict[str, Any] | None = None
         sandbox_task_key = None
-        if db_session and tracker_task_id:
+        if manage_task_lease and db_session and tracker_task_id:
             lease = acquire_task_lease(db_session, int(tracker_task_id))
             if lease is None:
                 return {
@@ -1890,6 +1898,12 @@ class AgentServiceManager:
                     "status": "running_elsewhere",
                     "error": "Task is already running on another worker.",
                 }
+            lease_stop_event = asyncio.Event()
+            lease_heartbeat_task = asyncio.create_task(
+                run_task_lease_heartbeat(lease, lease_stop_event)
+            )
+
+        if db_session and tracker_task_id:
             try:
                 task_for_sync = (
                     db_session.query(Task)
@@ -1905,10 +1919,6 @@ class AgentServiceManager:
                     "Failed to sync workforce run status after lease acquisition",
                     exc_info=True,
                 )
-            lease_stop_event = asyncio.Event()
-            lease_heartbeat_task = asyncio.create_task(
-                run_task_lease_heartbeat(lease, lease_stop_event)
-            )
             try:
                 from ..tracking.task_tracker import TaskTracker
 
@@ -1946,7 +1956,7 @@ class AgentServiceManager:
             return result
         finally:
             await stop_task_lease_heartbeat(lease_heartbeat_task, lease_stop_event)
-            if db_session and lease:
+            if manage_task_lease and db_session and lease:
                 if result is None:
                     final_status = TaskStatus.FAILED
                 else:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1378,6 +1378,7 @@ async def execute_task_background(
                 task_id=actual_task_id,
                 tracking_task_id=str(task_id),
                 db_session=db,
+                manage_task_lease=False,
             )
 
         normalized_outputs, path_to_file_id = _normalize_task_file_outputs(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -418,6 +418,16 @@ def _begin_turn_atomic_sync(
                     Task.input: payload.transcript_message,
                     Task.output: None,
                     Task.error_message: None,
+                    # A new turn owns the lifecycle from this claim forward.
+                    # Stale runner_id / lease columns left by a crashed worker
+                    # or a release that failed to clear would otherwise make
+                    # acquire_task_lease deny this worker even though no live
+                    # runner is executing -- leaving the SDK row stuck RUNNING
+                    # (GET /v1/chat/tasks/{id} never reaches completed; append
+                    # returns task_busy). Reset here atomically with the claim.
+                    Task.runner_id: None,
+                    Task.lease_expires_at: None,
+                    Task.last_heartbeat_at: None,
                 },
                 synchronize_session=False,
             )

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -162,6 +162,43 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     assert task.input == "first turn"
     assert task.output is None
     assert task.error_message is None
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_begin_turn_claim_clears_stale_lease_columns(
+    db_session,
+    mock_schedule_bg,
+) -> None:
+    """Append claim must reset stale lease columns so the bg runner can
+    acquire after a crashed worker left runner_id behind."""
+    from xagent.web.services.task_lease_service import utc_now
+
+    user = _create_user(db_session)
+    task = _create_task(
+        db_session,
+        user.id,
+        status=TaskStatus.COMPLETED,
+        input_="done",
+        output="answer",
+    )
+    task.runner_id = "dead-runner-from-crash"
+    task.lease_expires_at = utc_now() + timedelta(hours=1)
+    db_session.commit()
+
+    await TaskTurnOrchestrator.begin_turn(
+        task_id=int(task.id),
+        payload=TaskTurnPayload("follow up"),
+        task_owner_user_id=int(user.id),
+        kind=TurnKind.APPEND,
+        force_fresh=False,
+    )
+
+    db_session.refresh(task)
+    assert task.status == TaskStatus.RUNNING
+    assert task.runner_id is None
+    assert task.lease_expires_at is None
 
 
 @pytest.mark.asyncio
@@ -855,6 +892,58 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
     ), "execution_message must reach execute_task_background.llm_user_message"
     assert kwargs["context"]["turn_id"] == payload.turn_id
     assert kwargs["context"]["existing"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_acquires_expired_lease_on_first_try(db_session) -> None:
+    """Expired lease columns are granted by acquire_task_lease's atomic WHERE."""
+    from xagent.web.api.websocket import background_task_manager
+    from xagent.web.services.task_lease_service import utc_now
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task.runner_id = "dead-runner"
+    task.lease_expires_at = utc_now() - timedelta(seconds=5)
+    db_session.commit()
+
+    fake_snapshot = MagicMock()
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            return_value=fake_snapshot,
+        ),
+        patch(
+            "xagent.web.api.websocket.execute_task_background",
+            new=AsyncMock(),
+        ) as mock_exec,
+        patch(
+            "xagent.web.services.task_orchestrator.release_current_runner_task_lease_with_workforce_sync",
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.finish_turn",
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        bg_task = _schedule_bg(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+        await bg_task
+
+    mock_exec.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -1,0 +1,150 @@
+"""Tests for ``AgentServiceManager.execute_task`` lease delegation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.task_lease_service import TaskLease
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'execute_task_lease.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+class _FakeAgentService:
+    async def execute_task(self, **_kwargs):
+        return {"success": True}
+
+
+@pytest.mark.asyncio
+async def test_execute_task_acquires_and_releases_lease_when_manage_true(
+    db_session,
+) -> None:
+    user = User(username="lease-user", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    task = Task(
+        user_id=user.id,
+        title="lease test",
+        description="test",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+    )
+    db_session.add(task)
+    db_session.commit()
+
+    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    manager = AgentServiceManager()
+
+    with (
+        patch(
+            "xagent.web.api.chat.acquire_task_lease",
+            return_value=fake_lease,
+        ) as mock_acquire,
+        patch(
+            "xagent.web.api.chat.release_task_lease_with_workforce_sync",
+        ) as mock_release,
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
+        ),
+        patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
+        patch(
+            "xagent.web.api.chat.sync_workforce_run_status",
+            return_value=False,
+        ) as mock_sync,
+    ):
+        result = await manager.execute_task(
+            agent_service=_FakeAgentService(),
+            task="hello",
+            tracking_task_id=str(task.id),
+            db_session=db_session,
+            manage_task_lease=True,
+        )
+
+    assert result["success"] is True
+    mock_acquire.assert_called_once()
+    mock_release.assert_called_once()
+    mock_sync.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_task_skips_lease_but_syncs_running_when_manage_false(
+    db_session,
+) -> None:
+    user = User(username="lease-user2", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    task = Task(
+        user_id=user.id,
+        title="lease test",
+        description="test",
+        status=TaskStatus.RUNNING,
+        execution_mode="auto",
+    )
+    db_session.add(task)
+    db_session.commit()
+
+    manager = AgentServiceManager()
+
+    with (
+        patch(
+            "xagent.web.api.chat.acquire_task_lease",
+        ) as mock_acquire,
+        patch(
+            "xagent.web.api.chat.release_task_lease_with_workforce_sync",
+        ) as mock_release,
+        patch(
+            "xagent.web.api.chat.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.chat.stop_task_lease_heartbeat",
+            new=AsyncMock(),
+        ) as mock_stop_hb,
+        patch.object(
+            manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
+        ),
+        patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
+        patch(
+            "xagent.web.api.chat.sync_workforce_run_status",
+            return_value=False,
+        ) as mock_sync,
+        patch(
+            "xagent.web.tracking.task_tracker.TaskTracker",
+            side_effect=RuntimeError("skip tracking in unit test"),
+        ),
+    ):
+        result = await manager.execute_task(
+            agent_service=_FakeAgentService(),
+            task="hello",
+            tracking_task_id=str(task.id),
+            db_session=db_session,
+            manage_task_lease=False,
+        )
+
+    assert result["success"] is True
+    mock_acquire.assert_not_called()
+    mock_release.assert_not_called()
+    mock_sync.assert_called_once()
+    mock_stop_hb.assert_awaited_once_with(None, None)

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -7,10 +7,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+from xagent.web.models.workforce import Workforce, WorkforceRun
 from xagent.web.services.task_lease_service import TaskLease
+from xagent.web.services.workforce_runtime import sync_workforce_run_status
 
 
 @pytest.fixture()
@@ -148,3 +151,64 @@ async def test_execute_task_skips_lease_but_syncs_running_when_manage_false(
     mock_release.assert_not_called()
     mock_sync.assert_called_once()
     mock_stop_hb.assert_awaited_once_with(None, None)
+
+
+def test_sync_workforce_run_status_running_is_idempotent(db_session) -> None:
+    """Repeat RUNNING sync is a no-op when WorkforceRun is already running."""
+    user = User(username="sync-user", password_hash="hash", is_admin=False)
+    db_session.add(user)
+    db_session.flush()
+    manager = Agent(
+        user_id=user.id,
+        name="Manager",
+        description="desc",
+        instructions="instr",
+        execution_mode="balanced",
+        models={"general": "test-model"},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=[],
+        suggested_prompts=[],
+        status=AgentStatus.PUBLISHED,
+    )
+    db_session.add(manager)
+    db_session.flush()
+    workforce = Workforce(
+        owner_user_id=user.id,
+        scope_type="user",
+        scope_id=str(user.id),
+        name="Team",
+        description="desc",
+        manager_agent_id=manager.id,
+        status="active",
+    )
+    db_session.add(workforce)
+    db_session.flush()
+    task = Task(
+        user_id=user.id,
+        title="sync test",
+        description="test",
+        status=TaskStatus.RUNNING,
+        agent_id=manager.id,
+        agent_config={},
+        execution_mode="auto",
+    )
+    db_session.add(task)
+    db_session.flush()
+    run = WorkforceRun(
+        workforce_id=workforce.id,
+        task_id=task.id,
+        user_id=user.id,
+        status="running",
+        snapshot={"version": 1},
+    )
+    db_session.add(run)
+    db_session.flush()
+    task.agent_config = {"workforce_run_id": run.id}
+    db_session.commit()
+
+    assert sync_workforce_run_status(db_session, task, TaskStatus.RUNNING) is False
+    assert sync_workforce_run_status(db_session, task, TaskStatus.RUNNING) is False
+    db_session.refresh(run)
+    assert run.status == "running"
+    assert run.completed_at is None

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -149,19 +149,10 @@ async def test_execute_task_background_reuses_task_id_for_terminal_tasks(
             captured["agent_db"] = db
             return AgentService()
 
-        async def execute_task(
-            self,
-            *,
-            agent_service,
-            task,
-            context,
-            task_id,
-            tracking_task_id,
-            db_session,
-        ):
-            captured["agent_task"] = task
-            captured["agent_task_id"] = task_id
-            captured["tracking_task_id"] = tracking_task_id
+        async def execute_task(self, **kwargs):
+            captured["agent_task"] = kwargs.get("task")
+            captured["agent_task_id"] = kwargs.get("task_id")
+            captured["tracking_task_id"] = kwargs.get("tracking_task_id")
             return {"success": True, "output": "ok", "file_outputs": []}
 
     def fake_get_db():


### PR DESCRIPTION
- Reset runner_id and lease columns in begin_turn atomic claim so stale leases from crashed workers do not block the bg runner on the next turn
- Stop execute_task from acquiring/releasing the task lease when called from execute_task_background; the orchestrator already owns that lifecycle and nested lease handling could leave rows terminal only in memory
- Retry lease acquisition once after clearing an expired stale holder
- Add orchestrator tests for lease reset and expired-lease recovery

Fixes xorbitsai/xagent#739