### PR TITLE
fix(kb): shrink KBCoordinator to a pure router

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/coordinator.py
@@ -551,16 +551,17 @@ class KBCoordinator:
         user_id: Optional[int] = None,
         is_admin: bool = False,
     ) -> list:
-        """Delegate to the ingestion status store (async, collection-scoped).
-
-        # Status reads need no metadata/collection resolution; going direct keeps
-        # the nested-storage rebind test working and avoids an unnecessary collection
-        # lookup.
-        """
-        store = self._storage_shim.get_ingestion_status_store()
+        """Open the collection handle and load ingestion status (async)."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+                hide_missing=True,
+            )
+        )
         return await asyncio.to_thread(
-            store.load_ingestion_status,
-            collection=collection,
+            handle.load_ingestion_status,
             doc_id=doc_id,
             user_id=user_id,
             is_admin=is_admin,
@@ -589,15 +590,16 @@ class KBCoordinator:
         user_id: Optional[int] = None,
         is_admin: bool = False,
     ) -> list:
-        """Delegate to the ingestion status store (direct async, collection-scoped).
-
-        # Status reads need no metadata/collection resolution; going direct keeps
-        # the nested-storage rebind test working and avoids an unnecessary collection
-        # lookup.
-        """
-        store = self._storage_shim.get_ingestion_status_store()
-        return await store.load_ingestion_status_async(
-            collection=collection,
+        """Open the collection handle and load ingestion status (direct async)."""
+        handle = await self.open_collection(
+            KBContextRequest(
+                collection=collection,
+                user_id=user_id,
+                is_admin=is_admin,
+                hide_missing=True,
+            )
+        )
+        return await handle.load_ingestion_status_async(
             doc_id=doc_id,
             user_id=user_id,
             is_admin=is_admin,

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
@@ -844,3 +844,43 @@ class TestRollbackRestoreRouting:
         handle.restore_main_pointer_snapshot.assert_called_once_with(
             snapshot, operator="bob"
         )
+
+
+class TestCrossOwnerRollbackRouting:
+    """#514: multi-owner rollback opens the handle with the snapshot's OWN
+    owner identity, not the caller's — orchestration stays coordinator-owned."""
+
+    def test_restore_candidate_cleanup_uses_snapshot_owner(self) -> None:
+        handle = _make_mock_handle()
+        handle.restore_candidate_cleanup_snapshot = MagicMock(
+            return_value={"rolled_back": True}
+        )
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        captured: list = []
+
+        async def _spy_open(request):
+            captured.append(request)
+            return handle
+
+        coordinator.open_collection = _spy_open
+
+        snapshot = MagicMock()
+        snapshot.collection = "docs"
+        snapshot.user_id = 42
+        snapshot.is_admin = False
+
+        result = asyncio.run(
+            coordinator.restore_candidate_cleanup_snapshot(
+                snapshot, cleanup_executed=True
+            )
+        )
+
+        assert result == {"rolled_back": True}
+        assert len(captured) == 1
+        assert captured[0].collection == "docs"
+        assert captured[0].user_id == 42
+        assert captured[0].is_admin is False
+        handle.restore_candidate_cleanup_snapshot.assert_called_once_with(
+            snapshot, cleanup_executed=True
+        )

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
@@ -41,6 +41,8 @@ def _make_mock_handle() -> MagicMock:
     # H05 additions
     handle.list_collection_documents = MagicMock(return_value=[])
     handle.count_documents = MagicMock(return_value=0)
+    handle.load_ingestion_status = MagicMock(return_value=[{"doc_id": "d1"}])
+    handle.load_ingestion_status_async = AsyncMock(return_value=[{"doc_id": "d2"}])
     return handle
 
 
@@ -740,3 +742,42 @@ class TestRenameFacadeCoordinatorEarlyReturn:
 
         mock_store.rename_collection_status.assert_called_once()
         assert isinstance(result, list)
