### PR TITLE
feat: admin agent-config visibility and conversation-log rendering

### DIFF
--- a/frontend/src/components/build/agent-builder-admin-mcp.test.tsx
+++ b/frontend/src/components/build/agent-builder-admin-mcp.test.tsx
@@ -1,0 +1,213 @@
+import React from "react"
+import { cleanup, render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Exercises the admin cross-user MCP-list path in AgentBuilder's edit-mode
+// loadAgent effect: an admin opening another user's agent must fetch that
+// owner's MCP servers (?user_id=), a self-owned agent must not, and a load that
+// is torn down mid-flight must not fire the owner fetch (active cleanup flag).
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const authUser = vi.hoisted(() => ({ current: { id: "1", is_admin: true } as any }))
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://api.local",
+    getWsUrl: () => "ws://api.local",
+  }
+})
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    state: {
+      messages: [],
+      traceEvents: [],
+      currentTask: null,
+      isProcessing: false,
+      isHistoryLoading: false,
+      taskId: null,
+      filePreview: { isOpen: false },
+      dagExecution: null,
+      steps: [],
+    },
+    setTaskId: vi.fn(),
+    sendMessage: vi.fn(),
+    dispatch: vi.fn(),
+    closeFilePreview: vi.fn(),
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    openFilePreview: vi.fn(),
+    requestStatus: vi.fn(),
+  }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token", user: authUser.current }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string, vars?: Record<string, string>) =>
+      vars?.appName ? `${key}:${vars.appName}` : key,
+  }),
+}))
+
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => ({ apps: [], getAppIcon: () => null }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("@/components/layout/resizable-three-column-layout", () => ({
+  ResizableThreeColumnLayout: ({ middlePanel }: { middlePanel: React.ReactNode }) => (
+    <div>{middlePanel}</div>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => null,
+}))
+
+vi.mock("@/components/build/agent-builder-chat", () => ({ AgentBuilderChat: () => null }))
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+vi.mock("@/components/mcp/connect-mcp-dialog", () => ({ ConnectMcpDialog: () => null }))
+vi.mock("@/components/chat/FileMentionDropdown", () => ({ FileMentionDropdown: () => null }))
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    isOpen: false,
+    items: [],
+    selectedIndex: 0,
+    selectItem: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+vi.mock("@/components/ui/multi-select", () => ({ MultiSelect: () => null }))
+vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+vi.mock("@/components/build/build-file-preview-sheet", () => ({
+  BuildFilePreviewSheet: () => null,
+}))
+
+import { AgentBuilder } from "./agent-builder"
+
+const AGENT_ID = "5"
+
+function agentResponse(ownerId: number) {
+  return {
+    id: Number(AGENT_ID),
+    user_id: ownerId,
+    name: "Some Agent",
+    description: "",
+    instructions: "",
+    execution_mode: "balanced",
+    models: null,
+    knowledge_bases: [],
+    skills: [],
+    tool_categories: ["mcp:foo"],
+    suggested_prompts: [],
+    logo_url: null,
+    status: "draft",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    widget_enabled: false,
+    allowed_domains: [],
+    share_enabled: false,
+    share_updated_at: null,
+  }
+}
+
+// Base handler for the mount-time fetchData resources + agent detail. `ownerId`
+// controls who owns the loaded agent; `agentPromise` lets a test defer the agent
+// response to drive the mid-flight teardown case.
+function installApi(ownerId: number, opts: { agentPromise?: Promise<Response> } = {}) {
+  apiRequestMock.mockImplementation((url: string) => {
+    if (url.endsWith("/api/kb/collections"))
+      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
+    if (url.endsWith("/api/skills/"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/tools/available"))
+      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+    if (url.endsWith("/api/models/?category=llm"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/models/user-default"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith(`/api/agents/${AGENT_ID}`))
+      return opts.agentPromise ??
+        Promise.resolve(new Response(JSON.stringify(agentResponse(ownerId)), { status: 200 }))
+    // Both the mount-time (no user_id) and owner-scoped (?user_id=) MCP fetches.
+    if (url.includes("/api/mcp/servers"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+  })
+}
+
+const mcpCalls = () =>
+  apiRequestMock.mock.calls.map(([u]) => String(u)).filter((u) => u.includes("/api/mcp/servers"))
+
+describe("AgentBuilder admin cross-user MCP list", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    authUser.current = { id: "1", is_admin: true }
+    ;(globalThis as any).WebSocket = vi.fn()
+  })
+
+  afterEach(() => cleanup())
+
+  it("fetches the owner's MCP servers when an admin opens another user's agent", async () => {
+    installApi(99) // agent owned by user 99, admin is user 1
+    render(<AgentBuilder agentId={AGENT_ID} />)
+
+    await waitFor(() =>
+      expect(mcpCalls()).toContain("http://api.local/api/mcp/servers?user_id=99")
+    )
+  })
+
+  it("does not scope the MCP fetch when an admin opens their own agent", async () => {
+    installApi(1) // agent owned by the admin themselves
+    render(<AgentBuilder agentId={AGENT_ID} />)
+
+    await waitFor(() => expect(mcpCalls()).toContain("http://api.local/api/mcp/servers"))
+    expect(mcpCalls().some((u) => u.includes("user_id="))).toBe(false)
+  })
+
+  it("does not fire the owner-scoped fetch if unmounted before the agent load resolves", async () => {
+    let resolveAgent: (r: Response) => void = () => {}
+    const agentPromise = new Promise<Response>((resolve) => {
+      resolveAgent = resolve
+    })
+    installApi(99, { agentPromise })
+
+    const { unmount } = render(<AgentBuilder agentId={AGENT_ID} />)
+    unmount()
+    // Agent detail resolves only after teardown; the active flag must gate it.
+    resolveAgent(new Response(JSON.stringify(agentResponse(99)), { status: 200 }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mcpCalls().some((u) => u.includes("user_id=99"))).toBe(false)
+  })
+})

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -14,6 +14,7 @@ import { PlusCircle, MessageSquare, Upload, Settings2, Check, Zap, BookOpen, Che
 import { ConnectMcpDialog } from "@/components/mcp/connect-mcp-dialog"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
+import { useAuth } from "@/contexts/auth-context"
 import { useMcpApps } from "@/contexts/mcp-apps-context"
 import { createFileChipHTML } from "@/components/chat/FileChip"
 import { MultiSelect } from "@/components/ui/multi-select"
@@ -108,6 +109,10 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   const { state, setTaskId, sendMessage, dispatch, closeFilePreview } = useApp()
   const { t, locale } = useI18n()
   const { apps: officialApps, getAppIcon, refresh: refreshMcpApps } = useMcpApps()
+  const { user } = useAuth()
+  // Set once loadAgent decides to load an owner-scoped MCP list for an admin
+  // cross-user view, so the mount-time self-scoped fetch won't clobber it.
+  const ownerScopedMcpRef = useRef(false)
   const router = useRouter()
   const searchParams = useSearchParams()
   const templateId = searchParams.get("template")
@@ -494,9 +499,14 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           setTools((toolsData.tools || []).filter((t: Tool) => t.enabled))
         }
 
-        if (mcpRes.ok) {
+        if (mcpRes.ok && !ownerScopedMcpRef.current) {
+          // Skip when an admin cross-user view has taken over the MCP list
+          // (loadAgent fetches the owner's servers); otherwise this mount fetch
+          // could resolve last and clobber the owner list with the admin's own.
           const mcpData = await mcpRes.json()
-          setMcpServers(mcpData || [])
+          // Re-check after the await: loadAgent may have claimed the owner-scoped
+          // list during the JSON parse, and we must not clobber it.
+          if (!ownerScopedMcpRef.current) setMcpServers(mcpData || [])
         }
 
         let availableModels: Model[] = []
@@ -562,12 +572,19 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
   useEffect(() => {
     if (!isEditMode || !localAgentId) return
 
+    // Discard results of a stale load if the effect re-runs (e.g. switching
+    // agents) before its async fetches resolve, so a late response can't
+    // clobber the current agent's state.
+    let active = true
+
     const loadAgent = async () => {
       try {
         setLoadingAgent(true)
         const response = await apiRequest(`${getApiUrl()}/api/agents/${localAgentId}`)
+        if (!active) return
         if (response.ok) {
           const agent = await response.json()
+          if (!active) return
           setOriginalData(agent)
           setName(agent.name || "")
           setDescription(agent.description || "")
@@ -580,6 +597,28 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           const rawToolCategories = agent.tool_categories || []
           setSelectedToolCategories(rawToolCategories.filter((c: string) => !c.startsWith('mcp:')))
           setSelectedMcpServers(rawToolCategories.filter((c: string) => c.startsWith('mcp:')).map((c: string) => c.replace('mcp:', '')))
+
+          // Admin inspecting someone else's agent: the mount-time /api/mcp/servers
+          // fetch returned the admin's own servers, so the owner's mcp: entries have
+          // no matching row to render. Re-fetch scoped to the owner.
+          if (user?.is_admin && agent.user_id != null && String(agent.user_id) !== String(user.id)) {
+            ownerScopedMcpRef.current = true
+            const ownerMcpRes = await apiRequest(`${getApiUrl()}/api/mcp/servers?user_id=${agent.user_id}`)
+            if (!active) return
+            if (ownerMcpRes.ok) {
+              setMcpServers((await ownerMcpRes.json()) || [])
+            }
+          } else if (ownerScopedMcpRef.current) {
+            // Switching back to a self-owned agent after an admin cross-user view:
+            // reset the guard and reload the admin's own servers, since the
+            // mount-time fetch runs only once and won't re-populate them.
+            ownerScopedMcpRef.current = false
+            const selfMcpRes = await apiRequest(`${getApiUrl()}/api/mcp/servers`)
+            if (!active) return
+            if (selfMcpRes.ok) {
+              setMcpServers((await selfMcpRes.json()) || [])
+            }
+          }
 
           setLogoUrl(agent.logo_url || null)
 
@@ -598,12 +637,15 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       } catch (error) {
         console.error("Failed to load agent:", error)
       } finally {
-        setLoadingAgent(false)
+        if (active) setLoadingAgent(false)
       }
     }
 
     loadAgent()
-  }, [isEditMode, localAgentId])
+    return () => {
+      active = false
+    }
+  }, [isEditMode, localAgentId, user?.id, user?.is_admin])
 
   // Load template data when template parameter is present
   useEffect(() => {

--- a/frontend/src/components/pages/conversation-logs.test.tsx
+++ b/frontend/src/components/pages/conversation-logs.test.tsx
@@ -4,6 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 
+// TraceEventRenderer (reused for tool-call display) pulls in next/navigation
+// useRouter() and the app-context useApp(); both need providers that aren't
+// mounted when rendering in isolation under jsdom, so stub them.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    openFilePreview: vi.fn(),
+    dispatch: vi.fn(),
+  }),
+}))
+
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
     "@/lib/api-wrapper"
@@ -26,7 +40,10 @@ vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     locale: "zh",
     setLocale: vi.fn(),
-    t: (key: string) => {
+    t: (key: string, vars?: Record<string, string | number>) => {
+      // TraceEventRenderer labels the tool button via t(key, { tool }); mirror
+      // the interpolation so the tool name is assertable.
+      if (vars?.tool) return `${key}:${vars.tool}`
       const labels: Record<string, string> = {
         "conversationLogs.title": "Conversation Logs",
         "conversationLogs.searchPlaceholder": "Search conversations",
@@ -44,17 +61,6 @@ vi.mock("@/contexts/i18n-context", () => ({
     },
   }),
 }))
-
-vi.mock("lucide-react", () => {
-  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
-  return {
-    Bot: Icon,
-    ChevronLeft: Icon,
-    ChevronRight: Icon,
-    Inbox: Icon,
-    Search: Icon,
-  }
-})
 
 import { ConversationLogsPage } from "./conversation-logs"
 
@@ -128,7 +134,7 @@ const detailPayload = {
     {
       id: 2,
       role: "assistant",
-      content: "Lead qualified",
+      content: "**Lead** qualified",
       message_type: "chat",
       created_at: "2026-06-29T01:00:20Z",
     },
@@ -145,6 +151,29 @@ const detailPayload = {
     trigger: null,
     public_context: null,
   },
+  trace_events: [
+    {
+      event_id: "step-1",
+      event_type: "react_task_start",
+      step_id: "step-1",
+      timestamp: 1750000000,
+      data: { step_name: "Search", description: "Search" },
+    },
+    {
+      event_id: "tool-start",
+      event_type: "tool_execution_start",
+      step_id: "step-1",
+      timestamp: 1750000001,
+      data: { tool_name: "web_search", tool_args: { q: "x" } },
+    },
+    {
+      event_id: "tool-end",
+      event_type: "tool_execution_end",
+      step_id: "step-1",
+      timestamp: 1750000002,
+      data: { result: { success: true } },
+    },
+  ],
   read_only: true,
 }
 
@@ -207,10 +236,25 @@ describe("ConversationLogsPage", () => {
     expect(screen.getByText("REST API 1")).toBeInTheDocument()
     expect(screen.getByText("Webhook 1")).toBeInTheDocument()
     expect(await screen.findByText("Qualify this lead")).toBeInTheDocument()
-    expect(screen.getByText("Lead qualified")).toBeInTheDocument()
+    expect(await screen.findByText("Lead", { selector: "strong" })).toBeInTheDocument()
     expect(screen.getByText("Read-only")).toBeInTheDocument()
     expect(screen.queryByText("Upload")).not.toBeInTheDocument()
     expect(screen.queryByText("Send")).not.toBeInTheDocument()
+  })
+
+  it("renders assistant markdown as formatted html", async () => {
+    render(<ConversationLogsPage />)
+    const strong = await screen.findByText("Lead", { selector: "strong" })
+    expect(strong).toBeInTheDocument()
+  })
+
+  it("renders tool calls from trace events", async () => {
+    render(<ConversationLogsPage />)
+    // A completed task's trace is collapsed behind a toggle; expand it first.
+    fireEvent.click(await screen.findByRole("button", { name: /showProcess/ }))
+    expect(
+      await screen.findByRole("button", { name: /web_search/ })
+    ).toBeInTheDocument()
   })
 
   it("formats relative times with the app locale", async () => {

--- a/frontend/src/components/pages/conversation-logs.tsx
+++ b/frontend/src/components/pages/conversation-logs.tsx
@@ -5,6 +5,8 @@ import { Bot, ChevronLeft, ChevronRight, Inbox } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { TraceEventRenderer } from "@/components/chat/TraceEventRenderer"
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
 import { SearchInput } from "@/components/ui/search-input"
 import { useI18n } from "@/contexts/i18n-context"
 import {
@@ -421,7 +423,14 @@ function ConversationLogDetail({ detail }: { detail: ConversationLogDetailRespon
                       : "rounded-bl-sm border border-slate-200 bg-white text-slate-900"
                   )}
                 >
-                  <p className="whitespace-pre-wrap break-words">{message.content}</p>
+                  {message.role === "user" ? (
+                    <p className="whitespace-pre-wrap break-words">{message.content}</p>
+                  ) : (
+                    <MarkdownRenderer
+                      content={message.content}
+                      className="prose-sm break-words [overflow-wrap:anywhere]"
+                    />
+                  )}
                 </div>
                 {message.role === "user" ? (
                   <div className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-slate-100 text-xs font-semibold text-slate-500">
@@ -432,6 +441,11 @@ function ConversationLogDetail({ detail }: { detail: ConversationLogDetailRespon
             ))}
           </div>
         )}
+        {detail.trace_events && detail.trace_events.length > 0 ? (
+          <div className="mt-6 border-t border-slate-200 pt-4">
+            <TraceEventRenderer events={detail.trace_events as any} taskStatus={log.status} />
+          </div>
+        ) : null}
       </section>
     </div>
   )

--- a/frontend/src/lib/conversation-logs-api.ts
+++ b/frontend/src/lib/conversation-logs-api.ts
@@ -60,9 +60,19 @@ export interface ConversationLogTranscriptMessage {
   created_at?: string | null
 }
 
+export interface ConversationLogTraceEvent {
+  event_id?: string
+  event_type?: string
+  step_id?: string | null
+  timestamp?: number | null
+  data?: Record<string, unknown>
+  parent_event_id?: string | null
+}
+
 export interface ConversationLogDetailResponse {
   log: ConversationLogSummary
   transcript: ConversationLogTranscriptMessage[]
+  trace_events?: ConversationLogTraceEvent[]
   metadata: {
     task?: {
       task_id: number

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -16,7 +16,7 @@ from ...core.agent.service import AgentService
 from ...core.memory.in_memory import InMemoryMemoryStore
 from ...core.tools.core.document_search import find_missing_knowledge_bases
 from ...core.tracing import create_agent_tracer
-from ..auth_dependencies import get_current_user
+from ..auth_dependencies import get_current_user, is_admin_user
 from ..models.agent import Agent, AgentOrigin
 from ..models.database import get_db
 from ..models.model import Model as DBModel
@@ -556,7 +556,10 @@ async def get_agent(
 ) -> AgentResponse:
     """Get agent details."""
     try:
-        response = AgentStore(db).get_agent_response(int(current_user.id), agent_id)
+        store = AgentStore(db)
+        response = store.get_agent_response(int(current_user.id), agent_id)
+        if response is None and is_admin_user(current_user):
+            response = store.get_agent_response_for_admin(agent_id)
         if response is None:
             raise HTTPException(status_code=404, detail="Agent not found")
         return AgentResponse.model_validate(response)

--- a/src/xagent/web/api/conversation_logs.py
+++ b/src/xagent/web/api/conversation_logs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import math
+from datetime import timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -11,10 +13,12 @@ from ..auth_dependencies import get_current_user
 from ..models.agent import Agent
 from ..models.chat_message import TaskChatMessage
 from ..models.database import get_db
-from ..models.task import Task
+from ..models.task import Task, TraceEvent
 from ..models.trigger import AgentTrigger, TriggerRun
 from ..models.user import User
 from ..utils.db_timezone import format_datetime_for_api
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/conversation-logs", tags=["conversation-logs"])
 
@@ -234,6 +238,54 @@ def _serialize_transcript(messages: list[TaskChatMessage]) -> list[dict[str, Any
     ]
 
 
+def _event_epoch(dt: Any) -> float | None:
+    """Epoch seconds for a trace timestamp. Trace events are stored UTC, but
+    SQLite hands them back naive; treat naive as UTC so the epoch is correct
+    regardless of the server's local timezone."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return float(dt.timestamp())
+
+
+def _serialize_trace_events(db: Session, task_id: int) -> list[dict[str, Any]]:
+    """Historical trace events for a task, decoded and shaped for the frontend
+    TraceEventRenderer (event_id / event_type / step_id / timestamp / data)."""
+    from ..services.trace_message_storage import decode_trace_events_data
+
+    events = (
+        db.query(TraceEvent)
+        .filter(TraceEvent.task_id == task_id, TraceEvent.build_id.is_(None))
+        .order_by(TraceEvent.id.asc())
+        .all()
+    )
+    if not events:
+        return []
+    # Trace rendering is a non-essential enrichment: a blob-load / decode failure
+    # must not 500 the whole detail page (transcript + metadata), so fail soft.
+    try:
+        decoded = decode_trace_events_data(
+            db, task_id=task_id, data_items=[e.data for e in events], strict=False
+        )
+    except Exception:
+        logger.warning(
+            "Failed to decode trace events for task %s", task_id, exc_info=True
+        )
+        return []
+    return [
+        {
+            "event_id": e.event_id,
+            "event_type": e.event_type,
+            "step_id": e.step_id,
+            "timestamp": _event_epoch(e.timestamp),
+            "data": data,
+            "parent_event_id": e.parent_event_id,
+        }
+        for e, data in zip(events, decoded)
+    ]
+
+
 def _serialize_trigger_metadata(
     db: Session,
     task: Task,
@@ -428,6 +480,7 @@ async def get_conversation_log_detail(
     return {
         "log": _serialize_log_summary(task, ui_source),
         "transcript": _serialize_transcript(messages),
+        "trace_events": _serialize_trace_events(db, int(task.id)),
         "metadata": {
             "task": {
                 "task_id": int(task.id),

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -27,7 +27,7 @@ from ...config import (
 from ...core.file_storage.factory import get_file_storage
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
-from ..auth_dependencies import get_current_user
+from ..auth_dependencies import get_current_user, is_admin_user
 from ..config import (
     BINARY_EXTENSIONS,
     MAX_FILE_SIZE,
@@ -361,7 +361,7 @@ def _file_user_id_value(file_record: UploadedFile) -> int:
 
 
 def _is_admin_user(user: User) -> bool:
-    return bool(getattr(user, "is_admin", False))
+    return is_admin_user(user)
 
 
 def _parse_task_id(task_id: Optional[str]) -> Optional[int]:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -28,7 +28,7 @@ from ...core.tools.core.mcp.data_config import MCPServerConfig
 from ...core.tools.core.mcp.manager.db import DatabaseMCPServerManager
 from ...core.tools.core.mcp.model import MASKED_SECRET_VALUE, SENSITIVE_AUTH_FIELDS
 from ...core.utils.encryption import decrypt_value, encrypt_value
-from ..auth_dependencies import get_current_user
+from ..auth_dependencies import get_current_user, is_admin_user
 from ..mcp_apps import get_all_mcp_apps, get_app_by_name
 from ..models.database import get_db
 from ..models.mcp import MCPServer, UserMCPServer
@@ -1817,29 +1817,35 @@ def list_mcp_apps(
 
 @mcp_router.get("/servers", response_model=List[MCPServerResponse])
 def get_mcp_servers(
+    user_id: Optional[int] = None,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> List[MCPServerResponse]:
-    """List MCP servers for the current user."""
+    """List MCP servers for the current user (admins may pass user_id to inspect another user)."""
     try:
         manager = DatabaseMCPServerManager(db)
-        user_id = current_user.id
+        if user_id is not None and user_id != current_user.id:
+            if not is_admin_user(current_user):
+                raise HTTPException(status_code=403, detail="Admin required")
+            effective_user_id = int(user_id)
+        else:
+            effective_user_id = int(current_user.id)
 
         # Get user's MCP servers
         user_mcps = (
             db.query(UserMCPServer, MCPServer)
             .join(MCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
-            .filter(UserMCPServer.user_id == user_id)
+            .filter(UserMCPServer.user_id == effective_user_id)
             .order_by(MCPServer.created_at.desc())
             .all()
         )
 
-        logger.info(f"user_mcps: {user_mcps}")
-
         # Fetch oauth emails
         from ..models.user_oauth import UserOAuth
 
-        oauth_accounts = db.query(UserOAuth).filter(UserOAuth.user_id == user_id).all()
+        oauth_accounts = (
+            db.query(UserOAuth).filter(UserOAuth.user_id == effective_user_id).all()
+        )
         oauth_emails = {
             str(oauth.provider): str(oauth.email)
             for oauth in oauth_accounts
@@ -1870,7 +1876,7 @@ def get_mcp_servers(
         user_custom_apis = (
             db.query(UserCustomApi, CustomApi)
             .join(CustomApi, UserCustomApi.custom_api_id == CustomApi.id)
-            .filter(UserCustomApi.user_id == user_id)
+            .filter(UserCustomApi.user_id == effective_user_id)
             .all()
         )
 
@@ -1908,6 +1914,8 @@ def get_mcp_servers(
 
         return responses
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to list MCP servers: {e}")
         raise HTTPException(

--- a/src/xagent/web/auth_dependencies.py
+++ b/src/xagent/web/auth_dependencies.py
@@ -177,6 +177,15 @@ def require_user(user: User = Depends(get_current_user)) -> User:
     return user
 
 
+def is_admin_user(user: User) -> bool:
+    """Whether the user has platform-admin privileges.
+
+    Centralizes the ``is_admin`` check so cross-user authorization gates read
+    consistently instead of re-deriving ``getattr(user, "is_admin", False)``.
+    """
+    return bool(getattr(user, "is_admin", False))
+
+
 def get_user_from_websocket_token(token: str, db: Session) -> Optional[User]:
     """
     Get user from WebSocket authentication token

--- a/src/xagent/web/services/agent_store.py
+++ b/src/xagent/web/services/agent_store.py
@@ -138,6 +138,25 @@ class AgentStore:
             .first()
         )
 
+    def get_agent_response_for_admin(self, agent_id: int) -> dict[str, Any] | None:
+        """Read any agent's detail regardless of owner (admin-only path).
+
+        Deliberately bypasses the hot-path cache: the detail cache is keyed by
+        (viewer_user_id, agent_id) and only invalidated for the owner on write,
+        so caching an admin's cross-user read would go stale on owner edits.
+        """
+        agent = (
+            self.db.query(Agent)
+            .filter(
+                Agent.id == agent_id,
+                Agent.origin != AgentOrigin.WORKFORCE_GENERATED_MANAGER.value,
+            )
+            .first()
+        )
+        if agent is None:
+            return None
+        return self.agent_to_response_dict(agent)
+
     def agent_name_exists(
         self, user_id: int, name: str, *, exclude_agent_id: int | None = None
     ) -> bool:

--- a/src/xagent/web/services/trace_message_storage.py
+++ b/src/xagent/web/services/trace_message_storage.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -17,6 +18,8 @@ from sqlalchemy.orm import Session
 
 from ...core.agent.checkpoint import READABLE_CHECKPOINT_TYPES
 from ..models.task import TraceCheckpointBlob, TraceMessageBlob
+
+logger = logging.getLogger(__name__)
 
 MESSAGE_REFS_ENCODING = "xagent.message_refs_v1"
 CHECKPOINT_BLOB_REF_ENCODING = "xagent.checkpoint_blob_ref_v1"
@@ -351,7 +354,20 @@ def decode_trace_events_data(
     if verify_blob_hashes is None:
         verify_blob_hashes = strict
 
-    lookup = _load_trace_blob_lookup(db, task_id=task_id, data_items=data_items)
+    # A failed bulk blob lookup must not drop the whole task's events: under
+    # strict mode surface it, otherwise degrade to no-lookup so each item still
+    # decodes (blob-backed ones fall back per-item below).
+    try:
+        lookup = _load_trace_blob_lookup(db, task_id=task_id, data_items=data_items)
+    except Exception:
+        if strict:
+            raise
+        logger.warning(
+            "Bulk trace-blob lookup failed for task %s; decoding without blobs",
+            task_id,
+            exc_info=True,
+        )
+        lookup = None
     decoded_items: list[Any] = []
     for data in data_items:
         try:

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -37,6 +37,7 @@ from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
 from xagent.web.api.conversation_logs import router as conversation_logs_router
 from xagent.web.api.files import file_router
+from xagent.web.api.mcp import mcp_router
 from xagent.web.api.me import router as me_router
 from xagent.web.api.share import share_router
 from xagent.web.api.triggers import router as triggers_router
@@ -71,6 +72,7 @@ app_for_tests.include_router(agents_router)
 app_for_tests.include_router(agent_api_keys_router)
 app_for_tests.include_router(workforces_router)
 app_for_tests.include_router(file_router)
+app_for_tests.include_router(mcp_router)
 app_for_tests.include_router(widget_router)
 app_for_tests.include_router(share_router)
 app_for_tests.include_router(triggers_router)

--- a/tests/web/api/test_agents_management.py
+++ b/tests/web/api/test_agents_management.py
@@ -1149,3 +1149,40 @@ class TestDeleteAgent:
             )
         finally:
             db.close()
+
+
+def test_admin_can_read_other_users_agent_detail():
+    """管理员只读查看普通用户的 agent 详情。"""
+    admin = _admin_headers()
+    bob = _register_second_user("bob", "bobpass1")
+
+    created = client.post(
+        "/api/agents",
+        headers=bob,
+        json={
+            "name": "Bob Agent",
+            "instructions": "hi",
+            "tool_categories": ["mcp:foo"],
+        },
+    )
+    assert created.status_code == 200, created.text
+    agent_id = created.json()["id"]
+
+    resp = client.get(f"/api/agents/{agent_id}", headers=admin)
+    assert resp.status_code == 200, resp.text
+    assert "mcp:foo" in resp.json()["tool_categories"]
+
+
+def test_non_admin_cannot_read_other_users_agent_detail():
+    """普通用户读别人 agent 仍 404，不泄露存在性。"""
+    _admin_headers()
+    bob = _register_second_user("bob", "bobpass1")
+    carol = _register_second_user("carol", "carolpass1")
+
+    created = client.post(
+        "/api/agents", headers=bob, json={"name": "Bob Agent", "instructions": "hi"}
+    )
+    agent_id = created.json()["id"]
+
+    resp = client.get(f"/api/agents/{agent_id}", headers=carol)
+    assert resp.status_code == 404

--- a/tests/web/api/test_conversation_logs.py
+++ b/tests/web/api/test_conversation_logs.py
@@ -10,7 +10,7 @@ from sqlalchemy import event
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import get_engine
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.trigger import AgentTrigger, TriggerRun, TriggerRunStatus
 from xagent.web.models.user import User
 
@@ -701,3 +701,40 @@ def test_conversation_logs_list_batches_trigger_type_lookup() -> None:
         if "FROM trigger_runs" in statement or "FROM agent_triggers" in statement
     ]
     assert len(trigger_lookup_queries) <= 2
+
+
+def test_detail_returns_trace_events() -> None:
+    admin = _admin_headers()
+    admin_id = _user_id("admin")
+    agent_id = _create_agent_row(user_id=admin_id, name="Trace Agent")
+    task_id = _create_task_row(
+        user_id=admin_id,
+        title="Trace REST task",
+        source="sdk",
+        is_visible=False,
+        agent_id=agent_id,
+        input_text="hi",
+        output_text="done",
+    )
+
+    db = _direct_db_session()
+    try:
+        db.add(
+            TraceEvent(
+                task_id=task_id,
+                event_id="evt-1",
+                event_type="tool_call_start",
+                timestamp=datetime.now(timezone.utc),
+                data={"tool_name": "search", "tool_args": {"q": "x"}},
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.get(f"/api/conversation-logs/{task_id}", headers=admin)
+    assert resp.status_code == 200, resp.text
+    events = resp.json()["trace_events"]
+    assert len(events) == 1
+    assert events[0]["event_type"] == "tool_call_start"
+    assert events[0]["data"]["tool_name"] == "search"

--- a/tests/web/api/test_mcp_admin_visibility.py
+++ b/tests/web/api/test_mcp_admin_visibility.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.user import User
+
+from .conftest import _admin_headers, _direct_db_session, _register_second_user, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _uid(username: str) -> int:
+    db = _direct_db_session()
+    try:
+        return int(db.query(User).filter(User.username == username).one().id)
+    finally:
+        db.close()
+
+
+def _make_server_for(user_id: int, name: str) -> None:
+    db = _direct_db_session()
+    try:
+        server = MCPServer(
+            name=name, managed="external", transport="stdio", description="d"
+        )
+        db.add(server)
+        db.flush()
+        db.add(UserMCPServer(user_id=user_id, mcpserver_id=server.id, is_active=True))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_admin_can_list_other_users_mcp_servers():
+    admin = _admin_headers()
+    _register_second_user("bob", "bobpass1")
+    bob_id = _uid("bob")
+    _make_server_for(bob_id, "bob-server")
+
+    resp = client.get(f"/api/mcp/servers?user_id={bob_id}", headers=admin)
+    assert resp.status_code == 200, resp.text
+    names = [s["name"] for s in resp.json()]
+    assert "bob-server" in names
+
+
+def test_non_admin_cannot_pass_user_id():
+    _admin_headers()
+    bob = _register_second_user("bob", "bobpass1")
+    # Target a user id that is definitely not bob's, so the 403 comes from the
+    # admin gate rather than falling through to the own-scope branch.
+    admin_id = _uid("admin")
+    resp = client.get(f"/api/mcp/servers?user_id={admin_id}", headers=bob)
+    assert resp.status_code == 403

--- a/tests/web/test_trace_message_storage.py
+++ b/tests/web/test_trace_message_storage.py
@@ -393,6 +393,45 @@ def test_decode_trace_events_data_batches_blob_queries() -> None:
         db.close()
 
 
+def test_decode_trace_events_data_degrades_when_bulk_lookup_fails() -> None:
+    from unittest.mock import patch
+
+    import xagent.web.services.trace_message_storage as tms
+
+    SessionLocal = _session_factory()
+    db = SessionLocal()
+    try:
+        task = _create_task(db)
+        task_id = int(task.id)
+        messages = [{"role": "user", "content": "hello"}]
+        item = encode_checkpoint_data_for_storage(
+            db,
+            task_id=task_id,
+            data=_checkpoint_data_with_large_fields("exec-degrade", messages),
+        )
+        db.flush()
+
+        boom = RuntimeError("bulk lookup boom")
+
+        # Non-strict: a failed bulk lookup must not drop the event; it degrades to
+        # per-ref blob queries and still resolves the messages.
+        with patch.object(tms, "_load_trace_blob_lookup", side_effect=boom):
+            decoded = decode_trace_events_data(
+                db, task_id=task_id, data_items=[item], strict=False
+            )
+        assert len(decoded) == 1
+        assert decoded[0]["snapshot"]["context"]["messages"] == messages
+
+        # Strict: the failure surfaces instead of being swallowed.
+        with patch.object(tms, "_load_trace_blob_lookup", side_effect=boom):
+            with pytest.raises(RuntimeError):
+                decode_trace_events_data(
+                    db, task_id=task_id, data_items=[item], strict=True
+                )
+    finally:
+        db.close()
+
+
 def test_blob_lookups_respect_sqlite_bind_parameter_limit() -> None:
     SessionLocal = _session_factory()
     db = SessionLocal()


### PR DESCRIPTION
## What

Two related improvements that unblock admins debugging user-built agents:

### Admin visibility into user agent config
- `GET /api/agents/{id}`: when the caller is an admin and is not the owner, return the agent read-only (owner cache path is bypassed to avoid stale cross-user cache entries). Writes stay owner-only.
- `GET /api/mcp/servers?user_id=`: admins may pass `user_id` to list another user's MCP servers; non-admins passing it get 403. Env values stay masked.
- Agent builder: when an admin opens another user's agent, the MCP list is fetched scoped to the owner so the agent's `mcp:` tools render.

### Conversation-log detail rendering
- Assistant replies now render as markdown (reusing `MarkdownRenderer`) instead of plain text.
- Tool calls are shown: the detail endpoint returns decoded `trace_events` and the page reuses `TraceEventRenderer`.

## Notes
- Trace serialization fails soft: a decode/blob error logs a warning and returns an empty list rather than 500-ing the whole detail page.
- Admin cross-user MCP fetch is guarded against a race with the mount-time fetch so the owner-scoped list is authoritative.
- The markdown/tool-call rendering benefits all users viewing their own logs, not just admins.

## Test
- Backend: `pytest tests/web/api/test_agents_management.py tests/web/api/test_mcp_admin_visibility.py tests/web/api/test_conversation_logs.py`
- Frontend: `vitest run src/components/pages/conversation-logs.test.tsx`, `npm run type-check`
