### PR TITLE
feat(core): decouple sandbox mount root from full workspace segments (scope-prefix mounts)

### DIFF
--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -91,6 +91,17 @@ class ExecutionScope:
             (``user:{owner_id}`` becomes ``user:{owner_id}:{suffix}``).
         workspace_segments: Extra path segments inserted after the user root
             in workspace paths and storage keys.
+        sandbox_mount_segments: When set, the sandbox bind-mount root covers
+            only this **prefix** of ``workspace_segments`` instead of the full
+            tuple. Two scopes that share ``sandbox_key_suffix`` and this prefix
+            then produce an identical mount and can share one container, while
+            their deeper ``workspace_segments`` keep them in disjoint subtrees
+            of that shared mount (isolation stays at the tool/path-check
+            layer). Must be a prefix of ``workspace_segments``. ``None`` (the
+            default) means the mount covers the full ``workspace_segments`` —
+            byte-identical to pre-existing behavior. Consumed only by the
+            sandbox-mount composition; workspace paths and storage keys always
+            use the full ``workspace_segments``.
         memory_dimensions: Extra metadata stamped on memory notes on add and
             filtered on scoped search.
         strict_memory_isolation: When True, unscoped searches also exclude
@@ -104,9 +115,24 @@ class ExecutionScope:
 
     sandbox_key_suffix: Optional[str] = None
     workspace_segments: tuple[str, ...] = ()
+    sandbox_mount_segments: Optional[tuple[str, ...]] = None
     memory_dimensions: Mapping[str, str] = field(default_factory=dict)
     strict_memory_isolation: bool = False
     isolate_external_dirs: bool = False
