### PR TITLE
fix(memory): stop dropping data on LanceDB schema mismatch

### DIFF
--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -88,7 +88,9 @@ class LanceDBMemoryStore(MemoryStore):
         (preserving all rows) instead of dropping and recreating it. This path
         runs on every store construction, so a wipe here would destroy data with
         no write in flight. On any migration failure the original table is left
-        intact and the error propagates; we never fall back to a wipe.
+        intact and the error propagates (out of ``__init__``); we never fall back
+        to a wipe. Note the migration branch may perform a batched re-embed when
+        a table is both missing a base column and vector-mismatched.
         """
         conn = self._vector_store.get_raw_connection()
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -232,22 +232,23 @@ class LanceDBMemoryStore(MemoryStore):
         row_count = existing.num_rows
         names = set(existing.schema.names)
 
-        def _string_column(name: str) -> list[Optional[str]]:
+        def _string_column(name: str) -> Any:
+            # Stay in the Arrow format and let PyArrow cast natively instead of
+            # materializing Python lists per element.
             if name in names:
-                return [
-                    None if value is None else str(value)
-                    for value in existing.column(name).to_pylist()
-                ]
-            return [None] * row_count
+                return existing.column(name).cast(pa.string())
+            return pa.array([None] * row_count, pa.string())
 
         columns: dict[str, Any] = {
-            "id": pa.array(_string_column("id"), pa.string()),
-            "text": pa.array(_string_column("text"), pa.string()),
-            "metadata": pa.array(_string_column("metadata"), pa.string()),
+            "id": _string_column("id"),
+            "text": _string_column("text"),
+            "metadata": _string_column("metadata"),
         }
 
         if target_dim is not None:
-            texts = [text or "" for text in _string_column("text")]
+            # The batched embedding interface needs Python strings; reuse the
+            # already-cast text column so it is only materialized once.
+            texts = [text or "" for text in columns["text"].to_pylist()]
             vectors = self._embed_texts_batch(texts, target_dim)
             columns["vector"] = pa.array(vectors, pa.list_(pa.float32(), target_dim))
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -82,43 +82,41 @@ class LanceDBMemoryStore(MemoryStore):
         self._ensure_table_schema()
 
     def _ensure_table_schema(self) -> None:
-        """Ensure the table has the correct schema for memory storage."""
+        """Ensure the table has the correct schema for memory storage.
+
+        If the table is missing a required column, migrate it in place
+        (preserving all rows) instead of dropping and recreating it. This path
+        runs on every store construction, so a wipe here would destroy data with
+        no write in flight. On any migration failure the original table is left
+        intact and the error propagates; we never fall back to a wipe.
+        """
+        conn = self._vector_store.get_raw_connection()
+
+        # Determine whether the table already exists and read its columns.
         table = None
         try:
-            conn = self._vector_store.get_raw_connection()
             table = conn.open_table(self._collection_name)
-
-            # Check if table exists and has basic structure
-            df = table.search().limit(1).to_pandas()
-
-            # Table exists, check if it has required columns
-            if not all(col in df.columns for col in ["id", "text", "metadata"]):
-                # Schema is incompatible, drop and recreate
-                logger.warning(
-                    f"Table {self._collection_name} has incompatible schema, recreating"
-                )
-                inner_table = None
-                try:
-                    # Try to drop the table if the method exists
-                    if hasattr(conn, "drop_table"):
-                        conn.drop_table(self._collection_name)
-                    else:
-                        # Alternative: try to use delete all records instead
-                        inner_table = conn.open_table(self._collection_name)
-                        inner_table.delete()
-                except Exception:
-                    # If drop fails, continue with recreation
-                    pass
-                finally:
-                    _safe_close_table(inner_table)
-                self._create_empty_table()
-
+            column_names = set(table.schema.names)
         except Exception:
-            # Table doesn't exist, create it with basic schema
+            # Table doesn't exist yet, create it with the basic schema.
             logger.info(f"Creating table {self._collection_name} with basic schema")
             self._create_empty_table()
+            return
         finally:
             _safe_close_table(table)
+
+        # Table exists. Init's trigger is a missing required non-vector column;
+        # a vector-dimension mismatch is detected and migrated lazily on the
+        # add() path instead. Route the resolution through the shared classifier
+        # and transform-then-swap primitive so we migrate rather than wipe.
+        if not {"id", "text", "metadata"} <= column_names:
+            logger.warning(
+                f"Table {self._collection_name} has incompatible schema, "
+                "migrating in place"
+            )
+            self._resolve_schema_mismatch(
+                conn, self._current_embedding_dim(), raise_when_compatible=False
+            )
 
     def _create_empty_table(self) -> None:
         """Create an empty table with the correct schema."""
@@ -265,27 +263,26 @@ class LanceDBMemoryStore(MemoryStore):
         finally:
             _safe_close_table(table)
 
-    def _migrate_schema_mismatch(self, conn: Any, record: dict[str, Any]) -> None:
-        """Resolve a schema mismatch safely, routing through the 792-01 classifier.
+    def _resolve_schema_mismatch(
+        self, conn: Any, expected_dim: Optional[int], *, raise_when_compatible: bool
+    ) -> None:
+        """Classify and safely resolve a schema mismatch (shared by add/init).
 
         Missing non-vector columns are backfilled in place; a vector
         dimension/presence change rebuilds the table via transform-then-swap.
         On any failure the original table is left intact and the error
         propagates; no path drops or empties the table.
+
+        When the schema is classified compatible, ``raise_when_compatible``
+        controls behavior: the ``add()`` path passes ``True`` (its insert failed,
+        so a compatible schema means an unexpected error to surface rather than
+        silently drop); the init path passes ``False`` (nothing to migrate).
         """
         table = conn.open_table(self._collection_name)
         try:
             schema = table.schema
         finally:
             _safe_close_table(table)
-
-        # The dimension we are trying to store now determines the target schema.
-        if record.get("vector"):
-            expected_dim: Optional[int] = len(record["vector"])
-        elif self._embedding_model:
-            expected_dim = self._current_embedding_dim()
-        else:
-            expected_dim = None
 
         mismatch = classify_memory_schema_mismatch(schema, expected_dim)
 
@@ -298,12 +295,24 @@ class LanceDBMemoryStore(MemoryStore):
                 self._collection_name,
                 lambda existing: self._build_migrated_table(existing, target_dim),
             )
-        else:
+        elif raise_when_compatible:
             # add() failed but the schema looks compatible: do NOT drop the
             # table. Surface the original failure to the caller.
             raise RuntimeError(
                 "add() failed but no resolvable schema mismatch was detected"
             )
+
+    def _migrate_schema_mismatch(self, conn: Any, record: dict[str, Any]) -> None:
+        """Resolve the schema mismatch that made an ``add()`` insert fail."""
+        # The dimension we are trying to store now determines the target schema.
+        if record.get("vector"):
+            expected_dim: Optional[int] = len(record["vector"])
+        elif self._embedding_model:
+            expected_dim = self._current_embedding_dim()
+        else:
+            expected_dim = None
+
+        self._resolve_schema_mismatch(conn, expected_dim, raise_when_compatible=True)
 
     def _insert_record(self, table: Any, record: dict[str, Any]) -> None:
         """Insert a record, adapting it to the (possibly migrated) table schema."""
