### PR TITLE
feat(migrate): import agents from OpenClaw and Hermes

### DIFF
--- a/src/xagent/migration/__init__.py
+++ b/src/xagent/migration/__init__.py
@@ -1,0 +1,28 @@
+"""Migrate customization footprints from other agent platforms into xagent.
+
+This package implements ``xagent migrate``, the counterpart to Hermes'
+``hermes claw migrate``. It reads a source agent platform's on-disk state
+(OpenClaw's ``~/.openclaw`` or Hermes' ``~/.hermes``), normalizes it into a
+platform-neutral :class:`~xagent.migration.bundle.MigrationBundle`, previews
+what will be imported, and then loads it into xagent.
+
+Where Hermes archives cron/heartbeat jobs for manual re-creation, xagent
+imports them directly as scheduled ``AgentTrigger`` rows -- see
+``xagent.migration.loaders``.
+"""
+
+from .bundle import (
+    ArchivedItem,
+    MigrationBundle,
+    PersonaItem,
+    ScheduleItem,
+    SkillItem,
+)
+
+__all__ = [
+    "ArchivedItem",
+    "MigrationBundle",
+    "PersonaItem",
+    "ScheduleItem",
+    "SkillItem",
+]

--- a/src/xagent/migration/adapters/__init__.py
+++ b/src/xagent/migration/adapters/__init__.py
@@ -1,0 +1,49 @@
+"""Source-platform adapters that parse an on-disk footprint into a bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..bundle import MigrationBundle
+from .base import SourceAdapter
+from .hermes import HermesAdapter
+from .openclaw import OpenClawAdapter
+
+# Registry of source adapters keyed by their CLI ``--from`` value.
+ADAPTERS: dict[str, type[SourceAdapter]] = {
+    "openclaw": OpenClawAdapter,
+    "hermes": HermesAdapter,
+}
+
+
+def detect_sources() -> list[SourceAdapter]:
+    """Return an adapter for every source platform present on this machine."""
+    found: list[SourceAdapter] = []
+    for adapter_cls in ADAPTERS.values():
+        adapter = adapter_cls()
+        if adapter.default_root().exists():
+            found.append(adapter)
+    return found
+
+
+def get_adapter(source: str, root: Path | None = None) -> SourceAdapter:
+    """Return the adapter for an explicit ``--from`` value."""
+    try:
+        adapter_cls = ADAPTERS[source]
+    except KeyError:
+        raise ValueError(
+            f"Unknown migration source {source!r}. "
+            f"Known sources: {', '.join(sorted(ADAPTERS))}."
+        ) from None
+    return adapter_cls(root=root)
+
+
+__all__ = [
+    "ADAPTERS",
+    "SourceAdapter",
+    "OpenClawAdapter",
+    "HermesAdapter",
+    "MigrationBundle",
+    "detect_sources",
+    "get_adapter",
+]

--- a/src/xagent/migration/adapters/base.py
+++ b/src/xagent/migration/adapters/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 from ..bundle import MigrationBundle, SkillItem
 
@@ -33,9 +34,13 @@ class SourceAdapter:
 
 
 def read_text(path: Path) -> str:
-    """Read a text file, tolerating undecodable bytes, or ``""`` if absent."""
+    """Read a text file, tolerating undecodable bytes, or ``""`` if absent.
+
+    ``utf-8-sig`` strips a leading BOM (common in files written on Windows),
+    which would otherwise make ``json.loads`` reject an entire config file.
+    """
     try:
-        return path.read_text(encoding="utf-8", errors="replace")
+        return path.read_text(encoding="utf-8-sig", errors="replace")
     except (OSError, UnicodeError):
         return ""
 
@@ -60,12 +65,25 @@ def collect_skill_dirs(*roots: Path) -> dict[str, Path]:
 
 
 def load_skill_dir(name: str, skill_dir: Path) -> SkillItem | None:
-    """Load a skill directory into a :class:`SkillItem`, or ``None`` if unreadable."""
+    """Load a skill directory into a :class:`SkillItem`, or ``None`` if unreadable.
+
+    Symlinks (and anything resolving outside the skill directory) are skipped
+    so a stray link cannot pull external files into the bundle; hidden
+    dot-entries are skipped because the personal-skill writer rejects them.
+    """
     files: dict[str, bytes] = {}
+    root = skill_dir.resolve()
     for file_path in sorted(skill_dir.rglob("*")):
-        if not file_path.is_file():
+        if file_path.is_symlink() or not file_path.is_file():
+            continue
+        try:
+            if not file_path.resolve().is_relative_to(root):
+                continue
+        except OSError:
             continue
         rel = str(file_path.relative_to(skill_dir)).replace("\\", "/")
+        if any(part.startswith(".") for part in rel.split("/")):
+            continue
         try:
             files[rel] = file_path.read_bytes()
         except OSError:
@@ -79,6 +97,28 @@ def load_skill_dir(name: str, skill_dir: Path) -> SkillItem | None:
         source_path=str(skill_dir),
         description=description,
     )
+
+
+def normalize_cron_entries(data: Any) -> list[Any]:
+    """Normalize a cron config value into a flat list of job entries.
+
+    Sources store jobs either as a bare list, or as a dict with a ``jobs``
+    list, or as a dict keyed by job name.
+    """
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        jobs = data.get("jobs")
+        return jobs if isinstance(jobs, list) else list(data.values())
+    return []
+
+
+def parse_interval_seconds(entry: dict[str, Any]) -> int | None:
+    """Extract a positive integer interval from a cron entry, if present."""
+    value = entry.get("interval_seconds") or entry.get("intervalSeconds")
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
 
 
 def _skill_description(skill_md: bytes) -> str:

--- a/src/xagent/migration/adapters/base.py
+++ b/src/xagent/migration/adapters/base.py
@@ -1,0 +1,90 @@
+"""Shared adapter interface and parsing helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..bundle import MigrationBundle, SkillItem
+
+
+class SourceAdapter:
+    """Read one source platform's footprint into a :class:`MigrationBundle`.
+
+    Subclasses set :attr:`key` and implement :meth:`default_root` and
+    :meth:`parse`. ``root`` overrides the auto-detected home directory (used by
+    ``--source-dir`` and by tests pointing at fixtures).
+    """
+
+    key: str = ""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = Path(root).expanduser() if root is not None else None
+
+    def default_root(self) -> Path:
+        raise NotImplementedError
+
+    @property
+    def root(self) -> Path:
+        return self._root if self._root is not None else self.default_root()
+
+    def parse(self) -> MigrationBundle:
+        raise NotImplementedError
+
+
+def read_text(path: Path) -> str:
+    """Read a text file, tolerating undecodable bytes, or ``""`` if absent."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def collect_skill_dirs(*roots: Path) -> dict[str, Path]:
+    """Map skill name -> directory for every ``SKILL.md``-bearing subdir.
+
+    Earlier roots win on name collision, matching the highest-precedence-first
+    ordering the caller passes (workspace skills before shared skills).
+    """
+    found: dict[str, Path] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            if not (child / "SKILL.md").is_file():
+                continue
+            found.setdefault(child.name, child)
+    return found
+
+
+def load_skill_dir(name: str, skill_dir: Path) -> SkillItem | None:
+    """Load a skill directory into a :class:`SkillItem`, or ``None`` if unreadable."""
+    files: dict[str, bytes] = {}
+    for file_path in sorted(skill_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel = str(file_path.relative_to(skill_dir)).replace("\\", "/")
+        try:
+            files[rel] = file_path.read_bytes()
+        except OSError:
+            continue
+    if "SKILL.md" not in files:
+        return None
+    description = _skill_description(files["SKILL.md"])
+    return SkillItem(
+        name=name,
+        files=files,
+        source_path=str(skill_dir),
+        description=description,
+    )
+
+
+def _skill_description(skill_md: bytes) -> str:
+    """Best-effort one-line description from SKILL.md frontmatter or heading."""
+    text = skill_md.decode("utf-8", errors="replace")
+    match = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
+    if match:
+        return match.group(1).strip().strip("\"'")
+    return ""

--- a/src/xagent/migration/adapters/hermes.py
+++ b/src/xagent/migration/adapters/hermes.py
@@ -20,7 +20,14 @@ from pathlib import Path
 from typing import Any
 
 from ..bundle import MigrationBundle, PersonaItem, ScheduleItem
-from .base import SourceAdapter, collect_skill_dirs, load_skill_dir, read_text
+from .base import (
+    SourceAdapter,
+    collect_skill_dirs,
+    load_skill_dir,
+    normalize_cron_entries,
+    parse_interval_seconds,
+    read_text,
+)
 
 
 class HermesAdapter(SourceAdapter):
@@ -67,13 +74,7 @@ class HermesAdapter(SourceAdapter):
             bundle.warnings.append(f"Could not parse {jobs_path}; skipping cron jobs.")
             return []
 
-        if isinstance(data, dict):
-            jobs = data.get("jobs")
-            entries = jobs if isinstance(jobs, list) else list(data.values())
-        elif isinstance(data, list):
-            entries = data
-        else:
-            entries = []
+        entries = normalize_cron_entries(data)
 
         schedules: list[ScheduleItem] = []
         for index, entry in enumerate(entries):
@@ -85,17 +86,10 @@ class HermesAdapter(SourceAdapter):
                     name=str(entry.get("name") or f"hermes-cron-{index + 1}"),
                     prompt=str(entry.get("prompt") or ""),
                     cron_expression=str(expr) if expr else None,
-                    interval_seconds=self._interval(entry),
+                    interval_seconds=parse_interval_seconds(entry),
                     timezone=str(entry["timezone"]) if entry.get("timezone") else None,
                     deliver=str(entry["deliver"]) if entry.get("deliver") else None,
                     source_path=str(jobs_path),
                 )
             )
         return schedules
-
-    @staticmethod
-    def _interval(entry: dict[str, Any]) -> int | None:
-        value = entry.get("interval_seconds") or entry.get("intervalSeconds")
-        if isinstance(value, int) and value > 0:
-            return value
-        return None

--- a/src/xagent/migration/adapters/hermes.py
+++ b/src/xagent/migration/adapters/hermes.py
@@ -1,0 +1,101 @@
+"""Parse a Hermes (``~/.hermes``) footprint into a migration bundle.
+
+Hermes layout (see hermes-agent.nousresearch.com/docs):
+
+    ~/.hermes/
+        config.yaml            model, agent, tts, mcp_servers, ...
+        SOUL.md                persona
+        memories/              MEMORY.md USER.md
+        skills/                skill dirs (agentskills.io standard SKILL.md)
+        cron/jobs.json         scheduled jobs (5-field cron expression + tz)
+
+Hermes cron jobs are the one thing Hermes itself cannot migrate from OpenClaw
+(it archives them). We parse them here so xagent can import them directly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..bundle import MigrationBundle, PersonaItem, ScheduleItem
+from .base import SourceAdapter, collect_skill_dirs, load_skill_dir, read_text
+
+
+class HermesAdapter(SourceAdapter):
+    key = "hermes"
+
+    def default_root(self) -> Path:
+        return Path.home() / ".hermes"
+
+    def parse(self) -> MigrationBundle:
+        root = self.root
+        bundle = MigrationBundle(source=self.key, source_root=str(root))
+
+        bundle.agent_name = "Hermes Agent"
+        bundle.persona = self._persona(root)
+        bundle.skills = self._skills(root)
+        bundle.schedules = self._schedules(root, bundle)
+        return bundle
+
+    def _persona(self, root: Path) -> PersonaItem | None:
+        path = root / "SOUL.md"
+        text = read_text(path).strip()
+        if not text:
+            return None
+        return PersonaItem(instructions=text, source_paths=[str(path)])
+
+    def _skills(self, root: Path) -> list:
+        dirs = collect_skill_dirs(root / "skills")
+        skills = []
+        for name, skill_dir in sorted(dirs.items()):
+            item = load_skill_dir(name, skill_dir)
+            if item is not None:
+                item.slug = name
+                skills.append(item)
+        return skills
+
+    def _schedules(self, root: Path, bundle: MigrationBundle) -> list[ScheduleItem]:
+        jobs_path = root / "cron" / "jobs.json"
+        text = read_text(jobs_path).strip()
+        if not text:
+            return []
+        try:
+            data: Any = json.loads(text)
+        except json.JSONDecodeError:
+            bundle.warnings.append(f"Could not parse {jobs_path}; skipping cron jobs.")
+            return []
+
+        if isinstance(data, dict):
+            jobs = data.get("jobs")
+            entries = jobs if isinstance(jobs, list) else list(data.values())
+        elif isinstance(data, list):
+            entries = data
+        else:
+            entries = []
+
+        schedules: list[ScheduleItem] = []
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                continue
+            expr = entry.get("schedule") or entry.get("cron")
+            schedules.append(
+                ScheduleItem(
+                    name=str(entry.get("name") or f"hermes-cron-{index + 1}"),
+                    prompt=str(entry.get("prompt") or ""),
+                    cron_expression=str(expr) if expr else None,
+                    interval_seconds=self._interval(entry),
+                    timezone=str(entry["timezone"]) if entry.get("timezone") else None,
+                    deliver=str(entry["deliver"]) if entry.get("deliver") else None,
+                    source_path=str(jobs_path),
+                )
+            )
+        return schedules
+
+    @staticmethod
+    def _interval(entry: dict[str, Any]) -> int | None:
+        value = entry.get("interval_seconds") or entry.get("intervalSeconds")
+        if isinstance(value, int) and value > 0:
+            return value
+        return None

