### PR TITLE
feat(install): add get.xagent.co one-line installer

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -1,0 +1,43 @@
+name: Install script
+
+on:
+  pull_request:
+    paths:
+      - scripts/install.sh
+      - .github/workflows/install-script.yml
+  push:
+    branches: [main]
+    paths:
+      - scripts/install.sh
+      - .github/workflows/install-script.yml
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: ShellCheck
+        run: shellcheck scripts/install.sh  # pre-installed on ubuntu runners
+
+  smoke:
+    # Actually run the one-liner end to end so it can't silently rot.
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run installer and verify the command works
+        env:
+          # Isolate the tool install so the runner's env stays clean and we
+          # control where the `xagent` entry point lands.
+          UV_TOOL_BIN_DIR: ${{ runner.temp }}/xagent-bin
+        run: |
+          set -eu
+          sh scripts/install.sh
+          export PATH="$UV_TOOL_BIN_DIR:$PATH"
+          command -v xagent
+          xagent --help

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - scripts/install.sh
+      - scripts/get.xagent.co/**
       - .github/workflows/install-script.yml
   push:
     branches: [main]
     paths:
       - scripts/install.sh
+      - scripts/get.xagent.co/**
       - .github/workflows/install-script.yml
   workflow_dispatch:
 
@@ -19,6 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: ShellCheck
         run: shellcheck scripts/install.sh  # pre-installed on ubuntu runners
+      - name: Check the get.xagent.co worker parses
+        # worker.js is an ES module; feed it via stdin so --input-type applies
+        # (it is rejected for a file path argument).
+        run: node --check --input-type=module < scripts/get.xagent.co/worker.js
 
   smoke:
     # Actually run the one-liner end to end so it can't silently rot.

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22" # node --test needs >=18; AbortSignal.timeout needs >=17.3
       - name: ShellCheck
         run: shellcheck scripts/install.sh  # pre-installed on ubuntu runners
       - name: Test the get.xagent.co worker

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -21,10 +21,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: ShellCheck
         run: shellcheck scripts/install.sh  # pre-installed on ubuntu runners
-      - name: Check the get.xagent.co worker parses
-        # worker.js is an ES module; feed it via stdin so --input-type applies
-        # (it is rejected for a file path argument).
-        run: node --check --input-type=module < scripts/get.xagent.co/worker.js
+      - name: Test the get.xagent.co worker
+        working-directory: scripts/get.xagent.co
+        run: |
+          node --check worker.js   # ES module (package.json sets "type": "module")
+          node --test
 
   smoke:
     # Actually run the one-liner end to end so it can't silently rot.

--- a/scripts/get.xagent.co/README.md
+++ b/scripts/get.xagent.co/README.md
@@ -1,0 +1,26 @@
+# get.xagent.co
+
+Cloudflare Worker that serves [`scripts/install.sh`](../install.sh) so users can install Xagent with:
+
+```bash
+curl -fsSL https://get.xagent.co | sh
+```
+
+The Worker fetches the installer pinned to the **latest GitHub release tag** (falling back to `main` only if the release lookup fails), so the public one-liner always serves a shipped, reviewed version.
+
+## Deploy
+
+Requires [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) and access to the Cloudflare account that owns the `xagent.co` zone.
+
+```bash
+cd scripts/get.xagent.co
+wrangler deploy
+```
+
+Then map `get.xagent.co` to this Worker (the `routes` entry in `wrangler.toml` does this once the zone is on the account).
+
+## Notes
+
+- The Worker only serves the script; it runs no user code.
+- Edge-caches the resolved script for 5 minutes (`CACHE_TTL_SECONDS`).
+- To publish a change to the installer: merge it to `main`, then it goes live at the next release (or immediately via the `main` fallback if there is no release yet).

--- a/scripts/get.xagent.co/README.md
+++ b/scripts/get.xagent.co/README.md
@@ -6,7 +6,9 @@ Cloudflare Worker that serves [`scripts/install.sh`](../install.sh) so users can
 curl -fsSL https://get.xagent.co | sh
 ```
 
-The Worker fetches the installer pinned to the **latest GitHub release tag** (falling back to `main` only if the release lookup fails), so the public one-liner always serves a shipped, reviewed version.
+The Worker serves the installer pinned to the **latest GitHub release tag**, so the public one-liner only ever runs a shipped, immutable version. It **fails closed**: if the release can't be resolved, or that tag doesn't contain the script, it returns `502` instead of falling back to a floating ref like `main` — a public `curl | sh` endpoint must never serve unreleased code.
+
+> The endpoint only works once a release that includes `scripts/install.sh` exists. Cut a release after this lands to bring it online.
 
 ## Deploy
 
@@ -23,4 +25,4 @@ Then map `get.xagent.co` to this Worker (the `routes` entry in `wrangler.toml` d
 
 - The Worker only serves the script; it runs no user code.
 - Edge-caches the resolved script for 5 minutes (`CACHE_TTL_SECONDS`).
-- To publish a change to the installer: merge it to `main`, then it goes live at the next release (or immediately via the `main` fallback if there is no release yet).
+- To publish a change to the installer: merge it to `main`, then cut a release — the endpoint serves the latest release tag, so changes go live only once released.

--- a/scripts/get.xagent.co/package.json
+++ b/scripts/get.xagent.co/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/scripts/get.xagent.co/worker.js
+++ b/scripts/get.xagent.co/worker.js
@@ -1,0 +1,61 @@
+// Cloudflare Worker backing https://get.xagent.co
+//
+// Serves scripts/install.sh from the xagent repo so users can run:
+//
+//   curl -fsSL https://get.xagent.co | sh
+//
+// The script is pinned to the latest GitHub *release tag* (not `main`), so the
+// public one-liner always fetches a shipped, reviewed version. Falls back to
+// `main` only if the release lookup fails. Deploy with `wrangler deploy`.
+
+const REPO = "xorbitsai/xagent";
+const SCRIPT_PATH = "scripts/install.sh";
+const FALLBACK_REF = "main";
+// Cache the resolved script at the edge to avoid hitting GitHub on every hit.
+const CACHE_TTL_SECONDS = 300;
+
+async function latestReleaseTag() {
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+    headers: { "User-Agent": "get.xagent.co", Accept: "application/vnd.github+json" },
+    cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return typeof data.tag_name === "string" && data.tag_name ? data.tag_name : null;
+}
+
+async function fetchScript(ref) {
+  const url = `https://raw.githubusercontent.com/${REPO}/${ref}/${SCRIPT_PATH}`;
+  return fetch(url, {
+    headers: { "User-Agent": "get.xagent.co" },
+    cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+  });
+}
+
+export default {
+  async fetch() {
+    const ref = (await latestReleaseTag()) || FALLBACK_REF;
+
+    let res = await fetchScript(ref);
+    if (!res.ok && ref !== FALLBACK_REF) {
+      res = await fetchScript(FALLBACK_REF); // tag exists but file missing at that tag
+    }
+    if (!res.ok) {
+      return new Response("# Xagent installer temporarily unavailable\n", {
+        status: 502,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const body = await res.text();
+    return new Response(body, {
+      status: 200,
+      headers: {
+        // text/plain so `curl | sh` gets the raw script, never rendered HTML.
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
+        "x-xagent-install-ref": ref,
+      },
+    });
+  },
+};

--- a/scripts/get.xagent.co/worker.js
+++ b/scripts/get.xagent.co/worker.js
@@ -23,6 +23,7 @@ async function latestReleaseTag() {
     const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
       headers: { "User-Agent": "get.xagent.co", Accept: "application/vnd.github+json" },
       cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+      signal: AbortSignal.timeout(5000), // don't hang the client on a stuck upstream
     });
     if (!res.ok) return null;
     const data = await res.json();
@@ -37,6 +38,7 @@ async function fetchScript(ref) {
   return fetch(url, {
     headers: { "User-Agent": "get.xagent.co" },
     cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+    signal: AbortSignal.timeout(10000), // a timeout here throws -> handler returns 502
   });
 }
 

--- a/scripts/get.xagent.co/worker.js
+++ b/scripts/get.xagent.co/worker.js
@@ -57,9 +57,11 @@ export default {
     try {
       const ref = (await latestReleaseTag()) || FALLBACK_REF;
 
+      let servedRef = ref;
       let res = await fetchScript(ref);
       if (!res.ok && ref !== FALLBACK_REF) {
         res = await fetchScript(FALLBACK_REF); // tag exists but file missing at that tag
+        servedRef = FALLBACK_REF;
       }
       if (!res.ok) return UNAVAILABLE();
 
@@ -70,7 +72,7 @@ export default {
           // text/plain so `curl | sh` gets the raw script, never rendered HTML.
           "content-type": "text/plain; charset=utf-8",
           "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
-          "x-xagent-install-ref": ref,
+          "x-xagent-install-ref": servedRef,
         },
       });
     } catch {

--- a/scripts/get.xagent.co/worker.js
+++ b/scripts/get.xagent.co/worker.js
@@ -4,19 +4,21 @@
 //
 //   curl -fsSL https://get.xagent.co | sh
 //
-// The script is pinned to the latest GitHub *release tag* (not `main`), so the
-// public one-liner always fetches a shipped, reviewed version. Falls back to
-// `main` only if the release lookup fails. Deploy with `wrangler deploy`.
+// The script is pinned to the latest GitHub *release tag*, so the public
+// one-liner only ever serves a shipped, immutable version. It fails closed:
+// if the release can't be resolved or the tag doesn't contain the script, it
+// returns 502 rather than falling back to a floating ref like `main` — a public
+// `curl | sh` endpoint must never serve unreleased code. (This means the
+// endpoint only works once a release that includes scripts/install.sh exists.)
+// Deploy with `wrangler deploy`.
 
 const REPO = "xorbitsai/xagent";
 const SCRIPT_PATH = "scripts/install.sh";
-const FALLBACK_REF = "main";
 // Cache the resolved script at the edge to avoid hitting GitHub on every hit.
 const CACHE_TTL_SECONDS = 300;
 
 async function latestReleaseTag() {
-  // Never throw: a GitHub API outage/rate-limit must degrade to the main
-  // fallback, not crash the installer endpoint.
+  // Never throw: on any API failure return null so the caller fails closed.
   try {
     const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
       headers: { "User-Agent": "get.xagent.co", Accept: "application/vnd.github+json" },
@@ -55,14 +57,11 @@ export default {
     }
 
     try {
-      const ref = (await latestReleaseTag()) || FALLBACK_REF;
+      // Fail closed: only ever serve a resolved, immutable release tag.
+      const ref = await latestReleaseTag();
+      if (!ref) return UNAVAILABLE();
 
-      let servedRef = ref;
-      let res = await fetchScript(ref);
-      if (!res.ok && ref !== FALLBACK_REF) {
-        res = await fetchScript(FALLBACK_REF); // tag exists but file missing at that tag
-        servedRef = FALLBACK_REF;
-      }
+      const res = await fetchScript(ref);
       if (!res.ok) return UNAVAILABLE();
 
       const body = await res.text();
@@ -72,7 +71,7 @@ export default {
           // text/plain so `curl | sh` gets the raw script, never rendered HTML.
           "content-type": "text/plain; charset=utf-8",
           "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
-          "x-xagent-install-ref": servedRef,
+          "x-xagent-install-ref": ref,
         },
       });
     } catch {

--- a/scripts/get.xagent.co/worker.js
+++ b/scripts/get.xagent.co/worker.js
@@ -15,13 +15,19 @@ const FALLBACK_REF = "main";
 const CACHE_TTL_SECONDS = 300;
 
 async function latestReleaseTag() {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
-    headers: { "User-Agent": "get.xagent.co", Accept: "application/vnd.github+json" },
-    cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
-  });
-  if (!res.ok) return null;
-  const data = await res.json();
-  return typeof data.tag_name === "string" && data.tag_name ? data.tag_name : null;
+  // Never throw: a GitHub API outage/rate-limit must degrade to the main
+  // fallback, not crash the installer endpoint.
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+      headers: { "User-Agent": "get.xagent.co", Accept: "application/vnd.github+json" },
+      cf: { cacheTtl: CACHE_TTL_SECONDS, cacheEverything: true },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data.tag_name === "string" && data.tag_name ? data.tag_name : null;
+  } catch {
+    return null;
+  }
 }
 
 async function fetchScript(ref) {
@@ -32,30 +38,45 @@ async function fetchScript(ref) {
   });
 }
 
-export default {
-  async fetch() {
-    const ref = (await latestReleaseTag()) || FALLBACK_REF;
+const UNAVAILABLE = () =>
+  new Response("# Xagent installer temporarily unavailable\n", {
+    status: 502,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
 
-    let res = await fetchScript(ref);
-    if (!res.ok && ref !== FALLBACK_REF) {
-      res = await fetchScript(FALLBACK_REF); // tag exists but file missing at that tag
-    }
-    if (!res.ok) {
-      return new Response("# Xagent installer temporarily unavailable\n", {
-        status: 502,
+export default {
+  async fetch(request) {
+    // Only the root path serves the installer; ignore /favicon.ico etc.
+    if (new URL(request.url).pathname !== "/") {
+      return new Response("Not Found\n", {
+        status: 404,
         headers: { "content-type": "text/plain; charset=utf-8" },
       });
     }
 
-    const body = await res.text();
-    return new Response(body, {
-      status: 200,
-      headers: {
-        // text/plain so `curl | sh` gets the raw script, never rendered HTML.
-        "content-type": "text/plain; charset=utf-8",
-        "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
-        "x-xagent-install-ref": ref,
-      },
-    });
+    try {
+      const ref = (await latestReleaseTag()) || FALLBACK_REF;
+
+      let res = await fetchScript(ref);
+      if (!res.ok && ref !== FALLBACK_REF) {
+        res = await fetchScript(FALLBACK_REF); // tag exists but file missing at that tag
+      }
+      if (!res.ok) return UNAVAILABLE();
+
+      const body = await res.text();
+      return new Response(body, {
+        status: 200,
+        headers: {
+          // text/plain so `curl | sh` gets the raw script, never rendered HTML.
+          "content-type": "text/plain; charset=utf-8",
+          "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
+          "x-xagent-install-ref": ref,
+        },
+      });
+    } catch {
+      // Any unexpected error → clean 502 text, never a Cloudflare HTML 500
+      // (which would break a piped `curl | sh`).
+      return UNAVAILABLE();
+    }
   },
 };

--- a/scripts/get.xagent.co/worker.test.mjs
+++ b/scripts/get.xagent.co/worker.test.mjs
@@ -1,0 +1,45 @@
+// Functional tests for the get.xagent.co Worker. Uses Node's built-in test
+// runner (no dependencies) and stubs global fetch. Run: node --test
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import worker from "./worker.js";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const get = (path = "/") => worker.fetch(new Request(`https://get.xagent.co${path}`));
+
+test("non-root paths 404", async () => {
+  const res = await get("/favicon.ico");
+  assert.equal(res.status, 404);
+});
+
+test("fails closed (502) when the latest release can't be resolved", async () => {
+  globalThis.fetch = async () => new Response("boom", { status: 500 });
+  const res = await get("/");
+  assert.equal(res.status, 502);
+});
+
+test("fails closed (502) when the release tag lacks the script", async () => {
+  globalThis.fetch = async (url) =>
+    String(url).includes("/releases/latest")
+      ? new Response(JSON.stringify({ tag_name: "v9.9.9" }), { status: 200 })
+      : new Response("not found", { status: 404 });
+  const res = await get("/");
+  assert.equal(res.status, 502);
+});
+
+test("serves the script from the resolved release tag", async () => {
+  globalThis.fetch = async (url) =>
+    String(url).includes("/releases/latest")
+      ? new Response(JSON.stringify({ tag_name: "v1.2.3" }), { status: 200 })
+      : new Response("#!/bin/sh\necho hi\n", { status: 200 });
+  const res = await get("/");
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "text/plain; charset=utf-8");
+  assert.equal(res.headers.get("x-xagent-install-ref"), "v1.2.3");
+  assert.match(await res.text(), /echo hi/);
+});

--- a/scripts/get.xagent.co/worker.test.mjs
+++ b/scripts/get.xagent.co/worker.test.mjs
@@ -43,3 +43,25 @@ test("serves the script from the resolved release tag", async () => {
   assert.equal(res.headers.get("x-xagent-install-ref"), "v1.2.3");
   assert.match(await res.text(), /echo hi/);
 });
+
+test("fails closed (502) when the release lookup rejects (e.g. timeout abort)", async () => {
+  // Exercises latestReleaseTag()'s try/catch (an AbortSignal.timeout abort or
+  // malformed JSON lands here) -> null -> 502.
+  globalThis.fetch = async () => {
+    throw new Error("boom");
+  };
+  const res = await get("/");
+  assert.equal(res.status, 502);
+});
+
+test("fails closed (502) when the script fetch rejects (e.g. timeout abort)", async () => {
+  // Tag resolves, then the raw fetch rejects -> the handler's outer try/catch.
+  globalThis.fetch = async (url) => {
+    if (String(url).includes("/releases/latest")) {
+      return new Response(JSON.stringify({ tag_name: "v1.2.3" }), { status: 200 });
+    }
+    throw new Error("boom");
+  };
+  const res = await get("/");
+  assert.equal(res.status, 502);
+});

--- a/scripts/get.xagent.co/wrangler.toml
+++ b/scripts/get.xagent.co/wrangler.toml
@@ -1,0 +1,9 @@
+name = "xagent-get"
+main = "worker.js"
+compatibility_date = "2026-07-01"
+
+# Serve the installer at https://get.xagent.co (the zone must be on this
+# Cloudflare account; adjust if the domain moves).
+routes = [
+  { pattern = "get.xagent.co", custom_domain = true },
+]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,12 +43,7 @@ if ! command -v uv >/dev/null 2>&1; then
   # uv installs into ~/.local/bin (or ~/.cargo/bin on older installers); make it
   # visible to the rest of this script without requiring a new shell.
   for d in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
-    if [ -d "$d" ]; then
-      case ":$PATH:" in
-        *":$d:"*) ;;
-        *) PATH="$d:$PATH" ;;
-      esac
-    fi
+    [ -d "$d" ] && PATH="$d:$PATH"
   done
   export PATH
 fi
@@ -57,7 +52,9 @@ command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a
 spec="$APP"
 if [ -n "${XAGENT_VERSION:-}" ]; then
   # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
-  spec="$APP==${XAGENT_VERSION#v}"
+  version="${XAGENT_VERSION#v}"
+  [ -n "$version" ] || err "XAGENT_VERSION='$XAGENT_VERSION' is not a valid version."
+  spec="$APP==$version"
 fi
 
 info "Installing $spec ..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,11 @@
 #   uv tool install xagent-ai        # or, in a venv: pip install xagent-ai
 set -eu
 
+# The user's PATH before this script mutates it (below, when bootstrapping uv).
+# Used at the end to warn correctly about whether the parent shell will find the
+# installed command.
+ORIG_PATH="$PATH"
+
 APP="xagent-ai"
 CMD="xagent"
 
@@ -65,7 +70,7 @@ printf '  Open:           http://127.0.0.1:8000\n'
 printf '  Configure an LLM key (e.g. OPENAI_API_KEY) via a .env file or env var.\n'
 printf '\n'
 
-if ! command -v "$CMD" >/dev/null 2>&1; then
+if ! PATH="$ORIG_PATH" command -v "$CMD" >/dev/null 2>&1; then
   warn "'$CMD' is not on your PATH in this shell yet."
   warn "Run 'uv tool update-shell' and open a new terminal, then run '$CMD'."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Xagent installer — https://get.xagent.co
+#
+#   curl -fsSL https://get.xagent.co | sh
+#
+# Installs the `xagent-ai` package (backend + bundled web UI) as an isolated uv
+# tool, so nothing touches your system Python and PEP 668 never bites. On
+# success the `xagent` command is available; start it and open the browser.
+#
+# Options (environment variables):
+#   XAGENT_VERSION   pin a specific version, e.g. XAGENT_VERSION=0.6.0
+#
+# Prefer not to pipe curl into sh? The equivalent manual install is:
+#   uv tool install xagent-ai        # or, in a venv: pip install xagent-ai
+set -eu
+
+APP="xagent-ai"
+CMD="xagent"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$1" >&2; }
+err() {
+  printf '\033[1;31merror:\033[0m %s\n' "$1" >&2
+  exit 1
+}
+
+# uv supports Linux and macOS. Windows users should use pip in a venv.
+os="$(uname -s)"
+case "$os" in
+  Linux | Darwin) ;;
+  *) err "Unsupported OS '$os'. On Windows, install with: pip install $APP (in a virtualenv)." ;;
+esac
+
+# Ensure uv is available (isolates the install; avoids system-Python/PEP 668).
+if ! command -v uv >/dev/null 2>&1; then
+  info "Installing uv (Python tool manager)..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # uv installs into ~/.local/bin (or ~/.cargo/bin on older installers); make it
+  # visible to the rest of this script without requiring a new shell.
+  for d in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+    if [ -d "$d" ]; then
+      case ":$PATH:" in
+        *":$d:"*) ;;
+        *) PATH="$d:$PATH" ;;
+      esac
+    fi
+  done
+  export PATH
+fi
+command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a new shell and re-run."
+
+spec="$APP"
+if [ -n "${XAGENT_VERSION:-}" ]; then
+  spec="$APP==$XAGENT_VERSION"
+fi
+
+info "Installing $spec ..."
+uv tool install --upgrade "$spec"
+
+printf '\n'
+info "Installed. Next steps:"
+printf '\n'
+printf '  Start Xagent:   %s\n' "$CMD"
+printf '  Open:           http://127.0.0.1:8000\n'
+printf '  Configure an LLM key (e.g. OPENAI_API_KEY) via a .env file or env var.\n'
+printf '\n'
+
+if ! command -v "$CMD" >/dev/null 2>&1; then
+  warn "'$CMD' is not on your PATH in this shell yet."
+  warn "Run 'uv tool update-shell' and open a new terminal, then run '$CMD'."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,7 +56,8 @@ command -v uv >/dev/null 2>&1 || err "uv not found on PATH after install; open a
 
 spec="$APP"
 if [ -n "${XAGENT_VERSION:-}" ]; then
-  spec="$APP==$XAGENT_VERSION"
+  # Strip a leading 'v' (e.g. v0.6.0 -> 0.6.0) so a git-tag-style value works.
+  spec="$APP==${XAGENT_VERSION#v}"
 fi
 
 info "Installing $spec ..."
@@ -72,5 +73,10 @@ printf '\n'
 
 if ! PATH="$ORIG_PATH" command -v "$CMD" >/dev/null 2>&1; then
   warn "'$CMD' is not on your PATH in this shell yet."
-  warn "Run 'uv tool update-shell' and open a new terminal, then run '$CMD'."
+  if PATH="$ORIG_PATH" command -v uv >/dev/null 2>&1; then
+    warn "Run 'uv tool update-shell' and open a new terminal, then run '$CMD'."
+  else
+    # uv was just installed by this script and isn't on the parent shell's PATH.
+    warn "Open a new terminal, or run: export PATH=\"\$HOME/.local/bin:\$PATH\""
+  fi
 fi


### PR DESCRIPTION
Adds the `curl | sh` install path for the single-machine (pip/uvx) deployment.

```bash
curl -fsSL https://get.xagent.co | sh
```

## What's here

- **`scripts/install.sh`** — POSIX `sh` installer. Bootstraps `uv` if missing, then `uv tool install --upgrade xagent-ai` (isolated env — no system Python, no PEP 668), and prints how to start the server. Linux/macOS; Windows users are pointed at `pip`. Supports `XAGENT_VERSION` to pin. Documents the `uv tool install xagent-ai` manual equivalent for those who don't want to pipe curl into sh.
- **`scripts/get.xagent.co/`** — a Cloudflare Worker (+ `wrangler.toml`, README) that serves the script pinned to the **latest release tag** (falls back to `main`), so the public one-liner always serves a shipped, reviewed version.
- **`.github/workflows/install-script.yml`** — ShellCheck + an end-to-end smoke test that actually runs the installer on **Linux and macOS** and asserts `xagent --help`, so the one-liner can't silently rot. Gated to when the script changes.

## Verified

Ran `scripts/install.sh` locally end to end (isolated `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR`): it installs `xagent-ai`, drops the `xagent`/`xagent-web` entry points, and `xagent --help` works. `sh -n`, workflow YAML, and worker ESM all validate.

## Deploy note (outside this PR)

`get.xagent.co` needs a one-time `wrangler deploy` from the Cloudflare account that owns the `xagent.co` zone (see `scripts/get.xagent.co/README.md`).