+
+
+class TestIngestionStatusReadRouting:
+    """#514: load_ingestion_status(_async) must route through the handle,
+    not the injected storage shim."""
+
+    def test_load_ingestion_status_routes_through_handle(self) -> None:
+        handle = _make_mock_handle()
+        handle.load_ingestion_status = MagicMock(return_value=[{"doc_id": "d1"}])
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        result = asyncio.run(
+            coordinator.load_ingestion_status(
+                "docs", doc_id="d1", user_id=7, is_admin=False
+            )
+        )
+
+        assert result == [{"doc_id": "d1"}]
+        handle.load_ingestion_status.assert_called_once_with(
+            doc_id="d1", user_id=7, is_admin=False
+        )
+        coordinator._storage_shim.get_ingestion_status_store.assert_not_called()
+
+    def test_load_ingestion_status_async_routes_through_handle(self) -> None:
+        handle = _make_mock_handle()
+        handle.load_ingestion_status_async = AsyncMock(return_value=[{"doc_id": "d2"}])
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        result = asyncio.run(
+            coordinator.load_ingestion_status_async(
+                "docs", doc_id="d2", user_id=None, is_admin=True
+            )
+        )
+
+        assert result == [{"doc_id": "d2"}]
+        handle.load_ingestion_status_async.assert_awaited_once_with(
+            doc_id="d2", user_id=None, is_admin=True
+        )
+        coordinator._storage_shim.get_ingestion_status_store.assert_not_called()

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
@@ -815,9 +815,7 @@ class TestVersionPromotionRouting:
         handle.list_candidates = MagicMock(return_value={"candidates": []})
         coordinator = _make_coordinator_with_mock_handle(handle)
 
-        result = asyncio.run(
-            coordinator.list_candidates("docs", "doc-1", "parse")
-        )
+        result = asyncio.run(coordinator.list_candidates("docs", "doc-1", "parse"))
 
         assert result == {"candidates": []}
         handle.list_candidates.assert_called_once_with(

--- a/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_collection_lifecycle_facade_routing.py
@@ -43,6 +43,8 @@ def _make_mock_handle() -> MagicMock:
     handle.count_documents = MagicMock(return_value=0)
     handle.load_ingestion_status = MagicMock(return_value=[{"doc_id": "d1"}])
     handle.load_ingestion_status_async = AsyncMock(return_value=[{"doc_id": "d2"}])
+    handle.promote_version_main = MagicMock(return_value={"promoted": True})
+    handle.list_candidates = MagicMock(return_value={"candidates": []})
     return handle
 
 
@@ -781,3 +783,64 @@ class TestIngestionStatusReadRouting:
             doc_id="d2", user_id=None, is_admin=True
         )
         coordinator._storage_shim.get_ingestion_status_store.assert_not_called()