--- a/src/xagent/migration/adapters/openclaw.py
+++ b/src/xagent/migration/adapters/openclaw.py
@@ -29,7 +29,14 @@ from ..bundle import (
     PersonaItem,
     ScheduleItem,
 )
-from .base import SourceAdapter, collect_skill_dirs, load_skill_dir, read_text
+from .base import (
+    SourceAdapter,
+    collect_skill_dirs,
+    load_skill_dir,
+    normalize_cron_entries,
+    parse_interval_seconds,
+    read_text,
+)
 
 # Workspace docs that Hermes archives for manual review; we do the same rather
 # than guess at a mapping. SOUL/IDENTITY are handled as persona instead.
@@ -40,9 +47,9 @@ def _parse_jsonish(text: str) -> dict[str, Any]:
     """Parse JSON, tolerating the JSON5-isms OpenClaw permits.
 
     OpenClaw's ``openclaw.json`` is JSON5 (comments, trailing commas). We try
-    strict JSON first, then fall back to the optional ``json5`` package, then a
-    minimal cleanup pass. Returns ``{}`` on total failure so a malformed config
-    degrades to "nothing to migrate" rather than crashing the run.
+    strict JSON first, then a minimal cleanup pass. Returns ``{}`` on total
+    failure so a malformed config degrades to "nothing to migrate" rather than
+    crashing the run.
     """
     text = text.strip()
     if not text:
@@ -52,14 +59,7 @@ def _parse_jsonish(text: str) -> dict[str, Any]:
         return result if isinstance(result, dict) else {}
     except json.JSONDecodeError:
         pass
-    try:
-        import json5  # type: ignore
-
-        result = json5.loads(text)
-        return result if isinstance(result, dict) else {}
-    except Exception:
-        pass
-    # Last resort: strip // and /* */ comments and trailing commas.
+    # Fall back: strip // and /* */ comments and trailing commas.
     stripped = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     stripped = re.sub(r"(?m)//.*$", "", stripped)
     stripped = re.sub(r",(\s*[}\]])", r"\1", stripped)
@@ -141,28 +141,18 @@ class OpenClawAdapter(SourceAdapter):
         schedules: list[ScheduleItem] = []
 
         # 1. Structured cron entries in openclaw.json.
-        cron = config.get("cron")
-        entries: list[Any] = []
-        if isinstance(cron, list):
-            entries = cron
-        elif isinstance(cron, dict):
-            jobs = cron.get("jobs")
-            entries = jobs if isinstance(jobs, list) else list(cron.values())
+        entries = normalize_cron_entries(config.get("cron"))
         for index, entry in enumerate(entries):
             if not isinstance(entry, dict):
                 continue
             prompt = entry.get("prompt") or entry.get("task") or ""
             expr = entry.get("schedule") or entry.get("cron") or entry.get("expression")
