### PR TITLE
fix(sandbox): scoped executions fail closed instead of falling back to local execution

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -761,20 +761,22 @@ class AgentServiceManager:
         local fallback via XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY),
         and any other sandbox failure falls back to local execution.
 
-        A **scoped** execution (``scope is not None``) isolates an untrusted /
+        A scope that carries a ``sandbox_key_suffix`` isolates an untrusted /
         third-party workload in a per-scope container; running it outside that
         container would defeat the isolation the scope exists to provide. So
-        for any active scope both fallbacks are disabled and the task fails
+        when a suffix is present both fallbacks are disabled and the task fails
         closed regardless of configuration — neither capacity pressure (even
-        with the opt-in flag on) nor a sandbox-service failure may downgrade a
-        scoped task to local execution.
+        with the opt-in flag on) nor a sandbox-service failure may downgrade
+        such a task to local execution. A scope *without* a suffix shares the
+        unscoped ``user:{owner}`` container and thus has no isolation to
+        protect; it keeps the unscoped fallback behavior.
 
         Raises:
             SandboxCapacityError: The container cap is reached, nothing is
-                evictable, and (unscoped) local fallback on capacity is not
-                enabled, or the execution is scoped.
-            Exception: A scoped execution hit a non-capacity sandbox failure;
-                re-raised instead of falling back to local execution.
+                evictable, and (for a task with no scope suffix) local fallback
+                on capacity is not enabled, or the scope carries a suffix.
+            Exception: A suffix-scoped execution hit a non-capacity sandbox
+                failure; re-raised instead of falling back to local execution.
         """
         from ..sandbox_manager import SandboxCapacityError, get_sandbox_manager
 
@@ -783,9 +785,14 @@ class AgentServiceManager:
             self._agent_sandbox_keys.pop(task_id, None)
             return None
 
-        # A scoped execution must never silently run outside its sandbox.
-        scoped = scope is not None
+        # The isolation boundary is the per-scope key suffix, not
+        # scope-presence: a suffix-less scope resolves to the same
+        # ``user:{owner}`` lifecycle key as unscoped execution, so it has no
+        # container of its own to protect and must keep the unscoped fallback
+        # behavior. Gating on the suffix (not ``scope is not None``) honors the
+        # ExecutionScope contract that each field be consumed independently.
         suffix = scope.sandbox_key_suffix if scope is not None else None
+        scoped = suffix is not None
         try:
             sandbox = await sandbox_mgr.get_or_create_lease_provider(
                 USER_LIFECYCLE_TYPE,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -756,14 +756,25 @@ class AgentServiceManager:
         producing ``user:{owner}`` and reuses today's containers untouched.
 
         Capacity exhaustion and sandbox-service unavailability are distinct
-        failure classes: a ``SandboxCapacityError`` rejects the task by
-        default (opt-in local fallback via
-        XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY), while any other
-        sandbox failure keeps the local-execution fallback.
+        failure classes. For **unscoped** execution the historical behavior is
+        kept: a ``SandboxCapacityError`` rejects the task by default (opt-in
+        local fallback via XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY),
+        and any other sandbox failure falls back to local execution.
+
+        A **scoped** execution (``scope is not None``) isolates an untrusted /
+        third-party workload in a per-scope container; running it outside that
+        container would defeat the isolation the scope exists to provide. So
+        for any active scope both fallbacks are disabled and the task fails
+        closed regardless of configuration — neither capacity pressure (even
+        with the opt-in flag on) nor a sandbox-service failure may downgrade a
+        scoped task to local execution.
 
         Raises:
             SandboxCapacityError: The container cap is reached, nothing is
-                evictable, and local fallback on capacity is not enabled.
+                evictable, and (unscoped) local fallback on capacity is not
+                enabled, or the execution is scoped.
+            Exception: A scoped execution hit a non-capacity sandbox failure;
+                re-raised instead of falling back to local execution.
         """
         from ..sandbox_manager import SandboxCapacityError, get_sandbox_manager
 
@@ -772,6 +783,8 @@ class AgentServiceManager:
             self._agent_sandbox_keys.pop(task_id, None)
             return None
 
