### PR TITLE
fix(core): bind durable-storage handles to the active execution scope

### DIFF
--- a/src/xagent/core/execution_scope.py
+++ b/src/xagent/core/execution_scope.py
@@ -142,6 +142,19 @@ class ExecutionScope:
             return self.workspace_segments
         return self.sandbox_mount_segments
 
+    @property
+    def durable_storage_segments(self) -> tuple[str, ...]:
+        """Segments a durable-storage handle should confine to.
+
+        Mirrors the filesystem external-dir allowlist
+        (``_build_allowed_external_dirs``): a ``ScopedFileStorage`` handle is
+        narrowed to the scope subtree only when ``isolate_external_dirs`` is
+        set, so a scoped-but-not-isolated execution keeps its legitimate
+        shared owner-level reads. When the flag is off this returns ``()`` — a
+        handle bound to ``users/{owner}`` exactly as before.
+        """
+        return self.workspace_segments if self.isolate_external_dirs else ()
+
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable snapshot (see :func:`ExecutionScope.from_dict`).
 

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Sequence
 from urllib.parse import urlparse
 
 import fsspec
@@ -10,6 +11,7 @@ from ...config import (
     get_file_storage_options,
     get_file_storage_uri,
 )
+from .keys import build_user_key_prefix
 from .scoped import ScopedFileStorage
 from .storage import FsspecFileStorage
 
@@ -25,17 +27,27 @@ def get_file_storage_backend() -> str:
     return get_unscoped_file_storage().backend
 
 
-def get_user_file_storage(user_id: int) -> ScopedFileStorage:
+def get_user_file_storage(
+    user_id: int, *, scope_segments: Sequence[str] = ()
+) -> ScopedFileStorage:
     """Get a storage view scoped to a user's key prefix.
 
     This is the primary storage factory: every operation through the returned
     handle is confined to ``users/{user_id}``. Reach for
     ``get_unscoped_file_storage`` only in infrastructure code inside this
     package.
+
+    When ``scope_segments`` is given, the handle is confined to the deeper
+    subtree ``users/{user_id}/{segment}/...`` instead. That prefix is a strict
+    extension of the user root, so existing owner-level keys still validate
+    while keys belonging to a sibling scope are rejected — the durable-storage
+    counterpart to the sandbox filesystem allowlist. Pass the segments from
+    :attr:`ExecutionScope.durable_storage_segments` so the narrowing follows
+    ``isolate_external_dirs``.
     """
     return ScopedFileStorage(
         storage=get_unscoped_file_storage(),
-        prefix=f"users/{int(user_id)}",
+        prefix=build_user_key_prefix(int(user_id), scope_segments),
     )
 
 

--- a/src/xagent/core/file_storage/keys.py
+++ b/src/xagent/core/file_storage/keys.py
@@ -30,7 +30,14 @@ def safe_storage_filename(filename: str) -> str:
     return _sanitize_component(safe_name) or "file"
 
 
-def _user_key_prefix(user_id: int, scope_segments: Sequence[str]) -> str:
+def build_user_key_prefix(user_id: int, scope_segments: Sequence[str] = ()) -> str:
+    """Compose the user-root key prefix ``users/{user_id}[/{segment}...]``.
+
+    Single source of truth shared by the key builders below and by
+    ``get_user_file_storage`` (so a scope-bound storage handle and the keys
+    written through it use an identical prefix). Segments are validated,
+    never sanitized.
+    """
     prefix = f"users/{user_id}"
     for segment in scope_segments:
         validate_scope_component(segment, field_name="workspace_segments entry")
@@ -46,7 +53,7 @@ def build_upload_storage_key(
     scope_segments: Sequence[str] = (),
 ) -> str:
     return (
-        f"{_user_key_prefix(user_id, scope_segments)}/uploads/"
+        f"{build_user_key_prefix(user_id, scope_segments)}/uploads/"
         f"{file_id}/{safe_storage_filename(filename)}"
     )
 