-            interval = entry.get("interval_seconds") or entry.get("intervalSeconds")
-            interval_seconds = (
-                int(interval) if isinstance(interval, int) and interval > 0 else None
-            )
             schedules.append(
                 ScheduleItem(
                     name=str(entry.get("name") or f"openclaw-cron-{index + 1}"),
                     prompt=str(prompt),
                     cron_expression=str(expr) if expr else None,
-                    interval_seconds=interval_seconds,
+                    interval_seconds=parse_interval_seconds(entry),
                     timezone=(
                         str(entry["timezone"]) if entry.get("timezone") else None
                     ),

--- a/src/xagent/migration/adapters/openclaw.py
+++ b/src/xagent/migration/adapters/openclaw.py
@@ -1,0 +1,215 @@
+"""Parse an OpenClaw (``~/.openclaw``) footprint into a migration bundle.
+
+OpenClaw layout (see docs.openclaw.ai):
+
+    ~/.openclaw/
+        openclaw.json          JSON5 config (agents, models, channels, cron, ...)
+        skills/                shared skills
+        agents/ credentials/ sessions/
+        workspace/
+            SOUL.md IDENTITY.md AGENTS.md
+            MEMORY.md USER.md memory/YYYY-MM-DD.md
+            HEARTBEAT.md       natural-language schedule ("cron for your agent")
+            skills/            workspace-scoped skills (highest precedence)
+            .agents/skills/    project-shared skills
+
+Personal cross-project skills also live in ``~/.agents/skills/``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from ..bundle import (
+    ArchivedItem,
+    MigrationBundle,
+    PersonaItem,
+    ScheduleItem,
+)
+from .base import SourceAdapter, collect_skill_dirs, load_skill_dir, read_text
+
+# Workspace docs that Hermes archives for manual review; we do the same rather
+# than guess at a mapping. SOUL/IDENTITY are handled as persona instead.
+_ARCHIVE_DOCS = ("TOOLS.md", "BOOTSTRAP.md", "AGENTS.md")
+
+
+def _parse_jsonish(text: str) -> dict[str, Any]:
+    """Parse JSON, tolerating the JSON5-isms OpenClaw permits.
+
+    OpenClaw's ``openclaw.json`` is JSON5 (comments, trailing commas). We try
+    strict JSON first, then fall back to the optional ``json5`` package, then a
+    minimal cleanup pass. Returns ``{}`` on total failure so a malformed config
+    degrades to "nothing to migrate" rather than crashing the run.
+    """
+    text = text.strip()
+    if not text:
+        return {}
+    try:
+        result = json.loads(text)
+        return result if isinstance(result, dict) else {}
+    except json.JSONDecodeError:
+        pass
+    try:
+        import json5  # type: ignore
+
+        result = json5.loads(text)
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        pass
+    # Last resort: strip // and /* */ comments and trailing commas.
+    stripped = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    stripped = re.sub(r"(?m)//.*$", "", stripped)
+    stripped = re.sub(r",(\s*[}\]])", r"\1", stripped)
+    try:
+        result = json.loads(stripped)
+        return result if isinstance(result, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _dig(config: dict[str, Any], *path: str) -> Any:
+    """Walk nested dict keys, returning ``None`` if any hop is missing."""
+    node: Any = config
+    for key in path:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    return node
+
+
+class OpenClawAdapter(SourceAdapter):
+    key = "openclaw"
+
+    def default_root(self) -> Path:
+        return Path.home() / ".openclaw"
+
+    def parse(self) -> MigrationBundle:
+        root = self.root
+        workspace = root / "workspace"
+        bundle = MigrationBundle(source=self.key, source_root=str(root))
+
+        config = _parse_jsonish(read_text(root / "openclaw.json"))
+
+        bundle.agent_name = self._agent_name(config)
+        bundle.persona = self._persona(workspace)
+        bundle.skills = self._skills(root, workspace)
+        bundle.schedules = self._schedules(config, workspace, bundle)
+        self._archive_docs(workspace, bundle)
+        return bundle
+
+    def _agent_name(self, config: dict[str, Any]) -> str:
+        name = _dig(config, "agents", "defaults", "name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return "OpenClaw Agent"
+
+    def _persona(self, workspace: Path) -> PersonaItem | None:
+        parts: list[str] = []
+        sources: list[str] = []
+        for filename in ("SOUL.md", "IDENTITY.md"):
+            path = workspace / filename
+            text = read_text(path).strip()
+            if text:
+                parts.append(text)
+                sources.append(str(path))
+        if not parts:
+            return None
+        return PersonaItem(instructions="\n\n".join(parts), source_paths=sources)
+
+    def _skills(self, root: Path, workspace: Path) -> list:
+        # Highest precedence first, matching OpenClaw's own ordering.
+        dirs = collect_skill_dirs(
+            workspace / "skills",
+            workspace / ".agents" / "skills",
+            root / "skills",
+            Path.home() / ".agents" / "skills",
+        )
+        skills = []
+        for name, skill_dir in sorted(dirs.items()):
+            item = load_skill_dir(name, skill_dir)
+            if item is not None:
+                item.slug = name
+                skills.append(item)
+        return skills
+
+    def _schedules(
+        self, config: dict[str, Any], workspace: Path, bundle: MigrationBundle
+    ) -> list[ScheduleItem]:
+        schedules: list[ScheduleItem] = []
+
+        # 1. Structured cron entries in openclaw.json.
+        cron = config.get("cron")
+        entries: list[Any] = []
+        if isinstance(cron, list):
+            entries = cron
+        elif isinstance(cron, dict):
+            jobs = cron.get("jobs")
+            entries = jobs if isinstance(jobs, list) else list(cron.values())
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                continue
+            prompt = entry.get("prompt") or entry.get("task") or ""
+            expr = entry.get("schedule") or entry.get("cron") or entry.get("expression")
+            interval = entry.get("interval_seconds") or entry.get("intervalSeconds")
+            interval_seconds = (
+                int(interval) if isinstance(interval, int) and interval > 0 else None
+            )
+            schedules.append(
+                ScheduleItem(
+                    name=str(entry.get("name") or f"openclaw-cron-{index + 1}"),
+                    prompt=str(prompt),
+                    cron_expression=str(expr) if expr else None,
+                    interval_seconds=interval_seconds,
+                    timezone=(
+                        str(entry["timezone"]) if entry.get("timezone") else None
+                    ),
+                    deliver=str(entry["deliver"]) if entry.get("deliver") else None,
+                    source_path="openclaw.json:cron",
+                )
+            )
+
+        # 2. HEARTBEAT.md -- natural-language schedule. We cannot reliably parse
+        # free text into cron here, so each non-trivial line becomes a schedule
+        # carrying its natural-language text for the loader to resolve.
+        heartbeat = read_text(workspace / "HEARTBEAT.md").strip()
+        if heartbeat:
+            for index, line in enumerate(self._heartbeat_lines(heartbeat)):
+                schedules.append(
+                    ScheduleItem(
+                        name=f"heartbeat-{index + 1}",
+                        prompt=line,
+                        natural_language=line,
+                        source_path=str(workspace / "HEARTBEAT.md"),
+                    )
+                )
+        return schedules
+
+    @staticmethod
+    def _heartbeat_lines(heartbeat: str) -> list[str]:
+        """Extract actionable lines from HEARTBEAT.md, dropping headings/blanks."""
+        lines: list[str] = []
+        for raw in heartbeat.splitlines():
+            line = raw.strip().lstrip("-*").strip()
+            if not line or line.startswith("#"):
+                continue
+            lines.append(line)
+        return lines
+
+    def _archive_docs(self, workspace: Path, bundle: MigrationBundle) -> None:
+        for filename in _ARCHIVE_DOCS:
+            path = workspace / filename
+            if path.is_file():
+                bundle.archived.append(
+                    ArchivedItem(
+                        name=filename,
+                        reason=(
+                            "No direct xagent equivalent; review and fold into "
+                            "the agent instructions or a skill."
+                        ),
+                        content=path.read_bytes(),
+                        source_path=str(path),
+                    )
+                )

--- a/src/xagent/migration/bundle.py
+++ b/src/xagent/migration/bundle.py
@@ -26,7 +26,6 @@ class SkillItem:
     source_path: str
     description: str = ""
     slug: str | None = None
-    version: str | None = None
 
 
 @dataclass
@@ -47,9 +46,9 @@ class ScheduleItem:
 
     ``cron_expression`` is a standard 5-field cron string when the source used
     one; ``interval_seconds`` is the fallback when only an interval is known.
-    ``natural_language`` carries an unparsed HEARTBEAT.md line so the loader can
-    ask an LLM to derive a schedule (see loaders); it is mutually informative
-    with the parsed fields, not exclusive.
+    ``natural_language`` carries an unparsed HEARTBEAT.md line; the loader
+    cannot turn it into a trigger yet, so it archives such items with a
+    heartbeat-specific reason for manual re-creation (see loaders).
     """
 
     name: str

--- a/src/xagent/migration/bundle.py
+++ b/src/xagent/migration/bundle.py
@@ -1,0 +1,99 @@
+"""Platform-neutral intermediate representation for a migration.
+
+Every source adapter (OpenClaw, Hermes) parses its own on-disk layout into a
+single :class:`MigrationBundle`. Downstream planning, preview and loading only
+ever look at the bundle, so the loader logic is written once regardless of
+source. This mirrors the shape Hermes' migration reports use
+(migrated / skipped / archived), so the UX carries over.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SkillItem:
+    """A skill discovered in the source platform.
+
+    ``files`` maps a relative path (always containing ``SKILL.md``) to its raw
+    bytes, matching the shape :func:`xagent.skills.parser.SkillParser.parse_bundle`
+    and the personal-skill writer expect.
+    """
+
+    name: str
+    files: dict[str, bytes]
+    source_path: str
+    description: str = ""
+    slug: str | None = None
+    version: str | None = None
+
+
+@dataclass
+class PersonaItem:
+    """Persona / identity text destined for an agent's ``instructions``.
+
+    OpenClaw splits this across ``SOUL.md`` (+ ``IDENTITY.md``); Hermes keeps a
+    single ``SOUL.md``. Adapters concatenate the pieces into ``instructions``.
+    """
+
+    instructions: str
+    source_paths: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ScheduleItem:
+    """A recurring/one-shot job to become a scheduled ``AgentTrigger``.
+
+    ``cron_expression`` is a standard 5-field cron string when the source used
+    one; ``interval_seconds`` is the fallback when only an interval is known.
+    ``natural_language`` carries an unparsed HEARTBEAT.md line so the loader can
+    ask an LLM to derive a schedule (see loaders); it is mutually informative
+    with the parsed fields, not exclusive.
+    """
+
+    name: str
+    prompt: str
+    cron_expression: str | None = None
+    interval_seconds: int | None = None
+    timezone: str | None = None
+    deliver: str | None = None
+    natural_language: str | None = None
+    source_path: str = ""
+
+
+@dataclass
+class ArchivedItem:
+    """Something we could not migrate automatically, kept for manual review.
+
+    ``reason`` explains why (unsupported concept, missing target, ambiguous
+    schedule, ...). ``content`` is written verbatim into the archive dir so the
+    user still has it.
+    """
+
+    name: str
+    reason: str
+    content: bytes = b""
+    source_path: str = ""
+
+
+@dataclass
+class MigrationBundle:
+    """Everything a single source platform yields, normalized.
+
+    ``source`` is the platform key (``"openclaw"`` / ``"hermes"``);
+    ``source_root`` is the directory it was read from. ``warnings`` collects
+    non-fatal parse issues to surface in the preview.
+    """
+
+    source: str
+    source_root: str
+    agent_name: str = "Imported Agent"
+    persona: PersonaItem | None = None
+    skills: list[SkillItem] = field(default_factory=list)
+    schedules: list[ScheduleItem] = field(default_factory=list)
+    archived: list[ArchivedItem] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (self.persona or self.skills or self.schedules or self.archived)

--- a/src/xagent/migration/cli.py
+++ b/src/xagent/migration/cli.py
@@ -105,12 +105,20 @@ def _print_preview(preview: dict) -> None:
 
 
 def _print_report(report: "LoadReport", archive_paths: list[str]) -> None:
-    print("\nMigration complete.")
+    if report.ok:
+        print("\nMigration complete.")
+    else:
+        print("\nMigration finished with errors; some items were not imported.")
     print(f"  agent created        : {report.agent_name}")
     print(f"  skills imported      : {len(report.skills_imported)}")
     if report.skills_skipped:
         print(f"  skills skipped       : {len(report.skills_skipped)}")
     print(f"  schedules imported   : {len(report.schedules_imported)}")
+    if report.schedules_skipped:
+        print(
+            f"  schedules skipped    : {len(report.schedules_skipped)}"
+            " (already imported)"
+        )
     if report.archived:
         print(f"  archived (manual)    : {len(report.archived)}")
     if archive_paths:
@@ -127,10 +135,6 @@ def _parse_and_preview(adapter: SourceAdapter) -> MigrationBundle:
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..web.models.database import get_session_local, init_db
-
-    init_db()
-
     try:
         adapters = resolve_adapters(args.source, args.source_dir)
     except ValueError as exc:
@@ -143,6 +147,20 @@ def run(args: argparse.Namespace) -> int:
         )
         return 1
 
+    if args.dry_run:
+        # Parse/preview only. The DB stack is never initialized, so a fresh
+        # install (no users yet) can still preview what a migration would do.
+        for adapter in adapters:
+            bundle = _parse_and_preview(adapter)
+            if bundle.is_empty():
+                print("  (nothing to import from this source)")
+            else:
+                print("  dry-run: no changes made.")
+        return 0
+
+    from ..web.models.database import get_session_local, init_db
+
+    init_db()
     session_local = get_session_local()
     db: Session = session_local()
     try:
@@ -154,9 +172,6 @@ def run(args: argparse.Namespace) -> int:
             bundle = _parse_and_preview(adapter)
             if bundle.is_empty():
                 print("  (nothing to import from this source)")
-                continue
-            if args.dry_run:
-                print("  dry-run: no changes made.")
                 continue
             if not args.yes and not _confirm():
                 print("  skipped.")

--- a/src/xagent/migration/cli.py
+++ b/src/xagent/migration/cli.py
@@ -1,0 +1,193 @@
+"""``xagent migrate`` command line interface.
+
+Counterpart to ``hermes claw migrate``: auto-detects a source platform on this
+machine (or takes ``--from``/``--source-dir``), previews what will be imported,
+asks for confirmation, then loads it and reports what happened -- archiving
+anything that could not be migrated automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from .adapters.base import SourceAdapter
+from .bundle import MigrationBundle
+from .runner import build_preview, resolve_adapters, run_migration
+
+if TYPE_CHECKING:
+    from ..web.models.user import User
+    from .loaders import LoadReport
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--from",
+        dest="source",
+        choices=["openclaw", "hermes"],
+        help="Source platform. Omit to auto-detect installed platforms.",
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        help="Override the source home directory (requires --from).",
+    )
+    parser.add_argument(
+        "--user",
+        dest="username",
+        help="Target xagent username. Defaults to the sole/admin user.",
+    )
+    parser.add_argument(
+        "--skill-conflict",
+        choices=["skip", "overwrite", "rename"],
+        default="skip",
+        help="What to do when a skill of the same name already exists.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the preview and exit without importing anything.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
+
+
+def _resolve_user(db: Session, username: str | None) -> "User":
+    from ..web.models.user import User
+
+    if username:
+        user = db.query(User).filter(User.username == username).first()
+        if user is None:
+            raise SystemExit(f"No xagent user named {username!r}.")
+        return user
+
+    users = db.query(User).order_by(User.id).all()
+    if not users:
+        raise SystemExit(
+            "No xagent users exist yet. Start the web app and create the first "
+            "admin user, then re-run migrate."
+        )
+    admins = [u for u in users if bool(u.is_admin)]
+    if len(users) == 1:
+        return users[0]
+    if len(admins) == 1:
+        return admins[0]
+    names = ", ".join(str(u.username) for u in users)
+    raise SystemExit(
+        f"Multiple users exist ({names}); pass --user to choose the target."
+    )
+
+
+def _print_preview(preview: dict) -> None:
+    print(f"\nSource: {preview['source']}  ({preview['source_root']})")
+    print(f"Target agent: {preview['agent_name']}")
+    print(f"  persona/instructions : {'yes' if preview['has_persona'] else 'no'}")
+    print(f"  skills               : {len(preview['skills'])}")
+    for name in preview["skills"]:
+        print(f"      - {name}")
+    print(f"  scheduled triggers   : {len(preview['schedules_importable'])}")
+    for name in preview["schedules_importable"]:
+        print(f"      - {name}")
+    archived = list(preview["schedules_archived"]) + list(preview["archived"])
+    if archived:
+        print(f"  archived (manual)    : {len(archived)}")
+        for name in archived:
+            print(f"      - {name}")
+    for warning in preview["warnings"]:
+        print(f"  ! {warning}")
+
+
+def _print_report(report: "LoadReport", archive_paths: list[str]) -> None:
+    print("\nMigration complete.")
+    print(f"  agent created        : {report.agent_name}")
+    print(f"  skills imported      : {len(report.skills_imported)}")
+    if report.skills_skipped:
+        print(f"  skills skipped       : {len(report.skills_skipped)}")
+    print(f"  schedules imported   : {len(report.schedules_imported)}")
+    if report.archived:
+        print(f"  archived (manual)    : {len(report.archived)}")
+    if archive_paths:
+        archive_root = str(Path(archive_paths[0]).parent)
+        print(f"  archive directory    : {archive_root}")
+    for error in report.errors:
+        print(f"  ! {error}")
+
+
+def _parse_and_preview(adapter: SourceAdapter) -> MigrationBundle:
+    bundle = adapter.parse()
+    _print_preview(build_preview(bundle))
+    return bundle
+
+
+def run(args: argparse.Namespace) -> int:
+    from ..web.models.database import get_session_local, init_db
+
+    init_db()
+
+    try:
+        adapters = resolve_adapters(args.source, args.source_dir)
+    except ValueError as exc:
+        raise SystemExit(str(exc))
+
+    if not adapters:
+        print(
+            "No source platform detected. Looked for ~/.openclaw and ~/.hermes.\n"
+            "Pass --from openclaw|hermes with --source-dir to point at a copy."
+        )
+        return 1
+
+    session_local = get_session_local()
+    db: Session = session_local()
+    try:
+        user = _resolve_user(db, args.username)
+        print(f"Importing into xagent user: {user.username}")
+
+        exit_code = 0
+        for adapter in adapters:
+            bundle = _parse_and_preview(adapter)
+            if bundle.is_empty():
+                print("  (nothing to import from this source)")
+                continue
+            if args.dry_run:
+                print("  dry-run: no changes made.")
+                continue
+            if not args.yes and not _confirm():
+                print("  skipped.")
+                continue
+            report, archive_paths = run_migration(
+                db,
+                user=user,
+                bundle=bundle,
+                skill_conflict=args.skill_conflict,
+            )
+            _print_report(report, archive_paths)
+            if report.errors:
+                exit_code = 1
+        return exit_code
+    finally:
+        db.close()
+
+
+def _confirm() -> bool:
+    try:
+        answer = input("\nProceed with import? [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"y", "yes"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="xagent migrate",
+        description="Import an agent from OpenClaw or Hermes into xagent.",
+    )
+    add_arguments(parser)
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    return run(args)

--- a/src/xagent/migration/loaders.py
+++ b/src/xagent/migration/loaders.py
@@ -7,20 +7,22 @@ inherits the same validation and storage the product uses everywhere else:
 * persona   -> a new ``Agent`` (persona text becomes ``instructions``)
 * skills    -> personal ``UserSkill`` rows (same writer as Skill Hub imports)
 * schedules -> scheduled ``AgentTrigger`` rows when an interval is known;
-               cron-expression jobs are archived pending the cron engine
-               (see :data:`CRON_UNSUPPORTED_REASON`).
+               cron-expression jobs and natural-language heartbeat lines are
+               archived pending the cron engine (see
+               :data:`CRON_UNSUPPORTED_REASON` /
+               :data:`HEARTBEAT_UNSUPPORTED_REASON`).
 """
 
 from __future__ import annotations
 
-import hashlib
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
 from sqlalchemy.orm import Session
 
 from ..web.models.agent import Agent
-from ..web.models.skill import UserSkill, UserSkillFile
+from ..web.models.skill import UserSkill
 from ..web.models.user import User
 from .bundle import ArchivedItem, MigrationBundle
 
@@ -33,6 +35,19 @@ CRON_UNSUPPORTED_REASON = (
     "recreate this job as an interval-based trigger, or wait for cron support."
 )
 
+# HEARTBEAT.md lines carry a schedule in free text ("Check HN each morning").
+# We cannot reliably turn that into an interval, so they are archived with a
+# reason that says so instead of the cron-expression one.
+HEARTBEAT_UNSUPPORTED_REASON = (
+    "Natural-language schedules (HEARTBEAT.md) cannot be translated into a "
+    "trigger automatically; recreate this line as an interval-based trigger."
+)
+
+# Skill Hub requires names matching [A-Za-z0-9_-]+; source directory names may
+# contain anything the filesystem allows, so runs of other characters collapse
+# to a single dash before insert.
+_INVALID_SKILL_NAME_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
+
 
 @dataclass
 class LoadReport:
@@ -42,8 +57,14 @@ class LoadReport:
     skills_imported: list[str] = field(default_factory=list)
     skills_skipped: list[str] = field(default_factory=list)
     schedules_imported: list[str] = field(default_factory=list)
+    schedules_skipped: list[str] = field(default_factory=list)
     archived: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when every artifact loaded cleanly (a partial import is not ok)."""
+        return not self.errors
 
 
 class MigrationLoader:
@@ -118,9 +139,11 @@ class MigrationLoader:
                     name=skill.name,
                     files=skill.files,
                     slug=skill.slug,
-                    version=skill.version,
                 )
-            except Exception as exc:  # pragma: no cover - defensive per-skill
+            except Exception as exc:
+                # Reset the session so one bad skill cannot poison every
+                # subsequent write in this run with PendingRollbackError.
+                self.db.rollback()
                 report.errors.append(f"skill {skill.name!r}: {exc}")
                 continue
             if imported_name is None:
@@ -134,18 +157,22 @@ class MigrationLoader:
         name: str,
         files: dict[str, bytes],
         slug: str | None,
-        version: str | None,
     ) -> str | None:
         """Insert one personal skill, honoring the conflict strategy.
 
-        Returns the stored name, or ``None`` when a conflict caused a skip.
+        The actual write is delegated to Skill Hub's ``_write_personal_skill``
+        so migration inherits its name validation, path-traversal checks and
+        total-size budget. Returns the stored name, or ``None`` when a
+        conflict caused a skip.
         """
