### PR TITLE
fix(memory): push memory-dimension filters into lancedb where clause (#822)

### DIFF
--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -14,8 +14,9 @@ class InMemoryMemoryStore(MemoryStore):
 
     @staticmethod
     def _is_scope_excluded(note: MemoryNote, filters: dict[str, Any]) -> bool:
-        """#822: strict dimension-less exclusion (``scope_exclusive``) — a note
-        carrying any scope dimension is excluded."""
+        """#822: strict dimension-less exclusion (the ``__scope_exclusive__``
+        directive, ``SCOPE_EXCLUSIVE_FILTER_KEY``) — a note carrying any scope
+        dimension is excluded."""
         return bool(filters.get(SCOPE_EXCLUSIVE_FILTER_KEY)) and bool(
             encode_scope_dims(note.metadata)
         )

--- a/src/xagent/core/memory/in_memory.py
+++ b/src/xagent/core/memory/in_memory.py
@@ -5,11 +5,20 @@ from typing import Any, List, Optional
 
 from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
+from .scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY, encode_scope_dims
 
 
 class InMemoryMemoryStore(MemoryStore):
     def __init__(self) -> None:
         self._store: dict[str, MemoryNote] = {}
+
+    @staticmethod
+    def _is_scope_excluded(note: MemoryNote, filters: dict[str, Any]) -> bool:
+        """#822: strict dimension-less exclusion (``scope_exclusive``) — a note
+        carrying any scope dimension is excluded."""
+        return bool(filters.get(SCOPE_EXCLUSIVE_FILTER_KEY)) and bool(
+            encode_scope_dims(note.metadata)
+        )
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         note_id = note.id or str(uuid.uuid4())
@@ -56,13 +65,18 @@ class InMemoryMemoryStore(MemoryStore):
                 if filters:
                     match = True
 
+                    if self._is_scope_excluded(note, filters):
+                        match = False
+
                     # Category filter
                     if "category" in filters and note.category != filters["category"]:
                         match = False
 
                     # Other metadata filters
                     other_filters = {
-                        k: v for k, v in filters.items() if k != "category"
+                        k: v
+                        for k, v in filters.items()
+                        if k not in ("category", SCOPE_EXCLUSIVE_FILTER_KEY)
                     }
                     if other_filters and not all(
                         note.metadata.get(k) == v for k, v in other_filters.items()
@@ -85,6 +99,9 @@ class InMemoryMemoryStore(MemoryStore):
             filtered_results = []
             for note in results:
                 match = True
+
+                if self._is_scope_excluded(note, filters):
+                    match = False
 
                 # Category filter
                 if "category" in filters and note.category != filters["category"]:

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -24,6 +24,7 @@ from .schema_migration import (
 )
 from .scope_columns import (
     SCOPE_DIMS_COLUMN,
+    SCOPE_EXCLUSIVE_FILTER_KEY,
     USER_ID_COLUMN,
     build_scope_where,
     coerce_user_id,
@@ -480,7 +481,13 @@ class LanceDBMemoryStore(MemoryStore):
     ) -> bool:
         """Apply filters to metadata dict for text search results."""
         for key, value in filters.items():
-            if key == "metadata":
+            if key == SCOPE_EXCLUSIVE_FILTER_KEY:
+                # #822: the text-fallback form of the strict dimension-less
+                # exclusion the vector path pushes into `where`. Only notes
+                # carrying no scope dimensions pass.
+                if value and encode_scope_dims(metadata_dict):
+                    return False
+            elif key == "metadata":
                 # Handle nested metadata filters
                 if not self._apply_metadata_filters(metadata_dict, value):
                     return False

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -130,7 +130,7 @@ class LanceDBMemoryStore(MemoryStore):
             )
 
         # #822: promote user_id + scope_dims to real columns so scope filters
-        # can be pushed into a `where` prefilter (slice 002). Idempotent and
+        # can be pushed into a `where` prefilter (slice 001). Idempotent and
         # data-preserving; runs after the base-schema resolution above so it sees
         # a table that already has id/text/metadata.
         self._ensure_scope_columns(conn)

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -25,6 +25,7 @@ from .schema_migration import (
 from .scope_columns import (
     SCOPE_DIMS_COLUMN,
     USER_ID_COLUMN,
+    build_scope_where,
     coerce_user_id,
     derive_scope_columns,
     encode_scope_dims,
@@ -670,6 +671,11 @@ class LanceDBMemoryStore(MemoryStore):
             )
             results = []
 
+            # #822: push user_id + scope-dimension filters into a `where`
+            # prefilter so the ANN returns k already-scoped neighbours; the rest
+            # (category, arbitrary metadata keys) stays a Python post-filter.
+            where_sql, residual_filters = build_scope_where(filters)
+
             # Try vector search first
             try:
                 query_embedding = self._get_embedding(query)
@@ -679,13 +685,17 @@ class LanceDBMemoryStore(MemoryStore):
                     if not sample_df.empty and "vector" in sample_df.columns:
                         # Try vector search
                         try:
-                            vector_df = (
-                                table.search(
-                                    query_embedding, vector_column_name="vector"
-                                )
-                                .limit(k)
-                                .to_pandas()
+                            vector_query = table.search(
+                                query_embedding, vector_column_name="vector"
                             )
+                            if where_sql:
+                                # Prefilter: scope BEFORE the top-k selection, so
+                                # crowd-out from other principals cannot collapse
+                                # recall.
+                                vector_query = vector_query.where(
+                                    where_sql, prefilter=True
+                                )
+                            vector_df = vector_query.limit(k).to_pandas()
 
                             for _, row in vector_df.iterrows():
                                 # Check similarity threshold
@@ -712,17 +722,38 @@ class LanceDBMemoryStore(MemoryStore):
                                 }
                                 note = self._dict_to_memory_note(note_data)
 
-                                # Apply metadata filters to vector search results too
-                                if filters:
-                                    filter_match = self._apply_filters(note, filters)
+                                # user_id + scope dimensions were already applied
+                                # as a `where` prefilter; only residual filters
+                                # (category, arbitrary metadata keys) remain.
+                                if residual_filters:
+                                    filter_match = self._apply_filters(
+                                        note, residual_filters
+                                    )
                                     if not filter_match:
                                         continue
 
                                 results.append(note)
                         except Exception as vector_error:
-                            logger.warning(
-                                f"Vector search failed, falling back to text search: {vector_error}"
-                            )
+                            if where_sql:
+                                # Distinguish a pushdown-specific failure: the
+                                # text fallback re-applies the full filters in
+                                # Python, so isolation is preserved, but the
+                                # population-independent recall pushdown (#822)
+                                # is silently bypassed until the query is fixed.
+                                logger.warning(
+                                    "Scoped vector search with where-prefilter "
+                                    "%r failed; falling back to text search "
+                                    "(isolation preserved via Python filtering, "
+                                    "but the recall pushdown is bypassed): %s",
+                                    where_sql,
+                                    vector_error,
+                                )
+                            else:
+                                logger.warning(
+                                    "Vector search failed, falling back to text "
+                                    "search: %s",
+                                    vector_error,
+                                )
             except Exception as embedding_error:
                 logger.warning(
                     f"Embedding generation failed, using text search: {embedding_error}"

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -460,7 +460,14 @@ class LanceDBMemoryStore(MemoryStore):
         )
 
     def _apply_filters(self, note: MemoryNote, filters: dict[str, Any]) -> bool:
-        """Apply filters to a MemoryNote for vector search results."""
+        """Apply filters to a MemoryNote for vector search results.
+
+        Unlike ``_apply_text_search_filters``, this never checks
+        ``SCOPE_EXCLUSIVE_FILTER_KEY``: on the vector path that directive is
+        already turned into an ``array_length`` ``where`` term and popped out of
+        the residual filters by ``build_scope_where`` before it reaches here, so
+        it can only appear among these residual filters on the text fallback.
+        """
         for key, value in filters.items():
             # Special handling for category - check note.category first
             if key == "category":

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -22,6 +22,13 @@ from .schema_migration import (
     classify_memory_schema_mismatch,
     migrate_table_swap,
 )
+from .scope_columns import (
+    SCOPE_DIMS_COLUMN,
+    USER_ID_COLUMN,
+    coerce_user_id,
+    derive_scope_columns,
+    encode_scope_dims,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -120,9 +127,27 @@ class LanceDBMemoryStore(MemoryStore):
                 conn, self._current_embedding_dim(), raise_when_compatible=False
             )
 
+        # #822: promote user_id + scope_dims to real columns so scope filters
+        # can be pushed into a `where` prefilter (slice 002). Idempotent and
+        # data-preserving; runs after the base-schema resolution above so it sees
+        # a table that already has id/text/metadata.
+        self._ensure_scope_columns(conn)
+
     def _create_empty_table(self) -> None:
         """Create an empty table with the correct schema."""
         conn = self._vector_store.get_raw_connection()
+
+        # Base row carries the derived scope columns (#822) so their types are
+        # fixed at creation: user_id -> int64, scope_dims -> list<string>.
+        # Concrete values are only for schema inference; the sample row is
+        # deleted below.
+        base_sample = {
+            "id": "sample",
+            "text": "sample",
+            "metadata": "{}",
+            USER_ID_COLUMN: 0,
+            SCOPE_DIMS_COLUMN: ["sample"],
+        }
 
         # Check if we have an embedding model
         if self._embedding_model:
@@ -132,23 +157,16 @@ class LanceDBMemoryStore(MemoryStore):
                 sample_embedding = self._get_embedding("sample")
                 if sample_embedding:
                     # Create sample data with vector
-                    sample_data = [
-                        {
-                            "id": "sample",
-                            "text": "sample",
-                            "metadata": "{}",
-                            "vector": sample_embedding,
-                        }
-                    ]
+                    sample_data = [{**base_sample, "vector": sample_embedding}]
                 else:
                     # Fallback to non-vector schema
-                    sample_data = [{"id": "sample", "text": "sample", "metadata": "{}"}]
+                    sample_data = [base_sample]
             except Exception:
                 # If embedding fails, use non-vector schema
-                sample_data = [{"id": "sample", "text": "sample", "metadata": "{}"}]
+                sample_data = [base_sample]
         else:
             # No embedding model, create without vector column
-            sample_data = [{"id": "sample", "text": "sample", "metadata": "{}"}]
+            sample_data = [base_sample]
 
         # Create table with appropriate schema
         table = conn.create_table(self._collection_name, data=sample_data)
@@ -254,7 +272,73 @@ class LanceDBMemoryStore(MemoryStore):
             vectors = self._embed_texts_batch(texts, target_dim)
             columns["vector"] = pa.array(vectors, pa.list_(pa.float32(), target_dim))
 
+        # #822: keep the derived scope columns present through a vector rebuild so
+        # every migration path produces the full schema.
+        user_ids, scope_dims = self._derive_scope_arrays(columns["metadata"])
+        columns[USER_ID_COLUMN] = user_ids
+        columns[SCOPE_DIMS_COLUMN] = scope_dims
+
         return pa.table(columns)
+
+    def _derive_scope_arrays(self, metadata_column: Any) -> tuple[Any, Any]:
+        """Derive the (user_id, scope_dims) Arrow columns from a metadata column.
+
+        Shared by every migration transform so the write path and all rebuild
+        paths encode the columns identically.
+        """
+        user_ids: list[Optional[int]] = []
+        scope_dims: list[list[str]] = []
+        for metadata_json in metadata_column.to_pylist():
+            user_id, dims = derive_scope_columns(metadata_json)
+            user_ids.append(user_id)
+            scope_dims.append(dims)
+        return (
+            pa.array(user_ids, pa.int64()),
+            pa.array(scope_dims, pa.list_(pa.string())),
+        )
+
+    def _add_scope_columns(self, existing: Any) -> Any:
+        """Migration transform: add derived scope columns, preserve everything else.
+
+        Unlike the vector rebuild, this preserves the existing ``vector`` column
+        as-is (no re-embedding) — it only projects ``user_id`` / ``scope_dims``
+        out of each row's metadata JSON.
+        """
+        columns: dict[str, Any] = {
+            name: existing.column(name) for name in existing.schema.names
+        }
+        if "metadata" in columns:
+            metadata_column = columns["metadata"].cast(pa.string())
+        else:
+            metadata_column = pa.array([None] * existing.num_rows, pa.string())
+        user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
+        columns[USER_ID_COLUMN] = user_ids
+        columns[SCOPE_DIMS_COLUMN] = scope_dims
+        return pa.table(columns)
+
+    def _ensure_scope_columns(self, conn: Any) -> None:
+        """Promote user_id + scope_dims to real columns on an existing table (#822).
+
+        Idempotent: does nothing when both columns already exist (fresh tables are
+        created with them). Otherwise rebuilds the table via transform-then-swap,
+        back-filling both columns from each row's metadata JSON and preserving all
+        other columns (including ``vector``). On failure the original table is left
+        intact and the error propagates — this never drops data.
+        """
+        table = conn.open_table(self._collection_name)
+        try:
+            names = set(table.schema.names)
+        finally:
+            _safe_close_table(table)
+
+        if {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names:
+            return
+
+        logger.info(
+            "Promoting user_id/scope_dims to real columns on table '%s'",
+            self._collection_name,
+        )
+        migrate_table_swap(conn, self._collection_name, self._add_scope_columns)
 
     def _backfill_missing_columns(self, conn: Any, columns: tuple[str, ...]) -> None:
         """Add missing non-vector columns in place (no data loss, no rebuild)."""
@@ -348,6 +432,11 @@ class LanceDBMemoryStore(MemoryStore):
             "vector": embedding,
             "text": note.content,
             "metadata": json.dumps(metadata, ensure_ascii=False),
+            # #822: derived filter projections; the metadata JSON stays
+            # authoritative. Computed from the scope stamps the isolation layer
+            # writes onto note.metadata (user_id + execution_scope_* keys).
+            USER_ID_COLUMN: coerce_user_id(note.metadata.get("user_id")),
+            SCOPE_DIMS_COLUMN: encode_scope_dims(note.metadata),
         }
 
     def _dict_to_memory_note(self, data: dict[str, Any]) -> MemoryNote:
@@ -430,6 +519,8 @@ class LanceDBMemoryStore(MemoryStore):
                     "id": data["id"],
                     "text": data["text"],
                     "metadata": data["metadata"],
+                    USER_ID_COLUMN: data[USER_ID_COLUMN],
+                    SCOPE_DIMS_COLUMN: data[SCOPE_DIMS_COLUMN],
                 }
 
                 # Add vector if available

--- a/src/xagent/core/memory/scope_columns.py
+++ b/src/xagent/core/memory/scope_columns.py
@@ -1,0 +1,77 @@
+"""Derived filter columns for the LanceDB memory store (#822).
+
+Promotes the two fields that scope searches filter on — the owner ``user_id``
+and the execution-scope memory dimensions — out of the JSON ``metadata`` string
+into real, top-level columns. LanceDB ``where`` cannot reach fields inside the
+metadata JSON string, so these columns are the prerequisite for pushing the
+filters into a ``where`` prefilter (slice 002) instead of the Python
+post-filtering that collapses recall under shared collections (see #822).
+
+The ``metadata`` JSON stays authoritative: these columns are **derived
+projections**, computed from a note's metadata on write and back-filled from it
+on migration. Nothing reconstructs a note from them.
+
+``scope_dims`` is a ``list<string>`` column holding one ``"key=value"`` element
+per dimension (e.g. ``["agent=x", "tenant=acme"]``). Membership is tested with
+DataFusion's ``array_contains`` (slice 002), which is exact per-element string
+equality — so values may contain any character (``=``, ``/``, ``_`` …) with no
+escaping, and there is no substring-collision surface (``tenant=a`` never matches
+``tenant=ab``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional
+
+from ..execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
+
+# Real column names the memory dimensions are promoted into.
+USER_ID_COLUMN = "user_id"
+SCOPE_DIMS_COLUMN = "scope_dims"
+
+
+def scope_dim_element(dim_key: str, value: Any) -> str:
+    """The ``"key=value"`` list element stored/matched for one dimension."""
+    return f"{dim_key}={value}"
+
+
+def encode_scope_dims(metadata: Mapping[str, Any]) -> list[str]:
+    """The scope-dimension list for a note: one ``"key=value"`` per stamp.
+
+    Reads the ``execution_scope_<key>`` entries from ``metadata``, sorted by key
+    (order-independent). Returns ``[]`` when the note carries no dimensions.
+    """
+    return [
+        scope_dim_element(key[len(MEMORY_DIMENSION_METADATA_PREFIX) :], metadata[key])
+        for key in sorted(metadata)
+        if key.startswith(MEMORY_DIMENSION_METADATA_PREFIX)
+    ]
+
+
+def coerce_user_id(value: Any) -> Optional[int]:
+    """Best-effort integer owner id for the column; ``None`` when absent/bad."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def derive_scope_columns(
+    metadata_json: Optional[str],
+) -> tuple[Optional[int], list[str]]:
+    """Derive ``(user_id, scope_dims)`` from a stored metadata JSON string.
+
+    Used to back-fill the columns for existing rows during migration. Malformed
+    or non-object metadata yields ``(None, [])`` rather than raising, so one bad
+    row cannot abort a migration.
+    """
+    try:
+        metadata = json.loads(metadata_json) if metadata_json else {}
+    except (json.JSONDecodeError, TypeError):
+        metadata = {}
+    if not isinstance(metadata, dict):
+        return None, []
+    return coerce_user_id(metadata.get("user_id")), encode_scope_dims(metadata)

