### PR TITLE
fix(core): re-check containment when resolving relative workspace paths

### DIFF
--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -758,6 +758,16 @@ class WorkspaceFileOperations:
         # Use the centralized workspace method
         return self.workspace.resolve_path_with_search(file_path)
 
+    @staticmethod
+    def _in_workspace(path: Path, workspace_abs: Path) -> bool:
+        """Return True if ``path`` is the workspace root or lives inside it.
+
+        ``Path.is_relative_to`` already treats a path equal to the base as
+        relative to it, so no separate equality check against ``workspace_abs``
+        is needed.
+        """
+        return path.is_relative_to(workspace_abs)
+
     def _resolve_path(self, file_path: str, default_dir: str = "output") -> Path:
         """Resolve file path within workspace"""
         logger.debug(
@@ -767,11 +777,11 @@ class WorkspaceFileOperations:
         )
 
         path = Path(file_path)
+        workspace_abs = self.workspace.workspace_dir.resolve()
 
         if path.is_absolute():
             # Absolute path: check if within workspace
             abs_path = path.resolve()
-            workspace_abs = self.workspace.workspace_dir.resolve()
 
             logger.debug(
                 "Absolute path check - abs_path: %s, workspace_abs: %s",
@@ -779,7 +789,7 @@ class WorkspaceFileOperations:
                 workspace_abs,
             )
 
-            if abs_path == workspace_abs or abs_path.is_relative_to(workspace_abs):
+            if self._in_workspace(abs_path, workspace_abs):
                 logger.debug("Absolute path resolved to: %s", abs_path)
                 return abs_path
 
@@ -823,11 +833,7 @@ class WorkspaceFileOperations:
             # a relative path such as ``../../other/file`` can escape the
             # workspace; without this check the resolved path would be returned
             # unverified (the absolute-path branch above is already checked).
-            workspace_abs = self.workspace.workspace_dir.resolve()
-            if not (
-                resolved_path == workspace_abs
-                or resolved_path.is_relative_to(workspace_abs)
-            ):
+            if not self._in_workspace(resolved_path, workspace_abs):
                 error_msg = f"Path '{file_path}' is not within the workspace"
                 logger.error("ValueError: %s", error_msg)
                 raise ValueError(error_msg)

--- a/src/xagent/core/tools/core/workspace_file_tool.py
+++ b/src/xagent/core/tools/core/workspace_file_tool.py
@@ -819,6 +819,19 @@ class WorkspaceFileOperations:
             else:
                 resolved_path = (self.workspace.workspace_dir / path).resolve()
 
+            # Re-check containment. ``.resolve()`` collapses ``..`` segments, so
+            # a relative path such as ``../../other/file`` can escape the
+            # workspace; without this check the resolved path would be returned
+            # unverified (the absolute-path branch above is already checked).
+            workspace_abs = self.workspace.workspace_dir.resolve()
+            if not (
+                resolved_path == workspace_abs
+                or resolved_path.is_relative_to(workspace_abs)
+            ):
+                error_msg = f"Path '{file_path}' is not within the workspace"
+                logger.error("ValueError: %s", error_msg)
+                raise ValueError(error_msg)
+
             logger.debug("Relative path resolved to: %s", resolved_path)
             return resolved_path
 

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -902,11 +902,21 @@ class TaskWorkspace:
                             or existing_stem in request_stem
                         )
                     ):
+                        # Containment gate, mirroring the exact-match and
+                        # normalized-name branches. ``iterdir`` can surface a
+                        # symlink that resolves outside the workspace; skip such
+                        # a rogue candidate and keep searching rather than
+                        # aborting, so a legitimate later match is still found.
+                        resolved = existing_file.resolve()
+                        try:
+                            self._resolve_allowed_absolute_path(resolved)
+                        except ValueError:
+                            continue
                         logger.info(
                             f"File '{file_path}' fuzzy matched to: "
                             f"'{existing_file.name}'"
                         )
-                        return existing_file.resolve()
+                        return resolved
 
             # 4. Not found — include available files in error message
             hint = ""

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -15,7 +15,7 @@ import unicodedata
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
 from ..config import get_uploads_dir
@@ -720,25 +720,54 @@ class TaskWorkspace:
         except ValueError:
             return None
 