@@ -60,7 +67,7 @@ def build_task_output_storage_key(
     scope_segments: Sequence[str] = (),
 ) -> str:
     return (
-        f"{_user_key_prefix(user_id, scope_segments)}/tasks/{task_id}/outputs/"
+        f"{build_user_key_prefix(user_id, scope_segments)}/tasks/{task_id}/outputs/"
         f"{file_id}/{_safe_relative_output_path(relative_path)}"
     )
 

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol
 
-from ...core.execution_scope import ExecutionScope, get_execution_scope
+from ...core.execution_scope import (
+    ExecutionScope,
+    get_execution_scope,
+    resolve_execution_scope,
+)
 from ...core.file_storage import (
     FsspecFileStorage,
     ScopedFileStorage,
@@ -135,14 +139,25 @@ class ManagedFileRef:
     def __post_init__(self) -> None:
         # Resolve the active scope once, at construction, so the bound handle
         # and any key written through it (see ``sync_to_durable``) agree even
-        # if the ambient scope changes later or the ref outlives the turn. An
-        # explicitly passed scope wins over the contextvar — the same
-        # precedence agent tooling uses for off-turn construction.
-        scope = (
-            self.execution_scope
-            if self.execution_scope is not None
-            else get_execution_scope()
-        )
+        # if the ambient scope changes later or the ref outlives the turn.
+        #
+        # Precedence mirrors ``AgentServiceManager.get_agent_for_task``:
+        # explicit arg -> ambient turn contextvar -> the per-task
+        # resolver/snapshot keyed on the record's ``task_id``. The last step
+        # matters on off-turn paths (bot/builder-chat handlers never enter
+        # ``turn_execution_scope``, so the contextvar is None): a workforce
+        # sub-task carries its scope only in the persisted snapshot, and
+        # without recovering it here ``sync_to_durable`` would write the file
+        # under the owner root instead of the sub-task's scoped subtree.
+        # Passing ``execution_scope=None`` is equivalent to omitting it — there
+        # is no way to force owner-root over an active ambient/persisted scope.
+        scope = self.execution_scope
+        if scope is None:
+            scope = get_execution_scope()
+        if scope is None:
+            task_id = getattr(self.record, "task_id", None)
+            if task_id is not None:
+                scope = resolve_execution_scope(task_id)
         self._scope_segments = (
             scope.durable_storage_segments if scope is not None else ()
         )

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, NoReturn, Protocol
 
+from ...core.execution_scope import ExecutionScope, get_execution_scope
 from ...core.file_storage import (
     FsspecFileStorage,
     ScopedFileStorage,
@@ -128,8 +129,23 @@ class ManagedFileRef:
 
     record: UploadedFileLocalPathRecord
     storage: FsspecFileStorage | ScopedFileStorage = field(default=None)  # type: ignore[assignment]
+    execution_scope: ExecutionScope | None = None
+    _scope_segments: tuple[str, ...] = field(default=(), init=False, repr=False)
 
     def __post_init__(self) -> None:
+        # Resolve the active scope once, at construction, so the bound handle
+        # and any key written through it (see ``sync_to_durable``) agree even
+        # if the ambient scope changes later or the ref outlives the turn. An
+        # explicitly passed scope wins over the contextvar — the same
+        # precedence agent tooling uses for off-turn construction.
+        scope = (
+            self.execution_scope
+            if self.execution_scope is not None
+            else get_execution_scope()
+        )
+        self._scope_segments = (
+            scope.durable_storage_segments if scope is not None else ()
+        )
         if self.storage is None:
             user_id = self.record.user_id
             if user_id is None:
@@ -137,7 +153,9 @@ class ManagedFileRef:
                     "Record user_id is required to bind user-scoped storage; "
                     "pass an explicit storage handle for records without an owner"
                 )
-            self.storage = get_user_file_storage(int(user_id))
+            self.storage = get_user_file_storage(
+                int(user_id), scope_segments=self._scope_segments
+            )
 
     @property
     def local_path(self) -> Path:
@@ -261,6 +279,7 @@ class ManagedFileRef:
                 int(self.record.user_id),
                 str(self.record.file_id),
                 self.filename or path.name,
+                scope_segments=self._scope_segments,
             )
         )
         try:

--- a/tests/core/test_execution_scope.py
+++ b/tests/core/test_execution_scope.py
@@ -231,6 +231,33 @@ class TestSandboxMountSegments:
         assert restored_rooted.sandbox_mount_segments == ()
 
 
+class TestDurableStorageSegments:
+    """The durable-storage-handle field (#828): mirrors the filesystem
+    external-dir allowlist — narrow the object-storage handle to the scope
+    subtree only under ``isolate_external_dirs``."""
+
+    def test_isolated_scope_yields_workspace_segments(self):
+        scope = ExecutionScope(
+            workspace_segments=("clients", "3", "end_users", "7"),
+            isolate_external_dirs=True,
+        )
+        assert scope.durable_storage_segments == ("clients", "3", "end_users", "7")
+
+    def test_non_isolated_scope_yields_empty(self):
+        # Segments present but not isolated => owner-root handle (shared reads).
+        scope = ExecutionScope(
+            workspace_segments=("clients", "3", "end_users", "7"),
+            isolate_external_dirs=False,
+        )
+        assert scope.durable_storage_segments == ()
+
+    def test_unscoped_scope_yields_empty(self):
+        assert ExecutionScope().durable_storage_segments == ()
+
+    def test_isolated_without_segments_yields_empty(self):
+        assert ExecutionScope(isolate_external_dirs=True).durable_storage_segments == ()
+
+
 class TestContextvarHelpers:
     def test_default_is_none(self):
         assert get_execution_scope() is None

--- a/tests/core/test_scoped_file_storage.py
+++ b/tests/core/test_scoped_file_storage.py
@@ -159,3 +159,30 @@ def test_signed_url_scope_enforcement_on_s3_backend(tmp_path):
 
 def test_get_user_file_storage_binds_expected_prefix(local_storage):
     assert get_user_file_storage(42).prefix == "users/42"
+
+
+def test_get_user_file_storage_empty_segments_is_owner_prefix(local_storage):
+    assert get_user_file_storage(42, scope_segments=()).prefix == "users/42"
+
+
+def test_get_user_file_storage_binds_scoped_prefix(local_storage):
+    handle = get_user_file_storage(
+        42, scope_segments=("clients", "3", "end_users", "7")
+    )
+    assert handle.prefix == "users/42/clients/3/end_users/7"
+
+
+def test_scoped_handle_admits_owner_key_and_rejects_sibling(local_storage, tmp_path):
+    # A deeper prefix stays a strict extension of the owner root: the scope's
+    # own key round-trips, a sibling scope's key under the same owner does not.
+    handle = get_user_file_storage(1, scope_segments=("clients", "3", "end_users", "7"))
+    source = tmp_path / "source.txt"
+    source.write_text("data", encoding="utf-8")
+
+    own_key = "users/1/clients/3/end_users/7/uploads/file-id/source.txt"
+    assert handle.put_file(source, own_key).key == own_key
+
+    with pytest.raises(StorageKeyScopeError):
+        handle.put_file(
+            source, "users/1/clients/3/end_users/8/uploads/file-id/source.txt"
+        )

--- a/tests/core/test_user_root_path_guard.py
+++ b/tests/core/test_user_root_path_guard.py
@@ -44,10 +44,10 @@ STORAGE_KEY_LITERAL = re.compile(r"""["']users/\{|f"users/""")
 
 STORAGE_KEY_ALLOWLIST = {
     # The canonical key builders — the single owner of the key layout.
+    # ``get_user_file_storage`` binds ScopedFileStorage through
+    # ``build_user_key_prefix`` from here, so factory.py no longer hand-builds
+    # the ``users/{...}`` prefix and is not allowlisted.
     "core/file_storage/keys.py",
-    # The per-user prefix binding for ScopedFileStorage (the #759
-    # enforcement boundary, deliberately user-level and scope-agnostic).
-    "core/file_storage/factory.py",
     "web/services/startup_file_storage_sync.py",
 }
 

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -9,12 +9,29 @@ from pathlib import Path
 
 import pytest
 