+        from ..web.api.skill_hub import _write_personal_skill
+
+        target_name = _normalize_skill_name(name)
         existing = (
             self.db.query(UserSkill)
-            .filter(UserSkill.user_id == self.user_id, UserSkill.name == name)
+            .filter(UserSkill.user_id == self.user_id, UserSkill.name == target_name)
             .first()
         )
-        target_name = name
         if existing is not None:
             if self.skill_conflict == "skip":
                 return None
@@ -153,35 +180,22 @@ class MigrationLoader:
                 self.db.delete(existing)
                 self.db.flush()
             elif self.skill_conflict == "rename":
-                target_name = self._unique_skill_name(name)
+                target_name = self._unique_skill_name(target_name)
 
-        skill_row = UserSkill(
-            user_id=self.user_id,
+        _write_personal_skill(
+            db=self.db,
+            user=self.user,
             name=target_name,
+            files=files,
             origin="imported",
-            clawhub_slug=slug,
-            clawhub_version=version,
-            created_by_user_id=self.user_id,
-            updated_by_user_id=self.user_id,
+            clawhub_slug=slug[:128] if slug else None,
         )
-        self.db.add(skill_row)
-        self.db.flush()
-        for path, content in sorted(files.items()):
-            self.db.add(
-                UserSkillFile(
-                    skill_id=skill_row.id,
-                    path=path,
-                    content=content,
-                    size_bytes=len(content),
-                    sha256=hashlib.sha256(content).hexdigest(),
-                    media_type=_guess_media_type(path),
-                )
-            )
-        self.db.commit()
         return target_name
 
     def _unique_skill_name(self, desired: str) -> str:
-        candidate = f"{desired}-imported"
+        # Leave room for the suffix inside UserSkill.name's 100-char column.
+        base = desired[:80]
+        candidate = f"{base}-imported"
         suffix = 2
         while (
             self.db.query(UserSkill.id)
@@ -189,7 +203,7 @@ class MigrationLoader:
             .first()
             is not None
         ):
-            candidate = f"{desired}-imported-{suffix}"
+            candidate = f"{base}-imported-{suffix}"
             suffix += 1
         return candidate
 
@@ -201,17 +215,31 @@ class MigrationLoader:
         from ..web.services.triggers import create_agent_trigger
 
         for schedule in bundle.schedules:
-            # The scheduler only understands intervals today. A job that only
-            # carries a cron expression is archived rather than mis-scheduled.
+            # The scheduler only understands intervals today. Cron-expression
+            # jobs and natural-language heartbeat lines are archived (each with
+            # its own reason) rather than mis-scheduled.
             if schedule.interval_seconds is None:
+                reason = (
+                    HEARTBEAT_UNSUPPORTED_REASON
+                    if schedule.natural_language
+                    else CRON_UNSUPPORTED_REASON
+                )
                 bundle.archived.append(
                     ArchivedItem(
                         name=schedule.name,
-                        reason=CRON_UNSUPPORTED_REASON,
+                        reason=reason,
                         content=(schedule.prompt or "").encode("utf-8"),
                         source_path=schedule.source_path,
                     )
                 )
+                continue
+            trigger_name = schedule.name[:200]
+            interval = int(schedule.interval_seconds)
+            prompt = schedule.prompt or None
+            if self._trigger_exists(
+                name=trigger_name, interval=interval, prompt=prompt
+            ):
+                report.schedules_skipped.append(schedule.name)
                 continue
             try:
                 create_agent_trigger(
@@ -219,14 +247,44 @@ class MigrationLoader:
                     user_id=self.user_id,
                     agent_id=int(agent.id),
                     trigger_type="scheduled",
-                    name=schedule.name[:200],
-                    config={"interval_seconds": int(schedule.interval_seconds)},
-                    prompt_template=schedule.prompt or None,
+                    name=trigger_name,
+                    config={"interval_seconds": interval},
+                    prompt_template=prompt,
                 )
-            except Exception as exc:  # pragma: no cover - defensive per-schedule
+            except Exception as exc:
+                # Same session hygiene as the skill path above.
+                self.db.rollback()
                 report.errors.append(f"schedule {schedule.name!r}: {exc}")
                 continue
             report.schedules_imported.append(schedule.name)
+
+    def _trigger_exists(self, *, name: str, interval: int, prompt: str | None) -> bool:
+        """True when an earlier migration run already created this trigger.
+
+        Agents are renamed per run, so the lookup goes by the user's triggers
+        rather than the agent's -- otherwise every re-run would add another
+        independently-firing copy of the same source job.
+        """
+        from ..web.models.trigger import AgentTrigger
+
+        candidates = (
+            self.db.query(AgentTrigger)
+            .filter(
+                AgentTrigger.user_id == self.user_id,
+                AgentTrigger.type == "scheduled",
+                AgentTrigger.name == name,
+            )
+            .all()
+        )
+        for candidate in candidates:
+            raw_config = candidate.config
+            config: dict[str, Any] = raw_config if isinstance(raw_config, dict) else {}
+            if (
+                config.get("interval_seconds") == interval
+                and (candidate.prompt_template or None) == prompt
+            ):
+                return True
+        return False
 
     # -- archive -----------------------------------------------------------
 
@@ -235,14 +293,12 @@ class MigrationLoader:
             report.archived.append(item.name)
 
 
-def _guess_media_type(path: str) -> str | None:
-    """Reuse the Skill-library media-type guess, tolerating import failure."""
-    try:
-        from ..skills.library import guess_media_type
-
-        return guess_media_type(path)
-    except Exception:  # pragma: no cover - fallback only
-        return None
+def _normalize_skill_name(name: str) -> str:
+    """Map a source directory name onto Skill Hub's naming rule."""
+    cleaned = _INVALID_SKILL_NAME_CHARS.sub("-", name).strip("-_")[:100]
+    if not cleaned:
+        raise ValueError(f"skill name {name!r} has no usable characters")
+    return cleaned
 
 
 def as_dict(report: LoadReport) -> dict[str, Any]:
@@ -252,6 +308,8 @@ def as_dict(report: LoadReport) -> dict[str, Any]:
         "skills_imported": report.skills_imported,
         "skills_skipped": report.skills_skipped,
         "schedules_imported": report.schedules_imported,
+        "schedules_skipped": report.schedules_skipped,
         "archived": report.archived,
         "errors": report.errors,
+        "ok": report.ok,
     }