+    def _escapes_before_symlinks(self, candidate: Path) -> bool:
+        """True if ``candidate`` leaves every allowed root by path arithmetic alone.
+
+        ``os.path.normpath`` collapses ``..`` lexically without following
+        symlinks, so a ``..`` traversal is detected independently of what is on
+        disk — distinguishing it from a lexically-contained candidate whose
+        leaf only escapes once a symlink is resolved.
+        """
+        lexical = Path(os.path.normpath(candidate))
+        roots = [self.workspace_dir, *self.allowed_external_dirs]
+        for root in roots:
+            root_lexical = Path(os.path.normpath(root))
+            if lexical == root_lexical or lexical.is_relative_to(root_lexical):
+                return False
+        return True
+
     def _find_existing_candidate(
         self,
         search_dirs: List[Tuple[str, Path]],
-        candidate_fn: Callable[[Path], Path],
+        relative_path: Path,
     ) -> Optional[Path]:
-        """Return the first existing candidate across ``search_dirs``, else None.
+        """Return the first existing ``dir_path / relative_path``, else None.
 
-        ``candidate_fn(dir_path)`` builds the candidate path for each search
-        directory. Containment is validated (via
-        ``_resolve_allowed_absolute_path``) BEFORE touching the filesystem, so a
-        ``..`` traversal raises the same ``ValueError`` whether or not the target
-        exists — otherwise the ``ValueError``/``FileNotFoundError`` split would
-        be a cross-workspace file-existence oracle. A candidate whose leaf name
-        itself resolves outside the workspace (e.g. an out-of-tree symlink) is
-        rejected here too.
+        Containment is validated (via ``_resolve_allowed_absolute_path``)
+        BEFORE touching the filesystem, so the check runs before ``.exists()``
+        and a traversal cannot become a ``ValueError``/``FileNotFoundError``
+        cross-workspace existence oracle.
+
+        Two kinds of escape raise ``ValueError`` from the containment check and
+        are handled differently:
+
+        * A ``..`` traversal escapes lexically — by path arithmetic alone,
+          before any symlink is followed — and does so identically for every
+          (sibling) search dir, so no in-workspace match is possible. Re-raise
+          to fail closed uniformly; this is also the existence-oracle guard,
+          which must raise regardless of whether the out-of-tree target exists.
+        * A candidate that is lexically contained but escapes only when a
+          symlinked leaf is resolved is per-entry: skip it and keep searching
+          so a legitimate same-named file in a later dir stays reachable.
         """
         for _dir_name, dir_path in search_dirs:
-            candidate = candidate_fn(dir_path)
-            resolved_candidate = self._resolve_allowed_absolute_path(candidate)
+            candidate = dir_path / relative_path
+            try:
+                resolved_candidate = self._resolve_allowed_absolute_path(candidate)
+            except ValueError:
+                if self._escapes_before_symlinks(candidate):
+                    raise
+                continue
             if resolved_candidate.exists():
                 return resolved_candidate
         return None
@@ -857,9 +886,7 @@ class TaskWorkspace:
             ]
 
             # 1. Try exact match first
-            match = self._find_existing_candidate(
-                search_dirs, lambda dir_path: dir_path / clean_path
-            )
+            match = self._find_existing_candidate(search_dirs, clean_path)
             if match is not None:
                 return match
 
@@ -867,9 +894,7 @@ class TaskWorkspace:
             normalized_name = self._normalize_filename_for_search(clean_path.name)
             if normalized_name != clean_path.name:
                 normalized_clean = clean_path.parent / normalized_name
-                match = self._find_existing_candidate(
-                    search_dirs, lambda dir_path: dir_path / normalized_clean
-                )
+                match = self._find_existing_candidate(search_dirs, normalized_clean)
                 if match is not None:
                     logger.info(
                         f"File '{file_path}' matched via normalized name: "

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -15,7 +15,7 @@ import unicodedata
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
 from ..config import get_uploads_dir
@@ -720,6 +720,29 @@ class TaskWorkspace:
         except ValueError:
             return None
 
+    def _find_existing_candidate(
+        self,
+        search_dirs: List[Tuple[str, Path]],
+        candidate_fn: Callable[[Path], Path],
+    ) -> Optional[Path]:
+        """Return the first existing candidate across ``search_dirs``, else None.
+
+        ``candidate_fn(dir_path)`` builds the candidate path for each search
+        directory. Containment is validated (via
+        ``_resolve_allowed_absolute_path``) BEFORE touching the filesystem, so a
+        ``..`` traversal raises the same ``ValueError`` whether or not the target
+        exists — otherwise the ``ValueError``/``FileNotFoundError`` split would
+        be a cross-workspace file-existence oracle. A candidate whose leaf name
+        itself resolves outside the workspace (e.g. an out-of-tree symlink) is
+        rejected here too.
+        """
+        for _dir_name, dir_path in search_dirs:
+            candidate = candidate_fn(dir_path)
+            resolved_candidate = self._resolve_allowed_absolute_path(candidate)
+            if resolved_candidate.exists():
+                return resolved_candidate
+        return None
+
     def resolve_path(self, file_path: str, default_dir: str = "output") -> Path:
         """
         Resolve a file path within the workspace or allowed external directories.