@@ -676,11 +685,43 @@ class LanceDBMemoryStore(MemoryStore):
         except Exception as e:
             logger.error(f"Failed to clear memory store: {e}")
 
+    _LIST_SPECIAL_FILTERS = frozenset(
+        {"category", "date_from", "date_to", "tags", "keywords"}
+    )
+
+    def _note_matches_list_filters(
+        self, note: MemoryNote, filters: dict[str, Any]
+    ) -> bool:
+        """Apply list_all filter semantics to a note (mirrors InMemoryStore)."""
+        if "category" in filters and note.category != filters["category"]:
+            return False
+        if "date_from" in filters and note.timestamp < filters["date_from"]:
+            return False
+        if "date_to" in filters and note.timestamp > filters["date_to"]:
+            return False
+        if "tags" in filters and not all(tag in note.tags for tag in filters["tags"]):
+            return False
+        if "keywords" in filters and not all(
+            keyword in note.keywords for keyword in filters["keywords"]
+        ):
+            return False
+        # Remaining keys are direct metadata equality checks.
+        other = {
+            k: v for k, v in filters.items() if k not in self._LIST_SPECIAL_FILTERS
+        }
+        if other and not all(note.metadata.get(k) == v for k, v in other.items()):
+            return False
+        return True
+
     def list_all(self, filters: Optional[dict[str, Any]] = None) -> List[MemoryNote]:
         """List all memory notes with optional filtering."""
         try:
-            # Use empty query to get all results
-            return self.search(query="", k=10000, filters=filters or {})
+            # Fetch every note (empty query), then apply list-level filters such
+            # as category, date range, tags and keywords in Python.
+            notes = self.search(query="", k=10000)
+            if not filters:
+                return notes
+            return [n for n in notes if self._note_matches_list_filters(n, filters)]
         except Exception as e:
             logger.error(f"Failed to list all memories: {e}")
             return []

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -5,6 +5,8 @@ import logging
 from typing import Any, List, Optional, Union
 from uuid import uuid4
 