--- a/src/xagent/migration/loaders.py
+++ b/src/xagent/migration/loaders.py
@@ -1,0 +1,257 @@
+"""Load a :class:`MigrationBundle` into xagent, reusing existing services.
+
+The loader is intentionally source-agnostic: it only consumes the neutral
+bundle. Each artifact type maps to an existing xagent write path so migration
+inherits the same validation and storage the product uses everywhere else:
+
+* persona   -> a new ``Agent`` (persona text becomes ``instructions``)
+* skills    -> personal ``UserSkill`` rows (same writer as Skill Hub imports)
+* schedules -> scheduled ``AgentTrigger`` rows when an interval is known;
+               cron-expression jobs are archived pending the cron engine
+               (see :data:`CRON_UNSUPPORTED_REASON`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ..web.models.agent import Agent
+from ..web.models.skill import UserSkill, UserSkillFile
+from ..web.models.user import User
+from .bundle import ArchivedItem, MigrationBundle
+
+# xagent's scheduled triggers currently fire on a fixed interval only; standard
+# 5-field cron expressions are not yet supported by the scheduler. Until the
+# cron engine lands (planned follow-up), such jobs are archived with this reason
+# rather than silently approximated into the wrong cadence.
+CRON_UNSUPPORTED_REASON = (
+    "Cron-expression schedules are not yet supported by the xagent scheduler; "
+    "recreate this job as an interval-based trigger, or wait for cron support."
+)
+
+
+@dataclass
+class LoadReport:
+    """Per-run tally of what happened, mirroring Hermes' migration report."""
+
+    agent_name: str | None = None
+    skills_imported: list[str] = field(default_factory=list)
+    skills_skipped: list[str] = field(default_factory=list)
+    schedules_imported: list[str] = field(default_factory=list)
+    archived: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+class MigrationLoader:
+    """Write a parsed bundle into the database for a target user."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        user: User,
+        skill_conflict: str = "skip",
+    ) -> None:
+        self.db = db
+        self.user = user
+        self.user_id = int(user.id)
+        if skill_conflict not in {"skip", "overwrite", "rename"}:
+            raise ValueError(f"Unknown skill_conflict strategy {skill_conflict!r}")
+        self.skill_conflict = skill_conflict
+
+    def load(self, bundle: MigrationBundle) -> LoadReport:
+        report = LoadReport()
+        agent = self._load_agent(bundle, report)
+        self._load_skills(bundle, report)
+        self._load_schedules(bundle, agent, report)
+        self._record_archived(bundle, report)
+        return report
+
+    # -- agent / persona ---------------------------------------------------
+
+    def _load_agent(self, bundle: MigrationBundle, report: LoadReport) -> Agent:
+        """Create the owning agent, carrying persona text into instructions."""
+        instructions = bundle.persona.instructions if bundle.persona else None
+        name = self._unique_agent_name(bundle.agent_name)
+        agent = Agent(
+            user_id=self.user_id,
+            name=name,
+            description=f"Imported from {bundle.source}.",
+            instructions=instructions,
+            execution_mode="balanced",
+            models={},
+            knowledge_bases=[],
+            skills=[],
+            tool_categories=[],
+            suggested_prompts=[],
+        )
+        self.db.add(agent)
+        self.db.commit()
+        self.db.refresh(agent)
+        report.agent_name = name
+        return agent
+
+    def _unique_agent_name(self, desired: str) -> str:
+        base = (desired or "Imported Agent").strip()[:180]
+        candidate = base
+        suffix = 2
+        while (
+            self.db.query(Agent.id)
+            .filter(Agent.user_id == self.user_id, Agent.name == candidate)
+            .first()
+            is not None
+        ):
+            candidate = f"{base} ({suffix})"
+            suffix += 1
+        return candidate
+
+    # -- skills ------------------------------------------------------------
+
+    def _load_skills(self, bundle: MigrationBundle, report: LoadReport) -> None:
+        for skill in bundle.skills:
+            try:
+                imported_name = self._write_skill(
+                    name=skill.name,
+                    files=skill.files,
+                    slug=skill.slug,
+                    version=skill.version,
+                )
+            except Exception as exc:  # pragma: no cover - defensive per-skill
+                report.errors.append(f"skill {skill.name!r}: {exc}")
+                continue
+            if imported_name is None:
+                report.skills_skipped.append(skill.name)
+            else:
+                report.skills_imported.append(imported_name)
+
+    def _write_skill(
+        self,
+        *,
+        name: str,
+        files: dict[str, bytes],
+        slug: str | None,
+        version: str | None,
+    ) -> str | None:
+        """Insert one personal skill, honoring the conflict strategy.
+
+        Returns the stored name, or ``None`` when a conflict caused a skip.
+        """
+        existing = (
+            self.db.query(UserSkill)
+            .filter(UserSkill.user_id == self.user_id, UserSkill.name == name)
+            .first()
+        )
+        target_name = name
+        if existing is not None:
+            if self.skill_conflict == "skip":
+                return None
+            if self.skill_conflict == "overwrite":
+                self.db.delete(existing)
+                self.db.flush()
+            elif self.skill_conflict == "rename":
+                target_name = self._unique_skill_name(name)
+
+        skill_row = UserSkill(
+            user_id=self.user_id,
+            name=target_name,
+            origin="imported",
+            clawhub_slug=slug,
+            clawhub_version=version,
+            created_by_user_id=self.user_id,
+            updated_by_user_id=self.user_id,
+        )
+        self.db.add(skill_row)
+        self.db.flush()
+        for path, content in sorted(files.items()):
+            self.db.add(
+                UserSkillFile(
+                    skill_id=skill_row.id,
+                    path=path,
+                    content=content,
+                    size_bytes=len(content),
+                    sha256=hashlib.sha256(content).hexdigest(),
+                    media_type=_guess_media_type(path),
+                )
+            )
+        self.db.commit()
+        return target_name
+
+    def _unique_skill_name(self, desired: str) -> str:
+        candidate = f"{desired}-imported"
+        suffix = 2
+        while (
+            self.db.query(UserSkill.id)
+            .filter(UserSkill.user_id == self.user_id, UserSkill.name == candidate)
+            .first()
+            is not None
+        ):
+            candidate = f"{desired}-imported-{suffix}"
+            suffix += 1
+        return candidate
+
+    # -- schedules ---------------------------------------------------------
+
+    def _load_schedules(
+        self, bundle: MigrationBundle, agent: Agent, report: LoadReport
+    ) -> None:
+        from ..web.services.triggers import create_agent_trigger
+
+        for schedule in bundle.schedules:
+            # The scheduler only understands intervals today. A job that only
+            # carries a cron expression is archived rather than mis-scheduled.
+            if schedule.interval_seconds is None:
+                bundle.archived.append(
+                    ArchivedItem(
+                        name=schedule.name,
+                        reason=CRON_UNSUPPORTED_REASON,
+                        content=(schedule.prompt or "").encode("utf-8"),
+                        source_path=schedule.source_path,
+                    )
+                )
+                continue
+            try:
+                create_agent_trigger(
+                    self.db,
+                    user_id=self.user_id,
+                    agent_id=int(agent.id),
+                    trigger_type="scheduled",
+                    name=schedule.name[:200],
+                    config={"interval_seconds": int(schedule.interval_seconds)},
+                    prompt_template=schedule.prompt or None,
+                )
+            except Exception as exc:  # pragma: no cover - defensive per-schedule
+                report.errors.append(f"schedule {schedule.name!r}: {exc}")
+                continue
+            report.schedules_imported.append(schedule.name)
+
+    # -- archive -----------------------------------------------------------
+
+    def _record_archived(self, bundle: MigrationBundle, report: LoadReport) -> None:
+        for item in bundle.archived:
+            report.archived.append(item.name)
+
+
+def _guess_media_type(path: str) -> str | None:
+    """Reuse the Skill-library media-type guess, tolerating import failure."""
+    try:
+        from ..skills.library import guess_media_type
+
+        return guess_media_type(path)
+    except Exception:  # pragma: no cover - fallback only
+        return None
+
+
+def as_dict(report: LoadReport) -> dict[str, Any]:
+    """Serialize a report for JSON output / logging."""
+    return {
+        "agent_name": report.agent_name,
+        "skills_imported": report.skills_imported,
+        "skills_skipped": report.skills_skipped,
+        "schedules_imported": report.schedules_imported,
+        "archived": report.archived,
+        "errors": report.errors,
+    }

--- a/src/xagent/migration/runner.py
+++ b/src/xagent/migration/runner.py
@@ -83,9 +83,14 @@ def write_archive(bundle: MigrationBundle, archive_dir: Path) -> list[str]:
             continue
         reasons.append(f"{out_path.name}\t<- {item.source_path}\n  {item.reason}")
     if reasons:
-        (archive_dir / "REASON.txt").write_text(
-            "\n".join(reasons) + "\n", encoding="utf-8"
-        )
+        # By now the DB import has already committed; a full disk or bad
+        # permissions here must not abort the run after the fact.
+        try:
+            (archive_dir / "REASON.txt").write_text(
+                "\n".join(reasons) + "\n", encoding="utf-8"
+            )
+        except OSError:
+            pass
     return written
 
 

--- a/src/xagent/migration/runner.py
+++ b/src/xagent/migration/runner.py
@@ -1,0 +1,117 @@
+"""Orchestrate a migration: detect -> parse -> preview -> load -> archive.
+
+This is the engine behind ``xagent migrate``. It is deliberately free of
+argparse/stdio wiring (that lives in the CLI) so it can be unit-tested and
+reused by a future web endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from .adapters import detect_sources, get_adapter
+from .adapters.base import SourceAdapter
+from .bundle import MigrationBundle
+
+if TYPE_CHECKING:
+    from ..web.models.user import User
+    from .loaders import LoadReport
+
+
+def build_preview(bundle: MigrationBundle) -> dict[str, object]:
+    """Summarize a bundle for the pre-migration confirmation screen."""
+    interval_schedules = [s for s in bundle.schedules if s.interval_seconds is not None]
+    cron_only = [s for s in bundle.schedules if s.interval_seconds is None]
+    return {
+        "source": bundle.source,
+        "source_root": bundle.source_root,
+        "agent_name": bundle.agent_name,
+        "has_persona": bundle.persona is not None,
+        "skills": [s.name for s in bundle.skills],
+        "schedules_importable": [s.name for s in interval_schedules],
+        "schedules_archived": [s.name for s in cron_only],
+        "archived": [a.name for a in bundle.archived],
+        "warnings": list(bundle.warnings),
+    }
+
+
+def resolve_adapters(
+    source: str | None, source_dir: Path | None
+) -> list[SourceAdapter]:
+    """Pick adapters from an explicit ``--from`` or by auto-detection."""
+    if source:
+        return [get_adapter(source, root=source_dir)]
+    if source_dir is not None:
+        raise ValueError("--source-dir requires --from to name the platform.")
+    return detect_sources()
+
+
+def archive_dir_for(source: str, timestamp: datetime) -> Path:
+    """Return the archive directory for a run, matching Hermes' layout."""
+    from ..config import get_storage_root
+
+    stamp = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    return get_storage_root() / "migration" / source / stamp / "archive"
+
+
+def write_archive(bundle: MigrationBundle, archive_dir: Path) -> list[str]:
+    """Persist non-migratable items to disk for manual review.
+
+    Returns the list of written file paths. Each item is written under a
+    filesystem-safe name; a sibling ``REASON.txt`` records why it could not be
+    migrated automatically.
+    """
+    if not bundle.archived:
+        return []
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+    reasons: list[str] = []
+    for index, item in enumerate(bundle.archived):
+        safe = _safe_name(item.name) or f"item-{index + 1}"
+        out_path = archive_dir / safe
+        # Avoid clobbering same-named archived items (e.g. two "TOOLS.md").
+        if out_path.exists():
+            out_path = archive_dir / f"{index + 1}-{safe}"
+        try:
+            out_path.write_bytes(item.content or b"")
+            written.append(str(out_path))
+        except OSError:
+            continue
+        reasons.append(f"{out_path.name}\t<- {item.source_path}\n  {item.reason}")
+    if reasons:
+        (archive_dir / "REASON.txt").write_text(
+            "\n".join(reasons) + "\n", encoding="utf-8"
+        )
+    return written
+
+
+def _safe_name(name: str) -> str:
+    keep = [c if c.isalnum() or c in "-._" else "_" for c in name]
+    return "".join(keep).strip("._")[:120]
+
+
+def run_migration(
+    db: Session,
+    *,
+    user: "User",
+    bundle: MigrationBundle,
+    skill_conflict: str = "skip",
+    now: datetime | None = None,
+) -> tuple["LoadReport", list[str]]:
+    """Load a bundle and archive its non-migratable items.
+
+    Returns the load report and the list of archived file paths.
+    """
+    # Imported lazily so the parse/preview path (used by ``--dry-run`` and the
+    # confirmation screen) does not pull in the web DB model stack.
+    from .loaders import MigrationLoader
+
+    loader = MigrationLoader(db, user=user, skill_conflict=skill_conflict)
+    report = loader.load(bundle)
+    stamp = now or datetime.now(timezone.utc)
+    archive_paths = write_archive(bundle, archive_dir_for(bundle.source, stamp))
+    return report, archive_paths