+        # A scoped execution must never silently run outside its sandbox.
+        scoped = scope is not None
         suffix = scope.sandbox_key_suffix if scope is not None else None
         try:
             sandbox = await sandbox_mgr.get_or_create_lease_provider(
@@ -783,7 +796,7 @@ class AgentServiceManager:
             self._agent_sandbox_keys.pop(task_id, None)
             from ...config import get_sandbox_allow_local_fallback_on_capacity
 
-            if get_sandbox_allow_local_fallback_on_capacity():
+            if not scoped and get_sandbox_allow_local_fallback_on_capacity():
                 logger.warning(
                     "Sandbox capacity reached for workspace owner %s; "
                     "falling back to local execution "
@@ -794,14 +807,25 @@ class AgentServiceManager:
                 return None
             logger.warning(
                 "Sandbox capacity reached for workspace owner %s; "
-                "rejecting task %s: %s",
+                "rejecting task %s (scoped=%s): %s",
                 workspace_owner_id,
                 task_id,
+                scoped,
                 e,
             )
             raise
         except Exception as e:
             self._agent_sandbox_keys.pop(task_id, None)
+            if scoped:
+                logger.error(
+                    "Sandbox creation failed for scoped task %s (workspace "
+                    "owner %s); failing closed instead of running the scoped "
+                    "workload locally: %s",
+                    task_id,
+                    workspace_owner_id,
+                    e,
+                )
+                raise
             logger.warning(
                 "Sandbox creation failed for workspace owner %s, "
                 "falling back to local execution: %s",

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from xagent.core.execution_scope import ExecutionScope
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.sandbox_manager import SandboxCapacityError, SandboxManager
 
@@ -362,4 +363,63 @@ async def test_sandbox_unavailability_keeps_local_fallback(
     )
 
     assert sandbox is None
+    assert 1 not in manager._agent_sandbox_keys
+
+
+_SCOPE = ExecutionScope(
+    sandbox_key_suffix="client-3",
+    workspace_segments=("clients", "3", "end_users", "7"),
+)
+
+
+@pytest.mark.asyncio
+async def test_scoped_capacity_error_rejects_even_when_fallback_enabled(
+    sandbox_mgr, monkeypatch
+) -> None:
+    """A scoped task never takes the local fallback, even with the flag on.
+
+    Local fallback would run an isolated/untrusted scoped workload outside its
+    container, so capacity exhaustion must fail closed regardless of the flag.
+    """
+    monkeypatch.setenv("XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", "true")
+    manager = AgentServiceManager()
+    sandbox_mgr.get_or_create_lease_provider = AsyncMock(
+        side_effect=SandboxCapacityError(cap=2, in_use=2)
+    )
+
+    with pytest.raises(SandboxCapacityError):
+        await manager._get_or_create_task_sandbox(
+            task_id=1,
+            workspace_owner_id=7,
+            workspace_config={},
+            scope=_SCOPE,
+        )
+
+    assert 1 not in manager._agent_sandbox_keys
+
+
+@pytest.mark.asyncio
+async def test_scoped_sandbox_unavailability_fails_closed(
+    sandbox_mgr, monkeypatch
+) -> None:
+    """A non-capacity sandbox failure fails closed for a scoped task.
+
+    Unscoped tasks keep the local fallback (see
+    test_sandbox_unavailability_keeps_local_fallback); a scoped task must not
+    silently run its workload on the host during a sandbox outage.
+    """
+    monkeypatch.delenv("XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", raising=False)
+    manager = AgentServiceManager()
+    sandbox_mgr.get_or_create_lease_provider = AsyncMock(
+        side_effect=RuntimeError("docker daemon unreachable")
+    )
+
+    with pytest.raises(RuntimeError):
+        await manager._get_or_create_task_sandbox(
+            task_id=1,
+            workspace_owner_id=7,
+            workspace_config={},
+            scope=_SCOPE,
+        )
+
     assert 1 not in manager._agent_sandbox_keys

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -371,23 +371,54 @@ _SCOPE = ExecutionScope(
     workspace_segments=("clients", "3", "end_users", "7"),
 )
 
+# A scope that sets no ``sandbox_key_suffix`` resolves to the same
+# ``user:{owner}`` lifecycle key as unscoped execution, so it has no container
+# of its own to protect and must keep the unscoped fallback behavior.
+_SUFFIXLESS_SCOPE = ExecutionScope(
+    workspace_segments=("clients", "3", "end_users", "7"),
+)
+
 
 @pytest.mark.asyncio
-async def test_scoped_capacity_error_rejects_even_when_fallback_enabled(
-    sandbox_mgr, monkeypatch
+@pytest.mark.parametrize(
+    "fallback_flag, side_effect, expected_exc",
+    [
+        pytest.param(
+            "true",
+            SandboxCapacityError(cap=2, in_use=2),
+            SandboxCapacityError,
+            id="capacity-with-flag-on",
+        ),
+        pytest.param(
+            None,
+            RuntimeError("docker daemon unreachable"),
+            RuntimeError,
+            id="non-capacity-outage",
+        ),
+    ],
+)
+async def test_suffix_scoped_execution_fails_closed(
+    sandbox_mgr, monkeypatch, fallback_flag, side_effect, expected_exc
 ) -> None:
-    """A scoped task never takes the local fallback, even with the flag on.
+    """A suffix-scoped task never takes the local fallback.
 
     Local fallback would run an isolated/untrusted scoped workload outside its
-    container, so capacity exhaustion must fail closed regardless of the flag.
+    container, so both capacity exhaustion (even with the opt-in flag on) and a
+    non-capacity sandbox outage must fail closed rather than downgrade to
+    local execution.
     """
-    monkeypatch.setenv("XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", "true")
+    if fallback_flag is None:
+        monkeypatch.delenv(
+            "XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", raising=False
+        )
+    else:
+        monkeypatch.setenv(
+            "XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", fallback_flag
+        )
     manager = AgentServiceManager()
-    sandbox_mgr.get_or_create_lease_provider = AsyncMock(
-        side_effect=SandboxCapacityError(cap=2, in_use=2)
-    )
+    sandbox_mgr.get_or_create_lease_provider = AsyncMock(side_effect=side_effect)
 
-    with pytest.raises(SandboxCapacityError):
+    with pytest.raises(expected_exc):
         await manager._get_or_create_task_sandbox(
             task_id=1,
             workspace_owner_id=7,
@@ -399,27 +430,45 @@ async def test_scoped_capacity_error_rejects_even_when_fallback_enabled(
 
 
 @pytest.mark.asyncio
-async def test_scoped_sandbox_unavailability_fails_closed(
-    sandbox_mgr, monkeypatch
+@pytest.mark.parametrize(
+    "fallback_flag, side_effect",
+    [
+        pytest.param(
+            "true", SandboxCapacityError(cap=2, in_use=2), id="capacity-with-flag-on"
+        ),
+        pytest.param(
+            None, RuntimeError("docker daemon unreachable"), id="non-capacity-outage"
+        ),
+    ],
+)
+async def test_suffixless_scope_keeps_unscoped_fallback(
+    sandbox_mgr, monkeypatch, fallback_flag, side_effect
 ) -> None:
-    """A non-capacity sandbox failure fails closed for a scoped task.
+    """A scope without a suffix behaves exactly like unscoped execution.
 
-    Unscoped tasks keep the local fallback (see
-    test_sandbox_unavailability_keeps_local_fallback); a scoped task must not
-    silently run its workload on the host during a sandbox outage.
+    It shares the ``user:{owner}`` container, so there is no scope-owned
+    isolation to protect: capacity fallback (when the flag is on) and the
+    non-capacity local fallback both remain available. Gating fail-closed on
+    ``sandbox_key_suffix`` — not scope-presence — is what keeps this path from
+    becoming an availability regression.
     """
-    monkeypatch.delenv("XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", raising=False)
+    if fallback_flag is None:
+        monkeypatch.delenv(
+            "XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", raising=False
+        )
+    else:
+        monkeypatch.setenv(
+            "XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY", fallback_flag
+        )
     manager = AgentServiceManager()
-    sandbox_mgr.get_or_create_lease_provider = AsyncMock(
-        side_effect=RuntimeError("docker daemon unreachable")
+    sandbox_mgr.get_or_create_lease_provider = AsyncMock(side_effect=side_effect)
+
+    sandbox = await manager._get_or_create_task_sandbox(
+        task_id=1,
+        workspace_owner_id=7,
+        workspace_config={},
+        scope=_SUFFIXLESS_SCOPE,
     )
 
-    with pytest.raises(RuntimeError):
-        await manager._get_or_create_task_sandbox(
-            task_id=1,
-            workspace_owner_id=7,
-            workspace_config={},
-            scope=_SCOPE,
-        )
-
+    assert sandbox is None
     assert 1 not in manager._agent_sandbox_keys


### PR DESCRIPTION
Fixes #826.

## What
`ChatService._get_or_create_task_sandbox` could silently fall back to **local, non-sandboxed** execution in two paths, neither of which consulted the `ExecutionScope` it already receives:

1. **Capacity** (`SandboxCapacityError`): returned `None` (local) when `XAGENT_SANDBOX_ALLOW_LOCAL_FALLBACK_ON_CAPACITY` was enabled.
2. **Generic sandbox failure** (`except Exception`): returned `None` (local) **unconditionally**.

For a scoped execution — where the scope isolates an untrusted / third-party workload in a per-scope container — either path runs that workload outside the container boundary, defeating the isolation.

## Change
When `scope is not None`, both fallbacks are disabled and the task fails closed:
- Capacity: re-raise `SandboxCapacityError` regardless of the flag.
- Generic: re-raise the original error instead of returning `None`.

Unscoped (creator-direct) execution is unchanged: the flag is still honored on capacity, and non-capacity failures still fall back to local. No new configuration is introduced — fail-closed is the safe default for scoped executions.

## Tests
Added to `tests/web/test_agent_manager_sandbox_lifecycle.py`:
- `test_scoped_capacity_error_rejects_even_when_fallback_enabled` — scope set + flag on ⇒ raises `SandboxCapacityError`.
- `test_scoped_sandbox_unavailability_fails_closed` — scope set + non-capacity failure ⇒ raises.

The existing unscoped tests remain as regression coverage (flag-on ⇒ local fallback; non-capacity ⇒ local fallback).

## Notes
Distinct from #785 (capacity *cap counting* fail-open on daemon-listing failure); this is about the local-execution *fallback* for scoped tasks.