+import pyarrow as pa  # type: ignore
+
 from ...providers.vector_store.lancedb import (
     LanceDBConnectionManager,
     LanceDBVectorStore,
@@ -15,6 +17,11 @@ from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
+from .schema_migration import (
+    MemoryMismatchKind,
+    classify_memory_schema_mismatch,
+    migrate_table_swap,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +176,142 @@ class LanceDBMemoryStore(MemoryStore):
             logger.error(f"Failed to generate embedding for text '{text[:50]}...': {e}")
             return None
 
+    def _current_embedding_dim(self) -> Optional[int]:
+        """Return the vector dimension the store currently produces, or None.
+
+        None means no embedding model is available and the store operates in
+        vector-less (text-search) mode.
+        """
+        if not self._embedding_model:
+            return None
+        try:
+            dim = self._embedding_model.get_dimension()
+            if dim:
+                return int(dim)
+        except Exception:
+            pass
+        sample = self._get_embedding("sample")
+        return len(sample) if sample else None
+
+    def _embed_texts_batch(
+        self, texts: list[str], target_dim: int
+    ) -> list[list[float]]:
+        """Re-embed all texts in a single batched encode call (all-or-nothing).
+
+        Raises if no model is available, the batch shape is unexpected, or any
+        row's embedding is missing or has the wrong dimension. The caller relies
+        on this raising so the migration aborts with the original table intact
+        (never a partially-vectorized table).
+        """
+        if not self._embedding_model:
+            raise RuntimeError(
+                "Cannot rebuild vector column without an embedding model"
+            )
+        if not texts:
+            return []
+        result = self._embedding_model.encode(texts)
+        if not isinstance(result, list) or len(result) != len(texts):
+            raise RuntimeError(
+                f"Embedding batch returned unexpected shape for {len(texts)} rows"
+            )
+        vectors: list[list[float]] = []
+        for index, vector in enumerate(result):
+            if not isinstance(vector, list) or len(vector) != target_dim:
+                raise RuntimeError(
+                    f"Re-embedding row {index} failed or produced the wrong "
+                    f"dimension (expected {target_dim})"
+                )
+            vectors.append([float(value) for value in vector])
+        return vectors
+
+    def _build_migrated_table(self, existing: Any, target_dim: Optional[int]) -> Any:
+        """Transform for the migration primitive: rebuild rows at the target schema.
+
+        Preserves every existing row's id/text/metadata. When ``target_dim`` is
+        set, re-embeds all rows into a fresh fixed-width vector column; when it
+        is None, produces a vector-less table (text-only search).
+        """
+        row_count = existing.num_rows
+        names = set(existing.schema.names)
+
+        def _string_column(name: str) -> list[Optional[str]]:
+            if name in names:
+                return [
+                    None if value is None else str(value)
+                    for value in existing.column(name).to_pylist()
+                ]
+            return [None] * row_count
+
+        columns: dict[str, Any] = {
+            "id": pa.array(_string_column("id"), pa.string()),
+            "text": pa.array(_string_column("text"), pa.string()),
+            "metadata": pa.array(_string_column("metadata"), pa.string()),
+        }
+
+        if target_dim is not None:
+            texts = [text or "" for text in _string_column("text")]
+            vectors = self._embed_texts_batch(texts, target_dim)
+            columns["vector"] = pa.array(vectors, pa.list_(pa.float32(), target_dim))
+
+        return pa.table(columns)
+
+    def _backfill_missing_columns(self, conn: Any, columns: tuple[str, ...]) -> None:
+        """Add missing non-vector columns in place (no data loss, no rebuild)."""
+        table = conn.open_table(self._collection_name)
+        try:
+            for column in columns:
+                # All non-vector memory columns are strings.
+                table.add_columns({column: "cast(null as string)"})
+        finally:
+            _safe_close_table(table)
+
+    def _migrate_schema_mismatch(self, conn: Any, record: dict[str, Any]) -> None:
+        """Resolve a schema mismatch safely, routing through the 792-01 classifier.
+
+        Missing non-vector columns are backfilled in place; a vector
+        dimension/presence change rebuilds the table via transform-then-swap.
+        On any failure the original table is left intact and the error
+        propagates; no path drops or empties the table.
+        """
+        table = conn.open_table(self._collection_name)
+        try:
+            schema = table.schema
+        finally:
+            _safe_close_table(table)
+
+        # The dimension we are trying to store now determines the target schema.
+        if record.get("vector"):
+            expected_dim: Optional[int] = len(record["vector"])
+        elif self._embedding_model:
+            expected_dim = self._current_embedding_dim()
+        else:
+            expected_dim = None
+
+        mismatch = classify_memory_schema_mismatch(schema, expected_dim)
+
+        if mismatch.kind is MemoryMismatchKind.MISSING_NON_VECTOR_COLUMN:
+            self._backfill_missing_columns(conn, mismatch.missing_columns)
+        elif mismatch.kind is MemoryMismatchKind.VECTOR_REBUILD:
+            target_dim = expected_dim
+            migrate_table_swap(
+                conn,
+                self._collection_name,
+                lambda existing: self._build_migrated_table(existing, target_dim),
+            )
+        else:
+            # add() failed but the schema looks compatible: do NOT drop the
+            # table. Surface the original failure to the caller.
+            raise RuntimeError(
+                "add() failed but no resolvable schema mismatch was detected"
+            )
+
+    def _insert_record(self, table: Any, record: dict[str, Any]) -> None:
+        """Insert a record, adapting it to the (possibly migrated) table schema."""
+        schema_names = set(table.schema.names)
+        if "vector" in record and "vector" not in schema_names:
+            record = {k: v for k, v in record.items() if k != "vector"}
+        table.add([record])
+
     def _memory_note_to_dict(self, note: MemoryNote) -> dict[str, Any]:
         """Convert MemoryNote to dictionary for storage."""
         # Get embedding for the content
@@ -281,44 +424,35 @@ class LanceDBMemoryStore(MemoryStore):
                 if data["vector"]:
                     record["vector"] = data["vector"]
 
-                # Try to add the record, recreate table if schema mismatch
+                # Try to add the record. On a schema mismatch, migrate the
+                # existing table in place (preserving all rows) instead of
+                # dropping and recreating it.
                 try:
                     table.add([record])
                 except Exception as add_error:
                     logger.warning(
-                        f"Failed to add record due to schema mismatch: {add_error}"
+                        f"add() failed on possible schema mismatch: {add_error}; "
+                        "attempting safe in-place migration"
                     )
-                    # Recreate table and try again
-                    logger.info("Recreating table with fresh schema")
-                    inner_table = None
-                    try:
-                        # Try to drop the table if the method exists
-                        if hasattr(conn, "drop_table"):
-                            conn.drop_table(self._collection_name)
-                        else:
-                            # Alternative: try to use delete all records instead
-                            inner_table = conn.open_table(self._collection_name)
-                            inner_table.delete()
-                    except Exception:
-                        # If drop fails, continue with recreation
-                        pass
-                    finally:
-                        _safe_close_table(inner_table)
-                    self._create_empty_table()
                     _safe_close_table(table)
+                    table = None
+                    # Migrate safely; on any failure the original table is left
+                    # intact and we surface an error WITHOUT dropping data.
+                    try:
+                        self._migrate_schema_mismatch(conn, record)
+                    except Exception as migrate_error:
+                        logger.error(
+                            "Safe schema migration failed; table left intact: %s",
+                            migrate_error,
+                        )
+                        return MemoryResponse(
+                            success=False,
+                            error=f"Failed to add memory: {migrate_error}",
+                            memory_id=data["id"],
+                        )
+                    # Retry the insert against the migrated schema.
                     table = conn.open_table(self._collection_name)
-
-                    # After recreating, check if we should include vector
-                    # Get current table schema
-                    df = table.search().limit(1).to_pandas()
-                    if not df.empty and "vector" not in df.columns:
-                        # New table doesn't have vector column, remove vector from record
-                        record_without_vector = {
-                            k: v for k, v in record.items() if k != "vector"
-                        }
-                        table.add([record_without_vector])
-                    else:
-                        table.add([record])
+                    self._insert_record(table, record)
             finally:
                 _safe_close_table(table)
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -686,16 +686,15 @@ class LanceDBMemoryStore(MemoryStore):
         except Exception as e:
             logger.error(f"Failed to clear memory store: {e}")
 
-    _LIST_SPECIAL_FILTERS = frozenset(
-        {"category", "date_from", "date_to", "tags", "keywords"}
-    )
+    # Filters that search() does not understand and must be applied here.
+    # Everything else (category, nested `metadata`, direct-field equality) is
+    # delegated to search()'s proven filter path so list_all cannot diverge.
+    _LIST_ONLY_FILTERS = frozenset({"date_from", "date_to", "tags", "keywords"})
 
-    def _note_matches_list_filters(
+    def _matches_list_only_filters(
         self, note: MemoryNote, filters: dict[str, Any]
     ) -> bool:
-        """Apply list_all filter semantics to a note (mirrors InMemoryStore)."""
-        if "category" in filters and note.category != filters["category"]:
-            return False
+        """Apply the date-range/tags/keywords filters search() does not handle."""
         if "date_from" in filters and note.timestamp < filters["date_from"]:
             return False
         if "date_to" in filters and note.timestamp > filters["date_to"]:
@@ -706,23 +705,35 @@ class LanceDBMemoryStore(MemoryStore):
             keyword in note.keywords for keyword in filters["keywords"]
         ):
             return False
-        # Remaining keys are direct metadata equality checks.
-        other = {
-            k: v for k, v in filters.items() if k not in self._LIST_SPECIAL_FILTERS
-        }
-        if other and not all(note.metadata.get(k) == v for k, v in other.items()):
-            return False
         return True
 
     def list_all(self, filters: Optional[dict[str, Any]] = None) -> List[MemoryNote]:
-        """List all memory notes with optional filtering."""
+        """List all memory notes with optional filtering.
+
+        Delegates category / nested-``metadata`` / direct-field filters to
+        search() (its filter logic is the single source of truth, including the
+        nested ``{"metadata": {...}}`` shape the user-isolation layer relies on),
+        and applies the date-range/tags/keywords filters here. Results are sorted
+        newest-first to match InMemoryStore.list_all.
+        """
         try:
-            # Fetch every note (empty query), then apply list-level filters such
-            # as category, date range, tags and keywords in Python.
-            notes = self.search(query="", k=10000)
-            if not filters:
-                return notes
-            return [n for n in notes if self._note_matches_list_filters(n, filters)]
+            filters = filters or {}
+            # Let search() handle everything it understands...
+            search_filters = {
+                k: v for k, v in filters.items() if k not in self._LIST_ONLY_FILTERS
+            }
+            notes = self.search(query="", k=10000, filters=search_filters or None)
+            # ...then apply the list-only filters it does not.
+            list_only = {
+                k: v for k, v in filters.items() if k in self._LIST_ONLY_FILTERS
+            }
+            if list_only:
+                notes = [
+                    n for n in notes if self._matches_list_only_filters(n, list_only)
+                ]
+            # Mirror InMemoryStore: newest first.
+            notes.sort(key=lambda n: n.timestamp, reverse=True)
+            return notes
         except Exception as e:
             logger.error(f"Failed to list all memories: {e}")
             return []

--- a/src/xagent/core/memory/schema_migration.py
+++ b/src/xagent/core/memory/schema_migration.py
@@ -69,18 +69,10 @@ class MemorySchemaMismatch:
     kind: MemoryMismatchKind
     # Missing non-vector columns, in fixed order (subset of MEMORY_NON_VECTOR_COLUMNS).
     missing_columns: tuple[str, ...] = ()
-    # Whether the table currently has a vector column.
-    has_vector_column: bool = False
     # The table's current fixed vector width, or None if it has no fixed-width
-    # vector column.
+    # vector column. Retained as the only test-observable output of the private
+    # _vector_width helper.
     current_dim: Optional[int] = None
-    # The dimension the store now wants, or None when no vector is expected
-    # (no embedding model available).
-    expected_dim: Optional[int] = None
-
-    @property
-    def needs_migration(self) -> bool:
-        return self.kind is not MemoryMismatchKind.NONE
 
 
 def _vector_width(schema: Any) -> Optional[int]:
@@ -136,9 +128,7 @@ def classify_memory_schema_mismatch(
     return MemorySchemaMismatch(
         kind=kind,
         missing_columns=missing_columns,
-        has_vector_column=has_vector,
         current_dim=current_dim,
-        expected_dim=expected_dim,
     )
 
 
@@ -155,6 +145,13 @@ def migrate_table_swap(
     is touched, any failure in reading or transforming leaves the original table
     byte-for-byte intact and propagates the error. This function never drops or
     empties a table as a fallback.
+
+    Concurrency: the read snapshot (``to_arrow``) and the final overwrite are not
+    covered by a shared lock or transaction, and this store has no locking
+    elsewhere. A concurrent write that commits to the live table between the two
+    would be replaced by the overwrite (computed from the earlier snapshot) and
+    lost. The "never lose data" guarantee here is against migration *failure*,
+    not against concurrent writers during a migration.
 
     Args:
         conn: A LanceDB connection (must expose ``open_table`` and ``create_table``).

--- a/src/xagent/core/memory/schema_migration.py
+++ b/src/xagent/core/memory/schema_migration.py
@@ -30,6 +30,7 @@ from enum import Enum
 from typing import Any, Callable, Optional
 
 import pyarrow as pa  # type: ignore
+from lancedb.db import DBConnection
 
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
@@ -142,7 +143,7 @@ def classify_memory_schema_mismatch(
 
 
 def migrate_table_swap(
-    conn: object,
+    conn: DBConnection,
     table_name: str,
     transform: Callable[[Any], Any],
 ) -> None:
@@ -168,7 +169,7 @@ def migrate_table_swap(
         Exception: Any error raised while reading or transforming is propagated
             unchanged; the original table is left intact.
     """
-    table = conn.open_table(table_name)  # type: ignore[attr-defined]
+    table = conn.open_table(table_name)
     try:
         existing = table.to_arrow()
     finally:
@@ -185,9 +186,7 @@ def migrate_table_swap(
     # Replace the table atomically. mode="overwrite" commits a new table version
     # in a single transaction: if it fails, the previous version and its rows
     # remain intact. We never fall back to drop_table on error.
-    new_table = conn.create_table(  # type: ignore[attr-defined]
-        table_name, data=migrated, mode="overwrite"
-    )
+    new_table = conn.create_table(table_name, data=migrated, mode="overwrite")
     _safe_close_table(new_table)
     logger.info(
         "Migrated memory table '%s' via transform-then-swap (%d rows)",

--- a/src/xagent/core/memory/schema_migration.py
+++ b/src/xagent/core/memory/schema_migration.py
@@ -1,0 +1,196 @@
+"""Safe schema-migration primitives for the LanceDB memory store.
+
+This module is the shared foundation both memory-store fix sites resolve through
+(the ``add()`` write path and the ``_ensure_table_schema()`` init path). It
+provides two things and no call-site wiring:
+
+- :func:`migrate_table_swap` - a transform-then-swap migration primitive that
+  fully materializes the migrated table before touching the live one, and never
+  drops or empties a table as a fallback. On any failure the original table is
+  left intact and the error propagates.
+- :func:`classify_memory_schema_mismatch` - a mismatch classifier that reports
+  which class of schema mismatch a table has against the fixed memory schema
+  (``id`` / ``text`` / ``metadata`` / ``vector``) and the store's current
+  embedding dimension.
+
+The concrete transforms (batched re-embed rebuild, ``add_columns`` backfill) are
+introduced by the consuming slices; this module only supplies the swap mechanic
+and the classification.
+
+Modeled on ``RAG_tools/LanceDB/schema_manager.py::_migrate_table_user_id_to_int64``,
+which materializes converted data before swapping and raises rather than
+discarding data on failure.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Optional
+
+import pyarrow as pa  # type: ignore
+
+from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MEMORY_NON_VECTOR_COLUMNS",
+    "MEMORY_VECTOR_COLUMN",
+    "MemoryMismatchKind",
+    "MemorySchemaMismatch",
+    "classify_memory_schema_mismatch",
+    "migrate_table_swap",
+]
+
+# The memory schema is fixed: the only variable is the vector column's width.
+MEMORY_NON_VECTOR_COLUMNS = ("id", "text", "metadata")
+MEMORY_VECTOR_COLUMN = "vector"
+
+
+class MemoryMismatchKind(str, Enum):
+    """Class of schema mismatch, which determines how it is resolved."""
+
+    NONE = "none"
+    # A required non-vector column (id / text / metadata) is missing; resolvable
+    # by an additive ``add_columns`` backfill.
+    MISSING_NON_VECTOR_COLUMN = "missing_non_vector_column"
+    # The vector column's width changed, or its presence changed (table has no
+    # vector but records now do, or vice versa); requires a vector-column rebuild.
+    VECTOR_REBUILD = "vector_rebuild"
+
+
+@dataclass(frozen=True)
+class MemorySchemaMismatch:
+    """Result of classifying a memory table's schema against the current store state."""
+
+    kind: MemoryMismatchKind
+    # Missing non-vector columns, in fixed order (subset of MEMORY_NON_VECTOR_COLUMNS).
+    missing_columns: tuple[str, ...] = ()
+    # Whether the table currently has a vector column.
+    has_vector_column: bool = False
+    # The table's current fixed vector width, or None if it has no fixed-width
+    # vector column.
+    current_dim: Optional[int] = None
+    # The dimension the store now wants, or None when no vector is expected
+    # (no embedding model available).
+    expected_dim: Optional[int] = None
+
+    @property
+    def needs_migration(self) -> bool:
+        return self.kind is not MemoryMismatchKind.NONE
+
+
+def _vector_width(schema: Any) -> Optional[int]:
+    """Return the fixed width of the vector column, or None if it has none."""
+    if MEMORY_VECTOR_COLUMN not in schema.names:
+        return None
+    try:
+        vector_type = schema.field(MEMORY_VECTOR_COLUMN).type
+    except Exception:
+        return None
+    if pa.types.is_fixed_size_list(vector_type):
+        return int(vector_type.list_size)
+    # A variable-length list has no fixed width to compare against.
+    return None
+
+
+def classify_memory_schema_mismatch(
+    schema: Any, expected_dim: Optional[int]
+) -> MemorySchemaMismatch:
+    """Classify a memory table's schema against the store's current expectation.
+
+    Args:
+        schema: The existing table's Arrow schema (``table.schema``).
+        expected_dim: The vector dimension the store now produces, or ``None``
+            when no embedding model is available (no vector column expected).
+
+    Returns:
+        A :class:`MemorySchemaMismatch`. Precedence: a vector rebuild subsumes a
+        missing-column backfill (the rebuild produces a fresh, complete schema),
+        so ``VECTOR_REBUILD`` wins when both apply.
+    """
+    names = set(schema.names)
+    has_vector = MEMORY_VECTOR_COLUMN in names
+    current_dim = _vector_width(schema)
+    missing_columns = tuple(c for c in MEMORY_NON_VECTOR_COLUMNS if c not in names)
+
+    if expected_dim is None:
+        # Store no longer produces vectors: only a mismatch if the table still
+        # carries a vector column (presence change -> drop-vector rebuild).
+        vector_mismatch = has_vector
+    else:
+        # Store produces vectors of expected_dim: mismatch if the table has no
+        # vector column or its width differs.
+        vector_mismatch = (not has_vector) or (current_dim != expected_dim)
+
+    if vector_mismatch:
+        kind = MemoryMismatchKind.VECTOR_REBUILD
+    elif missing_columns:
+        kind = MemoryMismatchKind.MISSING_NON_VECTOR_COLUMN
+    else:
+        kind = MemoryMismatchKind.NONE
+
+    return MemorySchemaMismatch(
+        kind=kind,
+        missing_columns=missing_columns,
+        has_vector_column=has_vector,
+        current_dim=current_dim,
+        expected_dim=expected_dim,
+    )
+
+
+def migrate_table_swap(
+    conn: object,
+    table_name: str,
+    transform: Callable[[Any], Any],
+) -> None:
+    """Migrate a table by transform-then-swap, never dropping data on failure.
+
+    Reads the table's full contents, hands them to ``transform`` to produce the
+    migrated Arrow table (new schema and data), and only then replaces the live
+    table. Because the migrated data is fully materialized before the live table
+    is touched, any failure in reading or transforming leaves the original table
+    byte-for-byte intact and propagates the error. This function never drops or
+    empties a table as a fallback.
+
+    Args:
+        conn: A LanceDB connection (must expose ``open_table`` and ``create_table``).
+        table_name: Name of the table to migrate.
+        transform: Callable that receives the current table as a
+            :class:`pyarrow.Table` and returns the fully-migrated table. It must
+            materialize its result (not a lazy view) and may raise to abort the
+            migration with no side effects.
+
+    Raises:
+        TypeError: If ``transform`` does not return a :class:`pyarrow.Table`.
+        Exception: Any error raised while reading or transforming is propagated
+            unchanged; the original table is left intact.
+    """
+    table = conn.open_table(table_name)  # type: ignore[attr-defined]
+    try:
+        existing = table.to_arrow()
+    finally:
+        _safe_close_table(table)
+
+    # Fully materialize the migrated data BEFORE the live table is touched, so a
+    # transform failure cannot leave the store in a partial state.
+    migrated = transform(existing)
+    if not isinstance(migrated, pa.Table):
+        raise TypeError(
+            f"migration transform must return a pyarrow.Table, got {type(migrated)!r}"
+        )
+
+    # Replace the table atomically. mode="overwrite" commits a new table version
+    # in a single transaction: if it fails, the previous version and its rows
+    # remain intact. We never fall back to drop_table on error.
+    new_table = conn.create_table(  # type: ignore[attr-defined]
+        table_name, data=migrated, mode="overwrite"
+    )
+    _safe_close_table(new_table)
+    logger.info(
+        "Migrated memory table '%s' via transform-then-swap (%d rows)",
+        table_name,
+        migrated.num_rows,
+    )

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -312,6 +312,25 @@ def test_list_all_with_date_filters(memory_store):
     assert all(r.timestamp <= now for r in results)
 
 
+def test_list_all_with_nested_metadata_filter(memory_store):
+    """list_all must honor the nested {"metadata": {...}} shape (as used by
+    the user-isolation layer), matching search()'s filter semantics."""
+    assert memory_store.add(
+        MemoryNote(content="alice note", metadata={"user_id": 1})
+    ).success
+    assert memory_store.add(
+        MemoryNote(content="bob note", metadata={"user_id": 2})
+    ).success
+
+    nested = {"metadata": {"user_id": 1}}
+    # list_all must agree with search on the nested-metadata filter.
+    assert len(memory_store.search("", k=100, filters=nested)) == 1
+    results = memory_store.list_all(filters=nested)
+    assert len(results) == 1
+    assert results[0].metadata.get("user_id") == 1
+    assert results[0].content == "alice note"
+
+
 def test_list_all_with_tag_filters(memory_store):
     """Test listing memories with tag filters."""
     assert memory_store.add(

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -291,8 +291,6 @@ def test_list_all_with_date_filters(memory_store):
     """Test listing memories with date range filters."""
     from datetime import datetime, timedelta
 
-    import pytest
-
     # Add memories with different timestamps
     now = datetime.now()
     old_time = now - timedelta(days=1)
@@ -300,21 +298,8 @@ def test_list_all_with_date_filters(memory_store):
     old_memory = MemoryNote(content="Old memory", category="test", timestamp=old_time)
     recent_memory = MemoryNote(content="Recent memory", category="test", timestamp=now)
 
-    # Add memories - may fail due to schema issues
-    memory_store.add(old_memory)
-    memory_store.add(recent_memory)
-
-    # Check if memories were actually added by checking total count
-    initial_stats = memory_store.get_stats()
-    initial_count = initial_stats.get("total_count", 0)
-
-    # Skip test if we're seeing schema issues (indicated by no change in count)
-    # This is a workaround for LanceDB reporting success but not actually storing
-    final_stats = memory_store.get_stats()
-    final_count = final_stats.get("total_count", 0)
-
-    if final_count <= initial_count:
-        pytest.skip("LanceDB schema issues prevent adding test memories")
+    assert memory_store.add(old_memory).success
+    assert memory_store.add(recent_memory).success
 
     # Test date_from filter
     results = memory_store.list_all(filters={"date_from": now})
@@ -329,18 +314,48 @@ def test_list_all_with_date_filters(memory_store):
 
 def test_list_all_with_tag_filters(memory_store):
     """Test listing memories with tag filters."""
-    import pytest
+    assert memory_store.add(
+        MemoryNote(content="Work task", tags=["work", "urgent"])
+    ).success
+    assert memory_store.add(
+        MemoryNote(content="Personal note", tags=["personal"])
+    ).success
+    assert memory_store.add(
+        MemoryNote(content="Another work item", tags=["work"])
+    ).success
 
-    # Skip test due to persistent LanceDB schema issues
-    pytest.skip("LanceDB schema issues prevent adding test memories")
+    # Notes carrying the "work" tag
+    results = memory_store.list_all(filters={"tags": ["work"]})
+    assert len(results) == 2
+    assert all("work" in r.tags for r in results)
+
+    # A note must carry all requested tags
+    results = memory_store.list_all(filters={"tags": ["work", "urgent"]})
+    assert len(results) == 1
+    assert all({"work", "urgent"} <= set(r.tags) for r in results)
 
 
 def test_list_all_with_keyword_filters(memory_store):
     """Test listing memories with keyword filters."""
-    import pytest
+    assert memory_store.add(
+        MemoryNote(content="AI in Python", keywords=["python", "ai"])
+    ).success
+    assert memory_store.add(
+        MemoryNote(content="Cooking recipe", keywords=["cooking"])
+    ).success
+    assert memory_store.add(
+        MemoryNote(content="Python tips", keywords=["python"])
+    ).success
 
-    # Skip test due to persistent LanceDB schema issues
-    pytest.skip("LanceDB schema issues prevent adding test memories")
+    # Notes carrying the "python" keyword
+    results = memory_store.list_all(filters={"keywords": ["python"]})
+    assert len(results) == 2
+    assert all("python" in r.keywords for r in results)
+
+    # A note must carry all requested keywords
+    results = memory_store.list_all(filters={"keywords": ["python", "ai"]})
+    assert len(results) == 1
+    assert all({"python", "ai"} <= set(r.keywords) for r in results)
 
 
 def test_embedding_fallback(memory_store):

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -1,0 +1,182 @@
+"""Regression tests for safe schema migration on the ``add()`` path (792-02)."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import pyarrow as pa  # type: ignore
+import pytest
+
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.model.embedding import BaseEmbedding
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+
+class MockEmbedding(BaseEmbedding):
+    """Deterministic embedding of a configurable dimension."""
+
+    def __init__(self, dim: int = 64, value: float = 0.1):
+        self._dimension = dim
+        self._value = value
+
+    def encode(self, text, dimension=None, instruct=None):
+        if isinstance(text, str):
+            return [self._value] * self._dimension
+        return [[self._value] * self._dimension for _ in text]
+
+    def get_dimension(self):
+        return self._dimension
+
+    @property
+    def abilities(self):
+        return ["embed"]
+
+
+class BatchFailEmbedding(BaseEmbedding):
+    """Encodes single strings fine but fails on batched (list) input.
+
+    This lets a note be embedded on the write path (so the insert hits a real
+    dimension mismatch) while the migration's batched re-embed fails, exercising
+    the all-or-nothing abort.
+    """
+
+    def __init__(self, dim: int = 128):
+        self._dimension = dim
+
+    def encode(self, text, dimension=None, instruct=None):
+        if isinstance(text, str):
+            return [0.1] * self._dimension
+        raise RuntimeError("batched embedding failed")
+
+    def get_dimension(self):
+        return self._dimension
+
+    @property
+    def abilities(self):
+        return ["embed"]
+
+
+@pytest.fixture
+def temp_db_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _store(temp_db_dir, embedding_model, name="mem"):
+    return LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name=name,
+        embedding_model=embedding_model,
+    )
+
+
+def test_add_preserves_rows_on_dimension_change(temp_db_dir):
+    """Writing at dim A, switching to dim B, then add() keeps A-rows and stores B."""
+    store_a = _store(temp_db_dir, MockEmbedding(64))
+    added = store_a.add(MemoryNote(content="alpha"))
+    assert added.success
+    alpha_id = added.memory_id
+
+    # New store over the same table with a different embedding dimension.
+    store_b = _store(temp_db_dir, MockEmbedding(128))
+    new = store_b.add(MemoryNote(content="beta"))
+    assert new.success
+
+    # The dimension-A row survived the migration...
+    got_alpha = store_b.get(alpha_id)
+    assert got_alpha.success
+    assert got_alpha.content.content == "alpha"
+    # ...and the new dimension-B row was stored.
+    assert store_b.get(new.memory_id).success
+    # Both are retrievable via search at the new dimension.
+    contents = {n.content for n in store_b.search("beta", k=10)}
+    assert {"alpha", "beta"} <= contents
+
+
+def test_add_backfills_missing_non_vector_column(temp_db_dir):
+    """A missing non-vector column is backfilled in place, without a rebuild."""
+    store = _store(temp_db_dir, None)  # vector-less store
+    assert store.add(MemoryNote(id="x", content="old")).success
+
+    # Simulate a stale table that lost its metadata column.
+    conn = store._vector_store.get_raw_connection()
+    table = conn.open_table("mem")
+    try:
+        table.drop_columns(["metadata"])
+    finally:
+        _safe_close_table(table)
+
+    # add() must backfill metadata in place (no rebuild) and preserve rows.
+    assert store.add(MemoryNote(id="y", content="new")).success
+
+    table = conn.open_table("mem")
+    try:
+        arrow = table.to_arrow()
+    finally:
+        _safe_close_table(table)
+    # The metadata column was backfilled additively, and both rows survived.
+    assert "metadata" in arrow.schema.names
+    assert set(arrow.column("id").to_pylist()) == {"x", "y"}
+    # The fully-formed new row round-trips through get().
+    assert store.get("y").success
+
+
+def test_add_migration_failure_leaves_table_intact(temp_db_dir):
+    """If re-embedding fails mid-migration, no data is lost and add() fails."""
+    store_a = _store(temp_db_dir, MockEmbedding(64))
+    added = store_a.add(MemoryNote(content="alpha"))
+    assert added.success
+    alpha_id = added.memory_id
+
+    # Switch to a model that fails the batched re-embed at a new dimension.
+    store_fail = _store(temp_db_dir, BatchFailEmbedding(128))
+    result = store_fail.add(MemoryNote(content="beta"))
+    assert not result.success
+
+    # The original row is untouched and still retrievable via the dim-64 store.
+    got_alpha = store_a.get(alpha_id)
+    assert got_alpha.success
+    assert got_alpha.content.content == "alpha"
+    # No partial state: only the original row exists.
+    assert len(store_a.list_all()) == 1
+
+
+def test_build_migrated_table_vectorless_when_no_model(temp_db_dir):
+    """The rebuild transform produces a vector-less table (target_dim=None)."""
+    store = _store(temp_db_dir, None)
+    existing = pa.table(
+        {
+            "id": ["a", "b"],
+            "text": ["alpha", "beta"],
+            "metadata": ["{}", "{}"],
+            "vector": pa.array([[0.1] * 64, [0.1] * 64], pa.list_(pa.float32(), 64)),
+        }
+    )
+
+    migrated = store._build_migrated_table(existing, target_dim=None)
+
+    assert "vector" not in migrated.schema.names
+    assert migrated.num_rows == 2
+    assert migrated.column("id").to_pylist() == ["a", "b"]
+    assert migrated.column("text").to_pylist() == ["alpha", "beta"]
+
+
+def test_build_migrated_table_reembeds_at_target_dim(temp_db_dir):
+    """The rebuild transform re-embeds all rows at the new dimension."""
+    store = _store(temp_db_dir, MockEmbedding(128))
+    existing = pa.table(
+        {
+            "id": ["a", "b"],
+            "text": ["alpha", "beta"],
+            "metadata": ["{}", "{}"],
+            "vector": pa.array([[0.1] * 64, [0.1] * 64], pa.list_(pa.float32(), 64)),
+        }
+    )
+
+    migrated = store._build_migrated_table(existing, target_dim=128)
+
+    assert migrated.column("vector").type.list_size == 128
+    assert migrated.num_rows == 2

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 
+import lancedb  # type: ignore
 import pyarrow as pa  # type: ignore
 import pytest
 
@@ -180,3 +181,75 @@ def test_build_migrated_table_reembeds_at_target_dim(temp_db_dir):
 
     assert migrated.column("vector").type.list_size == 128
     assert migrated.num_rows == 2
+
+
+def _seed_table_missing_metadata(temp_db_dir, name="mem"):
+    """Create a table with id/text/vector but no metadata column."""
+    conn = lancedb.connect(temp_db_dir)
+    table = conn.create_table(
+        name,
+        data=pa.table(
+            {
+                "id": ["a"],
+                "text": ["alpha"],
+                "vector": pa.array([[0.1] * 64], pa.list_(pa.float32(), 64)),
+            }
+        ),
+    )
+    _safe_close_table(table)
+
+
+def test_init_backfills_missing_column_without_wipe(temp_db_dir):
+    """Store init migrates a table missing a required column, preserving rows."""
+    _seed_table_missing_metadata(temp_db_dir)
+
+    # Constructing the store runs _ensure_table_schema, which must migrate.
+    store = _store(temp_db_dir, MockEmbedding(64))
+
+    conn = store._vector_store.get_raw_connection()
+    table = conn.open_table("mem")
+    try:
+        arrow = table.to_arrow()
+    finally:
+        _safe_close_table(table)
+    assert "metadata" in arrow.schema.names
+    assert arrow.column("id").to_pylist() == ["a"]
+
+
+def test_init_does_not_wipe_on_dimension_change(temp_db_dir):
+    """Constructing a store over a different-dimension table preserves rows."""
+    store_a = _store(temp_db_dir, MockEmbedding(64))
+    added = store_a.add(MemoryNote(content="alpha"))
+    assert added.success
+
+    # A store at a different embedding dimension must not wipe on init; the
+    # dimension mismatch is migrated lazily on the add() path instead.
+    store_b = _store(temp_db_dir, MockEmbedding(128))
+    conn = store_b._vector_store.get_raw_connection()
+    table = conn.open_table("mem")
+    try:
+        ids = table.to_arrow().column("id").to_pylist()
+    finally:
+        _safe_close_table(table)
+    assert added.memory_id in ids
+
+
+def test_init_migration_failure_leaves_table_intact(temp_db_dir):
+    """If init migration fails, the original table is left intact (no wipe)."""
+    _seed_table_missing_metadata(temp_db_dir)
+
+    # Missing metadata + a vector-dimension change whose batched re-embed fails
+    # forces a rebuild that aborts; init must surface the error, not wipe.
+    with pytest.raises(Exception):
+        _store(temp_db_dir, BatchFailEmbedding(128))
+
+    conn = lancedb.connect(temp_db_dir)
+    table = conn.open_table("mem")
+    try:
+        arrow = table.to_arrow()
+    finally:
+        _safe_close_table(table)
+    assert arrow.column("id").to_pylist() == ["a"]
+    # The vector column was not rebuilt; the table is untouched.
+    assert "vector" in arrow.schema.names
+    assert "metadata" not in arrow.schema.names

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -253,3 +253,26 @@ def test_init_migration_failure_leaves_table_intact(temp_db_dir):
     # The vector column was not rebuilt; the table is untouched.
     assert "vector" in arrow.schema.names
     assert "metadata" not in arrow.schema.names
+
+
+def test_add_record_without_embedding_into_vector_table(temp_db_dir):
+    """A note with no embedding stored into a vector table keeps a null vector.
+
+    Exercises the `_insert_record` case where the record lacks a vector but the
+    table has a vector column: LanceDB accepts a null vector, the row persists,
+    and it stays retrievable (no migration, no data loss)."""
+    store = _store(temp_db_dir, MockEmbedding(64))
+    assert store.add(MemoryNote(id="withvec", content="alpha")).success
+
+    # Whitespace-only content yields no embedding, so the record has no vector.
+    assert store.add(MemoryNote(id="novec", content="   ")).success
+
+    conn = store._vector_store.get_raw_connection()
+    table = conn.open_table("mem")
+    try:
+        ids = set(table.to_arrow().column("id").to_pylist())
+    finally:
+        _safe_close_table(table)
+    assert {"withvec", "novec"} <= ids
+    # The vector-less row still round-trips through get().
+    assert store.get("novec").success

--- a/tests/core/memory/test_schema_migration.py
+++ b/tests/core/memory/test_schema_migration.py
@@ -59,16 +59,13 @@ def test_classify_no_mismatch_vectorless():
     """No vector column and no vector expected -> no mismatch."""
     result = classify_memory_schema_mismatch(_non_vector_schema(), expected_dim=None)
     assert result.kind is MemoryMismatchKind.NONE
-    assert not result.needs_migration
 
 
 def test_classify_no_mismatch_matching_dim():
     """Vector width matches expected dimension -> no mismatch."""
     result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=64)
     assert result.kind is MemoryMismatchKind.NONE
-    assert not result.needs_migration
     assert result.current_dim == 64
-    assert result.expected_dim == 64
 
 
 def test_classify_missing_non_vector_column():
@@ -77,7 +74,6 @@ def test_classify_missing_non_vector_column():
     result = classify_memory_schema_mismatch(schema, expected_dim=None)
     assert result.kind is MemoryMismatchKind.MISSING_NON_VECTOR_COLUMN
     assert result.missing_columns == ("metadata",)
-    assert result.needs_migration
 
 
 def test_classify_vector_dimension_change():
@@ -85,14 +81,12 @@ def test_classify_vector_dimension_change():
     result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=128)
     assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
     assert result.current_dim == 64
-    assert result.expected_dim == 128
 
 
 def test_classify_vector_presence_added():
     """Table has no vector but store now produces one -> rebuild."""
     result = classify_memory_schema_mismatch(_non_vector_schema(), expected_dim=64)
     assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
-    assert result.has_vector_column is False
     assert result.current_dim is None
 
 
@@ -100,8 +94,7 @@ def test_classify_vector_presence_removed():
     """Table has a vector but store no longer produces one -> rebuild (drop vector)."""
     result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=None)
     assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
-    assert result.has_vector_column is True
-    assert result.expected_dim is None
+    assert result.current_dim == 64
 
 
 def test_classify_vector_rebuild_takes_precedence_over_missing_column():

--- a/tests/core/memory/test_schema_migration.py
+++ b/tests/core/memory/test_schema_migration.py
@@ -1,0 +1,216 @@
+"""Unit tests for the safe memory schema-migration primitive and classifier (792-01)."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+import lancedb  # type: ignore
+import pyarrow as pa  # type: ignore
+import pytest
+
+from xagent.core.memory.schema_migration import (
+    MemoryMismatchKind,
+    classify_memory_schema_mismatch,
+    migrate_table_swap,
+)
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+
+@pytest.fixture
+def temp_db_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def conn(temp_db_dir):
+    return lancedb.connect(temp_db_dir)
+
+
+def _non_vector_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+        ]
+    )
+
+
+def _vector_schema(dim: int) -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), list_size=dim)),
+        ]
+    )
+
+
+# --------------------------------------------------------------------------
+# Classifier
+# --------------------------------------------------------------------------
+
+
+def test_classify_no_mismatch_vectorless():
+    """No vector column and no vector expected -> no mismatch."""
+    result = classify_memory_schema_mismatch(_non_vector_schema(), expected_dim=None)
+    assert result.kind is MemoryMismatchKind.NONE
+    assert not result.needs_migration
+
+
+def test_classify_no_mismatch_matching_dim():
+    """Vector width matches expected dimension -> no mismatch."""
+    result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=64)
+    assert result.kind is MemoryMismatchKind.NONE
+    assert not result.needs_migration
+    assert result.current_dim == 64
+    assert result.expected_dim == 64
+
+
+def test_classify_missing_non_vector_column():
+    """A missing id/text/metadata column with no vector mismatch -> backfill."""
+    schema = pa.schema([pa.field("id", pa.string()), pa.field("text", pa.string())])
+    result = classify_memory_schema_mismatch(schema, expected_dim=None)
+    assert result.kind is MemoryMismatchKind.MISSING_NON_VECTOR_COLUMN
+    assert result.missing_columns == ("metadata",)
+    assert result.needs_migration
+
+
+def test_classify_vector_dimension_change():
+    """Table at one width, store now produces another -> rebuild."""
+    result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=128)
+    assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
+    assert result.current_dim == 64
+    assert result.expected_dim == 128
+
+
+def test_classify_vector_presence_added():
+    """Table has no vector but store now produces one -> rebuild."""
+    result = classify_memory_schema_mismatch(_non_vector_schema(), expected_dim=64)
+    assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
+    assert result.has_vector_column is False
+    assert result.current_dim is None
+
+
+def test_classify_vector_presence_removed():
+    """Table has a vector but store no longer produces one -> rebuild (drop vector)."""
+    result = classify_memory_schema_mismatch(_vector_schema(64), expected_dim=None)
+    assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
+    assert result.has_vector_column is True
+    assert result.expected_dim is None
+
+
+def test_classify_vector_rebuild_takes_precedence_over_missing_column():
+    """When both a column is missing and the vector mismatches, rebuild wins."""
+    schema = pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("text", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), list_size=64)),
+        ]
+    )
+    result = classify_memory_schema_mismatch(schema, expected_dim=128)
+    assert result.kind is MemoryMismatchKind.VECTOR_REBUILD
+    assert result.missing_columns == ("metadata",)
+
+
+# --------------------------------------------------------------------------
+# Migration primitive
+# --------------------------------------------------------------------------
+
+
+def _seed_table(conn, name="mem"):
+    data = pa.table(
+        {
+            "id": ["a", "b"],
+            "text": ["hello", "world"],
+            "metadata": ["{}", "{}"],
+        }
+    )
+    tbl = conn.create_table(name, data=data)
+    _safe_close_table(tbl)
+    return name
+
+
+def test_swap_replaces_table_contents(conn):
+    """A successful transform swaps the table to the migrated data."""
+    name = _seed_table(conn)
+
+    def transform(existing: pa.Table) -> pa.Table:
+        # Migrate by appending a new row and a new column.
+        migrated = existing.append_column("extra", pa.array(["x"] * existing.num_rows))
+        new_row = pa.table(
+            {"id": ["c"], "text": ["new"], "metadata": ["{}"], "extra": ["x"]}
+        )
+        return pa.concat_tables([migrated, new_row])
+
+    migrate_table_swap(conn, name, transform)
+
+    tbl = conn.open_table(name)
+    try:
+        result = tbl.to_arrow()
+    finally:
+        _safe_close_table(tbl)
+    assert result.num_rows == 3
+    assert "extra" in result.schema.names
+    assert set(result.column("id").to_pylist()) == {"a", "b", "c"}
+
+
+def test_transform_failure_leaves_table_intact(conn):
+    """If the transform raises, the original rows and schema are untouched."""
+    name = _seed_table(conn)
+
+    def failing_transform(existing: pa.Table) -> pa.Table:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        migrate_table_swap(conn, name, failing_transform)
+
+    tbl = conn.open_table(name)
+    try:
+        result = tbl.to_arrow()
+    finally:
+        _safe_close_table(tbl)
+    assert result.num_rows == 2
+    assert result.schema.names == ["id", "text", "metadata"]
+    assert set(result.column("id").to_pylist()) == {"a", "b"}
+
+
+def test_transform_must_return_arrow_table(conn):
+    """A transform returning a non-Arrow value aborts without touching the table."""
+    name = _seed_table(conn)
+
+    def bad_transform(existing: pa.Table):
+        return [{"id": "c"}]
+
+    with pytest.raises(TypeError):
+        migrate_table_swap(conn, name, bad_transform)
+
+    tbl = conn.open_table(name)
+    try:
+        result = tbl.to_arrow()
+    finally:
+        _safe_close_table(tbl)
+    assert result.num_rows == 2
+
+
+def test_swap_supports_empty_migrated_table(conn):
+    """Swapping to an empty (but well-typed) table preserves schema, drops rows."""
+    name = _seed_table(conn)
+
+    def empty_transform(existing: pa.Table) -> pa.Table:
+        return existing.schema.empty_table()
+
+    migrate_table_swap(conn, name, empty_transform)
+
+    tbl = conn.open_table(name)
+    try:
+        result = tbl.to_arrow()
+    finally:
+        _safe_close_table(tbl)
+    assert result.num_rows == 0
+    assert result.schema.names == ["id", "text", "metadata"]


