### PR TITLE
feat: add A2A agent protocol support

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -169,6 +169,7 @@ class AgentExecutionAdapter:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> bool:
@@ -188,6 +189,7 @@ class AgentExecutionAdapter:
             execution_message=execution_message,
             display_message=display_message,
             files=files,
+            turn_id=turn_id,
             request_interrupt=request_interrupt,
             reason=reason,
         )

--- a/src/xagent/core/agent/registry.py
+++ b/src/xagent/core/agent/registry.py
@@ -209,6 +209,7 @@ class ExecutionRegistry:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -222,6 +223,7 @@ class ExecutionRegistry:
             execution_message=execution_message,
             display_message=display_message,
             files=files,
+            turn_id=turn_id,
             request_interrupt=request_interrupt,
             reason=reason,
         )
@@ -234,6 +236,7 @@ class ExecutionRegistry:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -243,6 +246,7 @@ class ExecutionRegistry:
             execution_message=execution_message,
             display_message=display_message,
             files=files,
+            turn_id=turn_id,
             request_interrupt=request_interrupt,
             reason=reason,
         )
@@ -262,6 +266,7 @@ class ExecutionRegistry:
                     "display_message": resolved_display_message,
                     "execution_message": resolved_execution_message,
                     "files": files,
+                    "turn_id": turn_id,
                     "request_interrupt": request_interrupt,
                 },
             )

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -307,6 +307,7 @@ class AgentRunner:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -340,6 +341,24 @@ class AgentRunner:
         resolved_display_message = (
             display_message if display_message is not None else message
         )
+        requested_turn_id = turn_id.strip() if turn_id and turn_id.strip() else None
+        if requested_turn_id is not None:
+            for existing in context.messages:
+                existing_metadata = getattr(existing, "metadata", None)
+                if (
+                    getattr(existing, "role", None) != "user"
+                    or not isinstance(existing_metadata, dict)
+                    or existing_metadata.get("turn_id") != requested_turn_id
+                ):
+                    continue
+                if existing.content != resolved_execution_message:
+                    raise ValueError(
+                        "turn_id is already associated with a different user message"
+                    )
+                if request_interrupt:
+                    self.pause(execution_id, reason=reason or "new user message")
+                return context
+
         # Attach files + display text to the new Message so they survive
         # checkpoint round-trips: Message.metadata is serialized by
         # ExecutionContext. The on_user_message_posted callback reads
@@ -348,6 +367,8 @@ class AgentRunner:
         metadata: dict[str, Any] = {"display_message": resolved_display_message}
         if files is not None:
             metadata["files"] = files
+        if requested_turn_id is not None:
+            metadata["turn_id"] = requested_turn_id
         self._ensure_user_message_turn_id(metadata)
 
         added = context.add_user_message(resolved_execution_message, metadata=metadata)
@@ -484,6 +505,7 @@ class AgentRunner:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> ExecutionContext | None:
@@ -498,6 +520,7 @@ class AgentRunner:
             execution_message=execution_message,
             display_message=display_message,
             files=files,
+            turn_id=turn_id,
             request_interrupt=request_interrupt,
             reason=reason,
         )

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -265,6 +265,7 @@ class AgentService:
         execution_message: str | None = None,
         display_message: str | None = None,
         files: list[dict[str, Any]] | None = None,
+        turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
     ) -> bool:
@@ -277,6 +278,7 @@ class AgentService:
                 execution_message=execution_message,
                 display_message=display_message,
                 files=files,
+                turn_id=turn_id,
                 request_interrupt=request_interrupt,
                 reason=reason,
             )

