### PR TITLE
fix(migrations): merge alembic heads left by #781

### DIFF
--- a/src/xagent/migrations/versions/20260707_merge_alembic_heads.py
+++ b/src/xagent/migrations/versions/20260707_merge_alembic_heads.py
@@ -1,0 +1,32 @@
+"""merge two alembic heads on main
+
+20260703_add_multi_key_support_to_agent_api_keys (multi API keys per
+agent) and 20260706_add_agent_widget_key (per-agent widget key) both
+branch from 20260705_add_user_mcpserver_env_source, leaving the
+migration graph with two heads. This is a no-op merge revision that
+reunites them into a single head.
+
+Revision ID: 20260707_merge_alembic_heads
+Revises: 20260703_add_multi_key_support_to_agent_api_keys, 20260706_add_agent_widget_key
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20260707_merge_alembic_heads"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260703_add_multi_key_support_to_agent_api_keys",
+    "20260706_add_agent_widget_key",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

Main CI is currently red: [#781](https://github.com/xorbitsai/xagent/pull/781) added `20260706_add_agent_widget_key` and the multi-API-key work added `20260703_add_multi_key_support_to_agent_api_keys`, and both revise `20260705_add_user_mcpserver_env_source`. After #781 merged, the migration graph has two heads, so `alembic upgrade head` fails with `MultipleHeads` in:

- **Test Database Migrations** (SQLite + PostgreSQL) on `main`
- the `alembic-check` pre-commit hook, which also fails **Pull Request Checks** on `main` and on every open PR's merge build (e.g. #780)

This PR adds a no-op merge revision `20260707_merge_alembic_heads` that reunites the two heads, following the precedent of `20260704_merge_alembic_heads`.

## Verification

- `alembic heads` now reports a single head: `20260707_merge_alembic_heads`
- `alembic upgrade head` on a fresh SQLite database runs the full chain successfully
- `scripts/check_alembic_heads.sh` (the failing pre-commit hook) passes
