### PR TITLE
fix(core): confine file-id resolution to the active execution scope

### DIFF
--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -607,33 +607,51 @@ class TaskWorkspace:
     ) -> bool:
         """Whether a file record lives under this workspace's scope subtree.
 
-        Only meaningful when ``scope_segments`` is non-empty. Confirms
-        containment via the durable storage key prefix
-        (``users/{owner}/{segments}/``) when present, else via the local
-        storage path under the scoped user root. Fails closed (returns False)
-        when neither can be confirmed, so an owner match alone can never admit
-        a sibling scope's file.
+        Only meaningful when ``scope_segments`` is non-empty. Validates the
+        artifact that ``resolve_file_id`` will actually hand back:
+
+        - When an explicit local ``path`` is supplied, that path *is* the
+          return value, so it is authoritative and must lie under the scoped
+          user root. An in-scope durable ``storage_key`` must never admit an
+          out-of-scope local path.
+        - Otherwise resolution materializes from the durable handle, so the
+          ``storage_key`` prefix (``users/{owner}/{segments}/``) is checked,
+          falling back to the record's own ``storage_path`` only when no key
+          is present.
+
+        Fails closed (returns False) when nothing can be confirmed, so an
+        owner match alone can never admit a sibling scope's file.
         """
         owner_user_id = self.owner_user_id
         if owner_user_id is None:
             return True
 
+        # Branch 1: the explicit local path is what gets returned. Confine it
+        # regardless of any storage_key, so an in-scope key can't smuggle an
+        # out-of-scope local path past the gate.
+        if path is not None:
+            return self._path_under_scoped_user_root(path, owner_user_id)
+
+        # Branch 2: no local path, so resolution materializes from the durable
+        # handle -- validate the key prefix when present.
         storage_key = getattr(record, "storage_key", None)
         if storage_key:
             key = str(storage_key)
             key_prefix = "/".join(["users", str(owner_user_id), *self.scope_segments])
             return key == key_prefix or key.startswith(key_prefix + "/")
 
-        candidate = path
-        if candidate is None:
-            storage_path = getattr(record, "storage_path", None)
-            candidate = Path(storage_path) if storage_path else None
-        if candidate is not None:
-            scoped_root = self._user_workspace_base_dir(int(owner_user_id)).resolve()
-            resolved = candidate.resolve()
-            return resolved == scoped_root or resolved.is_relative_to(scoped_root)
+        # No key: fall back to the record's own local storage path.
+        storage_path = getattr(record, "storage_path", None)
+        if storage_path:
+            return self._path_under_scoped_user_root(Path(storage_path), owner_user_id)
 
         return False
+
+    def _path_under_scoped_user_root(self, candidate: Path, owner_user_id: Any) -> bool:
+        """Whether ``candidate`` resolves under the scoped user workspace root."""
+        scoped_root = self._user_workspace_base_dir(int(owner_user_id)).resolve()
+        resolved = candidate.resolve()
+        return resolved == scoped_root or resolved.is_relative_to(scoped_root)
 
     def resolve_file_id(self, file_id: str) -> Optional[Path]:
         file_id = str(file_id).strip()

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -586,12 +586,54 @@ class TaskWorkspace:
         if record_user_id != owner_user_id:
             return False
 
+        # For a scoped workspace, an owner match is not sufficient: the record
+        # must also live under this workspace's scope subtree. Otherwise a task
+        # could resolve, by file_id, a record belonging to the same owner but a
+        # different scope (e.g. another end user's upload, which has
+        # task_id=None and would pass the checks below). Unscoped workspaces
+        # (no scope_segments) keep the owner-only behavior byte-for-byte.
+        if self.scope_segments and not self._record_in_scope_subtree(record, path):
+            return False
+
         record_task_id = getattr(record, "task_id", None)
         if record_task_id is None:
             return True
         return (
             self.current_task_id is not None and record_task_id == self.current_task_id
         )
