### PR TITLE
fix(ci): publish wheel only to PyPI (sdist exceeds 100 MB limit)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -40,10 +40,14 @@ jobs:
           rm -rf src/xagent/web/frontend_dist
           cp -r frontend/out src/xagent/web/frontend_dist
 
-      - name: Build distributions
+      - name: Build distribution (wheel only)
         run: |
           python -m pip install build
-          python -m build
+          # Wheel only: the wheel is a universal py3-none-any build, so pip never
+          # needs the sdist to install on any platform. An sdist would also drag
+          # in large repo assets (README GIFs, tutorial videos) and exceed PyPI's
+          # 100 MB per-file limit for this project.
+          python -m build --wheel
 
       - name: Verify the bundled frontend is in the artifacts
         run: |


### PR DESCRIPTION
## Problem

The `v0.6.0` release published the wheel successfully (`xagent_ai-0.6.0-py3-none-any.whl`, 21 MB — it's live on PyPI) but the release action **failed** on the sdist upload:

```
400 File too large. Limit for project 'xagent-ai' is 100 MB.
xagent_ai-0.6.0.tar.gz  (184.4 MB)
```

The sdist is bloated by large repo assets that aren't part of the distribution (e.g. `assets/task.gif` ~50 MB, `assets/xagent_stay_ahead.gif`, `frontend/public/videos/*.mp4`). The default sdist includes all VCS-tracked files.

## Fix

Build the **wheel only** (`python -m build --wheel`). The wheel is a universal `py3-none-any` build, so pip never needs the sdist to install on any platform/Python; the wheel contains only `src/xagent` + the bundled `frontend_dist` and stays ~21 MB.

## Notes

- The `xagent_ai-0.6.0` **wheel is already on PyPI** and installable — this only unblocks the release pipeline for future tags. If a green `v0.6.0`-equivalent release is wanted, cut a new tag (e.g. `v0.6.1`) after merge.
- The "Verify the bundled frontend is in the artifacts" guard still runs against the wheel.