### PR TITLE
fix(storage): strengthen object-storage key validation

### DIFF
--- a/src/xagent/core/file_storage/__init__.py
+++ b/src/xagent/core/file_storage/__init__.py
@@ -1,12 +1,21 @@
 """Durable file storage abstraction for user-visible files."""
 
-from .factory import get_file_storage
+from .factory import (
+    get_file_storage,
+    get_unscoped_file_storage,
+    get_user_file_storage,
+)
+from .scoped import ScopedFileStorage, StorageKeyScopeError
 from .storage import FsspecFileStorage, normalize_storage_key
 from .types import StoredObject
 
 __all__ = [
     "FsspecFileStorage",
+    "ScopedFileStorage",
+    "StorageKeyScopeError",
     "StoredObject",
     "get_file_storage",
+    "get_unscoped_file_storage",
+    "get_user_file_storage",
     "normalize_storage_key",
 ]

--- a/src/xagent/core/file_storage/__init__.py
+++ b/src/xagent/core/file_storage/__init__.py
@@ -1,7 +1,12 @@
 """Durable file storage abstraction for user-visible files."""
 
 from .factory import get_file_storage
-from .storage import FsspecFileStorage
+from .storage import FsspecFileStorage, normalize_storage_key
 from .types import StoredObject
 
-__all__ = ["FsspecFileStorage", "StoredObject", "get_file_storage"]
+__all__ = [
+    "FsspecFileStorage",
+    "StoredObject",
+    "get_file_storage",
+    "normalize_storage_key",
+]

--- a/src/xagent/core/file_storage/__init__.py
+++ b/src/xagent/core/file_storage/__init__.py
@@ -1,7 +1,7 @@
 """Durable file storage abstraction for user-visible files."""
 
 from .factory import (
-    get_file_storage,
+    get_file_storage_backend,
     get_unscoped_file_storage,
     get_user_file_storage,
 )
@@ -14,7 +14,7 @@ __all__ = [
     "ScopedFileStorage",
     "StorageKeyScopeError",
     "StoredObject",
-    "get_file_storage",
+    "get_file_storage_backend",
     "get_unscoped_file_storage",
     "get_user_file_storage",
     "normalize_storage_key",

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -20,6 +20,11 @@ _DEFAULT_S3_CONFIG_KWARGS = {
 }
 
 
+def get_file_storage_backend() -> str:
+    """Backend scheme of the configured durable storage ("s3", "file", ...)."""
+    return get_unscoped_file_storage().backend
+
+
 def get_user_file_storage(user_id: int) -> ScopedFileStorage:
     """Get a storage view scoped to a user's key prefix.
 
@@ -60,10 +65,6 @@ def get_unscoped_file_storage() -> FsspecFileStorage:
         base_uri=uri,
         materialize_dir=get_file_materialize_dir(),
     )
-
-
-# Transitional alias until every call site is migrated to scoped handles.
-get_file_storage = get_unscoped_file_storage
 
 
 def _with_default_s3_config_kwargs(options: dict) -> dict:

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -10,6 +10,7 @@ from ...config import (
     get_file_storage_options,
     get_file_storage_uri,
 )
+from .scoped import ScopedFileStorage
 from .storage import FsspecFileStorage
 
 _DEFAULT_S3_CONFIG_KWARGS = {
@@ -19,9 +20,23 @@ _DEFAULT_S3_CONFIG_KWARGS = {
 }
 
 
+def get_user_file_storage(user_id: int) -> ScopedFileStorage:
+    """Get a storage view scoped to a user's key prefix.
+
+    This is the primary storage factory: every operation through the returned
+    handle is confined to ``users/{user_id}``. Reach for
+    ``get_unscoped_file_storage`` only in infrastructure code inside this
+    package.
+    """
+    return ScopedFileStorage(
+        storage=get_unscoped_file_storage(),
+        prefix=f"users/{int(user_id)}",
+    )
+
+
 @lru_cache
-def get_file_storage() -> FsspecFileStorage:
-    """Build the configured durable file storage backend."""
+def get_unscoped_file_storage() -> FsspecFileStorage:
+    """Build the configured durable file storage backend (no prefix scope)."""
     uri = get_file_storage_uri()
     options = get_file_storage_options()
     parsed = urlparse(uri)
@@ -45,6 +60,10 @@ def get_file_storage() -> FsspecFileStorage:
         base_uri=uri,
         materialize_dir=get_file_materialize_dir(),
     )
+
+
+# Transitional alias until every call site is migrated to scoped handles.
+get_file_storage = get_unscoped_file_storage
 
 
 def _with_default_s3_config_kwargs(options: dict) -> dict:

--- a/src/xagent/core/file_storage/keys.py
+++ b/src/xagent/core/file_storage/keys.py
@@ -1,0 +1,51 @@
+"""Canonical builders for durable-storage keys.
+
+This module is the single source of truth for the object-storage key layout
+(``users/{user_id}/uploads/...`` and ``users/{user_id}/tasks/{task_id}/outputs/...``).
+Builders sanitize their inputs so the produced keys always pass strict
+normalization (see ``normalize_storage_key``); keys already persisted in the
+database are read back verbatim and never re-derived through these builders.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def safe_storage_filename(filename: str) -> str:
+    safe_name = Path(filename).name.strip()
+    if safe_name in ("", ".", ".."):
+        return "file"
+    return _sanitize_component(safe_name) or "file"
+
+
+def build_upload_storage_key(user_id: int, file_id: str, filename: str) -> str:
+    return f"users/{user_id}/uploads/{file_id}/{safe_storage_filename(filename)}"
+
+
+def build_task_output_storage_key(
+    user_id: int, task_id: int, file_id: str, relative_path: str
+) -> str:
+    return (
+        f"users/{user_id}/tasks/{task_id}/outputs/"
+        f"{file_id}/{_safe_relative_output_path(relative_path)}"
+    )
+
+
+def _safe_relative_output_path(relative_path: str) -> str:
+    components = [
+        part for part in relative_path.strip().split("/") if part not in ("", ".")
+    ]
+    if ".." in components:
+        # A traversal component means the structure cannot be trusted;
+        # keep only a safe basename.
+        return safe_storage_filename(relative_path)
+    if not components:
+        return "file"
+    return "/".join(_sanitize_component(part) for part in components)
+
+
+def _sanitize_component(component: str) -> str:
+    return "".join(
+        "_" if ch == "\\" or ord(ch) < 32 or ord(ch) == 127 else ch for ch in component
+    )

--- a/src/xagent/core/file_storage/scoped.py
+++ b/src/xagent/core/file_storage/scoped.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import BinaryIO
+
+from .storage import FsspecFileStorage, normalize_storage_key
+from .types import StoredObject
+
+
+class StorageKeyScopeError(Exception):
+    """Raised when a storage key falls outside a handle's bound prefix.
+
+    Deliberately not a ``ValueError`` so scope violations stay distinguishable
+    from the structural normalization errors raised by
+    ``normalize_storage_key``.
+    """
+
+
+class ScopedFileStorage:
+    """Storage view bound to a required key prefix.
+
+    Every operation normalizes the key (same strict/tolerant policy as
+    ``FsspecFileStorage``), then verifies it falls under the bound prefix
+    before delegating. Containment is separator-aware: binding ``users/1``
+    does not admit ``users/10/...``.
+    """
+
+    def __init__(self, *, storage: FsspecFileStorage, prefix: str) -> None:
+        self._storage = storage
+        self._prefix = normalize_storage_key(prefix)
+
+    @property
+    def prefix(self) -> str:
+        return self._prefix
+
+    def _scoped(self, key: str, *, strict: bool = True) -> str:
+        normalized = normalize_storage_key(key, strict=strict)
+        if normalized != self._prefix and not normalized.startswith(self._prefix + "/"):
+            raise StorageKeyScopeError(
+                f"Storage key {key!r} is outside the bound prefix {self._prefix!r}"
+            )
+        return normalized
+
+    def put_file(
+        self, source: Path, key: str, content_type: str | None = None
+    ) -> StoredObject:
+        return self._storage.put_file(source, self._scoped(key), content_type)
+
+    def put_bytes(
+        self, data: bytes, key: str, content_type: str | None = None
+    ) -> StoredObject:
+        return self._storage.put_bytes(data, self._scoped(key), content_type)
+
+    def open_read(self, key: str) -> BinaryIO:
+        return self._storage.open_read(self._scoped(key, strict=False))
+
+    def exists(self, key: str) -> bool:
+        return self._storage.exists(self._scoped(key, strict=False))
+
+    def stat(self, key: str) -> StoredObject:
+        return self._storage.stat(self._scoped(key, strict=False))
+
+    def signed_url(
+        self,
+        key: str,
+        *,
+        expires: int,
+        content_type: str | None = None,
+        content_disposition: str | None = None,
+    ) -> str | None:
+        return self._storage.signed_url(
+            self._scoped(key, strict=False),
+            expires=expires,
+            content_type=content_type,
+            content_disposition=content_disposition,
+        )
+
+    def content_hash(self, key: str) -> str:
+        return self._storage.content_hash(self._scoped(key, strict=False))
+
+    def list(self, prefix: str) -> list[StoredObject]:
+        return self._storage.list(self._scoped(prefix))
+
+    def delete(self, key: str) -> None:
+        self._storage.delete(self._scoped(key, strict=False))
+
+    def materialize(self, key: str, filename: str | None = None) -> Path:
+        return self._storage.materialize(self._scoped(key, strict=False), filename)
+
+    def copy_to_path(self, key: str, target_path: Path) -> Path:
+        return self._storage.copy_to_path(self._scoped(key, strict=False), target_path)

--- a/src/xagent/core/file_storage/scoped.py
+++ b/src/xagent/core/file_storage/scoped.py
@@ -33,6 +33,10 @@ class ScopedFileStorage:
     def prefix(self) -> str:
         return self._prefix
 
+    @property
+    def backend(self) -> str:
+        return self._storage.backend
+
     def _scoped(self, key: str, *, strict: bool = True) -> str:
         normalized = normalize_storage_key(key, strict=strict)
         if normalized != self._prefix and not normalized.startswith(self._prefix + "/"):

--- a/src/xagent/core/file_storage/storage.py
+++ b/src/xagent/core/file_storage/storage.py
@@ -70,6 +70,10 @@ class FsspecFileStorage:
         self._base_uri = base_uri.rstrip("/")
         self._materialize_dir = materialize_dir
 
+    @property
+    def backend(self) -> str:
+        return self._backend
+
     def put_file(
         self, source: Path, key: str, content_type: str | None = None
     ) -> StoredObject:

--- a/src/xagent/core/file_storage/storage.py
+++ b/src/xagent/core/file_storage/storage.py
@@ -23,11 +23,15 @@ def normalize_storage_key(key: str, *, strict: bool = True) -> str:
     request-derived key) components containing backslashes or control
     characters are rejected as well. Tolerant mode (``strict=False``) admits
     those characters and exists only for keys already persisted in the