@@ -834,35 +857,25 @@ class TaskWorkspace:
             ]
 
             # 1. Try exact match first
-            for _dir_name, dir_path in search_dirs:
-                candidate = dir_path / clean_path
-                # Validate containment BEFORE touching the filesystem, so a
-                # ``..`` traversal raises the same ValueError whether or not the
-                # target exists — otherwise the ValueError/FileNotFoundError
-                # split would be a cross-workspace file-existence oracle.
-                resolved_candidate = self._resolve_allowed_absolute_path(candidate)
-                if resolved_candidate.exists():
-                    return resolved_candidate
+            match = self._find_existing_candidate(
+                search_dirs, lambda dir_path: dir_path / clean_path
+            )
+            if match is not None:
+                return match
 
             # 2. Try normalized filename (handles spaces, brackets, etc.)
             normalized_name = self._normalize_filename_for_search(clean_path.name)
             if normalized_name != clean_path.name:
                 normalized_clean = clean_path.parent / normalized_name
-                for _dir_name, dir_path in search_dirs:
-                    candidate = dir_path / normalized_clean
-                    # Containment before existence, mirroring the exact-match
-                    # branch. For a plain ``..`` traversal the exact-match loop
-                    # above shares this parent path and already raises, so this
-                    # check is load-bearing only when the normalized leaf name
-                    # itself resolves outside the workspace (e.g. an out-of-tree
-                    # symlink), not for traversal.
-                    resolved_candidate = self._resolve_allowed_absolute_path(candidate)
-                    if resolved_candidate.exists():
-                        logger.info(
-                            f"File '{file_path}' matched via normalized name: "
-                            f"'{normalized_name}'"
-                        )
-                        return resolved_candidate
+                match = self._find_existing_candidate(
+                    search_dirs, lambda dir_path: dir_path / normalized_clean
+                )
+                if match is not None:
+                    logger.info(
+                        f"File '{file_path}' matched via normalized name: "
+                        f"'{normalized_name}'"
+                    )
+                    return match
 
             # 3. Try fuzzy match — also collect file list for error message
             request_stem = clean_path.stem.replace(" ", "").replace("_", "")

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -836,10 +836,13 @@ class TaskWorkspace:
             # 1. Try exact match first
             for _dir_name, dir_path in search_dirs:
                 candidate = dir_path / clean_path
-                if candidate.exists():
-                    # Re-check containment: ``clean_path`` may carry ``..``
-                    # segments that resolve outside the workspace.
-                    return self._resolve_allowed_absolute_path(candidate)
+                # Validate containment BEFORE touching the filesystem, so a
+                # ``..`` traversal raises the same ValueError whether or not the
+                # target exists — otherwise the ValueError/FileNotFoundError
+                # split would be a cross-workspace file-existence oracle.
+                resolved_candidate = self._resolve_allowed_absolute_path(candidate)
+                if resolved_candidate.exists():
+                    return resolved_candidate
 
             # 2. Try normalized filename (handles spaces, brackets, etc.)
             normalized_name = self._normalize_filename_for_search(clean_path.name)
@@ -847,13 +850,14 @@ class TaskWorkspace:
                 normalized_clean = clean_path.parent / normalized_name
                 for _dir_name, dir_path in search_dirs:
                     candidate = dir_path / normalized_clean
-                    if candidate.exists():
+                    # Containment before existence, as in the exact-match branch.
+                    resolved_candidate = self._resolve_allowed_absolute_path(candidate)
+                    if resolved_candidate.exists():
                         logger.info(
                             f"File '{file_path}' matched via normalized name: "
                             f"'{normalized_name}'"
                         )
-                        # Re-check containment (see exact-match branch above).
-                        return self._resolve_allowed_absolute_path(candidate)
+                        return resolved_candidate
 
             # 3. Try fuzzy match — also collect file list for error message
             request_stem = clean_path.stem.replace(" ", "").replace("_", "")

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -850,7 +850,12 @@ class TaskWorkspace:
                 normalized_clean = clean_path.parent / normalized_name
                 for _dir_name, dir_path in search_dirs:
                     candidate = dir_path / normalized_clean