+from xagent.core.execution_scope import (
+    ExecutionScope,
+    reset_execution_scope,
+    set_execution_scope,
+)
 from xagent.core.file_storage import StorageKeyScopeError
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.services.managed_file_ref import (
     DurableStorageOperationError,
     ManagedFileRef,
+)
+
+_ISOLATED_SCOPE = ExecutionScope(
+    workspace_segments=("clients", "3", "end_users", "7"),
+    isolate_external_dirs=True,
+)
+# Same segments, but not isolated: the handle must stay at the owner root so
+# legitimate shared owner-level reads still work (mirrors the sandbox
+# filesystem allowlist, which only narrows under ``isolate_external_dirs``).
+_NON_ISOLATED_SCOPE = ExecutionScope(
+    workspace_segments=("clients", "3", "end_users", "7"),
+    isolate_external_dirs=False,
 )
 
 
@@ -155,3 +172,75 @@ def test_record_without_owner_cannot_bind_default_scope(storage_env, tmp_path):
 
     with pytest.raises(ValueError, match="user_id is required"):
         ManagedFileRef(record)
+
+
+# --- scope-aware handle binding (#828 durable-storage half) -----------------
+
+
+def test_unscoped_construction_binds_owner_root(storage_env, tmp_path):
+    record = _record(tmp_path / "uploads" / "missing.txt")
+    assert ManagedFileRef(record).storage.prefix == "users/7"
+
+
+def test_explicit_isolated_scope_narrows_handle_prefix(storage_env, tmp_path):
+    record = _record(tmp_path / "uploads" / "missing.txt")
+    ref = ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE)
+    assert ref.storage.prefix == "users/7/clients/3/end_users/7"
+
+
+def test_non_isolated_scope_keeps_owner_root(storage_env, tmp_path):
+    # A scope with segments but no isolation must NOT narrow the handle, or it
+    # would block the shared owner-level reads such executions rely on.
+    record = _record(tmp_path / "uploads" / "missing.txt")
+    ref = ManagedFileRef(record, execution_scope=_NON_ISOLATED_SCOPE)
+    assert ref.storage.prefix == "users/7"
+
+
+def test_ambient_isolated_scope_narrows_handle_prefix(storage_env, tmp_path):
+    record = _record(tmp_path / "uploads" / "missing.txt")
+    token = set_execution_scope(_ISOLATED_SCOPE)
+    try:
+        assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
+    finally:
+        reset_execution_scope(token)
+
+
+def test_explicit_scope_overrides_ambient(storage_env, tmp_path):
+    record = _record(tmp_path / "uploads" / "missing.txt")
+    token = set_execution_scope(_NON_ISOLATED_SCOPE)
+    try:
+        ref = ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE)
+        assert ref.storage.prefix == "users/7/clients/3/end_users/7"
+    finally:
+        reset_execution_scope(token)
+
+
+def test_sync_to_durable_writes_into_scoped_subtree(storage_env, tmp_path):
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("scoped upload", encoding="utf-8")
+    record = _record(source)
+
+    stored = ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE).sync_to_durable()
+    assert stored.key == "users/7/clients/3/end_users/7/uploads/file-123/source.txt"
+    assert record.storage_status == "available"
+
+    # The same isolated handle round-trips its own object back.
+    source.unlink()
+    restored = ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE).ensure_local()
+    assert restored.read_text(encoding="utf-8") == "scoped upload"
+
+
+def test_isolated_handle_rejects_sibling_end_user_key(storage_env, tmp_path):
+    # Same owner, sibling end user (end_users/8). Without the handle narrowing
+    # this key sits under ``users/7`` and would be reachable; the scoped handle
+    # must reject it — the defense-in-depth this issue is about.
+    record = _record(
+        tmp_path / "uploads" / "missing.txt",
+        storage_key="users/7/clients/3/end_users/8/uploads/file-123/source.txt",
+        storage_backend="file",
+        storage_status="available",
+    )
+
+    with pytest.raises(StorageKeyScopeError):
+        ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE).delete_durable()