-    database, which may embed legacy POSIX filenames.
+    database, which may embed legacy POSIX filenames. Null bytes are rejected
+    in both modes: they cannot appear in any POSIX filename (so no persisted
+    key can contain one) and can truncate paths in native layers.
 
     Raises:
         ValueError: If the key is structurally invalid.
     """
+    if "\x00" in key:
+        raise ValueError(f"Invalid storage key: {key!r} (null byte)")
     normalized = key.strip().strip("/")
     if not normalized:
         raise ValueError(f"Invalid storage key: {key!r}")

--- a/src/xagent/core/file_storage/storage.py
+++ b/src/xagent/core/file_storage/storage.py
@@ -11,9 +11,49 @@ from .types import StoredObject
 
 _SHA256_METADATA_KEY = "xagent-sha256"
 
+_REJECTED_KEY_COMPONENTS = ("", ".", "..")
+
+
+def normalize_storage_key(key: str, *, strict: bool = True) -> str:
+    """Structurally validate a storage key and return its normalized form.
+
+    The key is stripped of surrounding whitespace and slashes, then validated
+    component by component: empty, ``.`` and ``..`` components are always
+    rejected. In strict mode (the default, required for every write and any
+    request-derived key) components containing backslashes or control
+    characters are rejected as well. Tolerant mode (``strict=False``) admits
+    those characters and exists only for keys already persisted in the
+    database, which may embed legacy POSIX filenames.
+
+    Raises:
+        ValueError: If the key is structurally invalid.
+    """
+    normalized = key.strip().strip("/")
+    if not normalized:
+        raise ValueError(f"Invalid storage key: {key!r}")
+    components = normalized.split("/")
+    for component in components:
+        if component in _REJECTED_KEY_COMPONENTS:
+            raise ValueError(f"Invalid storage key: {key!r}")
+        if strict and _component_has_forbidden_characters(component):
+            raise ValueError(
+                f"Invalid storage key: {key!r} "
+                "(backslash or control character in component)"
+            )
+    return "/".join(components)
+
+
+def _component_has_forbidden_characters(component: str) -> bool:
+    return any(ch == "\\" or ord(ch) < 32 or ord(ch) == 127 for ch in component)
+
 
 class FsspecFileStorage:
-    """Small fsspec-backed storage wrapper using keys relative to a root URI."""
+    """Small fsspec-backed storage wrapper using keys relative to a root URI.
+
+    Key validation policy: write operations and ``list`` normalize keys in
+    strict mode; read and delete operations use tolerant mode because their
+    keys may come from persisted DB records that embed legacy filenames.
+    """
 
     def __init__(
         self,
@@ -67,14 +107,18 @@ class FsspecFileStorage:
     def open_read(self, key: str) -> BinaryIO:
         return cast(
             BinaryIO,
-            self._fs.open(self._full_path(self._normalize_key(key)), "rb"),
+            self._fs.open(
+                self._full_path(self._normalize_key(key, strict=False)), "rb"
+            ),
         )
 
     def exists(self, key: str) -> bool:
-        return bool(self._fs.exists(self._full_path(self._normalize_key(key))))
+        return bool(
+            self._fs.exists(self._full_path(self._normalize_key(key, strict=False)))
+        )
 
     def stat(self, key: str) -> StoredObject:
-        return self._stored_object(self._normalize_key(key))
+        return self._stored_object(self._normalize_key(key, strict=False))
 
     def signed_url(
         self,
@@ -94,14 +138,14 @@ class FsspecFileStorage:
         if content_disposition:
             url_kwargs["ResponseContentDisposition"] = content_disposition
 
-        full_path = self._full_path(self._normalize_key(key))
+        full_path = self._full_path(self._normalize_key(key, strict=False))
         try:
             return str(self._fs.url(full_path, expires=expires, **url_kwargs))
         except TypeError:
             return str(self._fs.url(full_path, expires=expires))
 
     def content_hash(self, key: str) -> str:
-        normalized_key = self._normalize_key(key)
+        normalized_key = self._normalize_key(key, strict=False)
         if self._backend == "file":
             return self._sha256(Path(self._full_path(normalized_key)))
 
@@ -121,7 +165,7 @@ class FsspecFileStorage:
         )
 
     def list(self, prefix: str) -> list[StoredObject]:
-        normalized_prefix = self._normalize_key(prefix).rstrip("/")
+        normalized_prefix = self._normalize_key(prefix)
         full_prefix = self._full_path(normalized_prefix)
         if not self._fs.exists(full_prefix):
             return []
@@ -133,12 +177,12 @@ class FsspecFileStorage:
         ]
 
     def delete(self, key: str) -> None:
-        full_path = self._full_path(self._normalize_key(key))
+        full_path = self._full_path(self._normalize_key(key, strict=False))
         if self._fs.exists(full_path):
             self._fs.rm(full_path)
 
     def materialize(self, key: str, filename: str | None = None) -> Path:
-        normalized_key = self._normalize_key(key)
+        normalized_key = self._normalize_key(key, strict=False)
         target_name = Path(filename or normalized_key).name or "file"
         key_digest = hashlib.sha256(normalized_key.encode("utf-8")).hexdigest()[:16]
         target_path = (
@@ -154,7 +198,9 @@ class FsspecFileStorage:
 
     def copy_to_path(self, key: str, target_path: Path) -> Path:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        return self._copy_to_path_atomic(self._normalize_key(key), target_path)
+        return self._copy_to_path_atomic(
+            self._normalize_key(key, strict=False), target_path
+        )
 
     def _copy_to_path_atomic(self, key: str, target_path: Path) -> Path:
         temp_file = tempfile.NamedTemporaryFile(
@@ -227,11 +273,8 @@ class FsspecFileStorage:
         return {"content_type": content_type}
 
     @staticmethod
-    def _normalize_key(key: str) -> str:
-        normalized = key.strip().lstrip("/")
-        if not normalized or ".." in Path(normalized).parts:
-            raise ValueError(f"Invalid storage key: {key!r}")
-        return normalized
+    def _normalize_key(key: str, *, strict: bool = True) -> str:
+        return normalize_storage_key(key, strict=strict)
 
     def _store_content_hash(
         self, key: str, checksum: str, *, content_type: str | None

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class UploadedFileSnapshot:
     """Scalar upload metadata retained after closing the DB session."""
 
+    user_id: int
     file_id: str
     filename: str
     storage_path: str
@@ -98,6 +99,7 @@ def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
 
 def _snapshot_uploaded_file_record(record: Any) -> UploadedFileSnapshot:
     return UploadedFileSnapshot(
+        user_id=int(record.user_id),
         file_id=str(record.file_id),
         filename=str(record.filename),
         storage_path=str(record.storage_path),

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -322,8 +322,8 @@ class TaskWorkspace:
 
             # Import lazily: module-level file_storage imports would pull
             # fsspec into sandboxed executions that ship minimal deps.
-            from .file_storage.keys import build_task_output_storage_key
             from ..web.services.uploaded_file_store import UploadedFileStore
+            from .file_storage.keys import build_task_output_storage_key
 
             UploadedFileStore(db).create_from_local_path(
                 local_path=file_path,

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -26,23 +26,6 @@ logger = logging.getLogger(__name__)
 _auto_register = contextvars.ContextVar("_auto_register", default=False)
 
 
-def _safe_storage_relative_path(relative_path: str) -> str:
-    path = Path(relative_path)
-    safe_parts = [part for part in path.parts if part not in ("", ".", "..")]
-    if not safe_parts:
-        return "file"
-    return "/".join(safe_parts)
-
-
-def _build_workspace_storage_key(
-    user_id: int, task_id: int, file_id: str, relative_path: str
-) -> str:
-    return (
-        f"users/{user_id}/tasks/{task_id}/outputs/"
-        f"{file_id}/{_safe_storage_relative_path(relative_path)}"
-    )
-
-
 @dataclass
 class AgentContext:
     """Agent execution context"""
@@ -337,6 +320,9 @@ class TaskWorkspace:
                 )
             )
 
+            # Import lazily: module-level file_storage imports would pull
+            # fsspec into sandboxed executions that ship minimal deps.
+            from .file_storage.keys import build_task_output_storage_key
             from ..web.services.uploaded_file_store import UploadedFileStore
 
             UploadedFileStore(db).create_from_local_path(
@@ -345,7 +331,7 @@ class TaskWorkspace:
                 file_id=file_id,
                 task_id=task_id,
                 filename=file_path.name,
-                storage_key=_build_workspace_storage_key(
+                storage_key=build_task_output_storage_key(
                     int(task.user_id), task_id, file_id, relative_path
                 ),
                 workspace_relative_path=relative_path,
@@ -370,6 +356,7 @@ class TaskWorkspace:
         self, file_id: str, file_path: Path, db_session: Any = None
     ) -> None:
         """Sync an existing UploadedFile row with current local bytes."""
+        from .file_storage.keys import build_task_output_storage_key
         from .storage.manager import create_db_session
 
         if db_session:
@@ -442,7 +429,7 @@ class TaskWorkspace:
                     category=category,
                 )
             )
-            storage_key = _build_workspace_storage_key(
+            storage_key = build_task_output_storage_key(
                 user_id,
                 int(task_id) if task_id is not None else 0,
                 file_id,

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -24,7 +24,7 @@ from ...config import (
     get_storage_root,
     get_uploads_dir,
 )
-from ...core.file_storage.factory import get_file_storage
+from ...core.file_storage import get_user_file_storage
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ..auth_dependencies import get_current_user
@@ -304,7 +304,7 @@ async def store_uploaded_files(
         db.rollback()
         for storage_key in written_storage_keys:
             try:
-                get_file_storage().delete(storage_key)
+                get_user_file_storage(_user_id_value(user)).delete(storage_key)
             except Exception:
                 logger.warning("Failed to clean up durable upload: %s", storage_key)
         for path in written_paths:
@@ -319,7 +319,7 @@ async def store_uploaded_files(
         db.rollback()
         for storage_key in written_storage_keys:
             try:
-                get_file_storage().delete(storage_key)
+                get_user_file_storage(_user_id_value(user)).delete(storage_key)
             except Exception:
                 logger.warning("Failed to clean up durable upload: %s", storage_key)
         for path in written_paths:
@@ -1548,7 +1548,9 @@ async def delete_file(
         storage_status = str(file_record.storage_status or "")
         if storage_key and storage_status == "available":
             try:
-                get_file_storage().delete(storage_key)
+                get_user_file_storage(_file_user_id_value(file_record)).delete(
+                    storage_key
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to clean up durable file before deleting row: %s",

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -45,6 +45,7 @@ from googleapiclient.http import MediaIoBaseDownload  # type: ignore
 from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.orm import Session
 
+from ...core.file_storage.keys import build_upload_storage_key
 from ...core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
 from ...core.tools.core.RAG_tools.core.parser_registry import (
     get_supported_parsers,
@@ -146,7 +147,6 @@ from ..services.kb_ingest_targets import (
     tombstone_kb_ingest_target,
     tombstone_kb_ingest_targets_for_collection,
 )
-from ...core.file_storage.keys import build_upload_storage_key
 from ..services.managed_file_ref import (
     DurableObjectMissingError,
     ManagedFileRef,
@@ -3923,21 +3923,23 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3992,21 +3994,23 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                rollback_api_result,
-                lambda: _rollback_failed_ingestion(
-                    db=db,
-                    user=_user,
-                    collection_name=collection,
-                    result=rollback_result,
-                    file_path=file_path,
-                    file_record=file_record,
-                    collection_existed_before=effective_collection_existed_before,
-                    uploaded_file_existed_before=uploaded_file_existed_before,
-                    file_backup_path=file_backup_path,
-                    had_existing_file=had_existing_file,
-                    embedding_model_id=embedding_model_id,
-                ),
+            rollback_execution = (
+                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                    rollback_api_result,
+                    lambda: _rollback_failed_ingestion(
+                        db=db,
+                        user=_user,
+                        collection_name=collection,
+                        result=rollback_result,
+                        file_path=file_path,
+                        file_record=file_record,
+                        collection_existed_before=effective_collection_existed_before,
+                        uploaded_file_existed_before=uploaded_file_existed_before,
+                        file_backup_path=file_backup_path,
+                        had_existing_file=had_existing_file,
+                        embedding_model_id=embedding_model_id,
+                    ),
+                )
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -146,10 +146,10 @@ from ..services.kb_ingest_targets import (
     tombstone_kb_ingest_target,
     tombstone_kb_ingest_targets_for_collection,
 )
+from ...core.file_storage.keys import build_upload_storage_key
 from ..services.managed_file_ref import (
     DurableObjectMissingError,
     ManagedFileRef,
-    build_upload_storage_key,
 )
 from ..services.uploaded_file_store import UploadedFileStore
 from .cloud_storage import get_google_credentials
@@ -3923,23 +3923,21 @@ async def ingest(
         api_result = _get_api_compatibility_facade().with_result(api_result, result)
 
         if result.status in {"error", "partial"}:
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:
@@ -3994,23 +3992,21 @@ async def ingest(
                 message="Ingestion setup failed before completion.",
             )
             rollback_api_result = KBApiOperationResult(result=rollback_result)
-            rollback_execution = (
-                await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
-                    rollback_api_result,
-                    lambda: _rollback_failed_ingestion(
-                        db=db,
-                        user=_user,
-                        collection_name=collection,
-                        result=rollback_result,
-                        file_path=file_path,
-                        file_record=file_record,
-                        collection_existed_before=effective_collection_existed_before,
-                        uploaded_file_existed_before=uploaded_file_existed_before,
-                        file_backup_path=file_backup_path,
-                        had_existing_file=had_existing_file,
-                        embedding_model_id=embedding_model_id,
-                    ),
-                )
+            rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
+                rollback_api_result,
+                lambda: _rollback_failed_ingestion(
+                    db=db,
+                    user=_user,
+                    collection_name=collection,
+                    result=rollback_result,
+                    file_path=file_path,
+                    file_record=file_record,
+                    collection_existed_before=effective_collection_existed_before,
+                    uploaded_file_existed_before=uploaded_file_existed_before,
+                    file_backup_path=file_backup_path,
+                    had_existing_file=had_existing_file,
+                    embedding_model_id=embedding_model_id,
+                ),
             )
             rollback_api_result = rollback_execution.operation_result
             if rollback_execution.error is not None:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -41,6 +41,8 @@ from ..models.user import User
 
 if TYPE_CHECKING:
     from ..services.task_setup_snapshot import TaskSetupSnapshot
+
+from ...core.file_storage.keys import build_task_output_storage_key
 from ..services.chat_history_service import get_latest_waiting_question
 from ..services.hot_path_cache import (
     cache_get,
@@ -49,7 +51,6 @@ from ..services.hot_path_cache import (
     task_cache_ttl_seconds,
     web_task_history_key,
 )
-from ...core.file_storage.keys import build_task_output_storage_key
 from ..services.managed_file_ref import (
     DurableStorageOperationError,
     ensure_uploaded_file_local_path,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -49,9 +49,9 @@ from ..services.hot_path_cache import (
     task_cache_ttl_seconds,
     web_task_history_key,
 )
+from ...core.file_storage.keys import build_task_output_storage_key
 from ..services.managed_file_ref import (
     DurableStorageOperationError,
-    build_task_output_storage_key,
     ensure_uploaded_file_local_path,
 )
 from ..services.task_lease_service import (

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -11,6 +11,15 @@ from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol
 
 from ...core.file_storage import FsspecFileStorage, StoredObject, get_file_storage
+from ...core.file_storage.keys import (
+    build_task_output_storage_key as build_task_output_storage_key,
+)
+from ...core.file_storage.keys import (
+    build_upload_storage_key as build_upload_storage_key,
+)
+from ...core.file_storage.keys import (
+    safe_storage_filename as safe_storage_filename,
+)
 from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)
@@ -51,24 +60,6 @@ class UploadedFileLocalPathRecord(Protocol):
 
     @property
     def checksum(self) -> Any: ...
-
-
-def safe_storage_filename(filename: str) -> str:
-    safe_name = Path(filename).name.strip()
-    return safe_name or "file"
-
-
-def build_upload_storage_key(user_id: int, file_id: str, filename: str) -> str:
-    return f"users/{user_id}/uploads/{file_id}/{safe_storage_filename(filename)}"
-
-
-def build_task_output_storage_key(
-    user_id: int, task_id: int, file_id: str, relative_path: str
-) -> str:
-    safe_relative_path = str(Path(relative_path.strip().lstrip("/")))
-    if not safe_relative_path or ".." in Path(safe_relative_path).parts:
-        safe_relative_path = safe_storage_filename(relative_path)
-    return f"users/{user_id}/tasks/{task_id}/outputs/{file_id}/{safe_relative_path}"
 
 
 def guess_media_type(filename: str) -> str:

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -22,9 +22,7 @@ from ...core.file_storage.keys import (
 from ...core.file_storage.keys import (
     build_upload_storage_key as build_upload_storage_key,
 )
-from ...core.file_storage.keys import (
-    safe_storage_filename as safe_storage_filename,
-)
+from ...core.file_storage.keys import safe_storage_filename as safe_storage_filename
 from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -10,7 +10,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol
 
-from ...core.file_storage import FsspecFileStorage, StoredObject, get_file_storage
+from ...core.file_storage import (
+    FsspecFileStorage,
+    ScopedFileStorage,
+    StoredObject,
+    get_user_file_storage,
+)
 from ...core.file_storage.keys import (
     build_task_output_storage_key as build_task_output_storage_key,
 )
@@ -42,6 +47,9 @@ class DurableObjectIntegrityError(DurableStorageOperationError):
 
 class UploadedFileLocalPathRecord(Protocol):
     """Fields needed to restore or locate an uploaded file without an ORM session."""
+
+    @property
+    def user_id(self) -> Any: ...
 
     @property
     def file_id(self) -> Any: ...
@@ -121,7 +129,11 @@ class ManagedFileRef:
     """Registered file handle with local-first durable fallback semantics."""
 
     record: UploadedFileLocalPathRecord
-    storage: FsspecFileStorage = field(default_factory=get_file_storage)
+    storage: FsspecFileStorage | ScopedFileStorage = field(default=None)  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.storage is None:
+            self.storage = get_user_file_storage(int(self.record.user_id))
 
     @property
     def local_path(self) -> Path:
@@ -242,8 +254,8 @@ class ManagedFileRef:
             storage_key
             or self.storage_key
             or build_upload_storage_key(
-                int(getattr(self.record, "user_id")),
-                str(getattr(self.record, "file_id")),
+                int(self.record.user_id),
+                str(self.record.file_id),
                 self.filename or path.name,
             )
         )

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -133,7 +133,13 @@ class ManagedFileRef:
 
     def __post_init__(self) -> None:
         if self.storage is None:
-            self.storage = get_user_file_storage(int(self.record.user_id))
+            user_id = self.record.user_id
+            if user_id is None:
+                raise ValueError(
+                    "Record user_id is required to bind user-scoped storage; "
+                    "pass an explicit storage handle for records without an owner"
+                )
+            self.storage = get_user_file_storage(int(user_id))
 
     @property
     def local_path(self) -> Path:

--- a/src/xagent/web/services/startup_file_storage_sync.py
+++ b/src/xagent/web/services/startup_file_storage_sync.py
@@ -12,7 +12,12 @@ from typing import Any
 from filelock import FileLock, Timeout
 from sqlalchemy.orm import Session
 
-from ...core.file_storage import FsspecFileStorage, get_file_storage
+from ...core.file_storage import (
+    FsspecFileStorage,
+    ScopedFileStorage,
+    get_file_storage_backend,
+    get_user_file_storage,
+)
 from ...core.file_storage.keys import build_upload_storage_key
 from ..models.uploaded_file import UploadedFile
 from .managed_file_ref import ManagedFileRef
@@ -41,10 +46,7 @@ def sync_registered_files_to_durable_storage(
     batch_size: int = 500,
 ) -> StartupFileStorageSyncResult:
     """Reconcile registered local files with S3-backed durable storage."""
-    resolved_storage = storage or get_file_storage()
-    backend = str(getattr(resolved_storage, "backend", ""))
-    if not backend:
-        backend = str(getattr(resolved_storage, "_backend", ""))
+    backend = _detect_backend(storage)
 
     if backend != "s3":
         logger.info(
@@ -63,7 +65,7 @@ def sync_registered_files_to_durable_storage(
 
         return _sync_registered_files(
             db,
-            storage=resolved_storage,
+            storage=storage,
             batch_size=batch_size,
         )
     finally:
@@ -87,10 +89,27 @@ def _wait_for_lock_holder() -> None:
     time.sleep(_FILE_LOCK_RETRY_INTERVAL_SECONDS)
 
 
+def _detect_backend(storage: FsspecFileStorage | Any | None) -> str:
+    if storage is None:
+        return get_file_storage_backend()
+    backend = str(getattr(storage, "backend", "") or "")
+    if not backend:
+        backend = str(getattr(storage, "_backend", "") or "")
+    return backend
+
+
+def _user_scoped_storage(
+    storage: FsspecFileStorage | Any | None, user_id: int
+) -> ScopedFileStorage:
+    if storage is None:
+        return get_user_file_storage(user_id)
+    return ScopedFileStorage(storage=storage, prefix=f"users/{user_id}")
+
+
 def _sync_registered_files(
     db: Session,
     *,
-    storage: FsspecFileStorage | Any,
+    storage: FsspecFileStorage | Any | None,
     batch_size: int,
 ) -> StartupFileStorageSyncResult:
     scanned = 0
@@ -105,15 +124,17 @@ def _sync_registered_files(
         .yield_per(batch_size)
     )
     current_user_id: int | None = None
+    user_storage: ScopedFileStorage | None = None
     remote_objects: dict[str, Any] = {}
     batch_updates = 0
 
     for record in rows:
         scanned += 1
         user_id = int(getattr(record, "user_id"))
-        if user_id != current_user_id:
+        if user_id != current_user_id or user_storage is None:
             current_user_id = user_id
-            remote_objects = _list_remote_objects_for_user(storage, user_id)
+            user_storage = _user_scoped_storage(storage, user_id)
+            remote_objects = _list_remote_objects_for_user(user_storage, user_id)
 
         expected_key = _expected_storage_key(record)
         remote_object = remote_objects.get(expected_key)
@@ -121,7 +142,7 @@ def _sync_registered_files(
             if not _has_complete_durable_metadata(record):
                 try:
                     adopt_result = ManagedFileRef(
-                        record, storage=storage
+                        record, storage=user_storage
                     ).adopt_existing_object(expected_key)
                 except Exception:
                     failed += 1
@@ -155,7 +176,9 @@ def _sync_registered_files(
             continue
 
         try:
-            stored_object = ManagedFileRef(record, storage=storage).sync_to_durable(
+            stored_object = ManagedFileRef(
+                record, storage=user_storage
+            ).sync_to_durable(
                 storage_key=expected_key,
                 mime_type=getattr(record, "mime_type", None),
             )
@@ -218,7 +241,7 @@ def _has_complete_durable_metadata(record: UploadedFile) -> bool:
 
 
 def _list_remote_objects_for_user(
-    storage: FsspecFileStorage | Any, user_id: int
+    storage: ScopedFileStorage, user_id: int
 ) -> dict[str, Any]:
     return {stored.key: stored for stored in storage.list(f"users/{user_id}")}
 

--- a/src/xagent/web/services/startup_file_storage_sync.py
+++ b/src/xagent/web/services/startup_file_storage_sync.py
@@ -134,7 +134,7 @@ def _sync_registered_files(
         if user_id != current_user_id or user_storage is None:
             current_user_id = user_id
             user_storage = _user_scoped_storage(storage, user_id)
-            remote_objects = _list_remote_objects_for_user(user_storage, user_id)
+            remote_objects = _list_remote_objects_for_user(user_storage)
 
         expected_key = _expected_storage_key(record)
         remote_object = remote_objects.get(expected_key)
@@ -240,10 +240,8 @@ def _has_complete_durable_metadata(record: UploadedFile) -> bool:
     )
 
 
-def _list_remote_objects_for_user(
-    storage: ScopedFileStorage, user_id: int
-) -> dict[str, Any]:
-    return {stored.key: stored for stored in storage.list(f"users/{user_id}")}
+def _list_remote_objects_for_user(storage: ScopedFileStorage) -> dict[str, Any]:
+    return {stored.key: stored for stored in storage.list(storage.prefix)}
 
 
 def _get_lock_file_path() -> str:

--- a/src/xagent/web/services/startup_file_storage_sync.py
+++ b/src/xagent/web/services/startup_file_storage_sync.py
@@ -13,8 +13,9 @@ from filelock import FileLock, Timeout
 from sqlalchemy.orm import Session
 
 from ...core.file_storage import FsspecFileStorage, get_file_storage
+from ...core.file_storage.keys import build_upload_storage_key
 from ..models.uploaded_file import UploadedFile
-from .managed_file_ref import ManagedFileRef, build_upload_storage_key
+from .managed_file_ref import ManagedFileRef
 
 logger = logging.getLogger(__name__)
 

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 import xagent.core.file_storage.factory as file_storage_factory
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.file_storage.storage import FsspecFileStorage, normalize_storage_key
 
 
@@ -76,9 +76,9 @@ def test_normalize_storage_key_forbidden_characters_strict_only(key):
 
 def test_write_paths_reject_legacy_characters(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     source = tmp_path / "source.txt"
     source.write_text("data", encoding="utf-8")
 
@@ -93,9 +93,9 @@ def test_write_paths_reject_legacy_characters(monkeypatch, tmp_path):
 def test_read_and_delete_paths_tolerate_legacy_db_keys(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     legacy_key = "users/1/uploads/id/back\\slash.txt"
     legacy_object = tmp_path / "objects" / "users/1/uploads/id" / "back\\slash.txt"
     legacy_object.parent.mkdir(parents=True)
@@ -124,9 +124,9 @@ def test_local_file_storage_round_trips_file(monkeypatch, tmp_path):
 
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", storage_root.as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(materialize_dir))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_file(
         source, "users/1/uploads/file-id/source.txt", "text/plain"
     )
@@ -166,9 +166,9 @@ def test_s3_file_storage_uses_bounded_client_timeouts(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path))
     monkeypatch.delenv("XAGENT_FILE_STORAGE_OPTIONS", raising=False)
     monkeypatch.setattr(file_storage_factory.fsspec.core, "url_to_fs", fake_url_to_fs)
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
 
     assert storage._backend == "s3"
     assert captured["options"] == {
@@ -206,9 +206,9 @@ def test_s3_file_storage_keeps_explicit_client_timeout_overrides(monkeypatch, tm
         ),
     )
     monkeypatch.setattr(file_storage_factory.fsspec.core, "url_to_fs", fake_url_to_fs)
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    get_file_storage()
+    get_unscoped_file_storage()
 
     assert captured["options"] == {
         "endpoint_url": "http://minio:9000",
@@ -222,9 +222,9 @@ def test_s3_file_storage_keeps_explicit_client_timeout_overrides(monkeypatch, tm
 
 def test_put_file_hashes_while_copying(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     source = tmp_path / "single-pass.txt"
     source.write_bytes(b"hash while copying")
 
@@ -241,9 +241,9 @@ def test_put_file_hashes_while_copying(monkeypatch, tmp_path):
 
 def test_local_file_storage_put_bytes(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"abc", "bytes/data.bin")
 
     assert stored.size == 3
@@ -252,9 +252,9 @@ def test_local_file_storage_put_bytes(monkeypatch, tmp_path):
 
 def test_object_uri_quotes_key_without_backend_branch(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"abc", "uploads/file with spaces.txt")
 
     assert stored.uri.endswith("/uploads/file%20with%20spaces.txt")
@@ -262,9 +262,9 @@ def test_object_uri_quotes_key_without_backend_branch(monkeypatch, tmp_path):
 
 def test_local_file_storage_does_not_return_signed_url(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
 
     assert storage.signed_url("uploads/data.txt", expires=300) is None
 
@@ -514,9 +514,9 @@ def test_s3_content_hash_reads_native_sha256_checksum(tmp_path):
 
 def test_local_file_storage_copies_object_to_path(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"restore me", "copies/data.txt")
     target = tmp_path / "restored" / "data.txt"
 
@@ -530,9 +530,9 @@ def test_copy_to_path_does_not_publish_partial_file_on_read_failure(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     target = tmp_path / "restored" / "data.txt"
 
     class FailingRead:
@@ -562,9 +562,9 @@ def test_copy_to_path_does_not_publish_partial_file_on_read_failure(
 
 def test_copy_to_path_uses_unique_temp_file_per_attempt(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"restore me", "copies/data.txt")
     target = tmp_path / "restored" / "data.txt"
     wait_at_open = threading.Barrier(2)
@@ -627,9 +627,9 @@ def test_materialize_isolates_objects_with_same_filename(monkeypatch, tmp_path):
     materialize_dir = tmp_path / "materialized"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(materialize_dir))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     first = storage.put_bytes(b"first content", "users/1/tasks/1/output/report.txt")
     second = storage.put_bytes(b"second content", "users/2/tasks/2/output/report.txt")
 
@@ -649,9 +649,9 @@ def test_materialize_reuses_existing_cached_file(monkeypatch, tmp_path):
     materialize_dir = tmp_path / "materialized"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(materialize_dir))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"cached content", "users/1/uploads/file.txt")
     first_path = storage.materialize(stored.key, "file.txt")
 
@@ -670,9 +670,9 @@ def test_materialize_uses_content_hash_in_cache_path(monkeypatch, tmp_path):
     materialize_dir = tmp_path / "materialized"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(materialize_dir))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     content = b"cache identity"
     stored = storage.put_bytes(content, "users/1/uploads/file.txt")
     content_hash = hashlib.sha256(content).hexdigest()
@@ -692,9 +692,9 @@ def test_materialize_refreshes_cached_file_when_object_changes(monkeypatch, tmp_
     materialize_dir = tmp_path / "materialized"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(materialize_dir))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"old-data", "users/1/uploads/file.txt")
     first_path = storage.materialize(stored.key, "file.txt")
 

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -48,6 +48,8 @@ def test_normalize_storage_key_strips_surrounding_noise(key, expected):
         "users/1/..",
         "users/./file.txt",
         "users//file.txt",
+        "users/1/uploads/id/null\x00byte.txt",
+        "\x00",
     ],
 )
 def test_normalize_storage_key_rejects_structural_violations_in_both_modes(key):
@@ -61,7 +63,6 @@ def test_normalize_storage_key_rejects_structural_violations_in_both_modes(key):
     "key",
     [
         "users/1/uploads/id/back\\slash.txt",
-        "users/1/uploads/id/control\x00char.txt",
         "users/1/uploads/id/esc\x1b.txt",
         "users/1/uploads/id/del\x7f.txt",
         "users/1/up\\loads/id/file.txt",

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -8,7 +8,112 @@ import pytest
 
 import xagent.core.file_storage.factory as file_storage_factory
 from xagent.core.file_storage.factory import get_file_storage
-from xagent.core.file_storage.storage import FsspecFileStorage
+from xagent.core.file_storage.storage import FsspecFileStorage, normalize_storage_key
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "users/1/uploads/file-id/report.txt",
+        "users/1/tasks/2/outputs/id/nested/dir/report.txt",
+        "a",
+    ],
+)
+def test_normalize_storage_key_accepts_well_formed_keys(key):
+    assert normalize_storage_key(key) == key
+    assert normalize_storage_key(key, strict=False) == key
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("/users/1/file.txt", "users/1/file.txt"),
+        ("users/1/file.txt/", "users/1/file.txt"),
+        ("  users/1/file.txt  ", "users/1/file.txt"),
+    ],
+)
+def test_normalize_storage_key_strips_surrounding_noise(key, expected):
+    assert normalize_storage_key(key) == expected
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        "   ",
+        "/",
+        "..",
+        "../etc/passwd",
+        "users/1/../2/file.txt",
+        "users/1/..",
+        "users/./file.txt",
+        "users//file.txt",
+    ],
+)
+def test_normalize_storage_key_rejects_structural_violations_in_both_modes(key):
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        normalize_storage_key(key)
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        normalize_storage_key(key, strict=False)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "users/1/uploads/id/back\\slash.txt",
+        "users/1/uploads/id/control\x00char.txt",
+        "users/1/uploads/id/esc\x1b.txt",
+        "users/1/uploads/id/del\x7f.txt",
+        "users/1/up\\loads/id/file.txt",
+    ],
+)
+def test_normalize_storage_key_forbidden_characters_strict_only(key):
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        normalize_storage_key(key)
+
+    assert normalize_storage_key(key, strict=False) == key
+
+
+def test_write_paths_reject_legacy_characters(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    get_file_storage.cache_clear()
+
+    storage = get_file_storage()
+    source = tmp_path / "source.txt"
+    source.write_text("data", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        storage.put_file(source, "users/1/uploads/id/back\\slash.txt")
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        storage.put_bytes(b"data", "users/1/uploads/id/back\\slash.txt")
+    with pytest.raises(ValueError, match="Invalid storage key"):
+        storage.list("users\\1")
+
+
+def test_read_and_delete_paths_tolerate_legacy_db_keys(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
+    get_file_storage.cache_clear()
+
+    storage = get_file_storage()
+    legacy_key = "users/1/uploads/id/back\\slash.txt"
+    legacy_object = tmp_path / "objects" / "users/1/uploads/id" / "back\\slash.txt"
+    legacy_object.parent.mkdir(parents=True)
+    legacy_object.write_bytes(b"legacy data")
+
+    assert storage.exists(legacy_key)
+    assert storage.stat(legacy_key).size == len(b"legacy data")
+    with storage.open_read(legacy_key) as handle:
+        assert handle.read() == b"legacy data"
+
+    restored = storage.copy_to_path(legacy_key, tmp_path / "restored" / "file.txt")
+    assert restored.read_bytes() == b"legacy data"
+
+    materialized = storage.materialize(legacy_key, "file.txt")
+    assert materialized.read_bytes() == b"legacy data"
+
+    storage.delete(legacy_key)
+    assert not storage.exists(legacy_key)
 
 
 def test_local_file_storage_round_trips_file(monkeypatch, tmp_path):

--- a/tests/core/test_scoped_file_storage.py
+++ b/tests/core/test_scoped_file_storage.py
@@ -1,0 +1,161 @@
+import pytest
+
+from xagent.core.file_storage import (
+    ScopedFileStorage,
+    StorageKeyScopeError,
+    get_unscoped_file_storage,
+    get_user_file_storage,
+)
+from xagent.core.file_storage.storage import FsspecFileStorage
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
+    get_unscoped_file_storage.cache_clear()
+    yield get_unscoped_file_storage()
+    get_unscoped_file_storage.cache_clear()
+
+
+def test_user_scoped_round_trip(local_storage, tmp_path):
+    storage = get_user_file_storage(1)
+    source = tmp_path / "source.txt"
+    source.write_text("scoped content", encoding="utf-8")
+
+    stored = storage.put_file(source, "users/1/uploads/file-id/source.txt")
+    assert stored.key == "users/1/uploads/file-id/source.txt"
+    assert storage.exists(stored.key)
+    assert storage.stat(stored.key).size == len("scoped content")
+
+    with storage.open_read(stored.key) as handle:
+        assert handle.read() == b"scoped content"
+
+    assert [item.key for item in storage.list("users/1/uploads")] == [stored.key]
+
+    materialized = storage.materialize(stored.key, "source.txt")
+    assert materialized.read_bytes() == b"scoped content"
+
+    copied = storage.copy_to_path(stored.key, tmp_path / "restored" / "source.txt")
+    assert copied.read_bytes() == b"scoped content"
+
+    assert storage.content_hash(stored.key) == stored.checksum
+
+    storage.delete(stored.key)
+    assert not storage.exists(stored.key)
+
+
+def test_every_operation_rejects_out_of_scope_keys(local_storage, tmp_path):
+    storage = get_user_file_storage(1)
+    source = tmp_path / "source.txt"
+    source.write_text("data", encoding="utf-8")
+    foreign_key = "users/2/uploads/file-id/source.txt"
+
+    with pytest.raises(StorageKeyScopeError):
+        storage.put_file(source, foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.put_bytes(b"data", foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.open_read(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.exists(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.stat(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.content_hash(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.list("users/2/uploads")
+    with pytest.raises(StorageKeyScopeError):
+        storage.delete(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.materialize(foreign_key)
+    with pytest.raises(StorageKeyScopeError):
+        storage.copy_to_path(foreign_key, tmp_path / "restored" / "x.txt")
+    with pytest.raises(StorageKeyScopeError):
+        storage.signed_url(foreign_key, expires=300)
+
+
+def test_prefix_containment_is_separator_aware(local_storage):
+    storage = get_user_file_storage(1)
+
+    with pytest.raises(StorageKeyScopeError):
+        storage.exists("users/10/uploads/file-id/source.txt")
+    with pytest.raises(StorageKeyScopeError):
+        storage.list("users/10")
+
+
+def test_key_equal_to_prefix_is_in_scope(local_storage):
+    storage = get_user_file_storage(1)
+
+    assert storage.list("users/1") == []
+    assert storage.exists("users/1") is False
+
+
+def test_structural_violations_raise_value_error_not_scope_error(
+    local_storage, tmp_path
+):
+    storage = get_user_file_storage(1)
+
+    with pytest.raises(ValueError):
+        storage.put_bytes(b"data", "users/1/../2/escape.txt")
+    with pytest.raises(ValueError):
+        storage.open_read("users/1/uploads/../../2/escape.txt")
+    with pytest.raises(ValueError):
+        storage.put_bytes(b"data", "users/1/uploads/id/back\\slash.txt")
+
+
+def test_scoped_read_tolerates_in_scope_legacy_keys(local_storage, tmp_path):
+    storage = get_user_file_storage(1)
+    legacy_key = "users/1/uploads/id/back\\slash.txt"
+    legacy_object = tmp_path / "objects" / "users/1/uploads/id" / "back\\slash.txt"
+    legacy_object.parent.mkdir(parents=True)
+    legacy_object.write_bytes(b"legacy data")
+
+    with storage.open_read(legacy_key) as handle:
+        assert handle.read() == b"legacy data"
+
+    storage.delete(legacy_key)
+    assert not storage.exists(legacy_key)
+
+
+def test_scoped_read_rejects_out_of_scope_legacy_keys(local_storage):
+    storage = get_user_file_storage(1)
+
+    with pytest.raises(StorageKeyScopeError):
+        storage.open_read("users/2/uploads/id/back\\slash.txt")
+
+
+def test_signed_url_scope_enforcement_on_s3_backend(tmp_path):
+    class S3UrlStorage:
+        def __init__(self):
+            self.calls = []
+
+        def url(self, path, **kwargs):
+            self.calls.append((path, kwargs))
+            return "https://cdn.example.com/signed"
+
+    backend = S3UrlStorage()
+    storage = ScopedFileStorage(
+        storage=FsspecFileStorage(
+            fs=backend,
+            root="bucket/root",
+            backend="s3",
+            base_uri="s3://bucket/root",
+            materialize_dir=tmp_path,
+        ),
+        prefix="users/1",
+    )
+
+    signed = storage.signed_url("users/1/uploads/id/data.txt", expires=120)
+    assert signed == "https://cdn.example.com/signed"
+    assert backend.calls[0][0] == "bucket/root/users/1/uploads/id/data.txt"
+
+    with pytest.raises(StorageKeyScopeError):
+        storage.signed_url("users/2/uploads/id/data.txt", expires=120)
+    with pytest.raises(StorageKeyScopeError):
+        storage.signed_url("users/10/uploads/id/data.txt", expires=120)
+    assert len(backend.calls) == 1
+
+
+def test_get_user_file_storage_binds_expected_prefix(local_storage):
+    assert get_user_file_storage(42).prefix == "users/42"

--- a/tests/core/test_storage_keys.py
+++ b/tests/core/test_storage_keys.py
@@ -1,0 +1,100 @@
+"""Characterization tests for the canonical storage-key builders.
+
+The builders in ``xagent.core.file_storage.keys`` replace two near-duplicate
+implementations (``workspace._build_workspace_storage_key`` and
+``managed_file_ref.build_task_output_storage_key``). For every well-formed
+input the canonical builder must produce the exact key the old builders
+agreed on; the degenerate-input fallbacks are pinned here as the single
+documented behavior.
+"""
+
+import pytest
+
+from xagent.core.file_storage import normalize_storage_key
+from xagent.core.file_storage.keys import (
+    build_task_output_storage_key,
+    build_upload_storage_key,
+    safe_storage_filename,
+)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_suffix"),
+    [
+        # Well-formed inputs: both legacy builders produced exactly this.
+        ("report.txt", "report.txt"),
+        ("nested/dir/report.txt", "nested/dir/report.txt"),
+        ("output/data.csv", "output/data.csv"),
+        # Collapsible noise: both legacy builders normalized to the same key.
+        ("nested/./report.txt", "nested/report.txt"),
+        ("nested//report.txt", "nested/report.txt"),
+        ("nested/report.txt/", "nested/report.txt"),
+    ],
+)
+def test_task_output_key_matches_legacy_builders_for_well_formed_paths(
+    relative_path, expected_suffix
+):
+    key = build_task_output_storage_key(7, 42, "file-id", relative_path)
+    assert key == f"users/7/tasks/42/outputs/file-id/{expected_suffix}"
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_suffix"),
+    [
+        # Traversal component: fall back to a safe basename (the
+        # managed_file_ref behavior; the workspace builder used to drop the
+        # ".." components instead — no call site produces such input).
+        ("a/../b/report.txt", "report.txt"),
+        ("../report.txt", "report.txt"),
+        # Nothing usable left: fall back to "file" (the workspace behavior;
+        # the managed_file_ref builder used to degenerate to ".").
+        ("", "file"),
+        (".", "file"),
+        ("//", "file"),
+        # Traversal-only path: basename would be ".." — degrade to "file".
+        ("a/..", "file"),
+        # Leading slash: strip, keep structure (both legacy builders differed
+        # only in degenerate ways here).
+        ("/abs/report.txt", "abs/report.txt"),
+        # Forbidden characters are sanitized so strict writes accept the key.
+        ("dir/back\\slash.txt", "dir/back_slash.txt"),
+        ("dir/ctrl\x00char.txt", "dir/ctrl_char.txt"),
+    ],
+)
+def test_task_output_key_degenerate_input_fallbacks(relative_path, expected_suffix):
+    key = build_task_output_storage_key(7, 42, "file-id", relative_path)
+    assert key == f"users/7/tasks/42/outputs/file-id/{expected_suffix}"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_name"),
+    [
+        ("report.txt", "report.txt"),
+        ("dir/report.txt", "report.txt"),
+        ("  spaced.txt  ", "spaced.txt"),
+        ("", "file"),
+        (".", "file"),
+        ("..", "file"),
+        ("back\\slash.txt", "back_slash.txt"),
+        ("ctrl\x1fchar.txt", "ctrl_char.txt"),
+    ],
+)
+def test_upload_key_uses_safe_filename(filename, expected_name):
+    assert safe_storage_filename(filename) == expected_name
+    assert (
+        build_upload_storage_key(7, "file-id", filename)
+        == f"users/7/uploads/file-id/{expected_name}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("builder", "args"),
+    [
+        (build_upload_storage_key, (7, "file-id", "back\\slash\x00.txt")),
+        (build_task_output_storage_key, (7, 42, "file-id", "a/../\\weird\x1b//")),
+        (build_task_output_storage_key, (7, 42, "file-id", "")),
+    ],
+)
+def test_builder_output_always_passes_strict_normalization(builder, args):
+    key = builder(*args)
+    assert normalize_storage_key(key) == key

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.service import AgentService
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.core.workspace import TaskWorkspace, WorkspaceManager
 from xagent.web.models import Base
@@ -19,7 +19,7 @@ def test_workspace_register_file_writes_durable_storage(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -69,7 +69,7 @@ def test_agent_workspace_register_file_uses_explicit_db_task_id(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -127,7 +127,7 @@ def test_agent_workspace_register_file_rebinds_existing_output_to_db_task_id(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -201,7 +201,7 @@ def test_agent_workspace_register_file_avoids_parent_output_name_collision(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -275,7 +275,7 @@ def test_agent_workspace_register_file_is_idempotent_after_canonicalization(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -397,7 +397,7 @@ def test_workspace_register_file_uses_uploaded_file_store_create(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     create_calls = []
 
@@ -472,7 +472,7 @@ def test_workspace_register_file_resyncs_existing_modified_file(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -521,7 +521,7 @@ def test_auto_register_files_resyncs_modified_existing_file(
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}
@@ -567,7 +567,7 @@ def test_workspace_register_file_resyncs_external_file_without_reclassifying_upl
     del mock_workspace_db
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -355,6 +355,7 @@ async def test_create_kb_from_file_uses_shared_service(tmp_path):
     source_file = tmp_path / "notes.txt"
     source_file.write_text("hello", encoding="utf-8")
     file_record = SimpleNamespace(
+        user_id=7,
         filename="notes.txt",
         storage_path=str(source_file),
         file_id="file-1",
@@ -422,11 +423,13 @@ async def test_create_kb_from_file_continues_after_unexpected_ingest_error(tmp_p
     bad_file.write_text("bad", encoding="utf-8")
     good_file.write_text("good", encoding="utf-8")
     bad_record = SimpleNamespace(
+        user_id=7,
         filename="bad.txt",
         storage_path=str(bad_file),
         file_id="file-bad",
     )
     good_record = SimpleNamespace(
+        user_id=7,
         filename="good.txt",
         storage_path=str(good_file),
         file_id="file-good",
@@ -503,6 +506,7 @@ async def test_create_kb_from_file_failed_ingest_records_operation_outcome(
     source_file = tmp_path / "notes.txt"
     source_file.write_text("hello", encoding="utf-8")
     file_record = SimpleNamespace(
+        user_id=7,
         filename="notes.txt",
         storage_path=str(source_file),
         file_id="file-1",
@@ -608,6 +612,7 @@ async def test_create_kb_from_file_preserves_storage_context_in_executor(
     source_file = tmp_path / "notes.txt"
     source_file.write_text("hello", encoding="utf-8")
     file_record = SimpleNamespace(
+        user_id=7,
         filename="notes.txt",
         storage_path=str(source_file),
         file_id="file-1",
@@ -665,6 +670,7 @@ async def test_create_kb_from_file_restores_durable_only_upload_before_ingestion
     restored_source = tmp_path / "restored-notes.txt"
     restored_source.write_text("restored", encoding="utf-8")
     file_record = SimpleNamespace(
+        user_id=7,
         filename="notes.txt",
         storage_path=str(missing_source),
         file_id="file-1",
@@ -738,6 +744,7 @@ async def test_create_kb_from_file_returns_error_when_metadata_refresh_fails(tmp
     source_file = tmp_path / "notes.txt"
     source_file.write_text("hello", encoding="utf-8")
     file_record = SimpleNamespace(
+        user_id=7,
         filename="notes.txt",
         storage_path=str(source_file),
         file_id="file-1",

--- a/tests/e2e/app_harness.py
+++ b/tests/e2e/app_harness.py
@@ -14,7 +14,7 @@ import jwt
 import pytest
 from fastapi.testclient import TestClient
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.models.database import get_engine, get_session_local, init_db
 from xagent.web.models.uploaded_file import UploadedFile
@@ -215,7 +215,7 @@ def run_e2e_app_client(
             get_engine().dispose()
         except RuntimeError:
             pass
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
 
 def _patch_channel_modules_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/minio_harness.py
+++ b/tests/e2e/minio_harness.py
@@ -24,7 +24,7 @@ from tests.e2e.app_harness import (
     seed_registered_local_file,
 )
 from tests.e2e.scripted_llm import build_scripted_llm_from_json
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api.auth import hash_password
 from xagent.web.models.user import User
 
@@ -142,11 +142,11 @@ def run_minio_storage(monkeypatch: pytest.MonkeyPatch) -> Iterator[MinioStorage]
 
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", f"s3://{bucket}/xagent-test")
         monkeypatch.setenv("XAGENT_FILE_STORAGE_OPTIONS", json.dumps(storage_options))
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         yield MinioStorage(bucket=bucket, prefix="xagent-test", fs=fs)
     finally:
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
         container.remove(force=True)
 
 

--- a/tests/e2e/test_file_startup_sync_minio.py
+++ b/tests/e2e/test_file_startup_sync_minio.py
@@ -19,7 +19,7 @@ from tests.e2e.app_harness import (
     seed_registered_local_file,
 )
 from tests.e2e.minio_harness import MinioStorage, run_minio_storage
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.models.uploaded_file import UploadedFile
 
 pytestmark = [pytest.mark.e2e, pytest.mark.docker]
@@ -64,7 +64,7 @@ def test_startup_sync_repairs_only_files_that_need_durable_storage(
         missing_local_key = (
             f"users/{user_id}/uploads/{missing_local_file_id}/missing-local.txt"
         )
-        existing_object = get_file_storage().put_bytes(
+        existing_object = get_unscoped_file_storage().put_bytes(
             b"already durable\n",
             existing_key,
             content_type="text/plain",

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
 from xagent.core.tools.core.RAG_tools.storage.contracts import DocumentRecord
 from xagent.core.tools.core.RAG_tools.utils.string_utils import (
@@ -3274,7 +3274,7 @@ def test_delete_document_prefers_file_id_and_cleans_orphan_file(
 ):
     """Deleting by file_id should remove the UploadedFile row when it becomes orphaned."""
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     app, headers, user, TestingSessionLocal = test_env
     client = TestClient(app)
@@ -3302,7 +3302,7 @@ def test_delete_document_prefers_file_id_and_cleans_orphan_file(
     finally:
         session.close()
 
-    assert get_file_storage().exists(storage_key)
+    assert get_unscoped_file_storage().exists(storage_key)
 
     document_state = [
         DocumentRecord(
@@ -3334,7 +3334,7 @@ def test_delete_document_prefers_file_id_and_cleans_orphan_file(
 
     assert response.status_code == 200
     assert not file_path.exists()
-    assert not get_file_storage().exists(storage_key)
+    assert not get_unscoped_file_storage().exists(storage_key)
 
     session = TestingSessionLocal()
     try:
@@ -4415,7 +4415,7 @@ def test_kb_delete_collection_cleans_file_id_managed_root_file(
 ):
     """Collection delete should clean orphan UploadedFile rows even outside collection dir."""
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     app, headers, user, TestingSessionLocal = test_env
     client = TestClient(app)
@@ -4443,7 +4443,7 @@ def test_kb_delete_collection_cleans_file_id_managed_root_file(
     finally:
         session.close()
 
-    assert get_file_storage().exists(storage_key)
+    assert get_unscoped_file_storage().exists(storage_key)
 
     document_state = [
         DocumentRecord(
@@ -4488,7 +4488,7 @@ def test_kb_delete_collection_cleans_file_id_managed_root_file(
 
     assert response.status_code == 200
     assert not file_path.exists()
-    assert not get_file_storage().exists(storage_key)
+    assert not get_unscoped_file_storage().exists(storage_key)
 
     session = TestingSessionLocal()
     try:

--- a/tests/web/api/test_kb_web_ingestion_uploaded_file.py
+++ b/tests/web/api/test_kb_web_ingestion_uploaded_file.py
@@ -31,7 +31,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api.kb import (
     _WEB_FILE_LOCKS,
     _atomic_replace_file,
@@ -206,7 +206,7 @@ class TestWebIngestionUploadedFilePersistence:
     ):
         """Test creating a new file when no cache or DB record exists."""
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a temporary markdown file
@@ -272,7 +272,7 @@ class TestWebIngestionUploadedFilePersistence:
                     assert file_record.storage_key
                     assert file_record.storage_uri
                     assert persistent_file.exists()
-                    with get_file_storage().open_read(
+                    with get_unscoped_file_storage().open_read(
                         str(file_record.storage_key)
                     ) as handle:
                         assert handle.read() == persistent_file.read_bytes()
@@ -454,7 +454,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch.setenv(
             "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
         )
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         temp_dir = tmp_path / "ingest"
         temp_dir.mkdir()
@@ -525,7 +525,7 @@ class TestWebIngestionUploadedFilePersistence:
 
         assert atomic_replace.called
         assert existing_path.read_text(encoding="utf-8") == "old content"
-        with get_file_storage().open_read(str(existing_record.storage_key)) as handle:
+        with get_unscoped_file_storage().open_read(str(existing_record.storage_key)) as handle:
             assert handle.read() == b"old content"
         mock_snapshot_runs.assert_called_once_with(str(existing_record.file_id))
         mock_restore_runs.assert_called_once_with(ingestion_runs_snapshot)
@@ -596,7 +596,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         persistent_file = tmp_path / "uploads" / "web.md"
         persistent_file.parent.mkdir(parents=True)
@@ -614,7 +614,7 @@ class TestWebIngestionUploadedFilePersistence:
 
         rows = db_session.query(UploadedFile).all()
         assert rows == []
-        assert get_file_storage().list("users") == []
+        assert get_unscoped_file_storage().list("users") == []
 
     def test_refresh_existing_file_rolls_back_failed_upsert_before_restore(
         self,
@@ -628,7 +628,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch.setenv(
             "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
         )
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         temp_dir = tmp_path / "ingest"
         temp_dir.mkdir()
@@ -698,7 +698,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch.setenv(
             "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
         )
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         existing_path = tmp_path / "uploads" / "existing.md"
         existing_path.parent.mkdir()
@@ -759,7 +759,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch.setenv(
             "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
         )
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         existing_path = tmp_path / "uploads" / "existing.md"
         existing_path.parent.mkdir()
@@ -808,7 +808,7 @@ class TestWebIngestionUploadedFilePersistence:
         assert result is not None
         assert existing_path.read_text(encoding="utf-8") == "new content"
         assert processed_urls == {"hash": str(existing_record.file_id)}
-        with get_file_storage().open_read(str(existing_record.storage_key)) as handle:
+        with get_unscoped_file_storage().open_read(str(existing_record.storage_key)) as handle:
             assert handle.read() == b"new content"
 
     def test_recreate_missing_existing_file_removes_local_when_upsert_fails(
@@ -872,7 +872,7 @@ class TestWebIngestionUploadedFilePersistence:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         existing_path = tmp_path / "uploads" / "existing.md"
         existing_path.parent.mkdir(parents=True)
@@ -953,7 +953,7 @@ class TestWebIngestionUploadedFilePersistence:
                 )
 
         assert not existing_path.exists()
-        assert get_file_storage().list("users") == []
+        assert get_unscoped_file_storage().list("users") == []
         row = (
             db_session.query(UploadedFile)
             .filter(UploadedFile.file_id == old_file_id)
@@ -1281,7 +1281,7 @@ class TestIngestWebHandleWebFile:
         monkeypatch.setenv(
             "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
         )
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         uploads_root = tmp_path / "uploads"
         monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_root))
@@ -1331,7 +1331,7 @@ class TestIngestWebHandleWebFile:
                 filename,
             )
             assert expected_persistent.exists()
-            assert get_file_storage().exists(captured["storage_key"])
+            assert get_unscoped_file_storage().exists(captured["storage_key"])
 
             file_info["rollback_on_failure"](result)
             return result
@@ -1357,7 +1357,7 @@ class TestIngestWebHandleWebFile:
         assert response.status_code == 500
         assert captured["file_id"]
         assert not expected_persistent.exists()
-        assert not get_file_storage().exists(captured["storage_key"])
+        assert not get_unscoped_file_storage().exists(captured["storage_key"])
 
         session = TestingSessionLocal()
         try:

--- a/tests/web/api/test_kb_web_ingestion_uploaded_file.py
+++ b/tests/web/api/test_kb_web_ingestion_uploaded_file.py
@@ -525,7 +525,9 @@ class TestWebIngestionUploadedFilePersistence:
 
         assert atomic_replace.called
         assert existing_path.read_text(encoding="utf-8") == "old content"
-        with get_unscoped_file_storage().open_read(str(existing_record.storage_key)) as handle:
+        with get_unscoped_file_storage().open_read(
+            str(existing_record.storage_key)
+        ) as handle:
             assert handle.read() == b"old content"
         mock_snapshot_runs.assert_called_once_with(str(existing_record.file_id))
         mock_restore_runs.assert_called_once_with(ingestion_runs_snapshot)
@@ -808,7 +810,9 @@ class TestWebIngestionUploadedFilePersistence:
         assert result is not None
         assert existing_path.read_text(encoding="utf-8") == "new content"
         assert processed_urls == {"hash": str(existing_record.file_id)}
-        with get_unscoped_file_storage().open_read(str(existing_record.storage_key)) as handle:
+        with get_unscoped_file_storage().open_read(
+            str(existing_record.storage_key)
+        ) as handle:
             assert handle.read() == b"new content"
 
     def test_recreate_missing_existing_file_removes_local_when_upsert_fails(

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.memory.in_memory import InMemoryMemoryStore
 from xagent.web.api.chat import AgentServiceManager, resolve_agent_service_memory_policy
 from xagent.web.api.websocket import (
@@ -296,7 +296,7 @@ def test_normalize_file_outputs_rolls_back_when_durable_storage_fails(
 
 def test_normalize_file_outputs_refreshes_existing_output_row(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     engine = create_engine("sqlite:///:memory:")
     SessionLocal = sessionmaker(bind=engine)
     Base.metadata.create_all(engine)
@@ -341,12 +341,12 @@ def test_normalize_file_outputs_refreshes_existing_output_row(monkeypatch, tmp_p
 
         db.refresh(record)
         assert record.checksum is not None
-        with get_file_storage().open_read(storage_key) as handle:
+        with get_unscoped_file_storage().open_read(storage_key) as handle:
             assert handle.read() == b"new-data"
     finally:
         db.close()
         engine.dispose()
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.file_storage.types import StoredObject
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.services.managed_file_ref import (
@@ -16,7 +16,7 @@ from xagent.web.services.managed_file_ref import (
 def _configure_storage(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
 
 def _record(local_path, **overrides):
@@ -44,7 +44,7 @@ def test_ensure_local_returns_existing_local_file(tmp_path):
 
 def test_ensure_local_restores_missing_file_from_durable_storage(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"durable content", "users/7/uploads/file-123/local.txt")
     local_path = tmp_path / "uploads" / "local.txt"
     record = _record(
@@ -64,7 +64,7 @@ def test_ensure_local_restores_missing_file_from_durable_storage(monkeypatch, tm
 
 def test_materialize_uses_temp_dir_when_original_path_is_missing(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(
         b"preview content", "users/7/uploads/file-123/preview.txt"
     )
@@ -88,7 +88,7 @@ def test_materialize_uses_temp_dir_when_original_path_is_missing(monkeypatch, tm
 
 def test_ensure_local_rejects_restored_checksum_mismatch(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(
         b"wrong durable content", "users/7/uploads/file-123/bad.txt"
     )
@@ -113,7 +113,7 @@ def test_materialize_rejects_checksum_mismatch_and_discards_cache(
     monkeypatch, tmp_path
 ):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(
         b"wrong preview content", "users/7/uploads/file-123/bad-preview.txt"
     )
@@ -139,7 +139,7 @@ def test_materialize_rejects_checksum_mismatch_and_discards_cache(
 
 def test_materialize_retries_once_after_discarding_bad_cache(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(
         b"correct preview content", "users/7/uploads/file-123/cached-preview.txt"
     )
@@ -166,7 +166,7 @@ def test_open_read_restores_and_validates_durable_when_local_missing(
     monkeypatch, tmp_path
 ):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(b"stream me", "users/7/uploads/file-123/stream.txt")
     local_path = tmp_path / "uploads" / "stream.txt"
     record = _record(
@@ -185,7 +185,7 @@ def test_open_read_restores_and_validates_durable_when_local_missing(
 
 def test_open_read_prefers_existing_local_file_over_durable(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
-    storage = get_file_storage()
+    storage = get_unscoped_file_storage()
     stored = storage.put_bytes(
         b"stale durable content", "users/7/uploads/file-123/current.txt"
     )
@@ -320,7 +320,7 @@ def test_sync_to_durable_uploads_local_file_and_updates_record(monkeypatch, tmp_
     assert record.checksum is not None
     assert record.storage_status == "available"
     assert record.file_size == len("sync content")
-    with get_file_storage().open_read(stored.key) as handle:
+    with get_unscoped_file_storage().open_read(stored.key) as handle:
         assert handle.read() == b"sync content"
 
 

--- a/tests/web/services/test_uploaded_file_storage.py
+++ b/tests/web/services/test_uploaded_file_storage.py
@@ -1,4 +1,4 @@
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.services.managed_file_ref import (
     ManagedFileRef,
@@ -13,7 +13,7 @@ def test_create_uploaded_file_from_local_path_stores_durable_object(
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     source = tmp_path / "uploads" / "input.txt"
     source.parent.mkdir()
@@ -67,7 +67,7 @@ def test_managed_file_ref_materialize_prefers_existing_local_path(tmp_path):
 def test_ensure_uploaded_file_local_path_restores_original_path(monkeypatch, tmp_path):
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     source = tmp_path / "uploads" / "restored.txt"
     source.parent.mkdir()
@@ -92,7 +92,7 @@ def test_create_uploaded_file_from_local_path_accepts_custom_storage_key(
 ):
     object_root = tmp_path / "objects"
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     source = tmp_path / "workspace" / "output" / "report.txt"
     source.parent.mkdir(parents=True)

--- a/tests/web/services/test_uploaded_file_store.py
+++ b/tests/web/services/test_uploaded_file_store.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.models.database import Base
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -29,7 +29,7 @@ def test_create_from_local_path_persists_record_and_syncs_durable(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "input.txt"
@@ -49,13 +49,13 @@ def test_create_from_local_path_persists_record_and_syncs_durable(
     assert persisted.id == record.id
     assert persisted.storage_status == "available"
     assert persisted.storage_key == "users/1/uploads/file-store/input.txt"
-    with get_file_storage().open_read(str(persisted.storage_key)) as handle:
+    with get_unscoped_file_storage().open_read(str(persisted.storage_key)) as handle:
         assert handle.read() == b"store content"
 
 
 def test_sync_existing_refreshes_durable_object(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "refresh.txt"
@@ -74,13 +74,13 @@ def test_sync_existing_refreshes_durable_object(monkeypatch, tmp_path):
     store.sync_existing(record)
     db.commit()
 
-    with get_file_storage().open_read(storage_key) as handle:
+    with get_unscoped_file_storage().open_read(storage_key) as handle:
         assert handle.read() == b"new content"
 
 
 def test_delete_removes_local_durable_and_db_record(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "delete.txt"
@@ -95,19 +95,19 @@ def test_delete_removes_local_durable_and_db_record(monkeypatch, tmp_path):
     )
     storage_key = str(record.storage_key)
     assert source.exists()
-    assert get_file_storage().exists(storage_key)
+    assert get_unscoped_file_storage().exists(storage_key)
 
     store.delete(record, delete_local=True)
     db.commit()
 
     assert not source.exists()
-    assert not get_file_storage().exists(storage_key)
+    assert not get_unscoped_file_storage().exists(storage_key)
     assert db.query(UploadedFile).filter_by(file_id="file-delete").first() is None
 
 
 def test_delete_preserves_db_row_when_durable_cleanup_fails(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "delete-first.txt"
@@ -137,12 +137,12 @@ def test_delete_preserves_db_row_when_durable_cleanup_fails(monkeypatch, tmp_pat
         is not None
     )
     assert source.exists()
-    assert get_file_storage().exists(storage_key)
+    assert get_unscoped_file_storage().exists(storage_key)
 
 
 def test_delete_skips_local_file_outside_local_root(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "outside" / "unexpected.txt"
@@ -163,7 +163,7 @@ def test_delete_skips_local_file_outside_local_root(monkeypatch, tmp_path):
     db.commit()
 
     assert source.exists()
-    assert not get_file_storage().exists(storage_key)
+    assert not get_unscoped_file_storage().exists(storage_key)
     assert db.query(UploadedFile).filter_by(file_id="file-outside").first() is None
 
 
@@ -171,7 +171,7 @@ def test_upsert_by_storage_path_reuses_record_and_refreshes_durable(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "kb.md"
@@ -202,13 +202,13 @@ def test_upsert_by_storage_path_reuses_record_and_refreshes_durable(
     assert second.id == first.id
     assert second.filename == "kb-renamed.md"
     assert second.file_size == len("second")
-    with get_file_storage().open_read(first_key) as handle:
+    with get_unscoped_file_storage().open_read(first_key) as handle:
         assert handle.read() == b"second"
 
 
 def test_upsert_by_storage_path_refreshes_same_size_rewrite(monkeypatch, tmp_path):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "kb.md"
@@ -239,7 +239,7 @@ def test_upsert_by_storage_path_refreshes_same_size_rewrite(monkeypatch, tmp_pat
 
     assert second.id == first.id
     assert second.checksum != old_checksum
-    with get_file_storage().open_read(first_key) as handle:
+    with get_unscoped_file_storage().open_read(first_key) as handle:
         assert handle.read() == b"new-data"
 
 
@@ -247,7 +247,7 @@ def test_upsert_by_storage_path_syncs_when_requested_storage_key_changes(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "kb.md"
@@ -280,7 +280,7 @@ def test_upsert_by_storage_path_syncs_when_requested_storage_key_changes(
     assert second.id == first.id
     assert first_key != second_key
     assert second.storage_key == second_key
-    with get_file_storage().open_read(second_key) as handle:
+    with get_unscoped_file_storage().open_read(second_key) as handle:
         assert handle.read() == b"same-bytes"
 
 
@@ -288,7 +288,7 @@ def test_upsert_by_storage_path_skips_durable_sync_when_file_unchanged(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "kb.md"
@@ -327,7 +327,7 @@ def test_create_from_local_path_removes_record_when_durable_write_fails(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     db = _session()
     user = _user(db)
     source = tmp_path / "uploads" / "output.txt"

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -148,3 +148,10 @@ def test_separator_aware_scope_for_record_owner(storage_env, tmp_path):
 
     with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record).delete_durable()
+
+
+def test_record_without_owner_cannot_bind_default_scope(storage_env, tmp_path):
+    record = _record(tmp_path / "uploads" / "missing.txt", user_id=None)
+
+    with pytest.raises(ValueError, match="user_id is required"):
+        ManagedFileRef(record)

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -1,0 +1,150 @@
+"""End-to-end enforcement of user-scoped storage handles at the call sites.
+
+ManagedFileRef defaults to a handle scoped to ``users/{record.user_id}``;
+these tests prove a record whose storage_key targets another user's prefix
+cannot read, write, sign, adopt, or delete through any entry point.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from xagent.core.file_storage import StorageKeyScopeError
+from xagent.core.file_storage.factory import get_unscoped_file_storage
+from xagent.web.models.uploaded_file import UploadedFile
+from xagent.web.services.managed_file_ref import (
+    DurableStorageOperationError,
+    ManagedFileRef,
+)
+
+
+@pytest.fixture
+def storage_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
+    get_unscoped_file_storage.cache_clear()
+    yield tmp_path
+    get_unscoped_file_storage.cache_clear()
+
+
+def _record(local_path: Path, **overrides) -> UploadedFile:
+    values = {
+        "file_id": "file-123",
+        "user_id": 7,
+        "filename": local_path.name,
+        "storage_path": str(local_path),
+        "storage_status": "legacy",
+        "mime_type": "text/plain",
+        "file_size": 0,
+    }
+    values.update(overrides)
+    return UploadedFile(**values)
+
+
+def _foreign_key_record(local_path: Path) -> UploadedFile:
+    return _record(
+        local_path,
+        storage_key="users/8/uploads/file-123/source.txt",
+        storage_backend="file",
+        storage_status="available",
+    )
+
+
+def test_round_trip_through_default_user_scoped_storage(storage_env, tmp_path):
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("scoped round trip", encoding="utf-8")
+    record = _record(source)
+
+    stored = ManagedFileRef(record).sync_to_durable()
+    assert stored.key == "users/7/uploads/file-123/source.txt"
+    assert record.storage_status == "available"
+
+    source.unlink()
+    restored = ManagedFileRef(record).ensure_local()
+    assert restored.read_text(encoding="utf-8") == "scoped round trip"
+
+    ManagedFileRef(record).delete_durable()
+    assert not get_unscoped_file_storage().exists(stored.key)
+
+
+def test_sync_to_durable_rejects_foreign_explicit_key(storage_env, tmp_path):
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("data", encoding="utf-8")
+    record = _record(source)
+
+    with pytest.raises(DurableStorageOperationError) as excinfo:
+        ManagedFileRef(record).sync_to_durable(
+            storage_key="users/8/uploads/file-123/source.txt"
+        )
+    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
+    assert not get_unscoped_file_storage().exists("users/8/uploads/file-123/source.txt")
+
+
+def test_restore_rejects_foreign_storage_key(storage_env, tmp_path):
+    record = _foreign_key_record(tmp_path / "uploads" / "missing.txt")
+
+    with pytest.raises(DurableStorageOperationError) as excinfo:
+        ManagedFileRef(record).ensure_local()
+    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
+
+    with pytest.raises(DurableStorageOperationError) as excinfo:
+        ManagedFileRef(record).materialize()
+    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
+
+
+def test_signed_url_never_issued_for_foreign_storage_key(storage_env, tmp_path):
+    # signed_access_url degrades to None when the checksum probe fails; the
+    # scope check makes that probe fail for foreign keys, so no URL is issued
+    # even though the foreign object exists and the checksum matches.
+    foreign = get_unscoped_file_storage().put_bytes(
+        b"foreign", "users/8/uploads/file-123/missing.txt"
+    )
+    record = _record(
+        tmp_path / "uploads" / "missing.txt",
+        storage_key=foreign.key,
+        storage_backend="file",
+        storage_status="available",
+        checksum=foreign.checksum,
+    )
+
+    assert ManagedFileRef(record).signed_access_url(expires=300) is None
+
+
+def test_delete_durable_rejects_foreign_storage_key(storage_env, tmp_path):
+    record = _foreign_key_record(tmp_path / "uploads" / "missing.txt")
+
+    with pytest.raises(StorageKeyScopeError):
+        ManagedFileRef(record).delete_durable()
+
+
+def test_adopt_existing_object_rejects_foreign_expected_key(storage_env, tmp_path):
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("data", encoding="utf-8")
+    record = _record(source)
+    # The foreign object exists, so a scope bypass would return "adopted".
+    get_unscoped_file_storage().put_bytes(
+        b"foreign", "users/8/uploads/file-123/source.txt"
+    )
+
+    with pytest.raises(DurableStorageOperationError) as excinfo:
+        ManagedFileRef(record).adopt_existing_object(
+            "users/8/uploads/file-123/source.txt"
+        )
+    assert isinstance(excinfo.value.__cause__, StorageKeyScopeError)
+
+
+def test_separator_aware_scope_for_record_owner(storage_env, tmp_path):
+    # user 1's handle must not admit a users/10 key.
+    record = _record(
+        tmp_path / "uploads" / "missing.txt",
+        user_id=1,
+        storage_key="users/10/uploads/file-123/source.txt",
+        storage_backend="file",
+        storage_status="available",
+    )
+
+    with pytest.raises(StorageKeyScopeError):
+        ManagedFileRef(record).delete_durable()

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api.auth import hash_password
 from xagent.web.api.files import file_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