--- a/src/xagent/web/__main__.py
+++ b/src/xagent/web/__main__.py
@@ -119,7 +119,16 @@ Examples:
 
 
 def main() -> None:
-    """Main function"""
+    """Main function.
+
+    ``xagent migrate ...`` dispatches to the migration CLI; every other
+    invocation starts the web service (the historical behavior).
+    """
+    if len(sys.argv) > 1 and sys.argv[1] == "migrate":
+        from ..migration.cli import main as migrate_main
+
+        raise SystemExit(migrate_main(sys.argv[2:]))
+
     args = parse_args()
 
     # Configure logging BEFORE importing app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,14 @@ from xagent.core.tracing.langfuse import reset_langfuse_client
 # ==========================================
 
 
-if not hasattr(pathlib.Path, "_flavour") and hasattr(pathlib.PosixPath, "_flavour"):
+# On Windows this would shadow WindowsPath._flavour (Path precedes
+# PureWindowsPath in WindowsPath's MRO) and break every Path() call with
+# NotImplementedError, so it only applies on POSIX.
+if (
+    os.name != "nt"
+    and not hasattr(pathlib.Path, "_flavour")
+    and hasattr(pathlib.PosixPath, "_flavour")
+):
     pathlib.Path._flavour = pathlib.PosixPath._flavour
 
 # Load environment variables - try .env first, fallback to example.env