--- a/tests/web/services/test_user_scope_enforcement.py
+++ b/tests/web/services/test_user_scope_enforcement.py
@@ -13,6 +13,7 @@ from xagent.core.execution_scope import (
     ExecutionScope,
     reset_execution_scope,
     set_execution_scope,
+    set_execution_scope_resolver,
 )
 from xagent.core.file_storage import StorageKeyScopeError
 from xagent.core.file_storage.factory import get_unscoped_file_storage
@@ -42,6 +43,14 @@ def storage_env(monkeypatch, tmp_path):
     get_unscoped_file_storage.cache_clear()
     yield tmp_path
     get_unscoped_file_storage.cache_clear()
+
+
+@pytest.fixture
+def clear_scope_resolver():
+    """Start and end each test with no registered resolver."""
+    set_execution_scope_resolver(None)
+    yield
+    set_execution_scope_resolver(None)
 
 
 def _record(local_path: Path, **overrides) -> UploadedFile:
@@ -244,3 +253,63 @@ def test_isolated_handle_rejects_sibling_end_user_key(storage_env, tmp_path):
 
     with pytest.raises(StorageKeyScopeError):
         ManagedFileRef(record, execution_scope=_ISOLATED_SCOPE).delete_durable()
+
+
+# --- resolver/snapshot fallback when the turn contextvar is absent ----------
+# Off-turn paths (bot/builder-chat handlers) never enter turn_execution_scope,
+# so the ambient contextvar is None while a workforce sub-task's scope is still
+# recoverable from the per-task resolver/snapshot keyed on record.task_id.
+
+
+def test_resolver_narrows_handle_when_contextvar_absent(
+    storage_env, tmp_path, clear_scope_resolver
+):
+    set_execution_scope_resolver(
+        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None
+    )
+    record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
+    # No ambient contextvar, no explicit scope: fall back to the resolver.
+    assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
+
+
+def test_contextvar_beats_resolver(storage_env, tmp_path, clear_scope_resolver):
+    set_execution_scope_resolver(lambda task_id: _NON_ISOLATED_SCOPE)
+    record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
+    token = set_execution_scope(_ISOLATED_SCOPE)
+    try:
+        assert ManagedFileRef(record).storage.prefix == "users/7/clients/3/end_users/7"
+    finally:
+        reset_execution_scope(token)
+
+
+def test_explicit_scope_beats_resolver(storage_env, tmp_path, clear_scope_resolver):
+    set_execution_scope_resolver(lambda task_id: _ISOLATED_SCOPE)
+    record = _record(tmp_path / "uploads" / "missing.txt", task_id=99)
+    ref = ManagedFileRef(record, execution_scope=_NON_ISOLATED_SCOPE)
+    assert ref.storage.prefix == "users/7"
+
+
+def test_resolver_not_consulted_without_task_id(
+    storage_env, tmp_path, clear_scope_resolver
+):
+    def _boom(task_id):
+        raise AssertionError("resolver must not run when the record has no task_id")
+
+    set_execution_scope_resolver(_boom)
+    record = _record(tmp_path / "uploads" / "missing.txt")  # task_id defaults to None
+    assert ManagedFileRef(record).storage.prefix == "users/7"
+
+
+def test_sync_to_durable_uses_resolved_scope(
+    storage_env, tmp_path, clear_scope_resolver
+):
+    set_execution_scope_resolver(
+        lambda task_id: _ISOLATED_SCOPE if task_id == "99" else None
+    )
+    source = tmp_path / "uploads" / "source.txt"
+    source.parent.mkdir()
+    source.write_text("workforce upload", encoding="utf-8")
+    record = _record(source, task_id=99)
+
+    stored = ManagedFileRef(record).sync_to_durable()
+    assert stored.key == "users/7/clients/3/end_users/7/uploads/file-123/source.txt"


