### PR TITLE
feat: support ElevenLabs STT

### DIFF
--- a/example.env
+++ b/example.env
@@ -122,7 +122,7 @@ INFERENCE_API_KEY="your-inference-api-key"
 # Official default base URL does not use the legacy /v1 suffix
 # DEEPSEEK_BASE_URL="https://api.deepseek.com"
 # DEEPSEEK_REASONING_EFFORT="high"
-# ElevenLabs TTS
+# ElevenLabs speech (ASR/TTS)
 # ELEVENLABS_API_KEY="your-elevenlabs-api-key"
 # ELEVENLABS_BASE_URL="https://api.elevenlabs.io"
 # OpenRouter official-provider pinning is disabled by default to preserve

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from "react"
 import { SearchInput } from "@/components/ui/search-input"
 import { Button } from "@/components/ui/button"
-import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound, Webhook } from "lucide-react"
+import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound, Webhook, Mic, Square, Loader2 } from "lucide-react"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
@@ -25,6 +25,7 @@ import {
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
+import { useVoiceInputControls } from "@/components/voice-input-controller"
 
 interface LlmModel {
   model_id: string
@@ -69,6 +70,7 @@ export default function BuildsPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const hasAutoOpenedCreateRef = useRef(false)
+  const createPromptRef = useRef<HTMLTextAreaElement | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
@@ -184,6 +186,7 @@ export default function BuildsPage() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [createPrompt, setCreatePrompt] = useState("")
   const [isStartingTask, setIsStartingTask] = useState(false)
+  const createPromptVoiceInput = useVoiceInputControls()
 
   const handleCreate = () => {
     setIsCreateModalOpen(true)
@@ -289,6 +292,25 @@ export default function BuildsPage() {
   const handleManualCreate = () => {
     router.push("/build/new")
     setIsCreateModalOpen(false)
+  }
+
+  const createPromptVoiceInputLabel =
+    createPromptVoiceInput.status === "recording"
+      ? t("voiceInput.stop")
+      : createPromptVoiceInput.status === "transcribing"
+        ? t("voiceInput.transcribing")
+        : t("voiceInput.start")
+  const createPromptVoiceInputDisabled =
+    createPromptVoiceInput.status === "transcribing" ||
+    (createPromptVoiceInput.status === "idle" && isStartingTask)
+  const handleCreatePromptVoiceInputClick = () => {
+    if (createPromptVoiceInput.status === "recording") {
+      createPromptVoiceInput.stopRecording()
+      return
+    }
+    if (createPromptVoiceInput.status === "idle") {
+      createPromptVoiceInput.startRecording(createPromptRef.current)
+    }
   }
 
   const formatDate = (dateString: string) => {
@@ -621,6 +643,8 @@ export default function BuildsPage() {
 
               <div className="relative flex-1 w-full rounded-lg border border-input bg-background focus-within:ring-1 focus-within:ring-ring flex flex-col">
                 <Textarea
+                  ref={createPromptRef}
+                  data-voice-input="false"
                   value={createPrompt}
                   onChange={(e) => setCreatePrompt(e.target.value)}
                   placeholder={t("builds.list.createModal.placeholder")}
@@ -632,7 +656,32 @@ export default function BuildsPage() {
                     }
                   }}
                 />
-                <div className="p-2 flex justify-end">
+                <div className="p-2 flex justify-end gap-2">
+                  {createPromptVoiceInput.hasAsrModel && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={createPromptVoiceInputLabel}
+                      title={createPromptVoiceInputLabel}
+                      className={
+                        createPromptVoiceInput.status === "recording"
+                          ? "h-9 w-9 rounded-full bg-red-500 text-white hover:bg-red-600 hover:text-white"
+                          : "h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
+                      }
+                      disabled={createPromptVoiceInputDisabled}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={handleCreatePromptVoiceInputClick}
+                    >
+                      {createPromptVoiceInput.status === "recording" ? (
+                        <Square className="h-3.5 w-3.5 fill-current" />
+                      ) : createPromptVoiceInput.status === "transcribing" ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Mic className="h-4 w-4" />
+                      )}
+                    </Button>
+                  )}
                   <Button
                     onClick={handleBuildWithPrompt}
                     disabled={!createPrompt.trim() || isStartingTask}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { I18nProvider } from "@/contexts/i18n-context";
 import { getThemeFromEnv, themes } from "@/lib/theme";
 import { Toaster } from "@/components/ui/sonner";
 import { McpAppsProvider } from "@/contexts/mcp-apps-context";
+import { VoiceInputController } from "@/components/voice-input-controller";
 
 const branding = getBrandingFromEnv();
 
@@ -120,6 +121,7 @@ export default function RootLayout({
               <McpAppsProvider>
                 <AuthGuard>
                   <LayoutContent>{children}</LayoutContent>
+                  <VoiceInputController />
                   <Toaster />
                 </AuthGuard>
               </McpAppsProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import {
   ChevronRight, Layers, Bot, Database,
-  Sparkles, Play, Heart, Clock, Send, ListChecks, Loader2
+  Sparkles, Play, Heart, Clock, Send, ListChecks, Loader2, Mic, Square
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -21,11 +21,12 @@ import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { apiRequest } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
-import type { Template } from "@/types/template";
+import type { ConnectionInfo, Template } from "@/types/template";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { WelcomeModal } from "@/components/welcome-modal";
 import { getBrandingFromEnv } from "@/lib/branding";
+import { useVoiceInputControls } from "@/components/voice-input-controller";
 
 interface RecentTask {
   task_id: number | string;
@@ -59,6 +60,7 @@ export default function Home() {
   const [visibleGetStartedVideos, setVisibleGetStartedVideos] = useState<Set<number>>(new Set());
   const getStartedSectionRef = useRef<HTMLDivElement | null>(null);
   const homeChatInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const homeVoiceInput = useVoiceInputControls();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -230,6 +232,25 @@ export default function Home() {
     }
   };
 
+  const homeVoiceInputLabel =
+    homeVoiceInput.status === "recording"
+      ? t("voiceInput.stop")
+      : homeVoiceInput.status === "transcribing"
+        ? t("voiceInput.transcribing")
+        : t("voiceInput.start");
+  const homeVoiceInputDisabled =
+    homeVoiceInput.status === "transcribing" ||
+    (homeVoiceInput.status === "idle" && isCreating);
+  const handleHomeVoiceInputClick = () => {
+    if (homeVoiceInput.status === "recording") {
+      homeVoiceInput.stopRecording();
+      return;
+    }
+    if (homeVoiceInput.status === "idle") {
+      homeVoiceInput.startRecording(homeChatInputRef.current);
+    }
+  };
+
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[#FAFAFA] dark:bg-background overflow-y-auto">
       <WelcomeModal />
@@ -268,6 +289,7 @@ export default function Home() {
           <div className="w-full max-w-2xl bg-[hsl(234_30%_25%/0.4)] border border-[hsl(234_30%_35%)] rounded-[18px] p-3 flex items-end shadow-[0_12px_40px_rgba(0,0,0,0.25)] backdrop-blur-md focus-within:border-[hsl(234_50%_50%)] focus-within:shadow-[0_0_0_4px_hsl(234_50%_50%/0.2),0_12px_40px_rgba(0,0,0,0.25)] transition-all duration-200">
             <textarea
               ref={homeChatInputRef}
+              data-voice-input="false"
               placeholder={t("home.hero.searchPlaceholder")}
               className="border-0 bg-transparent text-white text-[16px] leading-relaxed placeholder:text-[hsl(240_5%_60%)] focus-visible:ring-0 focus-visible:outline-none flex-1 resize-none overflow-hidden min-h-[28px] max-h-[120px] py-1 px-2"
               rows={1}
@@ -285,6 +307,31 @@ export default function Home() {
                 }
               }}
             />
+            {homeVoiceInput.hasAsrModel && (
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                aria-label={homeVoiceInputLabel}
+                title={homeVoiceInputLabel}
+                className={`shrink-0 w-9 h-9 ml-2 rounded-full transition-colors ${
+                  homeVoiceInput.status === "recording"
+                    ? "bg-red-500 text-white hover:bg-red-600 hover:text-white"
+                    : "text-white/70 hover:bg-[hsl(234_30%_35%)] hover:text-white"
+                } ${homeVoiceInput.status === "transcribing" ? "cursor-wait opacity-80" : ""}`}
+                disabled={homeVoiceInputDisabled}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleHomeVoiceInputClick}
+              >
+                {homeVoiceInput.status === "recording" ? (
+                  <Square className="w-3.5 h-3.5 fill-current" />
+                ) : homeVoiceInput.status === "transcribing" ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Mic className="w-4 h-4" />
+                )}
+              </Button>
+            )}
             <Button
               size="icon"
               className="bg-[hsl(234_40%_40%)] hover:bg-[hsl(234_40%_45%)] text-white rounded-[12px] shrink-0 w-9 h-9 ml-3 transition-colors shadow-none disabled:opacity-50"
@@ -424,7 +471,7 @@ export default function Home() {
                         <div className="flex items-center">
                           {template.connections && template.connections.length > 0 ? (
                             <div className="flex gap-1.5">
-                              {template.connections.slice(0, 4).map((conn: any, idx: number) => (
+                              {template.connections.slice(0, 4).map((conn: ConnectionInfo, idx: number) => (
                                 <div key={idx} className="w-8 h-8 rounded-lg bg-background border border-border flex items-center justify-center overflow-hidden shadow-sm">
                                   {conn.logo ? <img src={conn.logo} alt={conn.name} className="w-5 h-5 object-contain" /> : <span className="text-[10px] font-bold text-primary/70">{(conn.name || "").substring(0, 2).toUpperCase()}</span>}
                                 </div>

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -152,6 +152,32 @@ describe("ChatInput", () => {
     expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
   })
 
+  it("renders voice input as an inline toolbar action when ASR is configured", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/models/?category=speech&limit=1000") {
+        return Promise.resolve(
+          new Response(JSON.stringify([{ abilities: ["asr"] }]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+
+    render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue=""
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByLabelText("voiceInput.start")).toBeInTheDocument()
+  })
+
   it("allows live guidance while a task is running", async () => {
     const onSend = vi.fn()
     const onPause = vi.fn()

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { createFileChipHTML } from "./FileChip";
 import { useRouter } from "next/navigation";
-import { Paperclip, X, File as FileIcon, Sparkles, Pause, Play, Loader2, ArrowUp, Globe } from "lucide-react";
+import { Paperclip, X, File as FileIcon, Sparkles, Pause, Play, Loader2, ArrowUp, Globe, Mic, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn, getApiUrl, getUploadApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
@@ -12,6 +12,7 @@ import { isPausableTaskStatus, isStoppedTaskStatus, normalizeTaskStatus, type Ta
 import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "@/components/ui/sonner";
+import { useVoiceInputControls } from "@/components/voice-input-controller";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -24,7 +25,7 @@ import {
 } from "@/components/ui/alert-dialog";
 
 interface ChatInputProps {
-  onSend: (message: string, config?: any) => void | Promise<void>;
+  onSend: (message: string, config?: AgentConfig) => void | Promise<void>;
   isLoading?: boolean;
   files?: File[];
   onFilesChange?: (files: File[]) => void;
@@ -36,13 +37,7 @@ interface ChatInputProps {
   taskStatus?: TaskStatus | string;
   onPause?: () => void;
   onResume?: () => void;
-  taskConfig?: {
-    model?: string;
-    smallFastModel?: string;
-    visualModel?: string;
-    compactModel?: string;
-    executionMode?: "flash" | "balanced" | "think";
-  };
+  taskConfig?: Partial<AgentConfig>;
   hideConfig?: boolean;
   readOnlyConfig?: boolean;
   hideFileUpload?: boolean;
@@ -57,6 +52,30 @@ interface ChatInputProps {
   onRemoveSelectedAgent?: (agentId: number | string) => void;
   uploadFile?: (file: File, params: { taskType: string }) => Promise<{ file_id: string }>;
   deferFileUpload?: boolean;
+}
+
+type ExecutionMode = "flash" | "balanced" | "think";
+type ExecutionModeConfig = ExecutionMode | { mode: ExecutionMode };
+
+interface AgentConfig {
+  model: string;
+  smallFastModel?: string;
+  visualModel?: string;
+  compactModel?: string;
+  memorySimilarityThreshold?: number;
+  executionMode?: ExecutionModeConfig;
+}
+
+interface ModelRecord {
+  id?: number | string;
+  model_id?: string;
+  model_name?: string;
+  is_default?: boolean;
+}
+
+interface DefaultModelRecord {
+  config_type?: string;
+  model?: ModelRecord | null;
 }
 
 export function ChatInput({
@@ -96,6 +115,7 @@ export function ChatInput({
   const dragDepthRef = useRef(0);
   const { t } = useI18n();
   const { openFilePreview } = useApp();
+  const voiceInput = useVoiceInputControls();
 
   useEffect(() => {
     if (!autoFocus || !editorRef.current) return;
@@ -238,21 +258,17 @@ export function ChatInput({
     editor.addEventListener('click', handleClick);
     return () => editor.removeEventListener('click', handleClick);
   }, [fileMention.fileList, openFilePreview]);
-  const [agentConfig, setAgentConfig] = useState<{
-    model: string;
-    smallFastModel?: string;
-    visualModel?: string;
-    compactModel?: string;
-    memorySimilarityThreshold?: number;
-    executionMode?: "flash" | "balanced" | "think";
-  }>({ model: "", memorySimilarityThreshold: 1.5 });
+  const [agentConfig, setAgentConfig] = useState<AgentConfig>({
+    model: "",
+    memorySimilarityThreshold: 1.5,
+  });
   const [defaultAgentConfig, setDefaultAgentConfig] = useState<{
     model: string;
     smallFastModel?: string;
     visualModel?: string;
     compactModel?: string;
   }>({ model: "" });
-  const [models, setModels] = useState<any[]>([]);
+  const [models, setModels] = useState<ModelRecord[]>([]);
 
   // State to track files currently being uploaded
   const [uploadingFiles, setUploadingFiles] = useState<Set<string>>(new Set());
@@ -335,8 +351,8 @@ export function ChatInput({
             });
           }
         }
-      } catch (error: any) {
-        if (error.name === 'AbortError') {
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
           // Upload cancelled, do nothing
         } else {
           console.error("Error uploading file:", error);
@@ -385,7 +401,7 @@ export function ChatInput({
           headers: {}
         });
 
-        let allModels: any[] = [];
+        let allModels: ModelRecord[] = [];
         if (modelsResponse.ok) {
           allModels = await modelsResponse.json();
           if (Array.isArray(allModels)) {
@@ -398,11 +414,11 @@ export function ChatInput({
           headers: {}
         });
 
-        let defaultModels: Record<string, any> = {};
+        const defaultModels: Record<string, ModelRecord | undefined> = {};
         if (defaultResponse.ok) {
           const defaults = await defaultResponse.json();
           if (Array.isArray(defaults)) {
-            defaults.forEach((defaultConfig: any) => {
+            defaults.forEach((defaultConfig: DefaultModelRecord) => {
               if (defaultConfig && defaultConfig.config_type && defaultConfig.model) {
                 defaultModels[defaultConfig.config_type] = defaultConfig.model;
               }
@@ -412,7 +428,7 @@ export function ChatInput({
 
         // Find default if no user preference
         if (!defaultModels.general && allModels.length > 0) {
-          const defaultModel = allModels.find((m: any) => m.is_default) || allModels[0];
+          const defaultModel = allModels.find((m) => m.is_default) || allModels[0];
           if (defaultModel) {
             defaultModels.general = { model_id: defaultModel.model_id };
           }
@@ -465,14 +481,7 @@ export function ChatInput({
     }
   }, [taskConfig, readOnlyConfig, defaultAgentConfig]);
 
-  const handleConfigChange = (config: {
-    model: string;
-    smallFastModel?: string;
-    visualModel?: string;
-    compactModel?: string;
-    memorySimilarityThreshold?: number;
-    executionMode?: "flash" | "balanced" | "think";
-  }) => {
+  const handleConfigChange = (config: AgentConfig) => {
     setAgentConfig(config);
   };
 
@@ -485,6 +494,24 @@ export function ChatInput({
     !!isLoading &&
     !allowsLiveGuidanceInput &&
     !isStoppedTaskStatus(normalizedTaskStatus);
+  const voiceInputLabel =
+    voiceInput.status === "recording"
+      ? t("voiceInput.stop")
+      : voiceInput.status === "transcribing"
+        ? t("voiceInput.transcribing")
+        : t("voiceInput.start");
+  const voiceInputDisabled =
+    voiceInput.status === "transcribing" ||
+    (voiceInput.status === "idle" && isInputBusy);
+  const handleVoiceInputClick = () => {
+    if (voiceInput.status === "recording") {
+      voiceInput.stopRecording();
+      return;
+    }
+    if (voiceInput.status === "idle") {
+      voiceInput.startRecording(editorRef.current);
+    }
+  };
 
   const hasDraft = message.trim().length > 0 || files.length > 0;
   const canSubmit = () => {
@@ -534,7 +561,7 @@ export function ChatInput({
     appendFiles(droppedFiles);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
 
     if (!canSubmit() || isSubmittingRef.current) return;
@@ -550,10 +577,18 @@ export function ChatInput({
       isSubmittingRef.current = true;
       const trimmed = message.trim();
       const messageToSend = trimmed;
+      const executionMode = taskConfig?.executionMode;
 
       const configToSend = {
         ...agentConfig,
-        ...(taskConfig?.executionMode ? { executionMode: { mode: taskConfig.executionMode } } : {}),
+        ...(executionMode
+          ? {
+              executionMode:
+                typeof executionMode === "string"
+                  ? { mode: executionMode }
+                  : executionMode,
+            }
+          : {}),
       };
 
       await onSend(messageToSend, configToSend);
@@ -583,7 +618,7 @@ export function ChatInput({
         return;
       }
       e.preventDefault();
-      handleSubmit(e as any);
+      handleSubmit(e);
     }
   };
 
@@ -598,7 +633,7 @@ export function ChatInput({
       fileItems.forEach((item, index) => {
         const file = item.getAsFile();
         if (file) {
-          const hasName = typeof (file as any).name === 'string' && (file as any).name.length > 0;
+          const hasName = file.name.length > 0;
           // Handle default "image.png" name which causes conflicts when pasting multiple images
           if (hasName && file.name !== 'image.png') {
             pastedFiles.push(file);
@@ -795,6 +830,7 @@ export function ChatInput({
             <div
               ref={editorRef}
               contentEditable
+              data-voice-input="false"
               className={cn(
                 "w-full rounded-md border-0 bg-transparent text-[15px] outline-none placeholder:text-muted-foreground/60 overflow-y-auto resize-none focus-visible:ring-0 focus-visible:ring-offset-0 whitespace-pre-wrap break-words text-left",
                 compact ? "min-h-[44px] px-3 py-3 pr-12 max-h-[150px]" : cn(minHeightClass, "px-4 py-3 pb-16 max-h-[400px]"),
@@ -802,7 +838,7 @@ export function ChatInput({
               )}
               onInput={handleInput}
               onKeyDown={handleKeyDown}
-              onPaste={handlePaste as any}
+              onPaste={handlePaste}
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               role="textbox"
@@ -840,6 +876,33 @@ export function ChatInput({
                     <Paperclip className="h-4 w-4" />
                   </Button>
                 </>
+              )}
+              {voiceInput.hasAsrModel && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={voiceInputLabel}
+                  title={voiceInputLabel}
+                  className={cn(
+                    "h-8 w-8 p-0 rounded-full transition-colors",
+                    voiceInput.status === "recording"
+                      ? "bg-red-500 text-white hover:bg-red-600 hover:text-white"
+                      : "text-muted-foreground hover:text-foreground hover:bg-secondary/80",
+                    voiceInput.status === "transcribing" && "cursor-wait opacity-80"
+                  )}
+                  disabled={voiceInputDisabled}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={handleVoiceInputClick}
+                >
+                  {voiceInput.status === "recording" ? (
+                    <Square className="h-3.5 w-3.5 fill-current" />
+                  ) : voiceInput.status === "transcribing" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Mic className="h-4 w-4" />
+                  )}
+                </Button>
               )}
               <Button
                 type="submit"
@@ -941,6 +1004,33 @@ export function ChatInput({
                 <span className="text-[13px] font-medium text-muted-foreground/50 select-none mr-1">
                   ⏎ {t("common.send")}
                 </span>
+                {voiceInput.hasAsrModel && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={voiceInputLabel}
+                    title={voiceInputLabel}
+                    className={cn(
+                      "h-8 w-8 p-0 rounded-full transition-colors",
+                      voiceInput.status === "recording"
+                        ? "bg-red-500 text-white hover:bg-red-600 hover:text-white"
+                        : "text-muted-foreground hover:text-foreground hover:bg-secondary/80",
+                      voiceInput.status === "transcribing" && "cursor-wait opacity-80"
+                    )}
+                    disabled={voiceInputDisabled}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={handleVoiceInputClick}
+                  >
+                    {voiceInput.status === "recording" ? (
+                      <Square className="h-3.5 w-3.5 fill-current" />
+                    ) : voiceInput.status === "transcribing" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Mic className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
                 <Button
                   type="submit"
                   size="icon"

--- a/frontend/src/components/pages/model-management-dialog.tsx
+++ b/frontend/src/components/pages/model-management-dialog.tsx
@@ -45,6 +45,53 @@ import { Model, ModelCreate, ProviderConfig, generateModelId, getModelDetailUrl 
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { Stepper } from "@/components/ui/stepper"
 
+const SPEECH_ABILITY_VALUES = new Set(["asr", "tts"])
+
+function getProviderModelAbilities(model?: ProviderModel): string[] {
+  const abilities = model?.abilities?.length
+    ? model.abilities
+    : model?.model_ability
+  return Array.isArray(abilities) ? abilities.map(String) : []
+}
+
+function modelSupportsAbilities(
+  model: ProviderModel | undefined,
+  requiredAbilities: string[] = []
+): boolean {
+  const required = requiredAbilities.filter((ability) =>
+    SPEECH_ABILITY_VALUES.has(ability)
+  )
+  if (required.length === 0 || !model) return true
+
+  const available = getProviderModelAbilities(model)
+  if (available.length === 0) return true
+
+  return required.every((ability) => available.includes(ability))
+}
+
+function filterModelsForAbilities(
+  models: ProviderModel[],
+  category: string,
+  abilities: string[] = []
+): ProviderModel[] {
+  if (category !== "speech") return models
+  return models.filter((model) => modelSupportsAbilities(model, abilities))
+}
+
+function normalizeAbilitiesForProvider(
+  category: string,
+  providerId: string,
+  abilities: string[]
+): string[] {
+  if (category === "speech" && providerId === "elevenlabs") {
+    const selectedSpeechAbility = [...abilities]
+      .reverse()
+      .find((ability) => SPEECH_ABILITY_VALUES.has(ability))
+    return selectedSpeechAbility ? [selectedSpeechAbility] : []
+  }
+  return abilities
+}
+
 export interface ModelManagementDialogProps {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
@@ -155,9 +202,13 @@ export function ModelManagementDialog({
     ]
   }
 
-  const resetConnectionState = () => {
+  const resetTestConnectionState = () => {
     setTestConnectionStatus('idle')
     setTestConnectionError(null)
+  }
+
+  const resetConnectionState = () => {
+    resetTestConnectionState()
     setFetchedModels([])
   }
 
@@ -262,6 +313,16 @@ export function ModelManagementDialog({
     if (!managingProviderId) return []
     return enabledModels.filter(m => m.model_provider === managingProviderId && m.category === activeTab)
   }, [enabledModels, managingProviderId, activeTab])
+
+  const filteredFetchedModels = useMemo(
+    () =>
+      filterModelsForAbilities(
+        fetchedModels,
+        formData.category,
+        formData.abilities || []
+      ),
+    [fetchedModels, formData.category, formData.abilities]
+  )
 
   function getModelDefaultTypes(modelId: number) {
     const types: string[] = []
@@ -429,9 +490,7 @@ export function ModelManagementDialog({
   const applyFetchedModelSelection = (modelName: string) => {
     const selected = fetchedModels.find(model => model.id === modelName)
     const suggestedBaseUrl = selected?.default_base_url || selected?.base_url
-    const suggestedAbilities = selected?.abilities?.length
-      ? selected.abilities
-      : selected?.model_ability
+    const suggestedAbilities = getProviderModelAbilities(selected)
 
     setFormData(prev => ({
       ...prev,
@@ -439,12 +498,36 @@ export function ModelManagementDialog({
       base_url: suggestedBaseUrl || prev.base_url,
       abilities: suggestedAbilities?.length
         ? suggestedAbilities
-        : getDefaultAbilitiesForProvider(prev.category, prev.model_provider),
+        : prev.abilities?.length
+          ? prev.abilities
+          : getDefaultAbilitiesForProvider(prev.category, prev.model_provider),
       default_config_types: [],
     }))
     setHasInitializedDefaults(false)
     setTestConnectionStatus('idle')
     setTestConnectionError(null)
+  }
+
+  const updateModelAbilities = (abilities: string[]) => {
+    resetTestConnectionState()
+    setFormData(prev => {
+      const nextAbilities = normalizeAbilitiesForProvider(
+        prev.category,
+        prev.model_provider,
+        abilities
+      )
+      const selectedModel = fetchedModels.find(model => model.id === prev.model_name)
+      const nextModelName = modelSupportsAbilities(selectedModel, nextAbilities)
+        ? prev.model_name
+        : ""
+
+      return {
+        ...prev,
+        model_name: nextModelName,
+        abilities: nextAbilities,
+        default_config_types: [],
+      }
+    })
   }
 
   const submitModelData = async (data: ModelCreate) => {
@@ -696,7 +779,7 @@ export function ModelManagementDialog({
                       <ScrollArea className="flex-1 border rounded-md overflow-y-scroll">
                         <div className="flex flex-col divide-y">
                           {providers
-                            .filter(p => p.category.includes(formData.category as any))
+                            .filter(p => p.category.includes(formData.category))
                             .filter(p => p.name.toLowerCase().includes(connectSearchQuery.toLowerCase()))
                             .map(provider => (
                               <div
@@ -792,7 +875,7 @@ export function ModelManagementDialog({
                             setTestConnectionStatus('testing')
                             try {
                               await handleFetchModels()
-                            } catch (err) {
+                            } catch {
                               // error handled in handleFetchModels
                             } finally {
                               setTestConnectionStatus('idle')
@@ -829,8 +912,8 @@ export function ModelManagementDialog({
                           onValueChange={(val) => {
                             applyFetchedModelSelection(val)
                           }}
-                          options={fetchedModels.map(m => ({ value: m.id, label: m.id }))}
-                          placeholder={fetchedModels.length > 0 ? t('models.form.selectModel') : t('models.form.enterModelName')}
+                          options={filteredFetchedModels.map(m => ({ value: m.id, label: m.id }))}
+                          placeholder={filteredFetchedModels.length > 0 ? t('models.form.selectModel') : t('models.form.enterModelName')}
                           allowCustom={formData.model_provider !== 'deepseek'}
                           customPlaceholder={t('models.form.customModel')}
                           customButtonText={t('models.form.addCustom')}
@@ -898,9 +981,16 @@ export function ModelManagementDialog({
                                 className={`rounded-full ${isSelected ? 'bg-primary text-primary-foreground border-primary hover:bg-primary/90' : ''}`}
                                 onClick={() => {
                                   const abilities = formData.abilities || []
-                                  resetConnectionState()
-                                  if (isSelected) setFormData({ ...formData, abilities: abilities.filter(a => a !== cap) })
-                                  else setFormData({ ...formData, abilities: [...abilities, cap] })
+                                  const isExclusiveSpeechProvider =
+                                    formData.category === "speech" &&
+                                    formData.model_provider === "elevenlabs"
+                                  if (isExclusiveSpeechProvider) {
+                                    updateModelAbilities([cap])
+                                  } else if (isSelected) {
+                                    updateModelAbilities(abilities.filter(a => a !== cap))
+                                  } else {
+                                    updateModelAbilities([...abilities, cap])
+                                  }
                                 }}
                               >
                                 {icons[cap]}
@@ -948,7 +1038,7 @@ export function ModelManagementDialog({
                             if (!hasInitializedDefaults) {
                               const targetType = getPrimaryDefaultType(formData.category, formData.abilities)
                               if (targetType) {
-                                const hasDefault = (defaultModels as any)[targetType]
+                                const hasDefault = defaultModels[targetType]
                                 if (!hasDefault) {
                                   setFormData(prev => ({
                                     ...prev,
@@ -1020,7 +1110,7 @@ export function ModelManagementDialog({
                           })();
 
                           const existingDefaults = relevantTypes
-                            .map(type => ({ type, model: (defaultModels as any)[type] }))
+                            .map(type => ({ type, model: defaultModels[type] }))
                             .filter(item => item.model);
 
                           if (existingDefaults.length === 0) return null;
@@ -1150,7 +1240,7 @@ export function ModelManagementDialog({
                   {(() => {
                     const defaultOptions = getDefaultOptionsForModel(defaultTargetModel.category, defaultTargetModel.abilities)
                     const existingDefaults = defaultOptions
-                      .map(option => ({ type: option.value, model: (defaultModels as any)[option.value] }))
+                      .map(option => ({ type: option.value, model: defaultModels[option.value] }))
                       .filter(item => item.model)
 
                     if (existingDefaults.length === 0) return null
@@ -1257,7 +1347,7 @@ export function ModelManagementDialog({
                     }}
                     disabled={!!editingModel}
                     options={providers
-                      .filter(p => p.category.includes(formData.category as any))
+                      .filter(p => p.category.includes(formData.category))
                       .map((provider) => ({
                         value: provider.id,
                         label: provider.name
@@ -1349,7 +1439,7 @@ export function ModelManagementDialog({
                   <Select
                     value={formData.model_name}
                     onValueChange={(value) => applyFetchedModelSelection(value)}
-                    options={fetchedModels.map(m => ({ value: m.id, label: m.id }))}
+                    options={filteredFetchedModels.map(m => ({ value: m.id, label: m.id }))}
                     placeholder={t('models.form.selectModel')}
                     allowCustom={formData.model_provider !== 'deepseek'}
                     customPlaceholder={t('models.form.enterModelName')}
@@ -1368,7 +1458,7 @@ export function ModelManagementDialog({
                 <Label className="mb-2 block">{t('models.form.abilities')}</Label>
                 <MultiSelect
                   values={formData.abilities || []}
-                  onValuesChange={(values) => setFormData({ ...formData, abilities: values })}
+                  onValuesChange={updateModelAbilities}
                   options={
                     formData.category === 'llm' ? abilityOptions :
                       formData.category === 'embedding' ? embeddingAbilityOptions :

--- a/frontend/src/components/voice-input-controller.test.tsx
+++ b/frontend/src/components/voice-input-controller.test.tsx
@@ -1,0 +1,415 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return {
+    ...actual,
+    apiRequest: apiRequestMock,
+  }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    cn: (...classes: Array<string | false | null | undefined>) =>
+      classes.filter(Boolean).join(" "),
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://upload.local",
+  }
+})
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}))
+
+vi.mock("lucide-react", () => {
+  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+  return {
+    Loader2: Icon,
+    Mic: Icon,
+    Square: Icon,
+  }
+})
+
+import { VoiceInputController } from "./voice-input-controller"
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function setVisibleRect(
+  element: HTMLElement,
+  rect: Partial<DOMRect> = {}
+): void {
+  const visibleRect = {
+    bottom: 50,
+    height: 40,
+    left: 10,
+    right: 210,
+    top: 10,
+    width: 200,
+    x: 10,
+    y: 10,
+    ...rect,
+  }
+  element.getBoundingClientRect = () =>
+    ({
+      ...visibleRect,
+      toJSON: () => ({}),
+    }) as DOMRect
+}
+
+class MediaRecorderMock {
+  static isTypeSupported = vi.fn(() => true)
+
+  mimeType: string
+  ondataavailable: ((event: BlobEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onstop: ((event: Event) => void) | null = null
+  state: RecordingState = "inactive"
+
+  constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+    this.mimeType = options?.mimeType || "audio/webm"
+  }
+
+  start(): void {
+    this.state = "recording"
+  }
+
+  stop(): void {
+    this.state = "inactive"
+    const blob = new Blob(["audio"], { type: this.mimeType })
+    this.ondataavailable?.({ data: blob } as BlobEvent)
+    this.onstop?.(new Event("stop"))
+  }
+}
+
+describe("VoiceInputController", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/models/?category=speech&limit=1000") {
+        return Promise.resolve(jsonResponse([{ abilities: ["asr"] }]))
+      }
+      if (url === "http://upload.local/api/models/speech/transcribe") {
+        return Promise.resolve(jsonResponse({ text: "voice text" }))
+      }
+      return Promise.reject(new Error(`unexpected request: ${url}`))
+    })
+
+    Object.defineProperty(globalThis, "MediaRecorder", {
+      configurable: true,
+      value: MediaRecorderMock,
+    })
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: MediaRecorderMock,
+    })
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getTracks: () => [{ stop: vi.fn() }],
+        } as unknown as MediaStream),
+      },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("inserts transcription into the field active when recording started", async () => {
+    render(
+      <>
+        <input aria-label="first prompt" data-voice-input="true" />
+        <input aria-label="second prompt" data-voice-input="true" />
+        <VoiceInputController />
+      </>
+    )
+
+    const first = screen.getByLabelText("first prompt") as HTMLInputElement
+    const second = screen.getByLabelText("second prompt") as HTMLInputElement
+    setVisibleRect(first)
+    setVisibleRect(second)
+
+    first.focus()
+    fireEvent.focusIn(first)
+    fireEvent.click(await screen.findByLabelText("voiceInput.start"))
+
+    await screen.findByLabelText("voiceInput.stop")
+    second.focus()
+    fireEvent.focusIn(second)
+    fireEvent.click(screen.getByLabelText("voiceInput.stop"))
+
+    await waitFor(() => {
+      expect(first).toHaveValue("voice text")
+    })
+    expect(second).toHaveValue("")
+  })
+
+  it("shows an error when voice recording is unsupported", async () => {
+    render(
+      <>
+        <input aria-label="prompt" data-voice-input="true" />
+        <VoiceInputController />
+      </>
+    )
+
+    const input = screen.getByLabelText("prompt")
+    setVisibleRect(input)
+    input.focus()
+    fireEvent.focusIn(input)
+
+    Object.defineProperty(globalThis, "MediaRecorder", {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: undefined,
+    })
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: undefined,
+    })
+
+    fireEvent.click(await screen.findByLabelText("voiceInput.start"))
+
+    expect(toastErrorMock).toHaveBeenCalledWith("voiceInput.errors.unsupported")
+  })
+
+  it("does not enable arbitrary contentEditable regions without opt-in", () => {
+    render(
+      <>
+        <div contentEditable suppressContentEditableWarning>
+          private draft
+        </div>
+        <VoiceInputController />
+      </>
+    )
+
+    const editable = screen.getByText("private draft")
+    setVisibleRect(editable)
+    editable.focus()
+    fireEvent.focusIn(editable)
+
+    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("voiceInput.start")).not.toBeInTheDocument()
+  })
+
+  it("does not enable regular form fields without opt-in", () => {
+    render(
+      <>
+        <input aria-label="agent name" />
+        <VoiceInputController />
+      </>
+    )
+
+    const input = screen.getByLabelText("agent name")
+    setVisibleRect(input)
+    input.focus()
+    fireEvent.focusIn(input)
+
+    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("voiceInput.start")).not.toBeInTheDocument()
+  })
+
+  it("positions contentEditable controls against the enclosing input shell", async () => {
+    render(
+      <>
+        <div data-testid="input-shell">
+          <div
+            contentEditable
+            data-voice-input="true"
+            role="textbox"
+            suppressContentEditableWarning
+          />
+        </div>
+        <VoiceInputController />
+      </>
+    )
+
+    const shell = screen.getByTestId("input-shell")
+    const editor = screen.getByRole("textbox")
+    Object.defineProperty(editor, "isContentEditable", {
+      configurable: true,
+      value: true,
+    })
+    setVisibleRect(shell, {
+      bottom: 160,
+      height: 140,
+      left: 40,
+      right: 440,
+      top: 20,
+      width: 400,
+      x: 40,
+      y: 20,
+    })
+    setVisibleRect(editor, {
+      bottom: 82,
+      height: 40,
+      left: 60,
+      right: 130,
+      top: 42,
+      width: 70,
+      x: 60,
+      y: 42,
+    })
+
+    editor.focus()
+    fireEvent.focusIn(editor)
+
+    const button = await screen.findByLabelText("voiceInput.start")
+    expect(button).toHaveStyle({ left: "336px", top: "104px" })
+  })
+
+  it("shows textarea controls on hover against the enclosing input shell", async () => {
+    render(
+      <>
+        <div data-testid="input-shell">
+          <textarea aria-label="task prompt" data-voice-input="true" />
+        </div>
+        <VoiceInputController />
+      </>
+    )
+
+    const shell = screen.getByTestId("input-shell")
+    const textarea = screen.getByLabelText("task prompt")
+    setVisibleRect(shell, {
+      bottom: 160,
+      height: 140,
+      left: 40,
+      right: 440,
+      top: 20,
+      width: 400,
+      x: 40,
+      y: 20,
+    })
+    setVisibleRect(textarea, {
+      bottom: 82,
+      height: 40,
+      left: 60,
+      right: 130,
+      top: 42,
+      width: 70,
+      x: 60,
+      y: 42,
+    })
+
+    fireEvent.pointerOver(textarea)
+
+    const button = await screen.findByLabelText("voiceInput.start")
+    expect(button).toHaveStyle({ left: "336px", top: "104px" })
+  })
+
+  it("does not float controls over large framed textareas", () => {
+    render(
+      <>
+        <div data-testid="input-shell">
+          <textarea aria-label="large prompt" />
+        </div>
+        <VoiceInputController />
+      </>
+    )
+
+    const shell = screen.getByTestId("input-shell")
+    const textarea = screen.getByLabelText("large prompt")
+    setVisibleRect(shell, {
+      bottom: 180,
+      height: 160,
+      left: 40,
+      right: 440,
+      top: 20,
+      width: 400,
+      x: 40,
+      y: 20,
+    })
+    setVisibleRect(textarea, {
+      bottom: 160,
+      height: 120,
+      left: 60,
+      right: 420,
+      top: 40,
+      width: 360,
+      x: 60,
+      y: 40,
+    })
+
+    fireEvent.pointerOver(textarea)
+
+    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("voiceInput.start")).not.toBeInTheDocument()
+  })
+
+  it("does not float controls over textareas with nearby action buttons", () => {
+    render(
+      <>
+        <div data-testid="input-shell">
+          <textarea aria-label="action prompt" />
+          <button type="button">Send</button>
+        </div>
+        <VoiceInputController />
+      </>
+    )
+
+    const shell = screen.getByTestId("input-shell")
+    const textarea = screen.getByLabelText("action prompt")
+    const button = screen.getByText("Send")
+    setVisibleRect(shell, {
+      bottom: 90,
+      height: 70,
+      left: 40,
+      right: 440,
+      top: 20,
+      width: 400,
+      x: 40,
+      y: 20,
+    })
+    setVisibleRect(textarea, {
+      bottom: 70,
+      height: 40,
+      left: 60,
+      right: 360,
+      top: 30,
+      width: 300,
+      x: 60,
+      y: 30,
+    })
+    setVisibleRect(button, {
+      bottom: 72,
+      height: 32,
+      left: 372,
+      right: 428,
+      top: 40,
+      width: 56,
+      x: 372,
+      y: 40,
+    })
+
+    fireEvent.pointerOver(textarea)
+
+    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("voiceInput.start")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/voice-input-controller.tsx
+++ b/frontend/src/components/voice-input-controller.tsx
@@ -1,0 +1,633 @@
+"use client"
+
+import React, { useCallback, useEffect, useRef, useState } from "react"
+import { Loader2, Mic, Square } from "lucide-react"
+
+import { toast } from "@/components/ui/sonner"
+import { useI18n } from "@/contexts/i18n-context"
+import {
+  apiRequest,
+  getApiErrorMessage,
+  isJsonRecord,
+  parseApiResponse,
+} from "@/lib/api-wrapper"
+import { cn, getApiUrl, getUploadApiUrl } from "@/lib/utils"
+
+export type VoiceTarget = HTMLInputElement | HTMLTextAreaElement | HTMLElement
+export type VoiceStatus = "idle" | "recording" | "transcribing"
+
+interface UseVoiceInputControlsOptions {
+  autoRefresh?: boolean
+}
+
+const TEXT_INPUT_TYPES = new Set(["", "email", "search", "tel", "text", "url"])
+const SENSITIVE_FIELD_PATTERN =
+  /(api[_-]?key|authorization|bearer|card[_-]?number|cardnumber|client[_-]?id|client[_-]?secret|credit[_-]?card|csc|cvc|cvv|one[_-]?time|otp|passcode|password|pin|security[_-]?code|securitycode|secret|social[_-]?security|ssn|token)/i
+const SENSITIVE_AUTOCOMPLETE_TOKENS = new Set([
+  "cc-additional-name",
+  "cc-csc",
+  "cc-exp",
+  "cc-exp-month",
+  "cc-exp-year",
+  "cc-family-name",
+  "cc-given-name",
+  "cc-name",
+  "cc-number",
+  "cc-type",
+  "current-password",
+  "new-password",
+  "one-time-code",
+])
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function isElementHidden(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect()
+  return rect.width <= 0 || rect.height <= 0
+}
+
+function getPositionAnchor(target: VoiceTarget): HTMLElement {
+  const explicitAnchor = target.closest<HTMLElement>("[data-voice-input-anchor]")
+  if (explicitAnchor && !isElementHidden(explicitAnchor)) {
+    return explicitAnchor
+  }
+
+  const canUseEnclosingAnchor =
+    target.isContentEditable || target instanceof HTMLTextAreaElement
+  if (!canUseEnclosingAnchor) {
+    return target
+  }
+
+  const targetRect = target.getBoundingClientRect()
+  let current = target.parentElement
+  while (current && current !== document.body) {
+    if (!isElementHidden(current)) {
+      const rect = current.getBoundingClientRect()
+      const containsTarget =
+        rect.left <= targetRect.left &&
+        rect.right >= targetRect.right &&
+        rect.top <= targetRect.top &&
+        rect.bottom >= targetRect.bottom
+      const expandsTarget =
+        rect.width >= targetRect.width + 48 ||
+        rect.height >= targetRect.height + 24
+      if (containsTarget && expandsTarget) {
+        return current
+      }
+    }
+    current = current.parentElement
+  }
+
+  return target
+}
+
+function fieldFingerprint(element: HTMLElement): string {
+  return [
+    element.getAttribute("aria-label"),
+    element.getAttribute("id"),
+    element.getAttribute("name"),
+    element.getAttribute("placeholder"),
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
+function hasSensitiveAutocomplete(element: HTMLElement): boolean {
+  const autocomplete = element.getAttribute("autocomplete")
+  if (!autocomplete) return false
+  return autocomplete
+    .toLowerCase()
+    .split(/\s+/)
+    .some((token) => SENSITIVE_AUTOCOMPLETE_TOKENS.has(token))
+}
+
+function isVoiceEligibleTarget(target: EventTarget | null): target is VoiceTarget {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.closest("[data-voice-input-root]")) return false
+  if (target.closest("[data-voice-input='false']")) return false
+  if (target.getAttribute("data-voice-input") !== "true") return false
+  if (target.getAttribute("aria-readonly") === "true") return false
+  if (SENSITIVE_FIELD_PATTERN.test(fieldFingerprint(target))) return false
+  if (hasSensitiveAutocomplete(target)) return false
+
+  if (target instanceof HTMLInputElement) {
+    return (
+      TEXT_INPUT_TYPES.has(target.type) &&
+      !target.disabled &&
+      !target.readOnly &&
+      !isElementHidden(target)
+    )
+  }
+
+  if (target instanceof HTMLTextAreaElement) {
+    return !target.disabled && !target.readOnly && !isElementHidden(target)
+  }
+
+  return (
+    target.isContentEditable &&
+    !isElementHidden(target)
+  )
+}
+
+function isInsideActiveVoiceArea(
+  eventTarget: EventTarget | null,
+  currentTarget: VoiceTarget | null
+): boolean {
+  if (!(eventTarget instanceof Element) || !currentTarget) return false
+  if (eventTarget.closest("[data-voice-input-root]")) return true
+
+  const anchor = getPositionAnchor(currentTarget)
+  return currentTarget.contains(eventTarget) || anchor.contains(eventTarget)
+}
+
+function dispatchInputEvents(target: HTMLElement, data: string): void {
+  try {
+    target.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data,
+        inputType: "insertText",
+      })
+    )
+  } catch {
+    target.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+  target.dispatchEvent(new Event("change", { bubbles: true }))
+}
+
+function setNativeValue(
+  target: HTMLInputElement | HTMLTextAreaElement,
+  value: string
+): void {
+  const prototype =
+    target instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, "value")
+  descriptor?.set?.call(target, value)
+}
+
+function withWordBoundary(
+  existing: string,
+  start: number,
+  end: number,
+  rawText: string
+): string {
+  const text = rawText.trim()
+  if (!text) return ""
+
+  const before = existing.slice(0, start)
+  const after = existing.slice(end)
+  const needsLeadingSpace =
+    before.length > 0 && !/\s$/.test(before) && !/^[,.;:!?，。！？、]/.test(text)
+  const needsTrailingSpace =
+    after.length > 0 && !/^\s/.test(after) && !/[([{（【「『]$/.test(text)
+
+  return `${needsLeadingSpace ? " " : ""}${text}${needsTrailingSpace ? " " : ""}`
+}
+
+function insertTranscribedText(target: VoiceTarget, rawText: string): void {
+  const text = rawText.trim()
+  if (!text) return
+
+  target.focus()
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    const value = target.value
+    const start = target.selectionStart ?? value.length
+    const end = target.selectionEnd ?? start
+    const insertion = withWordBoundary(value, start, end, text)
+    const nextValue = `${value.slice(0, start)}${insertion}${value.slice(end)}`
+    setNativeValue(target, nextValue)
+    const cursor = start + insertion.length
+    target.setSelectionRange(cursor, cursor)
+    dispatchInputEvents(target, insertion)
+    return
+  }
+
+  const selection = window.getSelection()
+  const currentText = target.textContent || ""
+  const insertion =
+    currentText.length > 0 && !/\s$/.test(currentText) ? ` ${text}` : text
+
+  if (
+    selection &&
+    selection.rangeCount > 0 &&
+    selection.anchorNode &&
+    target.contains(selection.anchorNode)
+  ) {
+    document.execCommand("insertText", false, insertion)
+  } else {
+    target.appendChild(document.createTextNode(insertion))
+  }
+  dispatchInputEvents(target, insertion)
+}
+
+function chooseMimeType(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+    "audio/ogg;codecs=opus",
+  ]
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type))
+}
+
+function extensionForMimeType(mimeType: string): string {
+  const normalized = mimeType.toLowerCase()
+  if (normalized.includes("mp4")) return "m4a"
+  if (normalized.includes("ogg")) return "ogg"
+  if (normalized.includes("wav")) return "wav"
+  return "webm"
+}
+
+export function useVoiceInputControls(
+  { autoRefresh = true }: UseVoiceInputControlsOptions = {}
+) {
+  const { t } = useI18n()
+  const [hasAsrModel, setHasAsrModel] = useState(false)
+  const [status, setStatus] = useState<VoiceStatus>("idle")
+  const targetRef = useRef<VoiceTarget | null>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const recordingTargetRef = useRef<VoiceTarget | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<BlobPart[]>([])
+  const lastAvailabilityFetchRef = useRef(0)
+
+  const refreshAvailability = useCallback(async () => {
+    lastAvailabilityFetchRef.current = Date.now()
+    try {
+      const response = await apiRequest(
+        `${getApiUrl()}/api/models/?category=speech&limit=1000`
+      )
+      if (!response.ok) {
+        setHasAsrModel(false)
+        return
+      }
+      const models = await response.json()
+      const available =
+        Array.isArray(models) &&
+        models.some((model) => {
+          const abilities = Array.isArray(model?.abilities) ? model.abilities : []
+          return abilities.map(String).includes("asr")
+        })
+      setHasAsrModel(available)
+    } catch {
+      setHasAsrModel(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (autoRefresh) {
+      refreshAvailability()
+    }
+  }, [autoRefresh, refreshAvailability])
+
+  const refreshAvailabilityIfStale = useCallback(() => {
+    if (Date.now() - lastAvailabilityFetchRef.current > 30_000) {
+      refreshAvailability()
+    }
+  }, [refreshAvailability])
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((track) => track.stop())
+    streamRef.current = null
+  }, [])
+
+  const transcribeBlob = useCallback(
+    async (blob: Blob, target: VoiceTarget | null) => {
+      if (!target) return
+      if (blob.size === 0) {
+        toast.error(t("voiceInput.errors.emptyAudio"))
+        return
+      }
+
+      setStatus("transcribing")
+      try {
+        const mimeType = blob.type || "audio/webm"
+        const extension = extensionForMimeType(mimeType)
+        const file = new File([blob], `voice-input.${extension}`, {
+          type: mimeType,
+        })
+        const formData = new FormData()
+        formData.append("file", file)
+
+        const response = await apiRequest(
+          `${getUploadApiUrl()}/api/models/speech/transcribe`,
+          {
+            method: "POST",
+            body: formData,
+          }
+        )
+        const parsed = await parseApiResponse(response)
+        if (!response.ok) {
+          throw new Error(
+            getApiErrorMessage(response, parsed, t("voiceInput.errors.failed"))
+          )
+        }
+
+        const text =
+          isJsonRecord(parsed.data) && typeof parsed.data.text === "string"
+            ? parsed.data.text
+            : ""
+        if (!text.trim()) {
+          toast.error(t("voiceInput.errors.noText"))
+          return
+        }
+        insertTranscribedText(target, text)
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : t("voiceInput.errors.failed")
+        )
+      } finally {
+        setStatus("idle")
+      }
+    },
+    [t]
+  )
+
+  const startRecording = useCallback(
+    async (target?: VoiceTarget | null) => {
+      const recordingTarget = target ?? targetRef.current
+      if (!recordingTarget || status !== "idle") return
+      if (
+        !navigator.mediaDevices?.getUserMedia ||
+        typeof MediaRecorder === "undefined"
+      ) {
+        toast.error(t("voiceInput.errors.unsupported"))
+        return
+      }
+
+      targetRef.current = recordingTarget
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        streamRef.current = stream
+        chunksRef.current = []
+        recordingTargetRef.current = recordingTarget
+        const mimeType = chooseMimeType()
+        const recorder = new MediaRecorder(
+          stream,
+          mimeType ? { mimeType } : undefined
+        )
+        recorderRef.current = recorder
+
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            chunksRef.current.push(event.data)
+          }
+        }
+        recorder.onstop = () => {
+          const blob = new Blob(chunksRef.current, {
+            type: recorder.mimeType || mimeType || "audio/webm",
+          })
+          chunksRef.current = []
+          recorderRef.current = null
+          const target = recordingTargetRef.current
+          recordingTargetRef.current = null
+          stopStream()
+          transcribeBlob(blob, target)
+        }
+        recorder.onerror = () => {
+          stopStream()
+          recorderRef.current = null
+          recordingTargetRef.current = null
+          chunksRef.current = []
+          setStatus("idle")
+          toast.error(t("voiceInput.errors.failed"))
+        }
+
+        recorder.start()
+        setStatus("recording")
+      } catch (error) {
+        stopStream()
+        recordingTargetRef.current = null
+        setStatus("idle")
+        toast.error(
+          error instanceof DOMException && error.name === "NotAllowedError"
+            ? t("voiceInput.errors.permissionDenied")
+            : t("voiceInput.errors.failed")
+        )
+      }
+    },
+    [status, stopStream, t, transcribeBlob]
+  )
+
+  const stopRecording = useCallback(() => {
+    const recorder = recorderRef.current
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop()
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (recorderRef.current?.state !== "inactive") {
+        recorderRef.current?.stop()
+      }
+      recordingTargetRef.current = null
+      stopStream()
+    }
+  }, [stopStream])
+
+  return {
+    hasAsrModel,
+    refreshAvailability,
+    refreshAvailabilityIfStale,
+    startRecording,
+    status,
+    stopRecording,
+  }
+}
+
+export function VoiceInputController() {
+  const { t } = useI18n()
+  const {
+    hasAsrModel,
+    refreshAvailabilityIfStale,
+    startRecording,
+    status,
+    stopRecording,
+  } = useVoiceInputControls({ autoRefresh: false })
+  const [activeTarget, setActiveTarget] = useState<VoiceTarget | null>(null)
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(
+    null
+  )
+  const targetRef = useRef<VoiceTarget | null>(null)
+
+  const updatePosition = useCallback((target = targetRef.current) => {
+    if (!target || isElementHidden(target)) {
+      setPosition(null)
+      return
+    }
+
+    const anchor = getPositionAnchor(target)
+    const rect = anchor.getBoundingClientRect()
+    if (
+      rect.bottom < 0 ||
+      rect.top > window.innerHeight ||
+      rect.right < 0 ||
+      rect.left > window.innerWidth
+    ) {
+      setPosition(null)
+      return
+    }
+
+    const buttonSize = 32
+    const viewportPadding = 8
+    const anchorInset = 8
+    const actionRowRightInset = 72
+    const actionRowBottomInset = 24
+    const useActionRowPosition = anchor !== target && rect.height >= 88
+    const regularTop =
+      rect.height > buttonSize + anchorInset * 2
+        ? rect.top + anchorInset
+        : rect.top + (rect.height - buttonSize) / 2
+    const anchorTop = useActionRowPosition
+      ? rect.bottom - buttonSize - actionRowBottomInset
+      : regularTop
+    const outsideLeft = rect.right + 6
+    const insideLeft =
+      rect.right -
+      buttonSize -
+      (useActionRowPosition ? actionRowRightInset : anchorInset)
+    const hasOutsideSpace =
+      anchor === target &&
+      outsideLeft + buttonSize <= window.innerWidth - viewportPadding
+    const left = clamp(
+      hasOutsideSpace ? outsideLeft : insideLeft,
+      viewportPadding,
+      window.innerWidth - buttonSize - viewportPadding
+    )
+    const top = clamp(
+      anchorTop,
+      viewportPadding,
+      window.innerHeight - buttonSize - viewportPadding
+    )
+    setPosition({ top, left })
+  }, [])
+
+  const activateTarget = useCallback(
+    (target: VoiceTarget) => {
+      if (status !== "idle") return
+
+      refreshAvailabilityIfStale()
+
+      targetRef.current = target
+      setActiveTarget(target)
+      updatePosition(target)
+    },
+    [refreshAvailabilityIfStale, status, updatePosition]
+  )
+
+  const clearTarget = useCallback(() => {
+    if (status !== "idle") return
+    setActiveTarget(null)
+    targetRef.current = null
+    setPosition(null)
+  }, [status])
+
+  useEffect(() => {
+    const focusedTarget = document.activeElement
+    if (isVoiceEligibleTarget(focusedTarget)) {
+      activateTarget(focusedTarget)
+    }
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target
+      if (!isVoiceEligibleTarget(target)) {
+        if (!isInsideActiveVoiceArea(target, targetRef.current)) clearTarget()
+        return
+      }
+      activateTarget(target)
+    }
+
+    const handlePointerOver = (event: PointerEvent) => {
+      const target = event.target
+      if (isVoiceEligibleTarget(target)) {
+        activateTarget(target)
+        return
+      }
+      if (isInsideActiveVoiceArea(target, targetRef.current)) return
+      if (document.activeElement === targetRef.current) return
+      clearTarget()
+    }
+
+    document.addEventListener("focusin", handleFocusIn)
+    document.addEventListener("pointerover", handlePointerOver)
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn)
+      document.removeEventListener("pointerover", handlePointerOver)
+    }
+  }, [activateTarget, clearTarget])
+
+  useEffect(() => {
+    let frameId: number | null = null
+    const reposition = () => {
+      if (frameId !== null) return
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null
+        updatePosition()
+      })
+    }
+    window.addEventListener("resize", reposition)
+    document.addEventListener("scroll", reposition, true)
+    return () => {
+      window.removeEventListener("resize", reposition)
+      document.removeEventListener("scroll", reposition, true)
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [updatePosition])
+
+  const visible = hasAsrModel && !!activeTarget && !!position
+
+  if (!visible || !position) {
+    return null
+  }
+
+  const label =
+    status === "recording"
+      ? t("voiceInput.stop")
+      : status === "transcribing"
+        ? t("voiceInput.transcribing")
+        : t("voiceInput.start")
+
+  return (
+    <button
+      type="button"
+      data-voice-input-root
+      aria-label={label}
+      title={label}
+      className={cn(
+        "fixed z-[70] inline-flex h-8 w-8 items-center justify-center rounded-full border shadow-md transition-all",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        status === "recording"
+          ? "border-red-400 bg-red-500 text-white hover:bg-red-600"
+          : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground",
+        status === "transcribing" && "cursor-wait opacity-80"
+      )}
+      style={{ top: position.top, left: position.left }}
+      disabled={status === "transcribing"}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (status === "recording") {
+          stopRecording()
+        } else if (status === "idle") {
+          startRecording(activeTarget)
+        }
+      }}
+    >
+      {status === "recording" ? (
+        <Square className="h-3.5 w-3.5 fill-current" />
+      ) : status === "transcribing" ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Mic className="h-4 w-4" />
+      )}
+    </button>
+  )
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -39,6 +39,18 @@ const en = {
       unknown: "Unknown error",
     },
   },
+  voiceInput: {
+    start: "Voice input",
+    stop: "Stop recording",
+    transcribing: "Transcribing voice",
+    errors: {
+      emptyAudio: "No usable audio was recorded",
+      failed: "Voice transcription failed",
+      noText: "No text was recognized",
+      permissionDenied: "Microphone access was denied",
+      unsupported: "This browser does not support recording",
+    },
+  },
   nav: {
     home: "Home",
     settings: "Settings",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -39,6 +39,18 @@ const zh = {
       unknown: "未知错误",
     },
   },
+  voiceInput: {
+    start: "语音输入",
+    stop: "停止录音",
+    transcribing: "正在识别语音",
+    errors: {
+      emptyAudio: "没有录到可识别的音频",
+      failed: "语音识别失败",
+      noText: "没有识别到文字",
+      permissionDenied: "无法访问麦克风，请检查浏览器权限",
+      unsupported: "当前浏览器不支持录音",
+    },
+  },
   nav: {
     home: "首页",
     settings: "系统设置",

--- a/src/xagent/core/model/asr/__init__.py
+++ b/src/xagent/core/model/asr/__init__.py
@@ -1,5 +1,6 @@
 from .adapter import get_asr_model
 from .base import ASRResult, ASRSegment, BaseASR
+from .elevenlabs import ElevenLabsASR
 from .xinference import XinferenceASR
 
 __all__ = [
@@ -7,5 +8,6 @@ __all__ = [
     "ASRResult",
     "ASRSegment",
     "BaseASR",
+    "ElevenLabsASR",
     "XinferenceASR",
 ]

--- a/src/xagent/core/model/asr/adapter.py
+++ b/src/xagent/core/model/asr/adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from .base import ASRResult, ASRSegment, BaseASR
+from .elevenlabs import ElevenLabsASR
 from .xinference import XinferenceASR
 
 
@@ -32,10 +33,16 @@ def get_asr_model_instance(db_model: Any) -> BaseASR:
             base_url=base_url,
             api_key=api_key,
         )
+    elif provider == "elevenlabs":
+        return ElevenLabsASR(
+            model=model_name,
+            base_url=base_url,
+            api_key=api_key,
+        )
     else:
         raise ValueError(
             f"Unsupported ASR provider: {provider}. "
-            "Currently only 'xinference' is supported."
+            "Supported providers: xinference, elevenlabs."
         )
 
 
@@ -49,7 +56,7 @@ def get_asr_model(
     Factory function to get ASR model instance by provider.
 
     Args:
-        provider: Model provider name (e.g., 'xinference')
+        provider: Model provider name (e.g., 'xinference', 'elevenlabs')
         model: Model name/identifier
         api_key: API key for the provider
         **kwargs: Additional provider-specific parameters
@@ -60,16 +67,26 @@ def get_asr_model(
     Raises:
         ValueError: If provider is not supported
     """
-    if provider == "xinference":
+    if provider is None:
+        raise ValueError("ASR provider cannot be None.")
+
+    normalized_provider = provider.lower().strip()
+    if normalized_provider == "xinference":
         return XinferenceASR(
             model=model or "whisper-base",
+            api_key=api_key,
+            **kwargs,
+        )
+    elif normalized_provider == "elevenlabs":
+        return ElevenLabsASR(
+            model=model or "scribe_v2",
             api_key=api_key,
             **kwargs,
         )
     else:
         raise ValueError(
             f"Unsupported ASR provider: {provider}. "
-            "Currently only 'xinference' is supported."
+            "Supported providers: xinference, elevenlabs"
         )
 
 
@@ -80,4 +97,5 @@ __all__ = [
     "ASRResult",
     "ASRSegment",
     "XinferenceASR",
+    "ElevenLabsASR",
 ]

--- a/src/xagent/core/model/asr/elevenlabs.py
+++ b/src/xagent/core/model/asr/elevenlabs.py
@@ -1,0 +1,391 @@
+"""ElevenLabs ASR provider implementation."""
+
+from __future__ import annotations
+
+import logging
+import math
+import mimetypes
+import os
+from collections.abc import Iterable
+from inspect import isawaitable
+from pathlib import Path
+from typing import Any, BinaryIO, Optional, Union
+
+from ...utils.security import redact_sensitive_text
+from .base import ASRResult, ASRSegment, BaseASR
+
+logger = logging.getLogger(__name__)
+
+ELEVENLABS_DEFAULT_BASE_URL = "https://api.elevenlabs.io"
+ELEVENLABS_DEFAULT_ASR_MODEL = "scribe_v2"
+
+_ELEVENLABS_ASR_MODELS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "scribe_v2",
+        "object": "model",
+        "owned_by": "elevenlabs",
+        "category": "speech",
+        "abilities": ["asr"],
+        "name": "Scribe v2",
+        "description": "ElevenLabs speech-to-text model",
+    },
+    {
+        "id": "scribe_v1",
+        "object": "model",
+        "owned_by": "elevenlabs",
+        "category": "speech",
+        "abilities": ["asr"],
+        "name": "Scribe v1",
+        "description": "ElevenLabs speech-to-text model",
+    },
+)
+
+_ELEVENLABS_STT_PROVIDER_OPTION_FIELDS = (
+    "enable_logging",
+    "language_code",
+    "tag_audio_events",
+    "num_speakers",
+    "timestamps_granularity",
+    "diarize",
+    "diarization_threshold",
+    "additional_formats",
+    "file_format",
+    "cloud_storage_url",
+    "source_url",
+    "webhook",
+    "webhook_id",
+    "temperature",
+    "seed",
+    "use_multi_channel",
+    "multichannel_output_style",
+    "webhook_metadata",
+    "entity_detection",
+    "no_verbatim",
+    "use_speaker_library",
+    "detect_speaker_roles",
+    "entity_redaction",
+    "entity_redaction_mode",
+    "keyterms",
+    "request_options",
+)
+
+_ELEVENLABS_FILE_FORMATS = {"pcm_s16le_16", "other"}
+
+
+def _get_field(value: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(value, dict) and name in value:
+            return value[name]
+        if hasattr(value, name):
+            return getattr(value, name)
+    return None
+
+
+def _to_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped: dict[str, Any] = value.model_dump(exclude_none=True)
+        return dumped
+    if hasattr(value, "dict"):
+        legacy_dumped: dict[str, Any] = value.dict(exclude_none=True)
+        return legacy_dumped
+    if hasattr(value, "__dict__"):
+        return {
+            key: item
+            for key, item in vars(value).items()
+            if not key.startswith("_") and item is not None
+        }
+    return {"value": str(value)}
+
+
+def _normalize_keyterms(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Iterable):
+        return [str(item) for item in value if item]
+    return [str(value)]
+
+
+def _content_type_for_filename(filename: str) -> str:
+    return mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+
+class ElevenLabsASR(BaseASR):
+    """ElevenLabs speech-to-text model client using the official SDK."""
+
+    provider_name = "elevenlabs"
+
+    def __init__(
+        self,
+        model: str = ELEVENLABS_DEFAULT_ASR_MODEL,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        language: Optional[str] = None,
+    ) -> None:
+        self.model = model
+        self.model_name = model
+        self.api_key = api_key or os.getenv("ELEVENLABS_API_KEY")
+        self.base_url = (
+            base_url or os.getenv("ELEVENLABS_BASE_URL") or ELEVENLABS_DEFAULT_BASE_URL
+        ).rstrip("/")
+        self.language = language
+        self._async_client: Any = None
+
+    @staticmethod
+    def _create_async_client(
+        api_key: Optional[str], base_url: Optional[str] = None
+    ) -> Any:
+        try:
+            from elevenlabs.client import AsyncElevenLabs
+        except ImportError as exc:
+            raise RuntimeError(
+                "The 'elevenlabs' package is required for ElevenLabs ASR. "
+                "Install project dependencies to enable this provider."
+            ) from exc
+
+        kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+
+        return AsyncElevenLabs(**kwargs)
+
+    def _ensure_async_client(self) -> Any:
+        if not self.api_key:
+            raise RuntimeError("ElevenLabs API key is required for ASR transcription")
+        if self._async_client is None:
+            self._async_client = self._create_async_client(self.api_key, self.base_url)
+        return self._async_client
+
+    @staticmethod
+    async def _close_client(client: Any) -> None:
+        if client is None:
+            return
+
+        close = getattr(client, "aclose", None) or getattr(client, "close", None)
+        if callable(close):
+            result = close()
+            if isawaitable(result):
+                await result
+
+    async def aclose(self) -> None:
+        """Close any cached ElevenLabs SDK clients."""
+        async_client = self._async_client
+        self._async_client = None
+        await self._close_client(async_client)
+
+    async def __aenter__(self) -> "ElevenLabsASR":
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()
+
+    @staticmethod
+    def _validate_provider_options(options: dict[str, Any]) -> None:
+        unsupported_keys = set(options) - set(_ELEVENLABS_STT_PROVIDER_OPTION_FIELDS)
+        if unsupported_keys:
+            supported = ", ".join(_ELEVENLABS_STT_PROVIDER_OPTION_FIELDS)
+            unsupported = ", ".join(sorted(unsupported_keys))
+            raise ValueError(
+                "Unsupported ElevenLabs STT provider_options keys: "
+                f"{unsupported}. Supported keys: {supported}."
+            )
+
+    def _build_request_kwargs(
+        self,
+        *,
+        language: Optional[str],
+        format: Optional[str],
+        verbose: bool,
+        kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        request_kwargs = {
+            key: value for key, value in kwargs.items() if value is not None
+        }
+
+        language_code = (
+            request_kwargs.pop("language_code", None) or language or self.language
+        )
+        if language_code:
+            request_kwargs["language_code"] = language_code
+
+        hotword = request_kwargs.pop("hotword", None)
+        if hotword is not None and "keyterms" not in request_kwargs:
+            request_kwargs["keyterms"] = _normalize_keyterms(hotword)
+
+        if verbose:
+            request_kwargs.setdefault("timestamps_granularity", "word")
+
+        if format:
+            normalized_format = format.lower().strip()
+            if (
+                normalized_format in _ELEVENLABS_FILE_FORMATS
+                and "file_format" not in request_kwargs
+            ):
+                request_kwargs["file_format"] = normalized_format
+
+        self._validate_provider_options(request_kwargs)
+        return request_kwargs
+
+    def _build_file_payload(
+        self, audio: Union[str, bytes], format: Optional[str]
+    ) -> Any:
+        if isinstance(audio, bytes):
+            extension = (format or "wav").strip().lstrip(".") or "wav"
+            filename = f"audio.{extension}"
+            return (filename, audio, _content_type_for_filename(filename))
+
+        audio_path = Path(audio)
+        return (
+            audio_path.name,
+            audio_path.open("rb"),
+            _content_type_for_filename(audio_path.name),
+        )
+
+    async def transcribe(
+        self,
+        audio: Union[str, bytes],
+        language: Optional[str] = None,
+        format: Optional[str] = None,
+        verbose: bool = False,
+        **kwargs: Any,
+    ) -> Union[str, ASRResult]:
+        """Transcribe audio to text."""
+
+        request_kwargs = self._build_request_kwargs(
+            language=language,
+            format=format,
+            verbose=verbose,
+            kwargs=kwargs,
+        )
+
+        client = self._ensure_async_client()
+        file_handle: Optional[BinaryIO] = None
+        if (
+            isinstance(audio, str)
+            and audio.startswith(("http://", "https://"))
+            and "source_url" not in request_kwargs
+            and "cloud_storage_url" not in request_kwargs
+        ):
+            request_kwargs["source_url"] = audio
+        elif (
+            "source_url" not in request_kwargs
+            and "cloud_storage_url" not in request_kwargs
+        ):
+            file_payload = self._build_file_payload(audio, format)
+            if hasattr(file_payload[1], "close"):
+                file_handle = file_payload[1]
+            request_kwargs["file"] = file_payload
+
+        try:
+            response = await client.speech_to_text.convert(
+                model_id=self.model,
+                **request_kwargs,
+            )
+        except Exception as exc:
+            redacted_error = redact_sensitive_text(str(exc))
+            logger.error("ElevenLabs ASR failed: %s", redacted_error)
+            raise RuntimeError(f"ElevenLabs ASR failed: {redacted_error}") from exc
+        finally:
+            if file_handle is not None:
+                file_handle.close()
+
+        text, segments, result_language, raw_response = self._normalize_response(
+            response
+        )
+        if not verbose:
+            return text
+
+        return ASRResult(
+            text=text,
+            segments=segments if segments else None,
+            language=result_language,
+            raw_response=raw_response,
+        )
+
+    @staticmethod
+    def _normalize_response(
+        response: Any,
+    ) -> tuple[str, list[ASRSegment], Optional[str], dict[str, Any]]:
+        raw_response = _to_dict(response)
+        transcripts = _get_field(response, "transcripts") or []
+
+        if transcripts:
+            transcript_texts = [
+                str(text)
+                for transcript in transcripts
+                if (text := _get_field(transcript, "text"))
+            ]
+            text = "\n".join(transcript_texts)
+            language = _get_field(transcripts[0], "language_code")
+            segments: list[ASRSegment] = []
+            for transcript in transcripts:
+                segments.extend(ElevenLabsASR._parse_word_segments(transcript))
+            return text, segments, language, raw_response
+
+        text = str(_get_field(response, "text") or "")
+        language = _get_field(response, "language_code")
+        segments = ElevenLabsASR._parse_word_segments(response)
+        return text, segments, language, raw_response
+
+    @staticmethod
+    def _word_confidence(word: Any) -> Optional[float]:
+        confidence = _get_field(word, "confidence")
+        if confidence is not None:
+            return float(confidence)
+
+        logprob = _get_field(word, "logprob")
+        if logprob is None:
+            return None
+
+        probability = math.exp(float(logprob))
+        return max(0.0, min(1.0, probability))
+
+    @staticmethod
+    def _parse_word_segments(response: Any) -> list[ASRSegment]:
+        words = _get_field(response, "words") or []
+        if not words:
+            return []
+
+        segments: list[ASRSegment] = []
+        for word in words:
+            word_text = _get_field(word, "text")
+            if word_text is None or not str(word_text).strip():
+                continue
+
+            start = _get_field(word, "start")
+            end = _get_field(word, "end")
+            if start is None or end is None:
+                continue
+
+            speaker = _get_field(word, "speaker_id")
+            confidence = ElevenLabsASR._word_confidence(word)
+            segments.append(
+                ASRSegment(
+                    text=str(word_text),
+                    start=float(start),
+                    end=float(end),
+                    speaker=str(speaker) if speaker is not None else None,
+                    confidence=confidence,
+                )
+            )
+
+        return segments
+
+    @property
+    def abilities(self) -> list[str]:
+        return [
+            "asr",
+            "timestamps",
+            "speaker_diarization",
+        ]
+
+    @staticmethod
+    async def async_list_available_models(
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        _ = api_key, base_url
+        return [dict(model) for model in _ELEVENLABS_ASR_MODELS]

--- a/src/xagent/core/model/providers.py
+++ b/src/xagent/core/model/providers.py
@@ -123,7 +123,7 @@ _SUPPORTED_PROVIDER_METADATA: tuple[dict[str, Any], ...] = (
     {
         "id": "elevenlabs",
         "name": "ElevenLabs",
-        "description": "ElevenLabs speech models for text-to-speech",
+        "description": "ElevenLabs speech models for transcription and text-to-speech",
         "requires_base_url": False,
         "category": ["speech"],
     },

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -4,9 +4,19 @@ import asyncio
 import logging
 import time
 import urllib.parse
-from typing import Any, List, Optional
+from inspect import isawaitable
+from typing import Any, List, Optional, cast
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+)
 from sqlalchemy.orm import Session
 
 from xagent.core.model.chat.basic.deepseek import DEEPSEEK_SUPPORTED_MODELS
@@ -69,6 +79,8 @@ def _can_user_share(user: User) -> bool:
 
 
 model_router = APIRouter(prefix="/api/models", tags=["models"])
+
+MAX_TRANSCRIBE_UPLOAD_BYTES = 25 * 1024 * 1024
 
 
 def _decode_model_identifier(model_id: str) -> str:
@@ -167,6 +179,123 @@ def _validate_requested_abilities(
         raise ValueError(
             f"Model '{provider_model.get('id', '')}' does not support abilities: {', '.join(missing)}"
         )
+
+
+def _model_has_ability(model: Any, ability: str) -> bool:
+    abilities = getattr(model, "abilities", None) or []
+    if isinstance(abilities, str):
+        return ability in abilities
+    if not isinstance(abilities, (list, tuple, set)):
+        return False
+    return ability in {str(item) for item in abilities}
+
+
+def _iter_accessible_asr_models(db: Session, user: User) -> list[DBModel]:
+    from ..services.model_service import (
+        _get_visible_user_ids,
+        build_user_model_visibility_filter,
+    )
+
+    user_id = int(user.id)
+    visible_ids = _get_visible_user_ids(db, user_id)
+    rows = (
+        db.query(DBModel, UserModel)
+        .join(UserModel, DBModel.id == UserModel.model_id)
+        .filter(
+            DBModel.category == "speech",
+            DBModel.is_active,
+            build_user_model_visibility_filter(user_id, visible_ids),
+        )
+        .order_by(
+            (UserModel.user_id == user_id).desc(),
+            UserModel.is_owner.desc(),
+            DBModel.id.asc(),
+        )
+        .all()
+    )
+
+    models: list[DBModel] = []
+    seen_model_ids: set[int] = set()
+    for db_model, _user_model in rows:
+        model_pk = int(db_model.id)
+        if model_pk in seen_model_ids or not _model_has_ability(db_model, "asr"):
+            continue
+        seen_model_ids.add(model_pk)
+        models.append(db_model)
+    return models
+
+
+def _resolve_asr_model_for_transcription(
+    db: Session,
+    user: User,
+    requested_model_id: Optional[str] = None,
+) -> DBModel:
+    if requested_model_id:
+        _, db_model, _user_model = _resolve_accessible_model(
+            db, user, requested_model_id
+        )
+        if db_model.category != "speech" or not _model_has_ability(db_model, "asr"):
+            raise HTTPException(
+                status_code=400,
+                detail="Selected model does not support ASR transcription",
+            )
+        return db_model
+
+    user_id = int(user.id)
+    asr_default = (
+        db.query(UserDefaultModel)
+        .join(DBModel, UserDefaultModel.model_id == DBModel.id)
+        .filter(
+            UserDefaultModel.user_id == user_id,
+            UserDefaultModel.config_type == "asr",
+            DBModel.is_active,
+        )
+        .first()
+    )
+    default_model: Optional[DBModel] = None
+    if asr_default and asr_default.model:
+        default_model = cast(DBModel, asr_default.model)
+        if not _model_has_ability(default_model, "asr"):
+            default_model = None
+
+    if default_model:
+        try:
+            _resolve_accessible_model(db, user, str(default_model.model_id))
+            return default_model
+        except HTTPException:
+            logger.warning(
+                "Ignoring invisible default ASR model %s for user %s",
+                default_model.model_id,
+                user_id,
+            )
+
+    accessible_models = _iter_accessible_asr_models(db, user)
+    if accessible_models:
+        return accessible_models[0]
+
+    raise HTTPException(status_code=404, detail="No ASR model is configured")
+
+
+def _format_from_upload(file: UploadFile) -> Optional[str]:
+    filename = file.filename or ""
+    if "." in filename:
+        suffix = filename.rsplit(".", 1)[-1].strip().lower()
+        if suffix:
+            return suffix
+
+    content_type = (file.content_type or "").lower()
+    if "/" in content_type:
+        subtype = content_type.split("/", 1)[1].split(";", 1)[0].strip()
+        if subtype:
+            return "mp3" if subtype == "mpeg" else subtype
+    return None
+
+
+async def _read_transcribe_upload_with_size_limit(file: UploadFile) -> bytes:
+    audio_bytes = await file.read(MAX_TRANSCRIBE_UPLOAD_BYTES + 1)
+    if len(audio_bytes) > MAX_TRANSCRIBE_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Audio file is too large")
+    return audio_bytes
 
 
 def _validate_provider_model_name(provider: str, model_name: str) -> None:
@@ -645,11 +774,13 @@ async def test_model_connection(
                 )
 
             if provider == "elevenlabs":
-                requested_abilities = request.abilities or ["tts"]
-                unsupported_abilities = sorted(set(requested_abilities) - {"tts"})
+                requested_abilities = request.abilities
+                unsupported_abilities = sorted(
+                    set(requested_abilities or []) - {"asr", "tts"}
+                )
                 if unsupported_abilities:
                     raise ValueError(
-                        "ElevenLabs speech connection test only supports TTS abilities: "
+                        "ElevenLabs speech connection test only supports ASR/TTS abilities: "
                         + ", ".join(unsupported_abilities)
                     )
             else:
@@ -759,6 +890,64 @@ async def test_model_connection(
             message="Connection failed",
             error=safe_error,
         )
+
+
+@model_router.post("/speech/transcribe")
+async def transcribe_speech_input(
+    file: UploadFile = File(...),
+    model_id: Optional[str] = Form(None),
+    language: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Transcribe a short UI voice input clip with an accessible ASR model."""
+
+    from xagent.core.model.asr.adapter import get_asr_model_instance
+
+    try:
+        audio_bytes = await _read_transcribe_upload_with_size_limit(file)
+    finally:
+        await file.close()
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="Audio file is empty")
+
+    db_model = _resolve_asr_model_for_transcription(db, user, model_id)
+    asr_model = get_asr_model_instance(db_model)
+    try:
+        result = await asyncio.wait_for(
+            asr_model.transcribe(
+                audio_bytes,
+                language=language,
+                format=_format_from_upload(file),
+            ),
+            timeout=180.0,
+        )
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="Transcription timed out") from exc
+    except Exception as exc:
+        safe_error = redact_sensitive_text(str(exc))
+        logger.error(
+            "Speech transcription failed for model %s: %s",
+            db_model.model_id,
+            safe_error,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Speech transcription failed: {safe_error}",
+        ) from exc
+    finally:
+        close = getattr(asr_model, "aclose", None)
+        if callable(close):
+            result_to_close = close()
+            if isawaitable(result_to_close):
+                await result_to_close
+
+    text = getattr(result, "text", result)
+    return {
+        "text": str(text or ""),
+        "model_id": db_model.model_id,
+        "model_name": db_model.model_name,
+    }
 
 
 @model_router.post("/test", response_model=List[ModelTestResponse])

--- a/src/xagent/web/services/model_list_service.py
+++ b/src/xagent/web/services/model_list_service.py
@@ -196,13 +196,27 @@ async def fetch_xinference_video_models(
 async def fetch_elevenlabs_models(
     api_key: str, base_url: Optional[str] = None
 ) -> List[Dict[str, Any]]:
-    """Fetch available ElevenLabs TTS models using the official SDK."""
+    """Fetch available ElevenLabs speech models.
 
+    ElevenLabs exposes Scribe ASR model ids through the speech-to-text API, not
+    the models list response. We use the TTS models.list call as the non-billed
+    account-level auth probe, then append curated Scribe ids so connection tests
+    do not need to run a paid transcription request.
+    """
+
+    from ...core.model.asr.elevenlabs import ElevenLabsASR
     from ...core.model.tts.elevenlabs import ElevenLabsTTS
 
-    return await ElevenLabsTTS.async_list_available_models(
+    tts_models = await ElevenLabsTTS.async_list_available_models(
         api_key=api_key, base_url=base_url
     )
+    asr_models = await ElevenLabsASR.async_list_available_models(
+        api_key=api_key, base_url=base_url
+    )
+    seen_model_ids = {str(model.get("id")) for model in tts_models}
+    return tts_models + [
+        model for model in asr_models if str(model.get("id")) not in seen_model_ids
+    ]
 
 
 async def fetch_dashscope_rerank_models(

--- a/src/xagent/web/services/model_service.py
+++ b/src/xagent/web/services/model_service.py
@@ -1088,10 +1088,15 @@ def _get_models_by_category(
 
                     models[str(db_model.model_name)] = model
                     logger.info(f"Added {model_type} model: {db_model.model_name}")
-                elif model_provider == "elevenlabs" and ability == "tts":
-                    from ...core.model.tts.adapter import get_tts_model_instance
+                elif model_provider == "elevenlabs" and ability in {"asr", "tts"}:
+                    if ability == "asr":
+                        from ...core.model.asr.adapter import get_asr_model_instance
 
-                    model = get_tts_model_instance(db_model)
+                        model = get_asr_model_instance(db_model)
+                    else:
+                        from ...core.model.tts.adapter import get_tts_model_instance
+
+                        model = get_tts_model_instance(db_model)
                     models[str(db_model.model_name)] = model
                     logger.info(f"Added {model_type} model: {db_model.model_name}")
                 else:

--- a/tests/core/model/asr/test_elevenlabs.py
+++ b/tests/core/model/asr/test_elevenlabs.py
@@ -1,0 +1,379 @@
+"""Unit tests for ElevenLabs ASR model."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from xagent.core.model.asr import ASRResult, ElevenLabsASR
+from xagent.core.model.asr.adapter import get_asr_model, get_asr_model_instance
+from xagent.core.model.asr.elevenlabs import (
+    ELEVENLABS_DEFAULT_ASR_MODEL,
+    ELEVENLABS_DEFAULT_BASE_URL,
+)
+
+
+def test_init_with_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    asr = ElevenLabsASR()
+
+    assert asr.model == ELEVENLABS_DEFAULT_ASR_MODEL
+    assert asr.model_name == ELEVENLABS_DEFAULT_ASR_MODEL
+    assert asr.base_url == ELEVENLABS_DEFAULT_BASE_URL
+    assert asr.api_key is None
+    assert asr.language is None
+
+
+async def test_transcribe_uses_sdk_convert_and_parses_words(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    convert_calls: list[dict[str, object]] = []
+
+    async def convert(**kwargs: object) -> object:
+        convert_calls.append(kwargs)
+        return SimpleNamespace(
+            text="Hello world",
+            language_code="eng",
+            words=[
+                SimpleNamespace(
+                    text="Hello",
+                    start=0.0,
+                    end=0.4,
+                    speaker_id="speaker_0",
+                    logprob=-0.1,
+                ),
+                SimpleNamespace(text=" ", start=None, end=None, speaker_id=None),
+                SimpleNamespace(
+                    text="world",
+                    start=0.5,
+                    end=0.9,
+                    speaker_id="speaker_0",
+                    logprob=-0.2,
+                ),
+            ],
+        )
+
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key", model="scribe_v2")
+    result = await asr.transcribe(
+        b"fake audio",
+        format="mp3",
+        language="eng",
+        verbose=True,
+        diarize=True,
+        hotword=["Xagent"],
+        tag_audio_events=False,
+    )
+
+    assert isinstance(result, ASRResult)
+    assert result.text == "Hello world"
+    assert result.language == "eng"
+    assert result.segments is not None
+    assert [segment.text for segment in result.segments] == ["Hello", "world"]
+    assert result.segments[0].start == 0.0
+    assert result.segments[0].end == 0.4
+    assert result.segments[0].speaker == "speaker_0"
+    assert result.segments[0].confidence == pytest.approx(0.904837418)
+    assert result.segments[1].confidence == pytest.approx(0.818730753)
+    assert len(convert_calls) == 1
+    call = convert_calls[0]
+    assert call["model_id"] == "scribe_v2"
+    assert call["language_code"] == "eng"
+    assert call["timestamps_granularity"] == "word"
+    assert call["diarize"] is True
+    assert call["keyterms"] == ["Xagent"]
+    assert call["tag_audio_events"] is False
+    assert call["file"][0] == "audio.mp3"
+    assert call["file"][1] == b"fake audio"
+    assert call["file"][2] == "audio/mpeg"
+
+
+async def test_transcribe_source_url_does_not_send_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    convert = AsyncMock(return_value=SimpleNamespace(text="remote audio", words=[]))
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    result = await asr.transcribe("https://example.com/audio.mp3")
+
+    assert result == "remote audio"
+    convert.assert_awaited_once()
+    call = convert.call_args.kwargs
+    assert call["source_url"] == "https://example.com/audio.mp3"
+    assert "file" not in call
+
+
+async def test_transcribe_source_url_kwarg_does_not_send_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"wav-data")
+    convert = AsyncMock(return_value=SimpleNamespace(text="remote audio", words=[]))
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    monkeypatch.setattr(
+        asr,
+        "_build_file_payload",
+        lambda audio, format: pytest.fail("source_url should skip file upload"),
+    )
+
+    result = await asr.transcribe(
+        str(audio_path), source_url="https://example.com/uploaded.wav"
+    )
+
+    assert result == "remote audio"
+    convert.assert_awaited_once()
+    call = convert.call_args.kwargs
+    assert call["source_url"] == "https://example.com/uploaded.wav"
+    assert "file" not in call
+
+
+async def test_transcribe_local_path_opens_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"wav-data")
+    observed_file_state: dict[str, object] = {}
+
+    async def convert(**kwargs: object) -> object:
+        file_payload = kwargs["file"]
+        observed_file_state["filename"] = file_payload[0]
+        observed_file_state["content_type"] = file_payload[2]
+        observed_file_state["data"] = file_payload[1].read()
+        observed_file_state["closed_during_call"] = file_payload[1].closed
+        return SimpleNamespace(text="local audio", words=[])
+
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    result = await asr.transcribe(str(audio_path), verbose=False)
+
+    assert result == "local audio"
+    assert observed_file_state == {
+        "filename": "sample.wav",
+        "content_type": "audio/x-wav",
+        "data": b"wav-data",
+        "closed_during_call": False,
+    }
+
+
+async def test_transcribe_parses_multichannel_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def convert(**kwargs: object) -> object:
+        return SimpleNamespace(
+            transcripts=[
+                SimpleNamespace(
+                    text="agent hello",
+                    language_code="en",
+                    words=[
+                        SimpleNamespace(
+                            text="agent",
+                            start=0.0,
+                            end=0.2,
+                            speaker_id="agent",
+                        )
+                    ],
+                ),
+                SimpleNamespace(
+                    text="customer hi",
+                    language_code="en",
+                    words=[
+                        SimpleNamespace(
+                            text="customer",
+                            start=0.3,
+                            end=0.6,
+                            speaker_id="customer",
+                        )
+                    ],
+                ),
+            ]
+        )
+
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    result = await asr.transcribe(b"fake audio", verbose=True, use_multi_channel=True)
+
+    assert isinstance(result, ASRResult)
+    assert result.text == "agent hello\ncustomer hi"
+    assert result.language == "en"
+    assert result.segments is not None
+    assert [segment.speaker for segment in result.segments] == ["agent", "customer"]
+
+
+async def test_transcribe_rejects_unsupported_provider_options() -> None:
+    asr = ElevenLabsASR(api_key="test-key")
+
+    with pytest.raises(ValueError) as exc_info:
+        await asr.transcribe(b"fake audio", reference_audio="ref.wav")
+
+    assert "Unsupported ElevenLabs STT provider_options keys: reference_audio" in str(
+        exc_info.value
+    )
+
+
+async def test_transcribe_redacts_sensitive_sdk_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def convert(**kwargs: object) -> object:
+        raise RuntimeError(
+            "request failed api_key=sk-elevenlabs-secret123 "
+            "Authorization: Bearer bearer-secret456"
+        )
+
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    with pytest.raises(RuntimeError) as exc_info:
+        await asr.transcribe(b"fake audio")
+
+    message = str(exc_info.value)
+    assert "sk-elevenlabs-secret123" not in message
+    assert "bearer-secret456" not in message
+    assert "api_key=***t123" in message
+    assert "Authorization: Bearer ***t456" in message
+
+
+async def test_transcribe_closes_local_file_on_sdk_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"wav-data")
+    file_handle = audio_path.open("rb")
+
+    async def convert(**kwargs: object) -> object:
+        raise RuntimeError("request failed")
+
+    fake_client = SimpleNamespace(speech_to_text=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    asr = ElevenLabsASR(api_key="test-key")
+    monkeypatch.setattr(
+        asr,
+        "_build_file_payload",
+        lambda audio, format: ("sample.wav", file_handle, "audio/x-wav"),
+    )
+
+    with pytest.raises(RuntimeError, match="ElevenLabs ASR failed"):
+        await asr.transcribe(str(audio_path))
+
+    assert file_handle.closed is True
+
+
+async def test_aclose_closes_cached_clients() -> None:
+    class AsyncClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    async_client = AsyncClient()
+    asr = ElevenLabsASR(api_key="test-key")
+    asr._async_client = async_client
+
+    await asr.aclose()
+
+    assert async_client.closed is True
+    assert asr._async_client is None
+
+
+async def test_transcribe_requires_api_key_before_opening_local_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"wav-data")
+    asr = ElevenLabsASR(api_key=None)
+    monkeypatch.setattr(
+        asr,
+        "_build_file_payload",
+        lambda audio, format: pytest.fail("missing API key should skip file open"),
+    )
+
+    with pytest.raises(RuntimeError, match="API key is required"):
+        await asr.transcribe(str(audio_path))
+
+
+def test_adapter_routes_elevenlabs() -> None:
+    asr = get_asr_model(provider="elevenlabs", model="scribe_v2")
+
+    assert isinstance(asr, ElevenLabsASR)
+    assert asr.model == "scribe_v2"
+
+
+def test_adapter_rejects_none_provider() -> None:
+    with pytest.raises(ValueError, match="ASR provider cannot be None"):
+        get_asr_model(provider=None)
+
+
+def test_get_asr_model_instance_routes_elevenlabs() -> None:
+    db_model = SimpleNamespace(
+        model_provider="elevenlabs",
+        model_name="scribe_v2",
+        api_key="test-key",
+        base_url=None,
+    )
+
+    asr = get_asr_model_instance(db_model)
+
+    assert isinstance(asr, ElevenLabsASR)
+    assert asr.model == "scribe_v2"
+    assert asr.api_key == "test-key"
+
+
+async def test_async_list_available_models_returns_scribe_models() -> None:
+    models = await ElevenLabsASR.async_list_available_models()
+
+    assert models[0]["id"] == "scribe_v2"
+    assert models[0]["abilities"] == ["asr"]
+    assert models[1]["id"] == "scribe_v1"
+
+
+def test_elevenlabs_advertises_asr_capabilities() -> None:
+    asr = ElevenLabsASR(api_key="test-key")
+
+    assert asr.provider_name == "elevenlabs"
+    assert asr.supports_speaker_diarization is True
+    assert asr.supports_timestamps is True
+    assert asr.abilities == ["asr", "timestamps", "speaker_diarization"]

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -366,6 +366,68 @@ class TestModelAPI:
         assert data["status"] == "passed"
         mock_fetch.assert_awaited_once()
 
+    def test_test_connection_speech_elevenlabs_uses_listing_for_custom_asr(
+        self, test_db, regular_user, regular_headers
+    ):
+        """ElevenLabs speech checks should not infer abilities from name prefixes."""
+        with patch(
+            "xagent.web.services.model_list_service.fetch_models_from_provider",
+            new=AsyncMock(
+                return_value=[
+                    {
+                        "id": "custom_transcriber",
+                        "abilities": ["asr"],
+                    }
+                ]
+            ),
+        ) as mock_fetch:
+            response = client.post(
+                "/api/models/test-connection",
+                json={
+                    "model_provider": "elevenlabs",
+                    "model_name": "custom_transcriber",
+                    "api_key": "test-api-key",
+                    "category": "speech",
+                },
+                headers=regular_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "passed"
+        mock_fetch.assert_awaited_once()
+
+    def test_test_connection_speech_elevenlabs_asr_uses_model_listing(
+        self, test_db, regular_user, regular_headers
+    ):
+        """ElevenLabs ASR connection checks should not transcribe paid audio."""
+        with patch(
+            "xagent.web.services.model_list_service.fetch_models_from_provider",
+            new=AsyncMock(
+                return_value=[
+                    {
+                        "id": "scribe_v2",
+                        "abilities": ["asr"],
+                    }
+                ]
+            ),
+        ) as mock_fetch:
+            response = client.post(
+                "/api/models/test-connection",
+                json={
+                    "model_provider": "elevenlabs",
+                    "model_name": "scribe_v2",
+                    "api_key": "test-api-key",
+                    "category": "speech",
+                },
+                headers=regular_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "passed"
+        mock_fetch.assert_awaited_once()
+
     def test_create_model_as_admin(
         self, test_db, admin_user, admin_headers, sample_model_data
     ):
@@ -741,6 +803,116 @@ class TestModelAPI:
         }
         assert defaults["asr"] == sample_speech_model_data["model_id"]
         assert defaults["tts"] == sample_speech_model_data["model_id"]
+
+    def test_transcribe_speech_requires_asr_model(
+        self,
+        test_db,
+        regular_user,
+        regular_headers,
+    ):
+        response = client.post(
+            "/api/models/speech/transcribe",
+            files={"file": ("voice.webm", b"audio-bytes", "audio/webm")},
+            headers=regular_headers,
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No ASR model is configured"
+
+    def test_transcribe_speech_rejects_oversized_audio(
+        self,
+        test_db,
+        regular_user,
+        regular_headers,
+    ):
+        with patch("xagent.web.api.model.MAX_TRANSCRIBE_UPLOAD_BYTES", 4):
+            response = client.post(
+                "/api/models/speech/transcribe",
+                files={"file": ("voice.webm", b"audio", "audio/webm")},
+                headers=regular_headers,
+            )
+
+        assert response.status_code == 413
+        assert response.json()["detail"] == "Audio file is too large"
+
+    def test_transcribe_speech_uses_user_default_asr_model(
+        self,
+        test_db,
+        regular_user,
+        regular_headers,
+        sample_speech_model_data,
+    ):
+        first_model = dict(sample_speech_model_data)
+        first_model["model_id"] = "test-asr-first"
+        first_model["model_name"] = "asr-first"
+        first_model["abilities"] = ["asr"]
+        second_model = dict(sample_speech_model_data)
+        second_model["model_id"] = "test-asr-second"
+        second_model["model_name"] = "asr-second"
+        second_model["abilities"] = ["asr"]
+
+        first_response = client.post(
+            "/api/models/",
+            json=first_model,
+            headers=regular_headers,
+        )
+        assert first_response.status_code == 200
+        second_response = client.post(
+            "/api/models/",
+            json=second_model,
+            headers=regular_headers,
+        )
+        assert second_response.status_code == 200
+
+        default_response = client.post(
+            "/api/models/user-default",
+            json={"model_id": second_response.json()["id"], "config_type": "asr"},
+            headers=regular_headers,
+        )
+        assert default_response.status_code == 200
+
+        class FakeASR:
+            def __init__(self, model_name: str):
+                self.model_name = model_name
+                self.calls = []
+                self.closed = False
+
+            async def transcribe(self, audio, language=None, format=None):
+                self.calls.append(
+                    {"audio": audio, "language": language, "format": format}
+                )
+                return f"text from {self.model_name}"
+
+            async def aclose(self):
+                self.closed = True
+
+        created_models = []
+
+        def create_fake_asr(db_model):
+            fake_asr = FakeASR(db_model.model_name)
+            created_models.append(fake_asr)
+            return fake_asr
+
+        with patch(
+            "xagent.core.model.asr.adapter.get_asr_model_instance",
+            side_effect=create_fake_asr,
+        ):
+            response = client.post(
+                "/api/models/speech/transcribe",
+                files={"file": ("voice.webm", b"audio-bytes", "audio/webm")},
+                data={"language": "en"},
+                headers=regular_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["text"] == "text from asr-second"
+        assert data["model_id"] == "test-asr-second"
+        assert len(created_models) == 1
+        assert created_models[0].calls == [
+            {"audio": b"audio-bytes", "language": "en", "format": "webm"}
+        ]
+        assert created_models[0].closed is True
 
     def test_reject_asr_only_speech_model_as_tts_default(
         self,

--- a/tests/web/test_model_list_service.py
+++ b/tests/web/test_model_list_service.py
@@ -1,0 +1,64 @@
+"""Tests for provider model listing service."""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.model.asr.elevenlabs import ElevenLabsASR
+from xagent.core.model.tts.elevenlabs import ElevenLabsTTS
+from xagent.web.services.model_list_service import fetch_elevenlabs_models
+
+
+async def test_fetch_elevenlabs_models_combines_tts_and_stt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def list_tts_models(api_key=None, base_url=None):
+        return [
+            {
+                "id": "eleven_v3",
+                "object": "model",
+                "owned_by": "elevenlabs",
+                "abilities": ["tts"],
+            }
+        ]
+
+    async def list_asr_models(api_key=None, base_url=None):
+        return [
+            {
+                "id": "scribe_v2",
+                "object": "model",
+                "owned_by": "elevenlabs",
+                "abilities": ["asr"],
+            }
+        ]
+
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "async_list_available_models",
+        staticmethod(list_tts_models),
+    )
+    monkeypatch.setattr(
+        ElevenLabsASR,
+        "async_list_available_models",
+        staticmethod(list_asr_models),
+    )
+
+    models = await fetch_elevenlabs_models(
+        api_key="test-key",
+        base_url="https://api.elevenlabs.io",
+    )
+
+    assert models == [
+        {
+            "id": "eleven_v3",
+            "object": "model",
+            "owned_by": "elevenlabs",
+            "abilities": ["tts"],
+        },
+        {
+            "id": "scribe_v2",
+            "object": "model",
+            "owned_by": "elevenlabs",
+            "abilities": ["asr"],
+        },
+    ]

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -569,6 +569,38 @@ class TestModelService:
 
             assert result == {"eleven_v3": mock_instance}
 
+    def test_get_asr_models_loads_elevenlabs_without_base_url(self):
+        """ElevenLabs ASR models use SDK defaults and should not require base_url."""
+        with (
+            patch(
+                "xagent.web.services.model_service._is_model_visible_to_user"
+            ) as mock_visibility,
+            patch(
+                "xagent.core.model.asr.adapter.get_asr_model_instance"
+            ) as mock_asr_instance,
+        ):
+            mock_db = MagicMock()
+
+            visible_model = MagicMock()
+            visible_model.id = 1
+            visible_model.abilities = ["asr"]
+            visible_model.api_key = "key1"
+            visible_model.base_url = None
+            visible_model.model_provider = "elevenlabs"
+            visible_model.model_name = "scribe_v2"
+
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                visible_model
+            ]
+
+            mock_visibility.return_value = True
+            mock_instance = MagicMock()
+            mock_asr_instance.return_value = mock_instance
+
+            result = get_asr_models(mock_db, user_id=42)
+
+            assert result == {"scribe_v2": mock_instance}
+
     def test_embedding_fallback_skips_invisible_returns_none(self, monkeypatch):
         """System fallback returns None when no visible embedding model exists."""
         from contextvars import copy_context


### PR DESCRIPTION
## Summary
- add an ElevenLabs ASR provider backed by the official speech_to_text SDK API
- wire ElevenLabs ASR into model adapters, model listing, connection testing, and model loading
- add unit and web regression tests for Scribe STT support

## Validation
- pre-commit via git commit: ruff check, ruff format, mypy, fix end of files, trim trailing whitespace, isort, codespell
- PYTHONPATH=/Users/xuyeqin/Workspace/xagent-elevenlabs-stt/src pytest tests/core/model/asr tests/core/model/tts/test_elevenlabs.py tests/web/test_model_api.py::TestModelAPI::test_test_connection_speech_elevenlabs_uses_model_listing tests/web/test_model_api.py::TestModelAPI::test_test_connection_speech_elevenlabs_asr_uses_model_listing tests/web/test_model_service.py tests/web/test_model_list_service.py