### PR DESCRIPTION
## Summary

Closes #792.

The LanceDB memory store has two code paths that **silently discard all existing
rows** when they encounter a schema mismatch:

1. `LanceDBMemoryStore.add()` — on a `table.add()` schema-mismatch failure it calls
   `drop_table()` / `table.delete()` then `_create_empty_table()`, wiping every row.
2. `LanceDBMemoryStore._ensure_table_schema()` — on init it drop-and-recreates when
   `id/text/metadata` columns look off. This runs on **every store construction**, so
   it can destroy data with no write in flight at all.

The real trigger is not a missing column but a **vector-dimension change** (e.g.
switching the embedding model from 1024 → 1536). `_create_empty_table()` infers a
fixed-width vector column from a sample embedding, so a table persisted at one
dimension rejects `add()` at another and falls into the destructive path.

This PR replaces both drop-and-recreate paths with **transform-then-swap** migration:
compute the migrated table fully in memory first, and only then replace the live
table. On any failure the original table is left byte-for-byte intact and the caller
gets an error — no path ever drops or empties a table as a fallback.

## Approach

Modeled on the existing precedent
`RAG_tools/LanceDB/schema_manager.py::_migrate_table_user_id_to_int64`, which
materializes converted data before swapping and raises rather than discarding on
failure.