--- a/tests/migration/test_platform_migration.py
+++ b/tests/migration/test_platform_migration.py
@@ -15,9 +15,15 @@ from typing import Iterator
 
 import pytest
 
+from xagent.migration.adapters.base import load_skill_dir
 from xagent.migration.adapters.hermes import HermesAdapter
 from xagent.migration.adapters.openclaw import OpenClawAdapter
-from xagent.migration.loaders import CRON_UNSUPPORTED_REASON, MigrationLoader
+from xagent.migration.bundle import MigrationBundle, ScheduleItem, SkillItem
+from xagent.migration.loaders import (
+    CRON_UNSUPPORTED_REASON,
+    HEARTBEAT_UNSUPPORTED_REASON,
+    MigrationLoader,
+)
 from xagent.migration.runner import build_preview, write_archive
 
 
@@ -133,6 +139,17 @@ def test_malformed_openclaw_config_does_not_crash(tmp_path: Path) -> None:
     bundle = OpenClawAdapter(root=root).parse()
     assert bundle.persona is not None
     assert bundle.schedules == []
+
+
+def test_openclaw_config_with_utf8_bom_parses(tmp_path: Path) -> None:
+    """Files written on Windows often carry a BOM; it must not nuke the config."""
+    root = tmp_path / "openclaw"
+    root.mkdir()
+    (root / "openclaw.json").write_bytes(
+        b'\xef\xbb\xbf{"agents": {"defaults": {"name": "Clawbot"}}}'
+    )
+    bundle = OpenClawAdapter(root=root).parse()
+    assert bundle.agent_name == "Clawbot"
 
 
 def test_build_preview_splits_importable_and_archived(openclaw_home: Path) -> None:
@@ -261,3 +278,135 @@ def test_write_archive_persists_items(tmp_path: Path, openclaw_home: Path) -> No
     assert written
     assert (archive_dir / "REASON.txt").exists()
     assert (archive_dir / "TOOLS.md").read_bytes() == b"legacy tool notes"