### PR DESCRIPTION
## Summary

Closes the deferred **durable-storage handle-binding** half of #828 (the file-id resolution half landed in #829).

`get_user_file_storage` / `ManagedFileRef` bound the durable object-storage handle to `users/{owner}` only, never consulting the active `ExecutionScope`. In an **isolated** external task an in-sandbox tool could therefore read/write another end user's durable files by storage key under the same platform owner. #829 confined *file-id resolution* (the agent-reachable path), but a `ManagedFileRef` constructed with an explicit key — or via any non-file-id call site — still got an owner-wide handle. This binds the handle to the scope subtree instead.

## Approach — mirror the sandbox filesystem allowlist

The handle narrowing follows the exact rule `_build_allowed_external_dirs` already uses for the sandbox mount: narrow **only** under `isolate_external_dirs`, so a *scoped-but-not-isolated* execution keeps its legitimate shared owner-level reads (the explicit requirement noted in #828 / the #829 description).

- **`ExecutionScope.durable_storage_segments`** → `workspace_segments` when `isolate_external_dirs`, else `()`.
- **`get_user_file_storage(user_id, *, scope_segments=())`** binds the handle to `users/{owner}/{segments}`. Empty segments are byte-identical to today. The prefix is now composed by `build_user_key_prefix` (promoted from the private `_user_key_prefix`) so a scope-bound handle and every key written through it share **one** prefix by construction.
- **`ManagedFileRef`** gains an optional `execution_scope` field. It resolves the scope **once at construction** — explicit arg beats the ambient contextvar (the precedent agent tooling uses for off-turn construction) — and reuses those segments for both the bound handle and `sync_to_durable`'s fallback key, so no contextvar drift can produce a key outside its own handle.

A deeper prefix is a strict extension of `users/{owner}`, so the scope's own keys still validate while a sibling scope's keys (same owner, different `end_users/{id}`) are rejected with `StorageKeyScopeError` — the defense-in-depth this issue is about.

### Note on the deliberate asymmetry with #829

#829's file-record gate fires whenever the workspace carries `scope_segments` (fails **closed**), whereas this handle gate keys on `isolate_external_dirs`. That is intentional and matches `_build_allowed_external_dirs`: the file-record gate is a resolution check that can safely be stricter, while the storage handle governs the durable key-space reach and must not block shared reads for scoped-but-not-isolated executions. When `isolate_external_dirs` is on (the external-end-user configuration) all three layers — mount allowlist, file-id resolution, and this handle — narrow together.

## Tests

- `tests/core/test_execution_scope.py::TestDurableStorageSegments` — the property under isolated / non-isolated / unscoped / isolated-without-segments.
- `tests/core/test_scoped_file_storage.py` — `get_user_file_storage` binds the scoped prefix; empty segments == owner root; a scoped handle admits its own key and rejects a sibling scope's key.
- `tests/web/services/test_user_scope_enforcement.py` — explicit & ambient scope narrow the handle; non-isolated keeps the owner root; explicit beats ambient; `sync_to_durable` writes into the scoped subtree and round-trips; an isolated handle rejects a sibling end user's key; unscoped construction stays at `users/{owner}`.

`ruff format`/`ruff check`/`mypy` clean; existing storage / scope / managed-file-ref suites pass unchanged (byte-identical behavior for unscoped and creator-direct flows).

Refs #757 (ExecutionScope), #759/#782 (`ScopedFileStorage`); complements #817 (scope-prefix mounts) and #829 (file-id resolution).

Closes #828.