- **Migration primitive** — materialize the migrated data + new schema before touching
  the live table; raise (never drop) on any failure.
- **Mismatch classifier** — single source of truth shared by both sites. Distinguishes:
  missing non-vector column, vector dimension/presence change, and no-mismatch.
- **Resolution transforms:**
  - Missing non-vector column (`id`/`text`/`metadata`) → `add_columns` backfill in place.
  - Vector dimension / presence change → rebuild the vector column:
    - embedding model available → **re-embed all rows in a single batched encode call**
      (not a per-row loop);
    - no model available → migrate to a vector-less schema so rows stay searchable via
      the text fallback.
  - Vector rebuild is **all-or-nothing**: if any row's embedding fails, the whole
    migration aborts with no partial state, the old table is untouched, and `add()`
    returns `MemoryResponse(success=False)`.
- `update()`'s delete-then-add sequence stays safe **at the table level** if migration
  triggers mid-update (no drop, other rows preserved). Note the pre-existing
  `get → delete → add` ordering means the single note being updated can still be lost
  if its own `add()` migration aborts — narrowing an earlier, broader claim; tracked as a
  follow-up (reorder to add-then-delete / verify-before-delete).

## Slices

This lands the parent issue as three reviewable slices:

| Slice | Description |
| --- | --- |
| **792-01** | Transform-then-swap migration primitive + mismatch classifier (prefactor; no call site changes, zero behavior change). |
| **792-02** | `add()` migrates on schema mismatch instead of dropping; introduces the vector-rebuild (batched re-embed) and `add_columns` backfill transforms. |
| **792-03** | Store init migrates stale schema in place; un-skips the three masked tests in `test_lancedb.py` (~317/335/343). |

## Explicitly out of scope

- **Filter pushdown into a LanceDB `where` clause** (recall-correctness fix; recall
  collapses to `1/R` under shared collections) — split into **#822**, ordered strictly
  after this work. Column promotion is a hard prerequisite for it.
- **Promoting metadata dimensions to real columns** — this PR only makes such a
  promotion safe to perform later without data loss.