--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -310,9 +310,9 @@ def create_a2a_agent_tools_from_configs(
             continue
         timeout_seconds = item.get("timeout_seconds", 60.0)
         try:
-            timeout = float(str(timeout_seconds))
+            request_timeout_seconds = float(str(timeout_seconds))
         except (TypeError, ValueError):
-            timeout = 60.0
+            request_timeout_seconds = 60.0
         tool = A2AAgentTool(
             name=raw_name,
             description=_optional_str(item.get("description")),
@@ -322,7 +322,7 @@ def create_a2a_agent_tools_from_configs(
             if isinstance(item.get("headers"), dict)
             else {},
             auth_token=_optional_str(item.get("auth_token")),
-            timeout_seconds=timeout,
+            timeout_seconds=request_timeout_seconds,
             allow_private_networks=item.get("allow_private_networks") is True,
         )
         tools.append(tool)

--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import re
+import socket
 import time
 from asyncio import sleep, timeout
 from typing import Any, Mapping, Optional, Type
@@ -11,12 +14,14 @@ from uuid import uuid4
 import httpx
 from pydantic import BaseModel, Field
 
+from ....utils.security import reject_private_network_host
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .config import BaseToolConfig
 from .factory import register_tool
 
 A2A_MEDIA_TYPE = "application/a2a+json"
 A2A_VERSION = "1.0"
+A2A_TOOL_ERROR_MESSAGE = "Remote A2A agent call failed."
 _TERMINAL_STATES = {
     "TASK_STATE_COMPLETED",
     "TASK_STATE_FAILED",
@@ -35,6 +40,8 @@ _FAILURE_STATES = {
     "TASK_STATE_CANCELLED",
     "TASK_STATE_REJECTED",
 }
+
+logger = logging.getLogger(__name__)
 
 
 class A2AAgentToolArgs(BaseModel):
@@ -86,13 +93,21 @@ class A2AAgentTool(AbstractBaseTool):
         headers: Mapping[str, Any] | None = None,
         auth_token: str | None = None,
         timeout_seconds: float = 60.0,
+        allow_private_networks: bool = False,
     ):
         self._name = _tool_name(name)
         self._description = description or (
             "Call a remote A2A agent and return its response."
         )
-        self._endpoint_url = _clean_url(endpoint_url)
-        self._agent_card_url = _clean_url(agent_card_url)
+        self._allow_private_networks = allow_private_networks is True
+        self._endpoint_url = _clean_url(
+            endpoint_url,
+            allow_private_networks=self._allow_private_networks,
+        )
+        self._agent_card_url = _clean_url(
+            agent_card_url,
+            allow_private_networks=self._allow_private_networks,
+        )
         self._headers = _string_headers(headers)
         self._auth_token = auth_token.strip() if isinstance(auth_token, str) else None
         self._timeout_seconds = max(float(timeout_seconds or 60.0), 1.0)
@@ -131,7 +146,13 @@ class A2AAgentTool(AbstractBaseTool):
 
         try:
             async with timeout(self._timeout_seconds):
-                async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+                async with httpx.AsyncClient(
+                    timeout=self._timeout_seconds,
+                    transport=_PinnedA2ATransport(
+                        allow_private_networks=self._allow_private_networks
+                    ),
+                    follow_redirects=False,
+                ) as client:
                     deadline = time.monotonic() + self._timeout_seconds
                     endpoint_url = await self._resolve_endpoint_url(client)
                     response = await client.post(
@@ -156,11 +177,12 @@ class A2AAgentTool(AbstractBaseTool):
                 response="",
                 error=f"A2A call timed out after {self._timeout_seconds:g}s.",
             ).model_dump()
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
+            logger.exception("A2A agent tool %s call failed", self._name)
             return A2AAgentToolResult(
                 success=False,
                 response="",
-                error=str(exc),
+                error=A2A_TOOL_ERROR_MESSAGE,
             ).model_dump()
 
         task = _extract_task_payload(payload)
@@ -248,7 +270,10 @@ class A2AAgentTool(AbstractBaseTool):
         endpoint_url = _endpoint_from_card(card)
         if not endpoint_url:
             raise ValueError("A2A agent card does not expose an HTTP+JSON endpoint.")
-        endpoint_url = _clean_url(endpoint_url)
+        endpoint_url = _clean_url(
+            endpoint_url,
+            allow_private_networks=self._allow_private_networks,
+        )
         if endpoint_url is None:
             raise ValueError("A2A agent card does not expose a valid endpoint URL.")
         if not _same_origin(self._agent_card_url, endpoint_url):
@@ -298,6 +323,7 @@ def create_a2a_agent_tools_from_configs(
             else {},
             auth_token=_optional_str(item.get("auth_token")),
             timeout_seconds=timeout,
+            allow_private_networks=item.get("allow_private_networks") is True,
         )
         tools.append(tool)
     return tools
@@ -479,7 +505,107 @@ def _tool_name(value: str) -> str:
     return normalized
 
 
-def _clean_url(value: str | None) -> str | None:
+class _PinnedA2ATransport(httpx.AsyncBaseTransport):
+    """Resolve, validate, and pin A2A hosts before opening a connection."""
+
+    def __init__(self, *, allow_private_networks: bool):
+        self._allow_private_networks = allow_private_networks
+        self._transport = httpx.AsyncHTTPTransport(trust_env=False, http2=False)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if self._allow_private_networks:
+            return await self._transport.handle_async_request(request)
+
+        original_url = request.url
+        original_host = request.headers.get("Host")
+        addresses = await _resolve_public_addresses(str(original_url))
+        last_error: httpx.TransportError | None = None
+        for index, address in enumerate(addresses):
+            request.url = original_url.copy_with(host=address)
+            request.headers["Host"] = _host_header_value(str(original_url))
+            if original_url.scheme == "https":
+                request.extensions["sni_hostname"] = _hostname_for_url(
+                    str(original_url)
+                )
+            try:
+                return await self._transport.handle_async_request(request)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                last_error = exc
+                if index == len(addresses) - 1:
+                    raise
+            finally:
+                request.url = original_url
+                if original_host is None:
+                    request.headers.pop("Host", None)
+                else:
+                    request.headers["Host"] = original_host
+        if last_error is not None:
+            raise last_error
+        raise httpx.ConnectError(
+            "A2A endpoint host could not be resolved.", request=request
+        )
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+async def _resolve_public_addresses(value: str) -> list[str]:
+    parsed = urlsplit(value)
+    hostname = (parsed.hostname or "").rstrip(".").lower()
+    reject_private_network_host(hostname)
+    port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    try:
+        loop = asyncio.get_running_loop()
+        records = await loop.run_in_executor(
+            None,
+            socket.getaddrinfo,
+            hostname,
+            port,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+    except OSError as exc:
+        raise httpx.ConnectError("A2A endpoint host could not be resolved.") from exc
+
+    addresses: list[str] = []
+    for record in records:
+        sockaddr = record[4]
+        if not sockaddr:
+            continue
+        address = str(sockaddr[0])
+        reject_private_network_host(address)
+        if address not in addresses:
+            addresses.append(address)
+    if not addresses:
+        raise httpx.ConnectError("A2A endpoint host could not be resolved.")
+    return addresses
+
+
+def _hostname_for_url(value: str) -> str:
+    hostname = urlsplit(value).hostname
+    if not hostname:
+        raise ValueError("A2A URL must include a hostname.")
+    return hostname.rstrip(".").lower()
+
+
+def _host_header_value(value: str) -> str:
+    parsed = urlsplit(value)
+    hostname = _hostname_for_url(value)
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    port = parsed.port
+    if port and not (
+        (parsed.scheme.lower() == "http" and port == 80)
+        or (parsed.scheme.lower() == "https" and port == 443)
+    ):
+        return f"{host}:{port}"
+    return host
+
+
+def _clean_url(
+    value: str | None,
+    *,
+    allow_private_networks: bool = False,
+) -> str | None:
     if not isinstance(value, str):
         return None
     value = value.strip()
@@ -498,6 +624,8 @@ def _clean_url(value: str | None) -> str | None:
         parsed.port
     except ValueError as exc:
         raise ValueError("A2A URLs must contain a valid port.") from exc
+    if not allow_private_networks:
+        reject_private_network_host(parsed.hostname)
     return value
 
 

--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from asyncio import sleep, timeout
+from typing import Any, Mapping, Optional, Type
+from urllib.parse import quote, urlsplit
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel, Field
+
+from .base import AbstractBaseTool, ToolCategory, ToolVisibility
+from .config import BaseToolConfig
+from .factory import register_tool
+
+A2A_MEDIA_TYPE = "application/a2a+json"
+A2A_VERSION = "1.0"
+_HTTP_JSON_BINDINGS = {"HTTP+JSON", "HTTP_JSON", "http+json", "http_json"}
+_TERMINAL_STATES = {
+    "TASK_STATE_COMPLETED",
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_CANCELLED",
+    "TASK_STATE_REJECTED",
+}
+_INTERRUPTED_STATES = {
+    "TASK_STATE_INPUT_REQUIRED",
+    "TASK_STATE_AUTH_REQUIRED",
+}
+_STOP_STATES = _TERMINAL_STATES | _INTERRUPTED_STATES
+_FAILURE_STATES = {
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_CANCELLED",
+    "TASK_STATE_REJECTED",
+}
+
+
+class A2AAgentToolArgs(BaseModel):
+    """Arguments for invoking a remote A2A agent."""
+
+    task: str = Field(description="Task or message to send to the remote A2A agent")
+    context_id: Optional[str] = Field(
+        default=None,
+        description="Optional remote A2A context ID for continuing a conversation",
+    )
+    task_id: Optional[str] = Field(
+        default=None,
+        description="Optional remote A2A task ID for continuing an interrupted task",
+    )
+    metadata: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Optional metadata to pass through in the A2A message",
+    )
+
+
+class A2AAgentToolResult(BaseModel):
+    """Result from a remote A2A agent invocation."""
+
+    success: bool = Field(description="Whether the remote A2A call completed")
+    task_id: Optional[str] = Field(default=None, description="Remote A2A task ID")
+    context_id: Optional[str] = Field(default=None, description="Remote A2A context ID")
+    state: Optional[str] = Field(default=None, description="Remote A2A task state")
+    response: str = Field(description="Text extracted from remote response")
+    artifacts: list[dict[str, Any]] = Field(default_factory=list)
+    raw: Optional[dict[str, Any]] = Field(
+        default=None, description="Raw A2A response payload"
+    )
+    error: Optional[str] = Field(default=None, description="Remote call error")
+
+
+class A2AAgentTool(AbstractBaseTool):
+    """Tool wrapper for a remote A2A HTTP+JSON agent."""
+
+    category: ToolCategory = ToolCategory.AGENT
+    concurrency_safe = True
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        endpoint_url: str | None = None,
+        agent_card_url: str | None = None,
+        headers: Mapping[str, Any] | None = None,
+        auth_token: str | None = None,
+        timeout_seconds: float = 60.0,
+    ):
+        self._name = _tool_name(name)
+        self._description = description or (
+            "Call a remote A2A agent and return its response."
+        )
+        self._endpoint_url = _clean_url(endpoint_url)
+        self._agent_card_url = _clean_url(agent_card_url)
+        self._headers = _string_headers(headers)
+        self._auth_token = auth_token.strip() if isinstance(auth_token, str) else None
+        self._timeout_seconds = max(float(timeout_seconds or 60.0), 1.0)
+        self._visibility = ToolVisibility.PUBLIC
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def tags(self) -> list[str]:
+        return ["a2a", "agent", "remote"]
+
+    def args_type(self) -> Type[BaseModel]:
+        return A2AAgentToolArgs
+
+    def return_type(self) -> Type[BaseModel]:
+        return A2AAgentToolResult
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        raise NotImplementedError("A2AAgentTool only supports async execution.")
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        parsed = A2AAgentToolArgs(**dict(args))
+        task_text = parsed.task.strip()
+        if not task_text:
+            return A2AAgentToolResult(
+                success=False,
+                response="",
+                error="Task must not be empty.",
+            ).model_dump()
+
+        try:
+            async with timeout(self._timeout_seconds):
+                async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+                    deadline = time.monotonic() + self._timeout_seconds
+                    endpoint_url = await self._resolve_endpoint_url(client)
+                    response = await client.post(
+                        _message_send_url(endpoint_url),
+                        json=_message_send_payload(parsed),
+                        headers=self._request_headers(),
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+                    task = _extract_task_payload(payload)
+                    if task is not None and _should_poll_task(task):
+                        task, payload = await self._poll_task_until_terminal(
+                            client=client,
+                            endpoint_url=endpoint_url,
+                            task=task,
+                            raw_payload=payload,
+                            deadline=deadline,
+                        )
+        except TimeoutError:
+            return A2AAgentToolResult(
+                success=False,
+                response="",
+                error=f"A2A call timed out after {self._timeout_seconds:g}s.",
+            ).model_dump()
+        except Exception as exc:  # noqa: BLE001
+            return A2AAgentToolResult(
+                success=False,
+                response="",
+                error=str(exc),
+            ).model_dump()
+
+        task = _extract_task_payload(payload)
+        if task is None:
+            message = _extract_message_payload(payload)
+            return A2AAgentToolResult(
+                success=True,
+                response=(
+                    "\n\n".join(_text_parts(message.get("parts"))).strip()
+                    if message is not None
+                    else _json_text(payload)
+                ),
+                raw=payload if isinstance(payload, dict) else {"response": payload},
+            ).model_dump()
+
+        state = _task_state(task)
+        response_text = _task_text(task)
+        normalized_state = _normalized_state(state)
+        failed = normalized_state in _FAILURE_STATES
+        interrupted = normalized_state in _INTERRUPTED_STATES
+        completed = normalized_state == "TASK_STATE_COMPLETED"
+        error = None
+        if failed or interrupted:
+            error = response_text or f"Remote A2A task stopped in {state}."
+        elif not completed:
+            error = f"Remote A2A task did not reach a completed state ({state})."
+        result = A2AAgentToolResult(
+            success=completed,
+            task_id=_optional_str(task.get("id")),
+            context_id=_optional_str(task.get("contextId")),
+            state=state,
+            response=response_text,
+            artifacts=_artifacts(task),
+            raw=payload if isinstance(payload, dict) else {"response": payload},
+            error=error,
+        )
+        return result.model_dump()
+
+    async def _poll_task_until_terminal(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        endpoint_url: str,
+        task: dict[str, Any],
+        raw_payload: Any,
+        deadline: float,
+    ) -> tuple[dict[str, Any], Any]:
+        task_id = _optional_str(task.get("id"))
+        if not task_id:
+            return task, raw_payload
+
+        while time.monotonic() < deadline:
+            await sleep(min(1.0, max(deadline - time.monotonic(), 0.0)))
+            response = await client.get(
+                _task_url(endpoint_url, task_id),
+                headers=self._request_headers(),
+            )
+            response.raise_for_status()
+            payload = response.json()
+            fresh = _extract_task_payload(payload)
+            if fresh is None:
+                return task, raw_payload
+            task = fresh
+            raw_payload = payload
+            if not _should_poll_task(task):
+                return task, raw_payload
+        raise TimeoutError(
+            f"A2A task {task_id} did not finish within {self._timeout_seconds:g}s."
+        )
+
+    async def _resolve_endpoint_url(self, client: httpx.AsyncClient) -> str:
+        if self._endpoint_url:
+            return self._endpoint_url
+        if not self._agent_card_url:
+            raise ValueError("A2A tool requires endpoint_url or agent_card_url.")
+
+        response = await client.get(
+            self._agent_card_url, headers=self._request_headers()
+        )
+        response.raise_for_status()
+        card = response.json()
+        if not isinstance(card, Mapping):
+            raise ValueError("A2A agent card response must be a JSON object.")
+
+        endpoint_url = _endpoint_from_card(card)
+        if not endpoint_url:
+            raise ValueError("A2A agent card does not expose an HTTP+JSON endpoint.")
+        self._endpoint_url = endpoint_url
+        if self._description == "Call a remote A2A agent and return its response.":
+            description = card.get("description")
+            if isinstance(description, str) and description.strip():
+                self._description = description.strip()
+        return endpoint_url
+
+    def _request_headers(self) -> dict[str, str]:
+        headers = dict(self._headers)
+        headers["Accept"] = A2A_MEDIA_TYPE
+        headers["Content-Type"] = A2A_MEDIA_TYPE
+        headers["A2A-Version"] = A2A_VERSION
+        if self._auth_token and "authorization" not in {key.lower() for key in headers}:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers
+
+
+def create_a2a_agent_tools_from_configs(
+    configs: list[dict[str, Any]],
+) -> list[A2AAgentTool]:
+    tools: list[A2AAgentTool] = []
+    for item in configs:
+        if not isinstance(item, dict):
+            continue
+        raw_name = item.get("name") or item.get("tool_name") or item.get("id")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            continue
+        timeout_seconds = item.get("timeout_seconds", item.get("timeout", 60.0))
+        try:
+            timeout = float(str(timeout_seconds))
+        except (TypeError, ValueError):
+            timeout = 60.0
+        tool = A2AAgentTool(
+            name=raw_name,
+            description=_optional_str(item.get("description")),
+            endpoint_url=_optional_str(item.get("endpoint_url") or item.get("url")),
+            agent_card_url=_optional_str(
+                item.get("agent_card_url") or item.get("card_url")
+            ),
+            headers=item.get("headers")
+            if isinstance(item.get("headers"), dict)
+            else {},
+            auth_token=_optional_str(item.get("auth_token") or item.get("api_key")),
+            timeout_seconds=timeout,
+        )
+        tools.append(tool)
+    return tools
+
+
+@register_tool(categories={"agent"})
+async def create_a2a_agent_tools(config: BaseToolConfig) -> list[AbstractBaseTool]:
+    configs = config.get_a2a_agent_configs()
+    if not configs:
+        return []
+    tools: list[AbstractBaseTool] = []
+    tools.extend(create_a2a_agent_tools_from_configs(configs))
+    return tools
+
+
+def _message_send_payload(args: A2AAgentToolArgs) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "messageId": str(uuid4()),
+        "role": "ROLE_USER",
+        "parts": [{"text": args.task}],
+    }
+    if args.context_id:
+        message["contextId"] = args.context_id
+    if args.task_id:
+        message["taskId"] = args.task_id
+    if args.metadata:
+        message["metadata"] = args.metadata
+    return {
+        "message": message,
+        "configuration": {
+            "acceptedOutputModes": ["text/plain"],
+            "returnImmediately": True,
+        },
+    }
+
+
+def _message_send_url(endpoint_url: str) -> str:
+    endpoint_url = endpoint_url.rstrip("/")
+    if endpoint_url.endswith("/message:send"):
+        return endpoint_url
+    return f"{endpoint_url}/message:send"
+
+
+def _task_url(endpoint_url: str, task_id: str) -> str:
+    endpoint_url = endpoint_url.rstrip("/")
+    if endpoint_url.endswith("/message:send"):
+        endpoint_url = endpoint_url.removesuffix("/message:send")
+    return f"{endpoint_url}/tasks/{quote(task_id, safe='')}"
+
+
+def _endpoint_from_card(card: Mapping[str, Any]) -> str | None:
+    interfaces = card.get("supportedInterfaces")
+    if isinstance(interfaces, list):
+        for item in interfaces:
+            if not isinstance(item, Mapping):
+                continue
+            url = _optional_str(item.get("url"))
+            if not url:
+                continue
+            binding = _optional_str(item.get("protocolBinding"))
+            protocol_version = _optional_str(item.get("protocolVersion"))
+            if (
+                binding in _HTTP_JSON_BINDINGS
+                and protocol_version is not None
+                and protocol_version.split(".", maxsplit=1)[0] == "1"
+            ):
+                return url
+    return None
+
+
+def _extract_task_payload(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, Mapping):
+        return None
+    if isinstance(payload.get("status"), Mapping) and payload.get("id") is not None:
+        return dict(payload)
+    direct_task = payload.get("task")
+    if isinstance(direct_task, dict):
+        return direct_task
+    result = payload.get("result")
+    if isinstance(result, dict):
+        nested_task = result.get("task")
+        if isinstance(nested_task, dict):
+            return nested_task
+        if "status" in result:
+            return result
+    return None
+
+
+def _extract_message_payload(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, Mapping):
+        return None
+    if payload.get("role") in {"ROLE_AGENT", "ROLE_USER"} and isinstance(
+        payload.get("parts"), list
+    ):
+        return dict(payload)
+    message = payload.get("message")
+    if isinstance(message, Mapping):
+        return dict(message)
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        nested = result.get("message")
+        if isinstance(nested, Mapping):
+            return dict(nested)
+    return None
+
+
+def _task_state(task: Mapping[str, Any]) -> str | None:
+    status = task.get("status")
+    if isinstance(status, Mapping):
+        return _optional_str(status.get("state"))
+    return None
+
+
+def _should_poll_task(task: Mapping[str, Any]) -> bool:
+    return bool(
+        _optional_str(task.get("id"))
+        and _normalized_state(_task_state(task)) not in _STOP_STATES
+    )
+
+
+def _normalized_state(state: str | None) -> str | None:
+    if not state:
+        return None
+    normalized = state.upper()
+    if not normalized.startswith("TASK_STATE_"):
+        normalized = f"TASK_STATE_{normalized}"
+    return normalized
+
+
+def _task_text(task: Mapping[str, Any]) -> str:
+    texts: list[str] = []
+    status = task.get("status")
+    if isinstance(status, Mapping):
+        message = status.get("message")
+        if isinstance(message, Mapping):
+            texts.extend(_text_parts(message.get("parts")))
+    for artifact in _artifacts(task):
+        texts.extend(_text_parts(artifact.get("parts")))
+    return "\n\n".join(text for text in texts if text).strip()
+
+
+def _artifacts(task: Mapping[str, Any]) -> list[dict[str, Any]]:
+    artifacts = task.get("artifacts")
+    if not isinstance(artifacts, list):
+        return []
+    return [dict(item) for item in artifacts if isinstance(item, Mapping)]
+
+
+def _text_parts(parts: Any) -> list[str]:
+    texts: list[str] = []
+    if not isinstance(parts, list):
+        return texts
+    for part in parts:
+        if not isinstance(part, Mapping):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+            continue
+        if "data" in part:
+            texts.append(json.dumps(part.get("data"), ensure_ascii=False))
+    return texts
+
+
+def _json_text(payload: Any) -> str:
+    try:
+        return json.dumps(payload, ensure_ascii=False)
+    except TypeError:
+        return str(payload)
+
+
+def _tool_name(value: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_]+", "_", value.strip()).strip("_").lower()
+    if not normalized:
+        normalized = "remote_agent"
+    if not normalized.startswith("a2a_"):
+        normalized = f"a2a_{normalized}"
+    return normalized
+
+
+def _clean_url(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("A2A URLs must be absolute HTTP(S) URLs.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("A2A URLs must not contain embedded credentials.")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _string_headers(headers: Mapping[str, Any] | None) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not isinstance(headers, Mapping):
+        return result
+    for key, value in headers.items():
+        if isinstance(key, str) and key and isinstance(value, str):
+            result[key] = value
+    return result

--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -17,7 +17,6 @@ from .factory import register_tool
 
 A2A_MEDIA_TYPE = "application/a2a+json"
 A2A_VERSION = "1.0"
-_HTTP_JSON_BINDINGS = {"HTTP+JSON", "HTTP_JSON", "http+json", "http_json"}
 _TERMINAL_STATES = {
     "TASK_STATE_COMPLETED",
     "TASK_STATE_FAILED",
@@ -249,6 +248,14 @@ class A2AAgentTool(AbstractBaseTool):
         endpoint_url = _endpoint_from_card(card)
         if not endpoint_url:
             raise ValueError("A2A agent card does not expose an HTTP+JSON endpoint.")
+        endpoint_url = _clean_url(endpoint_url)
+        if endpoint_url is None:
+            raise ValueError("A2A agent card does not expose a valid endpoint URL.")
+        if not _same_origin(self._agent_card_url, endpoint_url):
+            raise ValueError(
+                "A2A agent card endpoint must use the same origin as the card URL; "
+                "configure endpoint_url explicitly for a cross-origin endpoint."
+            )
         self._endpoint_url = endpoint_url
         if self._description == "Call a remote A2A agent and return its response.":
             description = card.get("description")
@@ -273,10 +280,10 @@ def create_a2a_agent_tools_from_configs(
     for item in configs:
         if not isinstance(item, dict):
             continue
-        raw_name = item.get("name") or item.get("tool_name") or item.get("id")
+        raw_name = item.get("name")
         if not isinstance(raw_name, str) or not raw_name.strip():
             continue
-        timeout_seconds = item.get("timeout_seconds", item.get("timeout", 60.0))
+        timeout_seconds = item.get("timeout_seconds", 60.0)
         try:
             timeout = float(str(timeout_seconds))
         except (TypeError, ValueError):
@@ -284,14 +291,12 @@ def create_a2a_agent_tools_from_configs(
         tool = A2AAgentTool(
             name=raw_name,
             description=_optional_str(item.get("description")),
-            endpoint_url=_optional_str(item.get("endpoint_url") or item.get("url")),
-            agent_card_url=_optional_str(
-                item.get("agent_card_url") or item.get("card_url")
-            ),
+            endpoint_url=_optional_str(item.get("endpoint_url")),
+            agent_card_url=_optional_str(item.get("agent_card_url")),
             headers=item.get("headers")
             if isinstance(item.get("headers"), dict)
             else {},
-            auth_token=_optional_str(item.get("auth_token") or item.get("api_key")),
+            auth_token=_optional_str(item.get("auth_token")),
             timeout_seconds=timeout,
         )
         tools.append(tool)
@@ -355,7 +360,8 @@ def _endpoint_from_card(card: Mapping[str, Any]) -> str | None:
             binding = _optional_str(item.get("protocolBinding"))
             protocol_version = _optional_str(item.get("protocolVersion"))
             if (
-                binding in _HTTP_JSON_BINDINGS
+                binding is not None
+                and binding.upper().replace("_", "+") == "HTTP+JSON"
                 and protocol_version is not None
                 and protocol_version.split(".", maxsplit=1)[0] == "1"
             ):
@@ -480,11 +486,33 @@ def _clean_url(value: str | None) -> str | None:
     if not value:
         return None
     parsed = urlsplit(value)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or not parsed.hostname
+    ):
         raise ValueError("A2A URLs must be absolute HTTP(S) URLs.")
     if parsed.username is not None or parsed.password is not None:
         raise ValueError("A2A URLs must not contain embedded credentials.")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("A2A URLs must contain a valid port.") from exc
     return value
+
+
+def _same_origin(left: str, right: str) -> bool:
+    return _url_origin(left) == _url_origin(right)
+
+
+def _url_origin(value: str) -> tuple[str, str, int]:
+    parsed = urlsplit(value)
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    return (
+        parsed.scheme.lower(),
+        str(parsed.hostname).lower(),
+        parsed.port or default_port,
+    )
 
 
 def _optional_str(value: Any) -> str | None:

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -145,6 +145,10 @@ class BaseToolConfig(ABC):
         """Get per-agent tool metadata/runtime overrides for delegation."""
         return {}
 
+    def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
+        """Get remote A2A agent tool configurations."""
+        return []
+
     def get_enable_global_agent_tools(self) -> bool:
         """Whether to include globally visible published agents as tools."""
         return True
@@ -236,6 +240,7 @@ class ToolConfig(BaseToolConfig):
         allowed_tools = config_dict.get("allowed_tools")
         allowed_agent_ids = config_dict.get("allowed_agent_ids")
         agent_tool_overrides = config_dict.get("agent_tool_overrides") or {}
+        a2a_agent_configs = config_dict.get("a2a_agent_configs") or []
         enable_global_agent_tools = config_dict.get("enable_global_agent_tools", True)
         allow_cross_user_agent_ids = config_dict.get(
             "allow_cross_user_agent_ids", False
@@ -299,6 +304,9 @@ class ToolConfig(BaseToolConfig):
         self.allowed_agent_ids: Optional[List[int]] = allowed_agent_ids
         self.agent_tool_overrides: Dict[int, Dict[str, Any]] = (
             agent_tool_overrides if isinstance(agent_tool_overrides, dict) else {}
+        )
+        self.a2a_agent_configs: List[Dict[str, Any]] = (
+            a2a_agent_configs if isinstance(a2a_agent_configs, list) else []
         )
         self.enable_global_agent_tools: bool = bool(enable_global_agent_tools)
         self.allow_cross_user_agent_ids: bool = bool(allow_cross_user_agent_ids)
@@ -408,6 +416,9 @@ class ToolConfig(BaseToolConfig):
 
     def get_agent_tool_overrides(self) -> Dict[int, Dict[str, Any]]:
         return self.agent_tool_overrides
+
+    def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
+        return self.a2a_agent_configs
 
     def get_enable_global_agent_tools(self) -> bool:
         return self.enable_global_agent_tools

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -146,7 +146,11 @@ class BaseToolConfig(ABC):
         return {}
 
     def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
-        """Get remote A2A agent tool configurations."""
+        """Get remote A2A agent tool configurations.
+
+        Private endpoints are rejected unless an entry explicitly sets
+        ``allow_private_networks`` to ``True``.
+        """
         return []
 
     def get_enable_global_agent_tools(self) -> bool:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -104,6 +104,7 @@ class ToolRegistry:
         try:
             # Import tool modules in priority order - these imports trigger @register_tool decorators
             from . import (  # noqa: F401 - imports trigger @register_tool decorators
+                a2a_agent_tool,
                 agent_tool,
                 ask_user_tool,
                 audio_tool,

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -1,5 +1,6 @@
 """Security helpers for redacting sensitive data from logs and errors."""
 
+import ipaddress
 import re
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -22,6 +23,35 @@ HEADER_KEY_PATTERNS = [
     re.compile(r"(?i)(x-goog-api-key\s*[:=]\s*)([^\s,;]+)"),
     re.compile(r"(?i)(x-api-key\s*[:=]\s*)([^\s,;]+)"),
 ]
+
+
+class PrivateNetworkHostError(ValueError):
+    """Raised when an outbound host targets a non-public network range."""
+
+
+def reject_private_network_host(hostname: str) -> None:
+    """Reject localhost and non-public literal IP address ranges."""
+
+    normalized = hostname.rstrip(".").lower()
+    if normalized in {"localhost", "ip6-localhost"}:
+        raise PrivateNetworkHostError("Host must not resolve to a private network.")
+    if "%" in normalized:
+        normalized = normalized.split("%", 1)[0]
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+        address = address.ipv4_mapped
+    if (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        raise PrivateNetworkHostError("Host must not resolve to a private network.")
 
 
 def _mask_secret(value: str) -> str:

--- a/src/xagent/migrations/versions/20260710_add_a2a_task_lookup_index.py
+++ b/src/xagent/migrations/versions/20260710_add_a2a_task_lookup_index.py
@@ -17,11 +17,15 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 INDEX_NAME = "ix_tasks_agent_id_source"
+INDEX_COLUMNS = {"agent_id", "source"}
 
 
 def upgrade() -> None:
     inspector = inspect(op.get_bind())
     if "tasks" not in inspector.get_table_names():
+        return
+    existing_columns = {item["name"] for item in inspector.get_columns("tasks")}
+    if not INDEX_COLUMNS.issubset(existing_columns):
         return
     existing_indexes = {item["name"] for item in inspector.get_indexes("tasks")}
     if INDEX_NAME not in existing_indexes:

--- a/src/xagent/migrations/versions/20260710_add_a2a_task_lookup_index.py
+++ b/src/xagent/migrations/versions/20260710_add_a2a_task_lookup_index.py
@@ -1,0 +1,37 @@
+"""add A2A task lookup index
+
+Revision ID: 20260710_a2a_task_index
+Revises: 1c2ae61b5a6d
+Create Date: 2026-07-10
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "20260710_a2a_task_index"
+down_revision: Union[str, None] = "1c2ae61b5a6d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = "ix_tasks_agent_id_source"
+
+
+def upgrade() -> None:
+    inspector = inspect(op.get_bind())
+    if "tasks" not in inspector.get_table_names():
+        return
+    existing_indexes = {item["name"] for item in inspector.get_indexes("tasks")}
+    if INDEX_NAME not in existing_indexes:
+        op.create_index(INDEX_NAME, "tasks", ["agent_id", "source"])
+
+
+def downgrade() -> None:
+    inspector = inspect(op.get_bind())
+    if "tasks" not in inspector.get_table_names():
+        return
+    existing_indexes = {item["name"] for item in inspector.get_indexes("tasks")}
+    if INDEX_NAME in existing_indexes:
+        op.drop_index(INDEX_NAME, table_name="tasks")

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from time import monotonic
 from typing import Any, Mapping, Tuple
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -15,6 +16,7 @@ from ..models.database import get_db, get_session_local
 from ..models.task import Task, TaskStatus
 from ..services.a2a_protocol import (
     A2A_VERSION,
+    ALL_TASK_STATES,
     a2a_error,
     a2a_json_response,
     build_agent_card,
@@ -47,6 +49,8 @@ _STREAM_END_STATUSES = _TERMINAL_STATUSES | {
     TaskStatus.PAUSED,
     TaskStatus.WAITING_FOR_USER,
 }
+A2A_BLOCKING_WAIT_TIMEOUT_SECONDS = 60.0
+A2A_STREAM_MAX_DURATION_SECONDS = 60.0 * 60.0
 
 
 async def _get_a2a_agent_from_api_key(
@@ -96,7 +100,14 @@ def _validate_a2a_version(request: Request) -> None:
     requested = request.headers.get("A2A-Version")
     if requested is None:
         requested = request.query_params.get("A2A-Version")
-    requested = (requested or "0.3").strip()
+    if requested is None or not requested.strip():
+        raise a2a_error(
+            "version_not_supported",
+            "A2A-Version header or query parameter is required.",
+            status_code=400,
+            details={"supportedVersions": A2A_VERSION},
+        )
+    requested = requested.strip()
     version_parts = requested.split(".")
     compatible = (
         len(version_parts) in {2, 3}
@@ -166,6 +177,7 @@ async def _start_a2a_turn(
     context_id: str | None,
     task_id: int | None,
 ) -> Task:
+    created_task = task_id is None
     normalized_waiting_task = False
     if task_id is None:
         context_id = context_id or new_context_id()
@@ -232,27 +244,55 @@ async def _start_a2a_turn(
             force_fresh=False,
         )
     except TaskTurnNotFoundError as exc:
-        _restore_waiting_status(db, int(task.id), normalized_waiting_task)
+        _recover_failed_turn_start(
+            db,
+            int(task.id),
+            created_task=created_task,
+            restore_waiting=normalized_waiting_task,
+        )
         raise a2a_error("task_not_found", "Task not found.", status_code=404) from exc
     except TaskTurnError as exc:
-        _restore_waiting_status(db, int(task.id), normalized_waiting_task)
+        _recover_failed_turn_start(
+            db,
+            int(task.id),
+            created_task=created_task,
+            restore_waiting=normalized_waiting_task,
+        )
         raise a2a_error(
             "unsupported_operation",
             "Task is currently running and cannot accept a new message.",
             status_code=400,
             details={"taskId": task.id},
         ) from exc
+    except Exception:
+        _recover_failed_turn_start(
+            db,
+            int(task.id),
+            created_task=created_task,
+            restore_waiting=normalized_waiting_task,
+        )
+        raise
 
     db.expire_all()
     return _resolve_a2a_task(db, int(task.id), agent)
 
 
-def _restore_waiting_status(db: Session, task_id: int, restore: bool) -> None:
-    if not restore:
-        return
+def _recover_failed_turn_start(
+    db: Session,
+    task_id: int,
+    *,
+    created_task: bool,
+    restore_waiting: bool,
+) -> None:
     db.expire_all()
     task = db.query(Task).filter(Task.id == task_id).first()
-    if task is not None and task.status == TaskStatus.PAUSED:
+    if task is None:
+        return
+    if created_task and task.status == TaskStatus.PENDING:
+        db.delete(task)
+        db.commit()
+        return
+    if restore_waiting and task.status == TaskStatus.PAUSED:
         task.status = TaskStatus.WAITING_FOR_USER
         db.commit()
 
@@ -284,10 +324,31 @@ def _message_payload(body: Mapping[str, Any]) -> Mapping[str, Any]:
     return message
 
 
+def _fetch_fresh_a2a_task(agent_id: int, task_id: int) -> Task | None:
+    session_local = get_session_local()
+    local_db = session_local()
+    try:
+        fresh = (
+            local_db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "a2a",
+            )
+            .first()
+        )
+        if fresh is not None:
+            local_db.expunge(fresh)
+        return fresh
+    finally:
+        local_db.close()
+
+
 def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
     started_task_id = int(task.id)
 
     async def _events() -> Any:
+        deadline = monotonic() + A2A_STREAM_MAX_DURATION_SECONDS
         yield sse_task_snapshot(task)
         if task.status in _STREAM_END_STATUSES:
             return
@@ -295,37 +356,27 @@ def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
         previous_output = str(task.output or "")
         previous_error = str(task.error_message or "")
         while True:
-            await asyncio.sleep(0.5)
-            session_local = get_session_local()
-            local_db = session_local()
-            try:
-                fresh = (
-                    local_db.query(Task)
-                    .filter(
-                        Task.id == started_task_id,
-                        Task.agent_id == int(agent.id),
-                        Task.source == "a2a",
-                    )
-                    .first()
-                )
-                if fresh is None:
-                    return
-                fresh_output = str(fresh.output or "")
-                fresh_state = task_state(fresh)
-                fresh_error = str(fresh.error_message or "")
-                if fresh_output and fresh_output != previous_output:
-                    artifacts = sse_task_artifacts(fresh)
-                    if artifacts:
-                        yield artifacts
-                if fresh_state != previous_state or fresh_error != previous_error:
-                    yield sse_task_update(fresh)
-                previous_state = fresh_state
-                previous_output = fresh_output
-                previous_error = fresh_error
-                if fresh.status in _STREAM_END_STATUSES:
-                    return
-            finally:
-                local_db.close()
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(0.5, remaining))
+            fresh = _fetch_fresh_a2a_task(int(agent.id), started_task_id)
+            if fresh is None:
+                return
+            fresh_output = str(fresh.output or "")
+            fresh_state = task_state(fresh)
+            fresh_error = str(fresh.error_message or "")
+            if fresh_output and fresh_output != previous_output:
+                artifacts = sse_task_artifacts(fresh)
+                if artifacts:
+                    yield artifacts
+            if fresh_state != previous_state or fresh_error != previous_error:
+                yield sse_task_update(fresh)
+            previous_state = fresh_state
+            previous_output = fresh_output
+            previous_error = fresh_error
+            if fresh.status in _STREAM_END_STATUSES:
+                return
 
     return StreamingResponse(
         _events(),
@@ -338,27 +389,19 @@ async def _wait_for_task(agent: Agent, task: Task) -> Task:
     if task.status in _STREAM_END_STATUSES:
         return task
     task_id = int(task.id)
+    deadline = monotonic() + A2A_BLOCKING_WAIT_TIMEOUT_SECONDS
+    fresh = task
     while True:
-        await asyncio.sleep(0.25)
-        session_local = get_session_local()
-        local_db = session_local()
-        try:
-            fresh = (
-                local_db.query(Task)
-                .filter(
-                    Task.id == task_id,
-                    Task.agent_id == int(agent.id),
-                    Task.source == "a2a",
-                )
-                .first()
-            )
-            if fresh is None:
-                raise a2a_error("task_not_found", "Task not found.", status_code=404)
-            if fresh.status in _STREAM_END_STATUSES:
-                local_db.expunge(fresh)
-                return fresh
-        finally:
-            local_db.close()
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return fresh
+        await asyncio.sleep(min(0.25, remaining))
+        fetched = _fetch_fresh_a2a_task(int(agent.id), task_id)
+        if fetched is None:
+            raise a2a_error("task_not_found", "Task not found.", status_code=404)
+        fresh = fetched
+        if fresh.status in _STREAM_END_STATUSES:
+            return fresh
 
 
 def _page_offset(page_token: str | None) -> int:
@@ -387,16 +430,6 @@ def _is_after(value: Any, threshold: datetime) -> bool:
 
 @router.get("/agents/{agent_id}/.well-known/agent-card.json")
 async def get_agent_card_well_known(
-    agent_id: int,
-    request: Request,
-    db: Session = Depends(get_db),
-) -> Any:
-    agent = _resolve_published_agent(db, agent_id)
-    return a2a_json_response(build_agent_card(agent, request))
-
-
-@router.get("/agents/{agent_id}/agent-card")
-async def get_agent_card(
     agent_id: int,
     request: Request,
     db: Session = Depends(get_db),
@@ -497,18 +530,7 @@ async def list_tasks(
     if context_id is not None:
         tasks = [task for task in tasks if task_context_id(task) == context_id]
     if status is not None:
-        allowed_states = {
-            "TASK_STATE_UNSPECIFIED",
-            "TASK_STATE_SUBMITTED",
-            "TASK_STATE_WORKING",
-            "TASK_STATE_COMPLETED",
-            "TASK_STATE_FAILED",
-            "TASK_STATE_CANCELED",
-            "TASK_STATE_INPUT_REQUIRED",
-            "TASK_STATE_REJECTED",
-            "TASK_STATE_AUTH_REQUIRED",
-        }
-        if status not in allowed_states:
+        if status not in ALL_TASK_STATES:
             raise a2a_error(
                 "invalid_argument",
                 f"Unknown A2A task status: {status}",

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from time import monotonic
 from typing import Any, Mapping, Tuple
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import String, and_, cast, false, or_
 from sqlalchemy.orm import Session
 
 from ..models.agent import Agent
@@ -51,6 +52,18 @@ _STREAM_END_STATUSES = _TERMINAL_STATUSES | {
 }
 A2A_BLOCKING_WAIT_TIMEOUT_SECONDS = 60.0
 A2A_STREAM_MAX_DURATION_SECONDS = 60.0 * 60.0
+_A2A_OVERRIDE_STATES = (
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_REJECTED",
+    "TASK_STATE_AUTH_REQUIRED",
+)
+_A2A_TASK_STATUS_MAP: dict[str, tuple[TaskStatus, ...]] = {
+    "TASK_STATE_SUBMITTED": (TaskStatus.PENDING,),
+    "TASK_STATE_WORKING": (TaskStatus.RUNNING,),
+    "TASK_STATE_INPUT_REQUIRED": (TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER),
+    "TASK_STATE_COMPLETED": (TaskStatus.COMPLETED,),
+    "TASK_STATE_FAILED": (TaskStatus.FAILED,),
+}
 
 
 async def _get_a2a_agent_from_api_key(
@@ -355,6 +368,9 @@ def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
         previous_state = task_state(task)
         previous_output = str(task.output or "")
         previous_error = str(task.error_message or "")
+        artifact_finalized = (
+            bool(previous_output) and task.status in _STREAM_END_STATUSES
+        )
         while True:
             remaining = deadline - monotonic()
             if remaining <= 0:
@@ -366,16 +382,37 @@ def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
             fresh_output = str(fresh.output or "")
             fresh_state = task_state(fresh)
             fresh_error = str(fresh.error_message or "")
+            stream_ended = fresh.status in _STREAM_END_STATUSES
             if fresh_output and fresh_output != previous_output:
-                artifacts = sse_task_artifacts(fresh)
+                append = bool(previous_output) and fresh_output.startswith(
+                    previous_output
+                )
+                chunk = fresh_output[len(previous_output) :] if append else fresh_output
+                artifacts = sse_task_artifacts(
+                    fresh,
+                    text=chunk,
+                    append=append,
+                    last_chunk=stream_ended,
+                )
                 if artifacts:
                     yield artifacts
+                artifact_finalized = stream_ended
+            elif stream_ended and fresh_output and not artifact_finalized:
+                artifacts = sse_task_artifacts(
+                    fresh,
+                    text=fresh_output,
+                    append=False,
+                    last_chunk=True,
+                )
+                if artifacts:
+                    yield artifacts
+                artifact_finalized = True
             if fresh_state != previous_state or fresh_error != previous_error:
                 yield sse_task_update(fresh)
             previous_state = fresh_state
             previous_output = fresh_output
             previous_error = fresh_error
-            if fresh.status in _STREAM_END_STATUSES:
+            if stream_ended:
                 return
 
     return StreamingResponse(
@@ -415,17 +452,6 @@ def _page_offset(page_token: str | None) -> int:
         status_code=400,
         details={"field": "pageToken"},
     )
-
-
-def _is_after(value: Any, threshold: datetime) -> bool:
-    if not isinstance(value, datetime):
-        return False
-    timestamp: datetime = value
-    if timestamp.tzinfo is None:
-        timestamp = timestamp.replace(tzinfo=timezone.utc)
-    if threshold.tzinfo is None:
-        threshold = threshold.replace(tzinfo=timezone.utc)
-    return timestamp.astimezone(timezone.utc) > threshold.astimezone(timezone.utc)
 
 
 @router.get("/agents/{agent_id}/.well-known/agent-card.json")
@@ -514,21 +540,33 @@ async def list_tasks(
     page_token: str | None = Query(default=None, alias="pageToken"),
     include_artifacts: bool = Query(default=False, alias="includeArtifacts"),
     status_timestamp_after: datetime | None = Query(
-        default=None, alias="statusTimestampAfter"
+        default=None,
+        alias="statusTimestampAfter",
+        description=(
+            "Filter by the timestamp exposed in each A2A task status; "
+            "this is backed by Task.updated_at."
+        ),
     ),
     authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
     db: Session = Depends(get_db),
 ) -> Any:
     agent, _key = authed
     _require_bound_agent(agent_id, agent)
-    tasks = (
-        db.query(Task)
-        .filter(Task.agent_id == int(agent.id), Task.source == "a2a")
-        .order_by(Task.id.desc())
-        .all()
+    query = db.query(Task).filter(
+        Task.agent_id == int(agent.id),
+        Task.source == "a2a",
     )
     if context_id is not None:
-        tasks = [task for task in tasks if task_context_id(task) == context_id]
+        stored_context_id = Task.agent_config["a2a_context_id"].as_string()
+        query = query.filter(
+            or_(
+                stored_context_id == context_id,
+                and_(
+                    stored_context_id.is_(None),
+                    cast(Task.id, String) == context_id,
+                ),
+            )
+        )
     if status is not None:
         if status not in ALL_TASK_STATES:
             raise a2a_error(
@@ -537,15 +575,28 @@ async def list_tasks(
                 status_code=400,
                 details={"field": "status"},
             )
-        tasks = [task for task in tasks if task_state(task) == status]
+        stored_a2a_state = Task.agent_config["a2a_state"].as_string()
+        state_filters: list[Any] = []
+        if status in _A2A_OVERRIDE_STATES:
+            state_filters.append(stored_a2a_state == status)
+        task_statuses = _A2A_TASK_STATUS_MAP.get(status)
+        if task_statuses:
+            state_filters.append(
+                and_(
+                    or_(
+                        stored_a2a_state.is_(None),
+                        ~stored_a2a_state.in_(_A2A_OVERRIDE_STATES),
+                    ),
+                    Task.status.in_(task_statuses),
+                )
+            )
+        query = query.filter(or_(*state_filters) if state_filters else false())
     if status_timestamp_after is not None:
-        tasks = [
-            task for task in tasks if _is_after(task.updated_at, status_timestamp_after)
-        ]
+        query = query.filter(Task.updated_at > status_timestamp_after)
 
     offset = _page_offset(page_token)
-    total_size = len(tasks)
-    page = tasks[offset : offset + page_size]
+    total_size = query.count()
+    page = query.order_by(Task.id.desc()).offset(offset).limit(page_size).all()
     next_offset = offset + len(page)
     next_page_token = str(next_offset) if next_offset < total_size else ""
     return a2a_json_response(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -150,6 +150,7 @@ async def _resume_waiting_a2a_task(
     agent: Agent,
     task: Task,
     text: str,
+    message_id: str,
 ) -> bool:
     task_id = int(task.id)
     claimed = (
@@ -193,6 +194,7 @@ async def _resume_waiting_a2a_task(
             str(task_id),
             execution_message=text,
             display_message=text,
+            turn_id=f"a2a:{task_id}:{message_id}",
             request_interrupt=False,
             reason="A2A input-required response",
         )
@@ -300,6 +302,7 @@ async def _start_a2a_turn(
     db: Session,
     agent: Agent,
     text: str,
+    message_id: str,
     context_id: str | None,
     task_id: int | None,
 ) -> Task:
@@ -358,6 +361,7 @@ async def _start_a2a_turn(
                 agent=agent,
                 task=task,
                 text=text,
+                message_id=message_id,
             ):
                 return task
             normalized_waiting_task = True
@@ -452,6 +456,18 @@ def _message_payload(body: Mapping[str, Any]) -> Mapping[str, Any]:
             status_code=400,
         )
     return message
+
+
+def _message_id(message: Mapping[str, Any]) -> str:
+    value = message.get("messageId")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise a2a_error(
+        "invalid_argument",
+        "message.messageId must be a non-empty string.",
+        status_code=400,
+        details={"field": "message.messageId"},
+    )
 
 
 def _fetch_fresh_a2a_task(agent_id: int, task_id: int) -> Task | None:
@@ -594,12 +610,14 @@ async def send_message(
     return_immediately = _validate_send_configuration(body)
     message = _message_payload(body)
     text = extract_message_text(message)
+    message_id = _message_id(message)
     context_id = message_context_id(message, body)
     task_id = message_task_id(message, body)
     task = await _start_a2a_turn(
         db=db,
         agent=agent,
         text=text,
+        message_id=message_id,
         context_id=context_id,
         task_id=task_id,
     )
@@ -622,12 +640,14 @@ async def stream_message(
     _validate_send_configuration(body)
     message = _message_payload(body)
     text = extract_message_text(message)
+    message_id = _message_id(message)
     context_id = message_context_id(message, body)
     task_id = message_task_id(message, body)
     task = await _start_a2a_turn(
         db=db,
         agent=agent,
         text=text,
+        message_id=message_id,
         context_id=context_id,
         task_id=task_id,
     )

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Mapping, Tuple
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from ..models.agent import Agent
+from ..models.agent_api_key import AgentApiKey
+from ..models.database import get_db, get_session_local
+from ..models.task import Task, TaskStatus
+from ..services.a2a_protocol import (
+    A2A_VERSION,
+    a2a_error,
+    a2a_json_response,
+    build_agent_card,
+    extract_message_text,
+    is_published_agent,
+    message_context_id,
+    message_task_id,
+    new_context_id,
+    sse_task_artifacts,
+    sse_task_snapshot,
+    sse_task_update,
+    task_context_id,
+    task_state,
+    task_to_a2a,
+)
+from ..services.task_orchestrator import (
+    TaskTurnError,
+    TaskTurnNotFoundError,
+    TaskTurnOrchestrator,
+    TaskTurnPayload,
+    TurnKind,
+)
+from .v1.deps import get_agent_from_api_key, record_key_usage
+from .v1.errors import V1ApiError
+
+router = APIRouter(prefix="/api/a2a", tags=["a2a"])
+_bearer = HTTPBearer(auto_error=False)
+_TERMINAL_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
+_STREAM_END_STATUSES = _TERMINAL_STATUSES | {
+    TaskStatus.PAUSED,
+    TaskStatus.WAITING_FOR_USER,
+}
+
+
+async def _get_a2a_agent_from_api_key(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+    db: Session = Depends(get_db),
+) -> Tuple[Agent, AgentApiKey]:
+    _validate_a2a_version(request)
+    try:
+        return await get_agent_from_api_key(credentials, db)
+    except V1ApiError as exc:
+        raise a2a_error(
+            "invalid_api_key",
+            exc.message,
+            status_code=exc.http_status,
+        ) from exc
+
+
+def _resolve_published_agent(db: Session, agent_id: int) -> Agent:
+    agent = db.query(Agent).filter(Agent.id == agent_id).first()
+    if agent is None or not is_published_agent(agent):
+        raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
+    return agent
+
+
+def _resolve_a2a_task(db: Session, task_id: int, agent: Agent) -> Task:
+    task = (
+        db.query(Task)
+        .filter(
+            Task.id == task_id,
+            Task.agent_id == int(agent.id),
+            Task.source == "a2a",
+        )
+        .first()
+    )
+    if task is None:
+        raise a2a_error("task_not_found", "Task not found.", status_code=404)
+    return task
+
+
+def _require_bound_agent(path_agent_id: int, agent: Agent) -> None:
+    if int(agent.id) != int(path_agent_id) or not is_published_agent(agent):
+        raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
+
+
+def _validate_a2a_version(request: Request) -> None:
+    requested = request.headers.get("A2A-Version")
+    if requested is None:
+        requested = request.query_params.get("A2A-Version")
+    requested = (requested or "0.3").strip()
+    version_parts = requested.split(".")
+    compatible = (
+        len(version_parts) in {2, 3}
+        and all(part.isdecimal() for part in version_parts)
+        and version_parts[0] == A2A_VERSION.split(".", maxsplit=1)[0]
+    )
+    if not compatible:
+        raise a2a_error(
+            "version_not_supported",
+            f"A2A protocol version {requested!r} is not supported.",
+            status_code=400,
+            details={"supportedVersions": A2A_VERSION},
+        )
+
+
+def _validate_send_configuration(body: Mapping[str, Any]) -> bool:
+    configuration = body.get("configuration")
+    if configuration is None:
+        return False
+    if not isinstance(configuration, Mapping):
+        raise a2a_error(
+            "invalid_argument",
+            "configuration must be a JSON object.",
+            status_code=400,
+            details={"field": "configuration"},
+        )
+    if configuration.get("taskPushNotificationConfig") is not None:
+        raise a2a_error(
+            "push_notification_not_supported",
+            "This agent does not support A2A push notifications.",
+            status_code=400,
+        )
+    accepted_modes = configuration.get("acceptedOutputModes")
+    if accepted_modes is not None:
+        if not isinstance(accepted_modes, list) or not all(
+            isinstance(mode, str) for mode in accepted_modes
+        ):
+            raise a2a_error(
+                "invalid_argument",
+                "acceptedOutputModes must be an array of media types.",
+                status_code=400,
+                details={"field": "configuration.acceptedOutputModes"},
+            )
+        if accepted_modes and "text/plain" not in accepted_modes:
+            raise a2a_error(
+                "content_type_not_supported",
+                "This agent currently returns text/plain output only.",
+                status_code=400,
+                details={"supportedMediaType": "text/plain"},
+            )
+    return_immediately = configuration.get("returnImmediately", False)
+    if not isinstance(return_immediately, bool):
+        raise a2a_error(
+            "invalid_argument",
+            "returnImmediately must be a boolean.",
+            status_code=400,
+            details={"field": "configuration.returnImmediately"},
+        )
+    return return_immediately
+
+
+async def _start_a2a_turn(
+    *,
+    db: Session,
+    agent: Agent,
+    text: str,
+    context_id: str | None,
+    task_id: int | None,
+) -> Task:
+    normalized_waiting_task = False
+    if task_id is None:
+        context_id = context_id or new_context_id()
+        task = Task(
+            user_id=int(agent.user_id),
+            title=(text[:50] or "A2A task"),
+            description=text,
+            status=TaskStatus.PENDING,
+            agent_id=int(agent.id),
+            input=text,
+            source="a2a",
+            is_visible=False,
+            execution_mode=agent.execution_mode,
+            agent_config={"a2a_context_id": context_id},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        kind = TurnKind.CREATE
+    else:
+        task = _resolve_a2a_task(db, task_id, agent)
+        if task.status in _TERMINAL_STATUSES:
+            raise a2a_error(
+                "unsupported_operation",
+                "Messages cannot be appended to a terminal A2A task.",
+                status_code=400,
+                details={"taskId": task.id},
+            )
+        stored_context_id = task_context_id(task)
+        if context_id is not None and context_id != stored_context_id:
+            raise a2a_error(
+                "invalid_argument",
+                "The supplied contextId does not match the referenced task.",
+                status_code=400,
+                details={"taskId": task.id, "contextId": context_id},
+            )
+        context_id = stored_context_id
+        agent_config: dict[str, Any] = (
+            dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+        )
+        if not agent_config.get("a2a_context_id"):
+            agent_config["a2a_context_id"] = context_id
+            setattr(task, "agent_config", agent_config)
+            db.commit()
+            db.refresh(task)
+        if task.status == TaskStatus.WAITING_FOR_USER:
+            # The web runtime's new-message path resumes PAUSED tasks as a new
+            # turn. Normalize WAITING_FOR_USER to that same durable path so an
+            # A2A follow-up does not depend on an in-memory WebSocket session.
+            task.status = TaskStatus.PAUSED
+            db.commit()
+            db.refresh(task)
+            normalized_waiting_task = True
+        kind = TurnKind.APPEND
+
+    payload = TaskTurnPayload(transcript_message=text)
+    try:
+        await TaskTurnOrchestrator.begin_turn(
+            task_id=int(task.id),
+            task_owner_user_id=int(agent.user_id),
+            actor_user_id=int(agent.user_id),
+            payload=payload,
+            kind=kind,
+            force_fresh=False,
+        )
+    except TaskTurnNotFoundError as exc:
+        _restore_waiting_status(db, int(task.id), normalized_waiting_task)
+        raise a2a_error("task_not_found", "Task not found.", status_code=404) from exc
+    except TaskTurnError as exc:
+        _restore_waiting_status(db, int(task.id), normalized_waiting_task)
+        raise a2a_error(
+            "unsupported_operation",
+            "Task is currently running and cannot accept a new message.",
+            status_code=400,
+            details={"taskId": task.id},
+        ) from exc
+
+    db.expire_all()
+    return _resolve_a2a_task(db, int(task.id), agent)
+
+
+def _restore_waiting_status(db: Session, task_id: int, restore: bool) -> None:
+    if not restore:
+        return
+    db.expire_all()
+    task = db.query(Task).filter(Task.id == task_id).first()
+    if task is not None and task.status == TaskStatus.PAUSED:
+        task.status = TaskStatus.WAITING_FOR_USER
+        db.commit()
+
+
+async def _json_body(request: Request) -> Mapping[str, Any]:
+    try:
+        body = await request.json()
+    except ValueError as exc:
+        raise a2a_error(
+            "invalid_request",
+            "Request body must be valid JSON.",
+            status_code=400,
+        ) from exc
+    if not isinstance(body, Mapping):
+        raise a2a_error(
+            "invalid_argument", "Request body must be a JSON object.", status_code=400
+        )
+    return body
+
+
+def _message_payload(body: Mapping[str, Any]) -> Mapping[str, Any]:
+    message = body.get("message")
+    if not isinstance(message, Mapping):
+        raise a2a_error(
+            "invalid_argument",
+            "Request body must include a message object.",
+            status_code=400,
+        )
+    return message
+
+
+def _task_stream_response(agent: Agent, task: Task) -> StreamingResponse:
+    started_task_id = int(task.id)
+
+    async def _events() -> Any:
+        yield sse_task_snapshot(task)
+        if task.status in _STREAM_END_STATUSES:
+            return
+        previous_state = task_state(task)
+        previous_output = str(task.output or "")
+        previous_error = str(task.error_message or "")
+        while True:
+            await asyncio.sleep(0.5)
+            session_local = get_session_local()
+            local_db = session_local()
+            try:
+                fresh = (
+                    local_db.query(Task)
+                    .filter(
+                        Task.id == started_task_id,
+                        Task.agent_id == int(agent.id),
+                        Task.source == "a2a",
+                    )
+                    .first()
+                )
+                if fresh is None:
+                    return
+                fresh_output = str(fresh.output or "")
+                fresh_state = task_state(fresh)
+                fresh_error = str(fresh.error_message or "")
+                if fresh_output and fresh_output != previous_output:
+                    artifacts = sse_task_artifacts(fresh)
+                    if artifacts:
+                        yield artifacts
+                if fresh_state != previous_state or fresh_error != previous_error:
+                    yield sse_task_update(fresh)
+                previous_state = fresh_state
+                previous_output = fresh_output
+                previous_error = fresh_error
+                if fresh.status in _STREAM_END_STATUSES:
+                    return
+            finally:
+                local_db.close()
+
+    return StreamingResponse(
+        _events(),
+        media_type="text/event-stream",
+        headers={"A2A-Version": A2A_VERSION},
+    )
+
+
+async def _wait_for_task(agent: Agent, task: Task) -> Task:
+    if task.status in _STREAM_END_STATUSES:
+        return task
+    task_id = int(task.id)
+    while True:
+        await asyncio.sleep(0.25)
+        session_local = get_session_local()
+        local_db = session_local()
+        try:
+            fresh = (
+                local_db.query(Task)
+                .filter(
+                    Task.id == task_id,
+                    Task.agent_id == int(agent.id),
+                    Task.source == "a2a",
+                )
+                .first()
+            )
+            if fresh is None:
+                raise a2a_error("task_not_found", "Task not found.", status_code=404)
+            if fresh.status in _STREAM_END_STATUSES:
+                local_db.expunge(fresh)
+                return fresh
+        finally:
+            local_db.close()
+
+
+def _page_offset(page_token: str | None) -> int:
+    if page_token is None or page_token == "":
+        return 0
+    if page_token.isdecimal():
+        return int(page_token)
+    raise a2a_error(
+        "invalid_argument",
+        "pageToken is invalid.",
+        status_code=400,
+        details={"field": "pageToken"},
+    )
+
+
+def _is_after(value: Any, threshold: datetime) -> bool:
+    if not isinstance(value, datetime):
+        return False
+    timestamp: datetime = value
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    if threshold.tzinfo is None:
+        threshold = threshold.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc) > threshold.astimezone(timezone.utc)
+
+
+@router.get("/agents/{agent_id}/.well-known/agent-card.json")
+async def get_agent_card_well_known(
+    agent_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    agent = _resolve_published_agent(db, agent_id)
+    return a2a_json_response(build_agent_card(agent, request))
+
+
+@router.get("/agents/{agent_id}/agent-card")
+async def get_agent_card(
+    agent_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    agent = _resolve_published_agent(db, agent_id)
+    return a2a_json_response(build_agent_card(agent, request))
+
+
+@router.post("/agents/{agent_id}/message:send")
+async def send_message(
+    agent_id: int,
+    request: Request,
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> Any:
+    agent, key = authed
+    _require_bound_agent(agent_id, agent)
+    body = await _json_body(request)
+    return_immediately = _validate_send_configuration(body)
+    message = _message_payload(body)
+    text = extract_message_text(message)
+    context_id = message_context_id(message, body)
+    task_id = message_task_id(message, body)
+    task = await _start_a2a_turn(
+        db=db,
+        agent=agent,
+        text=text,
+        context_id=context_id,
+        task_id=task_id,
+    )
+    record_key_usage(str(key.key_prefix))
+    if not return_immediately:
+        task = await _wait_for_task(agent, task)
+    return a2a_json_response({"task": task_to_a2a(task)})
+
+
+@router.post("/agents/{agent_id}/message:stream")
+async def stream_message(
+    agent_id: int,
+    request: Request,
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> StreamingResponse:
+    agent, key = authed
+    _require_bound_agent(agent_id, agent)
+    body = await _json_body(request)
+    _validate_send_configuration(body)
+    message = _message_payload(body)
+    text = extract_message_text(message)
+    context_id = message_context_id(message, body)
+    task_id = message_task_id(message, body)
+    task = await _start_a2a_turn(
+        db=db,
+        agent=agent,
+        text=text,
+        context_id=context_id,
+        task_id=task_id,
+    )
+    record_key_usage(str(key.key_prefix))
+    return _task_stream_response(agent, task)
+
+
+@router.get("/agents/{agent_id}/tasks/{task_id}")
+async def get_task(
+    agent_id: int,
+    task_id: int,
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> Any:
+    agent, _key = authed
+    _require_bound_agent(agent_id, agent)
+    task = _resolve_a2a_task(db, task_id, agent)
+    return a2a_json_response(task_to_a2a(task))
+
+
+@router.get("/agents/{agent_id}/tasks")
+async def list_tasks(
+    agent_id: int,
+    context_id: str | None = Query(default=None, alias="contextId"),
+    status: str | None = Query(default=None),
+    page_size: int = Query(default=50, ge=1, le=100, alias="pageSize"),
+    page_token: str | None = Query(default=None, alias="pageToken"),
+    include_artifacts: bool = Query(default=False, alias="includeArtifacts"),
+    status_timestamp_after: datetime | None = Query(
+        default=None, alias="statusTimestampAfter"
+    ),
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> Any:
+    agent, _key = authed
+    _require_bound_agent(agent_id, agent)
+    tasks = (
+        db.query(Task)
+        .filter(Task.agent_id == int(agent.id), Task.source == "a2a")
+        .order_by(Task.id.desc())
+        .all()
+    )
+    if context_id is not None:
+        tasks = [task for task in tasks if task_context_id(task) == context_id]
+    if status is not None:
+        allowed_states = {
+            "TASK_STATE_UNSPECIFIED",
+            "TASK_STATE_SUBMITTED",
+            "TASK_STATE_WORKING",
+            "TASK_STATE_COMPLETED",
+            "TASK_STATE_FAILED",
+            "TASK_STATE_CANCELED",
+            "TASK_STATE_INPUT_REQUIRED",
+            "TASK_STATE_REJECTED",
+            "TASK_STATE_AUTH_REQUIRED",
+        }
+        if status not in allowed_states:
+            raise a2a_error(
+                "invalid_argument",
+                f"Unknown A2A task status: {status}",
+                status_code=400,
+                details={"field": "status"},
+            )
+        tasks = [task for task in tasks if task_state(task) == status]
+    if status_timestamp_after is not None:
+        tasks = [
+            task for task in tasks if _is_after(task.updated_at, status_timestamp_after)
+        ]
+
+    offset = _page_offset(page_token)
+    total_size = len(tasks)
+    page = tasks[offset : offset + page_size]
+    next_offset = offset + len(page)
+    next_page_token = str(next_offset) if next_offset < total_size else ""
+    return a2a_json_response(
+        {
+            "tasks": [
+                task_to_a2a(task, include_artifacts=include_artifacts) for task in page
+            ],
+            "nextPageToken": next_page_token,
+            "pageSize": page_size,
+            "totalSize": total_size,
+        }
+    )
+
+
+@router.api_route(
+    "/agents/{agent_id}/tasks/{task_id}:subscribe", methods=["GET", "POST"]
+)
+async def subscribe_task(
+    agent_id: int,
+    task_id: int,
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> StreamingResponse:
+    agent, _key = authed
+    _require_bound_agent(agent_id, agent)
+    task = _resolve_a2a_task(db, task_id, agent)
+    if task.status in _TERMINAL_STATUSES:
+        raise a2a_error(
+            "unsupported_operation",
+            "A terminal task cannot be subscribed to.",
+            status_code=400,
+            details={"taskId": task.id},
+        )
+    return _task_stream_response(agent, task)
+
+
+@router.post("/agents/{agent_id}/tasks/{task_id}:cancel")
+async def cancel_task(
+    agent_id: int,
+    task_id: int,
+    authed: Tuple[Agent, AgentApiKey] = Depends(_get_a2a_agent_from_api_key),
+    db: Session = Depends(get_db),
+) -> Any:
+    agent, _key = authed
+    _require_bound_agent(agent_id, agent)
+    task = _resolve_a2a_task(db, task_id, agent)
+    agent_config: dict[str, Any] = (
+        dict(task.agent_config) if isinstance(task.agent_config, dict) else {}
+    )
+    if agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+        return a2a_json_response(task_to_a2a(task))
+    if task.status in _TERMINAL_STATUSES:
+        raise a2a_error(
+            "task_not_cancelable",
+            "Task is not in a cancelable state.",
+            status_code=400,
+            details={"taskId": task.id},
+        )
+
+    from .websocket import background_task_manager
+
+    await background_task_manager.cancel_task(int(task.id))
+    agent_config["a2a_state"] = "TASK_STATE_CANCELED"
+    setattr(task, "agent_config", agent_config)
+    task.status = TaskStatus.FAILED
+    setattr(task, "output", None)
+    setattr(task, "error_message", "Task canceled by A2A client.")
+    db.commit()
+    db.refresh(task)
+    return a2a_json_response(task_to_a2a(task))

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -109,6 +109,119 @@ def _require_bound_agent(path_agent_id: int, agent: Agent) -> None:
         raise a2a_error("agent_not_found", "Agent not found.", status_code=404)
 
 
+def _schedule_waiting_a2a_resume(
+    *,
+    task_id: int,
+    agent_service: Any,
+    task_owner_user_id: int,
+) -> None:
+    from .websocket import background_task_manager, execute_resume_background
+
+    previous_task = background_task_manager.running_tasks.get(task_id)
+    bg_task = asyncio.create_task(
+        execute_resume_background(
+            task_id=task_id,
+            agent_service=agent_service,
+            task_owner_user_id=task_owner_user_id,
+            previous_task=previous_task,
+        )
+    )
+    background_task_manager.register_task(task_id, bg_task)
+
+
+def _restore_waiting_resume_claim(db: Session, task_id: int) -> None:
+    db.rollback()
+    (
+        db.query(Task)
+        .filter(
+            Task.id == task_id,
+            Task.status == TaskStatus.RUNNING,
+            Task.runner_id.is_(None),
+        )
+        .update({Task.status: TaskStatus.WAITING_FOR_USER}, synchronize_session=False)
+    )
+    db.commit()
+    db.expire_all()
+
+
+async def _resume_waiting_a2a_task(
+    *,
+    db: Session,
+    agent: Agent,
+    task: Task,
+    text: str,
+) -> bool:
+    task_id = int(task.id)
+    claimed = (
+        db.query(Task)
+        .filter(
+            Task.id == task_id,
+            Task.agent_id == int(agent.id),
+            Task.source == "a2a",
+            Task.status == TaskStatus.WAITING_FOR_USER,
+        )
+        .update(
+            {
+                Task.status: TaskStatus.RUNNING,
+                Task.runner_id: None,
+                Task.lease_expires_at: None,
+                Task.last_heartbeat_at: None,
+            },
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+    if claimed != 1:
+        db.expire_all()
+        raise a2a_error(
+            "unsupported_operation",
+            "Task is currently running and cannot accept a new message.",
+            status_code=400,
+            details={"taskId": task_id},
+        )
+    db.refresh(task)
+
+    try:
+        from .chat import get_agent_manager
+
+        agent_service = await get_agent_manager().get_agent_for_task(
+            task_id,
+            db,
+            task_owner_user_id=int(agent.user_id),
+        )
+        posted = await agent_service.post_user_message(
+            str(task_id),
+            execution_message=text,
+            display_message=text,
+            request_interrupt=False,
+            reason="A2A input-required response",
+        )
+    except Exception:
+        _restore_waiting_resume_claim(db, task_id)
+        raise
+
+    if not posted:
+        # A WAITING_FOR_USER checkpoint should normally be durable. If it is
+        # unavailable, retain the previous restart-safe behavior by starting a
+        # new turn from transcript history instead of leaving the task stuck.
+        task.status = TaskStatus.PAUSED
+        db.commit()
+        db.refresh(task)
+        return False
+
+    setattr(task, "input", text)
+    setattr(task, "output", None)
+    setattr(task, "error_message", None)
+    db.commit()
+    db.refresh(task)
+    _schedule_waiting_a2a_resume(
+        task_id=task_id,
+        agent_service=agent_service,
+        task_owner_user_id=int(agent.user_id),
+    )
+    return True
+
+
 def _validate_a2a_version(request: Request) -> None:
     requested = request.headers.get("A2A-Version")
     if requested is None:
@@ -237,12 +350,16 @@ async def _start_a2a_turn(
             db.commit()
             db.refresh(task)
         if task.status == TaskStatus.WAITING_FOR_USER:
-            # The web runtime's new-message path resumes PAUSED tasks as a new
-            # turn. Normalize WAITING_FOR_USER to that same durable path so an
-            # A2A follow-up does not depend on an in-memory WebSocket session.
-            task.status = TaskStatus.PAUSED
-            db.commit()
-            db.refresh(task)
+            # Resume the trace-backed checkpoint so DAG/React step state is
+            # preserved across workers and restarts. Only a missing checkpoint
+            # falls back to the durable APPEND/replan path.
+            if await _resume_waiting_a2a_task(
+                db=db,
+                agent=agent,
+                task=task,
+                text=text,
+            ):
+                return task
             normalized_waiting_task = True
         kind = TurnKind.APPEND
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1512,7 +1512,21 @@ async def execute_task_background(
                 # bug for callers that never acquired the lease: the
                 # filter didn't match, so status was silently never
                 # written either (a quiet "stuck RUNNING" outcome).
-                if result.get("status") == "waiting_for_user":
+                task_agent_config: dict[str, Any] = (
+                    task_updated.agent_config
+                    if isinstance(task_updated.agent_config, dict)
+                    else {}
+                )
+                # A2A cancellation is durable even when the cancelled coroutine
+                # ignores cancellation and produces a result after the timeout.
+                if task_agent_config.get("a2a_state") == "TASK_STATE_CANCELED":
+                    waiting_for_control = True
+                    logger.info(
+                        "Task %s was canceled while execution was in flight; "
+                        "ignoring the late result",
+                        task_id,
+                    )
+                elif result.get("status") == "waiting_for_user":
                     task_updated.status = TaskStatus.WAITING_FOR_USER
                     sync_workforce_run_status(db_new, task_updated, task_updated.status)
                     db_new.commit()
@@ -1551,6 +1565,7 @@ async def execute_task_background(
                         "(pending commit with assistant message)"
                     )
                 else:
+                    waiting_for_control = True
                     logger.info(
                         f"Task {task_id} is paused, not updating status to {result.get('success')}"
                     )

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -25,6 +25,7 @@ from ..config import (
     get_uploads_dir,
 )
 from ..core.tracing.langfuse import flush_langfuse, initialize_langfuse
+from .api.a2a import router as a2a_router
 from .api.admin_mcp import admin_mcp_router
 from .api.admin_users import router as admin_users_router
 from .api.agent_api_keys import router as agent_api_keys_router
@@ -59,6 +60,7 @@ from .api.workforces import router as workforces_router
 from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
+from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
 
 # Configure logging when running under gunicorn/uwsgi (no __main__.py)
 setup_logging()  # Uses XAGENT_LOG_LEVEL env var or defaults to INFO
@@ -465,6 +467,21 @@ async def validation_exception_handler(
     logger.error(f"Validation error in {request.url}: {str(exc)}")
     logger.error(f"Traceback: {traceback.format_exc()}")
 
+    if request.url.path.startswith("/api/a2a/"):
+        errors = exc.errors()
+        first = errors[0] if errors else {}
+        msg = first.get("msg") or "Invalid A2A request"
+        loc = ".".join(str(part) for part in first.get("loc", []))
+        return await a2a_api_error_handler(
+            request,
+            a2a_error(
+                "invalid_argument",
+                f"{msg} ({loc})" if loc else str(msg),
+                status_code=400,
+                details={"field": loc},
+            ),
+        )
+
     if request.url.path.startswith("/v1/"):
         # Take the first validation error as the human message; full
         # list isn't echoed to keep the response surface small and
@@ -534,6 +551,17 @@ async def global_exception_handler(request: Request, exc: Exception) -> Any:
     logger.error(f"Unhandled exception in {request.url}: {exc}")
     logger.error(f"Traceback: {traceback.format_exc()}")
 
+    if request.url.path.startswith("/api/a2a/"):
+        logger.error("Unhandled A2A API error", exc_info=exc)
+        return await a2a_api_error_handler(
+            request,
+            a2a_error(
+                "internal",
+                "Internal server error.",
+                status_code=500,
+            ),
+        )
+
     if request.url.path.startswith("/v1/"):
         # Sanitize: never echo str(exc) -- it can leak SQL error
         # wording, table names, or storage backend identity. The full
@@ -562,6 +590,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> Any:
 # choose their own HTTP status (401 / 404 / 409 / 429).
 # See web/api/v1/errors.py for the contract.
 app.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: ignore[arg-type]
+app.add_exception_handler(A2AApiError, a2a_api_error_handler)  # type: ignore[arg-type]
 
 
 # Add CORS middleware
@@ -612,6 +641,7 @@ app.include_router(system_router)
 app.include_router(templates_router)
 app.include_router(agents_router)
 app.include_router(agent_api_keys_router)
+app.include_router(a2a_router)
 app.include_router(triggers_router)
 app.include_router(workforces_router)
 app.include_router(channel_router, prefix="/api/channels", tags=["Channels"])

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -71,6 +71,7 @@ class Task(Base):  # type: ignore
     """Task model"""
 
     __tablename__ = "tasks"
+    __table_args__ = (Index("ix_tasks_agent_id_source", "agent_id", "source"),)
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/src/xagent/web/services/a2a_protocol.py
+++ b/src/xagent/web/services/a2a_protocol.py
@@ -15,6 +15,20 @@ from ..models.task import Task, TaskStatus
 
 A2A_MEDIA_TYPE = "application/a2a+json"
 A2A_VERSION = "1.0"
+A2A_MAX_MESSAGE_TEXT_LENGTH = 200_000
+ALL_TASK_STATES = frozenset(
+    {
+        "TASK_STATE_UNSPECIFIED",
+        "TASK_STATE_SUBMITTED",
+        "TASK_STATE_WORKING",
+        "TASK_STATE_COMPLETED",
+        "TASK_STATE_FAILED",
+        "TASK_STATE_CANCELED",
+        "TASK_STATE_INPUT_REQUIRED",
+        "TASK_STATE_REJECTED",
+        "TASK_STATE_AUTH_REQUIRED",
+    }
+)
 
 
 class A2AApiError(Exception):
@@ -179,6 +193,24 @@ def extract_message_text(message: Mapping[str, Any]) -> str:
         )
 
     texts: list[str] = []
+    total_length = 0
+
+    def append_text(value: str, field: str) -> None:
+        nonlocal total_length
+        projected_length = total_length + (2 if texts else 0) + len(value)
+        if projected_length > A2A_MAX_MESSAGE_TEXT_LENGTH:
+            raise a2a_error(
+                "resource_exhausted",
+                "A2A message content exceeds the supported length limit.",
+                status_code=413,
+                details={
+                    "field": field,
+                    "maxLength": A2A_MAX_MESSAGE_TEXT_LENGTH,
+                },
+            )
+        texts.append(value)
+        total_length = projected_length
+
     for index, part in enumerate(parts):
         if not isinstance(part, Mapping):
             raise a2a_error(
@@ -215,7 +247,7 @@ def extract_message_text(message: Mapping[str, Any]) -> str:
                     status_code=400,
                     details={"mediaType": media_type},
                 )
-            texts.append(text.strip())
+            append_text(text.strip(), f"message.parts[{index}].text")
             continue
         if field == "data":
             if media_type and str(media_type).lower() != "application/json":
@@ -225,7 +257,10 @@ def extract_message_text(message: Mapping[str, Any]) -> str:
                     status_code=400,
                     details={"mediaType": media_type},
                 )
-            texts.append(json.dumps(part.get("data"), ensure_ascii=False))
+            append_text(
+                json.dumps(part.get("data"), ensure_ascii=False),
+                f"message.parts[{index}].data",
+            )
             continue
         raise a2a_error(
             "content_type_not_supported",
@@ -416,6 +451,7 @@ def _rpc_status(status_code: int, reason: str) -> str:
         403: "PERMISSION_DENIED",
         404: "NOT_FOUND",
         409: "ABORTED",
+        413: "RESOURCE_EXHAUSTED",
         429: "RESOURCE_EXHAUSTED",
         500: "INTERNAL",
         503: "UNAVAILABLE",

--- a/src/xagent/web/services/a2a_protocol.py
+++ b/src/xagent/web/services/a2a_protocol.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from http import HTTPStatus
+from typing import Any, Mapping
+from uuid import uuid4
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from ..models.agent import Agent, AgentStatus
+from ..models.task import Task, TaskStatus
+
+A2A_MEDIA_TYPE = "application/a2a+json"
+A2A_VERSION = "1.0"
+
+
+class A2AApiError(Exception):
+    """A2A REST error represented with the google.rpc.Status JSON shape."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int,
+        details: dict[str, Any] | None = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        reason = _error_reason(code)
+        metadata = {
+            str(key): str(value)
+            for key, value in (details or {}).items()
+            if value is not None
+        }
+        self.payload: dict[str, Any] = {
+            "code": status_code,
+            "status": _rpc_status(status_code, reason),
+            "message": message,
+            "details": [
+                {
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": reason,
+                    "domain": "a2a-protocol.org",
+                    "metadata": metadata,
+                }
+            ],
+        }
+
+
+def a2a_json_response(content: dict[str, Any], status_code: int = 200) -> JSONResponse:
+    return JSONResponse(
+        content=content,
+        status_code=status_code,
+        media_type=A2A_MEDIA_TYPE,
+        headers={"A2A-Version": A2A_VERSION},
+    )
+
+
+async def a2a_api_error_handler(request: Request, exc: A2AApiError) -> JSONResponse:
+    response = a2a_json_response({"error": exc.payload}, status_code=exc.status_code)
+    if exc.status_code == 401:
+        response.headers["WWW-Authenticate"] = "Bearer"
+    return response
+
+
+def a2a_error(
+    code: str,
+    message: str,
+    *,
+    status_code: int,
+    details: dict[str, Any] | None = None,
+) -> A2AApiError:
+    return A2AApiError(code, message, status_code=status_code, details=details)
+
+
+def is_published_agent(agent: Agent | None) -> bool:
+    if agent is None:
+        return False
+    status = getattr(agent, "status", None)
+    status = getattr(status, "value", status)
+    return status == AgentStatus.PUBLISHED.value
+
+
+def normalize_agent_card_base_url(request: Request, agent_id: int) -> str:
+    root = str(request.base_url).rstrip("/")
+    return f"{root}/api/a2a/agents/{agent_id}"
+
+
+def build_agent_card(agent: Agent, request: Request) -> dict[str, Any]:
+    if not is_published_agent(agent):
+        raise a2a_error(
+            "agent_not_found",
+            "Agent not found.",
+            status_code=404,
+        )
+
+    base_url = normalize_agent_card_base_url(request, int(agent.id))
+    # Agent Cards are public discovery documents. Never fall back to the
+    # private execution instructions when an owner omitted a description.
+    description = str(agent.description or agent.name)
+    raw_suggested: Any = agent.suggested_prompts
+    suggested_source = raw_suggested if isinstance(raw_suggested, list) else []
+    suggested = [
+        item for item in suggested_source if isinstance(item, str) and item.strip()
+    ]
+    skill_id = _slugify(str(agent.name or f"agent-{agent.id}")) or "default"
+    card: dict[str, Any] = {
+        "name": str(agent.name),
+        "description": description,
+        "version": "1.0.0",
+        "supportedInterfaces": [
+            {
+                "url": base_url,
+                "protocolBinding": "HTTP+JSON",
+                "protocolVersion": A2A_VERSION,
+            }
+        ],
+        "capabilities": {
+            "streaming": True,
+            "pushNotifications": False,
+            "extendedAgentCard": False,
+        },
+        "securitySchemes": {
+            "xagentAgentApiKey": {
+                "httpAuthSecurityScheme": {
+                    "scheme": "Bearer",
+                    "description": "Xagent agent API key",
+                }
+            }
+        },
+        "securityRequirements": [{"schemes": {"xagentAgentApiKey": {}}}],
+        "defaultInputModes": ["text/plain", "application/json"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [
+            {
+                "id": skill_id,
+                "name": str(agent.name),
+                "description": description,
+                "tags": ["xagent", "agent"],
+                "examples": suggested[:5],
+                "inputModes": ["text/plain", "application/json"],
+                "outputModes": ["text/plain"],
+            }
+        ],
+    }
+    if agent.logo_url:
+        card["iconUrl"] = str(agent.logo_url)
+    return card
+
+
+def extract_message_text(message: Mapping[str, Any]) -> str:
+    message_id = message.get("messageId")
+    if not isinstance(message_id, str) or not message_id.strip():
+        raise a2a_error(
+            "invalid_argument",
+            "A2A message must include a non-empty messageId.",
+            status_code=400,
+            details={"field": "message.messageId"},
+        )
+    if message.get("role") != "ROLE_USER":
+        raise a2a_error(
+            "invalid_argument",
+            "A2A request messages must use role ROLE_USER.",
+            status_code=400,
+            details={"field": "message.role"},
+        )
+
+    parts = message.get("parts")
+    if not isinstance(parts, list) or not parts:
+        raise a2a_error(
+            "invalid_argument",
+            "A2A message must include at least one part.",
+            status_code=400,
+            details={"field": "message.parts"},
+        )
+
+    texts: list[str] = []
+    for index, part in enumerate(parts):
+        if not isinstance(part, Mapping):
+            raise a2a_error(
+                "invalid_argument",
+                "Each A2A message part must be an object.",
+                status_code=400,
+                details={"field": f"message.parts[{index}]"},
+            )
+        content_fields = [
+            field for field in ("text", "raw", "url", "data") if field in part
+        ]
+        if len(content_fields) != 1:
+            raise a2a_error(
+                "invalid_argument",
+                "Each A2A message part must contain exactly one content field.",
+                status_code=400,
+                details={"field": f"message.parts[{index}]"},
+            )
+        field = content_fields[0]
+        media_type = part.get("mediaType")
+        if field == "text":
+            text = part.get("text")
+            if not isinstance(text, str) or not text.strip():
+                raise a2a_error(
+                    "invalid_argument",
+                    "A2A text parts must contain non-empty text.",
+                    status_code=400,
+                    details={"field": f"message.parts[{index}].text"},
+                )
+            if media_type and not str(media_type).lower().startswith("text/"):
+                raise a2a_error(
+                    "content_type_not_supported",
+                    f"Unsupported text media type: {media_type}",
+                    status_code=400,
+                    details={"mediaType": media_type},
+                )
+            texts.append(text.strip())
+            continue
+        if field == "data":
+            if media_type and str(media_type).lower() != "application/json":
+                raise a2a_error(
+                    "content_type_not_supported",
+                    f"Unsupported data media type: {media_type}",
+                    status_code=400,
+                    details={"mediaType": media_type},
+                )
+            texts.append(json.dumps(part.get("data"), ensure_ascii=False))
+            continue
+        raise a2a_error(
+            "content_type_not_supported",
+            "Xagent A2A agents currently accept text and JSON data parts only.",
+            status_code=400,
+            details={"field": f"message.parts[{index}].{field}"},
+        )
+    if not texts:
+        raise a2a_error(
+            "invalid_argument",
+            "A2A message must include at least one text or data part.",
+            status_code=400,
+        )
+    return "\n\n".join(texts)
+
+
+def message_context_id(
+    message: Mapping[str, Any], body: Mapping[str, Any]
+) -> str | None:
+    context_id = message.get("contextId") or body.get("contextId")
+    if isinstance(context_id, str) and context_id.strip():
+        return context_id.strip()
+    return None
+
+
+def new_context_id() -> str:
+    return str(uuid4())
+
+
+def message_task_id(message: Mapping[str, Any], body: Mapping[str, Any]) -> int | None:
+    raw = message.get("taskId") or body.get("taskId")
+    if raw is None:
+        return None
+    if isinstance(raw, int) and not isinstance(raw, bool):
+        if raw > 0:
+            return raw
+    if isinstance(raw, str) and raw.isdecimal():
+        value = int(raw)
+        if value > 0:
+            return value
+    raise a2a_error(
+        "invalid_argument",
+        "taskId must reference a valid Xagent A2A task ID.",
+        status_code=400,
+        details={"field": "message.taskId"},
+    )
+
+
+def task_context_id(task: Task) -> str:
+    agent_config: dict[str, Any] = (
+        task.agent_config if isinstance(task.agent_config, dict) else {}
+    )
+    context_id = agent_config.get("a2a_context_id")
+    if isinstance(context_id, str) and context_id:
+        return context_id
+    return str(task.id)
+
+
+def task_to_a2a(task: Task, *, include_artifacts: bool = True) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "id": str(task.id),
+        "contextId": task_context_id(task),
+        "status": {
+            "state": task_state(task),
+            "timestamp": _iso_timestamp(task.updated_at),
+        },
+    }
+    if task.error_message:
+        result["status"]["message"] = _agent_message(str(task.error_message), task)
+    if include_artifacts and task.output and task_state(task) != "TASK_STATE_CANCELED":
+        output = str(task.output)
+        result["artifacts"] = [
+            {
+                "artifactId": f"task-{task.id}-output",
+                "name": "final_output",
+                "parts": [{"text": output}],
+            }
+        ]
+    return result
+
+
+def task_state(task_or_status: Task | Any) -> str:
+    task = task_or_status if isinstance(task_or_status, Task) else None
+    status = task.status if task is not None else task_or_status
+    if task is not None:
+        agent_config: dict[str, Any] = (
+            task.agent_config if isinstance(task.agent_config, dict) else {}
+        )
+        override = agent_config.get("a2a_state")
+        if override in {
+            "TASK_STATE_CANCELED",
+            "TASK_STATE_REJECTED",
+            "TASK_STATE_AUTH_REQUIRED",
+        }:
+            return str(override)
+    if isinstance(status, str):
+        try:
+            status = TaskStatus(status)
+        except ValueError:
+            return "TASK_STATE_UNSPECIFIED"
+    if status == TaskStatus.PENDING:
+        return "TASK_STATE_SUBMITTED"
+    if status == TaskStatus.RUNNING:
+        return "TASK_STATE_WORKING"
+    if status in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
+        return "TASK_STATE_INPUT_REQUIRED"
+    if status == TaskStatus.COMPLETED:
+        return "TASK_STATE_COMPLETED"
+    if status == TaskStatus.FAILED:
+        return "TASK_STATE_FAILED"
+    return "TASK_STATE_UNSPECIFIED"
+
+
+def sse_task_snapshot(task: Task) -> str:
+    return _sse_event({"task": task_to_a2a(task)})
+
+
+def sse_task_update(task: Task) -> str:
+    return _sse_event(
+        {
+            "statusUpdate": {
+                "status": task_to_a2a(task, include_artifacts=False)["status"],
+                "taskId": str(task.id),
+                "contextId": task_context_id(task),
+            }
+        }
+    )
+
+
+def sse_task_artifacts(task: Task) -> str | None:
+    artifacts = task_to_a2a(task).get("artifacts")
+    if not artifacts:
+        return None
+    return _sse_event(
+        {
+            "artifactUpdate": {
+                "taskId": str(task.id),
+                "contextId": task_context_id(task),
+                "artifact": artifacts[0],
+                "lastChunk": True,
+            }
+        }
+    )
+
+
+def _agent_message(content: str, task: Task) -> dict[str, Any]:
+    return {
+        "messageId": f"task-{task.id}-status",
+        "contextId": task_context_id(task),
+        "taskId": str(task.id),
+        "role": "ROLE_AGENT",
+        "parts": [{"text": content}],
+    }
+
+
+def _iso_timestamp(value: Any) -> str:
+    if not isinstance(value, datetime):
+        timestamp = datetime.now(timezone.utc)
+    elif value.tzinfo is None:
+        timestamp = value.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = value.astimezone(timezone.utc)
+    return timestamp.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _sse_event(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _error_reason(code: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", code).strip("_").upper()
+    return normalized.removesuffix("_ERROR") or "INTERNAL"
+
+
+def _rpc_status(status_code: int, reason: str) -> str:
+    if reason in {
+        "TASK_NOT_CANCELABLE",
+        "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        "UNSUPPORTED_OPERATION",
+        "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+        "EXTENSION_SUPPORT_REQUIRED",
+        "VERSION_NOT_SUPPORTED",
+    }:
+        return "FAILED_PRECONDITION"
+    mapping = {
+        400: "INVALID_ARGUMENT",
+        401: "UNAUTHENTICATED",
+        403: "PERMISSION_DENIED",
+        404: "NOT_FOUND",
+        409: "ABORTED",
+        429: "RESOURCE_EXHAUSTED",
+        500: "INTERNAL",
+        503: "UNAVAILABLE",
+    }
+    if status_code in mapping:
+        return mapping[status_code]
+    try:
+        return HTTPStatus(status_code).phrase.replace(" ", "_").upper()
+    except ValueError:
+        return "UNKNOWN"
+
+
+def _slugify(value: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_-]+", "_", value.strip()).strip("_")
+    return normalized.lower()

--- a/src/xagent/web/services/a2a_protocol.py
+++ b/src/xagent/web/services/a2a_protocol.py
@@ -390,17 +390,28 @@ def sse_task_update(task: Task) -> str:
     )
 
 
-def sse_task_artifacts(task: Task) -> str | None:
-    artifacts = task_to_a2a(task).get("artifacts")
-    if not artifacts:
+def sse_task_artifacts(
+    task: Task,
+    *,
+    text: str | None = None,
+    append: bool = False,
+    last_chunk: bool = True,
+) -> str | None:
+    output = str(task.output or "") if text is None else text
+    if not output or task_state(task) == "TASK_STATE_CANCELED":
         return None
     return _sse_event(
         {
             "artifactUpdate": {
                 "taskId": str(task.id),
                 "contextId": task_context_id(task),
-                "artifact": artifacts[0],
-                "lastChunk": True,
+                "artifact": {
+                    "artifactId": f"task-{task.id}-output",
+                    "name": "final_output",
+                    "parts": [{"text": output}],
+                },
+                "append": append,
+                "lastChunk": last_chunk,
             }
         }
     )

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import ipaddress
 import json
 import logging
 import re
@@ -17,6 +16,10 @@ import httpx
 from sqlalchemy.orm import sessionmaker
 
 from ...config import get_mcp_oauth_allow_private_hosts, get_mcp_oauth_proxy_url
+from ...core.utils.security import (
+    PrivateNetworkHostError,
+    reject_private_network_host,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1481,33 +1484,10 @@ def _truncate(value: str, max_length: int) -> str:
 def _reject_blocked_host(hostname: str) -> None:
     if get_mcp_oauth_allow_private_hosts():
         return
-    if hostname in {"localhost", "ip6-localhost"}:
-        raise MCPOAuthDiscoveryError(
-            "invalid_resource",
-            "OAuth metadata host must not resolve to local addresses",
-        )
-    hostname = _strip_ipv6_zone_id(hostname)
     try:
-        ip_address = ipaddress.ip_address(hostname)
-    except ValueError:
-        return
-    if isinstance(ip_address, ipaddress.IPv6Address) and ip_address.ipv4_mapped:
-        ip_address = ip_address.ipv4_mapped
-    if (
-        ip_address.is_private
-        or ip_address.is_loopback
-        or ip_address.is_link_local
-        or ip_address.is_multicast
-        or ip_address.is_reserved
-        or ip_address.is_unspecified
-    ):
+        reject_private_network_host(hostname)
+    except PrivateNetworkHostError as exc:
         raise MCPOAuthDiscoveryError(
             "invalid_resource",
             "OAuth metadata host must not resolve to local addresses",
-        )
-
-
-def _strip_ipv6_zone_id(hostname: str) -> str:
-    if "%" not in hostname:
-        return hostname
-    return hostname.split("%", 1)[0]
+        ) from exc

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -383,6 +383,7 @@ class WebToolConfig(BaseToolConfig):
         allowed_skills: Optional[List[str]] = None,
         allowed_agent_ids: Optional[List[int]] = None,
         agent_tool_overrides: Optional[Dict[int, Dict[str, Any]]] = None,
+        a2a_agent_configs: Optional[List[Dict[str, Any]]] = None,
         enable_global_agent_tools: bool = True,
         allow_cross_user_agent_ids: bool = False,
         parent_task_id: Optional[str] = None,
@@ -464,6 +465,9 @@ class WebToolConfig(BaseToolConfig):
         self._allowed_agent_ids = allowed_agent_ids
         self._agent_tool_overrides = (
             agent_tool_overrides if isinstance(agent_tool_overrides, dict) else {}
+        )
+        self._a2a_agent_configs = (
+            a2a_agent_configs if isinstance(a2a_agent_configs, list) else []
         )
         self._enable_global_agent_tools = bool(enable_global_agent_tools)
         self._allow_cross_user_agent_ids = bool(allow_cross_user_agent_ids)
@@ -884,6 +888,10 @@ class WebToolConfig(BaseToolConfig):
     def get_agent_tool_overrides(self) -> Dict[int, Dict[str, Any]]:
         """Get per-agent tool metadata/runtime overrides for delegation."""
         return self._agent_tool_overrides
+
+    def get_a2a_agent_configs(self) -> List[Dict[str, Any]]:
+        """Get remote A2A agent tool configurations."""
+        return self._a2a_agent_configs
 
     def get_enable_global_agent_tools(self) -> bool:
         """Whether to include globally visible published agents as tools."""

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -363,6 +363,52 @@ def build_plan(*steps: PlanStep) -> ExecutionPlan:
     return ExecutionPlan(steps=list(steps))
 
 
+def test_dag_waiting_response_preserves_active_step_state() -> None:
+    completed_step = PlanStep(id="collect", task="Collect inputs")
+    completed_step.status = "completed"
+    active_step = PlanStep(
+        id="confirm",
+        task="Confirm the selected option",
+        dependencies=["collect"],
+    )
+    active_step.status = "running"
+    pattern = DAGPattern(lambda **_: build_plan(completed_step, active_step))
+    pattern.status = "waiting_for_user"
+    pattern.plan = build_plan(completed_step, active_step)
+    pattern.step_results = {"collect": "Options A and B collected"}
+    pattern.active_step_id = "confirm"
+    pattern.active_step_ids = ["confirm"]
+    pattern.active_step_pattern_states = {
+        "confirm": {
+            "status": "waiting_for_user",
+            "waiting_for_user_request": {"message": "Choose A or B"},
+        }
+    }
+    child_context = ExecutionContext(execution_id="dag-waiting:confirm")
+    child_context.add_user_message("Compare A and B")
+    pattern.active_step_contexts = {"confirm": child_context.to_dict()}
+    pattern.planned_user_message_count = 1
+
+    root_context = ExecutionContext(execution_id="dag-waiting")
+    root_context.add_user_message("Help me choose")
+    root_context.add_user_message("Choose B")
+
+    forwarded = pattern._forward_user_response_to_waiting_step(root_context)
+
+    assert forwarded is True
+    assert pattern.status == "running"
+    assert pattern.step_results == {"collect": "Options A and B collected"}
+    assert [step.id for step in pattern.plan.steps] == ["collect", "confirm"]
+    restored_child = ExecutionContext.from_dict(pattern.active_step_contexts["confirm"])
+    forwarded_message = restored_child.messages[-1]
+    assert forwarded_message.content == "Choose B"
+    assert forwarded_message.metadata == {
+        "kind": "dag_waiting_user_response",
+        "forwarded_from_root": True,
+        "dag_step_id": "confirm",
+    }
+
+
 async def run_invalid_plan(plan: ExecutionPlan) -> dict[str, Any]:
     pattern = DAGPattern(lambda **_: plan)
     return await pattern.run(

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -175,6 +175,11 @@ class TrackingCallback:
         self.events.append(("end", context.execution_id))
 
 
+class FailingUserMessageCallback:
+    async def on_user_message_posted(self, **_: Any) -> None:
+        raise RuntimeError("trace callback failed")
+
+
 class RecordingTraceEventTracer:
     def __init__(self) -> None:
         self.events: list[dict[str, Any]] = []
@@ -700,6 +705,98 @@ async def test_runner_post_user_message_alias_matches_inject_behavior(
         message.content for message in context.messages if message.role == "user"
     ]
     assert user_messages == ["Original task", "Follow-up from user."]
+
+
+@pytest.mark.asyncio
+async def test_runner_post_user_message_deduplicates_explicit_turn_id_after_failure(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-idempotent-message"
+    checkpoint_context = ExecutionContext(execution_id=execution_id)
+    checkpoint_context.add_user_message("Original task")
+    await tracer.checkpoint(
+        type="checkpoint",
+        execution_id=execution_id,
+        pattern="FakePattern",
+        label="waiting_for_user",
+        status="waiting_for_user",
+        context=checkpoint_context.to_dict(),
+        pattern_state={},
+        metadata={},
+    )
+    failing_runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[FakePattern({"success": True})]),
+        tracer=tracer,
+        callbacks=[FailingUserMessageCallback()],
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    with pytest.raises(RuntimeError, match="trace callback failed"):
+        await failing_runner.post_user_message(
+            execution_id,
+            "Choose B",
+            turn_id="a2a:42:msg-1",
+            request_interrupt=False,
+        )
+
+    failing_runner.context_manager.remove_context(execution_id)
+    retry_runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[FakePattern({"success": True})]),
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    context = await retry_runner.post_user_message(
+        execution_id,
+        "Choose B",
+        turn_id="a2a:42:msg-1",
+        request_interrupt=False,
+    )
+
+    assert context is not None
+    retried_messages = [
+        message
+        for message in context.messages
+        if message.role == "user" and message.metadata.get("turn_id") == "a2a:42:msg-1"
+    ]
+    assert len(retried_messages) == 1
+    assert retried_messages[0].content == "Choose B"
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_reused_turn_id_with_different_content(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-conflicting-message"
+    checkpoint_context = ExecutionContext(execution_id=execution_id)
+    checkpoint_context.add_user_message(
+        "Choose A",
+        metadata={"turn_id": "a2a:42:msg-1"},
+    )
+    await tracer.checkpoint(
+        type="checkpoint",
+        execution_id=execution_id,
+        pattern="FakePattern",
+        label="waiting_for_user",
+        status="waiting_for_user",
+        context=checkpoint_context.to_dict(),
+        pattern_state={},
+        metadata={},
+    )
+    runner = AgentRunner(
+        agent=Agent(name="writer", patterns=[FakePattern({"success": True})]),
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    with pytest.raises(ValueError, match="different user message"):
+        await runner.post_user_message(
+            execution_id,
+            "Choose B",
+            turn_id="a2a:42:msg-1",
+            request_interrupt=False,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_a2a_agent_tool.py
+++ b/tests/core/tools/test_a2a_agent_tool.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
 import pytest
 
 from xagent.core.tools.adapters.vibe import a2a_agent_tool
 from xagent.core.tools.adapters.vibe.a2a_agent_tool import (
+    A2A_TOOL_ERROR_MESSAGE,
     A2AAgentTool,
     create_a2a_agent_tools,
 )
@@ -141,6 +143,13 @@ class _WorkingAsyncClient(_FakeAsyncClient):
         )
 
 
+class _LeakyErrorAsyncClient(_FakeAsyncClient):
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        raise httpx.ConnectError(
+            "connection failed for http://127.0.0.1/private?token=secret"
+        )
+
+
 class _CrossOriginCardAsyncClient(_FakeAsyncClient):
     async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
         self.calls.append(("GET", url, kwargs))
@@ -198,6 +207,7 @@ async def test_create_a2a_agent_tools_from_tool_config() -> None:
                     "description": "Use for remote research tasks.",
                     "endpoint_url": "https://remote.example/a2a",
                     "headers": {"X-Remote": "1"},
+                    "allow_private_networks": True,
                 }
             ]
         }
@@ -209,6 +219,7 @@ async def test_create_a2a_agent_tools_from_tool_config() -> None:
     assert tools[0].name == "a2a_remote_researcher"
     assert tools[0].metadata.category == "agent"
     assert tools[0].description == "Use for remote research tasks."
+    assert tools[0]._allow_private_networks is True
 
 
 @pytest.mark.asyncio
@@ -274,7 +285,7 @@ async def test_a2a_agent_tool_rejects_cross_origin_card_endpoint(monkeypatch) ->
     result = await tool.run_json_async({"task": "do work"})
 
     assert result["success"] is False
-    assert "same origin" in result["error"]
+    assert result["error"] == A2A_TOOL_ERROR_MESSAGE
     assert [call[0] for call in _CrossOriginCardAsyncClient.calls] == ["GET"]
 
 
@@ -295,17 +306,68 @@ async def test_a2a_agent_tool_revalidates_discovered_endpoint(monkeypatch) -> No
     result = await tool.run_json_async({"task": "do work"})
 
     assert result["success"] is False
-    assert "embedded credentials" in result["error"]
+    assert result["error"] == A2A_TOOL_ERROR_MESSAGE
     assert [call[0] for call in _FakeAsyncClient.calls] == ["GET"]
 
 
-def test_a2a_agent_tool_allows_explicit_private_endpoint() -> None:
+def test_a2a_agent_tool_rejects_private_endpoint_by_default() -> None:
+    with pytest.raises(ValueError, match="private network"):
+        A2AAgentTool(
+            name="Internal Agent",
+            endpoint_url="http://127.0.0.1:8000/a2a",
+        )
+
+
+def test_a2a_agent_tool_allows_explicit_private_network_opt_in() -> None:
     tool = A2AAgentTool(
         name="Internal Agent",
         endpoint_url="http://127.0.0.1:8000/a2a",
+        allow_private_networks=True,
     )
 
     assert tool._endpoint_url == "http://127.0.0.1:8000/a2a"
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_rejects_hostname_resolving_to_private_ip(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        a2a_agent_tool.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (
+                a2a_agent_tool.socket.AF_INET,
+                a2a_agent_tool.socket.SOCK_STREAM,
+                6,
+                "",
+                ("127.0.0.1", 443),
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="private network"):
+        await a2a_agent_tool._resolve_public_addresses("https://remote.example/a2a")
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_sanitizes_unexpected_errors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        a2a_agent_tool.httpx,
+        "AsyncClient",
+        _LeakyErrorAsyncClient,
+    )
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        endpoint_url="https://remote.example/a2a",
+    )
+
+    result = await tool.run_json_async({"task": "do work"})
+
+    assert result["success"] is False
+    assert result["error"] == A2A_TOOL_ERROR_MESSAGE
+    assert "127.0.0.1" not in result["error"]
+    assert "secret" not in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_a2a_agent_tool.py
+++ b/tests/core/tools/test_a2a_agent_tool.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.adapters.vibe import a2a_agent_tool
+from xagent.core.tools.adapters.vibe.a2a_agent_tool import (
+    A2AAgentTool,
+    create_a2a_agent_tools,
+)
+from xagent.core.tools.adapters.vibe.config import ToolConfig
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        self.timeout = kwargs.get("timeout")
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("GET", url, kwargs))
+        if url == "https://remote.example/.well-known/agent-card.json":
+            return _FakeResponse(
+                {
+                    "name": "Remote Agent",
+                    "description": "Remote A2A worker",
+                    "supportedInterfaces": [
+                        {
+                            "url": "https://remote.example/a2a",
+                            "protocolBinding": "HTTP+JSON",
+                            "protocolVersion": "1.0",
+                        }
+                    ],
+                }
+            )
+        if url == "https://remote.example/a2a/tasks/task-1":
+            return _FakeResponse(
+                {
+                    "id": "task-1",
+                    "contextId": "ctx-1",
+                    "status": {
+                        "state": "TASK_STATE_COMPLETED",
+                        "message": {
+                            "role": "ROLE_AGENT",
+                            "parts": [{"text": "done"}],
+                        },
+                    },
+                    "artifacts": [
+                        {
+                            "artifactId": "artifact-1",
+                            "parts": [{"text": "artifact text"}],
+                        }
+                    ],
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("POST", url, kwargs))
+        assert url == "https://remote.example/a2a/message:send"
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert kwargs["headers"]["A2A-Version"] == "1.0"
+        assert kwargs["json"]["message"]["parts"] == [{"text": "do work"}]
+        assert kwargs["json"]["configuration"]["returnImmediately"] is True
+        return _FakeResponse(
+            {
+                "task": {
+                    "id": "task-1",
+                    "contextId": "ctx-1",
+                    "status": {"state": "TASK_STATE_WORKING"},
+                }
+            }
+        )
+
+
+class _InterruptedAsyncClient(_FakeAsyncClient):
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("POST", url, kwargs))
+        return _FakeResponse(
+            {
+                "task": {
+                    "id": "task-input",
+                    "contextId": "ctx-input",
+                    "status": {
+                        "state": "TASK_STATE_INPUT_REQUIRED",
+                        "message": {
+                            "role": "ROLE_AGENT",
+                            "parts": [{"text": "Which region?"}],
+                        },
+                    },
+                }
+            }
+        )
+
+    async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        raise AssertionError(f"Interrupted tasks must not be polled: {url}")
+
+
+class _DirectMessageAsyncClient(_FakeAsyncClient):
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("POST", url, kwargs))
+        return _FakeResponse(
+            {
+                "message": {
+                    "messageId": "response-1",
+                    "role": "ROLE_AGENT",
+                    "parts": [{"text": "direct answer"}],
+                }
+            }
+        )
+
+
+class _WorkingAsyncClient(_FakeAsyncClient):
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(
+            {
+                "task": {
+                    "id": "task-working",
+                    "contextId": "ctx-working",
+                    "status": {"state": "TASK_STATE_WORKING"},
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_fetches_card_sends_and_polls(monkeypatch) -> None:
+    _FakeAsyncClient.calls = []
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncClient", _FakeAsyncClient)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(a2a_agent_tool, "sleep", _no_sleep)
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        agent_card_url="https://remote.example/.well-known/agent-card.json",
+        auth_token="secret",
+    )
+
+    result = await tool.run_json_async({"task": "do work"})
+
+    assert result["success"] is True
+    assert result["task_id"] == "task-1"
+    assert result["context_id"] == "ctx-1"
+    assert result["state"] == "TASK_STATE_COMPLETED"
+    assert result["response"] == "done\n\nartifact text"
+    assert [call[0] for call in _FakeAsyncClient.calls] == ["GET", "POST", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_create_a2a_agent_tools_from_tool_config() -> None:
+    config = ToolConfig(
+        {
+            "a2a_agent_configs": [
+                {
+                    "name": "Remote Researcher",
+                    "description": "Use for remote research tasks.",
+                    "endpoint_url": "https://remote.example/a2a",
+                    "headers": {"X-Remote": "1"},
+                }
+            ]
+        }
+    )
+
+    tools = await create_a2a_agent_tools(config)
+
+    assert len(tools) == 1
+    assert tools[0].name == "a2a_remote_researcher"
+    assert tools[0].metadata.category == "agent"
+    assert tools[0].description == "Use for remote research tasks."
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_returns_interrupted_task_without_polling(
+    monkeypatch,
+) -> None:
+    _InterruptedAsyncClient.calls = []
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncClient", _InterruptedAsyncClient)
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        endpoint_url="https://remote.example/a2a",
+    )
+
+    result = await tool.run_json_async({"task": "research", "task_id": "task-1"})
+
+    assert result["success"] is False
+    assert result["state"] == "TASK_STATE_INPUT_REQUIRED"
+    assert result["task_id"] == "task-input"
+    assert result["response"] == "Which region?"
+    assert result["error"] == "Which region?"
+    sent_message = _InterruptedAsyncClient.calls[0][2]["json"]["message"]
+    assert sent_message["taskId"] == "task-1"
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_extracts_direct_message_response(monkeypatch) -> None:
+    _DirectMessageAsyncClient.calls = []
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncClient", _DirectMessageAsyncClient)
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        endpoint_url="https://remote.example/a2a",
+    )
+
+    result = await tool.run_json_async({"task": "quick answer"})
+
+    assert result["success"] is True
+    assert result["response"] == "direct answer"
+    assert result["task_id"] is None
+
+
+def test_a2a_agent_tool_rejects_url_with_embedded_credentials() -> None:
+    with pytest.raises(ValueError, match="embedded credentials"):
+        A2AAgentTool(
+            name="Remote Agent",
+            endpoint_url="https://user:secret@remote.example/a2a",
+        )
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_reports_timeout_as_failure(monkeypatch) -> None:
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncClient", _WorkingAsyncClient)
+
+    async def _time_out(_self: Any, **kwargs: Any) -> tuple[dict[str, Any], Any]:
+        raise TimeoutError
+
+    monkeypatch.setattr(A2AAgentTool, "_poll_task_until_terminal", _time_out)
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        endpoint_url="https://remote.example/a2a",
+        timeout_seconds=1,
+    )
+
+    result = await tool.run_json_async({"task": "slow task"})
+
+    assert result["success"] is False
+    assert result["error"] == "A2A call timed out after 1s."

--- a/tests/core/tools/test_a2a_agent_tool.py
+++ b/tests/core/tools/test_a2a_agent_tool.py
@@ -141,6 +141,28 @@ class _WorkingAsyncClient(_FakeAsyncClient):
         )
 
 
+class _CrossOriginCardAsyncClient(_FakeAsyncClient):
+    async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(("GET", url, kwargs))
+        assert url == "https://remote.example/.well-known/agent-card.json"
+        return _FakeResponse(
+            {
+                "supportedInterfaces": [
+                    {
+                        "url": "http://169.254.169.254/latest/meta-data",
+                        "protocolBinding": "HTTP+JSON",
+                        "protocolVersion": "1.0",
+                    }
+                ]
+            }
+        )
+
+    async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        raise AssertionError(
+            f"Cross-origin discovered endpoint must not be called: {url}"
+        )
+
+
 @pytest.mark.asyncio
 async def test_a2a_agent_tool_fetches_card_sends_and_polls(monkeypatch) -> None:
     _FakeAsyncClient.calls = []
@@ -233,6 +255,57 @@ def test_a2a_agent_tool_rejects_url_with_embedded_credentials() -> None:
             name="Remote Agent",
             endpoint_url="https://user:secret@remote.example/a2a",
         )
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_rejects_cross_origin_card_endpoint(monkeypatch) -> None:
+    _CrossOriginCardAsyncClient.calls = []
+    monkeypatch.setattr(
+        a2a_agent_tool.httpx,
+        "AsyncClient",
+        _CrossOriginCardAsyncClient,
+    )
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        agent_card_url="https://remote.example/.well-known/agent-card.json",
+        auth_token="secret",
+    )
+
+    result = await tool.run_json_async({"task": "do work"})
+
+    assert result["success"] is False
+    assert "same origin" in result["error"]
+    assert [call[0] for call in _CrossOriginCardAsyncClient.calls] == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_tool_revalidates_discovered_endpoint(monkeypatch) -> None:
+    _FakeAsyncClient.calls = []
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(
+        a2a_agent_tool,
+        "_endpoint_from_card",
+        lambda _card: "https://user:secret@remote.example/a2a",
+    )
+    tool = A2AAgentTool(
+        name="Remote Agent",
+        agent_card_url="https://remote.example/.well-known/agent-card.json",
+    )
+
+    result = await tool.run_json_async({"task": "do work"})
+
+    assert result["success"] is False
+    assert "embedded credentials" in result["error"]
+    assert [call[0] for call in _FakeAsyncClient.calls] == ["GET"]
+
+
+def test_a2a_agent_tool_allows_explicit_private_endpoint() -> None:
+    tool = A2AAgentTool(
+        name="Internal Agent",
+        endpoint_url="http://127.0.0.1:8000/a2a",
+    )
+
+    assert tool._endpoint_url == "http://127.0.0.1:8000/a2a"
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -32,6 +32,7 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from xagent.web.api.a2a import router as a2a_router
 from xagent.web.api.agent_api_keys import router as agent_api_keys_router
 from xagent.web.api.agents import router as agents_router
 from xagent.web.api.auth import auth_router
@@ -46,6 +47,11 @@ from xagent.web.api.v1.errors import V1ApiError, v1_api_error_handler
 from xagent.web.api.widget import widget_router
 from xagent.web.api.workforces import router as workforces_router
 from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.services.a2a_protocol import (
+    A2AApiError,
+    a2a_api_error_handler,
+    a2a_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +76,7 @@ app_for_tests.include_router(me_router)
 app_for_tests.include_router(conversation_logs_router)
 app_for_tests.include_router(agents_router)
 app_for_tests.include_router(agent_api_keys_router)
+app_for_tests.include_router(a2a_router)
 app_for_tests.include_router(workforces_router)
 app_for_tests.include_router(file_router)
 app_for_tests.include_router(mcp_router)
@@ -78,6 +85,7 @@ app_for_tests.include_router(share_router)
 app_for_tests.include_router(triggers_router)
 app_for_tests.include_router(v1_router)
 app_for_tests.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: ignore[arg-type]
+app_for_tests.add_exception_handler(A2AApiError, a2a_api_error_handler)  # type: ignore[arg-type]
 
 
 # Mirror production's /v1/* envelope guarantee in tests: any non-V1ApiError
@@ -90,6 +98,11 @@ app_for_tests.add_exception_handler(V1ApiError, v1_api_error_handler)  # type: i
 @app_for_tests.exception_handler(Exception)
 async def _v1_internal_error_handler(request: Request, exc: Exception):
     logger.error(f"Unhandled exception in {request.url}: {exc}", exc_info=True)
+    if request.url.path.startswith("/api/a2a/"):
+        return await a2a_api_error_handler(
+            request,
+            a2a_error("internal", "Internal server error.", status_code=500),
+        )
     if request.url.path.startswith("/v1/"):
         return JSONResponse(
             status_code=500,
@@ -110,6 +123,20 @@ async def _v1_internal_error_handler(request: Request, exc: Exception):
 # /api/* falls through to FastAPI's default {"detail": [...]}.
 @app_for_tests.exception_handler(RequestValidationError)
 async def _v1_validation_error_handler(request: Request, exc: RequestValidationError):
+    if request.url.path.startswith("/api/a2a/"):
+        errors = exc.errors()
+        first = errors[0] if errors else {}
+        msg = first.get("msg") or "Invalid A2A request"
+        loc = ".".join(str(part) for part in first.get("loc", []))
+        return await a2a_api_error_handler(
+            request,
+            a2a_error(
+                "invalid_argument",
+                f"{msg} ({loc})" if loc else str(msg),
+                status_code=400,
+                details={"field": loc},
+            ),
+        )
     if request.url.path.startswith("/v1/"):
         errors = exc.errors()
         first = errors[0] if errors else {}

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -275,6 +275,27 @@ def test_message_send_rejects_oversized_content() -> None:
     )
 
 
+def test_message_send_requires_message_id() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/message:send",
+        headers=_bearer(full_key),
+        json={
+            "message": {
+                "role": "ROLE_USER",
+                "parts": [{"text": "missing id"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["details"][0]["reason"] == "INVALID_ARGUMENT"
+    assert error["details"][0]["metadata"]["field"] == "message.messageId"
+
+
 def test_a2a_fastapi_validation_uses_protocol_error_shape() -> None:
     agent_id, full_key = _create_published_agent_with_key()
 
@@ -548,6 +569,7 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
         task_id,
         execution_message="follow up",
         display_message="follow up",
+        turn_id=f"a2a:{task_id}:msg-follow-up",
         request_interrupt=False,
         reason="A2A input-required response",
     )
@@ -612,6 +634,68 @@ def test_failed_follow_up_restores_input_required_status() -> None:
         )
 
     assert response.status_code == 400, response.text
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
+
+
+def test_checkpoint_resume_exception_restores_input_required_status() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="waiting",
+            status=TaskStatus.WAITING_FOR_USER,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-resume-error"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(
+        side_effect=RuntimeError("checkpoint callback failed")
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-resume-error",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry safely"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 500
+    agent_service.post_user_message.assert_awaited_once_with(
+        str(task_id),
+        execution_message="retry safely",
+        display_message="retry safely",
+        turn_id=f"a2a:{task_id}:msg-resume-error",
+        request_interrupt=False,
+        reason="A2A input-required response",
+    )
     db = _direct_db_session()
     try:
         recovered = db.query(Task).filter(Task.id == task_id).one()

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1,0 +1,511 @@
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xagent.web.models.agent import Agent
+from xagent.web.models.agent_api_key import AgentApiKey
+from xagent.web.models.task import Task, TaskStatus
+
+from .conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _bearer(full_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {full_key}",
+        "A2A-Version": "1.0",
+    }
+
+
+def _create_agent(headers: dict[str, str], name: str = "A2A Test Agent") -> int:
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "A2A test agent",
+            "instructions": "You are an A2A test agent.",
+            "execution_mode": "balanced",
+            "suggested_prompts": ["Summarize this"],
+        },
+    )
+    assert response.status_code == 200, response.text
+    return int(response.json()["id"])
+
+
+def _publish_agent(headers: dict[str, str], agent_id: int) -> None:
+    response = client.post(f"/api/agents/{agent_id}/publish", headers=headers)
+    assert response.status_code == 200, response.text
+
+
+def _create_published_agent_with_key() -> tuple[int, str]:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    _publish_agent(headers, agent_id)
+    key_response = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+    assert key_response.status_code == 200, key_response.text
+    return agent_id, key_response.json()["full_key"]
+
+
+def test_agent_card_exposes_published_agent() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    _publish_agent(headers, agent_id)
+
+    response = client.get(f"/api/a2a/agents/{agent_id}/.well-known/agent-card.json")
+
+    assert response.status_code == 200, response.text
+    assert response.headers["a2a-version"] == "1.0"
+    assert response.headers["content-type"].startswith("application/a2a+json")
+    body = response.json()
+    assert body["name"] == "A2A Test Agent"
+    assert body["defaultInputModes"] == ["text/plain", "application/json"]
+    assert body["defaultOutputModes"] == ["text/plain"]
+    assert body["supportedInterfaces"] == [
+        {
+            "url": f"http://testserver/api/a2a/agents/{agent_id}",
+            "protocolBinding": "HTTP+JSON",
+            "protocolVersion": "1.0",
+        }
+    ]
+    assert body["securitySchemes"]["xagentAgentApiKey"] == {
+        "httpAuthSecurityScheme": {
+            "scheme": "Bearer",
+            "description": "Xagent agent API key",
+        }
+    }
+    assert body["securityRequirements"] == [{"schemes": {"xagentAgentApiKey": {}}}]
+    assert body["skills"][0]["examples"] == ["Summarize this"]
+
+
+def test_agent_card_hides_draft_agent() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+
+    response = client.get(f"/api/a2a/agents/{agent_id}/.well-known/agent-card.json")
+
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == 404
+    assert error["status"] == "NOT_FOUND"
+    assert error["details"][0]["reason"] == "AGENT_NOT_FOUND"
+
+
+def test_agent_card_does_not_expose_private_instructions() -> None:
+    headers = _admin_headers()
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "Private Prompt Agent",
+            "instructions": "secret system prompt",
+            "execution_mode": "balanced",
+        },
+    )
+    assert response.status_code == 200, response.text
+    agent_id = int(response.json()["id"])
+    _publish_agent(headers, agent_id)
+
+    card = client.get(f"/api/a2a/agents/{agent_id}/.well-known/agent-card.json").json()
+
+    assert card["description"] == "Private Prompt Agent"
+    assert "secret system prompt" not in json.dumps(card)
+
+
+def test_message_send_creates_hidden_a2a_task() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as schedule_bg:
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-1",
+                    "contextId": "ctx-1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hello from a2a"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    task = body["task"]
+    assert task["contextId"] == "ctx-1"
+    assert task["status"]["state"] == "TASK_STATE_WORKING"
+
+    db = _direct_db_session()
+    try:
+        row = db.query(Task).filter(Task.id == int(task["id"])).one()
+        assert row.agent_id == agent_id
+        assert row.source == "a2a"
+        assert row.is_visible is False
+        assert row.input == "hello from a2a"
+        assert row.agent_config == {"a2a_context_id": "ctx-1"}
+        assert row.status == TaskStatus.RUNNING
+
+        key = db.query(AgentApiKey).filter(AgentApiKey.agent_id == agent_id).one()
+        assert key.usage_month == datetime.now(UTC).strftime("%Y-%m")
+        assert key.usage_month_calls == 1
+    finally:
+        db.close()
+
+    assert schedule_bg.call_count == 1
+    assert schedule_bg.call_args.kwargs["task_id"] == int(task["id"])
+
+
+def test_message_send_rejects_key_bound_to_different_agent() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    headers = _admin_headers()
+    other_agent_id = _create_agent(headers, name="Other A2A Agent")
+    _publish_agent(headers, other_agent_id)
+
+    response = client.post(
+        f"/api/a2a/agents/{other_agent_id}/message:send",
+        headers=_bearer(full_key),
+        json={
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "wrong target"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    assert other_agent_id != agent_id
+    assert response.status_code == 404
+    assert response.json()["error"]["details"][0]["reason"] == "AGENT_NOT_FOUND"
+
+
+def test_message_send_rejects_draft_agent_key() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    key_response = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+    assert key_response.status_code == 200, key_response.text
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/message:send",
+        headers=_bearer(key_response.json()["full_key"]),
+        json={
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "draft should not run"}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["details"][0]["reason"] == "AGENT_NOT_FOUND"
+
+
+def test_message_send_requires_supported_a2a_version() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    payload = {
+        "message": {
+            "messageId": "msg-version",
+            "role": "ROLE_USER",
+            "parts": [{"text": "hello"}],
+        },
+        "configuration": {"returnImmediately": True},
+    }
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/message:send",
+        headers={"Authorization": f"Bearer {full_key}"},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
+    assert error["details"][0]["metadata"]["supportedVersions"] == "1.0"
+
+
+def test_a2a_fastapi_validation_uses_protocol_error_shape() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    response = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"pageSize": 0},
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["status"] == "INVALID_ARGUMENT"
+    assert error["details"][0]["reason"] == "INVALID_ARGUMENT"
+
+
+def test_a2a_auth_error_includes_bearer_challenge() -> None:
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    _publish_agent(headers, agent_id)
+
+    response = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers={"A2A-Version": "1.0"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    assert response.json()["error"]["status"] == "UNAUTHENTICATED"
+
+
+def test_message_send_blocks_by_default_until_task_finishes() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    async def _complete_turn(**kwargs: object) -> object:
+        db = _direct_db_session()
+        try:
+            row = db.query(Task).filter(Task.id == int(kwargs["task_id"])).one()
+            row.status = TaskStatus.COMPLETED
+            row.output = "blocking response"
+            db.commit()
+        finally:
+            db.close()
+        return object()
+
+    with patch(
+        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        new=_complete_turn,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-blocking",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "wait for me"}],
+                }
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    task = response.json()["task"]
+    assert task["status"]["state"] == "TASK_STATE_COMPLETED"
+    assert task["artifacts"][0]["parts"] == [{"text": "blocking response"}]
+
+
+def test_unexpected_a2a_error_uses_internal_protocol_envelope() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    with patch(
+        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        side_effect=RuntimeError("sensitive implementation detail"),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-error",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "fail"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 500
+    error = response.json()["error"]
+    assert error["status"] == "INTERNAL"
+    assert error["details"][0]["reason"] == "INTERNAL"
+    assert "sensitive implementation detail" not in response.text
+
+
+def test_get_and_list_tasks_use_rest_binding_shapes() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        created = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-list",
+                    "contextId": "ctx-list",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "list me"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+    task_id = created.json()["task"]["id"]
+
+    db = _direct_db_session()
+    try:
+        row = db.query(Task).filter(Task.id == int(task_id)).one()
+        row.status = TaskStatus.COMPLETED
+        row.output = "listed output"
+        db.commit()
+    finally:
+        db.close()
+
+    fetched = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}",
+        headers=_bearer(full_key),
+    )
+    listed = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"contextId": "ctx-list"},
+    )
+    listed_with_artifacts = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"includeArtifacts": "true"},
+    )
+
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["id"] == task_id
+    assert "task" not in fetched.json()
+    assert fetched.json()["artifacts"][0]["parts"] == [{"text": "listed output"}]
+    assert listed.json()["totalSize"] == 1
+    assert "artifacts" not in listed.json()["tasks"][0]
+    assert listed_with_artifacts.json()["tasks"][0]["artifacts"][0]["parts"] == [
+        {"text": "listed output"}
+    ]
+
+
+def test_follow_up_infers_context_for_input_required_task() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        created = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-initial",
+                    "contextId": "ctx-follow-up",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "initial"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+    task_id = created.json()["task"]["id"]
+    db = _direct_db_session()
+    try:
+        row = db.query(Task).filter(Task.id == int(task_id)).one()
+        row.status = TaskStatus.WAITING_FOR_USER
+        db.commit()
+    finally:
+        db.close()
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-follow-up",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "follow up"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["contextId"] == "ctx-follow-up"
+    assert response.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
+
+
+def test_cancel_is_idempotent_and_subscribe_rejects_terminal_task() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        created = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-cancel",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "cancel me"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+    task_id = created.json()["task"]["id"]
+
+    first = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:cancel",
+        headers=_bearer(full_key),
+    )
+    second = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:cancel",
+        headers=_bearer(full_key),
+    )
+    subscribed = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:subscribe",
+        headers=_bearer(full_key),
+    )
+
+    assert first.status_code == 200, first.text
+    assert first.json()["status"]["state"] == "TASK_STATE_CANCELED"
+    assert second.status_code == 200, second.text
+    assert second.json()["status"]["state"] == "TASK_STATE_CANCELED"
+    assert subscribed.status_code == 400
+    assert subscribed.json()["error"]["details"][0]["reason"] == "UNSUPPORTED_OPERATION"
+
+
+def test_subscribe_stream_starts_with_wrapped_task_snapshot() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="paused",
+            status=TaskStatus.PAUSED,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-stream"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:subscribe",
+        headers=_bearer(full_key),
+    )
+
+    assert response.status_code == 200, response.text
+    data_lines = [
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert len(data_lines) == 1
+    event = json.loads(data_lines[0])
+    assert event["task"]["id"] == str(task_id)
+    assert event["task"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -4,9 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from xagent.web.api import a2a as a2a_api
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.services.a2a_protocol import A2A_MAX_MESSAGE_TEXT_LENGTH
+from xagent.web.services.task_orchestrator import TaskTurnError
 
 from .conftest import _admin_headers, _direct_db_session, client
 
@@ -228,8 +231,33 @@ def test_message_send_requires_supported_a2a_version() -> None:
 
     assert response.status_code == 400
     error = response.json()["error"]
+    assert error["message"] == "A2A-Version header or query parameter is required."
     assert error["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
     assert error["details"][0]["metadata"]["supportedVersions"] == "1.0"
+
+
+def test_message_send_rejects_oversized_content() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/message:send",
+        headers=_bearer(full_key),
+        json={
+            "message": {
+                "messageId": "msg-too-large",
+                "role": "ROLE_USER",
+                "parts": [{"text": "x" * (A2A_MAX_MESSAGE_TEXT_LENGTH + 1)}],
+            },
+            "configuration": {"returnImmediately": True},
+        },
+    )
+
+    assert response.status_code == 413
+    error = response.json()["error"]
+    assert error["status"] == "RESOURCE_EXHAUSTED"
+    assert error["details"][0]["metadata"]["maxLength"] == str(
+        A2A_MAX_MESSAGE_TEXT_LENGTH
+    )
 
 
 def test_a2a_fastapi_validation_uses_protocol_error_shape() -> None:
@@ -298,6 +326,60 @@ def test_message_send_blocks_by_default_until_task_finishes() -> None:
     assert task["artifacts"][0]["parts"] == [{"text": "blocking response"}]
 
 
+def test_message_send_returns_working_task_when_wait_deadline_expires(
+    monkeypatch,
+) -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    monkeypatch.setattr(a2a_api, "A2A_BLOCKING_WAIT_TIMEOUT_SECONDS", 0.0)
+
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-wait-timeout",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "keep working"}],
+                }
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
+
+
+def test_failed_create_does_not_leave_pending_a2a_task() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+
+    with patch(
+        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        side_effect=TaskTurnError("busy"),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-failed-create",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "fail before scheduling"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    db = _direct_db_session()
+    try:
+        assert db.query(Task).filter(Task.source == "a2a").count() == 0
+    finally:
+        db.close()
+
+
 def test_unexpected_a2a_error_uses_internal_protocol_envelope() -> None:
     agent_id, full_key = _create_published_agent_with_key()
 
@@ -323,6 +405,11 @@ def test_unexpected_a2a_error_uses_internal_protocol_envelope() -> None:
     assert error["status"] == "INTERNAL"
     assert error["details"][0]["reason"] == "INTERNAL"
     assert "sensitive implementation detail" not in response.text
+    db = _direct_db_session()
+    try:
+        assert db.query(Task).filter(Task.source == "a2a").count() == 0
+    finally:
+        db.close()
 
 
 def test_get_and_list_tasks_use_rest_binding_shapes() -> None:
@@ -509,3 +596,39 @@ def test_subscribe_stream_starts_with_wrapped_task_snapshot() -> None:
     event = json.loads(data_lines[0])
     assert event["task"]["id"] == str(task_id)
     assert event["task"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+
+
+def test_subscribe_stream_ends_at_server_lifetime_limit(monkeypatch) -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="running",
+            status=TaskStatus.RUNNING,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-stream-limit"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+    monkeypatch.setattr(a2a_api, "A2A_STREAM_MAX_DURATION_SECONDS", 0.0)
+
+    response = client.post(
+        f"/api/a2a/agents/{agent_id}/tasks/{task_id}:subscribe",
+        headers=_bearer(full_key),
+    )
+
+    assert response.status_code == 200, response.text
+    data_lines = [
+        line for line in response.text.splitlines() if line.startswith("data: ")
+    ]
+    assert len(data_lines) == 1
+    event = json.loads(data_lines[0].removeprefix("data: "))
+    assert event["task"]["status"]["state"] == "TASK_STATE_WORKING"

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1,5 +1,6 @@
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -517,6 +518,199 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
     assert response.status_code == 200, response.text
     assert response.json()["task"]["contextId"] == "ctx-follow-up"
     assert response.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
+
+
+def test_failed_follow_up_restores_input_required_status() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="waiting",
+            status=TaskStatus.WAITING_FOR_USER,
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-recover"},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    with patch(
+        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+        side_effect=TaskTurnError("busy"),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-recover",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "retry"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+    finally:
+        db.close()
+
+
+def test_list_tasks_uses_database_filters_and_pagination() -> None:
+    agent_id, full_key = _create_published_agent_with_key()
+    base_time = datetime.now(UTC) - timedelta(minutes=10)
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task_specs = [
+            (TaskStatus.PENDING, "ctx-a", {}, 0),
+            (TaskStatus.RUNNING, "ctx-b", {}, 1),
+            (TaskStatus.FAILED, "ctx-a", {"a2a_state": "TASK_STATE_CANCELED"}, 2),
+            (TaskStatus.FAILED, "ctx-b", {}, 3),
+            (TaskStatus.COMPLETED, "ctx-a", {}, 4),
+        ]
+        tasks: list[Task] = []
+        for status, context_id, extra_config, minute in task_specs:
+            task = Task(
+                user_id=owner_id,
+                title=f"task-{minute}",
+                status=status,
+                updated_at=base_time + timedelta(minutes=minute),
+                agent_id=agent_id,
+                source="a2a",
+                is_visible=False,
+                agent_config={"a2a_context_id": context_id, **extra_config},
+            )
+            db.add(task)
+            tasks.append(task)
+        db.commit()
+        task_ids = [int(task.id) for task in tasks]
+    finally:
+        db.close()
+
+    first = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"pageSize": 2},
+    )
+    second = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"pageSize": 2, "pageToken": first.json()["nextPageToken"]},
+    )
+    canceled = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"status": "TASK_STATE_CANCELED"},
+    )
+    failed = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"status": "TASK_STATE_FAILED"},
+    )
+    context = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"contextId": "ctx-a"},
+    )
+    recent = client.get(
+        f"/api/a2a/agents/{agent_id}/tasks",
+        headers=_bearer(full_key),
+        params={"statusTimestampAfter": (base_time + timedelta(minutes=2)).isoformat()},
+    )
+
+    assert first.status_code == 200, first.text
+    assert first.json()["totalSize"] == 5
+    assert [item["id"] for item in first.json()["tasks"]] == [
+        str(task_ids[4]),
+        str(task_ids[3]),
+    ]
+    assert first.json()["nextPageToken"] == "2"
+    assert [item["id"] for item in second.json()["tasks"]] == [
+        str(task_ids[2]),
+        str(task_ids[1]),
+    ]
+    assert canceled.json()["totalSize"] == 1
+    assert canceled.json()["tasks"][0]["id"] == str(task_ids[2])
+    assert failed.json()["totalSize"] == 1
+    assert failed.json()["tasks"][0]["id"] == str(task_ids[3])
+    assert context.json()["totalSize"] == 3
+    assert recent.json()["totalSize"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_artifact_updates_are_incremental_and_finalize(
+    monkeypatch,
+) -> None:
+    task = Task(
+        id=101,
+        user_id=1,
+        title="stream",
+        status=TaskStatus.RUNNING,
+        output="part",
+        agent_id=7,
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-artifact"},
+    )
+    running = Task(
+        id=101,
+        user_id=1,
+        title="stream",
+        status=TaskStatus.RUNNING,
+        output="partial",
+        agent_id=7,
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-artifact"},
+    )
+    completed = Task(
+        id=101,
+        user_id=1,
+        title="stream",
+        status=TaskStatus.COMPLETED,
+        output="partial",
+        agent_id=7,
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-artifact"},
+    )
+    fresh_tasks = iter([running, completed])
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(a2a_api.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        a2a_api,
+        "_fetch_fresh_a2a_task",
+        lambda _agent_id, _task_id: next(fresh_tasks),
+    )
+
+    response = a2a_api._task_stream_response(SimpleNamespace(id=7), task)
+    events = [
+        json.loads(chunk.removeprefix("data: "))
+        async for chunk in response.body_iterator
+    ]
+    artifact_updates = [
+        event["artifactUpdate"] for event in events if "artifactUpdate" in event
+    ]
+
+    assert artifact_updates[0]["artifact"]["parts"] == [{"text": "ial"}]
+    assert artifact_updates[0]["append"] is True
+    assert artifact_updates[0]["lastChunk"] is False
+    assert artifact_updates[1]["artifact"]["parts"] == [{"text": "partial"}]
+    assert artifact_updates[1]["append"] is False
+    assert artifact_updates[1]["lastChunk"] is True
 
 
 def test_cancel_is_idempotent_and_subscribe_rejects_terminal_task() -> None:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -235,6 +235,20 @@ def test_message_send_requires_supported_a2a_version() -> None:
     assert error["message"] == "A2A-Version header or query parameter is required."
     assert error["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
     assert error["details"][0]["metadata"]["supportedVersions"] == "1.0"
+
+    incompatible = client.post(
+        f"/api/a2a/agents/{agent_id}/message:send",
+        headers={
+            "Authorization": f"Bearer {full_key}",
+            "A2A-Version": "2.0",
+        },
+        json=payload,
+    )
+
+    assert incompatible.status_code == 400
+    incompatible_error = incompatible.json()["error"]
+    assert incompatible_error["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
+    assert incompatible_error["details"][0]["metadata"]["supportedVersions"] == ("1.0")
 
 
 def test_message_send_rejects_oversized_content() -> None:
@@ -497,9 +511,21 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
     finally:
         db.close()
 
-    with patch(
-        "xagent.web.services.task_orchestrator._schedule_bg",
-        new=MagicMock(),
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    begin_turn = AsyncMock()
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=agent_manager,
+        ),
+        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume") as schedule_resume,
+        patch(
+            "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -518,6 +544,22 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
     assert response.status_code == 200, response.text
     assert response.json()["task"]["contextId"] == "ctx-follow-up"
     assert response.json()["task"]["status"]["state"] == "TASK_STATE_WORKING"
+    agent_service.post_user_message.assert_awaited_once_with(
+        task_id,
+        execution_message="follow up",
+        display_message="follow up",
+        request_interrupt=False,
+        reason="A2A input-required response",
+    )
+    begin_turn.assert_not_awaited()
+    schedule_resume.assert_called_once()
+    db = _direct_db_session()
+    try:
+        resumed = db.query(Task).filter(Task.id == int(task_id)).one()
+        assert resumed.status == TaskStatus.RUNNING
+        assert resumed.input == "follow up"
+    finally:
+        db.close()
 
 
 def test_failed_follow_up_restores_input_required_status() -> None:
@@ -541,9 +583,19 @@ def test_failed_follow_up_restores_input_required_status() -> None:
     finally:
         db.close()
 
-    with patch(
-        "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
-        side_effect=TaskTurnError("busy"),
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=False)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=agent_manager,
+        ),
+        patch(
+            "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+            side_effect=TaskTurnError("busy"),
+        ),
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -308,6 +308,53 @@ async def test_completion_broadcast_failure_keeps_task_completed(
 
 
 @pytest.mark.asyncio
+async def test_late_execution_result_does_not_resurrect_canceled_a2a_task(
+    db_session, monkeypatch
+):
+    user = _create_user(db_session, 1, "owner")
+    _create_task(db_session, task_id=14, user_id=1, status=TaskStatus.RUNNING)
+    db_session.commit()
+
+    class BroadcastManager:
+        async def broadcast_to_task(self, event, task_id):
+            pass
+
+    class AgentManager:
+        async def get_agent_for_task(self, task_id, db, **kwargs):
+            return _NoopAgentService()
+
+        async def execute_task(self, **kwargs):
+            SessionLocal = sessionmaker(bind=db_session.get_bind())
+            with SessionLocal() as cancel_db:
+                task = cancel_db.query(Task).filter(Task.id == 14).one()
+                task.status = TaskStatus.FAILED
+                task.agent_config = {"a2a_state": "TASK_STATE_CANCELED"}
+                task.output = None
+                task.error_message = "Task canceled by A2A client."
+                cancel_db.commit()
+            db_session.expire_all()
+            return {"success": True, "output": "late result", "file_outputs": []}
+
+    _wire_execute_task_background(monkeypatch, db_session, BroadcastManager())
+
+    await execute_task_background(
+        task_id=14,
+        user_message="hi",
+        context={},
+        agent_manager=AgentManager(),
+        task_owner_user_id=int(user.id),
+        llm_user_message="hi",
+    )
+
+    db_session.expire_all()
+    task = db_session.query(Task).filter(Task.id == 14).one()
+    assert task.status == TaskStatus.FAILED
+    assert task.agent_config == {"a2a_state": "TASK_STATE_CANCELED"}
+    assert task.output is None
+    assert task.error_message == "Task canceled by A2A client."
+
+
+@pytest.mark.asyncio
 async def test_execution_failure_routes_real_error_to_terminal_payload(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- expose published Xagent agents through A2A 1.0 HTTP+JSON discovery, task, message, cancellation, and SSE endpoints
- add a configurable A2A Agent Tool so Xagent agents can call remote A2A agents
- keep workforce orchestration and agent import semantics unchanged

## Why

This adds the protocol boundary needed for external A2A interoperability without coupling A2A to Xagent workforce internals.

## Validation

- `ruff check` and `ruff format`
- `21 passed` across focused A2A API and Agent Tool tests
- official `a2a-python` 1.0 REST and SSE client interoperability checks
- targeted mypy checks for the new A2A modules; full-repository mypy still reports unrelated existing errors