+
+
+def test_loader_one_bad_skill_does_not_poison_the_run(db_session) -> None:
+    """A failing skill is reported, and everything after it still imports."""
+    user = _make_user(db_session)
+    bundle = MigrationBundle(source="hermes", source_root="x")
+    bundle.skills = [
+        # No SKILL.md -> rejected by the Skill Hub writer's validation.
+        SkillItem(name="broken", files={"notes.md": b"n"}, source_path="x"),
+        SkillItem(
+            name="good",
+            files={"SKILL.md": b"---\ndescription: d\n---\n"},
+            source_path="x",
+        ),
+    ]
+    bundle.schedules = [ScheduleItem(name="tick", prompt="tick", interval_seconds=60)]
+
+    report = MigrationLoader(db_session, user=user).load(bundle)
+
+    assert len(report.errors) == 1
+    assert "broken" in report.errors[0]
+    assert report.skills_imported == ["good"]
+    assert report.schedules_imported == ["tick"]
+    assert not report.ok
+
+
+def test_loader_normalizes_skill_names_to_hub_rules(db_session) -> None:
+    from xagent.web.models.skill import UserSkill
+
+    user = _make_user(db_session)
+    bundle = MigrationBundle(source="hermes", source_root="x")
+    bundle.skills = [
+        SkillItem(
+            name="my skill!",
+            files={"SKILL.md": b"---\ndescription: d\n---\n"},
+            source_path="x",
+        ),
+    ]
+
+    report = MigrationLoader(db_session, user=user).load(bundle)
+
+    assert report.skills_imported == ["my-skill"]
+    names = {
+        s.name for s in db_session.query(UserSkill).filter(UserSkill.user_id == user.id)
+    }
+    assert names == {"my-skill"}
+
+
+def test_rerunning_migration_does_not_duplicate_triggers(
+    db_session, hermes_home: Path
+) -> None:
+    from xagent.web.models.trigger import AgentTrigger
+
+    user = _make_user(db_session)
+    MigrationLoader(db_session, user=user).load(HermesAdapter(root=hermes_home).parse())
+    report2 = MigrationLoader(db_session, user=user).load(
+        HermesAdapter(root=hermes_home).parse()
+    )
+
+    triggers = (
+        db_session.query(AgentTrigger).filter(AgentTrigger.user_id == user.id).all()
+    )
+    assert len(triggers) == 1
+    assert report2.schedules_imported == []
+    assert report2.schedules_skipped == ["tick"]
+
+
+def test_heartbeat_schedules_archived_with_their_own_reason(
+    db_session, openclaw_home: Path
+) -> None:
+    user = _make_user(db_session)
+    bundle = OpenClawAdapter(root=openclaw_home).parse()
+
+    MigrationLoader(db_session, user=user).load(bundle)
+
+    reasons = {a.name: a.reason for a in bundle.archived}
+    assert reasons["brief"] == CRON_UNSUPPORTED_REASON
+    assert reasons["heartbeat-1"] == HEARTBEAT_UNSUPPORTED_REASON
+
+
+def test_load_skill_dir_skips_hidden_files(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skill"
+    _write(skill_dir / "SKILL.md", "---\ndescription: d\n---\n")
+    _write(skill_dir / ".DS_Store", "junk")
+    _write(skill_dir / ".git" / "config", "junk")
+
+    item = load_skill_dir("skill", skill_dir)
+
+    assert item is not None
+    assert set(item.files) == {"SKILL.md"}
+
+
+def test_load_skill_dir_skips_symlinks(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    skill_dir = tmp_path / "skill"
+    _write(skill_dir / "SKILL.md", "---\ndescription: d\n---\n")
+    try:
+        (skill_dir / "leak.txt").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available on this platform/user")
+
+    item = load_skill_dir("skill", skill_dir)
+
+    assert item is not None
+    assert set(item.files) == {"SKILL.md"}
+
+
+def test_dry_run_never_initializes_the_db(
+    openclaw_home: Path, monkeypatch, capsys
+) -> None:
+    """A fresh install (no users yet) must still be able to preview."""
+    import argparse
+
+    from xagent.migration import cli
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("dry-run must not initialize the DB")
+
+    monkeypatch.setattr("xagent.web.models.database.init_db", _boom)
+    args = argparse.Namespace(
+        source="openclaw",
+        source_dir=openclaw_home,
+        username=None,
+        skill_conflict="skip",
+        dry_run=True,
+        yes=False,
+    )
+
+    assert cli.run(args) == 0
+    out = capsys.readouterr().out
+    assert "dry-run: no changes made." in out

--- a/tests/migration/test_platform_migration.py
+++ b/tests/migration/test_platform_migration.py
@@ -1,0 +1,263 @@
+"""Tests for ``xagent migrate`` (OpenClaw / Hermes -> xagent).
+
+Covers adapter parsing (pure, filesystem fixtures) and the end-to-end loader
+against a fresh SQLite database.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from xagent.migration.adapters.hermes import HermesAdapter
+from xagent.migration.adapters.openclaw import OpenClawAdapter
+from xagent.migration.loaders import CRON_UNSUPPORTED_REASON, MigrationLoader
+from xagent.migration.runner import build_preview, write_archive
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Fixtures: synthetic source homes
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def openclaw_home(tmp_path: Path) -> Path:
+    root = tmp_path / "openclaw"
+    ws = root / "workspace"
+    _write(ws / "SOUL.md", "You are Clawbot. Be terse.")
+    _write(ws / "IDENTITY.md", "Name: Clawbot")
+    _write(ws / "TOOLS.md", "legacy tool notes")
+    _write(ws / "HEARTBEAT.md", "# Heartbeat\n- Check HN each morning\n")
+    _write(
+        ws / "skills" / "hn-digest" / "SKILL.md",
+        "---\ndescription: Summarize HN\n---\n## Description\nSummarize HN.\n",
+    )
+    _write(ws / "skills" / "hn-digest" / "template.md", "body")
+    _write(
+        root / "openclaw.json",
+        # JSON5: comment + trailing comma exercise the tolerant parser.
+        '{\n  // config\n  "agents": {"defaults": {"name": "Clawbot"}},\n'
+        '  "cron": [\n'
+        '    {"name": "brief", "prompt": "morning brief", "schedule": "0 8 * * *"},\n'
+        '    {"name": "poll", "prompt": "poll inbox", "interval_seconds": 900},\n'
+        "  ],\n}\n",
+    )
+    return root
+
+
+@pytest.fixture
+def hermes_home(tmp_path: Path) -> Path:
+    root = tmp_path / "hermes"
+    _write(root / "SOUL.md", "I am the Hermes persona.")
+    _write(root / "skills" / "greet" / "SKILL.md", "---\ndescription: greet\n---\n")
+    _write(
+        root / "cron" / "jobs.json",
+        json.dumps(
+            {
+                "jobs": [
+                    {"name": "hn", "prompt": "summarize HN", "schedule": "0 9 * * *"},
+                    {"name": "tick", "prompt": "tick", "interval_seconds": 1800},
+                ]
+            }
+        ),
+    )
+    return root
+
+
+# --------------------------------------------------------------------------
+# Adapter parsing
+# --------------------------------------------------------------------------
+
+
+def test_openclaw_adapter_parses_footprint(openclaw_home: Path) -> None:
+    bundle = OpenClawAdapter(root=openclaw_home).parse()
+
+    assert bundle.source == "openclaw"
+    assert bundle.agent_name == "Clawbot"
+    # Persona merges SOUL.md + IDENTITY.md.
+    assert bundle.persona is not None
+    assert "Clawbot" in bundle.persona.instructions
+    assert "Name: Clawbot" in bundle.persona.instructions
+
+    skills = {s.name: s for s in bundle.skills}
+    assert "hn-digest" in skills
+    assert set(skills["hn-digest"].files) == {"SKILL.md", "template.md"}
+    assert skills["hn-digest"].description == "Summarize HN"
+
+    by_name = {s.name: s for s in bundle.schedules}
+    # Interval job is importable; cron-expression job carries the expression.
+    assert by_name["poll"].interval_seconds == 900
+    assert by_name["brief"].cron_expression == "0 8 * * *"
+    assert by_name["brief"].interval_seconds is None
+    # HEARTBEAT.md becomes a natural-language schedule.
+    assert any(s.natural_language for s in bundle.schedules)
+
+    # TOOLS.md is archived, not silently dropped.
+    assert any(a.name == "TOOLS.md" for a in bundle.archived)
+
+
+def test_hermes_adapter_parses_footprint(hermes_home: Path) -> None:
+    bundle = HermesAdapter(root=hermes_home).parse()
+
+    assert bundle.source == "hermes"
+    assert bundle.persona is not None
+    assert "Hermes persona" in bundle.persona.instructions
+    assert [s.name for s in bundle.skills] == ["greet"]
+
+    by_name = {s.name: s for s in bundle.schedules}
+    assert by_name["tick"].interval_seconds == 1800
+    assert by_name["hn"].cron_expression == "0 9 * * *"
+
+
+def test_missing_source_home_yields_empty_bundle(tmp_path: Path) -> None:
+    bundle = OpenClawAdapter(root=tmp_path / "does-not-exist").parse()
+    assert bundle.is_empty()
+
+
+def test_malformed_openclaw_config_does_not_crash(tmp_path: Path) -> None:
+    root = tmp_path / "openclaw"
+    _write(root / "openclaw.json", "{ this is : not json ]")
+    _write(root / "workspace" / "SOUL.md", "persona")
+    # Parsing should degrade gracefully: persona survives, no schedules.
+    bundle = OpenClawAdapter(root=root).parse()
+    assert bundle.persona is not None
+    assert bundle.schedules == []
+
+
+def test_build_preview_splits_importable_and_archived(openclaw_home: Path) -> None:
+    bundle = OpenClawAdapter(root=openclaw_home).parse()
+    preview = build_preview(bundle)
+    assert "poll" in preview["schedules_importable"]
+    # cron-expression + heartbeat schedules are archived (no interval).
+    assert "brief" in preview["schedules_archived"]
+
+
+# --------------------------------------------------------------------------
+# Loader (end to end against a real SQLite DB)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_session() -> Iterator[object]:
+    from xagent.web.models.database import Base, get_engine, get_session_local, init_db
+
+    temp_dir = tempfile.mkdtemp()
+    db_url = f"sqlite:///{os.path.join(temp_dir, 'test.db')}"
+    init_db(db_url=db_url)
+    session = get_session_local()()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=get_engine())
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _make_user(db) -> object:
+    from xagent.web.models.user import User
+
+    user = User(
+        username="alice",
+        email="alice@example.com",
+        password_hash="x",
+        is_admin=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_loader_imports_agent_skills_and_interval_schedule(
+    db_session, openclaw_home: Path
+) -> None:
+    from xagent.web.models.agent import Agent
+    from xagent.web.models.skill import UserSkill
+    from xagent.web.models.trigger import AgentTrigger
+
+    user = _make_user(db_session)
+    bundle = OpenClawAdapter(root=openclaw_home).parse()
+
+    report = MigrationLoader(db_session, user=user).load(bundle)
+
+    # Agent created with persona as instructions.
+    agent = db_session.query(Agent).filter(Agent.user_id == user.id).one()
+    assert agent.name == report.agent_name == "Clawbot"
+    assert "Clawbot" in (agent.instructions or "")
+
+    # Skill imported into user_skills.
+    skills = db_session.query(UserSkill).filter(UserSkill.user_id == user.id).all()
+    assert {s.name for s in skills} == {"hn-digest"}
+    assert skills[0].origin == "imported"
+
+    # Interval schedule became a scheduled trigger; cron ones were archived.
+    triggers = (
+        db_session.query(AgentTrigger).filter(AgentTrigger.user_id == user.id).all()
+    )
+    assert [t.type for t in triggers] == ["scheduled"]
+    assert triggers[0].config.get("interval_seconds") == 900
+    assert "poll" in report.schedules_imported
+    assert any(CRON_UNSUPPORTED_REASON in a.reason for a in bundle.archived)
+
+
+def test_loader_skill_conflict_strategies(db_session, hermes_home: Path) -> None:
+    from xagent.web.models.skill import UserSkill
+
+    user = _make_user(db_session)
+
+    # First import creates "greet".
+    bundle1 = HermesAdapter(root=hermes_home).parse()
+    report1 = MigrationLoader(db_session, user=user).load(bundle1)
+    assert "greet" in report1.skills_imported
+
+    # Second import with skip leaves one "greet".
+    bundle2 = HermesAdapter(root=hermes_home).parse()
+    report2 = MigrationLoader(db_session, user=user, skill_conflict="skip").load(
+        bundle2
+    )
+    assert report2.skills_skipped == ["greet"]
+
+    # Third import with rename creates "greet-imported".
+    bundle3 = HermesAdapter(root=hermes_home).parse()
+    report3 = MigrationLoader(db_session, user=user, skill_conflict="rename").load(
+        bundle3
+    )
+    assert "greet-imported" in report3.skills_imported
+
+    names = {
+        s.name for s in db_session.query(UserSkill).filter(UserSkill.user_id == user.id)
+    }
+    assert names == {"greet", "greet-imported"}
+
+
+def test_loader_makes_agent_name_unique(db_session, hermes_home: Path) -> None:
+    from xagent.web.models.agent import Agent
+
+    user = _make_user(db_session)
+    MigrationLoader(db_session, user=user).load(HermesAdapter(root=hermes_home).parse())
+    MigrationLoader(db_session, user=user).load(HermesAdapter(root=hermes_home).parse())
+
+    names = sorted(
+        a.name for a in db_session.query(Agent).filter(Agent.user_id == user.id)
+    )
+    assert names == ["Hermes Agent", "Hermes Agent (2)"]
+
+
+def test_write_archive_persists_items(tmp_path: Path, openclaw_home: Path) -> None:
+    bundle = OpenClawAdapter(root=openclaw_home).parse()
+    archive_dir = tmp_path / "archive"
+    written = write_archive(bundle, archive_dir)
+    assert written
+    assert (archive_dir / "REASON.txt").exists()
+    assert (archive_dir / "TOOLS.md").read_bytes() == b"legacy tool notes"


### PR DESCRIPTION
## What

Adds **`xagent migrate`**, the xagent counterpart to `hermes claw migrate`. It auto-detects a source agent platform on the machine (`~/.openclaw` or `~/.hermes`), previews what will be imported, asks for confirmation, loads it, and prints a report — archiving anything it cannot migrate automatically.

```bash
xagent migrate                                   # auto-detect ~/.openclaw and ~/.hermes
xagent migrate --from hermes --dry-run
xagent migrate --from openclaw --skill-conflict rename --yes
```

## Why

Users coming from OpenClaw / Hermes have an existing customization footprint (persona, skills, scheduled jobs). This gives them a one-command on-ramp into xagent instead of rebuilding by hand.

## How it works

A single source-neutral `MigrationBundle` decouples **parsing** from **loading**, so the two source adapters and the DB loader evolve independently:

```
detect → adapter.parse() → MigrationBundle → preview → confirm → loader → report + archive
```

- **Adapters** (`OpenClawAdapter`, `HermesAdapter`) read each platform's on-disk layout into the bundle. OpenClaw's `openclaw.json` is parsed tolerantly (JSON5 comments / trailing commas).
- **Loader** reuses existing write paths so migration inherits the same validation/storage as the rest of the product.
- The parse/preview path is import-light (no DB stack), so `--dry-run` and the confirmation screen work without initializing the web models.

## What migrates today

| Artifact | Source | xagent target |
|---|---|---|
| Persona | `SOUL.md` (+ `IDENTITY.md`) | `Agent.instructions` |
| Skills | `SKILL.md` bundles | personal `UserSkill` rows (skip / overwrite / rename conflict strategies) |
| Interval cron jobs | `openclaw.json` cron / `cron/jobs.json` | scheduled `AgentTrigger` rows |

Non-migratable items are written to `~/.xagent/migration/<source>/<timestamp>/archive/` with a `REASON.txt`, mirroring Hermes' report UX.

## Known limitation (intentional)

xagent's trigger scheduler currently supports **interval-based** schedules only, not standard 5-field cron expressions. So:

- **Interval** jobs import directly as triggers — this already goes beyond Hermes, which archives OpenClaw cron jobs for manual re-creation.
- **Cron-expression** jobs and **HEARTBEAT.md** natural-language schedules are **archived with a reason** rather than approximated into the wrong cadence.

A follow-up can add `cron_expression` + timezone support to the scheduler (compute `next_run_at` via croniter) to import those directly. Memory (`MEMORY.md`/`USER.md`) and model/MCP/secret mapping are also planned follow-ups.

## Testing

- `ruff check` + `ruff format --check` clean on all new files.
- New `tests/migration/test_platform_migration.py`: adapter parsing (filesystem fixtures, incl. malformed-config and missing-home degradation) + end-to-end loader against a fresh SQLite DB (agent/skill/trigger creation, conflict strategies, name uniqueness, archive writing).

## Entry point

Wired into the existing `xagent` console script: `xagent migrate ...` dispatches to the migration CLI; every other invocation starts the web service unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)