### PR TITLE
feat: add OAuth token resolver hook for MCP configs

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -502,52 +502,92 @@ class ToolFactory:
     ) -> List[Tool]:
         """Create MCP tools from configurations."""
         try:
-            from .mcp_adapter import load_mcp_tools_as_agent_tools
+            from .mcp_adapter import UnavailableMCPTool, load_mcp_tools_as_agent_tools
 
-            # Convert configs to connection format
-            connections = {}
+            unavailable_tools: List[Tool] = []
+            normal_configs: List[Dict[str, Any]] = []
 
             for config in mcp_configs:
-                connection_config = {
-                    "transport": config["transport"],
-                    **config["config"],
-                }
-                for runtime_key in (
-                    "runtime_bindings",
-                    "runtime_input_schema",
-                    "connector_runtime",
-                    "allow_delegated_authorization",
-                ):
-                    if runtime_key in config:
-                        connection_config[runtime_key] = config[runtime_key]
-
-                # Fix args field if it's a string instead of list
-                if "args" in connection_config and isinstance(
-                    connection_config["args"], str
-                ):
-                    # Split args string into list, handling quoted arguments
-                    import shlex
-
+                inner_config = config.get("config")
+                if isinstance(inner_config, dict) and inner_config.get("unavailable"):
                     try:
-                        connection_config["args"] = shlex.split(
-                            connection_config["args"]
-                        )
-                        logger.info(
-                            f"Converted args string to list: {connection_config['args']}"
+                        server_name = config.get("name")
+                        allow_users = config.get("allow_users")
+                        unavailable_tools.append(
+                            UnavailableMCPTool(
+                                server_name=server_name
+                                if isinstance(server_name, str)
+                                else "",
+                                server_id=inner_config.get("server_id"),
+                                allow_users=allow_users
+                                if isinstance(allow_users, list)
+                                else None,
+                            )
                         )
                     except Exception as e:
-                        logger.warning(f"Failed to parse args string: {e}")
-                        # Fallback to simple split
-                        connection_config["args"] = connection_config["args"].split()
+                        logger.warning(
+                            "Failed to create unavailable MCP tool for server '%s': %s",
+                            config.get("name", "<unknown>"),
+                            type(e).__name__,
+                        )
+                    continue
+                normal_configs.append(config)
 
-                connections[config["name"]] = connection_config
+            normal_tools: List[Tool] = []
+            if normal_configs:
+                # Convert configs to connection format
+                connections = {}
 
-            # Load MCP tools
-            mcp_tools = await load_mcp_tools_as_agent_tools(
-                connections,
-                sandbox=sandbox,
-            )  # type: ignore[arg-type]
-            return mcp_tools if mcp_tools else []  # type: ignore[return-value]
+                for config in normal_configs:
+                    connection_config = {
+                        "transport": config["transport"],
+                        **config["config"],
+                    }
+                    for runtime_key in (
+                        "runtime_bindings",
+                        "runtime_input_schema",
+                        "connector_runtime",
+                        "allow_delegated_authorization",
+                    ):
+                        if runtime_key in config:
+                            connection_config[runtime_key] = config[runtime_key]
+
+                    # Fix args field if it's a string instead of list
+                    if "args" in connection_config and isinstance(
+                        connection_config["args"], str
+                    ):
+                        # Split args string to list, handling quoted arguments
+                        import shlex
+
+                        try:
+                            connection_config["args"] = shlex.split(
+                                connection_config["args"]
+                            )
+                            logger.info(
+                                f"Converted args string to list: {connection_config['args']}"
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to parse args string: {e}")
+                            # Fallback to simple split
+                            connection_config["args"] = connection_config[
+                                "args"
+                            ].split()
+
+                    connections[config["name"]] = connection_config
+
+                try:
+                    # Load MCP tools
+                    mcp_tools = await load_mcp_tools_as_agent_tools(
+                        connections,
+                        sandbox=sandbox,
+                    )  # type: ignore[arg-type]
+                    normal_tools = mcp_tools if mcp_tools else []  # type: ignore[assignment]
+                except ConnectorRuntimeError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"Failed to create MCP tools: {e}")
+
+            return unavailable_tools + normal_tools
         except ConnectorRuntimeError:
             raise
         except Exception as e:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -535,47 +535,54 @@ class ToolFactory:
 
             normal_tools: List[Tool] = []
             if normal_configs:
-                # Convert configs to connection format
-                connections = {}
-
-                for config in normal_configs:
-                    connection_config = {
-                        "transport": config["transport"],
-                        **config["config"],
-                    }
-                    for runtime_key in (
-                        "runtime_bindings",
-                        "runtime_input_schema",
-                        "connector_runtime",
-                        "allow_delegated_authorization",
-                    ):
-                        if runtime_key in config:
-                            connection_config[runtime_key] = config[runtime_key]
-
-                    # Fix args field if it's a string instead of list
-                    if "args" in connection_config and isinstance(
-                        connection_config["args"], str
-                    ):
-                        # Split args string to list, handling quoted arguments
-                        import shlex
-
-                        try:
-                            connection_config["args"] = shlex.split(
-                                connection_config["args"]
-                            )
-                            logger.info(
-                                f"Converted args string to list: {connection_config['args']}"
-                            )
-                        except Exception as e:
-                            logger.warning(f"Failed to parse args string: {e}")
-                            # Fallback to simple split
-                            connection_config["args"] = connection_config[
-                                "args"
-                            ].split()
-
-                    connections[config["name"]] = connection_config
-
                 try:
+                    # Convert configs to connection format
+                    connections = {}
+
+                    for config in normal_configs:
+                        inner_config = config.get("config")
+                        if not isinstance(inner_config, dict):
+                            raise ValueError(
+                                "MCP server config 'config' field for server "
+                                f"'{config.get('name', '<unknown>')}' must be a "
+                                f"dictionary, got {type(inner_config).__name__}"
+                            )
+                        connection_config = {
+                            "transport": config["transport"],
+                            **inner_config,
+                        }
+                        for runtime_key in (
+                            "runtime_bindings",
+                            "runtime_input_schema",
+                            "connector_runtime",
+                            "allow_delegated_authorization",
+                        ):
+                            if runtime_key in config:
+                                connection_config[runtime_key] = config[runtime_key]
+
+                        # Fix args field if it's a string instead of list
+                        if "args" in connection_config and isinstance(
+                            connection_config["args"], str
+                        ):
+                            # Split args string to list, handling quoted arguments
+                            import shlex
+
+                            try:
+                                connection_config["args"] = shlex.split(
+                                    connection_config["args"]
+                                )
+                                logger.info(
+                                    f"Converted args string to list: {connection_config['args']}"
+                                )
+                            except Exception as e:
+                                logger.warning(f"Failed to parse args string: {e}")
+                                # Fallback to simple split
+                                connection_config["args"] = connection_config[
+                                    "args"
+                                ].split()
+
+                        connections[config["name"]] = connection_config
+
                     # Load MCP tools
                     mcp_tools = await load_mcp_tools_as_agent_tools(
                         connections,

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -155,6 +155,25 @@ def _mcp_access_denied_result(user_id: Optional[str], tool_name: str) -> dict[st
     }
 
 
+def _mcp_return_value_as_string(value: Any) -> str:
+    try:
+        if isinstance(value, dict):
+            content = value.get("content", [])
+            if content:
+                texts = []
+                for item in content:
+                    if isinstance(item, dict) and "text" in item:
+                        texts.append(item["text"])
+                    else:
+                        texts.append(str(item))
+                return "\n".join(texts)
+            return "No content returned"
+        return str(value)
+    except Exception as e:
+        logger.warning(f"Failed to convert return value to string: {e}")
+        return str(value)
+
+
 def _format_unavailable_mcp_tool_name(server_name: str, server_id: Any | None) -> str:
     from .selection_spec import normalize_mcp_server_name
 
@@ -714,23 +733,7 @@ class MCPToolAdapter(AbstractBaseTool):
 
     def return_value_as_string(self, value: Any) -> str:
         """Convert return value to string representation."""
-        try:
-            if isinstance(value, dict):
-                content = value.get("content", [])
-                if content:
-                    # Extract text from content items
-                    texts = []
-                    for item in content:
-                        if isinstance(item, dict) and "text" in item:
-                            texts.append(item["text"])
-                        else:
-                            texts.append(str(item))
-                    return "\n".join(texts)
-                return "No content returned"
-            return str(value)
-        except Exception as e:
-            logger.warning(f"Failed to convert return value to string: {e}")
-            return str(value)
+        return _mcp_return_value_as_string(value)
 
 
 class _UnavailableMCPToolResult(BaseModel):
@@ -787,7 +790,10 @@ class UnavailableMCPTool(AbstractBaseTool):
     def state_type(self) -> Optional[Type[BaseModel]]:
         return None
 
-    def _credential_unavailable_result(self) -> Dict[str, Any]:
+    def _run_unavailable(self) -> Dict[str, Any]:
+        current_user_id = _get_current_mcp_user_id()
+        if not _is_mcp_user_allowed(current_user_id, self._allow_users):
+            return _mcp_access_denied_result(current_user_id, self.name)
         return {
             "content": [
                 {
@@ -800,23 +806,11 @@ class UnavailableMCPTool(AbstractBaseTool):
             "is_error": True,
         }
 
-    def _check_access(self) -> dict[str, Any] | None:
-        current_user_id = _get_current_mcp_user_id()
-        if not _is_mcp_user_allowed(current_user_id, self._allow_users):
-            return _mcp_access_denied_result(current_user_id, self.name)
-        return None
-
     async def run_json_async(self, args: Mapping[str, Any]) -> Any:
-        access_denied = self._check_access()
-        if access_denied is not None:
-            return access_denied
-        return self._credential_unavailable_result()
+        return self._run_unavailable()
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
-        access_denied = self._check_access()
-        if access_denied is not None:
-            return access_denied
-        return self._credential_unavailable_result()
+        return self._run_unavailable()
 
     async def save_state_json(self) -> Mapping[str, Any]:
         return {}
@@ -825,22 +819,7 @@ class UnavailableMCPTool(AbstractBaseTool):
         pass
 
     def return_value_as_string(self, value: Any) -> str:
-        try:
-            if isinstance(value, dict):
-                content = value.get("content", [])
-                if content:
-                    texts = []
-                    for item in content:
-                        if isinstance(item, dict) and "text" in item:
-                            texts.append(item["text"])
-                        else:
-                            texts.append(str(item))
-                    return "\n".join(texts)
-                return "No content returned"
-            return str(value)
-        except Exception as e:
-            logger.warning(f"Failed to convert return value to string: {e}")
-            return str(value)
+        return _mcp_return_value_as_string(value)
 
 
 def _build_mcp_tool_adapter(

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -159,7 +159,7 @@ def _mcp_return_value_as_string(value: Any) -> str:
     try:
         if isinstance(value, dict):
             content = value.get("content", [])
-            if content:
+            if isinstance(content, list) and content:
                 texts = []
                 for item in content:
                     if isinstance(item, dict) and "text" in item:
@@ -167,6 +167,8 @@ def _mcp_return_value_as_string(value: Any) -> str:
                     else:
                         texts.append(str(item))
                 return "\n".join(texts)
+            if content:
+                return str(content)
             return "No content returned"
         return str(value)
     except Exception as e:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -117,6 +117,62 @@ def _mcp_tool_is_concurrency_safe(
     return tool_name in set(concurrent_tools)
 
 
+def _get_current_mcp_user_id() -> Optional[str]:
+    """Get current user ID from environment or context."""
+    # Try to get user ID from environment variable (set by web system)
+    user_id = os.environ.get("XAGENT_USER_ID")
+    if user_id:
+        return user_id
+
+    # If no user ID found, this might be a system-level execution
+    # In production, this should be replaced with proper context passing
+    logger.warning(
+        "No user ID found in environment, MCP tool may not be properly isolated"
+    )
+    return None
+
+
+def _is_mcp_user_allowed(
+    user_id: Optional[str], allow_users: Optional[List[str]]
+) -> bool:
+    if not user_id:
+        # If no user ID, this might be a system execution. For security, deny
+        # access unless the tool explicitly allows the system identity.
+        return allow_users is None or "system" in allow_users
+
+    if allow_users is None:
+        return True
+
+    return user_id in allow_users
+
+
+def _mcp_access_denied_result(user_id: Optional[str], tool_name: str) -> dict[str, Any]:
+    error_msg = f"User {user_id} is not authorized to use tool {tool_name}"
+    logger.warning(error_msg)
+    return {
+        "content": [{"text": f"Access denied: {error_msg}"}],
+        "is_error": True,
+    }
+
+
+def _format_unavailable_mcp_tool_name(server_name: str, server_id: Any | None) -> str:
+    from .selection_spec import normalize_mcp_server_name
+
+    normalized_server = re.sub(
+        r"[^A-Za-z0-9_]+", "_", normalize_mcp_server_name(server_name)
+    ).strip("_")
+    parts = ["mcp"]
+    if normalized_server:
+        parts.append(normalized_server)
+    if server_id is not None:
+        normalized_id = re.sub(r"[^A-Za-z0-9_]+", "_", str(server_id)).strip("_")
+        if normalized_id:
+            parts.append(normalized_id)
+    parts.append("unavailable")
+    name = "_".join(parts)
+    return name if name != "mcp_unavailable" else "mcp_server_unavailable"
+
+
 class MCPToolAdapter(AbstractBaseTool):
     """
     Adapter that converts an MCP tool into an Agent system Tool.
@@ -437,12 +493,7 @@ class MCPToolAdapter(AbstractBaseTool):
 
             # Validate user permissions
             if not self._is_user_allowed(current_user_id):
-                error_msg = f"User {current_user_id} is not authorized to use tool {self.mcp_tool.name}"
-                logger.warning(error_msg)
-                return {
-                    "content": [{"text": f"Access denied: {error_msg}"}],
-                    "is_error": True,
-                }
+                return _mcp_access_denied_result(current_user_id, self.mcp_tool.name)
 
             # Validate arguments
             normalized_args = self._normalize_args_by_schema(args)
@@ -577,17 +628,7 @@ class MCPToolAdapter(AbstractBaseTool):
 
     def _get_current_user_id(self) -> Optional[str]:
         """Get current user ID from environment or context."""
-        # Try to get user ID from environment variable (set by web system)
-        user_id = os.environ.get("XAGENT_USER_ID")
-        if user_id:
-            return user_id
-
-        # If no user ID found, this might be a system-level execution
-        # In production, this should be replaced with proper context passing
-        logger.warning(
-            "No user ID found in environment, MCP tool may not be properly isolated"
-        )
-        return None
+        return _get_current_mcp_user_id()
 
     def _input_schema_properties(self) -> dict[str, Any]:
         schema = self.mcp_tool.inputSchema
@@ -655,16 +696,7 @@ class MCPToolAdapter(AbstractBaseTool):
 
     def _is_user_allowed(self, user_id: Optional[str]) -> bool:
         """Check if user is allowed to use this tool."""
-        if not user_id:
-            # If no user ID, this might be a system execution
-            # For security, we should deny access unless explicitly allowed
-            return self._allow_users is None or "system" in self._allow_users
-
-        if self._allow_users is None:
-            # No specific user restrictions, allow access
-            return True
-
-        return user_id in self._allow_users
+        return _is_mcp_user_allowed(user_id, self._allow_users)
 
     def run_json_sync(self, args: Mapping[str, Any]) -> Any:
         """MCP tools are async only."""
@@ -687,6 +719,116 @@ class MCPToolAdapter(AbstractBaseTool):
                 content = value.get("content", [])
                 if content:
                     # Extract text from content items
+                    texts = []
+                    for item in content:
+                        if isinstance(item, dict) and "text" in item:
+                            texts.append(item["text"])
+                        else:
+                            texts.append(str(item))
+                    return "\n".join(texts)
+                return "No content returned"
+            return str(value)
+        except Exception as e:
+            logger.warning(f"Failed to convert return value to string: {e}")
+            return str(value)
+
+
+class _UnavailableMCPToolResult(BaseModel):
+    content: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Tool execution result content"
+    )
+    is_error: bool = Field(
+        default=True,
+        description="Whether the tool execution resulted in an error",
+    )
+
+
+class UnavailableMCPTool(AbstractBaseTool):
+    """Server-level MCP tool returned when credentials are unavailable."""
+
+    read_only = True
+    concurrency_safe = True
+
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        server_id: Any | None,
+        allow_users: Optional[List[str]] = None,
+    ) -> None:
+        from .base import ToolCategory
+        from .selection_spec import normalize_mcp_server_name
+
+        self._server_name = server_name
+        self._server_id = server_id
+        self._allow_users = allow_users
+        self._name = _format_unavailable_mcp_tool_name(server_name, server_id)
+        self.source_server = normalize_mcp_server_name(server_name)
+        self.category = ToolCategory.MCP
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "MCP server credentials are unavailable."
+
+    @property
+    def tags(self) -> List[str]:
+        return ["mcp"]
+
+    def args_type(self) -> Type[BaseModel]:
+        return EmptyArgsModel
+
+    def return_type(self) -> Type[BaseModel]:
+        return _UnavailableMCPToolResult
+
+    def state_type(self) -> Optional[Type[BaseModel]]:
+        return None
+
+    def _credential_unavailable_result(self) -> Dict[str, Any]:
+        return {
+            "content": [
+                {
+                    "text": (
+                        "MCP server credentials are unavailable. Please reconnect "
+                        "the MCP server credentials and retry."
+                    )
+                }
+            ],
+            "is_error": True,
+        }
+
+    def _check_access(self) -> dict[str, Any] | None:
+        current_user_id = _get_current_mcp_user_id()
+        if not _is_mcp_user_allowed(current_user_id, self._allow_users):
+            return _mcp_access_denied_result(current_user_id, self.name)
+        return None
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        access_denied = self._check_access()
+        if access_denied is not None:
+            return access_denied
+        return self._credential_unavailable_result()
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        access_denied = self._check_access()
+        if access_denied is not None:
+            return access_denied
+        return self._credential_unavailable_result()
+
+    async def save_state_json(self) -> Mapping[str, Any]:
+        return {}
+
+    async def load_state_json(self, state: Mapping[str, Any]) -> None:
+        pass
+
+    def return_value_as_string(self, value: Any) -> str:
+        try:
+            if isinstance(value, dict):
+                content = value.get("content", [])
+                if content:
                     texts = []
                     for item in content:
                         if isinstance(item, dict) and "text" in item:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -105,6 +105,12 @@ class _OAuthTokenResolverFailed(Exception):
         self.exception_type = exception_type
 
 
+class _OAuthLaunchConfigInvalid(Exception):
+    def __init__(self, *, field: str) -> None:
+        super().__init__(field)
+        self.field = field
+
+
 def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
     text = str(value)
     if len(text) <= max_length:
@@ -147,6 +153,27 @@ def _oauth_launch_config_args(launch_config: Mapping[str, Any]) -> list[Any]:
         return args.copy()
     logger.warning("Ignoring OAuth MCP launch config args because args must be a list")
     return []
+
+
+def _oauth_launch_config_command(launch_config: Mapping[str, Any]) -> str:
+    command = launch_config.get("command")
+    if isinstance(command, str) and command:
+        return command
+    raise _OAuthLaunchConfigInvalid(field="command")
+
+
+def _oauth_launch_config_env_mapping(
+    launch_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    env_mapping = launch_config.get("env_mapping")
+    if env_mapping is None:
+        return {}
+    if isinstance(env_mapping, Mapping):
+        return env_mapping
+    logger.warning(
+        "Ignoring OAuth MCP launch config env_mapping because env_mapping must be a mapping"
+    )
+    return {}
 
 
 async def refresh_oauth_token_if_needed(
@@ -1208,12 +1235,14 @@ class WebToolConfig(BaseToolConfig):
         if launch_config:
             transport_config: Dict[str, Any] = {
                 "transport": "stdio",
-                "command": launch_config["command"],
+                "command": _oauth_launch_config_command(launch_config),
                 "args": _oauth_launch_config_args(launch_config),
             }
 
             env = {}
-            for env_key, token_type in launch_config.get("env_mapping", {}).items():
+            for env_key, token_type in _oauth_launch_config_env_mapping(
+                launch_config
+            ).items():
                 if token_type == "access_token":
                     env[env_key] = access_token
 
@@ -1359,13 +1388,23 @@ class WebToolConfig(BaseToolConfig):
 
                     if hook_token is not None:
                         assert app_info is not None
+                        try:
+                            transport_config = (
+                                self._build_oauth_mcp_stdio_transport_config(
+                                    server=server,
+                                    app_info=app_info,
+                                    access_token=hook_token.access_token,
+                                )
+                            )
+                        except _OAuthLaunchConfigInvalid as error:
+                            logger.warning(
+                                "Skipping OAuth MCP server '%s' because launch_config.%s is invalid",
+                                getattr(server, "name", "<unknown>"),
+                                error.field,
+                            )
+                            continue
                         self._mark_hook_token_cache_metadata(hook_token)
                         config["transport"] = "stdio"
-                        transport_config = self._build_oauth_mcp_stdio_transport_config(
-                            server=server,
-                            app_info=app_info,
-                            access_token=hook_token.access_token,
-                        )
                         logger.info(
                             "OAuth token resolver supplied token for MCP server '%s' via provider '%s'",
                             getattr(server, "name", "<unknown>"),
@@ -1424,14 +1463,22 @@ class WebToolConfig(BaseToolConfig):
                                 logger.info(
                                     f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
                                 )
-                                config["transport"] = "stdio"
-                                transport_config = (
-                                    self._build_oauth_mcp_stdio_transport_config(
-                                        server=server,
-                                        app_info=app_info,
-                                        access_token=oauth_account.access_token,
+                                try:
+                                    transport_config = (
+                                        self._build_oauth_mcp_stdio_transport_config(
+                                            server=server,
+                                            app_info=app_info,
+                                            access_token=oauth_account.access_token,
+                                        )
                                     )
-                                )
+                                except _OAuthLaunchConfigInvalid as error:
+                                    logger.warning(
+                                        "Skipping OAuth MCP server '%s' because launch_config.%s is invalid",
+                                        getattr(server, "name", "<unknown>"),
+                                        error.field,
+                                    )
+                                    continue
+                                config["transport"] = "stdio"
 
                         else:
                             logger.info(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -208,6 +208,16 @@ def _oauth_launch_config_env_mapping(
     return {}
 
 
+def _oauth_launch_config_mapping(
+    launch_config: Any,
+) -> Mapping[str, Any] | None:
+    if launch_config is None:
+        return None
+    if isinstance(launch_config, Mapping):
+        return launch_config
+    raise _OAuthLaunchConfigInvalid(field="type")
+
+
 async def refresh_oauth_token_if_needed(
     db: Any, oauth_account: Any, provider_name: str
 ) -> bool:
@@ -1275,7 +1285,7 @@ class WebToolConfig(BaseToolConfig):
         app_info: Mapping[str, Any],
         access_token: str,
     ) -> Dict[str, Any]:
-        launch_config = app_info.get("launch_config")
+        launch_config = _oauth_launch_config_mapping(app_info.get("launch_config"))
         if launch_config:
             transport_config: Dict[str, Any] = {
                 "transport": "stdio",

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1181,6 +1181,8 @@ class WebToolConfig(BaseToolConfig):
                 resolved = await _maybe_await_oauth_token_resolver_result(
                     resolver(request)
                 )
+            except ConnectorRuntimeError:
+                raise
             except Exception as exc:
                 raise _OAuthTokenResolverFailed(
                     providers=providers,
@@ -1451,6 +1453,8 @@ class WebToolConfig(BaseToolConfig):
                                 error=error,
                             )
                             self._mcp_oauth_diagnostics.append(diagnostic)
+                            # Do not log the resolver exception message or
+                            # traceback here; they can contain token material.
                             logger.warning(
                                 "OAuth token resolver failed for MCP server '%s' with %s",
                                 getattr(server, "name", "<unknown>"),

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -7,9 +7,10 @@ and other web-specific sources.
 
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional
 
 import httpx
 
@@ -35,6 +36,109 @@ from ..services.tool_credentials import (
 logger = logging.getLogger(__name__)
 
 
+OAUTH_TOKEN_EXPIRY_SKEW = timedelta(minutes=5)
+OAUTH_TOKEN_RESOLVER_FAILURE_CODE = "oauth_token_resolver_failed"
+OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE = "OAuth token resolver failed"
+UNAVAILABLE_MCP_CREDENTIAL_MESSAGE = "MCP server credentials are unavailable."
+
+
+@dataclass(frozen=True)
+class TokenRequest:
+    """Request passed to the OAuth token resolver hook.
+
+    Providers are requested in the same candidate order used by the built-in
+    UserOAuth lookup: provider name first, then app id, de-duplicated. The
+    first resolver hit wins. ``scope`` is the current execution scope from
+    ``WebToolConfig.get_execution_scope()`` when present; it is typed as
+    Optional[Any] to avoid importing the core scope type into this config layer.
+    """
+
+    provider: str
+    user_id: int
+    scope: Optional[Any] = None
+
+
+@dataclass(frozen=True)
+class ResolvedToken:
+    """OAuth access token supplied by the resolver hook.
+
+    ``expires_at`` should be an aware UTC datetime when set. Naive datetimes
+    are interpreted as UTC for compatibility with the existing OAuth refresh
+    comparison. Resolvers SHOULD set ``expires_at`` to enable MCP config
+    caching; ``expires_at=None`` means the token is usable for this build only
+    and this ``WebToolConfig`` instance will reload MCP configs on later calls.
+    """
+
+    access_token: str
+    expires_at: datetime | None = None
+
+
+TokenResolver = Callable[[TokenRequest], Awaitable[ResolvedToken | None]]
+
+_oauth_token_resolver_hook: TokenResolver | None = None
+_oauth_token_resolver_generation = 0
+
+
+def set_oauth_token_resolver_hook(resolver: TokenResolver | None) -> None:
+    """Register or clear the process-wide OAuth token resolver hook."""
+    global _oauth_token_resolver_generation, _oauth_token_resolver_hook
+
+    _oauth_token_resolver_hook = resolver
+    _oauth_token_resolver_generation += 1
+
+
+def _get_oauth_token_resolver_hook() -> tuple[TokenResolver | None, int]:
+    return _oauth_token_resolver_hook, _oauth_token_resolver_generation
+
+
+@dataclass(frozen=True)
+class _ResolvedHookToken:
+    provider: str
+    access_token: str
+    expires_at: datetime | None
+
+
+class _OAuthTokenResolverFailed(Exception):
+    def __init__(self, *, providers: list[str], exception_type: str) -> None:
+        super().__init__(OAUTH_TOKEN_RESOLVER_FAILURE_CODE)
+        self.providers = providers
+        self.exception_type = exception_type
+
+
+def _bounded_oauth_metadata(value: Any, *, max_length: int = 128) -> str:
+    text = str(value)
+    if len(text) <= max_length:
+        return text
+    return f"{text[: max_length - 3]}..."
+
+
+def _normalize_oauth_expires_at(expires_at: datetime | None) -> datetime | None:
+    if expires_at is None:
+        return None
+    if expires_at.tzinfo is None:
+        return expires_at.replace(tzinfo=timezone.utc)
+    return expires_at.astimezone(timezone.utc)
+
+
+def _oauth_token_is_expired(expires_at: datetime) -> bool:
+    return expires_at <= datetime.now(timezone.utc)
+
+
+def _oauth_token_expires_after_cache_window(expires_at: datetime) -> bool:
+    return expires_at > datetime.now(timezone.utc) + OAUTH_TOKEN_EXPIRY_SKEW
+
+
+def _oauth_token_provider_candidates(app_info: Mapping[str, Any]) -> list[str]:
+    candidates: list[str] = []
+    for key in ("provider", "id"):
+        value = app_info.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        if value not in candidates:
+            candidates.append(value)
+    return candidates
+
+
 async def refresh_oauth_token_if_needed(
     db: Any, oauth_account: Any, provider_name: str
 ) -> bool:
@@ -50,7 +154,7 @@ async def refresh_oauth_token_if_needed(
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
 
-    if expires_at > now + timedelta(minutes=5):
+    if expires_at > now + OAUTH_TOKEN_EXPIRY_SKEW:
         return True  # Token is still valid
 
     logger.info(f"Token expired for {provider_name}, attempting to refresh...")

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1442,11 +1442,7 @@ class WebToolConfig(BaseToolConfig):
                             )
                             continue
 
-                    if hook_token is not None:
-                        if app_info is None:
-                            raise RuntimeError(
-                                "OAuth token resolver supplied a token without app metadata"
-                            )
+                    if app_info and hook_token is not None:
                         try:
                             transport_config = (
                                 self._build_oauth_mcp_stdio_transport_config(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -9,7 +9,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import httpx
 
@@ -921,6 +921,56 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default TTS model: {e}")
             return None
 
+    def _build_oauth_mcp_stdio_transport_config(
+        self,
+        *,
+        server: Any,
+        app_info: Mapping[str, Any],
+        access_token: str,
+    ) -> Dict[str, Any]:
+        launch_config = app_info.get("launch_config")
+        if launch_config:
+            transport_config: Dict[str, Any] = {
+                "transport": "stdio",
+                "command": launch_config["command"],
+                "args": launch_config.get("args", []).copy(),
+            }
+
+            env = {}
+            for env_key, token_type in launch_config.get("env_mapping", {}).items():
+                if token_type == "access_token":
+                    env[env_key] = access_token
+
+            env.update(
+                {
+                    "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
+                    "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
+                    "https_proxy": os.environ.get("https_proxy", ""),
+                    "http_proxy": os.environ.get("http_proxy", ""),
+                }
+            )
+            allowed_file_dirs = self._build_mcp_file_allowed_dirs()
+            if allowed_file_dirs:
+                env["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] = allowed_file_dirs
+            transport_config["env"] = env
+            return transport_config
+
+        return {
+            "transport": "stdio",
+            "command": "npx",
+            "args": [
+                "-y",
+                f"@mcp-servers/{str(server.name).lower().replace(' ', '-')}",
+            ],
+            "env": {
+                f"{str(server.name).upper().replace(' ', '_')}_ACCESS_TOKEN": access_token,
+                "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
+                "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
+                "https_proxy": os.environ.get("https_proxy", ""),
+                "http_proxy": os.environ.get("http_proxy", ""),
+            },
+        }
+
     async def _load_mcp_server_configs(self) -> List[Dict[str, Any]]:
         """Load MCP server configurations from database with user context."""
         logger = logging.getLogger(__name__)
@@ -1053,56 +1103,14 @@ class WebToolConfig(BaseToolConfig):
                             logger.info(
                                 f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
                             )
-
-                            launch_config = app_info.get("launch_config")
-                            if launch_config:
-                                config["transport"] = "stdio"
-                                transport_config["transport"] = "stdio"
-                                transport_config["command"] = launch_config["command"]
-                                transport_config["args"] = launch_config.get(
-                                    "args", []
-                                ).copy()
-
-                                env = {}
-                                for env_key, token_type in launch_config.get(
-                                    "env_mapping", {}
-                                ).items():
-                                    if token_type == "access_token":
-                                        env[env_key] = oauth_account.access_token
-
-                                env.update(
-                                    {
-                                        "HTTPS_PROXY": os.environ.get(
-                                            "HTTPS_PROXY", ""
-                                        ),
-                                        "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
-                                        "https_proxy": os.environ.get(
-                                            "https_proxy", ""
-                                        ),
-                                        "http_proxy": os.environ.get("http_proxy", ""),
-                                    }
+                            config["transport"] = "stdio"
+                            transport_config = (
+                                self._build_oauth_mcp_stdio_transport_config(
+                                    server=server,
+                                    app_info=app_info,
+                                    access_token=oauth_account.access_token,
                                 )
-                                allowed_file_dirs = self._build_mcp_file_allowed_dirs()
-                                if allowed_file_dirs:
-                                    env["XAGENT_LINKEDIN_IMAGE_ALLOWED_DIRS"] = (
-                                        allowed_file_dirs
-                                    )
-                                transport_config["env"] = env
-                            else:
-                                config["transport"] = "stdio"
-                                transport_config["transport"] = "stdio"
-                                transport_config["command"] = "npx"
-                                transport_config["args"] = [
-                                    "-y",
-                                    f"@mcp-servers/{str(server.name).lower().replace(' ', '-')}",
-                                ]
-                                transport_config["env"] = {
-                                    f"{str(server.name).upper().replace(' ', '_')}_ACCESS_TOKEN": oauth_account.access_token,
-                                    "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
-                                    "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
-                                    "https_proxy": os.environ.get("https_proxy", ""),
-                                    "http_proxy": os.environ.get("http_proxy", ""),
-                                }
+                            )
 
                     else:
                         logger.info(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -49,7 +49,9 @@ class TokenRequest:
 
     Providers are requested in the same candidate order used by the built-in
     UserOAuth lookup: provider name first, then app id, de-duplicated. The
-    first resolver hit wins. ``scope`` is the current execution scope from
+    first resolver hit wins. ``resource`` is the configured MCP OAuth resource
+    URI for the current app/server when present, passed verbatim without
+    canonicalization. ``scope`` is the current execution scope from
     ``WebToolConfig.get_execution_scope()`` when present; it is typed as
     Optional[Any] to avoid importing the core scope type into this config layer.
     """
@@ -57,6 +59,7 @@ class TokenRequest:
     provider: str
     user_id: int
     scope: Optional[Any] = None
+    resource: str | None = None
 
 
 @dataclass(frozen=True)
@@ -100,10 +103,17 @@ class _ResolvedHookToken:
 
 
 class _OAuthTokenResolverFailed(Exception):
-    def __init__(self, *, providers: list[str], exception_type: str) -> None:
+    def __init__(
+        self,
+        *,
+        providers: list[str],
+        exception_type: str,
+        resource: str | None = None,
+    ) -> None:
         super().__init__(OAUTH_TOKEN_RESOLVER_FAILURE_CODE)
         self.providers = providers
         self.exception_type = exception_type
+        self.resource = resource
 
 
 class _OAuthLaunchConfigInvalid(Exception):
@@ -144,6 +154,18 @@ def _oauth_token_provider_candidates(app_info: Mapping[str, Any]) -> list[str]:
         if value not in candidates:
             candidates.append(value)
     return candidates
+
+
+def _oauth_token_configured_resource(app_info: Mapping[str, Any]) -> str | None:
+    resource = app_info.get("resource")
+    if isinstance(resource, str) and resource != "":
+        return resource
+    launch_config = app_info.get("launch_config")
+    if isinstance(launch_config, Mapping):
+        resource = launch_config.get("resource")
+        if isinstance(resource, str) and resource != "":
+            return resource
+    return None
 
 
 def _oauth_launch_config_args(launch_config: Mapping[str, Any]) -> list[Any]:
@@ -1112,6 +1134,7 @@ class WebToolConfig(BaseToolConfig):
         self,
         *,
         providers: list[str],
+        resource: str | None,
     ) -> _ResolvedHookToken | None:
         resolver, _ = _get_oauth_token_resolver_hook()
         if resolver is None or not providers or self._user_id is None:
@@ -1122,6 +1145,7 @@ class WebToolConfig(BaseToolConfig):
                 provider=provider,
                 user_id=int(self._user_id),
                 scope=self.get_execution_scope(),
+                resource=resource,
             )
             try:
                 resolved = await resolver(request)
@@ -1129,6 +1153,7 @@ class WebToolConfig(BaseToolConfig):
                 raise _OAuthTokenResolverFailed(
                     providers=providers,
                     exception_type=_bounded_oauth_metadata(type(exc).__name__),
+                    resource=resource,
                 ) from exc
 
             if resolved is None:
@@ -1136,6 +1161,7 @@ class WebToolConfig(BaseToolConfig):
             return self._validate_resolved_oauth_token(
                 provider=provider,
                 providers=providers,
+                resource=resource,
                 resolved=resolved,
             )
 
@@ -1146,17 +1172,20 @@ class WebToolConfig(BaseToolConfig):
         *,
         provider: str,
         providers: list[str],
+        resource: str | None,
         resolved: ResolvedToken,
     ) -> _ResolvedHookToken:
         if not isinstance(resolved, ResolvedToken):
             raise _OAuthTokenResolverFailed(
                 providers=providers,
                 exception_type=_bounded_oauth_metadata(type(resolved).__name__),
+                resource=resource,
             )
         if not isinstance(resolved.access_token, str) or not resolved.access_token:
             raise _OAuthTokenResolverFailed(
                 providers=providers,
                 exception_type="InvalidAccessToken",
+                resource=resource,
             )
         if resolved.expires_at is not None and not isinstance(
             resolved.expires_at, datetime
@@ -1164,6 +1193,7 @@ class WebToolConfig(BaseToolConfig):
             raise _OAuthTokenResolverFailed(
                 providers=providers,
                 exception_type="InvalidExpiresAt",
+                resource=resource,
             )
 
         expires_at = _normalize_oauth_expires_at(resolved.expires_at)
@@ -1171,6 +1201,7 @@ class WebToolConfig(BaseToolConfig):
             raise _OAuthTokenResolverFailed(
                 providers=providers,
                 exception_type="ExpiredAccessToken",
+                resource=resource,
             )
 
         return _ResolvedHookToken(
@@ -1206,6 +1237,9 @@ class WebToolConfig(BaseToolConfig):
             server,
             code=OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
             message=OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE,
+            resource=_bounded_oauth_metadata(error.resource)
+            if error.resource is not None
+            else None,
         )
         diagnostic["providers"] = [
             _bounded_oauth_metadata(provider) for provider in error.providers[:2]
@@ -1369,12 +1403,14 @@ class WebToolConfig(BaseToolConfig):
 
                     hook_token: _ResolvedHookToken | None = None
                     if app_info:
+                        configured_resource = _oauth_token_configured_resource(app_info)
                         providers_to_resolve = _oauth_token_provider_candidates(
                             app_info
                         )
                         try:
                             hook_token = await self._resolve_oauth_token_from_hook(
-                                providers=providers_to_resolve
+                                providers=providers_to_resolve,
+                                resource=configured_resource,
                             )
                         except _OAuthTokenResolverFailed as error:
                             self._mcp_hook_resolution_failed = True

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -84,7 +84,13 @@ _oauth_token_resolver_generation = 0
 
 
 def set_oauth_token_resolver_hook(resolver: TokenResolver | None) -> None:
-    """Register or clear the process-wide OAuth token resolver hook."""
+    """Register or clear the process-wide OAuth token resolver hook.
+
+    Every registration invalidates existing per-instance MCP config caches, even
+    when the callable identity is unchanged. Embedders can re-register the hook
+    after external token-store changes to force already-created ``WebToolConfig``
+    instances to reload credentials.
+    """
     global _oauth_token_resolver_generation, _oauth_token_resolver_hook
 
     _oauth_token_resolver_hook = resolver
@@ -146,14 +152,13 @@ def _oauth_token_expires_after_cache_window(expires_at: datetime) -> bool:
 
 
 def _oauth_token_provider_candidates(app_info: Mapping[str, Any]) -> list[str]:
-    candidates: list[str] = []
-    for key in ("provider", "id"):
-        value = app_info.get(key)
-        if not isinstance(value, str) or not value:
-            continue
-        if value not in candidates:
-            candidates.append(value)
-    return candidates
+    return list(
+        dict.fromkeys(
+            value
+            for value in (app_info.get("provider"), app_info.get("id"))
+            if isinstance(value, str) and value
+        )
+    )
 
 
 def _oauth_token_configured_resource(app_info: Mapping[str, Any]) -> str | None:
@@ -609,6 +614,8 @@ class WebToolConfig(BaseToolConfig):
         return configs
 
     def _mcp_config_cache_is_valid(self) -> bool:
+        # MCP config caching is aware of hook-supplied token expiry only. The
+        # legacy UserOAuth path keeps the pre-existing per-instance cache shape.
         _, current_generation = _get_oauth_token_resolver_hook()
         if self._mcp_hook_generation_at_load != current_generation:
             return False
@@ -1651,6 +1658,9 @@ class WebToolConfig(BaseToolConfig):
         except ConnectorRuntimeError:
             raise
         except Exception as e:
+            # Preserve the legacy partial-return behavior for unrelated load
+            # errors. Resolver and OAuth launch-config failures are handled
+            # per server above so later servers can still load.
             logger.warning(f"Failed to load MCP server configs: {e}", exc_info=True)
 
         logger.info(f"Loaded {len(configs)} MCP server configurations")

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -7,6 +7,7 @@ and other web-specific sources.
 
 import logging
 import os
+import shlex
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -151,6 +152,15 @@ def _oauth_launch_config_args(launch_config: Mapping[str, Any]) -> list[Any]:
         return []
     if isinstance(args, list):
         return args.copy()
+    if isinstance(args, str):
+        try:
+            return shlex.split(args)
+        except ValueError as exc:
+            logger.warning(
+                "Falling back to whitespace split for OAuth MCP launch config args because args string could not be parsed: %s",
+                type(exc).__name__,
+            )
+            return args.split()
     logger.warning("Ignoring OAuth MCP launch config args because args must be a list")
     return []
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1443,6 +1443,7 @@ class WebToolConfig(BaseToolConfig):
                             continue
 
                     if app_info and hook_token is not None:
+                        self._mark_hook_token_cache_metadata(hook_token)
                         try:
                             transport_config = (
                                 self._build_oauth_mcp_stdio_transport_config(
@@ -1458,7 +1459,6 @@ class WebToolConfig(BaseToolConfig):
                                 error.field,
                             )
                             continue
-                        self._mark_hook_token_cache_metadata(hook_token)
                         config["transport"] = "stdio"
                         logger.info(
                             "OAuth token resolver supplied token for MCP server '%s' via provider '%s'",

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -188,7 +188,9 @@ def _oauth_launch_config_args(launch_config: Mapping[str, Any]) -> list[Any]:
                 type(exc).__name__,
             )
             return args.split()
-    logger.warning("Ignoring OAuth MCP launch config args because args must be a list")
+    logger.warning(
+        "Ignoring OAuth MCP launch config args because args must be a list or a string"
+    )
     return []
 
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1433,7 +1433,10 @@ class WebToolConfig(BaseToolConfig):
                             continue
 
                     if hook_token is not None:
-                        assert app_info is not None
+                        if app_info is None:
+                            raise RuntimeError(
+                                "OAuth token resolver supplied a token without app metadata"
+                            )
                         try:
                             transport_config = (
                                 self._build_oauth_mcp_stdio_transport_config(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -139,6 +139,16 @@ def _oauth_token_provider_candidates(app_info: Mapping[str, Any]) -> list[str]:
     return candidates
 
 
+def _oauth_launch_config_args(launch_config: Mapping[str, Any]) -> list[Any]:
+    args = launch_config.get("args")
+    if args is None:
+        return []
+    if isinstance(args, list):
+        return args.copy()
+    logger.warning("Ignoring OAuth MCP launch config args because args must be a list")
+    return []
+
+
 async def refresh_oauth_token_if_needed(
     db: Any, oauth_account: Any, provider_name: str
 ) -> bool:
@@ -1199,7 +1209,7 @@ class WebToolConfig(BaseToolConfig):
             transport_config: Dict[str, Any] = {
                 "transport": "stdio",
                 "command": launch_config["command"],
-                "args": launch_config.get("args", []).copy(),
+                "args": _oauth_launch_config_args(launch_config),
             }
 
             env = {}

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -395,6 +395,10 @@ class WebToolConfig(BaseToolConfig):
         self._cached_tts_models: Optional[Dict[str, Any]] = None
         self._cached_tts_model: Optional[Any] = None
         self._cached_mcp_configs: Optional[List[Dict[str, Any]]] = None
+        self._mcp_hook_token_cache_expires_at: datetime | None = None
+        self._mcp_hook_token_cache_uncacheable = False
+        self._mcp_hook_generation_at_load: int | None = None
+        self._mcp_hook_resolution_failed = False
         self._cached_embedding_model: Optional[str] = None
         self._cached_rerank_model: Optional[str] = None
 
@@ -518,9 +522,41 @@ class WebToolConfig(BaseToolConfig):
         if not self._include_mcp_tools:
             return []
 
-        if self._cached_mcp_configs is None:
-            self._cached_mcp_configs = await self._load_mcp_server_configs()
-        return self._cached_mcp_configs
+        if self._cached_mcp_configs is not None and self._mcp_config_cache_is_valid():
+            return self._cached_mcp_configs
+
+        configs = await self._load_mcp_server_configs()
+        self._store_mcp_config_cache_if_cacheable(configs)
+        return configs
+
+    def _mcp_config_cache_is_valid(self) -> bool:
+        _, current_generation = _get_oauth_token_resolver_hook()
+        if self._mcp_hook_generation_at_load != current_generation:
+            return False
+        if self._mcp_hook_resolution_failed:
+            return False
+        if self._mcp_hook_token_cache_uncacheable:
+            return False
+        if self._mcp_hook_token_cache_expires_at is not None:
+            return _oauth_token_expires_after_cache_window(
+                self._mcp_hook_token_cache_expires_at
+            )
+        return True
+
+    def _reset_mcp_config_load_cache_state(self) -> None:
+        _, current_generation = _get_oauth_token_resolver_hook()
+        self._mcp_hook_token_cache_expires_at = None
+        self._mcp_hook_token_cache_uncacheable = False
+        self._mcp_hook_generation_at_load = current_generation
+        self._mcp_hook_resolution_failed = False
+
+    def _store_mcp_config_cache_if_cacheable(
+        self, configs: List[Dict[str, Any]]
+    ) -> None:
+        if self._mcp_hook_resolution_failed or self._mcp_hook_token_cache_uncacheable:
+            self._cached_mcp_configs = None
+            return
+        self._cached_mcp_configs = configs
 
     def get_mcp_oauth_diagnostics(self) -> List[Dict[str, Any]]:
         """Return structured MCP OAuth runtime diagnostics from the last load."""
@@ -1025,6 +1061,132 @@ class WebToolConfig(BaseToolConfig):
             logger.warning(f"Failed to load default TTS model: {e}")
             return None
 
+    async def _resolve_oauth_token_from_hook(
+        self,
+        *,
+        providers: list[str],
+    ) -> _ResolvedHookToken | None:
+        resolver, _ = _get_oauth_token_resolver_hook()
+        if resolver is None or not providers or self._user_id is None:
+            return None
+
+        for provider in providers:
+            request = TokenRequest(
+                provider=provider,
+                user_id=int(self._user_id),
+                scope=self.get_execution_scope(),
+            )
+            try:
+                resolved = await resolver(request)
+            except Exception as exc:
+                raise _OAuthTokenResolverFailed(
+                    providers=providers,
+                    exception_type=_bounded_oauth_metadata(type(exc).__name__),
+                ) from exc
+
+            if resolved is None:
+                continue
+            return self._validate_resolved_oauth_token(
+                provider=provider,
+                providers=providers,
+                resolved=resolved,
+            )
+
+        return None
+
+    def _validate_resolved_oauth_token(
+        self,
+        *,
+        provider: str,
+        providers: list[str],
+        resolved: ResolvedToken,
+    ) -> _ResolvedHookToken:
+        if not isinstance(resolved, ResolvedToken):
+            raise _OAuthTokenResolverFailed(
+                providers=providers,
+                exception_type=_bounded_oauth_metadata(type(resolved).__name__),
+            )
+        if not isinstance(resolved.access_token, str) or not resolved.access_token:
+            raise _OAuthTokenResolverFailed(
+                providers=providers,
+                exception_type="InvalidAccessToken",
+            )
+        if resolved.expires_at is not None and not isinstance(
+            resolved.expires_at, datetime
+        ):
+            raise _OAuthTokenResolverFailed(
+                providers=providers,
+                exception_type="InvalidExpiresAt",
+            )
+
+        expires_at = _normalize_oauth_expires_at(resolved.expires_at)
+        if expires_at is not None and _oauth_token_is_expired(expires_at):
+            raise _OAuthTokenResolverFailed(
+                providers=providers,
+                exception_type="ExpiredAccessToken",
+            )
+
+        return _ResolvedHookToken(
+            provider=provider,
+            access_token=resolved.access_token,
+            expires_at=expires_at,
+        )
+
+    def _mark_hook_token_cache_metadata(self, resolved: _ResolvedHookToken) -> None:
+        if resolved.expires_at is None:
+            self._mcp_hook_token_cache_uncacheable = True
+            return
+        if not _oauth_token_expires_after_cache_window(resolved.expires_at):
+            self._mcp_hook_token_cache_uncacheable = True
+            return
+        if self._mcp_hook_token_cache_expires_at is None:
+            self._mcp_hook_token_cache_expires_at = resolved.expires_at
+            return
+        self._mcp_hook_token_cache_expires_at = min(
+            self._mcp_hook_token_cache_expires_at,
+            resolved.expires_at,
+        )
+
+    def _build_oauth_token_resolver_diagnostic(
+        self,
+        *,
+        server: Any,
+        error: _OAuthTokenResolverFailed,
+    ) -> Dict[str, Any]:
+        from ...web.services.mcp_runtime import mcp_oauth_runtime_diagnostic
+
+        diagnostic = mcp_oauth_runtime_diagnostic(
+            server,
+            code=OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
+            message=OAUTH_TOKEN_RESOLVER_FAILURE_MESSAGE,
+        )
+        diagnostic["providers"] = [
+            _bounded_oauth_metadata(provider) for provider in error.providers[:2]
+        ]
+        diagnostic["exception_type"] = _bounded_oauth_metadata(error.exception_type)
+        return diagnostic
+
+    def _build_unavailable_oauth_mcp_config(
+        self,
+        *,
+        server: Any,
+        diagnostic: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "name": server.name,
+            "transport": "unavailable",
+            "description": server.description,
+            "config": {
+                "unavailable": True,
+                "reason": OAUTH_TOKEN_RESOLVER_FAILURE_CODE,
+                "message": UNAVAILABLE_MCP_CREDENTIAL_MESSAGE,
+                "server_id": getattr(server, "id", None),
+                "diagnostic": diagnostic,
+            },
+            "user_id": str(self._user_id),
+            "allow_users": [str(self._user_id)],
+        }
+
     def _build_oauth_mcp_stdio_transport_config(
         self,
         *,
@@ -1080,6 +1242,7 @@ class WebToolConfig(BaseToolConfig):
         logger = logging.getLogger(__name__)
         configs = []
         self._mcp_oauth_diagnostics = []
+        self._reset_mcp_config_load_cache_state()
 
         try:
             from ...web.models.mcp import MCPServer, UserMCPServer
@@ -1155,71 +1318,115 @@ class WebToolConfig(BaseToolConfig):
                     # For example, "google-drive" instead of "google"
                     app_id = app_info.get("id") if app_info else None
 
-                    if app_id:
-                        providers_to_check = [provider_name, app_id]
-                        oauth_account = (
-                            self.db.query(UserOAuth)
-                            .filter(
-                                UserOAuth.user_id == self._user_id,
-                                UserOAuth.provider.in_(providers_to_check),
+                    hook_token: _ResolvedHookToken | None = None
+                    if app_info:
+                        providers_to_resolve = _oauth_token_provider_candidates(
+                            app_info
+                        )
+                        try:
+                            hook_token = await self._resolve_oauth_token_from_hook(
+                                providers=providers_to_resolve
                             )
-                            .first()
-                        )
-                        logger.info(
-                            f"OAUTH CONFIG: Checked providers {providers_to_check} for user {self._user_id}. Found: {oauth_account is not None}"
-                        )
-                    else:
-                        oauth_account = (
-                            self.db.query(UserOAuth)
-                            .filter(
-                                UserOAuth.user_id == self._user_id,
-                                UserOAuth.provider == provider_name,
+                        except _OAuthTokenResolverFailed as error:
+                            self._mcp_hook_resolution_failed = True
+                            diagnostic = self._build_oauth_token_resolver_diagnostic(
+                                server=server,
+                                error=error,
                             )
-                            .first()
-                        )
-                        logger.info(
-                            f"OAUTH CONFIG: Checked provider '{provider_name}' for user {self._user_id}. Found: {oauth_account is not None}"
-                        )
-
-                    if oauth_account and oauth_account.access_token:
-                        logger.info(
-                            f"OAUTH CONFIG: Token found for '{provider_name}'. Refresh token present: {oauth_account.refresh_token is not None}, Expires: {oauth_account.expires_at}"
-                        )
-                        # Check and refresh token if needed before using it
-                        is_valid = await refresh_oauth_token_if_needed(
-                            self.db,
-                            oauth_account,
-                            str(provider_name) if provider_name else "",
-                        )
-
-                        if not is_valid:
+                            self._mcp_oauth_diagnostics.append(diagnostic)
                             logger.warning(
-                                f"OAUTH CONFIG: Token for '{provider_name}' is invalid and could not be refreshed. "
-                                "Deleting OAuth record to prompt user for reconnection."
+                                "OAuth token resolver failed for MCP server '%s' with %s",
+                                getattr(server, "name", "<unknown>"),
+                                error.exception_type,
                             )
-                            # Delete the invalid oauth record so UI shows it as disconnected
-                            self.db.delete(oauth_account)
-                            self.db.commit()
-                            continue
-
-                        if is_valid and app_info:
-                            app_id = app_info.get("id")
-                            logger.info(
-                                f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
-                            )
-                            config["transport"] = "stdio"
-                            transport_config = (
-                                self._build_oauth_mcp_stdio_transport_config(
+                            configs.append(
+                                self._build_unavailable_oauth_mcp_config(
                                     server=server,
-                                    app_info=app_info,
-                                    access_token=oauth_account.access_token,
+                                    diagnostic=diagnostic,
                                 )
                             )
+                            continue
 
-                    else:
-                        logger.info(
-                            f"OAUTH CONFIG: No valid token found for '{provider_name}'."
+                    if hook_token is not None:
+                        assert app_info is not None
+                        self._mark_hook_token_cache_metadata(hook_token)
+                        config["transport"] = "stdio"
+                        transport_config = self._build_oauth_mcp_stdio_transport_config(
+                            server=server,
+                            app_info=app_info,
+                            access_token=hook_token.access_token,
                         )
+                        logger.info(
+                            "OAuth token resolver supplied token for MCP server '%s' via provider '%s'",
+                            getattr(server, "name", "<unknown>"),
+                            hook_token.provider,
+                        )
+                    else:
+                        if app_id:
+                            providers_to_check = [provider_name, app_id]
+                            oauth_account = (
+                                self.db.query(UserOAuth)
+                                .filter(
+                                    UserOAuth.user_id == self._user_id,
+                                    UserOAuth.provider.in_(providers_to_check),
+                                )
+                                .first()
+                            )
+                            logger.info(
+                                f"OAUTH CONFIG: Checked providers {providers_to_check} for user {self._user_id}. Found: {oauth_account is not None}"
+                            )
+                        else:
+                            oauth_account = (
+                                self.db.query(UserOAuth)
+                                .filter(
+                                    UserOAuth.user_id == self._user_id,
+                                    UserOAuth.provider == provider_name,
+                                )
+                                .first()
+                            )
+                            logger.info(
+                                f"OAUTH CONFIG: Checked provider '{provider_name}' for user {self._user_id}. Found: {oauth_account is not None}"
+                            )
+
+                        if oauth_account and oauth_account.access_token:
+                            logger.info(
+                                f"OAUTH CONFIG: Token found for '{provider_name}'. Refresh token present: {oauth_account.refresh_token is not None}, Expires: {oauth_account.expires_at}"
+                            )
+                            # Check and refresh token if needed before using it
+                            is_valid = await refresh_oauth_token_if_needed(
+                                self.db,
+                                oauth_account,
+                                str(provider_name) if provider_name else "",
+                            )
+
+                            if not is_valid:
+                                logger.warning(
+                                    f"OAUTH CONFIG: Token for '{provider_name}' is invalid and could not be refreshed. "
+                                    "Deleting OAuth record to prompt user for reconnection."
+                                )
+                                # Delete the invalid oauth record so UI shows it as disconnected
+                                self.db.delete(oauth_account)
+                                self.db.commit()
+                                continue
+
+                            if is_valid and app_info:
+                                app_id = app_info.get("id")
+                                logger.info(
+                                    f"OAUTH CONFIG: Mapping '{app_id}' to executable proxy"
+                                )
+                                config["transport"] = "stdio"
+                                transport_config = (
+                                    self._build_oauth_mcp_stdio_transport_config(
+                                        server=server,
+                                        app_info=app_info,
+                                        access_token=oauth_account.access_token,
+                                    )
+                                )
+
+                        else:
+                            logger.info(
+                                f"OAUTH CONFIG: No valid token found for '{provider_name}'."
+                            )
 
                 if server.transport == "stdio":
                     if server.command:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -5,6 +5,7 @@ Provides web-specific configuration classes that load from database
 and other web-specific sources.
 """
 
+import inspect
 import logging
 import os
 import shlex
@@ -77,7 +78,8 @@ class ResolvedToken:
     expires_at: datetime | None = None
 
 
-TokenResolver = Callable[[TokenRequest], Awaitable[ResolvedToken | None]]
+TokenResolverResult = ResolvedToken | Awaitable[ResolvedToken | None] | None
+TokenResolver = Callable[[TokenRequest], TokenResolverResult]
 
 _oauth_token_resolver_hook: TokenResolver | None = None
 _oauth_token_resolver_generation = 0
@@ -85,6 +87,9 @@ _oauth_token_resolver_generation = 0
 
 def set_oauth_token_resolver_hook(resolver: TokenResolver | None) -> None:
     """Register or clear the process-wide OAuth token resolver hook.
+
+    Resolvers may return ``ResolvedToken`` or ``None`` directly, or return an
+    awaitable that resolves to either value.
 
     Every registration invalidates existing per-instance MCP config caches, even
     when the callable identity is unchanged. Embedders can re-register the hook
@@ -99,6 +104,12 @@ def set_oauth_token_resolver_hook(resolver: TokenResolver | None) -> None:
 
 def _get_oauth_token_resolver_hook() -> tuple[TokenResolver | None, int]:
     return _oauth_token_resolver_hook, _oauth_token_resolver_generation
+
+
+async def _maybe_await_oauth_token_resolver_result(result: object) -> object:
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 @dataclass(frozen=True)
@@ -1167,7 +1178,9 @@ class WebToolConfig(BaseToolConfig):
                 resource=resource,
             )
             try:
-                resolved = await resolver(request)
+                resolved = await _maybe_await_oauth_token_resolver_result(
+                    resolver(request)
+                )
             except Exception as exc:
                 raise _OAuthTokenResolverFailed(
                     providers=providers,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1175,7 +1175,7 @@ class WebToolConfig(BaseToolConfig):
 
             if resolved is None:
                 continue
-            return self._validate_resolved_oauth_token(
+            return self._normalize_resolved_oauth_token_from_hook(
                 provider=provider,
                 providers=providers,
                 resource=resource,
@@ -1184,13 +1184,13 @@ class WebToolConfig(BaseToolConfig):
 
         return None
 
-    def _validate_resolved_oauth_token(
+    def _normalize_resolved_oauth_token_from_hook(
         self,
         *,
         provider: str,
         providers: list[str],
         resource: str | None,
-        resolved: ResolvedToken,
+        resolved: object,
     ) -> _ResolvedHookToken:
         if not isinstance(resolved, ResolvedToken):
             raise _OAuthTokenResolverFailed(

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -7,6 +7,7 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPToolAdapter,
     _build_mcp_tool_adapter,
     _exception_indicates_http_401,
+    _mcp_return_value_as_string,
 )
 
 
@@ -91,6 +92,10 @@ def test_exception_indicates_http_401_uses_bounded_status_signals():
         RuntimeError("connection reset on port 401")
     )
     assert not _exception_indicates_http_401(RuntimeError("tool returned id 40123"))
+
+
+def test_mcp_return_value_as_string_keeps_malformed_scalar_content_together():
+    assert _mcp_return_value_as_string({"content": "error"}) == "error"
 
 
 def test_build_mcp_tool_adapter_honors_concurrent_tool_allowlist():

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 
 import pytest
@@ -233,6 +234,22 @@ async def test_factory_normal_loader_failure_keeps_unavailable_tool(monkeypatch)
     )
 
     assert [tool.name for tool in tools] == ["mcp_google_drive_42_unavailable"]
+
+
+@pytest.mark.asyncio
+async def test_factory_malformed_normal_config_keeps_unavailable_tool(caplog):
+    caplog.set_level(logging.WARNING)
+
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            _unavailable_config(),
+            {"name": "normal", "transport": "stdio", "config": None},
+        ]
+    )
+
+    assert [tool.name for tool in tools] == ["mcp_google_drive_42_unavailable"]
+    assert "MCP server config 'config' field for server 'normal'" in caplog.text
+    assert "dictionary, got NoneType" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -6,6 +6,8 @@ import pytest
 from mcp.types import Tool as MCPTool
 
 from xagent.core.tools.adapters.vibe.base import ToolCategory
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPToolAdapter,
     UnavailableMCPTool,
@@ -24,6 +26,26 @@ def _unavailable_tool(
         server_id=server_id,
         allow_users=allow_users,
     )
+
+
+def _unavailable_config(
+    *,
+    name: str | None = "Google Drive",
+    server_id: int | None = 42,
+    allow_users: list[str] | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "transport": "unavailable",
+        "description": f"{name} server",
+        "config": {
+            "unavailable": True,
+            "reason": "oauth_token_resolver_failed",
+            "message": "MCP server credentials are unavailable.",
+            "server_id": server_id,
+        },
+        "allow_users": allow_users,
+    }
 
 
 def test_unavailable_tool_name_is_llm_safe_and_uses_server_id():
@@ -176,6 +198,173 @@ def test_unavailable_tool_return_value_as_string_extracts_text():
         )
         == "first\nsecond"
     )
+
+
+@pytest.mark.asyncio
+async def test_factory_builds_unavailable_tools_without_normal_loader(monkeypatch):
+    async def fail_loader(*args, **kwargs):
+        raise AssertionError("normal loader should not be called")
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        fail_loader,
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs([_unavailable_config()])
+
+    assert [tool.name for tool in tools] == ["mcp_google_drive_42_unavailable"]
+
+
+@pytest.mark.asyncio
+async def test_factory_normal_loader_failure_keeps_unavailable_tool(monkeypatch):
+    async def fail_loader(*args, **kwargs):
+        raise RuntimeError("loader failed")
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        fail_loader,
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            _unavailable_config(),
+            {"name": "normal", "transport": "stdio", "config": {"command": "echo"}},
+        ]
+    )
+
+    assert [tool.name for tool in tools] == ["mcp_google_drive_42_unavailable"]
+
+
+@pytest.mark.asyncio
+async def test_factory_does_not_pass_unavailable_config_to_normal_loader(monkeypatch):
+    seen_connections = None
+
+    async def loader(connections, **kwargs):
+        nonlocal seen_connections
+        seen_connections = connections
+        return []
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        loader,
+    )
+
+    await ToolFactory._create_mcp_tools_from_configs(
+        [
+            _unavailable_config(),
+            {
+                "name": "normal",
+                "transport": "stdio",
+                "config": {"command": "echo", "args": "--flag value"},
+            },
+        ]
+    )
+
+    assert seen_connections == {
+        "normal": {"transport": "stdio", "command": "echo", "args": ["--flag", "value"]}
+    }
+
+
+@pytest.mark.asyncio
+async def test_factory_preserves_runtime_keys_for_normal_configs(monkeypatch):
+    seen_connections = None
+
+    async def loader(connections, **kwargs):
+        nonlocal seen_connections
+        seen_connections = connections
+        return []
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        loader,
+    )
+
+    await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {
+                "name": "normal",
+                "transport": "streamable_http",
+                "config": {"url": "https://mcp.example.test"},
+                "runtime_bindings": [{"binding": "value"}],
+                "runtime_input_schema": {"context": {"account": {"type": "string"}}},
+                "connector_runtime": {"context": {"account": "a"}},
+                "allow_delegated_authorization": True,
+            },
+        ]
+    )
+
+    assert seen_connections == {
+        "normal": {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "runtime_bindings": [{"binding": "value"}],
+            "runtime_input_schema": {"context": {"account": {"type": "string"}}},
+            "connector_runtime": {"context": {"account": "a"}},
+            "allow_delegated_authorization": True,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_factory_propagates_connector_runtime_error(monkeypatch):
+    async def fail_loader(*args, **kwargs):
+        raise ConnectorRuntimeError(
+            "connector_runtime_unavailable",
+            "Connector runtime context is unavailable.",
+        )
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        fail_loader,
+    )
+
+    with pytest.raises(ConnectorRuntimeError):
+        await ToolFactory._create_mcp_tools_from_configs(
+            [
+                _unavailable_config(),
+                {"name": "normal", "transport": "stdio", "config": {"command": "echo"}},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_unavailable_tools_before_normal_tools(monkeypatch):
+    normal_tool = _unavailable_tool(server_name="Normal", server_id=99)
+
+    async def loader(connections, **kwargs):
+        return [normal_tool]
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.mcp_adapter.load_mcp_tools_as_agent_tools",
+        loader,
+    )
+
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            {"name": "normal", "transport": "stdio", "config": {"command": "echo"}},
+            _unavailable_config(),
+        ]
+    )
+
+    assert [tool.name for tool in tools] == [
+        "mcp_google_drive_42_unavailable",
+        "mcp_normal_99_unavailable",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_factory_malformed_unavailable_config_does_not_drop_valid_one():
+    tools = await ToolFactory._create_mcp_tools_from_configs(
+        [
+            _unavailable_config(name=None, server_id=None),
+            _unavailable_config(name="Google Drive", server_id=42),
+        ]
+    )
+
+    assert [tool.name for tool in tools] == [
+        "mcp_server_unavailable",
+        "mcp_google_drive_42_unavailable",
+    ]
 
 
 def test_selection_plain_mcp_admits_unavailable_tool():

--- a/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from mcp.types import Tool as MCPTool
+
+from xagent.core.tools.adapters.vibe.base import ToolCategory
+from xagent.core.tools.adapters.vibe.mcp_adapter import (
+    MCPToolAdapter,
+    UnavailableMCPTool,
+)
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+
+
+def _unavailable_tool(
+    *,
+    server_name: str = "Google Drive",
+    server_id: int | None = 42,
+    allow_users: list[str] | None = None,
+) -> UnavailableMCPTool:
+    return UnavailableMCPTool(
+        server_name=server_name,
+        server_id=server_id,
+        allow_users=allow_users,
+    )
+
+
+def test_unavailable_tool_name_is_llm_safe_and_uses_server_id():
+    tool = _unavailable_tool(server_name="Google Drive", server_id=42)
+
+    assert tool.name == "mcp_google_drive_42_unavailable"
+    assert re.fullmatch(r"[A-Za-z0-9_]+", tool.name)
+
+
+def test_unavailable_tool_names_avoid_flat_collisions_with_server_id():
+    first = _unavailable_tool(server_name="Google Drive", server_id=1)
+    second = _unavailable_tool(server_name="google-drive", server_id=2)
+
+    assert first.name == "mcp_google_drive_1_unavailable"
+    assert second.name == "mcp_google_drive_2_unavailable"
+    assert first.name != second.name
+
+
+def test_unavailable_tool_empty_server_name_has_stable_fallback():
+    tool = _unavailable_tool(server_name="!!!", server_id=None)
+
+    assert tool.name == "mcp_server_unavailable"
+    assert re.fullmatch(r"[A-Za-z0-9_]+", tool.name)
+
+
+def test_unavailable_tool_metadata_is_mcp_and_server_scoped():
+    tool = _unavailable_tool(allow_users=["7"])
+
+    assert tool.metadata.category == ToolCategory.MCP
+    assert tool.metadata.source_server == "google_drive"
+    assert tool.metadata.allow_users == ["7"]
+    assert tool.metadata.read_only is True
+    assert tool.metadata.concurrency_safe is True
+
+
+@pytest.mark.asyncio
+async def test_unavailable_tool_async_authorized_returns_clean_error(monkeypatch):
+    monkeypatch.setenv("XAGENT_USER_ID", "7")
+    tool = _unavailable_tool(allow_users=["7"])
+
+    result = await tool.run_json_async({})
+
+    assert result["is_error"] is True
+    text = result["content"][0]["text"]
+    assert "MCP server credentials are unavailable" in text
+    assert "resolver" not in text
+    assert "provider" not in text
+    assert "RuntimeError" not in text
+
+
+def test_unavailable_tool_sync_authorized_returns_clean_error(monkeypatch):
+    monkeypatch.setenv("XAGENT_USER_ID", "7")
+    tool = _unavailable_tool(allow_users=["7"])
+
+    result = tool.run_json_sync({})
+
+    assert result["is_error"] is True
+    assert "MCP server credentials are unavailable" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_tool_async_unauthorized_uses_mcp_access_denied(
+    monkeypatch,
+):
+    monkeypatch.setenv("XAGENT_USER_ID", "8")
+    tool = _unavailable_tool(allow_users=["7"])
+
+    result = await tool.run_json_async({})
+
+    assert result == {
+        "content": [
+            {
+                "text": (
+                    "Access denied: User 8 is not authorized to use tool "
+                    "mcp_google_drive_42_unavailable"
+                )
+            }
+        ],
+        "is_error": True,
+    }
+
+
+def test_unavailable_tool_sync_unauthorized_uses_mcp_access_denied(monkeypatch):
+    monkeypatch.setenv("XAGENT_USER_ID", "8")
+    tool = _unavailable_tool(allow_users=["7"])
+
+    result = tool.run_json_sync({})
+
+    assert result["is_error"] is True
+    assert "Access denied" in result["content"][0]["text"]
+
+
+def test_unavailable_tool_missing_user_permission_regression(monkeypatch):
+    monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+
+    assert _unavailable_tool(allow_users=None).run_json_sync({})["is_error"] is True
+    assert (
+        "MCP server credentials"
+        in _unavailable_tool(allow_users=None).run_json_sync({})["content"][0]["text"]
+    )
+    assert (
+        "Access denied"
+        in _unavailable_tool(allow_users=["7"]).run_json_sync({})["content"][0]["text"]
+    )
+    assert (
+        "MCP server credentials"
+        in _unavailable_tool(allow_users=["system"]).run_json_sync({})["content"][0][
+            "text"
+        ]
+    )
+
+
+def test_mcp_tool_adapter_permission_helper_regression(monkeypatch):
+    adapter = MCPToolAdapter(
+        MCPTool(name="remote_tool", description="Remote tool", inputSchema={}),
+        {"transport": "stdio", "command": "echo"},
+        allow_users=["7"],
+    )
+
+    monkeypatch.delenv("XAGENT_USER_ID", raising=False)
+    assert adapter._get_current_user_id() is None
+    assert adapter._is_user_allowed(None) is False
+
+    system_adapter = MCPToolAdapter(
+        MCPTool(name="remote_tool", description="Remote tool", inputSchema={}),
+        {"transport": "stdio", "command": "echo"},
+        allow_users=["system"],
+    )
+    assert system_adapter._is_user_allowed(None) is True
+
+    unrestricted_adapter = MCPToolAdapter(
+        MCPTool(name="remote_tool", description="Remote tool", inputSchema={}),
+        {"transport": "stdio", "command": "echo"},
+        allow_users=None,
+    )
+    assert unrestricted_adapter._is_user_allowed(None) is True
+
+    monkeypatch.setenv("XAGENT_USER_ID", "8")
+    assert adapter._get_current_user_id() == "8"
+    assert adapter._is_user_allowed("8") is False
+    assert adapter._is_user_allowed("7") is True
+
+
+def test_unavailable_tool_return_value_as_string_extracts_text():
+    tool = _unavailable_tool()
+
+    assert (
+        tool.return_value_as_string(
+            {"content": [{"text": "first"}, {"text": "second"}], "is_error": True}
+        )
+        == "first\nsecond"
+    )
+
+
+def test_selection_plain_mcp_admits_unavailable_tool():
+    tool = _unavailable_tool()
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp"])
+
+    assert spec.compute_allowed_names([tool]) == frozenset({tool.name})
+
+
+def test_selection_scoped_mcp_admits_unavailable_tool_by_source_server():
+    tool = _unavailable_tool()
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Google Drive"])
+
+    assert spec.compute_allowed_names([tool]) == frozenset({tool.name})
+
+
+def test_selection_unrelated_scoped_mcp_rejects_unavailable_tool():
+    tool = _unavailable_tool()
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:Slack"])
+
+    assert spec.compute_allowed_names([tool]) == frozenset()

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -329,6 +329,36 @@ async def test_launch_config_args_none_matches_user_oauth_shape(db_session):
 
 
 @pytest.mark.asyncio
+async def test_launch_config_args_string_matches_user_oauth_shape(db_session):
+    db, user = db_session
+    launch_config = _launch_config()
+    launch_config["args"] = '--flag "two words"'
+    _add_oauth_server(db, user, launch_config=launch_config)
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    hook_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+    set_oauth_token_resolver_hook(None)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    user_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    assert hook_config["config"]["args"] == ["--flag", "two words"]
+    _assert_same_oauth_config_except_token(
+        hook_config,
+        user_config,
+        token_key="GOOGLE_ACCESS_TOKEN",
+        hook_token="hook-token",
+        user_token="user-token",
+    )
+
+
+@pytest.mark.asyncio
 async def test_launch_config_env_mapping_none_matches_user_oauth_shape(db_session):
     db, user = db_session
     launch_config = _launch_config()

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -299,6 +299,36 @@ async def test_hook_supply_launch_config_env_matches_user_oauth_shape(db_session
 
 
 @pytest.mark.asyncio
+async def test_launch_config_args_none_matches_user_oauth_shape(db_session):
+    db, user = db_session
+    launch_config = _launch_config()
+    launch_config["args"] = None
+    _add_oauth_server(db, user, launch_config=launch_config)
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    hook_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+    set_oauth_token_resolver_hook(None)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    user_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    assert hook_config["config"]["args"] == []
+    _assert_same_oauth_config_except_token(
+        hook_config,
+        user_config,
+        token_key="GOOGLE_ACCESS_TOKEN",
+        hook_token="hook-token",
+        user_token="user-token",
+    )
+
+
+@pytest.mark.asyncio
 async def test_hook_is_not_asked_without_app_info(db_session):
     db, user = db_session
     _add_oauth_server(db, user, name="Unregistered OAuth", register_app=False)

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools.config import (
+    ResolvedToken,
+    TokenRequest,
+    WebToolConfig,
+    set_oauth_token_resolver_hook,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_oauth_token_resolver_hook():
+    set_oauth_token_resolver_hook(None)
+    yield
+    set_oauth_token_resolver_hook(None)
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "oauth-token-resolver.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _launch_config(env_key: str = "GOOGLE_ACCESS_TOKEN") -> dict:
+    return {
+        "command": "npx",
+        "args": ["-y", "@mcp-servers/google-drive"],
+        "env_mapping": {env_key: "access_token", "IGNORED": "refresh_token"},
+    }
+
+
+def _add_oauth_server(
+    db,
+    user: User,
+    *,
+    name: str = "Google Drive",
+    app_id: str | None = "google-drive",
+    provider: str | None = "google",
+    launch_config: dict | None = None,
+    register_app: bool = True,
+) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} server",
+        managed="external",
+        transport="oauth",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    if register_app:
+        db.add(
+            PublicMCPApp(
+                app_id=app_id or f"{name.lower()}-app",
+                name=name,
+                description=f"{name} app",
+                transport="oauth",
+                provider_name=provider,
+                launch_config=launch_config if launch_config is not None else {},
+            )
+        )
+    db.commit()
+    return server
+
+
+def _add_stdio_server(db, user: User, *, name: str) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} server",
+        managed="external",
+        transport="stdio",
+        command="echo",
+        args=["ok"],
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+    return server
+
+
+def _add_user_oauth(
+    db,
+    user: User,
+    *,
+    provider: str = "google",
+    access_token: str = "user-token",
+) -> UserOAuth:
+    account = UserOAuth(
+        user_id=user.id,
+        provider=provider,
+        access_token=access_token,
+        provider_user_id=f"{provider}-user",
+    )
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    return account
+
+
+def _tool_config(db, user: User, **kwargs) -> WebToolConfig:
+    return WebToolConfig(
+        db=db,
+        request=None,
+        user=user,
+        user_id=user.id,
+        workspace_config={"base_dir": "/tmp", "task_id": "task-1"},
+        **kwargs,
+    )
+
+
+def _access_token_env(config: dict, key: str = "GOOGLE_ACCESS_TOKEN") -> str:
+    return config["config"]["env"][key]
+
+
+def _assert_same_oauth_config_except_token(
+    hook_config: dict,
+    user_config: dict,
+    *,
+    token_key: str,
+    hook_token: str,
+    user_token: str,
+) -> None:
+    hook_env = dict(hook_config["config"]["env"])
+    user_env = dict(user_config["config"]["env"])
+    assert hook_env.pop(token_key) == hook_token
+    assert user_env.pop(token_key) == user_token
+    assert hook_config["transport"] == user_config["transport"] == "stdio"
+    assert hook_config["config"]["transport"] == user_config["config"]["transport"]
+    assert hook_config["config"]["command"] == user_config["config"]["command"]
+    assert hook_config["config"]["args"] == user_config["config"]["args"]
+    assert hook_env == user_env
+
+
+@pytest.mark.asyncio
+async def test_hook_receives_provider_candidates_in_order_and_first_hit_wins(
+    db_session,
+):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append(request.provider)
+        if request.provider == "google-drive":
+            return ResolvedToken(
+                access_token="hook-token",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert seen == ["google", "google-drive"]
+    assert len(configs) == 1
+    assert configs[0]["transport"] == "stdio"
+    assert _access_token_env(configs[0]) == "hook-token"
+
+
+@pytest.mark.asyncio
+async def test_hook_dedupes_provider_candidates(db_session):
+    db, user = db_session
+    _add_oauth_server(
+        db,
+        user,
+        app_id="google",
+        provider="google",
+        launch_config=_launch_config(),
+    )
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append(request.provider)
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+    await _tool_config(db, user).get_mcp_server_configs()
+
+    assert seen == ["google"]
+
+
+@pytest.mark.asyncio
+async def test_hook_decline_falls_back_to_user_oauth(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "stdio"
+    assert _access_token_env(configs[0]) == "user-token"
+
+
+@pytest.mark.asyncio
+async def test_hook_supply_fallback_npx_env_matches_user_oauth_shape(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, name="Legacy App", app_id="legacy-app")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    hook_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+    set_oauth_token_resolver_hook(None)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    user_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    _assert_same_oauth_config_except_token(
+        hook_config,
+        user_config,
+        token_key="LEGACY_APP_ACCESS_TOKEN",
+        hook_token="hook-token",
+        user_token="user-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_hook_supply_launch_config_env_matches_user_oauth_shape(db_session):
+    db, user = db_session
+    _add_oauth_server(
+        db,
+        user,
+        launch_config=_launch_config(env_key="CUSTOM_ACCESS_TOKEN"),
+    )
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    hook_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+    set_oauth_token_resolver_hook(None)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    user_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    _assert_same_oauth_config_except_token(
+        hook_config,
+        user_config,
+        token_key="CUSTOM_ACCESS_TOKEN",
+        hook_token="hook-token",
+        user_token="user-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_hook_is_not_asked_without_app_info(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, name="Unregistered OAuth", register_app=False)
+    seen: list[str] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append(request.provider)
+        raise AssertionError("resolver should not be called")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert seen == []
+    assert len(configs) == 1
+    assert configs[0]["name"] == "Unregistered OAuth"
+    assert configs[0]["transport"] == "oauth"
+
+
+@pytest.mark.asyncio
+async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    oauth_server = _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    _add_stdio_server(db, user, name="after")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise RuntimeError("secret-token-in-exception")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == [
+        "before",
+        "Google Drive",
+        "after",
+    ]
+    unavailable = configs[1]
+    assert unavailable["transport"] == "unavailable"
+    assert unavailable["config"]["reason"] == "oauth_token_resolver_failed"
+    assert unavailable["config"]["server_id"] == oauth_server.id
+    assert "secret-token-in-exception" not in str(unavailable)
+    assert "secret-token-in-exception" not in caplog.text
+    assert "runtime_input_schema" not in unavailable
+    assert "runtime_bindings" not in unavailable
+    assert "allow_delegated_authorization" not in unavailable
+    assert "connector_runtime" not in unavailable
+    assert cfg.get_mcp_oauth_diagnostics() == [
+        {
+            "code": "oauth_token_resolver_failed",
+            "message": "OAuth token resolver failed",
+            "server_id": oauth_server.id,
+            "server_name": "Google Drive",
+            "resource_owner_key": None,
+            "resource": None,
+            "scope": "",
+            "issuer": None,
+            "providers": ["google", "google-drive"],
+            "exception_type": "RuntimeError",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hook_expires_at_none_is_used_but_not_cached(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(access_token=f"hook-token-{calls}", expires_at=None)
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    second = await cfg.get_mcp_server_configs()
+
+    assert calls == 2
+    assert _access_token_env(first[0]) == "hook-token-1"
+    assert _access_token_env(second[0]) == "hook-token-2"
+
+
+@pytest.mark.asyncio
+async def test_hook_future_expiry_is_cached_until_generation_changes(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(
+            access_token=f"hook-token-{calls}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    second = await cfg.get_mcp_server_configs()
+    set_oauth_token_resolver_hook(resolver)
+    third = await cfg.get_mcp_server_configs()
+
+    assert calls == 2
+    assert _access_token_env(first[0]) == "hook-token-1"
+    assert _access_token_env(second[0]) == "hook-token-1"
+    assert _access_token_env(third[0]) == "hook-token-2"
+
+
+@pytest.mark.asyncio
+async def test_hook_naive_expiry_is_interpreted_as_utc(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert _access_token_env(configs[0]) == "hook-token"
+
+
+@pytest.mark.asyncio
+async def test_hook_near_expiry_token_is_used_but_not_cached(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(
+            access_token=f"hook-token-{calls}",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    second = await cfg.get_mcp_server_configs()
+
+    assert calls == 2
+    assert _access_token_env(first[0]) == "hook-token-1"
+    assert _access_token_env(second[0]) == "hook-token-2"
+
+
+@pytest.mark.asyncio
+async def test_hook_expired_token_creates_unavailable_config(db_session):
+    db, user = db_session
+    server = _add_oauth_server(db, user, launch_config=_launch_config())
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["server_id"] == server.id
+    assert cfg.get_mcp_oauth_diagnostics()[0]["exception_type"] == (
+        "ExpiredAccessToken"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hook_request_receives_execution_scope(db_session):
+    db, user = db_session
+    scope = object()
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    seen_scope: list[object] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen_scope.append(request.scope)
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(
+        db, user, execution_scope=scope
+    ).get_mcp_server_configs()
+
+    assert seen_scope == [scope]
+    assert _access_token_env(configs[0]) == "hook-token"

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -599,6 +599,89 @@ async def test_hook_failure_diagnostic_includes_bounded_resource(db_session):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("resolved", "exception_type"),
+    [
+        (object(), "object"),
+        (ResolvedToken(access_token="", expires_at=None), "InvalidAccessToken"),
+        (ResolvedToken(access_token=123, expires_at=None), "InvalidAccessToken"),
+        (
+            ResolvedToken(access_token="hook-token", expires_at="soon"),
+            "InvalidExpiresAt",
+        ),
+    ],
+)
+async def test_hook_malformed_token_creates_unavailable_config(
+    db_session,
+    resolved,
+    exception_type,
+):
+    db, user = db_session
+    server = _add_oauth_server(db, user, launch_config=_launch_config())
+
+    async def resolver(request: TokenRequest):
+        return resolved
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["server_id"] == server.id
+    assert cfg.get_mcp_oauth_diagnostics()[0]["exception_type"] == exception_type
+
+
+@pytest.mark.asyncio
+async def test_hook_is_skipped_when_user_id_is_none(db_session):
+    db, user = db_session
+    seen: list[TokenRequest] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append(request)
+        return ResolvedToken(access_token="hook-token", expires_at=None)
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    cfg._user_id = None
+    resolved = await cfg._resolve_oauth_token_from_hook(
+        providers=["google"],
+        resource=None,
+    )
+
+    assert resolved is None
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_launch_config_with_uncacheable_hook_token_is_not_cached(
+    db_session,
+):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config="not-a-mapping")
+    calls = 0
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(access_token=f"hook-token-{calls}", expires_at=None)
+
+    set_oauth_token_resolver_hook(resolver)
+    cfg = _tool_config(db, user)
+
+    first = await cfg.get_mcp_server_configs()
+    app = db.query(PublicMCPApp).filter(PublicMCPApp.name == "Google Drive").one()
+    app.launch_config = _launch_config()
+    db.commit()
+    second = await cfg.get_mcp_server_configs()
+
+    assert first == []
+    assert calls == 2
+    assert _access_token_env(second[0]) == "hook-token-2"
+
+
+@pytest.mark.asyncio
 async def test_hook_expires_at_none_is_used_but_not_cached(db_session):
     db, user = db_session
     _add_oauth_server(db, user, launch_config=_launch_config())

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -67,7 +67,7 @@ def _add_oauth_server(
     name: str = "Google Drive",
     app_id: str | None = "google-drive",
     provider: str | None = "google",
-    launch_config: dict | None = None,
+    launch_config: object | None = None,
     register_app: bool = True,
 ) -> MCPServer:
     server = MCPServer(
@@ -462,6 +462,49 @@ async def test_launch_config_missing_command_skips_only_that_server_for_user_oau
 
     assert [config["name"] for config in configs] == ["before", "after"]
     assert "launch_config.command is invalid" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_launch_config_non_mapping_skips_only_that_server_for_hook(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    _add_oauth_server(db, user, launch_config="not-a-mapping")
+    _add_stdio_server(db, user, name="after")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == ["before", "after"]
+    assert "launch_config.type is invalid" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_launch_config_non_mapping_skips_only_that_server_for_user_oauth(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    _add_oauth_server(db, user, launch_config=["not", "a", "mapping"])
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    _add_stdio_server(db, user, name="after")
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == ["before", "after"]
+    assert "launch_config.type is invalid" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -207,6 +207,28 @@ async def test_hook_receives_provider_candidates_in_order_and_first_hit_wins(
 
 
 @pytest.mark.asyncio
+async def test_hook_accepts_sync_resolver(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    seen: list[str] = []
+
+    def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append(request.provider)
+        return ResolvedToken(
+            access_token="sync-hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert seen == ["google"]
+    assert configs[0]["transport"] == "stdio"
+    assert _access_token_env(configs[0]) == "sync-hook-token"
+
+
+@pytest.mark.asyncio
 async def test_hook_dedupes_provider_candidates(db_session):
     db, user = db_session
     _add_oauth_server(

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -394,6 +394,34 @@ async def test_launch_config_args_string_matches_user_oauth_shape(db_session):
 
 
 @pytest.mark.asyncio
+async def test_launch_config_args_unsupported_type_warning_matches_contract(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    launch_config = _launch_config()
+    launch_config["args"] = {"not": "supported"}
+    _add_oauth_server(db, user, launch_config=launch_config)
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    assert config["config"]["args"] == []
+    assert (
+        "Ignoring OAuth MCP launch config args because args must be a list or a string"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
 async def test_launch_config_env_mapping_none_matches_user_oauth_shape(db_session):
     db, user = db_session
     launch_config = _launch_config()

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -47,12 +47,17 @@ def db_session(tmp_path):
     engine.dispose()
 
 
-def _launch_config(env_key: str = "GOOGLE_ACCESS_TOKEN") -> dict:
-    return {
+def _launch_config(
+    env_key: str = "GOOGLE_ACCESS_TOKEN", resource: str | None = None
+) -> dict:
+    launch_config = {
         "command": "npx",
         "args": ["-y", "@mcp-servers/google-drive"],
         "env_mapping": {env_key: "access_token", "IGNORED": "refresh_token"},
     }
+    if resource is not None:
+        launch_config["resource"] = resource
+    return launch_config
 
 
 def _add_oauth_server(
@@ -221,6 +226,36 @@ async def test_hook_dedupes_provider_candidates(db_session):
     await _tool_config(db, user).get_mcp_server_configs()
 
     assert seen == ["google"]
+
+
+@pytest.mark.asyncio
+async def test_hook_request_receives_provider_resource_and_scope_verbatim(db_session):
+    db, user = db_session
+    scope = object()
+    resource = "https://MCP.EXAMPLE.com:443/mcp/%7Euser/?Q=1#Fragment"
+    _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
+    seen: list[tuple[str, str | None, object | None]] = []
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        seen.append((request.provider, request.resource, request.scope))
+        if request.provider == "google-drive":
+            return ResolvedToken(
+                access_token="hook-token",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(
+        db, user, execution_scope=scope
+    ).get_mcp_server_configs()
+
+    assert seen == [
+        ("google", resource, scope),
+        ("google-drive", resource, scope),
+    ]
+    assert _access_token_env(configs[0]) == "hook-token"
 
 
 @pytest.mark.asyncio
@@ -498,6 +533,26 @@ async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
             "exception_type": "RuntimeError",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_hook_failure_diagnostic_includes_bounded_resource(db_session):
+    db, user = db_session
+    resource = "https://mcp.example.com/" + "r" * 160
+    _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise RuntimeError("resolver failed")
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    configs = await cfg.get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    diagnostic = cfg.get_mcp_oauth_diagnostics()[0]
+    assert diagnostic["resource"] == f"{resource[:125]}..."
+    assert len(diagnostic["resource"]) == 128
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -329,6 +329,77 @@ async def test_launch_config_args_none_matches_user_oauth_shape(db_session):
 
 
 @pytest.mark.asyncio
+async def test_launch_config_env_mapping_none_matches_user_oauth_shape(db_session):
+    db, user = db_session
+    launch_config = _launch_config()
+    launch_config["env_mapping"] = None
+    _add_oauth_server(db, user, launch_config=launch_config)
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    hook_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+    set_oauth_token_resolver_hook(None)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    user_config = (await _tool_config(db, user).get_mcp_server_configs())[0]
+
+    assert "GOOGLE_ACCESS_TOKEN" not in hook_config["config"]["env"]
+    assert hook_config == user_config
+
+
+@pytest.mark.asyncio
+async def test_launch_config_missing_command_skips_only_that_server_for_hook(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    launch_config = _launch_config()
+    launch_config.pop("command")
+    _add_oauth_server(db, user, launch_config=launch_config)
+    _add_stdio_server(db, user, name="after")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == ["before", "after"]
+    assert "launch_config.command is invalid" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_launch_config_missing_command_skips_only_that_server_for_user_oauth(
+    db_session,
+    caplog,
+):
+    db, user = db_session
+    caplog.set_level(logging.WARNING)
+    _add_stdio_server(db, user, name="before")
+    launch_config = _launch_config()
+    launch_config.pop("command")
+    _add_oauth_server(db, user, launch_config=launch_config)
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+    _add_stdio_server(db, user, name="after")
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == ["before", "after"]
+    assert "launch_config.command is invalid" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_hook_is_not_asked_without_app_info(db_session):
     db, user = db_session
     _add_oauth_server(db, user, name="Unregistered OAuth", register_app=False)

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
@@ -626,6 +627,28 @@ async def test_hook_failure_does_not_fallback_and_later_servers_still_build(
             "exception_type": "RuntimeError",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_hook_connector_runtime_error_propagates(db_session):
+    db, user = db_session
+    _add_oauth_server(db, user, launch_config=_launch_config())
+    _add_user_oauth(db, user, provider="google", access_token="user-token")
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        raise ConnectorRuntimeError(
+            "connector_runtime_unavailable",
+            "Connector runtime context is unavailable.",
+            status_code=503,
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    cfg = _tool_config(db, user)
+    with pytest.raises(ConnectorRuntimeError):
+        await cfg.get_mcp_server_configs()
+
+    assert cfg.get_mcp_oauth_diagnostics() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a process-wide OAuth token resolver hook for MCP OAuth config loading, with stable provider ordering, execution scope forwarding, configured resource forwarding, and explicit expiry/cache semantics.
- Share the OAuth MCP stdio token injection logic between the existing UserOAuth path and the new resolver path to keep env construction consistent.
- Surface resolver failures as an unavailable MCP credential tool instead of silently falling back to another identity or dropping later MCP servers.

## Architecture Decisions
- Credential failures are materialized as `UnavailableMCPTool` instances so the agent can see a callable tool that returns a clear credential error. Omitting the server would hide the failure from tool selection and make recovery less actionable.
- The resolver hook is process-wide by design. Tenant, actor, task, and resource-owner context stay with the embedding layer and execution scope instead of making OSS hold per-tenant resolver state.
- MCP config caching tracks hook-supplied token expiry and resolver generation. Re-registering the hook intentionally invalidates existing per-instance MCP config caches, even when the callable identity is unchanged, so embedders can force reload after external token-store changes.
- Legacy UserOAuth config caching keeps its pre-existing per-instance behavior; this PR only adds expiry awareness for hook-supplied tokens.
- Resolver and OAuth launch-config failures are handled per server so later MCP servers still load. The inherited outer catch remains the compatibility fallback for unrelated load errors.

## Behavior
- Resolver requests include the configured MCP OAuth resource URI when present, passed verbatim without OSS-side canonicalization.
- Resolver decline falls back to the existing UserOAuth path unchanged.
- Resolver failure produces a sanitized unavailable MCP config/tool for that server and keeps loading subsequent MCP servers.
- Expired resolver tokens fail closed; near-expiry and no-expiry tokens are usable for the current config build but are not cached.
- Connector runtime errors still propagate instead of being treated as unavailable OAuth credentials.

## Validation
- `uv run ruff check src/xagent/web/tools/config.py src/xagent/core/tools/adapters/vibe/mcp_adapter.py src/xagent/core/tools/adapters/vibe/factory.py tests/web/tools/test_oauth_token_resolver_hook.py tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py`
- `uv run pytest tests/web/tools/test_oauth_token_resolver_hook.py tests/web/tools/test_mcp_oauth_runtime.py tests/web/tools/test_web_tool_config_session_factory.py tests/core/tools/adapters/vibe/test_mcp_unavailable_tool.py tests/core/tools/adapters/vibe/test_mcp_adapter.py tests/core/tools/adapters/vibe/test_connector_runtime_contract.py tests/core/tools/adapters/vibe/test_selection_spec.py tests/core/test_execution_scope.py -q`
- `uv run pytest tests/core/tools/test_mcp_database_integration.py tests/core/tools/adapters/vibe/test_custom_api_factory.py -q`

Closes #758