+
+
+class TestVersionPromotionRouting:
+    """#514: version promotion/listing must route through the handle."""
+
+    def test_promote_version_main_routes_through_handle(self) -> None:
+        handle = _make_mock_handle()
+        handle.promote_version_main = MagicMock(return_value={"promoted": True})
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        result = asyncio.run(
+            coordinator.promote_version_main(
+                "docs", "doc-1", "parse", "cand-9", operator="alice", confirm=True
+            )
+        )
+
+        assert result == {"promoted": True}
+        handle.promote_version_main.assert_called_once_with(
+            "doc-1",
+            "parse",
+            "cand-9",
+            operator="alice",
+            preview_only=False,
+            confirm=True,
+            model_tag=None,
+        )
+
+    def test_list_candidates_routes_through_handle(self) -> None:
+        handle = _make_mock_handle()
+        handle.list_candidates = MagicMock(return_value={"candidates": []})
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        result = asyncio.run(
+            coordinator.list_candidates("docs", "doc-1", "parse")
+        )
+
+        assert result == {"candidates": []}
+        handle.list_candidates.assert_called_once_with(
+            "doc-1", "parse", None, None, 50, "created_at desc"
+        )
+
+
+class TestRollbackRestoreRouting:
+    """#514 rollback additions: rollback data-plane restore routes through the handle."""
+
+    def test_restore_main_pointer_snapshot_routes_through_handle(self) -> None:
+        handle = _make_mock_handle()
+        handle.restore_main_pointer_snapshot = MagicMock(return_value=True)
+        coordinator = _make_coordinator_with_mock_handle(handle)
+
+        snapshot = MagicMock()
+        snapshot.collection = "docs"
+
+        result = asyncio.run(
+            coordinator.restore_main_pointer_snapshot(snapshot, operator="bob")
+        )
+
+        assert result is True
+        handle.restore_main_pointer_snapshot.assert_called_once_with(
+            snapshot, operator="bob"
+        )

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -1,0 +1,71 @@
+"""#514 - Router boundary guard for KBCoordinator.
+
+The coordinator must stay a router: it must not import backend-specific store
+modules or FastAPI/web route modules. This is a forward-looking static guard
+(it catches future import-based leaks). The current runtime-shim routing is
+covered separately by the fake-handle routing tests.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import xagent.core.tools.core.RAG_tools.kb.coordinator as coordinator_module
+
+# ponytail: hardcoded list with a known ceiling — a NEW backend store impl
+# (e.g. qdrant_stores.py) is NOT auto-detected and must be appended here.
+FORBIDDEN_SUBSTRINGS = (
+    "lancedb_stores",
+    "lancedb_filter_utils",
+    "lancedb_query_utils",
+    "schema_manager",
+    "fastapi",
+    "starlette",
+)
+FORBIDDEN_ROOT_PACKAGES = ("lancedb",)
+FORBIDDEN_PREFIXES = ("xagent.web",)
+
+
+def _imported_modules(source: str):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield node.lineno, alias.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.lineno, node.module or ""
+
+
+def _is_forbidden(module: str) -> bool:
+    if not module:
+        return False
+    root = module.lstrip(".").split(".")[0]
+    if root in FORBIDDEN_ROOT_PACKAGES:
+        return True
+    if any(sub in module for sub in FORBIDDEN_SUBSTRINGS):
+        return True
+    if any(module == p or module.startswith(p + ".") for p in FORBIDDEN_PREFIXES):
+        return True
+    return False
+
+
+def test_coordinator_imports_no_backend_or_web_modules() -> None:
+    source = Path(coordinator_module.__file__).read_text()
+    offenders = [
+        (lineno, mod) for lineno, mod in _imported_modules(source) if _is_forbidden(mod)
+    ]
+    assert offenders == [], (
+        "KBCoordinator must not import backend-store or web/route modules "
+        f"(keep it a router): {offenders}"
+    )
+
+
+def test_guard_flags_forbidden_imports() -> None:
+    # Positive control: the checker must actually fire, so a future refactor
+    # that neuters it is caught.
+    snippet = "from fastapi import APIRouter\nimport lancedb\nfrom x.lancedb_stores import Y\n"
+    flagged = [mod for _, mod in _imported_modules(snippet) if _is_forbidden(mod)]
+    assert "fastapi" in flagged
+    assert "lancedb" in flagged
+    assert "x.lancedb_stores" in flagged

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -16,14 +16,11 @@ import xagent.core.tools.core.RAG_tools.kb.coordinator as coordinator_module
 # ponytail: hardcoded list with a known ceiling — a NEW backend store impl
 # (e.g. qdrant_stores.py) is NOT auto-detected and must be appended here.
 FORBIDDEN_SUBSTRINGS = (
-    "lancedb_stores",
-    "lancedb_filter_utils",
-    "lancedb_query_utils",
+    "lancedb",
     "schema_manager",
     "fastapi",
     "starlette",
 )
-FORBIDDEN_ROOT_PACKAGES = ("lancedb",)
 FORBIDDEN_PREFIXES = ("xagent.web",)
 
 
@@ -40,9 +37,6 @@ def _imported_modules(source: str):
 def _is_forbidden(module: str) -> bool:
     if not module:
         return False
-    root = module.lstrip(".").split(".")[0]
-    if root in FORBIDDEN_ROOT_PACKAGES:
-        return True
     if any(sub in module for sub in FORBIDDEN_SUBSTRINGS):
         return True
     if any(module == p or module.startswith(p + ".") for p in FORBIDDEN_PREFIXES):

--- a/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_coordinator_router_boundary.py
@@ -31,7 +31,10 @@ def _imported_modules(source: str):
             for alias in node.names:
                 yield node.lineno, alias.name
         elif isinstance(node, ast.ImportFrom):
-            yield node.lineno, node.module or ""
+            module = node.module or ""
+            yield node.lineno, module
+            for alias in node.names:
+                yield node.lineno, f"{module}.{alias.name}" if module else alias.name
 
 
 def _is_forbidden(module: str) -> bool:
@@ -58,8 +61,14 @@ def test_coordinator_imports_no_backend_or_web_modules() -> None:
 def test_guard_flags_forbidden_imports() -> None:
     # Positive control: the checker must actually fire, so a future refactor
     # that neuters it is caught.
-    snippet = "from fastapi import APIRouter\nimport lancedb\nfrom x.lancedb_stores import Y\n"
+    snippet = (
+        "from fastapi import APIRouter\n"
+        "import lancedb\n"
+        "from x.lancedb_stores import Y\n"
+        "from xagent.core.tools.core.RAG_tools.storage import lancedb_stores\n"
+    )
     flagged = [mod for _, mod in _imported_modules(snippet) if _is_forbidden(mod)]
     assert "fastapi" in flagged
     assert "lancedb" in flagged
     assert "x.lancedb_stores" in flagged
+    assert "xagent.core.tools.core.RAG_tools.storage.lancedb_stores" in flagged

--- a/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_management_facade.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any, Optional, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -259,6 +260,21 @@ def test_nested_management_facade_rebinds_inner_coordinator_storage() -> None:
 
         def get_ingestion_status_store(self) -> IngestionStatusStore:
             return self.status_store
+
+        def get_metadata_store(self):
+            metadata = MagicMock()
+            # hide_missing=True swallows this; _is_missing_collection_error matches
+            # exactly "Collection 'docs' not found" (coordinator.py:1558-1561).
+            metadata.get_collection = AsyncMock(
+                side_effect=ValueError("Collection 'docs' not found")
+            )
+            return metadata
+
+        def get_vector_index_store(self):
+            return MagicMock()
+
+        def get_main_pointer_store(self):
+            return MagicMock()
 
     outer_store = IngestionStatusStore("outer-store")
     inner_store = IngestionStatusStore("inner-store")


### PR DESCRIPTION
## Summary

Closes the last two direct-store leaks in `KBCoordinator` and locks the router boundary in place, per #514 (H07).

- `load_ingestion_status` / `load_ingestion_status_async` bypassed `KBCollectionHandle` and called the injected storage shim directly. Both now route through `open_collection(KBContextRequest(..., hide_missing=True))` like every other collection-scoped method (mirrors `clear_ingestion_status`), preserving public signatures, sync/async shapes, and return types.
- Added a static AST import guard (`test_coordinator_router_boundary.py`) asserting the coordinator never imports backend-store or FastAPI/web modules, with a positive control proving the checker actually fires.
- Added a fake-handle routing test matrix covering ingestion-status reads, version promotion, candidate listing, main-pointer rollback restore, and cross-owner candidate-cleanup rollback restore — each asserting argument shapes, not just call counts.
- Every routing/characterization test is proven to have teeth via a red→green cycle or a targeted one-line mutation check (mutations reverted before commit; `coordinator.py` diff is confined entirely to commit 1).

Out of scope (explicitly, per Global Constraints): compatibility-facade thinning (#515), threading/locking changes (#657), new coordinator search/embedding methods (facade-level, deferred to #515).

## Test plan

- [x] `pytest tests/core/tools/core/RAG_tools/kb/ tests/core/tools/core/RAG_tools/storage/ tests/core/tools/core/RAG_tools/management/ -q` — all green
- [x] `pytest tests/core/tools/core/RAG_tools/kb/ tests/core/tools/core/RAG_tools/pipelines/ tests/core/tools/core/RAG_tools/retrieval/ tests/core/tools/core/RAG_tools/version_management/ tests/core/tools/core/RAG_tools/vector_storage/ -q` — all green except one pre-existing, environment-caused failure unrelated to this change (`test_promote_version_main.py::test_default_lancedb_dir_when_missing_env`, verified via git-stash bisection to fail identically before this branch)
- [x] `pytest tests/web/api/ -k kb -q` — all green
- [x] `ruff check` / `ruff format --check` on all changed files — clean
- [x] Per-task subagent review (spec compliance + code quality) for all 3 commits — approved
- [x] Final whole-branch review — Ready to merge: Yes, no Critical/Important issues

Claude-Session: https://claude.ai/code/session_01SArUtzeJWFRipQZtCjSmuC