### PR TITLE
fix(memory): enforce scope on by-id get/update/delete

### DIFF
--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -29,6 +29,13 @@ class UserIsolatedMemoryStore(MemoryStore):
     over rows already fetched from the vector search, so a strict search may
     return fewer than ``k`` results.
 
+    The by-id methods (``get``/``update``/``delete``) enforce the same scope
+    dimensions as ``search``/``list_all`` (see ``_scope_permits``), so a
+    caller cannot read, modify, or delete another scope's note by id even
+    when both notes share a ``user_id``. A mismatch returns the combined
+    "not found or access denied" response, indistinguishable from a genuine
+    miss.
+
     Scope is a cooperative namespace, not a security boundary: ``user_id``
     remains the only access-control key.
     """
@@ -95,6 +102,49 @@ class UserIsolatedMemoryStore(MemoryStore):
             if not metadata_carries_scope_dimensions(note.metadata)
         ]
 
+    @staticmethod
+    def _scope_gates_by_id_access() -> bool:
+        """Whether the active scope constrains by-id (get/update/delete)
+        access. An unscoped or empty non-strict scope gates nothing, so the
+        by-id path stays byte-for-byte unchanged when no scope is active."""
+        scope: Optional[ExecutionScope] = get_execution_scope()
+        if scope is None:
+            return False
+        return bool(scope.memory_dimensions) or scope.strict_memory_isolation
+
+    @staticmethod
+    def _scope_permits(note: MemoryNote) -> bool:
+        """Whether the active scope may touch ``note`` by id, mirroring the
+        equality-filter semantics of ``search``/``add``/``list_all``:
+
+        - a scoped caller (non-empty ``memory_dimensions``) matches only a
+          note carrying all of its dimension stamps;
+        - a dimension-less caller under ``strict_memory_isolation`` cannot
+          touch a scope-stamped note (mirrors ``_apply_strict_isolation``);
+        - unscoped / dimension-less non-strict callers keep one-way
+          visibility (access allowed).
+        """
+        scope: Optional[ExecutionScope] = get_execution_scope()
+        dimension_metadata = memory_dimension_metadata(scope)
+        if dimension_metadata:
+            return all(
+                note.metadata.get(key) == value
+                for key, value in dimension_metadata.items()
+            )
+        if scope is not None and scope.strict_memory_isolation:
+            return not metadata_carries_scope_dimensions(note.metadata)
+        return True
+
+    @staticmethod
+    def _not_found_or_denied(note_id: str) -> MemoryResponse:
+        """Combined miss/denial response: a scope or ownership mismatch is
+        indistinguishable from a genuine miss."""
+        return MemoryResponse(
+            success=False,
+            error="Memory note not found or access denied",
+            memory_id=note_id,
+        )
+
     def add(self, note: MemoryNote) -> MemoryResponse:
         """
         Add a memory note with user isolation.
@@ -132,11 +182,11 @@ class UserIsolatedMemoryStore(MemoryStore):
             # Check if the note belongs to the user
             user_id = self._get_current_user_id()
             if user_id is not None and note.metadata.get("user_id") != user_id:
-                return MemoryResponse(
-                    success=False,
-                    error="Memory note not found or access denied",
-                    memory_id=note_id,
-                )
+                return self._not_found_or_denied(note_id)
+            # Enforce the active scope's dimensions on the by-id path too
+            # (mirrors search/list_all). No-op when unscoped.
+            if not self._scope_permits(note):
+                return self._not_found_or_denied(note_id)
 
         return response
 
@@ -150,9 +200,11 @@ class UserIsolatedMemoryStore(MemoryStore):
         Returns:
             Memory response
         """
-        # First verify ownership
+        # First verify ownership and scope access. get() enforces both;
+        # call it whenever a user or a gating scope is present. When fully
+        # unscoped with no user context, the original no-check path is kept.
         user_id = self._get_current_user_id()
-        if user_id is not None and note.id:
+        if note.id and (user_id is not None or self._scope_gates_by_id_access()):
             existing_response = self.get(note.id)
             if not existing_response.success:
                 return existing_response
@@ -173,9 +225,10 @@ class UserIsolatedMemoryStore(MemoryStore):
         Returns:
             Memory response
         """
-        # First verify ownership
+        # First verify ownership and scope access (see update()). Unscoped
+        # with no user context keeps the original no-check path.
         user_id = self._get_current_user_id()
-        if user_id is not None:
+        if user_id is not None or self._scope_gates_by_id_access():
             existing_response = self.get(note_id)
             if not existing_response.success:
                 return existing_response

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -234,3 +234,89 @@ class TestResolverPathAndNestedReactivation:
             assert {n.id for n in store.search("nested")} == {nested_note.id}
         with UserContext(1), ExecutionScopeContext(SCOPE_B):
             assert store.search("nested") == []