@@ -376,7 +376,7 @@ class TestAdminFileAccess:
         self, test_db, temp_uploads_dir, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
         admin_user, regular_user, test_app, session = test_db
         del admin_user
         regular_user_id = int(cast(Any, regular_user.id))
@@ -405,7 +405,7 @@ class TestAdminFileAccess:
             f"users/{regular_user_id}/tasks/{task.id}/outputs/asset-file/"
             "output/assets/app.js"
         )
-        stored_object = get_file_storage().put_file(
+        stored_object = get_unscoped_file_storage().put_file(
             asset_path,
             storage_key,
             "application/javascript",

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1135,11 +1135,11 @@ def test_kb_web_job_existing_collection_partial_restores_previous_config(
 def test_background_web_file_new_branch_returns_rollback_callback(
     tmp_path, monkeypatch
 ):
-    from xagent.core.file_storage.factory import get_file_storage
+    from xagent.core.file_storage.factory import get_unscoped_file_storage
     from xagent.web.jobs.kb_tasks import _handle_web_file
 
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     SessionLocal = _init_test_db(tmp_path / "web-file-handler.db")
     db = SessionLocal()
@@ -1197,7 +1197,7 @@ def test_background_web_file_new_branch_returns_rollback_callback(
         mock_rollback_rag.assert_called_once()
     finally:
         db.close()
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
 
 def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monkeypatch):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api.auth import hash_password
 from xagent.web.api.files import _content_disposition_header, file_router
 from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
@@ -138,7 +138,7 @@ def temp_uploads_dir(monkeypatch):
         import xagent.web.config
 
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (temp_path / "objects").as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
         monkeypatch.setattr(xagent.web.config, "get_uploads_dir", lambda: temp_path)
         monkeypatch.setattr(xagent.web.api.files, "get_uploads_dir", lambda: temp_path)
 
@@ -188,7 +188,7 @@ class TestFileUpload:
         """Uploaded files should download from durable storage, not local uploads."""
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         response = client.post(
             "/api/files/upload",
@@ -504,7 +504,7 @@ class TestFileUpload:
     ):
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         upload = client.post(
             "/api/files/upload",
@@ -541,7 +541,7 @@ class TestFileUpload:
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
         monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         upload = client.post(
             "/api/files/upload",
@@ -706,7 +706,7 @@ class TestFileUpload:
     ):
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         upload = client.post(
             "/api/files/upload",
@@ -742,7 +742,7 @@ class TestFileUpload:
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
         monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         upload = client.post(
             "/api/files/upload",
@@ -783,7 +783,7 @@ class TestFileUpload:
     ):
         object_root = tmp_path / "objects"
         monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
         upload = client.post(
             "/api/files/upload",

--- a/tests/web/test_kb_file_service_compensation.py
+++ b/tests/web/test_kb_file_service_compensation.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
-from xagent.core.file_storage import get_file_storage
+from xagent.core.file_storage import get_unscoped_file_storage
 from xagent.web.models.database import Base
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -29,7 +29,7 @@ def compensation_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", objects_dir.as_uri())
     monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized"))
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -41,7 +41,7 @@ def compensation_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         yield db, uploads_dir
     finally:
         db.close()
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
 
 def test_compensate_new_uploaded_file_removes_row_local_and_durable(
@@ -62,7 +62,7 @@ def test_compensate_new_uploaded_file_removes_row_local_and_durable(
     )
     file_id = str(file_record.file_id)
     storage_key = str(file_record.storage_key)
-    assert get_file_storage().exists(storage_key)
+    assert get_unscoped_file_storage().exists(storage_key)
 
     result = compensate_new_uploaded_file(db, file_id=file_id, user_id=1)
     db.commit()
@@ -72,7 +72,7 @@ def test_compensate_new_uploaded_file_removes_row_local_and_durable(
         db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first() is None
     )
     assert not file_path.exists()
-    assert not get_file_storage().exists(storage_key)
+    assert not get_unscoped_file_storage().exists(storage_key)
 
     second = compensate_new_uploaded_file(db, file_id=file_id, user_id=1)
     assert second.complete
@@ -147,7 +147,7 @@ def test_restore_uploaded_file_refresh_snapshot_restores_row_local_and_durable(
     assert result.complete
     assert file_path.read_text(encoding="utf-8") == "old content"
     assert file_record.filename == "page.md"
-    with get_file_storage().open_read(storage_key) as handle:
+    with get_unscoped_file_storage().open_read(storage_key) as handle:
         assert handle.read() == b"old content"
 
 

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.trace import get_display_user_message
-from xagent.core.file_storage.factory import get_file_storage
+from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.chat import _build_task_agent_config
 from xagent.web.api.websocket import (
@@ -761,7 +761,7 @@ def test_normalize_file_outputs_registers_current_task_output_path(
     uploads_dir = tmp_path / "uploads"
     monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
-    get_file_storage.cache_clear()
+    get_unscoped_file_storage.cache_clear()
     _create_user(db_session, 1, "owner")
     _create_task(db_session, task_id=20, user_id=1)
     output_path = uploads_dir / "user_1" / "web_task_20" / "output" / "report.txt"
@@ -776,7 +776,7 @@ def test_normalize_file_outputs_registers_current_task_output_path(
             file_outputs=[{"path": str(output_path), "filename": "report.txt"}],
         )
     finally:
-        get_file_storage.cache_clear()
+        get_unscoped_file_storage.cache_clear()
 
     assert len(normalized_outputs) == 1
     assert normalized_outputs[0]["filename"] == "report.txt"


### PR DESCRIPTION
Closes #759

## Summary

Brings the object-storage layer up to parity with the local-workspace path checks: keys are structurally validated, and all workspace/upload/KB/websocket call sites now operate through storage handles bound to `users/{user_id}` — a well-formed key pointing at another user's prefix is rejected at the storage layer instead of silently reading/writing foreign data.

Implements all decisions from the issue thread: option (a) for legacy keys, separator-aware containment, user-level scope granularity, `get_user_file_storage` as the primary factory, unified key builders, and `StorageKeyScopeError` across every storage method including `list`'s prefix argument and `signed_url`.

## Commits (one per slice)

1. **Structural key normalization with strict/tolerant modes** — `normalize_storage_key` splits keys on `/` and validates component-wise (empty/`.`/`..` always rejected). Strict mode additionally rejects backslashes and control characters and applies to writes and `list`; read/delete operations use tolerant mode so objects whose persisted keys embed legacy POSIX filenames stay restorable and deletable (option (a) — no data migration).
2. **Prefix-scoped storage handles** — `ScopedFileStorage` enforces separator-aware containment (`users/1` does not admit `users/10/...`) on all 11 operations, raising `StorageKeyScopeError` (distinct from normalization's `ValueError`). `get_user_file_storage(user_id)` becomes the primary factory; the raw factory is renamed `get_unscoped_file_storage`.
3. **Unified key builders** — the near-duplicate builders in `workspace.py` and `managed_file_ref.py` collapse into canonical builders in `core/file_storage/keys.py`. Characterization tests pin every well-formed input to the exact legacy key. Degenerate-input fallbacks are now single and documented: `..` → safe basename, empty → `file`, backslash/control chars → sanitized to `_` so builder output always passes strict writes (uploads of legally-named files like `a\b.txt` keep working). Persisted keys are read back verbatim and never re-derived, so existing objects/URLs are unaffected.
4. **Call-site migration** — `ManagedFileRef` defaults to a handle scoped to the owning record (`UploadedFileLocalPathRecord` gains `user_id`), covering restore/materialize/signed-URL/delete/`adopt_existing_object`; files API rollback deletions use the uploader's scope and `delete_file` the record owner's scope (admin case); startup sync builds a per-user scope inside its loop. The transitional alias is removed — nothing outside `core/file_storage` can obtain the unscoped client.

## Behavior notes

- No behavior change for well-formed keys; all hardening rejections target keys that were already malformed or cross-user.
- New writes of filenames containing backslash/control characters now produce sanitized keys (`a\b.txt` → `a_b.txt`); pre-existing objects with such keys remain fully readable/deletable via tolerant mode.
- `workspace.py` imports the key builder lazily — a module-level `file_storage` import would pull `fsspec` into sandboxed executions that ship minimal dependencies.

## Testing

- New suites: normalization matrix (traversal, absolute-ish keys, control chars, both modes), scoped-handle enforcement per method incl. `users/1` vs `users/10` and signed-URL scope, builder characterization, and end-to-end user-scope enforcement through `ManagedFileRef` (round-trip + cross-user rejection at every entry point incl. `adopt_existing_object`).
- 370+ storage-affected tests green; `mypy` and `ruff` clean on touched modules. Remaining full-sweep failures (pptxgenjs missing, sandbox pip network, order-dependent workspace tests) reproduce identically on a clean tree.