--- a/src/xagent/core/memory/scope_columns.py
+++ b/src/xagent/core/memory/scope_columns.py
@@ -59,6 +59,68 @@ def coerce_user_id(value: Any) -> Optional[int]:
         return None
 
 
+def _sql_string_literal(text: str) -> str:
+    return "'" + text.replace("'", "''") + "'"
+
+
+def user_id_where_term(value: Any) -> Optional[str]:
+    """Equality predicate on the ``user_id`` column, or ``None`` if unparsable."""
+    user_id = coerce_user_id(value)
+    if user_id is None:
+        return None
+    return f"{USER_ID_COLUMN} = {user_id}"
+
+
+def scope_dim_where_term(dim_key: str, value: Any) -> str:
+    """An ``array_contains`` predicate matching notes carrying this dimension.
+
+    Exact per-element string equality, so a note carrying a superset of the
+    queried dimensions still matches while a different value or a prefix does
+    not — no escaping or collision reasoning required.
+    """
+    element = _sql_string_literal(scope_dim_element(dim_key, value))
+    return f"array_contains({SCOPE_DIMS_COLUMN}, {element})"
+
+
+def build_scope_where(
+    filters: Optional[Mapping[str, Any]],
+) -> tuple[Optional[str], dict[str, Any]]:
+    """Split ``filters`` into a pushable ``where`` clause and residual filters.
+
+    Extracts ``user_id`` and the ``execution_scope_*`` dimensions from the nested
+    ``filters["metadata"]`` into column predicates (``user_id`` equality +
+    ``array_contains`` per dimension), AND-ed together and applied as a prefilter
+    so the ANN returns ``k`` already-scoped neighbours. Everything the clause
+    cannot express — category, arbitrary metadata keys, an unparsable
+    ``user_id`` — is returned as residual filters for the Python post-filter.
+
+    Returns ``(where_sql or None, residual_filters)``.
+    """
+    if not filters:
+        return None, {}
+    residual: dict[str, Any] = dict(filters)
+    clauses: list[str] = []
+    metadata = filters.get("metadata")
+    if isinstance(metadata, Mapping):
+        residual_metadata = dict(metadata)
+        if "user_id" in residual_metadata:
+            term = user_id_where_term(residual_metadata["user_id"])
+            if term is not None:
+                clauses.append(term)
+                residual_metadata.pop("user_id")
+        for key in list(residual_metadata):
+            if key.startswith(MEMORY_DIMENSION_METADATA_PREFIX):
+                dim = key[len(MEMORY_DIMENSION_METADATA_PREFIX) :]
+                clauses.append(scope_dim_where_term(dim, residual_metadata[key]))
+                residual_metadata.pop(key)
+        if residual_metadata:
+            residual["metadata"] = residual_metadata
+        else:
+            residual.pop("metadata", None)
+    where_sql = " AND ".join(clauses) if clauses else None
+    return where_sql, residual
+
+
 def derive_scope_columns(
     metadata_json: Optional[str],
 ) -> tuple[Optional[int], list[str]]:

--- a/src/xagent/core/memory/scope_columns.py
+++ b/src/xagent/core/memory/scope_columns.py
@@ -128,8 +128,15 @@ def build_scope_where(
     # Popped from residual so it never reaches equality matching. DataFusion
     # returns 0 (not NULL) for an empty list, so `= 0` matches exactly the
     # dimension-less notes (covered by the strict-exclusion integration test).
+    # Every write/migration path (encode_scope_dims / derive_scope_columns /
+    # _derive_scope_arrays; _backfill_missing_columns never touches scope_dims)
+    # produces `[]`, never NULL — but since `array_length(NULL) IS NULL` would
+    # silently drop a NULL row from a strict search, guard the invariant with an
+    # explicit `IS NULL` branch so a future write path cannot break isolation.
     if residual.pop(SCOPE_EXCLUSIVE_FILTER_KEY, None):
-        clauses.append(f"array_length({SCOPE_DIMS_COLUMN}) = 0")
+        clauses.append(
+            f"(array_length({SCOPE_DIMS_COLUMN}) = 0 OR {SCOPE_DIMS_COLUMN} IS NULL)"
+        )
     where_sql = " AND ".join(clauses) if clauses else None
     return where_sql, residual
 

--- a/src/xagent/core/memory/scope_columns.py
+++ b/src/xagent/core/memory/scope_columns.py
@@ -1,19 +1,18 @@
 """Derived filter columns for the LanceDB memory store (#822).
 
-Promotes the two fields that scope searches filter on — the owner ``user_id``
-and the execution-scope memory dimensions — out of the JSON ``metadata`` string
-into real, top-level columns. LanceDB ``where`` cannot reach fields inside the
-metadata JSON string, so these columns are the prerequisite for pushing the
-filters into a ``where`` prefilter (slice 002) instead of the Python
-post-filtering that collapses recall under shared collections (see #822).
+Promotes the two fields scope searches filter on — the owner ``user_id`` and the
+execution-scope memory dimensions — out of the JSON ``metadata`` string into
+real, top-level columns, so they can be pushed into a LanceDB ``where`` prefilter
+instead of the Python post-filtering that collapses recall under shared
+collections (see #822).
 
-The ``metadata`` JSON stays authoritative: these columns are **derived
-projections**, computed from a note's metadata on write and back-filled from it
-on migration. Nothing reconstructs a note from them.
+The ``metadata`` JSON stays authoritative: these columns are derived
+projections, computed from a note's metadata on write and back-filled from it on
+migration. Nothing reconstructs a note from them.
 
 ``scope_dims`` is a ``list<string>`` column holding one ``"key=value"`` element
-per dimension (e.g. ``["agent=x", "tenant=acme"]``). Membership is tested with
-DataFusion's ``array_contains`` (slice 002), which is exact per-element string
+per dimension (e.g. ``["agent=x", "tenant=acme"]``). Dimension membership is
+tested with DataFusion's ``array_contains``, which is exact per-element string
 equality — so values may contain any character (``=``, ``/``, ``_`` …) with no
 escaping, and there is no substring-collision surface (``tenant=a`` never matches
 ``tenant=ab``).
@@ -29,6 +28,14 @@ from ..execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 # Real column names the memory dimensions are promoted into.
 USER_ID_COLUMN = "user_id"
 SCOPE_DIMS_COLUMN = "scope_dims"
+
+# Reserved, namespaced top-level filter key (#822). When truthy, the search must
+# return only notes carrying NO scope dimensions — the pushdown form of
+# ``strict_memory_isolation`` for a dimension-less scope. The ``__`` prefix keeps
+# it from colliding with a caller's real equality-filter key. It is consumed by
+# the store's filter layer (an ``array_length`` term on the vector path, a Python
+# check on the text fallback) and never reaches equality matching.
+SCOPE_EXCLUSIVE_FILTER_KEY = "__scope_exclusive__"
 
 
 def scope_dim_element(dim_key: str, value: Any) -> str:
@@ -117,6 +124,12 @@ def build_scope_where(
             residual["metadata"] = residual_metadata
         else:
             residual.pop("metadata", None)
+    # Strict dimension-less exclusion: only notes with an empty dimension list.
+    # Popped from residual so it never reaches equality matching. DataFusion
+    # returns 0 (not NULL) for an empty list, so `= 0` matches exactly the
+    # dimension-less notes (covered by the strict-exclusion integration test).
+    if residual.pop(SCOPE_EXCLUSIVE_FILTER_KEY, None):
+        clauses.append(f"array_length({SCOPE_DIMS_COLUMN}) = 0")
     where_sql = " AND ".join(clauses) if clauses else None
     return where_sql, residual
 

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -11,6 +11,7 @@ from xagent.core.execution_scope import (
 )
 from xagent.core.memory.base import MemoryStore
 from xagent.core.memory.core import MemoryNote, MemoryResponse
+from xagent.core.memory.scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY
 from xagent.core.user_context import current_user_id
 
 
@@ -24,10 +25,11 @@ class UserIsolatedMemoryStore(MemoryStore):
     only see notes carrying their dimensions, while unscoped searches see
     everything under the user — including scoped notes. With
     ``strict_memory_isolation`` on the active scope, dimension-less searches
-    additionally post-filter out any scope-stamped note (the flag is
-    consumed even when the rest of the scope is empty). The post-filter runs
-    over rows already fetched from the vector search, so a strict search may
-    return fewer than ``k`` results.
+    additionally exclude any scope-stamped note (the flag is consumed even
+    when the rest of the scope is empty). That exclusion is carried to the
+    store as the ``scope_exclusive`` filter directive: pushed into the ``where``
+    prefilter on the vector path (so it no longer crowds the top-k) and applied
+    in Python on the text-search fallback.
 
     The by-id methods (``get``/``update``/``delete``) enforce the same scope
     dimensions as ``search``/``list_all`` (see ``_scope_permits``), so a
@@ -77,30 +79,24 @@ class UserIsolatedMemoryStore(MemoryStore):
         # Scoped searches filter on the active scope's memory dimensions;
         # dimension-less scopes add nothing (unscoped searches see
         # everything under the user — one-way visibility by default).
-        metadata_filters.update(memory_dimension_metadata(get_execution_scope()))
+        scope = get_execution_scope()
+        metadata_filters.update(memory_dimension_metadata(scope))
 
         filters["metadata"] = metadata_filters
-        return filters
 
-    @staticmethod
-    def _apply_strict_isolation(notes: List[MemoryNote]) -> List[MemoryNote]:
-        """Post-filter for ``strict_memory_isolation``: a dimension-less
-        search under a strict scope excludes scope-stamped notes. Python-
-        level on purpose — the metadata filters are equality checks over
-        already-fetched rows, so "key absent" needs no backend support.
-        May shrink results below ``k``."""
-        scope: Optional[ExecutionScope] = get_execution_scope()
+        # strict_memory_isolation on a dimension-less scope: exclude any
+        # scope-stamped note. Pushed into the store's filter (#822 slice 003) as
+        # a `where` prefilter on the vector path — so a strict search over a
+        # collection dominated by scoped notes no longer has its own notes
+        # crowded out of the top-k — and honored in Python on the text fallback.
         if (
-            scope is None
-            or not scope.strict_memory_isolation
-            or scope.memory_dimensions
+            scope is not None
+            and scope.strict_memory_isolation
+            and not scope.memory_dimensions
         ):
-            return notes
-        return [
-            note
-            for note in notes
-            if not metadata_carries_scope_dimensions(note.metadata)
-        ]
+            filters[SCOPE_EXCLUSIVE_FILTER_KEY] = True
+
+        return filters
 
     @staticmethod
     def _scope_gates_by_id_access() -> bool:
@@ -120,7 +116,8 @@ class UserIsolatedMemoryStore(MemoryStore):
         - a scoped caller (non-empty ``memory_dimensions``) matches only a
           note carrying all of its dimension stamps;
         - a dimension-less caller under ``strict_memory_isolation`` cannot
-          touch a scope-stamped note (mirrors ``_apply_strict_isolation``);
+          touch a scope-stamped note (the same exclusion ``search``/``list_all``
+          push into the store via the ``scope_exclusive`` directive);
         - unscoped / dimension-less non-strict callers keep one-way
           visibility (access allowed).
         """
@@ -254,16 +251,16 @@ class UserIsolatedMemoryStore(MemoryStore):
         Returns:
             List of matching memory notes
         """
-        # Add user (and scope-dimension) filters to existing filters
+        # Add user (and scope-dimension) filters to existing filters. Strict
+        # dimension-less isolation is carried inside the filters and applied by
+        # the store (prefilter on the vector path), not post-filtered here.
         filtered_filters = self._add_user_filter(filters)
 
-        return self._apply_strict_isolation(
-            self._base_store.search(
-                query=query,
-                k=k,
-                filters=filtered_filters,
-                similarity_threshold=similarity_threshold,
-            )
+        return self._base_store.search(
+            query=query,
+            k=k,
+            filters=filtered_filters,
+            similarity_threshold=similarity_threshold,
         )
 
     def clear(self) -> None:
@@ -290,10 +287,12 @@ class UserIsolatedMemoryStore(MemoryStore):
         Returns:
             List of memory notes
         """
-        # Add user (and scope-dimension) filters to existing filters
+        # Add user (and scope-dimension) filters to existing filters. Strict
+        # dimension-less isolation is carried inside the filters and applied by
+        # the store, not post-filtered here.
         filtered_filters = self._add_user_filter(filters)
 
-        return self._apply_strict_isolation(self._base_store.list_all(filtered_filters))
+        return self._base_store.list_all(filtered_filters)
 
     def get_stats(self) -> dict[str, Any]:
         """

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -27,7 +27,7 @@ class UserIsolatedMemoryStore(MemoryStore):
     ``strict_memory_isolation`` on the active scope, dimension-less searches
     additionally exclude any scope-stamped note (the flag is consumed even
     when the rest of the scope is empty). That exclusion is carried to the
-    store as the ``scope_exclusive`` filter directive: pushed into the ``where``
+    store as the ``__scope_exclusive__`` filter directive: pushed into the ``where``
     prefilter on the vector path (so it no longer crowds the top-k) and applied
     in Python on the text-search fallback.
 
@@ -67,11 +67,13 @@ class UserIsolatedMemoryStore(MemoryStore):
         Returns:
             Updated filters with user isolation
         """
-        if filters is None:
-            filters = {}
+        # Work on shallow copies so a caller-supplied ``filters`` dict (and its
+        # nested ``metadata`` dict) is never mutated in place — callers may
+        # reuse the same object across scopes.
+        filters = dict(filters) if filters else {}
 
         # Add user ID to metadata filters
-        metadata_filters = filters.get("metadata", {})
+        metadata_filters = dict(filters.get("metadata", {}))
         user_id = self._get_current_user_id()
         if user_id is not None:
             metadata_filters["user_id"] = user_id
@@ -117,7 +119,7 @@ class UserIsolatedMemoryStore(MemoryStore):
           note carrying all of its dimension stamps;
         - a dimension-less caller under ``strict_memory_isolation`` cannot
           touch a scope-stamped note (the same exclusion ``search``/``list_all``
-          push into the store via the ``scope_exclusive`` directive);
+          push into the store via the ``__scope_exclusive__`` directive);
         - unscoped / dimension-less non-strict callers keep one-way
           visibility (access allowed).
         """

--- a/tests/core/memory/conftest.py
+++ b/tests/core/memory/conftest.py
@@ -1,0 +1,61 @@
+"""Shared embedding stubs for the LanceDB memory-store tests (#822).
+
+``ConstantEmbedding`` returns the same vector for every text, so vector distance
+cannot rank results — isolating where-prefilter / top-k selection from similarity
+ranking (used by the population-independence and column-promotion suites).
+
+``VaryingEmbedding`` maps each registered text to a distinct vector, so cosine/L2
+distance is meaningful and similarity ordering can be asserted *alongside* the
+where-prefilter (used by the ranking-under-prefilter test).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from xagent.core.model.embedding import BaseEmbedding
+
+
+class ConstantEmbedding(BaseEmbedding):
+    """Every text embeds to the same vector (configurable dimension/value)."""
+
+    def __init__(self, dim: int = 8, value: float = 0.1) -> None:
+        self._dimension = dim
+        self._value = value
+
+    def encode(self, text: Any, dimension: Any = None, instruct: Any = None) -> Any:
+        if isinstance(text, str):
+            return [self._value] * self._dimension
+        return [[self._value] * self._dimension for _ in text]
+
+    def get_dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def abilities(self) -> list[str]:
+        return ["embed"]
+
+
+class VaryingEmbedding(BaseEmbedding):
+    """Maps each registered text to a distinct vector so distance ranks results;
+    an unregistered text falls back to a fixed zero vector."""
+
+    def __init__(self, vectors: Mapping[str, Sequence[float]], dim: int) -> None:
+        self._vectors = {key: list(value) for key, value in vectors.items()}
+        self._dimension = dim
+        self._default = [0.0] * dim
+
+    def _one(self, text: str) -> list[float]:
+        return list(self._vectors.get(text, self._default))
+
+    def encode(self, text: Any, dimension: Any = None, instruct: Any = None) -> Any:
+        if isinstance(text, str):
+            return self._one(text)
+        return [self._one(item) for item in text]
+
+    def get_dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def abilities(self) -> list[str]:
+        return ["embed"]

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -4,8 +4,10 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.core.memory.scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY
 
 
 @pytest.fixture
@@ -357,3 +359,23 @@ def test_clear(memory_store):
 
     results = memory_store.search("temporary")
     assert len(results) == 0
+
+
+def test_scope_exclusive_filters_scoped_notes(memory_store):
+    """#822: the `scope_exclusive` directive (strict dimension-less isolation)
+    excludes any scope-stamped note on the real InMemoryMemoryStore, via
+    `_is_scope_excluded`, on both search() and list_all()."""
+    prefix = MEMORY_DIMENSION_METADATA_PREFIX
+    memory_store.add(MemoryNote(id="u", content="hello unscoped", metadata={}))
+    memory_store.add(
+        MemoryNote(id="s", content="hello scoped", metadata={f"{prefix}tenant": "acme"})
+    )
+
+    got = memory_store.search("hello", k=10, filters={SCOPE_EXCLUSIVE_FILTER_KEY: True})
+    assert {n.content for n in got} == {"hello unscoped"}
+
+    got = memory_store.list_all(filters={SCOPE_EXCLUSIVE_FILTER_KEY: True})
+    assert {n.content for n in got} == {"hello unscoped"}
+
+    # Without the directive, both notes are visible.
+    assert len(memory_store.search("hello", k=10)) == 2

--- a/tests/core/memory/test_in_memory.py
+++ b/tests/core/memory/test_in_memory.py
@@ -362,9 +362,9 @@ def test_clear(memory_store):
 
 
 def test_scope_exclusive_filters_scoped_notes(memory_store):
-    """#822: the `scope_exclusive` directive (strict dimension-less isolation)
-    excludes any scope-stamped note on the real InMemoryMemoryStore, via
-    `_is_scope_excluded`, on both search() and list_all()."""
+    """#822: the `__scope_exclusive__` directive (strict dimension-less
+    isolation) excludes any scope-stamped note on the real InMemoryMemoryStore,
+    via `_is_scope_excluded`, on both search() and list_all()."""
     prefix = MEMORY_DIMENSION_METADATA_PREFIX
     memory_store.add(MemoryNote(id="u", content="hello unscoped", metadata={}))
     memory_store.add(

--- a/tests/core/memory/test_scope_column_promotion.py
+++ b/tests/core/memory/test_scope_column_promotion.py
@@ -1,0 +1,173 @@
+"""Store-level tests for scope-column promotion (#822, slice 001).
+
+Covers that fresh tables are born with the derived columns, that the write path
+populates them from note metadata, and that a legacy table lacking the columns
+is migrated in place — back-filling from each row's metadata JSON, preserving all
+existing rows and the authoritative metadata JSON byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+
+import lancedb  # type: ignore
+import pytest
+
+from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.memory.scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN
+from xagent.core.model.embedding import BaseEmbedding
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+P = MEMORY_DIMENSION_METADATA_PREFIX
+
+
+class MockEmbedding(BaseEmbedding):
+    def __init__(self, dim: int = 64):
+        self._dimension = dim
+
+    def encode(self, text, dimension=None, instruct=None):
+        if isinstance(text, str):
+            return [0.1] * self._dimension
+        return [[0.1] * self._dimension for _ in text]
+
+    def get_dimension(self):
+        return self._dimension
+
+    @property
+    def abilities(self):
+        return ["embed"]
+
+
+@pytest.fixture
+def temp_db_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _store(temp_db_dir, name="mem", embedding=None):
+    return LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name=name,
+        embedding_model=embedding if embedding is not None else MockEmbedding(64),
+    )
+
+
+def _arrow(store, name="mem"):
+    conn = store._vector_store.get_raw_connection()
+    table = conn.open_table(name)
+    try:
+        return table.to_arrow()
+    finally:
+        _safe_close_table(table)
+
+
+def test_fresh_table_has_scope_columns(temp_db_dir):
+    store = _store(temp_db_dir)
+    names = set(_arrow(store).schema.names)
+    assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names
+
+
+def test_write_path_populates_scope_columns(temp_db_dir):
+    store = _store(temp_db_dir)
+    res = store.add(
+        MemoryNote(
+            id="n1",
+            content="alpha",
+            metadata={"user_id": 7, f"{P}tenant": "acme", f"{P}agent": "x"},
+        )
+    )
+    assert res.success
+
+    arrow = _arrow(store)
+    row = {c: arrow.column(c).to_pylist() for c in arrow.schema.names}
+    idx = row["id"].index("n1")
+    assert row[USER_ID_COLUMN][idx] == 7
+    assert row[SCOPE_DIMS_COLUMN][idx] == ["agent=x", "tenant=acme"]
+
+
+def test_write_path_empty_dims_and_no_user(temp_db_dir):
+    store = _store(temp_db_dir)
+    assert store.add(MemoryNote(id="n2", content="beta")).success
+
+    arrow = _arrow(store)
+    row = {c: arrow.column(c).to_pylist() for c in arrow.schema.names}
+    idx = row["id"].index("n2")
+    assert row[USER_ID_COLUMN][idx] is None
+    assert row[SCOPE_DIMS_COLUMN][idx] == []
+
+
+def _create_legacy_table(temp_db_dir, name="mem"):
+    """A pre-#822 table: id/text/metadata/vector, no derived scope columns."""
+    db = lancedb.connect(temp_db_dir)
+    ts = "2026-01-01T00:00:00"
+    rows = [
+        {
+            "id": "1",
+            "text": "alpha",
+            "metadata": json.dumps(
+                {
+                    "content": "alpha",
+                    "timestamp": ts,
+                    "user_id": 7,
+                    f"{P}tenant": "acme",
+                }
+            ),
+            "vector": [0.1] * 64,
+        },
+        {
+            "id": "2",
+            "text": "beta",
+            "metadata": json.dumps({"content": "beta", "timestamp": ts, "user_id": 9}),
+            "vector": [0.2] * 64,
+        },
+    ]
+    table = db.create_table(name, data=rows)
+    _safe_close_table(table)
+
+
+def test_legacy_table_is_migrated_and_backfilled(temp_db_dir):
+    _create_legacy_table(temp_db_dir)
+
+    # Constructing the store triggers _ensure_scope_columns during init.
+    store = _store(temp_db_dir)
+
+    arrow = _arrow(store)
+    names = set(arrow.schema.names)
+    assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names
+    # The existing vector column is preserved (no re-embed / drop).
+    assert "vector" in names
+
+    by_id = {arrow.column("id").to_pylist()[i]: i for i in range(arrow.num_rows)}
+    assert set(by_id) == {"1", "2"}, "all legacy rows preserved"
+
+    uid = arrow.column(USER_ID_COLUMN).to_pylist()
+    dims = arrow.column(SCOPE_DIMS_COLUMN).to_pylist()
+    assert uid[by_id["1"]] == 7
+    assert dims[by_id["1"]] == ["tenant=acme"]
+    assert uid[by_id["2"]] == 9
+    assert dims[by_id["2"]] == []
+
+    # The authoritative metadata JSON is untouched by the promotion.
+    meta1 = json.loads(arrow.column("metadata").to_pylist()[by_id["1"]])
+    assert meta1["content"] == "alpha"
+    assert meta1["user_id"] == 7
+    assert meta1[f"{P}tenant"] == "acme"
+
+    # Rows still round-trip through the store API.
+    assert store.get("1").content.content == "alpha"
+    assert store.get("2").content.content == "beta"
+
+
+def test_promotion_is_idempotent(temp_db_dir):
+    _create_legacy_table(temp_db_dir)
+    _store(temp_db_dir)  # first construction migrates
+    # Second construction must not error, wipe, or duplicate rows.
+    store = _store(temp_db_dir)
+    arrow = _arrow(store)
+    assert arrow.num_rows == 2
+    assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= set(arrow.schema.names)

--- a/tests/core/memory/test_scope_column_promotion.py
+++ b/tests/core/memory/test_scope_column_promotion.py
@@ -19,27 +19,11 @@ from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore
 from xagent.core.memory.scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN
-from xagent.core.model.embedding import BaseEmbedding
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
+from .conftest import ConstantEmbedding
+
 P = MEMORY_DIMENSION_METADATA_PREFIX
-
-
-class MockEmbedding(BaseEmbedding):
-    def __init__(self, dim: int = 64):
-        self._dimension = dim
-
-    def encode(self, text, dimension=None, instruct=None):
-        if isinstance(text, str):
-            return [0.1] * self._dimension
-        return [[0.1] * self._dimension for _ in text]
-
-    def get_dimension(self):
-        return self._dimension
-
-    @property
-    def abilities(self):
-        return ["embed"]
 
 
 @pytest.fixture
@@ -53,7 +37,7 @@ def _store(temp_db_dir, name="mem", embedding=None):
     return LanceDBMemoryStore(
         db_dir=temp_db_dir,
         collection_name=name,
-        embedding_model=embedding if embedding is not None else MockEmbedding(64),
+        embedding_model=embedding if embedding is not None else ConstantEmbedding(64),
     )
 
 

--- a/tests/core/memory/test_scope_columns.py
+++ b/tests/core/memory/test_scope_columns.py
@@ -1,10 +1,11 @@
-"""Unit tests for the derived scope-column encoding + where builder (#822)."""
+"""Unit tests for the derived scope-column encoding (#822, slice 001/002)."""
 
 from __future__ import annotations
 
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.scope_columns import (
     SCOPE_DIMS_COLUMN,
+    SCOPE_EXCLUSIVE_FILTER_KEY,
     USER_ID_COLUMN,
     build_scope_where,
     coerce_user_id,
@@ -80,7 +81,7 @@ def test_scope_dim_where_term_is_exact_array_contains():
         scope_dim_where_term("tenant", "acme")
         == f"array_contains({SCOPE_DIMS_COLUMN}, 'tenant=acme')"
     )
-    # Values with SQL-special quotes are doubled; no wildcard escaping needed.
+    # Values with SQL-special quotes are doubled; no LIKE wildcards to escape.
     assert scope_dim_where_term("t", "a'b") == (
         f"array_contains({SCOPE_DIMS_COLUMN}, 't=a''b')"
     )
@@ -124,3 +125,14 @@ def test_build_scope_where_unparsable_user_id_falls_back_to_python():
     where_sql, residual = build_scope_where({"metadata": {"user_id": "abc"}})
     assert where_sql is None
     assert residual == {"metadata": {"user_id": "abc"}}
+
+
+def test_build_scope_where_exclusive_directive():
+    where_sql, residual = build_scope_where(
+        {"metadata": {"user_id": 1}, SCOPE_EXCLUSIVE_FILTER_KEY: True}
+    )
+    assert where_sql == (
+        f"{USER_ID_COLUMN} = 1 AND array_length({SCOPE_DIMS_COLUMN}) = 0"
+    )
+    # The reserved directive is consumed, never left for equality matching.
+    assert residual == {}

--- a/tests/core/memory/test_scope_columns.py
+++ b/tests/core/memory/test_scope_columns.py
@@ -1,12 +1,17 @@
-"""Unit tests for the derived scope-column encoding (#822, slice 001)."""
+"""Unit tests for the derived scope-column encoding + where builder (#822)."""
 
 from __future__ import annotations
 
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.scope_columns import (
+    SCOPE_DIMS_COLUMN,
+    USER_ID_COLUMN,
+    build_scope_where,
     coerce_user_id,
     derive_scope_columns,
     encode_scope_dims,
+    scope_dim_where_term,
+    user_id_where_term,
 )
 
 P = MEMORY_DIMENSION_METADATA_PREFIX
@@ -58,3 +63,64 @@ def test_derive_scope_columns_tolerates_bad_input():
     assert derive_scope_columns("") == (None, [])
     assert derive_scope_columns("not json") == (None, [])
     assert derive_scope_columns("[1, 2, 3]") == (None, [])
+
+
+# --- where-clause construction (slice 002) ---------------------------------
+
+
+def test_user_id_where_term():
+    assert user_id_where_term(7) == f"{USER_ID_COLUMN} = 7"
+    assert user_id_where_term("7") == f"{USER_ID_COLUMN} = 7"
+    assert user_id_where_term(None) is None
+    assert user_id_where_term("bad") is None
+
+
+def test_scope_dim_where_term_is_exact_array_contains():
+    assert (
+        scope_dim_where_term("tenant", "acme")
+        == f"array_contains({SCOPE_DIMS_COLUMN}, 'tenant=acme')"
+    )
+    # Values with SQL-special quotes are doubled; no wildcard escaping needed.
+    assert scope_dim_where_term("t", "a'b") == (
+        f"array_contains({SCOPE_DIMS_COLUMN}, 't=a''b')"
+    )
+    # Underscore/equals are stored/matched literally (no wildcard semantics).
+    assert scope_dim_where_term("t", "a_b") == (
+        f"array_contains({SCOPE_DIMS_COLUMN}, 't=a_b')"
+    )
+
+
+def test_build_scope_where_pushes_user_and_dims():
+    where_sql, residual = build_scope_where(
+        {"metadata": {"user_id": 1, f"{P}tenant": "acme"}}
+    )
+    assert where_sql is not None
+    assert f"{USER_ID_COLUMN} = 1" in where_sql
+    assert f"array_contains({SCOPE_DIMS_COLUMN}, 'tenant=acme')" in where_sql
+    assert " AND " in where_sql
+    assert residual == {}
+
+
+def test_build_scope_where_keeps_residual_filters():
+    where_sql, residual = build_scope_where(
+        {
+            "category": "work",
+            "metadata": {"user_id": 1, f"{P}tenant": "acme", "custom": "v"},
+        }
+    )
+    assert where_sql is not None
+    assert residual == {"category": "work", "metadata": {"custom": "v"}}
+
+
+def test_build_scope_where_unscoped_and_empty():
+    assert build_scope_where(None) == (None, {})
+    assert build_scope_where({}) == (None, {})
+    where_sql, residual = build_scope_where({"metadata": {"user_id": 5}})
+    assert where_sql == f"{USER_ID_COLUMN} = 5"
+    assert residual == {}
+
+
+def test_build_scope_where_unparsable_user_id_falls_back_to_python():
+    where_sql, residual = build_scope_where({"metadata": {"user_id": "abc"}})
+    assert where_sql is None
+    assert residual == {"metadata": {"user_id": "abc"}}

--- a/tests/core/memory/test_scope_columns.py
+++ b/tests/core/memory/test_scope_columns.py
@@ -132,7 +132,9 @@ def test_build_scope_where_exclusive_directive():
         {"metadata": {"user_id": 1}, SCOPE_EXCLUSIVE_FILTER_KEY: True}
     )
     assert where_sql == (
-        f"{USER_ID_COLUMN} = 1 AND array_length({SCOPE_DIMS_COLUMN}) = 0"
+        f"{USER_ID_COLUMN} = 1 AND "
+        f"(array_length({SCOPE_DIMS_COLUMN}) = 0 "
+        f"OR {SCOPE_DIMS_COLUMN} IS NULL)"
     )
     # The reserved directive is consumed, never left for equality matching.
     assert residual == {}

--- a/tests/core/memory/test_scope_columns.py
+++ b/tests/core/memory/test_scope_columns.py
@@ -1,0 +1,60 @@
+"""Unit tests for the derived scope-column encoding (#822, slice 001)."""
+
+from __future__ import annotations
+
+from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
+from xagent.core.memory.scope_columns import (
+    coerce_user_id,
+    derive_scope_columns,
+    encode_scope_dims,
+)
+
+P = MEMORY_DIMENSION_METADATA_PREFIX
+
+
+def test_encode_empty_when_no_dimensions():
+    assert encode_scope_dims({}) == []
+    assert encode_scope_dims({"user_id": 7, "content": "x"}) == []
+
+
+def test_encode_single_and_multiple_dimensions():
+    assert encode_scope_dims({f"{P}tenant": "acme"}) == ["tenant=acme"]
+    # Sorted by key (order-independent).
+    assert encode_scope_dims({f"{P}tenant": "acme", f"{P}agent": "x"}) == [
+        "agent=x",
+        "tenant=acme",
+    ]
+
+
+def test_encoding_is_order_independent():
+    a = encode_scope_dims({f"{P}tenant": "acme", f"{P}agent": "x"})
+    b = encode_scope_dims({f"{P}agent": "x", f"{P}tenant": "acme"})
+    assert a == b
+
+
+def test_encode_preserves_raw_values_without_escaping():
+    # array_contains is exact per-element equality, so no delimiter escaping.
+    assert encode_scope_dims({f"{P}path": "/a=b/c"}) == ["path=/a=b/c"]
+    assert encode_scope_dims({f"{P}t": "a_b"}) == ["t=a_b"]
+
+
+def test_coerce_user_id():
+    assert coerce_user_id(7) == 7
+    assert coerce_user_id("7") == 7
+    assert coerce_user_id(None) is None
+    assert coerce_user_id("not-an-int") is None
+
+
+def test_derive_scope_columns_from_json():
+    uid, dims = derive_scope_columns(
+        '{"user_id": 7, "' + P + 'tenant": "acme", "content": "x"}'
+    )
+    assert uid == 7
+    assert dims == ["tenant=acme"]
+
+
+def test_derive_scope_columns_tolerates_bad_input():
+    assert derive_scope_columns(None) == (None, [])
+    assert derive_scope_columns("") == (None, [])
+    assert derive_scope_columns("not json") == (None, [])
+    assert derive_scope_columns("[1, 2, 3]") == (None, [])

--- a/tests/core/memory/test_scope_filter_pushdown.py
+++ b/tests/core/memory/test_scope_filter_pushdown.py
@@ -1,0 +1,229 @@
+"""Recall regression + scope-filter semantics for the where pushdown (#822, 822-02).
+
+The centerpiece is the population-independence test: a single ``user_id`` shared
+by ``N`` principals (isolated only by scope dimensions), the target principal
+holding ``R`` notes, searched at ``k = R``. With Python post-filtering the target
+is crowded out of the top-k before the filter runs and recall collapses to
+``~1/N``; with the ``where`` prefilter it stays ``1.0`` regardless of ``N``.
+
+All notes share one identical vector so the vector distance cannot itself
+separate principals — top-k selection is decided purely by whether the scope
+filter is applied before (prefilter) or after (post-filter) the limit.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+
+import lancedb  # type: ignore
+import pytest
+
+from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.model.embedding import BaseEmbedding
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+P = MEMORY_DIMENSION_METADATA_PREFIX
+DIM = 8
+_VECTOR = [0.1] * DIM
+
+
+class FixedEmbedding(BaseEmbedding):
+    """Every text embeds to the same vector, so distance cannot rank principals."""
+
+    def encode(self, text, dimension=None, instruct=None):
+        if isinstance(text, str):
+            return list(_VECTOR)
+        return [list(_VECTOR) for _ in text]
+
+    def get_dimension(self):
+        return DIM
+
+    @property
+    def abilities(self):
+        return ["embed"]
+
+
+@pytest.fixture
+def temp_db_dir():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _scope_filter(tenant, user_id=1):
+    return {"metadata": {"user_id": user_id, f"{P}tenant": tenant}}
+
+
+def _bulk_build(db_dir, n_principals, r=10, name="mem"):
+    """Create a shared collection: one user_id, N principals, R notes each.
+
+    Notes are inserted round-robin (principal-major within each note index) so
+    the target principal's notes are spread across the population rather than
+    clustered — without a prefilter, an insertion-order top-k would pick at most
+    ~1 of them.
+    """
+    db = lancedb.connect(db_dir)
+    ts = "2026-01-01T00:00:00"
+    rows = []
+    for j in range(r):
+        for p in range(n_principals):
+            tenant = f"t{p}"
+            note_id = f"{tenant}-{j}"
+            metadata = {
+                "content": note_id,
+                "timestamp": ts,
+                "user_id": 1,
+                f"{P}tenant": tenant,
+            }
+            rows.append(
+                {
+                    "id": note_id,
+                    "text": note_id,
+                    "metadata": json.dumps(metadata),
+                    "user_id": 1,
+                    "scope_dims": [f"tenant={tenant}"],
+                    "vector": list(_VECTOR),
+                }
+            )
+    table = db.create_table(name, data=rows)
+    _safe_close_table(table)
+
+
+def _store(db_dir, name="mem"):
+    return LanceDBMemoryStore(
+        db_dir=db_dir, collection_name=name, embedding_model=FixedEmbedding()
+    )
+
+
+@pytest.mark.parametrize("n_principals", [10, 100, 1000])
+def test_scoped_recall_is_population_independent(temp_db_dir, n_principals):
+    r = 10
+    _bulk_build(temp_db_dir, n_principals, r=r)
+    store = _store(temp_db_dir)
+
+    # Search the target principal (t0) at k = R over a collection of N*R notes.
+    results = store.search("anything", k=r, filters=_scope_filter("t0"))
+
+    returned = {n.content for n in results}
+    expected = {f"t0-{j}" for j in range(r)}
+    recall = len(returned & expected) / r
+    assert recall == 1.0, (
+        f"N={n_principals}: recall collapsed to {recall} "
+        f"(returned {len(results)} notes)"
+    )
+    # And nothing from another principal leaked in.
+    assert returned <= expected
+
+
+def test_unscoped_search_sees_all_principals(temp_db_dir):
+    _bulk_build(temp_db_dir, n_principals=5, r=4)
+    store = _store(temp_db_dir)
+
+    # Unscoped: user_id only, no dimension predicate -> sees every principal.
+    results = store.search("anything", k=1000, filters={"metadata": {"user_id": 1}})
+    tenants = {n.content.split("-")[0] for n in results}
+    assert tenants == {f"t{p}" for p in range(5)}
+
+
+def test_dimension_value_matches_exactly_through_search(temp_db_dir):
+    """End-to-end: a value with a would-be LIKE wildcard (`_`) matches only its
+    exact sibling, driven through store.search (guards the array_contains term
+    against any accidental widening)."""
+    store = _store(temp_db_dir)
+    for tenant in ("a_b", "axb", "a-b", "ab"):
+        store.add(
+            MemoryNote(
+                id=tenant, content=tenant, metadata={"user_id": 1, f"{P}tenant": tenant}
+            )
+        )
+
+    for tenant in ("a_b", "axb", "a-b", "ab"):
+        got = {
+            n.content for n in store.search("x", k=10, filters=_scope_filter(tenant))
+        }
+        assert got == {tenant}, f"{tenant!r} matched {got!r}"
+
+
+def test_pushed_dims_combine_with_residual_category_filter(temp_db_dir):
+    """user_id + dimension go into the `where` prefilter; a category filter is
+    not pushable and stays a Python post-filter over the already-scoped rows."""
+    store = _store(temp_db_dir)
+    store.add(
+        MemoryNote(
+            id="w",
+            content="w",
+            category="work",
+            metadata={"user_id": 1, f"{P}tenant": "acme"},
+        )
+    )
+    store.add(
+        MemoryNote(
+            id="p",
+            content="p",
+            category="personal",
+            metadata={"user_id": 1, f"{P}tenant": "acme"},
+        )
+    )
+
+    got = {
+        n.content
+        for n in store.search(
+            "x",
+            k=10,
+            filters={
+                "category": "work",
+                "metadata": {"user_id": 1, f"{P}tenant": "acme"},
+            },
+        )
+    }
+    assert got == {"w"}
+
+
+def test_subset_match_superset_returned_missing_excluded(temp_db_dir):
+    store = _store(temp_db_dir)
+    # A carries a superset {tenant, agent}; B carries only {tenant}; C differs.
+    store.add(
+        MemoryNote(
+            id="A",
+            content="A",
+            metadata={"user_id": 1, f"{P}tenant": "acme", f"{P}agent": "x"},
+        )
+    )
+    store.add(
+        MemoryNote(id="B", content="B", metadata={"user_id": 1, f"{P}tenant": "acme"})
+    )
+    store.add(
+        MemoryNote(id="C", content="C", metadata={"user_id": 1, f"{P}tenant": "other"})
+    )
+
+    # Query {tenant=acme}: A (superset) and B match; C does not.
+    got = {n.content for n in store.search("x", k=10, filters=_scope_filter("acme"))}
+    assert got == {"A", "B"}
+
+    # Query {tenant=acme, agent=x}: only A carries both.
+    got = {
+        n.content
+        for n in store.search(
+            "x",
+            k=10,
+            filters={"metadata": {"user_id": 1, f"{P}tenant": "acme", f"{P}agent": "x"}},
+        )
+    }
+    assert got == {"A"}
+
+
+def test_scoped_search_excludes_other_users(temp_db_dir):
+    store = _store(temp_db_dir)
+    store.add(
+        MemoryNote(id="u1", content="u1", metadata={"user_id": 1, f"{P}tenant": "acme"})
+    )
+    store.add(
+        MemoryNote(id="u2", content="u2", metadata={"user_id": 2, f"{P}tenant": "acme"})
+    )
+
+    got = {n.content for n in store.search("x", k=10, filters=_scope_filter("acme", 1))}
+    assert got == {"u1"}

--- a/tests/core/memory/test_scope_filter_pushdown.py
+++ b/tests/core/memory/test_scope_filter_pushdown.py
@@ -23,6 +23,7 @@ import pytest
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.memory.scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY
 from xagent.core.model.embedding import BaseEmbedding
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
@@ -210,7 +211,9 @@ def test_subset_match_superset_returned_missing_excluded(temp_db_dir):
         for n in store.search(
             "x",
             k=10,
-            filters={"metadata": {"user_id": 1, f"{P}tenant": "acme", f"{P}agent": "x"}},
+            filters={
+                "metadata": {"user_id": 1, f"{P}tenant": "acme", f"{P}agent": "x"}
+            },
         )
     }
     assert got == {"A"}
@@ -227,3 +230,90 @@ def test_scoped_search_excludes_other_users(temp_db_dir):
 
     got = {n.content for n in store.search("x", k=10, filters=_scope_filter("acme", 1))}
     assert got == {"u1"}
+
+
+def _bulk_build_with_unscoped(db_dir, n_principals, r=10, name="mem"):
+    """Shared collection: N scoped principals plus R unscoped notes for user 1."""
+    db = lancedb.connect(db_dir)
+    ts = "2026-01-01T00:00:00"
+    rows = []
+
+    def _row(note_id, dims, meta_extra):
+        metadata = {"content": note_id, "timestamp": ts, "user_id": 1, **meta_extra}
+        return {
+            "id": note_id,
+            "text": note_id,
+            "metadata": json.dumps(metadata),
+            "user_id": 1,
+            "scope_dims": dims,
+            "vector": list(_VECTOR),
+        }
+
+    for j in range(r):
+        rows.append(_row(f"unscoped-{j}", [], {}))
+        for p in range(n_principals):
+            rows.append(_row(f"t{p}-{j}", [f"tenant=t{p}"], {f"{P}tenant": f"t{p}"}))
+    table = db.create_table(name, data=rows)
+    _safe_close_table(table)
+
+
+@pytest.mark.parametrize("n_principals", [10, 100, 1000])
+def test_strict_exclusion_recall_is_population_independent(temp_db_dir, n_principals):
+    """The pushed-down strict exclusion (scope_exclusive) keeps recall of a
+    dimension-less strict search independent of how many scoped notes crowd the
+    collection."""
+    r = 10
+    _bulk_build_with_unscoped(temp_db_dir, n_principals, r=r)
+    store = _store(temp_db_dir)
+
+    # A strict dimension-less search: user_id only + the scope_exclusive directive.
+    results = store.search(
+        "anything",
+        k=r,
+        filters={"metadata": {"user_id": 1}, SCOPE_EXCLUSIVE_FILTER_KEY: True},
+    )
+    returned = {n.content for n in results}
+    expected = {f"unscoped-{j}" for j in range(r)}
+    recall = len(returned & expected) / r
+    assert recall == 1.0, f"N={n_principals}: strict recall collapsed to {recall}"
+    # No scope-stamped note leaked in.
+    assert returned <= expected
+
+
+def test_text_fallback_honors_scope_exclusive_and_dims(temp_db_dir):
+    """With no embedding model the store uses the text-search fallback, which
+    applies the `scope_exclusive` directive and dimension filters in Python
+    (the vector `where` path is never taken)."""
+    store = LanceDBMemoryStore(
+        db_dir=temp_db_dir, collection_name="mem", embedding_model=None
+    )
+    store.add(MemoryNote(id="u", content="hello unscoped", metadata={"user_id": 1}))
+    store.add(
+        MemoryNote(
+            id="s",
+            content="hello scoped",
+            metadata={"user_id": 1, f"{P}tenant": "acme"},
+        )
+    )
+
+    # scope_exclusive over the text fallback keeps only the dimension-less note.
+    got = {
+        n.content
+        for n in store.search(
+            "hello",
+            k=10,
+            filters={"metadata": {"user_id": 1}, SCOPE_EXCLUSIVE_FILTER_KEY: True},
+        )
+    }
+    assert got == {"hello unscoped"}
+
+    # A dimension filter over the text fallback returns only the scoped note.
+    got = {
+        n.content
+        for n in store.search(
+            "hello",
+            k=10,
+            filters={"metadata": {"user_id": 1, f"{P}tenant": "acme"}},
+        )
+    }
+    assert got == {"hello scoped"}

--- a/tests/core/memory/test_scope_filter_pushdown.py
+++ b/tests/core/memory/test_scope_filter_pushdown.py
@@ -24,28 +24,13 @@ from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore
 from xagent.core.memory.scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY
-from xagent.core.model.embedding import BaseEmbedding
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+from .conftest import ConstantEmbedding, VaryingEmbedding
 
 P = MEMORY_DIMENSION_METADATA_PREFIX
 DIM = 8
 _VECTOR = [0.1] * DIM
-
-
-class FixedEmbedding(BaseEmbedding):
-    """Every text embeds to the same vector, so distance cannot rank principals."""
-
-    def encode(self, text, dimension=None, instruct=None):
-        if isinstance(text, str):
-            return list(_VECTOR)
-        return [list(_VECTOR) for _ in text]
-
-    def get_dimension(self):
-        return DIM
-
-    @property
-    def abilities(self):
-        return ["embed"]
 
 
 @pytest.fixture
@@ -96,7 +81,7 @@ def _bulk_build(db_dir, n_principals, r=10, name="mem"):
 
 def _store(db_dir, name="mem"):
     return LanceDBMemoryStore(
-        db_dir=db_dir, collection_name=name, embedding_model=FixedEmbedding()
+        db_dir=db_dir, collection_name=name, embedding_model=ConstantEmbedding(DIM)
     )
 
 
@@ -182,6 +167,50 @@ def test_pushed_dims_combine_with_residual_category_filter(temp_db_dir):
         )
     }
     assert got == {"w"}
+
+
+def test_where_prefilter_preserves_similarity_ranking(temp_db_dir):
+    """With genuinely varying embeddings the where-prefilter restricts candidates
+    to the scoped rows while distance still orders them: a closer *other-tenant*
+    note is excluded, and the scoped rows come back nearest-first (guards against
+    the prefilter silently flattening or reordering similarity ranking)."""
+    vectors = {
+        "acme near": [1.0, 0.0, 0.0],
+        "acme far": [0.0, 0.0, 1.0],
+        # Identical to the query — the single closest note overall, but wrong
+        # tenant, so the prefilter must drop it despite its rank.
+        "other near": [1.0, 0.0, 0.0],
+        "q": [1.0, 0.0, 0.0],
+    }
+    store = LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="mem",
+        embedding_model=VaryingEmbedding(vectors, dim=3),
+    )
+    store.add(
+        MemoryNote(
+            id="an", content="acme near", metadata={"user_id": 1, f"{P}tenant": "acme"}
+        )
+    )
+    store.add(
+        MemoryNote(
+            id="af", content="acme far", metadata={"user_id": 1, f"{P}tenant": "acme"}
+        )
+    )
+    store.add(
+        MemoryNote(
+            id="on",
+            content="other near",
+            metadata={"user_id": 1, f"{P}tenant": "other"},
+        )
+    )
+
+    # Large threshold so the far scoped note is not dropped on distance alone.
+    results = store.search(
+        "q", k=10, filters=_scope_filter("acme"), similarity_threshold=10.0
+    )
+    # Only the scoped tenant survives, and nearest-first within it.
+    assert [n.content for n in results] == ["acme near", "acme far"]
 
 
 def test_subset_match_superset_returned_missing_excluded(temp_db_dir):

--- a/tests/core/memory/test_scope_filter_pushdown.py
+++ b/tests/core/memory/test_scope_filter_pushdown.py
@@ -259,14 +259,14 @@ def _bulk_build_with_unscoped(db_dir, n_principals, r=10, name="mem"):
 
 @pytest.mark.parametrize("n_principals", [10, 100, 1000])
 def test_strict_exclusion_recall_is_population_independent(temp_db_dir, n_principals):
-    """The pushed-down strict exclusion (scope_exclusive) keeps recall of a
-    dimension-less strict search independent of how many scoped notes crowd the
+    """The pushed-down strict exclusion (``__scope_exclusive__``) keeps recall of
+    a dimension-less strict search independent of how many scoped notes crowd the
     collection."""
     r = 10
     _bulk_build_with_unscoped(temp_db_dir, n_principals, r=r)
     store = _store(temp_db_dir)
 
-    # A strict dimension-less search: user_id only + the scope_exclusive directive.
+    # A strict dimension-less search: user_id only + the __scope_exclusive__ directive.
     results = store.search(
         "anything",
         k=r,
@@ -321,7 +321,7 @@ def test_where_prefilter_query_failure_falls_back_with_isolation(
 
 def test_text_fallback_honors_scope_exclusive_and_dims(temp_db_dir):
     """With no embedding model the store uses the text-search fallback, which
-    applies the `scope_exclusive` directive and dimension filters in Python
+    applies the `__scope_exclusive__` directive and dimension filters in Python
     (the vector `where` path is never taken)."""
     store = LanceDBMemoryStore(
         db_dir=temp_db_dir, collection_name="mem", embedding_model=None
@@ -335,7 +335,7 @@ def test_text_fallback_honors_scope_exclusive_and_dims(temp_db_dir):
         )
     )
 
-    # scope_exclusive over the text fallback keeps only the dimension-less note.
+    # __scope_exclusive__ over the text fallback keeps only the dimension-less note.
     got = {
         n.content
         for n in store.search(

--- a/tests/core/memory/test_scope_filter_pushdown.py
+++ b/tests/core/memory/test_scope_filter_pushdown.py
@@ -280,6 +280,45 @@ def test_strict_exclusion_recall_is_population_independent(temp_db_dir, n_princi
     assert returned <= expected
 
 
+def test_where_prefilter_query_failure_falls_back_with_isolation(
+    temp_db_dir, monkeypatch, caplog
+):
+    """If the where-prefiltered vector query itself raises (not embedding
+    generation — the embedding model here works), the except branch falls back
+    to text search, which re-applies the full filters in Python so isolation is
+    preserved, and logs the distinguishable pushdown-bypassed warning."""
+    import logging
+
+    from xagent.core.memory import lancedb as lancedb_module
+    from xagent.core.memory.scope_columns import build_scope_where
+
+    store = _store(temp_db_dir)
+    store.add(
+        MemoryNote(id="a", content="x", metadata={"user_id": 1, f"{P}tenant": "acme"})
+    )
+    store.add(
+        MemoryNote(id="b", content="x", metadata={"user_id": 1, f"{P}tenant": "other"})
+    )
+
+    # Force only the pushdown clause to be invalid SQL so `.where(...)` raises at
+    # query time; keep the residual filters build intact so the full `filters`
+    # dict the text fallback re-applies is unchanged.
+    def _broken_where(filters):
+        _, residual = build_scope_where(filters)
+        return "this is not valid sql !!!", residual
+
+    monkeypatch.setattr(lancedb_module, "build_scope_where", _broken_where)
+
+    with caplog.at_level(logging.WARNING):
+        results = store.search("x", k=10, filters=_scope_filter("acme"))
+
+    # Isolation preserved by the text-fallback's Python filtering.
+    assert {n.content for n in results} == {"x"}
+    assert {n.id for n in results} == {"a"}
+    # Distinguishable pushdown-bypassed warning fired (not the generic one).
+    assert any("recall pushdown is bypassed" in r.getMessage() for r in caplog.records)
+
+
 def test_text_fallback_honors_scope_exclusive_and_dims(temp_db_dir):
     """With no embedding model the store uses the text-search fallback, which
     applies the `scope_exclusive` directive and dimension filters in Python

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -216,6 +216,35 @@ class TestStrictIsolation:
         assert [str(n.content) for n in results] == ["note tenant a"]
 
 
+class TestCallerFiltersNotMutated:
+    """``_add_user_filter`` must work on copies: a caller-supplied ``filters``
+    dict (and its nested ``metadata`` dict) is never mutated in place, so the
+    same object can be reused across scopes."""
+
+    def test_search_leaves_caller_filters_untouched(self, store):
+        _seed_user_notes(store)
+        original = {"metadata": {"foo": "bar"}}
+        strict = ExecutionScope(strict_memory_isolation=True)
+        with UserContext(1), ExecutionScopeContext(strict):
+            store.search("note", filters=original)
+        # No injected user_id / scope-exclusive directive leaked back out.
+        assert original == {"metadata": {"foo": "bar"}}
+
+    def test_same_filters_dict_reused_across_scopes(self, store):
+        _seed_user_notes(store)
+        shared = {"metadata": {}}
+        with UserContext(1):
+            with ExecutionScopeContext(SCOPE_A):
+                seen_a = {n.id for n in store.search("note", filters=shared)}
+            with ExecutionScopeContext(SCOPE_B):
+                seen_b = {n.id for n in store.search("note", filters=shared)}
+        # A leaked SCOPE_A dimension would empty (or cross-contaminate) the
+        # SCOPE_B search; disjoint results prove no state carried over.
+        assert seen_a and seen_b
+        assert seen_a.isdisjoint(seen_b)
+        assert shared == {"metadata": {}}
+
+
 class TestResolverPathAndNestedReactivation:
     def test_turn_scope_reaches_memory_via_resolver(self, store):
         """The resolver path: memory operations inside a turn carry the

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -3,10 +3,13 @@
 ``UserIsolatedMemoryStore`` stamps the active scope's ``memory_dimensions``
 onto note metadata on add and filters on them on search, alongside the
 existing ``user_id`` handling. Default visibility is one-way; strict
-isolation post-filters scope-stamped notes out of dimension-less searches.
+isolation excludes scope-stamped notes from dimension-less searches. That
+exclusion is carried in the filters as ``scope_exclusive`` and applied by the
+store (#822 slice 003), not post-filtered in the wrapper.
 
 The fake base store mirrors the LanceDB filter semantics: nested
-``filters["metadata"]`` entries applied as string-equality checks.
+``filters["metadata"]`` entries applied as string-equality checks, plus the
+``scope_exclusive`` directive.
 """
 
 from typing import Any, List, Optional
@@ -21,6 +24,10 @@ from xagent.core.execution_scope import (
 )
 from xagent.core.memory.base import MemoryStore
 from xagent.core.memory.core import MemoryNote, MemoryResponse
+from xagent.core.memory.scope_columns import (
+    SCOPE_EXCLUSIVE_FILTER_KEY,
+    encode_scope_dims,
+)
 from xagent.web.user_isolated_memory import UserContext, UserIsolatedMemoryStore
 
 SCOPE_A = ExecutionScope(memory_dimensions={"tenant": "a"})
@@ -52,7 +59,12 @@ class FakeBaseStore(MemoryStore):
         return MemoryResponse(success=True, memory_id=note_id)
 
     def _matches(self, note: MemoryNote, filters: Optional[dict]) -> bool:
-        metadata_filters = (filters or {}).get("metadata", {})
+        filters = filters or {}
+        # Mirror the store's scope_exclusive handling: strict dimension-less
+        # searches exclude any scope-stamped note.
+        if filters.get(SCOPE_EXCLUSIVE_FILTER_KEY) and encode_scope_dims(note.metadata):
+            return False
+        metadata_filters = filters.get("metadata", {})
         return all(
             str(note.metadata.get(key, "")) == str(value)
             for key, value in metadata_filters.items()

--- a/tests/web/test_execution_scope_memory.py
+++ b/tests/web/test_execution_scope_memory.py
@@ -4,12 +4,12 @@
 onto note metadata on add and filters on them on search, alongside the
 existing ``user_id`` handling. Default visibility is one-way; strict
 isolation excludes scope-stamped notes from dimension-less searches. That
-exclusion is carried in the filters as ``scope_exclusive`` and applied by the
-store (#822 slice 003), not post-filtered in the wrapper.
+exclusion is carried in the filters as ``__scope_exclusive__`` and applied by
+the store (#822 slice 003), not post-filtered in the wrapper.
 
 The fake base store mirrors the LanceDB filter semantics: nested
 ``filters["metadata"]`` entries applied as string-equality checks, plus the
-``scope_exclusive`` directive.
+``__scope_exclusive__`` directive.
 """
 
 from typing import Any, List, Optional
@@ -60,7 +60,7 @@ class FakeBaseStore(MemoryStore):
 
     def _matches(self, note: MemoryNote, filters: Optional[dict]) -> bool:
         filters = filters or {}
-        # Mirror the store's scope_exclusive handling: strict dimension-less
+        # Mirror the store's __scope_exclusive__ handling: strict dimension-less
         # searches exclude any scope-stamped note.
         if filters.get(SCOPE_EXCLUSIVE_FILTER_KEY) and encode_scope_dims(note.metadata):
             return False


### PR DESCRIPTION
## Dependency (satisfied)

This completes the locked sequence from #792:

> ① safe migration infra (#792, merged via #823) → ② promote dimensions to real columns → ③ push filters into a `where` clause

#792 (#823) is now merged to `main`; this branch is rebased onto it, so the diff
is just the three `822-*` commits:

- `822-01` — promote `user_id` + `scope_dims` to real LanceDB columns (+ migration)
- `822-02` — push scope filters into a `where` prefilter (the recall fix)
- `822-03` — push the strict-isolation exclusion into `where`; drop the wrapper post-filter

## The bug

`LanceDBMemoryStore.search()` ran `.limit(k)` at the DB layer and then
post-filtered `user_id` + scope dimensions in Python. When many principals share
one collection under a single `user_id` (isolated only by scope dimensions), the
target's notes get crowded out of the top-k **before** the filter runs, so recall
silently collapses to ~`1/N`. A fixed over-fetch factor `F` only helps while
`N ≲ F`; covering thousands of principals needs `F ≈ N` — a full scan that defeats
the ANN index. The text-search fallback already filters before truncating, so only
the vector path was affected.

## The fix

`where` cannot filter fields inside the JSON `metadata` string, so the two fields
scope searches filter on are promoted to real columns and the filter is pushed
into a `where` **prefilter** (scoping happens before the top-k selection), making
recall population-independent.

- **`user_id`** (int64) — filtered by equality.
- **`scope_dims`** (`list<string>`) — one `"key=value"` element per dimension,
  e.g. `["agent=x", "tenant=acme"]`. Each required dimension becomes an
  `array_contains(scope_dims, 'key=value')` term. `array_contains` is exact
  per-element string equality, so a note carrying a **superset** of the queried
  dimensions still matches while a different value or a prefix does not — values
  may contain any character (`=`, `/`, `_` …) with no escaping, and there is no
  substring-collision surface.

The `metadata` JSON stays authoritative — the columns are derived projections
computed on write and back-filled from metadata on migration; nothing
reconstructs a note from them. Only `user_id` + scope dimensions are pushed;
category and arbitrary metadata keys remain a Python post-filter over the (now
already-scoped) results, and the no-embedding text fallback keeps its
filter-before-truncate behavior. The `strict_memory_isolation` dimension-less
exclusion is carried as a reserved, namespaced `scope_exclusive` filter directive
and pushed into the same `where` clause (`array_length(scope_dims) = 0`),
removing the last crowd-out path; `UserIsolatedMemoryStore`, the text fallback,
and `InMemoryMemoryStore` all honor it, replacing the wrapper's Python
`_apply_strict_isolation` post-filter.

Existing tables migrate in place via the #792 `migrate_table_swap` primitive,
preserving every row and the vector column (no re-embed) and leaving the table
intact on failure.

> Encoding note: an earlier revision used a delimited token string matched with
> `LIKE ... ESCAPE`. Per review, this was replaced with the `list<string>` +
> `array_contains` design above, which removes all delimiter/wildcard escaping
> and the substring-collision surface entirely.

## Acceptance criteria (#822)

- [x] `user_id` + scope-dimension filters are pushed into a LanceDB `where` clause
      instead of Python post-filtering.
- [x] Recall is population-independent (regression test simulating shared
      collections across N principals).
- [x] Text-search fallback filter-before-truncate behavior is preserved.

## Test plan

- New population-independence regressions assert recall `1.0` for `N ∈ {10, 100, 1000}`
  on a shared collection, for both scoped searches and strict dimension-less
  searches, matching the measurement in #822.
- End-to-end exact-match test drives a value containing `_` (a would-be LIKE
  wildcard) through `store.search` and asserts it matches only its exact sibling.
- Encoding unit tests: order-independent, raw values (no escaping), empty case.
- Where-clause construction unit tests: `user_id` equality, `array_contains`
  per dimension, residual-filter split, `scope_exclusive` → `array_length = 0`.
- Migration tests: legacy table (no derived columns) is back-filled from metadata
  with zero data loss and the metadata JSON left intact; promotion is idempotent.
- `tests/core/memory/` and the execution-scope memory suites
  (`tests/web/test_execution_scope_memory.py`, `tests/web/test_execution_scope_delegation.py`,
  `tests/web/test_memory_api.py`) pass; `ruff` and `mypy` clean.

## Follow-up (out of scope, tracked separately)

A pre-existing `InMemoryMemoryStore` filtering bug (nested `filters["metadata"]`
ignored → default-path `list_all` is fail-open on `user_id` isolation), surfaced
during review, is tracked in #842 and is not addressed here.

Closes #822