+
+    @property
+    def effective_mount_segments(self) -> tuple[str, ...]:
+        """Segments the sandbox bind-mount root covers.
+
+        Defaults to the full ``workspace_segments`` (mount root == workspace
+        root), so an unset prefix reproduces today's behavior exactly. When
+        ``sandbox_mount_segments`` is set, the mount root covers only that
+        prefix and scopes sharing ``sandbox_key_suffix`` + this prefix share
+        one container.
+        """
+        if self.sandbox_mount_segments is None:
+            return self.workspace_segments
+        return self.sandbox_mount_segments
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable snapshot (see :func:`ExecutionScope.from_dict`).
@@ -118,6 +144,11 @@ class ExecutionScope:
         return {
             "sandbox_key_suffix": self.sandbox_key_suffix,
             "workspace_segments": list(self.workspace_segments),
+            "sandbox_mount_segments": (
+                None
+                if self.sandbox_mount_segments is None
+                else list(self.sandbox_mount_segments)
+            ),
             "memory_dimensions": dict(self.memory_dimensions),
             "strict_memory_isolation": self.strict_memory_isolation,
             "isolate_external_dirs": self.isolate_external_dirs,
@@ -126,9 +157,11 @@ class ExecutionScope:
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "ExecutionScope":
         """Rebuild a scope from :meth:`to_dict` output (re-validated)."""
+        raw_mount = data.get("sandbox_mount_segments")
         return cls(
             sandbox_key_suffix=data.get("sandbox_key_suffix"),
             workspace_segments=tuple(data.get("workspace_segments") or ()),
+            sandbox_mount_segments=(None if raw_mount is None else tuple(raw_mount)),
             memory_dimensions=dict(data.get("memory_dimensions") or {}),
             strict_memory_isolation=bool(data.get("strict_memory_isolation", False)),
             isolate_external_dirs=bool(data.get("isolate_external_dirs", False)),
@@ -155,6 +188,29 @@ class ExecutionScope:
         for segment in segments:
             validate_scope_component(segment, field_name="workspace_segments entry")
         object.__setattr__(self, "workspace_segments", segments)
+
+        if self.sandbox_mount_segments is not None:
+            mount_segments = tuple(self.sandbox_mount_segments)
+            for segment in mount_segments:
+                validate_scope_component(
+                    segment, field_name="sandbox_mount_segments entry"
+                )
+            # The mount root must be a prefix of the workspace root: the
+            # workspace subtree (full segments) has to live *inside* the
+            # mounted directory to be visible in the container, and a
+            # non-prefix mount could expose an unrelated subtree.
+            if mount_segments != segments[: len(mount_segments)]:
+                logger.error(
+                    "sandbox_mount_segments %r is not a prefix of "
+                    "workspace_segments %r",
+                    mount_segments,
+                    segments,
+                )
+                raise InvalidScopeComponentError(
+                    f"sandbox_mount_segments {mount_segments!r} must be a "
+                    f"prefix of workspace_segments {segments!r}"
+                )
+            object.__setattr__(self, "sandbox_mount_segments", mount_segments)
 
         dimensions = dict(self.memory_dimensions)
         for key, dim_value in dimensions.items():

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1233,9 +1233,14 @@ class AgentServiceManager:
         )
         workspace_owner_id = int(task.user_id)
         scope_segments = scope.workspace_segments if scope is not None else ()
+        # The sandbox bind mount covers the scope's mount prefix (the full
+        # workspace_segments when no prefix is declared); the deeper
+        # workspace subtree lives inside it and stays confined by the
+        # tool/path-check layer, not by a per-subtree mount.
+        mount_segments = scope.effective_mount_segments if scope is not None else ()
         sandbox_workspace_config = {
             "base_dir": str(
-                scoped_user_root(get_uploads_dir(), workspace_owner_id, scope_segments)
+                scoped_user_root(get_uploads_dir(), workspace_owner_id, mount_segments)
             ),
             "task_id": f"web_task_{task_id}",
             "user_id": workspace_owner_id,
@@ -1758,10 +1763,16 @@ class AgentServiceManager:
                     else int(runtime_user.id)
                 )
                 scope_segments = scope.workspace_segments if scope is not None else ()
+                # Sandbox mount covers the scope's mount prefix (full
+                # workspace_segments when no prefix is declared); the deeper
+                # workspace subtree is confined at the tool/path-check layer.
+                mount_segments = (
+                    scope.effective_mount_segments if scope is not None else ()
+                )
                 sandbox_workspace_config = {
                     "base_dir": str(
                         scoped_user_root(
-                            get_uploads_dir(), workspace_owner_id, scope_segments
+                            get_uploads_dir(), workspace_owner_id, mount_segments
                         )
                     ),
                     "task_id": f"web_task_{task_id}",

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -137,6 +137,100 @@ class TestExecutionScope:
         assert scope.workspace_segments == ()
 
 
+class TestSandboxMountSegments:
+    """The mount-prefix field (#79-01): decouples the sandbox mount root from
+    the full workspace_segments so scopes sharing a suffix + prefix share one
+    container while deeper segments stay in disjoint subtrees."""
+
+    def test_default_mount_covers_full_workspace_segments(self):
+        """Unset prefix => mount root == workspace root (byte-identical)."""
+        scope = ExecutionScope(
+            sandbox_key_suffix="client-3",
+            workspace_segments=("clients", "3", "end_users", "7"),
+        )
+        assert scope.sandbox_mount_segments is None
+        assert scope.effective_mount_segments == ("clients", "3", "end_users", "7")
+
+    def test_unscoped_scope_has_empty_effective_mount(self):
+        assert ExecutionScope().effective_mount_segments == ()
+
+    def test_prefix_mount_shared_across_deeper_segments(self):
+        """Two end users of one CA share a mount prefix; only deeper differs."""
+        a = ExecutionScope(
+            sandbox_key_suffix="client-3",
+            workspace_segments=("clients", "3", "end_users", "7"),
+            sandbox_mount_segments=("clients", "3"),
+        )
+        b = ExecutionScope(
+            sandbox_key_suffix="client-3",
+            workspace_segments=("clients", "3", "end_users", "8"),
+            sandbox_mount_segments=("clients", "3"),
+        )
+        assert a.effective_mount_segments == ("clients", "3")
+        assert b.effective_mount_segments == ("clients", "3")
+        assert a.workspace_segments != b.workspace_segments
+
+    def test_mount_segments_normalized_to_tuple(self):
+        scope = ExecutionScope(
+            workspace_segments=["clients", "3", "end_users", "7"],
+            sandbox_mount_segments=["clients", "3"],
+        )
+        assert scope.sandbox_mount_segments == ("clients", "3")
+
+    def test_empty_prefix_mounts_at_user_root(self):
+        """() is a valid prefix of any segments — mount at the user root."""
+        scope = ExecutionScope(
+            workspace_segments=("clients", "3"),
+            sandbox_mount_segments=(),
+        )
+        assert scope.effective_mount_segments == ()
+
+    def test_rejects_non_prefix_mount_segments(self):
+        with pytest.raises(InvalidScopeComponentError, match="must be a prefix"):
+            ExecutionScope(
+                workspace_segments=("clients", "3", "end_users", "7"),
+                sandbox_mount_segments=("clients", "4"),
+            )
+
+    def test_rejects_mount_longer_than_workspace_segments(self):
+        with pytest.raises(InvalidScopeComponentError, match="must be a prefix"):
+            ExecutionScope(
+                workspace_segments=("clients", "3"),
+                sandbox_mount_segments=("clients", "3", "end_users", "7"),
+            )
+
+    def test_rejects_invalid_mount_segment_component(self):
+        with pytest.raises(InvalidScopeComponentError):
+            ExecutionScope(
+                workspace_segments=("clients", "3"),
+                sandbox_mount_segments=("clients", "../escape"),
+            )
+
+    def test_to_dict_from_dict_round_trips_prefix(self):
+        scope = ExecutionScope(
+            sandbox_key_suffix="client-3",
+            workspace_segments=("clients", "3", "end_users", "7"),
+            sandbox_mount_segments=("clients", "3"),
+        )
+        assert ExecutionScope.from_dict(scope.to_dict()) == scope
+        assert scope.to_dict()["sandbox_mount_segments"] == ["clients", "3"]
+
+    def test_to_dict_preserves_none_vs_empty_distinction(self):
+        """None (mount == full segments) must not collapse into () (mount at
+        user root) across a serialization round-trip."""
+        default = ExecutionScope(workspace_segments=("clients", "3"))
+        assert default.to_dict()["sandbox_mount_segments"] is None
+        restored_default = ExecutionScope.from_dict(default.to_dict())
+        assert restored_default.sandbox_mount_segments is None
+
+        rooted = ExecutionScope(
+            workspace_segments=("clients", "3"), sandbox_mount_segments=()
+        )
+        assert rooted.to_dict()["sandbox_mount_segments"] == []
+        restored_rooted = ExecutionScope.from_dict(rooted.to_dict())
+        assert restored_rooted.sandbox_mount_segments == ()
+
+
 class TestContextvarHelpers:
     def test_default_is_none(self):
         assert get_execution_scope() is None

--- a/tests/web/test_execution_scope_sandbox.py
+++ b/tests/web/test_execution_scope_sandbox.py
@@ -353,3 +353,46 @@ class TestSandboxManagerScopedKeys:
 
         unscoped = SandboxManager._workspace_mount_paths("user", "7", None)
         assert unscoped == [(tmp_path / "user_7", True)]
+
+    def test_ca_prefix_mount_is_shared_across_end_users(self, tmp_path) -> None:
+        """#79-01: two end users of one client application supply a
+        workspace_config whose ``base_dir`` is the CA-level mount prefix, so
+        both produce the identical mount root — the prerequisite for sharing
+        one container without tripping config-equivalence."""
+        ca_root = tmp_path / "user_5" / "clients" / "3"
+        cfg_eu7 = {"base_dir": str(ca_root)}
+        cfg_eu8 = {"base_dir": str(ca_root)}
+
+        paths_eu7 = SandboxManager._workspace_mount_paths(
+            "user", "5:client-3", cfg_eu7
+        )
+        paths_eu8 = SandboxManager._workspace_mount_paths(
+            "user", "5:client-3", cfg_eu8
+        )
+        assert paths_eu7 == paths_eu8 == [(ca_root, True)]
+
+    def test_full_segment_mounts_would_differ_between_end_users(
+        self, tmp_path
+    ) -> None:
+        """Guard: had the mount stayed at the *full* workspace_segments, the
+        two end users' mount roots would differ — which is exactly the
+        config-equivalence rejection #79-01 removes by mounting the prefix."""
+        eu7_root = tmp_path / "user_5" / "clients" / "3" / "end_users" / "7"
+        eu8_root = tmp_path / "user_5" / "clients" / "3" / "end_users" / "8"
+        paths_eu7 = SandboxManager._workspace_mount_paths(
+            "user", "5:client-3", {"base_dir": str(eu7_root)}
+        )
+        paths_eu8 = SandboxManager._workspace_mount_paths(
+            "user", "5:client-3", {"base_dir": str(eu8_root)}
+        )
+        assert paths_eu7 != paths_eu8
+
+    def test_prefix_and_full_configs_config_equivalent_for_shared_ca(self) -> None:
+        """The two end users' sandbox configs are config-equivalent once the
+        mount is the shared CA prefix, so the manager reuses one container."""
+        from xagent.web.sandbox_manager import SandboxConfig
+
+        ca_volume = ("/host/user_5/clients/3", "/sandbox/workspace", "rw")
+        left = SandboxConfig(volumes=[ca_volume])
+        right = SandboxConfig(volumes=[ca_volume])
+        assert SandboxManager._config_equivalent(left, right)


### PR DESCRIPTION
Closes #815.

## Summary

Adds an optional `ExecutionScope.sandbox_mount_segments` field declaring that the sandbox bind-mount root covers only a **prefix** of `workspace_segments`. Scopes sharing `sandbox_key_suffix` + this prefix then produce an identical mount and can share one container, while their deeper segments keep them in disjoint subtrees of the shared mount.

Today the sandbox `base_dir` is composed from the **full** `workspace_segments`, so every distinct segment tuple demands its own container (the config-equivalence check in `SandboxManager._ensure_config_equivalent` rejects a second task reusing a lifecycle id with a different mount). That makes "one container per scope *group*, path-enforced sub-scopes inside it" impossible.

## Changes

- `core/execution_scope.py`: new `sandbox_mount_segments` field, `effective_mount_segments` property, prefix validation in `__post_init__` (rejected, not coerced), and `to_dict`/`from_dict` round-trip that preserves the `None` (mount == full segments) vs `()` (mount at user root) distinction.
- `web/api/chat.py`: the two `sandbox_workspace_config` composition sites derive the mount `base_dir` from `effective_mount_segments`; the tool workspace and `AgentService.workspace_base_dir` keep using the full segments.

## Behavior / safety

- `None` (default) ⇒ mount covers the full segments; **byte-identical** to today, unscoped execution untouched.
- Path enforcement still confines file access to the full-segment subtree — this only widens the *mount*, not the allowed paths. Cross-subtree reads via the shared mount from inside the sandbox are the documented residual risk of the soft-boundary model (guarantee is at the tool/path-check layer).

## Tests

- `tests/core/test_execution_scope.py::TestSandboxMountSegments` — field defaults, prefix validation, serialization round-trip (incl. None-vs-empty).
- `tests/web/test_execution_scope_sandbox.py` — prefix-shared mount across end users, guard that full-segment mounts would differ, config-equivalence.

## Acceptance criteria

- [x] Two scopes with the same `sandbox_key_suffix` and mount prefix but different deeper segments produce an identical mount — no config-equivalence rejection.
- [x] File access stays confined to the full-segment subtree.
- [x] A scope without a mount prefix, and unscoped execution, produce mounts and paths byte-identical to before this change.