### PR TITLE
fix(migrations): merge MCP OAuth and trigger provider alembic heads

### DIFF
--- a/src/xagent/migrations/versions/20260703_merge_mcp_oauth_and_trigger_heads.py
+++ b/src/xagent/migrations/versions/20260703_merge_mcp_oauth_and_trigger_heads.py
@@ -1,0 +1,26 @@
+"""merge MCP OAuth authorization and trigger provider foundation heads
+
+Revision ID: 20260703_merge_mcp_oauth_and_trigger_heads
+Revises: 20260702_add_mcp_oauth_tables, 20260702_add_trigger_provider_foundation
+Create Date: 2026-07-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20260703_merge_mcp_oauth_and_trigger_heads"
+down_revision: Union[str, tuple[str, str], None] = (
+    "20260702_add_mcp_oauth_tables",
+    "20260702_add_trigger_provider_foundation",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- `main` currently has two diverging Alembic heads (`20260702_add_mcp_oauth_tables` from #732's OAuth work and `20260702_add_trigger_provider_foundation` from #731's trigger framework), both branching off `20260629_add_gmail_watch_states` without being rebased against each other. This breaks `alembic heads`/`alembic upgrade head` and is currently failing `Pull Request Checks` / `Test Database Migrations` on main.
- Adds a no-op merge migration (`20260703_merge_mcp_oauth_and_trigger_heads`) joining both heads into one.

## Test plan
- [x] `alembic heads` resolves to a single head after this change
- [x] `pytest tests/alembic` passes
- [x] `pre-commit run alembic-check --all-files` passes