+
+
+_DENIED = "Memory note not found or access denied"
+
+
+class TestScopedByIdAccess:
+    """get/update/delete enforce the active scope's dimensions, mirroring
+    search/list_all — a scoped caller cannot read, modify, or delete another
+    scope's note by id even under a shared user_id (#80 review point 4). A
+    mismatch is indistinguishable from a genuine miss."""
+
+    @staticmethod
+    def _note_in(store, scope, content):
+        with UserContext(1), ExecutionScopeContext(scope):
+            return _add(store, content)
+
+    def test_get_denied_across_dimensions(self, store):
+        note_b = self._note_in(store, SCOPE_B, "b note")
+        with UserContext(1), ExecutionScopeContext(SCOPE_A):
+            resp = store.get(note_b.id)
+        assert resp.success is False
+        assert resp.error == _DENIED
+
+    def test_get_allowed_for_own_dimensions(self, store):
+        note_a = self._note_in(store, SCOPE_A, "a note")
+        with UserContext(1), ExecutionScopeContext(SCOPE_A):
+            resp = store.get(note_a.id)
+        assert resp.success is True
+        assert resp.content.id == note_a.id
+
+    def test_update_denied_across_dimensions_leaves_note_intact(self, store):
+        note_b = self._note_in(store, SCOPE_B, "b note")
+        edited = note_b.model_copy(deep=True)
+        edited.content = "hijacked"
+        with UserContext(1), ExecutionScopeContext(SCOPE_A):
+            resp = store.update(edited)
+        assert resp.success is False
+        assert resp.error == _DENIED
+        assert store._base_store.notes[note_b.id].content == "b note"
+
+    def test_delete_denied_across_dimensions_leaves_note_intact(self, store):
+        note_b = self._note_in(store, SCOPE_B, "b note")
+        with UserContext(1), ExecutionScopeContext(SCOPE_A):
+            resp = store.delete(note_b.id)
+        assert resp.success is False
+        assert note_b.id in store._base_store.notes
+
+    def test_update_and_delete_allowed_for_own_dimensions(self, store):
+        note_a = self._note_in(store, SCOPE_A, "a note")
+        edited = note_a.model_copy(deep=True)
+        edited.content = "edited a"
+        with UserContext(1), ExecutionScopeContext(SCOPE_A):
+            assert store.update(edited).success is True
+            assert store.delete(note_a.id).success is True
+        assert note_a.id not in store._base_store.notes
+
+    def test_strict_dimensionless_cannot_touch_scoped_note_by_id(self, store):
+        note_a = self._note_in(store, SCOPE_A, "a note")
+        strict = ExecutionScope(strict_memory_isolation=True)
+        with UserContext(1), ExecutionScopeContext(strict):
+            assert store.get(note_a.id).success is False
+            assert store.delete(note_a.id).success is False
+        assert note_a.id in store._base_store.notes
+
+    def test_nonstrict_dimensionless_keeps_one_way_by_id_access(self, store):
+        """Default one-way visibility: a dimension-less non-strict caller can
+        still reach a scoped note by id (matches unscoped search seeing
+        everything under the user)."""
+        note_a = self._note_in(store, SCOPE_A, "a note")
+        with UserContext(1):
+            assert store.get(note_a.id).success is True
+            assert store.delete(note_a.id).success is True
+        assert note_a.id not in store._base_store.notes
+
+    def test_unscoped_by_id_behavior_unchanged(self, store):
+        """No user context and no scope: the original no-check by-id path is
+        preserved (get/update/delete all succeed)."""
+        note = MemoryNote(content="free")
+        store.add(note)
+        assert store.get(note.id).success is True
+        edited = note.model_copy(deep=True)
+        edited.content = "free edited"
+        assert store.update(edited).success is True
+        assert store._base_store.notes[note.id].content == "free edited"
+        assert store.delete(note.id).success is True
+        assert note.id not in store._base_store.notes


### PR DESCRIPTION
## Summary

Closes #818.

`UserIsolatedMemoryStore.get()` / `update()` / `delete()` verified ownership by comparing only `metadata["user_id"]` and never consulted the active `ExecutionScope`. Since a scope is a cooperative namespace *within* a single `user_id`, a scoped caller could read, modify, or delete another scope's note **by id** as long as both notes lived under the same `user_id` — the dimension isolation that `search`/`add`/`list_all` already enforce was silently absent on the by-id path.

This enforces the active scope's memory dimensions on the by-id path, mirroring the equality-filter semantics of `search`/`list_all`.

## Changes

- **`_scope_permits(note)`** — a dimensioned scope matches only notes carrying **all** its dimension stamps; a dimension-less scope under `strict_memory_isolation` excludes any scope-stamped note (mirrors `_apply_strict_isolation`); unscoped / dimension-less non-strict callers keep the existing one-way visibility (access allowed).
- **`_scope_gates_by_id_access()`** — true only when the active scope has dimensions or is strict, so the unscoped path stays byte-for-byte unchanged.
- **`get()`** applies the `_scope_permits` check after the existing `user_id` check.
- **`update()` / `delete()`** route through `get()` whenever a user context or a gating scope is present (unscoped-with-no-user keeps the original no-check path).
- A scope/dimension mismatch returns the store's existing `"Memory note not found or access denied"` response, so a denial is indistinguishable from a genuine miss.

`user_id` remains the access-control key; the scope stays a cooperative namespace, consistent with the rest of the store.

## Behavior

| Caller | By-id access to a note |
|---|---|
| Scoped (dimensions A) | only notes carrying all of A's stamps |
| Dimension-less, `strict_memory_isolation` | denied for any scope-stamped note |
| Dimension-less, non-strict | one-way visibility preserved (allowed) |
| Unscoped (no scope) | unchanged |

## Tests

Added `tests/web/test_execution_scope_memory.py::TestScopedByIdAccess` (8 tests): cross-dimension get/update/delete denial (note left intact), own-dimension access allowed, strict dimension-less denial, non-strict one-way access, and the unscoped path unchanged. Full `test_execution_scope_*` suite passes.

## Context

Motivated by the memory partitioning work in xorbitsai/xagent-saas#80, where all end users of a client application execute under one creator's `user_id` and are isolated only by scope dimensions. Note ids are returned from `add`/`search`, so this was a reachable cross-principal path. The fix is defense-in-depth on the layer that already owns dimension filtering, applied unconditionally regardless of whether any HTTP surface currently exposes a by-id memory op.