### PR TITLE
fix: scope model providers by category

### DIFF
--- a/frontend/src/components/pages/models.tsx
+++ b/frontend/src/components/pages/models.tsx
@@ -107,67 +107,54 @@ export interface ProviderConfig {
 const LOCAL_PROVIDER_CONFIGS: Record<string, Partial<ProviderConfig>> = {
   openai: {
     icon: <img src="/openai.svg" alt="OpenAI" className="w-6 h-6" />,
-    category: ["llm", "embedding"],
     defaultBaseUrl: "https://api.openai.com/v1",
   },
   openrouter: {
     icon: <img src="/openrouter.jpg" alt="OpenRouter" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://openrouter.ai/api/v1",
   },
   deepseek: {
     icon: <img src="/deepseek.svg" alt="DeepSeek" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.deepseek.com",
   },
   "minimax-coding-plan": {
     icon: <img src="/minimax.svg" alt="MiniMax" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.minimax.io/anthropic"
   },
   "minimax-cn-coding-plan": {
     icon: <img src="/minimax.svg" alt="MiniMax" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.minimaxi.com/anthropic"
   },
   "kimi-for-coding": {
     icon: <img src="/kimi.svg" alt="Kimi" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.kimi.com/coding"
   },
   "zai-coding-plan": {
     icon: <img src="/zhipu.svg" alt="Z.AI" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.z.ai/api/coding/paas/v4"
   },
   "zhipuai-coding-plan": {
     icon: <img src="/zhipu.svg" alt="Zhipu" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"
   },
   "alibaba-coding-plan": {
     icon: <img src="/dashscope.png" alt="Alibaba Bailian" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1"
   },
   "alibaba-coding-plan-cn": {
     icon: <img src="/dashscope.png" alt="Alibaba Bailian" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://coding.dashscope.aliyuncs.com/v1"
   },
   azure_openai: {
     icon: <Zap className="w-6 h-6 text-blue-500" />,
-    category: ["llm"]
     // No default base url for Azure, user must provide
   },
   zhipu: {
     icon: <img src="/zhipu.svg" alt="Zhipu" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4",
   },
   dashscope: {
     icon: <img src="/dashscope.png" alt="DashScope" className="w-6 h-6" />,
-    category: ["llm", "embedding", "image", "rerank"],
     defaultBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
     categoryBaseUrls: {
       embedding: "https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding",
@@ -177,37 +164,30 @@ const LOCAL_PROVIDER_CONFIGS: Record<string, Partial<ProviderConfig>> = {
   },
   gemini: {
     icon: <img src="/gemini.svg" alt="Gemini" className="w-6 h-6" />,
-    category: ["llm", "image"],
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
   },
   claude: {
     icon: <img src="/claude.svg" alt="Claude" className="w-6 h-6" />,
-    category: ["llm"],
     defaultBaseUrl: "https://api.anthropic.com/v1",
   },
   xinference: {
     icon: <img src="/xagent_logo.png" alt="Xinference" className="w-6 h-6" />,
-    category: ["llm", "embedding", "image", "video", "speech", "rerank"],
     defaultBaseUrl: "http://localhost:9997",
   },
   "volcengine-ark": {
     icon: <img src="/volcengine.png" alt="Volcengine" className="w-6 h-6" />,
-    category: ["video"],
     defaultBaseUrl: "https://ark.cn-beijing.volces.com/api/v3",
   },
   "byteplus-ark": {
     icon: <img src="/byteplus.png" alt="BytePlus" className="w-6 h-6" />,
-    category: ["video"],
     defaultBaseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3",
   },
   elevenlabs: {
     icon: <img src="/elevenlabs.svg" alt="ElevenLabs" className="h-6 w-24 object-contain object-left" />,
-    category: ["speech"],
     defaultBaseUrl: "https://api.elevenlabs.io",
   },
   ollama: {
     icon: <Box className="w-6 h-6" />,
-    category: ["llm", "embedding"],
     defaultBaseUrl: "http://localhost:11434"
   }
 }
@@ -292,7 +272,7 @@ export function ModelsPage() {
           icon: localConfig.icon || <Brain className="w-6 h-6" />,
           defaultBaseUrl: p.default_base_url || localConfig.defaultBaseUrl,
           categoryBaseUrls: localConfig.categoryBaseUrls,
-          category: localConfig.category || ["llm", "embedding", "image", "speech"],
+          category: p.category || ["llm"],
           requires_base_url: p.requires_base_url
         }
       })
@@ -311,13 +291,25 @@ export function ModelsPage() {
       })
 
       if (response.ok) {
-        const defaults = await response.json()
+        const defaults: unknown = await response.json()
         const defaultModelMap: Record<string, Model> = {}
 
         if (Array.isArray(defaults)) {
-          defaults.forEach((defaultConfig: any) => {
-            if (defaultConfig && defaultConfig.config_type && defaultConfig.model) {
-              defaultModelMap[defaultConfig.config_type] = defaultConfig.model
+          defaults.forEach((defaultConfig: unknown) => {
+            if (typeof defaultConfig !== "object" || defaultConfig === null) {
+              return
+            }
+
+            const candidate = defaultConfig as {
+              config_type?: unknown
+              model?: Model
+            }
+
+            if (
+              typeof candidate.config_type === "string" &&
+              candidate.model
+            ) {
+              defaultModelMap[candidate.config_type] = candidate.model
             }
           })
         }
@@ -426,7 +418,7 @@ export function ModelsPage() {
 
   // Filter explore providers by active tab
   const exploreProviders = useMemo(() => {
-    return providers.filter(p => p.category.includes(activeTab as any))
+    return providers.filter(p => p.category.includes(activeTab))
   }, [activeTab, providers])
 
   if (loading && models.length === 0) {
@@ -510,14 +502,13 @@ export function ModelsPage() {
               {Object.entries(enabledProviders).map(([providerId, providerModels]) => {
                 const knownConfig = providers.find(p => p.id === providerId)
                 const hasKnownProvider = knownConfig !== undefined
-                const providerConfig = knownConfig || {
+                const providerConfig: ProviderConfig = knownConfig || {
                   id: providerId,
                   name: providerId.charAt(0).toUpperCase() + providerId.slice(1),
                   description: "",
                   icon: <Brain className="w-6 h-6" />,
-                  category: ["llm", "video"] as any,
+                  category: ["llm", "video"],
                   defaultBaseUrl: "",
-                  models: [],
                 }
                 // Surface a real model label for the unknown-provider fallback
                 // so a stale or unrecognized provider id does not render
@@ -545,7 +536,7 @@ export function ModelsPage() {
                   asr: t('models.abilities.asr'),
                   tts: t('models.abilities.tts')
                 }
-                const icons: Record<string, any> = {
+                const icons: Record<string, ReactNode> = {
                   chat: <Brain className="w-3 h-3 mr-1" />,
                   vision: <ImageIcon className="w-3 h-3 mr-1" />,
                   thinking_mode: <Box className="w-3 h-3 mr-1" />,

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -170,6 +170,7 @@ export interface Provider {
   id: string;
   name: string;
   description: string;
+  category?: string[];
   requires_base_url?: boolean;
   icon?: string;
   default_base_url?: string;

--- a/src/xagent/core/model/providers.py
+++ b/src/xagent/core/model/providers.py
@@ -96,6 +96,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "OpenAI API compatible models",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm", "embedding"],
     },
     {
         "id": "claude",
@@ -103,30 +104,35 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "Anthropic's Claude models",
         "requires_base_url": False,
         "compatibility": "claude_compatible",
+        "category": ["llm"],
     },
     {
         "id": "gemini",
         "name": "Google Gemini",
         "description": "Google's Gemini models",
         "requires_base_url": False,
+        "category": ["llm", "image"],
     },
     {
         "id": "xinference",
         "name": "Xinference",
         "description": "Xinference models for local inference",
         "requires_base_url": True,
+        "category": ["llm", "embedding", "image", "video", "speech", "rerank"],
     },
     {
         "id": "elevenlabs",
         "name": "ElevenLabs",
         "description": "ElevenLabs speech models for text-to-speech",
         "requires_base_url": False,
+        "category": ["speech"],
     },
     {
         "id": "deepseek",
         "name": "DeepSeek",
         "description": "DeepSeek v4 models with tool calling and thinking mode",
         "requires_base_url": False,
+        "category": ["llm"],
     },
     {
         "id": "openrouter",
@@ -138,6 +144,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         ),
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm"],
     },
     {
         "id": "dashscope",
@@ -145,6 +152,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "Alibaba Cloud's DashScope models",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm", "embedding", "image", "rerank"],
     },
     {
         "id": "volcengine-ark",
@@ -152,6 +160,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "Volcengine ModelArk provider for Seedance video generation",
         "requires_base_url": False,
         "default_base_url": "https://ark.cn-beijing.volces.com/api/v3",
+        "category": ["video"],
     },
     {
         "id": "byteplus-ark",
@@ -159,6 +168,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "BytePlus ModelArk provider for Seedance video generation",
         "requires_base_url": False,
         "default_base_url": "https://ark.ap-southeast.bytepluses.com/api/v3",
+        "category": ["video"],
     },
     {
         "id": "alibaba-coding-plan",
@@ -166,6 +176,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "Alibaba Bailian (Model Studio) coding plan",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm"],
     },
     {
         "id": "alibaba-coding-plan-cn",
@@ -173,12 +184,14 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "Alibaba Bailian (Model Studio) coding plan (China)",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm"],
     },
     {
         "id": "zhipu",
         "name": "Zhipu AI",
         "description": "Zhipu AI models (GLM series) using zai SDK",
         "requires_base_url": False,
+        "category": ["llm"],
     },
     {
         "id": "zai-coding-plan",
@@ -186,6 +199,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "GLM coding plan via Z.AI",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm"],
     },
     {
         "id": "zhipuai-coding-plan",
@@ -193,6 +207,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "description": "GLM coding plan via Zhipu AI",
         "requires_base_url": False,
         "compatibility": "openai_compatible",
+        "category": ["llm"],
     },
     {
         "id": "minimax-coding-plan",
@@ -201,6 +216,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "requires_base_url": False,
         "compatibility": "claude_compatible",
         "default_base_url": "https://api.minimax.io/anthropic",
+        "category": ["llm"],
     },
     {
         "id": "minimax-cn-coding-plan",
@@ -209,6 +225,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "requires_base_url": False,
         "compatibility": "claude_compatible",
         "default_base_url": "https://api.minimaxi.com/anthropic",
+        "category": ["llm"],
     },
     {
         "id": "kimi-for-coding",
@@ -217,6 +234,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
         "requires_base_url": False,
         "compatibility": "claude_compatible",
         "default_base_url": "https://api.kimi.com/coding",
+        "category": ["llm"],
     },
 )
 

--- a/src/xagent/web/schemas/model.py
+++ b/src/xagent/web/schemas/model.py
@@ -395,6 +395,7 @@ class ProviderInfo(BaseModel):
     id: str
     name: str
     description: str
+    category: List[str]
     requires_base_url: bool
     default_base_url: Optional[str] = None
     compatibility: Optional[str] = None

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -858,7 +858,45 @@ class TestModelAPI:
         )
         assert deepseek is not None
         assert deepseek["name"] == "DeepSeek"
+        assert deepseek["category"] == ["llm"]
         assert deepseek["default_base_url"] == "https://api.deepseek.com"
+
+    def test_list_supported_providers_includes_multi_category_provider(
+        self, test_db, regular_user, regular_headers
+    ):
+        response = client.get(
+            "/api/models/providers/supported",
+            headers=regular_headers,
+        )
+
+        assert response.status_code == 200
+        providers = response.json()["providers"]
+        openai = next(
+            (provider for provider in providers if provider["id"] == "openai"),
+            None,
+        )
+        assert openai is not None
+        assert openai["name"] == "OpenAI"
+        assert openai["category"] == ["llm", "embedding"]
+        assert openai["default_base_url"] == "https://api.openai.com/v1"
+
+    def test_list_supported_providers_scopes_elevenlabs_to_speech(
+        self, test_db, regular_user, regular_headers
+    ):
+        response = client.get(
+            "/api/models/providers/supported",
+            headers=regular_headers,
+        )
+
+        assert response.status_code == 200
+        providers = response.json()["providers"]
+        elevenlabs = next(
+            (provider for provider in providers if provider["id"] == "elevenlabs"),
+            None,
+        )
+        assert elevenlabs is not None
+        assert elevenlabs["name"] == "ElevenLabs"
+        assert elevenlabs["category"] == ["speech"]
 
     def test_list_supported_providers_includes_ark_platforms(
         self, test_db, regular_user, regular_headers
@@ -880,11 +918,13 @@ class TestModelAPI:
         )
         assert volcengine is not None
         assert volcengine["name"] == "Volcengine Ark"
+        assert volcengine["category"] == ["video"]
         assert (
             volcengine["default_base_url"] == "https://ark.cn-beijing.volces.com/api/v3"
         )
         assert byteplus is not None
         assert byteplus["name"] == "BytePlus Ark"
+        assert byteplus["category"] == ["video"]
         assert (
             byteplus["default_base_url"]
             == "https://ark.ap-southeast.bytepluses.com/api/v3"


### PR DESCRIPTION
## Summary
- add explicit category metadata to supported model providers
- use backend provider categories as the frontend fallback instead of broad default categories
- cover ElevenLabs speech-only and Ark video-only provider categories in API tests

## Tests
- pre-commit run --all-files
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent/src pytest tests/web/test_model_api.py::TestModelAPI::test_list_supported_providers_includes_deepseek tests/web/test_model_api.py::TestModelAPI::test_list_supported_providers_scopes_elevenlabs_to_speech tests/web/test_model_api.py::TestModelAPI::test_list_supported_providers_includes_ark_platforms
- npm --prefix frontend run type-check