### PR TITLE
fix: scan due scheduled triggers in-process so they fire without Celery beat

### DIFF
--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -197,7 +197,21 @@ async def _run_trigger_dispatcher(
 ) -> None:
     from .models.database import get_session_local
     from .services.gmail_triggers import scan_due_gmail_watch_renewals
-    from .services.triggers import dispatch_pending_trigger_runs
+    from .services.triggers import (
+        dispatch_pending_trigger_runs,
+        scan_due_scheduled_triggers,
+    )
+
+    def _scan_due_scheduled_triggers_tick() -> int:
+        # Scan in-process so scheduled triggers fire without a Celery
+        # beat/worker. Idempotent with the Celery beat scan (unique run key +
+        # next_run_at advanced in one committed txn), so running both is safe.
+        SessionLocal = get_session_local()
+        db = SessionLocal()
+        try:
+            return len(scan_due_scheduled_triggers(db))
+        finally:
+            db.close()
 
     def _scan_due_gmail_watch_renewals_tick() -> int:
         SessionLocal = get_session_local()
@@ -246,6 +260,10 @@ async def _run_trigger_dispatcher(
                     next_gmail_watch_scan_at = (
                         now + get_gmail_watch_renewal_interval_seconds()
                     )
+
+            prepared = await asyncio.to_thread(_scan_due_scheduled_triggers_tick)
+            if prepared:
+                logger.info("Trigger dispatcher prepared %s scheduled run(s)", prepared)
 
             SessionLocal = get_session_local()
             db = SessionLocal()

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -261,9 +261,11 @@ async def _run_trigger_dispatcher(
                         now + get_gmail_watch_renewal_interval_seconds()
                     )
 
-            prepared = await asyncio.to_thread(_scan_due_scheduled_triggers_tick)
-            if prepared:
-                logger.info("Trigger dispatcher prepared %s scheduled run(s)", prepared)
+            processed = await asyncio.to_thread(_scan_due_scheduled_triggers_tick)
+            if processed:
+                logger.info(
+                    "Trigger dispatcher processed %s due schedule(s)", processed
+                )
 
             SessionLocal = get_session_local()
             db = SessionLocal()

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -1221,6 +1221,62 @@ def test_scheduled_scan_fires_due_trigger_and_advances_next_run(
     assert mock_bg_scheduler.call_count == 1
 
 
+def test_trigger_dispatcher_loop_scans_due_scheduled_trigger(mock_bg_scheduler) -> None:
+    """End-to-end: the in-process dispatcher loop itself scans a due scheduled
+    trigger (no Celery) and creates a PENDING run on its first tick."""
+    from xagent.web import app as app_module
+
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "scheduled",
+            "name": "Loop scan",
+            "config": {"interval_seconds": 60},
+        },
+    )
+    assert created.status_code == 200, created.text
+    trigger_id = created.json()["id"]
+
+    due_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    db = _direct_db_session()
+    try:
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+        trigger.next_run_at = due_at
+        db.add(trigger)
+        db.commit()
+    finally:
+        db.close()
+
+    async def fake_dispatch(_db, *, limit):
+        # Stop the loop right after the (real) scan tick so the agent runner
+        # never actually spins; we only assert the scan wired up correctly.
+        raise asyncio.CancelledError
+
+    with (
+        patch("xagent.web.app.get_gmail_watch_enabled", return_value=False),
+        patch(
+            "xagent.web.services.triggers.dispatch_pending_trigger_runs",
+            new=fake_dispatch,
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        asyncio.run(
+            app_module._run_trigger_dispatcher(poll_interval_seconds=60, batch_size=25)
+        )
+
+    db = _direct_db_session()
+    try:
+        runs = db.query(TriggerRun).filter(TriggerRun.trigger_id == trigger_id).all()
+        assert len(runs) == 1
+        assert runs[0].status == TriggerRunStatus.PENDING.value
+        assert runs[0].task_id is not None
+    finally:
+        db.close()
+
+
 def test_trigger_config_rejects_persisted_runtime_secrets() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers)

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -1277,6 +1277,105 @@ def test_trigger_dispatcher_loop_scans_due_scheduled_trigger(mock_bg_scheduler) 
         db.close()
 
 
+class _FirstNoneQuery:
+    """Query wrapper whose ``.first()`` returns None, delegating everything else."""
+
+    def __init__(self, query):
+        self._query = query
+
+    def filter(self, *args, **kwargs):
+        return _FirstNoneQuery(self._query.filter(*args, **kwargs))
+
+    def first(self):
+        return None
+
+    def __getattr__(self, name):
+        return getattr(self._query, name)
+
+
+class _PrecheckMissSession:
+    """Delegate to a real session but force the first ``TriggerRun`` lookup to
+    miss, simulating a scanner whose idempotency pre-check ran before a
+    concurrent insert committed. The following insert then collides on the
+    unique key, driving the IntegrityError recovery branch."""
+
+    def __init__(self, db):
+        self._db = db
+        self._missed = False
+
+    def query(self, *args, **kwargs):
+        query = self._db.query(*args, **kwargs)
+        if not self._missed and args and args[0] is TriggerRun:
+            self._missed = True
+            return _FirstNoneQuery(query)
+        return query
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+
+def test_get_or_create_trigger_run_recovers_from_racing_insert(
+    mock_bg_scheduler,
+) -> None:
+    """Dedup safety the in-process scan relies on: if a concurrent scan commits
+    the run between this call's pre-check and its own insert, the insert hits
+    the unique idempotency key and recovers the existing run rather than
+    creating a duplicate or raising."""
+    from xagent.web.services import triggers as triggers_mod
+
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={
+            "type": "scheduled",
+            "name": "Racing",
+            "config": {"interval_seconds": 60},
+        },
+    )
+    assert created.status_code == 200, created.text
+    trigger_id = created.json()["id"]
+
+    event_payload = {"trigger_id": trigger_id, "scheduled_at": "t"}
+    source_event_id = f"scheduled:{trigger_id}:once"
+
+    db = _direct_db_session()
+    try:
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+
+        first_run, first_created = triggers_mod._get_or_create_trigger_run(
+            db,
+            trigger=trigger,
+            event_payload=event_payload,
+            source_event_id=source_event_id,
+            background_job_id=None,
+            test=False,
+        )
+        assert first_created is True
+
+        # Second scan's pre-check misses; its insert collides on the unique key.
+        racing_session = _PrecheckMissSession(db)
+        second_run, second_created = triggers_mod._get_or_create_trigger_run(
+            racing_session,
+            trigger=trigger,
+            event_payload=event_payload,
+            source_event_id=source_event_id,
+            background_job_id=None,
+            test=False,
+        )
+        # The forced pre-check miss means created=False could only come from the
+        # IntegrityError recovery branch, not an early pre-check return.
+        assert racing_session._missed is True
+        assert second_created is False
+        assert second_run.id == first_run.id
+
+        rows = db.query(TriggerRun).filter(TriggerRun.trigger_id == trigger_id).all()
+        assert len(rows) == 1
+    finally:
+        db.close()
+
+
 def test_trigger_config_rejects_persisted_runtime_secrets() -> None:
     headers = _admin_headers()
     agent_id = _create_agent(headers)