-                    # Containment before existence, as in the exact-match branch.
+                    # Containment before existence, mirroring the exact-match
+                    # branch. For a plain ``..`` traversal the exact-match loop
+                    # above shares this parent path and already raises, so this
+                    # check is load-bearing only when the normalized leaf name
+                    # itself resolves outside the workspace (e.g. an out-of-tree
+                    # symlink), not for traversal.
                     resolved_candidate = self._resolve_allowed_absolute_path(candidate)
                     if resolved_candidate.exists():
                         logger.info(

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -744,15 +744,20 @@ class TaskWorkspace:
             if cwd_relative is not None:
                 return cwd_relative
 
-            # For relative paths, resolve relative to default directory
+            # For relative paths, resolve relative to the default directory,
+            # then re-check containment. ``.resolve()`` collapses ``..``
+            # segments, so a relative path such as ``../../other/file`` can
+            # escape the workspace; returning it without re-verifying would let
+            # a relative path reach outside the allowed subtree.
             if default_dir == "input":
-                return (self.input_dir / path).resolve()
+                candidate = (self.input_dir / path).resolve()
             elif default_dir == "output":
-                return (self.output_dir / path).resolve()
+                candidate = (self.output_dir / path).resolve()
             elif default_dir == "temp":
-                return (self.temp_dir / path).resolve()
+                candidate = (self.temp_dir / path).resolve()
             else:
-                return (self.workspace_dir / path).resolve()
+                candidate = (self.workspace_dir / path).resolve()
+            return self._resolve_allowed_absolute_path(candidate)
 
     @staticmethod
     def _normalize_filename_for_search(filename: str) -> str:
@@ -832,7 +837,9 @@ class TaskWorkspace:
             for _dir_name, dir_path in search_dirs:
                 candidate = dir_path / clean_path
                 if candidate.exists():
-                    return candidate.resolve()
+                    # Re-check containment: ``clean_path`` may carry ``..``
+                    # segments that resolve outside the workspace.
+                    return self._resolve_allowed_absolute_path(candidate)
 
             # 2. Try normalized filename (handles spaces, brackets, etc.)
             normalized_name = self._normalize_filename_for_search(clean_path.name)
@@ -845,7 +852,8 @@ class TaskWorkspace:
                             f"File '{file_path}' matched via normalized name: "
                             f"'{normalized_name}'"
                         )
-                        return candidate.resolve()
+                        # Re-check containment (see exact-match branch above).
+                        return self._resolve_allowed_absolute_path(candidate)
 
             # 3. Try fuzzy match — also collect file list for error message
             request_stem = clean_path.stem.replace(" ", "").replace("_", "")

--- a/tests/core/test_workspace_path_containment.py
+++ b/tests/core/test_workspace_path_containment.py
@@ -89,6 +89,49 @@ def test_resolve_path_with_search_finds_legitimate_file(workspace):
     assert resolved == target.resolve()
 
 
+def test_resolve_path_with_search_rejects_symlink_escape_in_fuzzy_match(
+    workspace, tmp_path
+):
+    # A symlink inside a search dir that resolves outside the workspace must
+    # not be returned by the fuzzy-match branch, even when its stem fuzzy-
+    # matches the request. Under the pre-fix code the out-of-tree target was
+    # returned unchecked; now containment rejects it and, with no other match,
+    # the search reports the file as not found.
+    workspace.output_dir.mkdir(parents=True, exist_ok=True)
+    secret = tmp_path / "other" / "secret.txt"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_text("out-of-tree secret", encoding="utf-8")
+
+    link = workspace.output_dir / "report.txt"
+    link.symlink_to(secret)
+
+    with pytest.raises(FileNotFoundError):
+        workspace.resolve_path_with_search("reportt.txt")
+
+
+def test_resolve_path_with_search_skips_symlink_escape_but_finds_legit_match(
+    workspace, tmp_path
+):
+    # The containment gate skips a rogue candidate and keeps searching, so a
+    # legitimate fuzzy match in a later directory is still returned.
+    workspace.output_dir.mkdir(parents=True, exist_ok=True)
+    workspace.temp_dir.mkdir(parents=True, exist_ok=True)
+
+    secret = tmp_path / "other" / "secret.txt"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_text("out-of-tree secret", encoding="utf-8")
+    # Rogue escaping symlink in output/ (searched before temp/).
+    (workspace.output_dir / "report.txt").symlink_to(secret)
+    # Legitimate in-workspace file that also fuzzy-matches the request.
+    legit = workspace.temp_dir / "report.txt"
+    legit.write_text("in-workspace report", encoding="utf-8")
+
+    resolved = workspace.resolve_path_with_search("reportt.txt")
+
+    assert resolved == legit.resolve()
+    assert resolved.is_relative_to(workspace.workspace_dir.resolve())
+
+
 def test_resolve_path_still_rejects_absolute_escape(workspace, tmp_path):
     # Regression: the absolute-path branch keeps rejecting out-of-workspace paths.
     outside = tmp_path / "outside.txt"