+
+    def _record_in_scope_subtree(
+        self, record: Any, path: Optional[Path] = None
+    ) -> bool:
+        """Whether a file record lives under this workspace's scope subtree.
+
+        Only meaningful when ``scope_segments`` is non-empty. Confirms
+        containment via the durable storage key prefix
+        (``users/{owner}/{segments}/``) when present, else via the local
+        storage path under the scoped user root. Fails closed (returns False)
+        when neither can be confirmed, so an owner match alone can never admit
+        a sibling scope's file.
+        """
+        owner_user_id = self.owner_user_id
+        if owner_user_id is None:
+            return True
+
+        storage_key = getattr(record, "storage_key", None)
+        if storage_key:
+            key = str(storage_key)
+            key_prefix = "/".join(["users", str(owner_user_id), *self.scope_segments])
+            return key == key_prefix or key.startswith(key_prefix + "/")
+
+        candidate = path
+        if candidate is None:
+            storage_path = getattr(record, "storage_path", None)
+            candidate = Path(storage_path) if storage_path else None
+        if candidate is not None:
+            scoped_root = self._user_workspace_base_dir(int(owner_user_id)).resolve()
+            resolved = candidate.resolve()
+            return resolved == scoped_root or resolved.is_relative_to(scoped_root)
+
+        return False
 
     def resolve_file_id(self, file_id: str) -> Optional[Path]:
         file_id = str(file_id).strip()

--- a/tests/core/test_workspace_scope_file_access.py
+++ b/tests/core/test_workspace_scope_file_access.py
@@ -94,6 +94,57 @@ def test_scoped_path_under_workspace_dir_allowed(tmp_path):
     assert ws._file_record_allowed_for_workspace(record, inside) is True
 
 
+def test_scoped_rejects_in_scope_key_with_out_of_scope_local_path(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    # A record whose durable key is in scope but whose local storage_path
+    # points at a sibling scope. resolve_file_id's local-path branch hands
+    # back the local path, so an in-scope key must NOT admit it.
+    out_of_scope = (
+        tmp_path
+        / "user_5"
+        / "clients"
+        / "3"
+        / "end_users"
+        / "8"
+        / "uploads"
+        / "leak.txt"
+    )
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/clients/3/end_users/7/uploads/f1/report.txt",
+        storage_path=str(out_of_scope),
+    )
+    # Called as resolve_file_id's local-path branch does: explicit path == the
+    # local storage_path that would be returned.
+    assert ws._file_record_allowed_for_workspace(record, out_of_scope) is False
+
+
+def test_scoped_durable_key_not_rejected_by_out_of_scope_local_path(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    # Same divergent record, but reached via the durable-materialize branch
+    # (no explicit path): resolution builds a fresh path from the in-scope
+    # key, so the stale/out-of-scope local storage_path must not cause a
+    # false rejection.
+    out_of_scope = (
+        tmp_path
+        / "user_5"
+        / "clients"
+        / "3"
+        / "end_users"
+        / "8"
+        / "uploads"
+        / "leak.txt"
+    )
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/clients/3/end_users/7/uploads/f1/report.txt",
+        storage_path=str(out_of_scope),
+    )
+    assert ws._file_record_allowed_for_workspace(record) is True
+
+
 def test_unscoped_workspace_keeps_owner_only_behavior(tmp_path):
     # No scope_segments → the new confinement is skipped; owner + task_id only.
     ws = TaskWorkspace("web_task_10", str(tmp_path))