--- a/tests/web/test_trigger_dispatcher_gmail_gate.py
+++ b/tests/web/test_trigger_dispatcher_gmail_gate.py
@@ -64,3 +64,56 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
     # but the Gmail watch-renewal scan stays gated off when watch is disabled.
     assert "_scan_due_scheduled_triggers_tick" in calls
     assert "_scan_due_gmail_watch_renewals_tick" not in calls
+
+
+@pytest.mark.asyncio
+async def test_trigger_dispatcher_survives_scheduled_scan_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scheduled-scan tick that raises must not kill the loop: it is caught
+    at the loop level, logged, and the loop survives to the next tick."""
+
+    class FakeSession:
+        def close(self) -> None:
+            return None
+
+    scan_calls = {"n": 0}
+    dispatch_calls = {"n": 0}
+
+    def flaky_scan(_db):
+        scan_calls["n"] += 1
+        if scan_calls["n"] == 1:
+            raise RuntimeError("scan blew up")
+        return []
+
+    async def fake_dispatch(_db, *, limit: int) -> int:
+        dispatch_calls["n"] += 1
+        # Only reached on a surviving tick; stop the loop here.
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        app_module, "get_gmail_watch_enabled", lambda: False, raising=False
+    )
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local",
+        lambda: FakeSession,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.scan_due_scheduled_triggers",
+        flaky_scan,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.dispatch_pending_trigger_runs",
+        fake_dispatch,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await app_module._run_trigger_dispatcher(
+            poll_interval_seconds=0,
+            batch_size=25,
+        )
+
+    # First tick's scan raised; the loop caught it and ran a second tick where
+    # dispatch was finally reached.
+    assert scan_calls["n"] == 2
+    assert dispatch_calls["n"] == 1

--- a/tests/web/test_trigger_dispatcher_gmail_gate.py
+++ b/tests/web/test_trigger_dispatcher_gmail_gate.py
@@ -23,6 +23,9 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
     def fake_scan_due_gmail_watch_renewals(_db) -> int:
         return 0
 
+    def fake_scan_due_scheduled_triggers(_db):
+        return []
+
     async def fake_dispatch_pending_trigger_runs(_db, *, limit: int) -> int:
         raise asyncio.CancelledError
 
@@ -43,6 +46,10 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
         fake_scan_due_gmail_watch_renewals,
     )
     monkeypatch.setattr(
+        "xagent.web.services.triggers.scan_due_scheduled_triggers",
+        fake_scan_due_scheduled_triggers,
+    )
+    monkeypatch.setattr(
         "xagent.web.services.triggers.dispatch_pending_trigger_runs",
         fake_dispatch_pending_trigger_runs,
     )
@@ -53,4 +60,7 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
             batch_size=25,
         )
 
-    assert calls == []
+    # Scheduled triggers are scanned in-process every tick (no Celery needed),
+    # but the Gmail watch-renewal scan stays gated off when watch is disabled.
+    assert "_scan_due_scheduled_triggers_tick" in calls
+    assert "_scan_due_gmail_watch_renewals_tick" not in calls


### PR DESCRIPTION
## Problem

Fixes #794.

Scheduled triggers never fired: after configuring one, no run was ever
recorded. Webhook and Gmail triggers worked fine.

Root cause: a scheduled trigger needs two steps — **scan** (turn a due
schedule into a runnable `TriggerRun`) and **dispatch** (start the agent
task). The always-on in-process dispatcher loop (`_run_trigger_dispatcher`,
enabled by default in the backend) only *dispatched* already-prepared runs;
`scan_due_scheduled_triggers` was invoked **solely** from the Celery beat
task. So scheduled triggers only fired when both a Celery beat *and* a
`triggers`-queue worker were running. Webhook/Gmail triggers were unaffected
because they arrive via HTTP callback and call `fire_trigger` directly, never
needing the scan.

## Fix

Run the scan every dispatcher tick, right before dispatch. It is idempotent
with the Celery beat scan (unique trigger-run idempotency key + `next_run_at`
advanced in one committed transaction), so running both is safe whether or
not Celery is deployed. As a bonus, scheduled triggers now fire within the
dispatcher poll interval (~5s) instead of the beat sweep interval (300s).

## Testing

- New end-to-end test `test_trigger_dispatcher_loop_scans_due_scheduled_trigger`:
  drives the real dispatcher loop for one tick against a due scheduled trigger
  (scan not mocked, dispatch stubbed) and asserts a PENDING `TriggerRun` is
  created by the loop. Verified it fails (`assert 0 == 1`) with the fix
  removed, so it genuinely guards the regression.
- Updated `test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled` to
  reflect the new always-on scheduled scan while keeping the Gmail
  watch-renewal gate assertion.
- Existing `scan`/`dispatch` scheduled-trigger tests still pass.
