### PR TITLE
fix: keep durable file previews independent of storage paths

### DIFF
--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -388,6 +388,13 @@ def _build_unique_file_path(path: Path) -> Path:
 
 
 def _ensure_under_uploads(path: Path, user_id: int) -> None:
+    if _is_under_uploads(path, user_id):
+        return
+
+    raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _is_under_uploads(path: Path, user_id: int) -> bool:
     resolved_path = path.resolve()
     uploads_dir = get_uploads_dir()
     uploads_root = uploads_dir.resolve()
@@ -395,8 +402,9 @@ def _ensure_under_uploads(path: Path, user_id: int) -> None:
     try:
         resolved_path.relative_to(uploads_root)
         resolved_path.relative_to(user_root)
-    except ValueError as exc:
-        raise HTTPException(status_code=403, detail="Access denied") from exc
+    except ValueError:
+        return False
+    return True
 
 
 def _resolve_public_preview_target(
@@ -1079,7 +1087,7 @@ async def download_file(
         file_ref = ManagedFileRef(file_record)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
-        _ensure_under_uploads(full_path, owner_user_id)
+        local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
         content_disposition = _inline_download_disposition(media_type)
         redirect_response = _durable_redirect_response(
             file_ref,
@@ -1089,7 +1097,7 @@ async def download_file(
         )
         if redirect_response is not None:
             return redirect_response
-        if full_path.exists() and full_path.is_file():
+        if local_path_is_trusted and full_path.exists() and full_path.is_file():
             accel_response = _accel_redirect_response(
                 full_path,
                 owner_user_id=owner_user_id,
@@ -1111,16 +1119,19 @@ async def download_file(
             )
         if file_ref.has_durable_object:
             try:
-                restored_path = file_ref.ensure_local()
-                accel_response = _accel_redirect_response(
-                    restored_path,
-                    owner_user_id=owner_user_id,
-                    filename=file_name,
-                    media_type=media_type,
-                    disposition=content_disposition,
-                )
-                if accel_response is not None:
-                    return accel_response
+                if local_path_is_trusted:
+                    restored_path = file_ref.ensure_local()
+                    accel_response = _accel_redirect_response(
+                        restored_path,
+                        owner_user_id=owner_user_id,
+                        filename=file_name,
+                        media_type=media_type,
+                        disposition=content_disposition,
+                    )
+                    if accel_response is not None:
+                        return accel_response
+                else:
+                    restored_path = file_ref.materialize(allow_existing_local=False)
                 return FileResponse(
                     path=str(restored_path),
                     filename=file_name,
@@ -1133,6 +1144,19 @@ async def download_file(
                 )
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
+            except DurableObjectMissingError:
+                restored_path = file_ref.local_path
+                _ensure_under_uploads(restored_path, owner_user_id)
+                return FileResponse(
+                    path=str(restored_path),
+                    filename=file_name,
+                    media_type=media_type,
+                    headers={
+                        "Content-Disposition": _content_disposition_header(
+                            content_disposition, file_name
+                        )
+                    },
+                )
             except DurableStorageOperationError as exc:
                 raise _durable_storage_unavailable() from exc
     else:
@@ -1189,7 +1213,7 @@ async def preview_file(
         file_ref = ManagedFileRef(file_record)
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
-        _ensure_under_uploads(full_path, owner_user_id)
+        local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
         if _preview_can_redirect(full_path, media_type):
             redirect_response = _durable_redirect_response(
                 file_ref,
@@ -1199,24 +1223,28 @@ async def preview_file(
             )
             if redirect_response is not None:
                 return redirect_response
-            accel_response = _accel_redirect_response(
-                full_path,
-                owner_user_id=owner_user_id,
-                filename=file_name,
-                media_type=media_type,
-                disposition="inline",
-            )
-            if accel_response is not None:
-                return accel_response
+            if local_path_is_trusted:
+                accel_response = _accel_redirect_response(
+                    full_path,
+                    owner_user_id=owner_user_id,
+                    filename=file_name,
+                    media_type=media_type,
+                    disposition="inline",
+                )
+                if accel_response is not None:
+                    return accel_response
         if file_ref.has_durable_object:
             try:
-                materialized_path = file_ref.materialize()
+                materialized_path = file_ref.materialize(
+                    allow_existing_local=local_path_is_trusted
+                )
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
                 raise _durable_storage_unavailable() from exc
             except DurableObjectMissingError:
                 materialized_path = file_ref.local_path
+                _ensure_under_uploads(materialized_path, owner_user_id)
             return FileResponse(
                 path=str(materialized_path),
                 filename=file_name,
@@ -1287,11 +1315,13 @@ async def preview_pptx_as_pdf(
     if file_record:
         _check_file_access(file_record, user)
         file_name = str(file_record.filename)
-        _ensure_under_uploads(full_path, owner_user_id)
         file_ref = ManagedFileRef(file_record)
+        local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
         if file_ref.has_durable_object:
             try:
-                pptx_path = file_ref.materialize()
+                pptx_path = file_ref.materialize(
+                    allow_existing_local=local_path_is_trusted
+                )
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
@@ -1300,6 +1330,9 @@ async def preview_pptx_as_pdf(
                 # Durable record points at nothing; fall back to whatever
                 # is on disk (or 404 below if it's gone too).
                 pptx_path = file_ref.local_path
+                _ensure_under_uploads(pptx_path, owner_user_id)
+        else:
+            _ensure_under_uploads(full_path, owner_user_id)
     else:
         if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
             raise HTTPException(status_code=403, detail="Access denied")
@@ -1361,6 +1394,7 @@ async def public_download_file(
     """
     file_record: Optional[UploadedFile] = None
     target_path: Optional[Path] = None
+    target_is_durable = False
     file_name: str
 
     if is_valid_uuid(file_id):
@@ -1372,11 +1406,14 @@ async def public_download_file(
         _validate_public_task_file_access(db, file_record, token)
         file_ref = ManagedFileRef(file_record)
         owner_user_id = _file_user_id_value(file_record)
-        _ensure_under_uploads(file_ref.local_path, owner_user_id)
         file_name = str(file_record.filename)
+        local_path_is_trusted = _is_under_uploads(file_ref.local_path, owner_user_id)
         if file_ref.has_durable_object:
             try:
-                target_path = file_ref.ensure_local()
+                target_path = file_ref.materialize(
+                    allow_existing_local=local_path_is_trusted
+                )
+                target_is_durable = True
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
@@ -1394,6 +1431,9 @@ async def public_download_file(
         target_path, owner_user_id = result
         _ensure_under_uploads(target_path, owner_user_id)
         file_name = target_path.name
+
+    if not target_is_durable:
+        _ensure_under_uploads(target_path, owner_user_id)
 
     if not target_path.exists() or not target_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")
@@ -1435,16 +1475,18 @@ async def public_preview_file(
         file_ref = ManagedFileRef(file_record)
         base_path = file_ref.local_path
         owner_user_id = _file_user_id_value(file_record)
-        _ensure_under_uploads(base_path, owner_user_id)
         if file_ref.has_durable_object and not relative_path:
             try:
-                target_path = file_ref.materialize()
+                target_path = file_ref.materialize(
+                    allow_existing_local=_is_under_uploads(base_path, owner_user_id)
+                )
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
                 raise _durable_storage_unavailable() from exc
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
+                _ensure_under_uploads(target_path, owner_user_id)
             return FileResponse(
                 path=str(target_path),
                 filename=str(file_record.filename),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -869,12 +869,14 @@ def _add_file_link_aliases(
     if not normalized_relative_path:
         return
 
-    path_to_file_id[normalized_relative_path] = file_id
-    path_to_file_id[f"/{normalized_relative_path}"] = file_id
-    path_to_file_id[f"preview/{normalized_relative_path}"] = file_id
-    path_to_file_id[f"/preview/{normalized_relative_path}"] = file_id
-    path_to_file_id[f"uploads/{normalized_relative_path}"] = file_id
-    path_to_file_id[f"/uploads/{normalized_relative_path}"] = file_id
+    for prefix in ("", "/", "preview/", "/preview/", "uploads/", "/uploads/"):
+        _set_file_link_alias(
+            path_to_file_id, f"{prefix}{normalized_relative_path}", file_id
+        )
+
+    basename = Path(normalized_relative_path).name
+    if basename and basename != normalized_relative_path:
+        _set_file_link_alias(path_to_file_id, basename, file_id)
 
     parts = Path(normalized_relative_path).parts
     task_local_parts: tuple[str, ...] = ()
@@ -894,8 +896,24 @@ def _add_file_link_aliases(
 
     if task_local_parts and task_local_parts[0] in {"input", "output", "temp"}:
         task_local_path = "/".join(task_local_parts)
-        path_to_file_id[task_local_path] = file_id
-        path_to_file_id[f"/{task_local_path}"] = file_id
+        _set_file_link_alias(path_to_file_id, task_local_path, file_id)
+        _set_file_link_alias(path_to_file_id, f"/{task_local_path}", file_id)
+
+
+def _set_file_link_alias(
+    path_to_file_id: Dict[str, str], alias: str, file_id: str
+) -> None:
+    existing_file_id = path_to_file_id.get(alias)
+    if existing_file_id is None or existing_file_id == file_id:
+        path_to_file_id[alias] = file_id
+        return
+
+    # A bare ``file:report.txt`` link is ambiguous when multiple outputs can
+    # claim the same alias. Keep scoped aliases but disable ambiguous rewriting
+    # so we never point the user at the wrong artifact. The empty string is a
+    # sticky sentinel for this alias: once ambiguous, later registrations cannot
+    # reclaim it for a single file.
+    path_to_file_id[alias] = ""
 
 
 def _uploaded_file_record_in_task_scope(
@@ -995,12 +1013,14 @@ def _normalize_file_outputs(
         for raw_path in raw_paths:
             stripped = raw_path.strip()
             if stripped:
-                path_to_file_id[stripped] = final_file_id
-                path_to_file_id[stripped.lstrip("/")] = final_file_id
+                _set_file_link_alias(path_to_file_id, stripped, final_file_id)
+                _set_file_link_alias(
+                    path_to_file_id, stripped.lstrip("/"), final_file_id
+                )
 
         storage_path = getattr(file_record, "storage_path", None)
         if storage_path:
-            path_to_file_id[str(storage_path)] = final_file_id
+            _set_file_link_alias(path_to_file_id, str(storage_path), final_file_id)
 
         workspace_relative_path = getattr(file_record, "workspace_relative_path", None)
         if isinstance(workspace_relative_path, str) and workspace_relative_path.strip():
@@ -1182,12 +1202,11 @@ def _normalize_file_outputs(
 
         if workspace_relative_path != normalized_relative_path:
             final_file_id = str(file_record.file_id)
-            path_to_file_id[workspace_relative_path] = final_file_id
-            path_to_file_id[f"/{workspace_relative_path}"] = final_file_id
-            path_to_file_id[f"preview/{workspace_relative_path}"] = final_file_id
-            path_to_file_id[f"/preview/{workspace_relative_path}"] = final_file_id
-            path_to_file_id[f"uploads/{workspace_relative_path}"] = final_file_id
-            path_to_file_id[f"/uploads/{workspace_relative_path}"] = final_file_id
+            _add_file_link_aliases(
+                path_to_file_id,
+                workspace_relative_path,
+                final_file_id,
+            )
 
     if changed:
         db.commit()

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -186,9 +186,9 @@ class ManagedFileRef:
                 f"Failed to restore durable object: {self.storage_key}"
             ) from exc
 
-    def materialize(self) -> Path:
+    def materialize(self, *, allow_existing_local: bool = True) -> Path:
         path = self.local_path
-        if path.exists() and path.is_file():
+        if allow_existing_local and path.exists() and path.is_file():
             return path
 
         if not self.has_durable_object:

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -86,6 +86,31 @@ def test_materialize_uses_temp_dir_when_original_path_is_missing(monkeypatch, tm
     assert not local_path.exists()
 
 
+def test_materialize_can_ignore_existing_local_path(monkeypatch, tmp_path):
+    _configure_storage(monkeypatch, tmp_path)
+    storage = get_unscoped_file_storage()
+    stored = storage.put_bytes(
+        b"durable content", "users/7/uploads/file-123/preview.txt"
+    )
+    local_path = tmp_path / "stale-worktree" / "preview.txt"
+    local_path.parent.mkdir()
+    local_path.write_text("stale local content", encoding="utf-8")
+    record = _record(
+        local_path,
+        storage_backend=stored.backend,
+        storage_key=stored.key,
+        storage_uri=stored.uri,
+        storage_status="available",
+        checksum=stored.checksum,
+    )
+
+    materialized = ManagedFileRef(record).materialize(allow_existing_local=False)
+
+    assert materialized.is_relative_to(tmp_path / "materialized")
+    assert materialized.read_text(encoding="utf-8") == "durable content"
+    assert local_path.read_text(encoding="utf-8") == "stale local content"
+
+
 def test_ensure_local_rejects_restored_checksum_mismatch(monkeypatch, tmp_path):
     _configure_storage(monkeypatch, tmp_path)
     storage = get_unscoped_file_storage()

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -155,6 +155,18 @@ def _corrupt_durable_copy_and_remove_local(
             path.unlink()
 
 
+def _replace_uploaded_file_storage_path(test_app: FastAPI, file_id: str, path: Path):
+    db = next(test_app.dependency_overrides[get_db]())
+    try:
+        file_record = (
+            db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+        )
+        file_record.storage_path = str(path)
+        db.commit()
+    finally:
+        db.close()
+
+
 class TestFileUpload:
     """Test file upload functionality"""
 
@@ -215,6 +227,103 @@ class TestFileUpload:
 
         assert download.status_code == 200
         assert download.content == b"durable content"
+
+    def test_registered_file_uses_durable_storage_when_storage_path_is_stale(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, tmp_path
+    ):
+        """A stale worktree storage_path must not block durable file access."""
+        _, test_app = test_db
+        monkeypatch.setenv(
+            "XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path / "materialized")
+        )
+        get_unscoped_file_storage.cache_clear()
+
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("stale.txt", b"durable bytes", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        stale_path = (
+            tmp_path
+            / "deleted-worktree"
+            / "src"
+            / "xagent"
+            / "web"
+            / "uploads"
+            / "user_1"
+            / "web_task_99"
+            / "output"
+            / "stale.txt"
+        )
+        stale_path.parent.mkdir(parents=True)
+        stale_path.write_bytes(b"wrong local bytes")
+        _replace_uploaded_file_storage_path(test_app, file_id, stale_path)
+
+        for endpoint, headers in [
+            (f"/api/files/preview/{file_id}", auth_headers),
+            (f"/api/files/download/{file_id}", auth_headers),
+            (f"/api/files/public/preview/{file_id}", {}),
+            (f"/api/files/public/download/{file_id}", {}),
+        ]:
+            result = client.get(endpoint, headers=headers)
+            assert result.status_code == 200
+            assert result.content == b"durable bytes"
+
+        assert stale_path.read_bytes() == b"wrong local bytes"
+
+    def test_durable_missing_fallback_rejects_untrusted_storage_path(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, tmp_path
+    ):
+        """Durable fallback must not serve an untrusted local storage_path."""
+        from xagent.web.services.managed_file_ref import (
+            DurableObjectMissingError,
+            ManagedFileRef,
+        )
+
+        _, test_app = test_db
+        response = client.post(
+            "/api/files/upload",
+            files={
+                "file": (
+                    "missing.pptx",
+                    b"durable bytes",
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                )
+            },
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        file_id = response.json()["file_id"]
+
+        stale_path = tmp_path / "outside-uploads" / "missing.txt"
+        stale_path.parent.mkdir()
+        stale_path.write_bytes(b"wrong local bytes")
+        _replace_uploaded_file_storage_path(test_app, file_id, stale_path)
+
+        def missing_durable_object(
+            self: ManagedFileRef, *, allow_existing_local: bool = True
+        ):
+            del allow_existing_local
+            raise DurableObjectMissingError(self.local_path)
+
+        monkeypatch.setattr(ManagedFileRef, "materialize", missing_durable_object)
+
+        for endpoint, headers in [
+            (f"/api/files/download/{file_id}", auth_headers),
+            (f"/api/files/preview/{file_id}", auth_headers),
+            (f"/api/files/preview-pdf/{file_id}", auth_headers),
+            (f"/api/files/public/download/{file_id}", {}),
+            (f"/api/files/public/preview/{file_id}", {}),
+        ]:
+            result = client.get(endpoint, headers=headers)
+            assert result.status_code == 403
+
+        assert stale_path.read_bytes() == b"wrong local bytes"
 
     def test_download_redirects_to_signed_durable_url_when_enabled(
         self, client, temp_uploads_dir, auth_headers, monkeypatch

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -17,6 +17,7 @@ from xagent.web.api.websocket import (
     _normalize_file_outputs,
     _normalize_task_file_outputs,
     _register_uploaded_files_for_agent,
+    _rewrite_file_links_to_file_id,
     _selected_file_refs_from_task,
     execute_task_background,
     handle_file_upload_for_task,
@@ -712,7 +713,103 @@ def test_normalize_file_outputs_accepts_registered_agent_workspace_output(
     )
     assert path_to_file_id[str(worker_path)] == "delegated-output"
     assert path_to_file_id["output/report.txt"] == "delegated-output"
+    assert path_to_file_id["report.txt"] == "delegated-output"
+    assert (
+        _rewrite_file_links_to_file_id(
+            "Final file: [report.txt](file:report.txt)", path_to_file_id
+        )
+        == "Final file: [report.txt](file:delegated-output)"
+    )
     assert db_session.query(UploadedFile).count() == 1
+
+
+def test_normalize_file_outputs_does_not_rewrite_ambiguous_basename(
+    db_session,
+    tmp_path,
+    monkeypatch,
+):
+    uploads_dir = tmp_path / "uploads"
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(uploads_dir))
+    _create_user(db_session, 1, "owner")
+    _create_task(db_session, task_id=20, user_id=1)
+
+    first_path = uploads_dir / "agent_2_abcd1234" / "output" / "first" / "report.txt"
+    second_path = uploads_dir / "agent_2_abcd1234" / "output" / "second" / "report.txt"
+    exact_path = uploads_dir / "agent_2_abcd1234" / "output" / "report.txt"
+    first_path.parent.mkdir(parents=True)
+    second_path.parent.mkdir(parents=True)
+    exact_path.parent.mkdir(parents=True, exist_ok=True)
+    first_path.write_text("first")
+    second_path.write_text("second")
+    exact_path.write_text("exact")
+    db_session.add_all(
+        [
+            UploadedFile(
+                file_id="first-output",
+                user_id=1,
+                task_id=20,
+                filename="report.txt",
+                storage_path=str(first_path),
+                mime_type="text/plain",
+                file_size=len("first"),
+                workspace_relative_path="output/first/report.txt",
+                workspace_category="output",
+            ),
+            UploadedFile(
+                file_id="second-output",
+                user_id=1,
+                task_id=20,
+                filename="report.txt",
+                storage_path=str(second_path),
+                mime_type="text/plain",
+                file_size=len("second"),
+                workspace_relative_path="output/second/report.txt",
+                workspace_category="output",
+            ),
+            UploadedFile(
+                file_id="exact-output",
+                user_id=1,
+                task_id=20,
+                filename="report.txt",
+                storage_path=str(exact_path),
+                mime_type="text/plain",
+                file_size=len("exact"),
+                workspace_relative_path="report.txt",
+                workspace_category="output",
+            ),
+        ]
+    )
+    db_session.flush()
+
+    normalized_outputs, path_to_file_id = _normalize_file_outputs(
+        db_session,
+        task_id=20,
+        task_user_id=1,
+        file_outputs=[{"path": str(first_path)}, {"path": str(second_path)}],
+    )
+
+    assert len(normalized_outputs) == 2
+    assert path_to_file_id["output/first/report.txt"] == "first-output"
+    assert path_to_file_id["output/second/report.txt"] == "second-output"
+    assert path_to_file_id["report.txt"] == ""
+    assert (
+        _rewrite_file_links_to_file_id(
+            "Ambiguous file: [report.txt](file:report.txt)", path_to_file_id
+        )
+        == "Ambiguous file: [report.txt](file:report.txt)"
+    )
+
+    normalized_outputs, path_to_file_id = _normalize_file_outputs(
+        db_session,
+        task_id=20,
+        task_user_id=1,
+        file_outputs=[{"path": str(first_path)}, {"path": str(exact_path)}],
+    )
+
+    assert len(normalized_outputs) == 2
+    assert path_to_file_id["output/first/report.txt"] == "first-output"
+    assert path_to_file_id["preview/report.txt"] == "exact-output"
+    assert path_to_file_id["report.txt"] == ""
 
 
 def test_normalize_file_outputs_rejects_registered_non_output_agent_file(


### PR DESCRIPTION
## Summary
- rewrite bare generated file links like `file:report.txt` to registered `file_id` values when unambiguous
- serve registered durable files through durable storage even when the stored local `storage_path` points at a stale/deleted worktree
- keep uploads-root enforcement for legacy paths and untrusted local fallbacks

## Root Cause
Generated outputs could be persisted to durable storage, but final markdown sometimes linked them by bare filename. That left the frontend calling preview routes with a legacy path token instead of the registered `file_id`. Even after resolving a `file_id`, stale `storage_path` values could still block preview/download before durable storage fallback ran.

## Validation
- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent-storage-path/src pytest tests/web/test_file_upload.py`
- `PYTHONPATH=/Users/xuyeqin/Workspace/xagent-storage-path/src pytest tests/web/test_websocket_uploaded_files_context.py tests/web/services/test_managed_file_ref.py tests/web/services/test_uploaded_file_storage.py`
- targeted public preview and websocket link rewrite tests
- pre-commit hooks: ruff check, ruff format, mypy, isort, codespell