--- a/tests/core/test_workspace_scope_file_access.py
+++ b/tests/core/test_workspace_scope_file_access.py
@@ -1,0 +1,109 @@
+"""Scope confinement for file-id resolution in TaskWorkspace.
+
+`_file_record_allowed_for_workspace` gates `resolve_file_id`. Before this
+change it keyed only on the owner `user_id` (+ optional task_id), so a scoped
+task could resolve, by file_id, a record belonging to the same owner but a
+different scope subtree (e.g. another end user's upload, `task_id=None`).
+These tests pin the scope-subtree confinement, and confirm unscoped workspaces
+keep the owner-only behavior byte-for-byte.
+"""
+
+from types import SimpleNamespace
+
+from xagent.core.workspace import TaskWorkspace
+
+_SEGMENTS = ("clients", "3", "end_users", "7")
+
+
+def _scoped_workspace(tmp_path, owner=5):
+    base_dir = tmp_path / "user_5" / "clients" / "3" / "end_users" / "7"
+    ws = TaskWorkspace("web_task_10", str(base_dir), scope_segments=_SEGMENTS)
+    ws.owner_user_id = owner
+    return ws
+
+
+def _record(**kwargs):
+    kwargs.setdefault("storage_path", None)
+    kwargs.setdefault("storage_key", None)
+    return SimpleNamespace(**kwargs)
+
+
+def test_scoped_allows_record_in_own_scope_subtree(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/clients/3/end_users/7/uploads/f1/report.txt",
+    )
+    assert ws._file_record_allowed_for_workspace(record) is True
+
+
+def test_scoped_rejects_sibling_end_user_record(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    # Same owner, different end user (8) — the pre-fix leak.
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/clients/3/end_users/8/uploads/f1/secret.txt",
+    )
+    assert ws._file_record_allowed_for_workspace(record) is False
+
+
+def test_scoped_rejects_owner_unscoped_upload(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    # Creator's own unscoped upload (task_id=None) — allowed pre-fix, now denied.
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/uploads/f1/creator.txt",
+    )
+    assert ws._file_record_allowed_for_workspace(record) is False
+
+
+def test_scoped_rejects_different_owner(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    record = _record(
+        user_id=6,
+        task_id=None,
+        storage_key="users/6/clients/3/end_users/7/uploads/f1/x.txt",
+    )
+    assert ws._file_record_allowed_for_workspace(record) is False
+
+
+def test_scoped_path_based_containment(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    in_scope = (
+        tmp_path / "user_5" / "clients" / "3" / "end_users" / "7" / "uploads" / "a.txt"
+    )
+    sibling = (
+        tmp_path / "user_5" / "clients" / "3" / "end_users" / "8" / "uploads" / "a.txt"
+    )
+
+    in_record = _record(user_id=5, task_id=None, storage_path=str(in_scope))
+    sibling_record = _record(user_id=5, task_id=None, storage_path=str(sibling))
+
+    assert ws._file_record_allowed_for_workspace(in_record) is True
+    assert ws._file_record_allowed_for_workspace(sibling_record) is False
+
+
+def test_scoped_path_under_workspace_dir_allowed(tmp_path):
+    ws = _scoped_workspace(tmp_path)
+    inside = ws.workspace_dir / "output" / "result.txt"
+    record = _record(user_id=5, task_id=None)
+    # The explicit path lands inside the task workspace → always allowed.
+    assert ws._file_record_allowed_for_workspace(record, inside) is True
+
+
+def test_unscoped_workspace_keeps_owner_only_behavior(tmp_path):
+    # No scope_segments → the new confinement is skipped; owner + task_id only.
+    ws = TaskWorkspace("web_task_10", str(tmp_path))
+    ws.owner_user_id = 5
+    record = _record(
+        user_id=5,
+        task_id=None,
+        storage_key="users/5/uploads/f1/creator.txt",
+    )
+    assert ws._file_record_allowed_for_workspace(record) is True
+
+    foreign = _record(user_id=6, task_id=None, storage_key="users/6/uploads/f/x.txt")
+    assert ws._file_record_allowed_for_workspace(foreign) is False


### PR DESCRIPTION
Partially addresses #828 — the **file-id resolution** gate (the agent-reachable half).

## Problem
`TaskWorkspace._file_record_allowed_for_workspace` (which gates `resolve_file_id`) confined a lookup to the owner `user_id` (plus optional `task_id`) only, never consulting the workspace's `scope_segments`. In a scoped workspace, a tool could therefore resolve, by `file_id`, a record owned by the same platform user but living in a **different** scope subtree — e.g. another end user's upload, which has `task_id=None` and passed the existing checks. Guarded today only by `file_id` being an unguessable UUID, not by scope.

## Change
Add a scope-subtree containment check that runs **only when the workspace carries `scope_segments`**:
- if the record has a durable `storage_key`, require it under `users/{owner}/{segments}` (prefix match);
- else (local-only record) require the `storage_path` under the scoped user root (`_user_workspace_base_dir`);
- fail closed if neither can be confirmed.

Unscoped workspaces (no `scope_segments`) skip the check entirely, so owner-only behavior is byte-for-byte unchanged.

## Tests
`tests/core/test_workspace_scope_file_access.py` (7 cases): in-scope allowed; sibling end-user rejected; owner's unscoped upload rejected; different owner rejected; path-based containment (in-scope vs sibling); explicit path under the task workspace allowed; and an unscoped-workspace regression confirming owner-only behavior is preserved. Existing `resolve_file_id`/workspace suites pass unchanged.

## Not in this PR
The durable-storage **handle binding** part of #828 (`get_user_file_storage` / `ManagedFileRef` binding to the scope prefix) is intentionally deferred: a safe version must mirror the filesystem allowlist (gate on `isolate_external_dirs`, so it doesn't block legitimate shared-file reads for scoped-but-not-isolated executions) and must account for execution-scope contextvar propagation into `ManagedFileRef`'s construction contexts. Tracked in #828.

Refs #757 (ExecutionScope), #759/#782 (ScopedFileStorage); complements #817 (scope-prefix mounts) and #825 (relative-path containment).