--- a/tests/core/test_workspace_path_containment.py
+++ b/tests/core/test_workspace_path_containment.py
@@ -14,37 +14,46 @@ import pytest
 from xagent.core.tools.core.workspace_file_tool import WorkspaceFileOperations
 from xagent.core.workspace import TaskWorkspace
 
+# Relative inputs that resolve outside the workspace and must be rejected.
+# ``plain`` climbs out directly; ``prefixed`` starts under a legit "output/"
+# prefix before climbing out — both share the same expected outcome.
+TRAVERSAL_PATHS = [
+    pytest.param("../../other/secret.txt", id="plain"),
+    pytest.param("output/../../../escape.txt", id="prefixed"),
+]
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    return TaskWorkspace("task7", str(tmp_path))
+
+
+@pytest.fixture
+def ops(workspace):
+    return WorkspaceFileOperations(workspace)
+
+
 # --------------------------------------------------------------------------
 # SITE 1 — TaskWorkspace.resolve_path / resolve_path_with_search
 # --------------------------------------------------------------------------
 
 
-def test_resolve_path_rejects_relative_traversal_out_of_workspace(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
-
+@pytest.mark.parametrize("rel_path", TRAVERSAL_PATHS)
+def test_resolve_path_rejects_relative_traversal(workspace, rel_path):
     with pytest.raises(ValueError):
-        workspace.resolve_path("../../other/secret.txt")
+        workspace.resolve_path(rel_path)
 
 
-def test_resolve_path_rejects_prefixed_relative_traversal(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
-
-    # An "output/"-prefixed path that then climbs out must still be rejected.
-    with pytest.raises(ValueError):
-        workspace.resolve_path("output/../../../escape.txt")
-
-
-def test_resolve_path_allows_legitimate_relative_path(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
-
+def test_resolve_path_allows_legitimate_relative_path(workspace):
     resolved = workspace.resolve_path("report.txt")
 
     assert resolved.is_relative_to(workspace.workspace_dir.resolve())
     assert resolved == (workspace.output_dir / "report.txt").resolve()
 
 
-def test_resolve_path_with_search_rejects_existing_sibling_via_traversal(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
+def test_resolve_path_with_search_rejects_existing_sibling_via_traversal(
+    workspace, tmp_path
+):
     workspace.input_dir.mkdir(parents=True, exist_ok=True)
 
     # A real file outside the workspace that a traversal would otherwise reach:
@@ -58,21 +67,19 @@ def test_resolve_path_with_search_rejects_existing_sibling_via_traversal(tmp_pat
 
 
 def test_resolve_path_with_search_rejects_nonexistent_traversal_without_oracle(
-    tmp_path,
+    workspace,
 ):
     # Containment is checked before existence, so a traversal to a path that
     # does NOT exist raises ValueError (the same as an existing target) rather
     # than FileNotFoundError. Otherwise the exception type would leak whether a
     # file exists outside the workspace.
-    workspace = TaskWorkspace("task7", str(tmp_path))
     workspace.input_dir.mkdir(parents=True, exist_ok=True)
 
     with pytest.raises(ValueError):
         workspace.resolve_path_with_search("../../other/does_not_exist.txt")
 
 
-def test_resolve_path_with_search_finds_legitimate_file(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
+def test_resolve_path_with_search_finds_legitimate_file(workspace):
     target = workspace.output_dir / "data.csv"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("a,b\n1,2\n", encoding="utf-8")
@@ -82,9 +89,8 @@ def test_resolve_path_with_search_finds_legitimate_file(tmp_path):
     assert resolved == target.resolve()
 
 
-def test_resolve_path_still_rejects_absolute_escape(tmp_path):
+def test_resolve_path_still_rejects_absolute_escape(workspace, tmp_path):
     # Regression: the absolute-path branch keeps rejecting out-of-workspace paths.
-    workspace = TaskWorkspace("task7", str(tmp_path))
     outside = tmp_path / "outside.txt"
     outside.write_text("x", encoding="utf-8")
 
@@ -98,34 +104,20 @@ def test_resolve_path_still_rejects_absolute_escape(tmp_path):
 # --------------------------------------------------------------------------
 
 
-def test_ops_resolve_path_rejects_relative_traversal(tmp_path):
-    ops = WorkspaceFileOperations(TaskWorkspace("task7", str(tmp_path)))
-
+@pytest.mark.parametrize("rel_path", TRAVERSAL_PATHS)
+def test_ops_resolve_path_rejects_relative_traversal(ops, rel_path):
     with pytest.raises(ValueError):
-        ops._resolve_path("../../other/secret.txt", "output")
+        ops._resolve_path(rel_path, "output")
 
 
-def test_ops_resolve_path_rejects_prefixed_relative_traversal(tmp_path):
-    ops = WorkspaceFileOperations(TaskWorkspace("task7", str(tmp_path)))
-
-    with pytest.raises(ValueError):
-        ops._resolve_path("output/../../../escape.txt", "output")
-
-
-def test_ops_resolve_path_allows_legitimate_relative(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
-    ops = WorkspaceFileOperations(workspace)
-
+def test_ops_resolve_path_allows_legitimate_relative(workspace, ops):
     resolved = ops._resolve_path("report.txt", "output")
 
     assert resolved.is_relative_to(workspace.workspace_dir.resolve())
     assert resolved == (workspace.output_dir / "report.txt").resolve()
 
 
-def test_write_file_refuses_relative_traversal_end_to_end(tmp_path):
-    workspace = TaskWorkspace("task7", str(tmp_path))
-    ops = WorkspaceFileOperations(workspace)
-
+def test_write_file_refuses_relative_traversal_end_to_end(ops, tmp_path):
     with pytest.raises(ValueError):
         ops.write_file("../../other/pwned.txt", "malicious content")
 

--- a/tests/core/test_workspace_path_containment.py
+++ b/tests/core/test_workspace_path_containment.py
@@ -14,7 +14,6 @@ import pytest
 from xagent.core.tools.core.workspace_file_tool import WorkspaceFileOperations
 from xagent.core.workspace import TaskWorkspace
 
-
 # --------------------------------------------------------------------------
 # SITE 1 — TaskWorkspace.resolve_path / resolve_path_with_search
 # --------------------------------------------------------------------------
@@ -56,6 +55,20 @@ def test_resolve_path_with_search_rejects_existing_sibling_via_traversal(tmp_pat
 
     with pytest.raises(ValueError):
         workspace.resolve_path_with_search("../../other/secret.txt")
+
+
+def test_resolve_path_with_search_rejects_nonexistent_traversal_without_oracle(
+    tmp_path,
+):
+    # Containment is checked before existence, so a traversal to a path that
+    # does NOT exist raises ValueError (the same as an existing target) rather
+    # than FileNotFoundError. Otherwise the exception type would leak whether a
+    # file exists outside the workspace.
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    workspace.input_dir.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(ValueError):
+        workspace.resolve_path_with_search("../../other/does_not_exist.txt")
 
 
 def test_resolve_path_with_search_finds_legitimate_file(tmp_path):

--- a/tests/core/test_workspace_path_containment.py
+++ b/tests/core/test_workspace_path_containment.py
@@ -1,0 +1,120 @@
+"""Relative-path containment tests for the workspace path resolvers.
+
+Absolute-path resolution already re-checks that the target stays inside the
+workspace. Relative paths were resolved against a base directory and returned
+without a second check, so a ``../``-laden relative path could escape the
+workspace once ``Path.resolve()`` collapsed the ``..`` segments. These tests
+pin the containment re-check on every relative branch, across both
+independent implementations (``TaskWorkspace`` and ``WorkspaceFileOperations``,
+which do not delegate to one another).
+"""
+
+import pytest
+
+from xagent.core.tools.core.workspace_file_tool import WorkspaceFileOperations
+from xagent.core.workspace import TaskWorkspace
+
+
+# --------------------------------------------------------------------------
+# SITE 1 — TaskWorkspace.resolve_path / resolve_path_with_search
+# --------------------------------------------------------------------------
+
+
+def test_resolve_path_rejects_relative_traversal_out_of_workspace(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+
+    with pytest.raises(ValueError):
+        workspace.resolve_path("../../other/secret.txt")
+
+
+def test_resolve_path_rejects_prefixed_relative_traversal(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+
+    # An "output/"-prefixed path that then climbs out must still be rejected.
+    with pytest.raises(ValueError):
+        workspace.resolve_path("output/../../../escape.txt")
+
+
+def test_resolve_path_allows_legitimate_relative_path(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+
+    resolved = workspace.resolve_path("report.txt")
+
+    assert resolved.is_relative_to(workspace.workspace_dir.resolve())
+    assert resolved == (workspace.output_dir / "report.txt").resolve()
+
+
+def test_resolve_path_with_search_rejects_existing_sibling_via_traversal(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    workspace.input_dir.mkdir(parents=True, exist_ok=True)
+
+    # A real file outside the workspace that a traversal would otherwise reach:
+    # input_dir/../../other/secret.txt == tmp_path/other/secret.txt.
+    sibling = tmp_path / "other" / "secret.txt"
+    sibling.parent.mkdir(parents=True, exist_ok=True)
+    sibling.write_text("sibling end user's secret", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        workspace.resolve_path_with_search("../../other/secret.txt")
+
+
+def test_resolve_path_with_search_finds_legitimate_file(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    target = workspace.output_dir / "data.csv"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    resolved = workspace.resolve_path_with_search("data.csv")
+
+    assert resolved == target.resolve()
+
+
+def test_resolve_path_still_rejects_absolute_escape(tmp_path):
+    # Regression: the absolute-path branch keeps rejecting out-of-workspace paths.
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        workspace.resolve_path(str(outside))
+
+
+# --------------------------------------------------------------------------
+# SITE 2 — WorkspaceFileOperations._resolve_path (separate implementation;
+# it ignores allowed_external_dirs and confines strictly to workspace_dir)
+# --------------------------------------------------------------------------
+
+
+def test_ops_resolve_path_rejects_relative_traversal(tmp_path):
+    ops = WorkspaceFileOperations(TaskWorkspace("task7", str(tmp_path)))
+
+    with pytest.raises(ValueError):
+        ops._resolve_path("../../other/secret.txt", "output")
+
+
+def test_ops_resolve_path_rejects_prefixed_relative_traversal(tmp_path):
+    ops = WorkspaceFileOperations(TaskWorkspace("task7", str(tmp_path)))
+
+    with pytest.raises(ValueError):
+        ops._resolve_path("output/../../../escape.txt", "output")
+
+
+def test_ops_resolve_path_allows_legitimate_relative(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    ops = WorkspaceFileOperations(workspace)
+
+    resolved = ops._resolve_path("report.txt", "output")
+
+    assert resolved.is_relative_to(workspace.workspace_dir.resolve())
+    assert resolved == (workspace.output_dir / "report.txt").resolve()
+
+
+def test_write_file_refuses_relative_traversal_end_to_end(tmp_path):
+    workspace = TaskWorkspace("task7", str(tmp_path))
+    ops = WorkspaceFileOperations(workspace)
+
+    with pytest.raises(ValueError):
+        ops.write_file("../../other/pwned.txt", "malicious content")
+
+    # Nothing was written outside the workspace.
+    assert not (tmp_path / "other" / "pwned.txt").exists()

--- a/tests/core/test_workspace_path_containment.py
+++ b/tests/core/test_workspace_path_containment.py
@@ -44,6 +44,15 @@ def test_resolve_path_rejects_relative_traversal(workspace, rel_path):
         workspace.resolve_path(rel_path)
 
 
+@pytest.mark.parametrize("default_dir", ["input", "output", "temp", "other"])
+def test_resolve_path_rejects_traversal_for_every_default_dir(workspace, default_dir):
+    # The input/temp branches and the ``else`` fallback (resolving against
+    # workspace_dir) share the output branch's logic; pin that each still
+    # rejects an out-of-workspace traversal, not just default_dir="output".
+    with pytest.raises(ValueError):
+        workspace.resolve_path("../../other/secret.txt", default_dir=default_dir)
+
+
 def test_resolve_path_allows_legitimate_relative_path(workspace):
     resolved = workspace.resolve_path("report.txt")
 
@@ -132,6 +141,30 @@ def test_resolve_path_with_search_skips_symlink_escape_but_finds_legit_match(
     assert resolved.is_relative_to(workspace.workspace_dir.resolve())
 
 
+def test_resolve_path_with_search_skips_exact_match_symlink_escape_for_legit_later(
+    workspace, tmp_path
+):
+    # An escaping symlink named exactly like the request in an EARLIER search
+    # dir (input/) must not abort the search: a legitimate same-named file in a
+    # LATER dir (output/) stays reachable via exact match. Only a lexical
+    # ``..`` traversal hard-aborts; a symlinked leaf is skipped.
+    workspace.input_dir.mkdir(parents=True, exist_ok=True)
+    workspace.output_dir.mkdir(parents=True, exist_ok=True)
+
+    secret = tmp_path / "other" / "notes.txt"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_text("out-of-tree secret", encoding="utf-8")
+    (workspace.input_dir / "notes.txt").symlink_to(secret)
+
+    legit = workspace.output_dir / "notes.txt"
+    legit.write_text("in-workspace notes", encoding="utf-8")
+
+    resolved = workspace.resolve_path_with_search("notes.txt")
+
+    assert resolved == legit.resolve()
+    assert resolved.is_relative_to(workspace.workspace_dir.resolve())
+
+
 def test_resolve_path_still_rejects_absolute_escape(workspace, tmp_path):
     # Regression: the absolute-path branch keeps rejecting out-of-workspace paths.
     outside = tmp_path / "outside.txt"
@@ -139,6 +172,24 @@ def test_resolve_path_still_rejects_absolute_escape(workspace, tmp_path):
 
     with pytest.raises(ValueError):
         workspace.resolve_path(str(outside))
+
+
+def test_resolve_path_accepts_traversal_into_allowed_external_dir(tmp_path):
+    # The other half of #824's expected behavior: a relative path that climbs
+    # out of the workspace but lands inside a legitimately-allowed external dir
+    # is ACCEPTED, not rejected.
+    external = tmp_path / "external"
+    external.mkdir(parents=True, exist_ok=True)
+    target = external / "shared.txt"
+    target.write_text("shared", encoding="utf-8")
+
+    workspace = TaskWorkspace(
+        "task7", str(tmp_path), allowed_external_dirs=[str(external)]
+    )
+    # output_dir/../../external/shared.txt == tmp_path/external/shared.txt.
+    resolved = workspace.resolve_path("../../external/shared.txt", default_dir="output")
+
+    assert resolved == target.resolve()
 
 
 # --------------------------------------------------------------------------
@@ -166,3 +217,22 @@ def test_write_file_refuses_relative_traversal_end_to_end(ops, tmp_path):
 
     # Nothing was written outside the workspace.
     assert not (tmp_path / "other" / "pwned.txt").exists()
+
+
+def test_ops_resolve_path_ignores_allowed_external_dirs(tmp_path):
+    # WorkspaceFileOperations confines strictly to workspace_dir and, unlike
+    # TaskWorkspace, does NOT honor allowed_external_dirs. Prove the documented
+    # difference: the same path is accepted by TaskWorkspace but rejected here.
+    external = tmp_path / "external"
+    external.mkdir(parents=True, exist_ok=True)
+    target = external / "shared.txt"
+    target.write_text("shared", encoding="utf-8")
+
+    workspace = TaskWorkspace(
+        "task7", str(tmp_path), allowed_external_dirs=[str(external)]
+    )
+    assert workspace.resolve_path(str(target)) == target.resolve()
+
+    ops = WorkspaceFileOperations(workspace)
+    with pytest.raises(ValueError):
+        ops._resolve_path(str(target), "output")


### PR DESCRIPTION
### What
Relative-path resolution in the workspace resolvers returned Path.resolve()'d
results without re-checking that the target stays inside the workspace. Because
resolve() collapses "..", a relative path such as "../../other/file" could
escape the workspace subtree. The absolute-path branches already re-check; this
brings the relative branches in line.

### Changes
- TaskWorkspace.resolve_path and resolve_path_with_search route the resolved
  candidate through _resolve_allowed_absolute_path.
- WorkspaceFileOperations._resolve_path verifies the resolved path stays under
  workspace_dir (this resolver intentionally does not consult
  allowed_external_dirs).
- Tests for relative traversal (plain + prefixed), the search resolver hitting
  an existing out-of-tree file, and legitimate relative paths, across both
  resolvers.

### Notes
Fixes #824. No behavior change for legitimate relative or absolute paths;
only out-of-workspace relative traversals now raise ValueError, as the
absolute branch already does.