### PR TITLE
fix: make task message delivery interrupt-safe

### DIFF
--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -20,6 +20,10 @@ vi.mock("@/lib/api-wrapper", async () => {
 vi.mock("@/lib/utils", () => ({
   cn: (...classes: Array<string | false | null | undefined>) =>
     classes.filter(Boolean).join(" "),
+  generateClientMessageId: vi.fn()
+    .mockReturnValueOnce("client-message-1")
+    .mockReturnValueOnce("client-message-2")
+    .mockReturnValue("client-message-next"),
   getApiUrl: () => "http://api.local",
   getUploadApiUrl: () => "http://upload.local",
 }))

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -207,6 +207,31 @@ describe("ChatInput", () => {
     })
   })
 
+  it("keeps the draft when durable delivery is rejected", async () => {
+    const onInputChange = vi.fn()
+    const onSend = vi.fn().mockRejectedValue(new Error("Message was rejected"))
+    const { container } = render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue="keep this draft"
+        onInputChange={onInputChange}
+        onSend={onSend}
+        readOnlyConfig
+      />
+    )
+
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
+    await waitFor(() => {
+      expect(onInputChange).not.toHaveBeenCalledWith("")
+    })
+    expect(onSend.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ clientMessageId: expect.any(String) })
+    )
+  })
+
   it("keeps generic loading input disabled without a live task status", () => {
     const { container } = render(
       <ChatInput

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -64,6 +64,7 @@ interface AgentConfig {
   compactModel?: string;
   memorySimilarityThreshold?: number;
   executionMode?: ExecutionModeConfig;
+  clientMessageId?: string;
 }
 
 interface ModelRecord {
@@ -112,6 +113,7 @@ export function ChatInput({
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isSubmittingRef = useRef(false);
+  const deliveryAttemptRef = useRef<{ key: string; clientMessageId: string } | null>(null);
   const dragDepthRef = useRef(0);
   const { t } = useI18n();
   const { openFilePreview } = useApp();
@@ -578,9 +580,20 @@ export function ChatInput({
       const trimmed = message.trim();
       const messageToSend = trimmed;
       const executionMode = taskConfig?.executionMode;
+      const deliveryKey = JSON.stringify([
+        messageToSend,
+        files.map((file) => [file.name, file.size, file.lastModified]),
+      ]);
+      const previousAttempt = deliveryAttemptRef.current;
+      const clientMessageId = previousAttempt?.key === deliveryKey
+        ? previousAttempt.clientMessageId
+        : globalThis.crypto?.randomUUID?.()
+          ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      deliveryAttemptRef.current = { key: deliveryKey, clientMessageId };
 
       const configToSend = {
         ...agentConfig,
+        clientMessageId,
         ...(executionMode
           ? {
               executionMode:
@@ -592,6 +605,7 @@ export function ChatInput({
       };
 
       await onSend(messageToSend, configToSend);
+      deliveryAttemptRef.current = null;
       fileMention.resetMention();
 
       if (isControlled) {
@@ -599,6 +613,12 @@ export function ChatInput({
       } else {
         setInternalMessage("");
       }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("builds.list.chat.sendFailed") || "Message was not sent"
+      );
     } finally {
       // Small delay to prevent double submission
       setTimeout(() => {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -3,7 +3,7 @@ import { createFileChipHTML } from "./FileChip";
 import { useRouter } from "next/navigation";
 import { Paperclip, X, File as FileIcon, Sparkles, Pause, Play, Loader2, ArrowUp, Globe, Mic, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { cn, getApiUrl, getUploadApiUrl } from "@/lib/utils";
+import { cn, generateClientMessageId, getApiUrl, getUploadApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { ConfigDialog } from "@/components/config-dialog";
@@ -587,8 +587,7 @@ export function ChatInput({
       const previousAttempt = deliveryAttemptRef.current;
       const clientMessageId = previousAttempt?.key === deliveryKey
         ? previousAttempt.clientMessageId
-        : globalThis.crypto?.randomUUID?.()
-          ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        : generateClientMessageId();
       deliveryAttemptRef.current = { key: deliveryKey, clientMessageId };
 
       const configToSend = {
@@ -614,6 +613,12 @@ export function ChatInput({
         setInternalMessage("");
       }
     } catch (error) {
+      if (
+        error instanceof Error
+        && (error as Error & { retryWithNewId?: boolean }).retryWithNewId === true
+      ) {
+        deliveryAttemptRef.current = null;
+      }
       toast.error(
         error instanceof Error
           ? error.message

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -35,7 +35,7 @@ export interface Interaction {
 }
 import { useWebSocket } from "@/hooks/use-websocket"
 import { useAuth } from "@/contexts/auth-context"
-import { getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview } from "@/lib/utils"
+import { generateClientMessageId, getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview } from "@/lib/utils"
 import { apiRequest, getApiErrorMessage, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
 import { normalizeTimestampMs } from "@/lib/time-utils"
@@ -4102,8 +4102,7 @@ export function AppProvider({
 
     const clientMessageId = typeof config?.clientMessageId === 'string'
       ? config.clientMessageId
-      : globalThis.crypto?.randomUUID?.()
-        ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      : generateClientMessageId()
     const targetTaskId = typeof config?.targetTaskId === 'number' ? config.targetTaskId : null
     if (targetTaskId !== null && state.taskId !== targetTaskId) {
       await queuePendingMessage({

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1043,6 +1043,16 @@ function appReducer(state: AppState, action: AppAction): AppState {
   }
 }
 
+interface PendingMessage {
+  message: string
+  files?: File[]
+  targetTaskId?: number
+  force?: boolean
+  clientMessageId?: string
+  resolve?: () => void
+  reject?: (error: Error) => void
+}
+
 interface AppContextType {
   state: AppState
   dispatch: React.Dispatch<AppAction>
@@ -1066,7 +1076,7 @@ interface AppContextType {
   setReplayPlaying: (isPlaying: boolean) => void
   setReplaySpeed: (speed: number) => void
   setReplayProgress: (progress: number) => void
-  setPendingMessage: React.Dispatch<React.SetStateAction<{ message: string; files?: File[]; targetTaskId?: number } | null>>
+  setPendingMessage: React.Dispatch<React.SetStateAction<PendingMessage | null>>
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined)
@@ -1091,11 +1101,10 @@ export function AppProvider({
   transport?: AppProviderTransportConfig
 }) {
   const [state, dispatch] = useReducer(appReducer, initialState)
-  const [pendingMessage, setPendingMessage] = useState<{ message: string; files?: File[]; targetTaskId?: number } | null>(null)
+  const [pendingMessage, setPendingMessage] = useState<PendingMessage | null>(null)
   const { token: authToken } = useAuth() // Get auth token from context
   const { t } = useI18n()
   const router = useRouter()
-  const pendingOptimisticMessageId = useRef<string | null>(null)
   const lastConnectedTaskId = useRef<number | null>(null)
 
   // Ref to track current state for WebSocket message handler
@@ -1112,14 +1121,9 @@ export function AppProvider({
     // This prevents stale data issues and fixes race conditions
     if (lastConnectedTaskId.current === stateRef.current.taskId) {
       // Reconnection to SAME task -> Clear messages
-      // Keep pending optimistic message if exists
-      const keepMessageId = pendingOptimisticMessageId.current
-      pendingOptimisticMessageId.current = null
-
       dispatch({
         type: "CLEAR_MESSAGES",
         payload: {
-          keepMessageId,
           preserveUserMessages: true,
           preserveStreamingFinalAnswers: true,
         },
@@ -1207,10 +1211,45 @@ export function AppProvider({
         hasFiles: pendingMessage.files && pendingMessage.files.length > 0,
         targetTaskId: pendingMessage.targetTaskId
       })
-      sendChatMessage(pendingMessage.message, pendingMessage.files)
-      setPendingMessage(null)
+      void Promise.resolve(
+        sendChatMessage(
+          pendingMessage.message,
+          pendingMessage.files,
+          pendingMessage.force,
+          pendingMessage.clientMessageId,
+        )
+      ).then(() => {
+        pendingMessage.resolve?.()
+        setPendingMessage(current => current === pendingMessage ? null : current)
+      }).catch((error) => {
+        const deliveryError = error instanceof Error ? error : new Error(String(error))
+        pendingMessage.reject?.(deliveryError)
+        setPendingMessage(current => current === pendingMessage ? null : current)
+      })
     }
   }, [isConnected, pendingMessage, sendChatMessage])
+
+  const queuePendingMessage = useCallback((message: Omit<PendingMessage, 'resolve' | 'reject'>) => {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        setPendingMessage(current => (
+          current?.clientMessageId === message.clientMessageId ? null : current
+        ))
+        reject(new Error('Message not sent: timed out waiting for the task connection.'))
+      }, 30000)
+      setPendingMessage({
+        ...message,
+        resolve: () => {
+          window.clearTimeout(timeout)
+          resolve()
+        },
+        reject: (error) => {
+          window.clearTimeout(timeout)
+          reject(error)
+        },
+      })
+    })
+  }, [])
 
   // Handle auto-execute pending task separately
   useEffect(() => {
@@ -4061,34 +4100,19 @@ export function AppProvider({
   const sendMessage = useCallback(async (message: string, config?: any, files?: File[]) => {
     console.log('🚀 sendMessage called:', { message, files: files?.map(f => f.name), taskId: state.taskId })
 
+    const clientMessageId = typeof config?.clientMessageId === 'string'
+      ? config.clientMessageId
+      : globalThis.crypto?.randomUUID?.()
+        ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`
     const targetTaskId = typeof config?.targetTaskId === 'number' ? config.targetTaskId : null
     if (targetTaskId !== null && state.taskId !== targetTaskId) {
-      setPendingMessage({ message, files, targetTaskId })
-
-      if (!isDuplicateMessage(message, 'user-message', config?.force)) {
-        let content: React.ReactNode = message
-        if (files && files.length > 0) {
-          content = (
-            <div className="space-y-2">
-              <div className="whitespace-pre-wrap max-h-60 overflow-y-auto">{message}</div>
-              <FileAttachment
-                files={files.map(f => ({ name: f.name, type: f.type, size: f.size, path: '' }))}
-                variant="user-message"
-              />
-            </div>
-          )
-        }
-
-        dispatch({
-          type: "ADD_MESSAGE",
-          payload: {
-            id: generateMessageId("msg-user-optimistic"),
-            role: "user",
-            content,
-            timestamp: Date.now().toString(),
-          }
-        })
-      }
+      await queuePendingMessage({
+        message,
+        files,
+        targetTaskId,
+        force: config?.force,
+        clientMessageId,
+      })
       return
     }
 
@@ -4234,38 +4258,15 @@ export function AppProvider({
             hasFiles: files && files.length > 0
           })
 
-          // Store the message to be sent after WebSocket connects
-          setPendingMessage({ message, files, targetTaskId: newTaskId })
-
-          // Optimistically add the user message to the UI
-          if (!isDuplicateMessage(message, 'user-message')) {
-            let content: React.ReactNode = message
-            if (files && files.length > 0) {
-              content = (
-                <div className="space-y-2">
-                  <div className="whitespace-pre-wrap max-h-60 overflow-y-auto">{message}</div>
-                  <FileAttachment
-                    files={files.map(f => ({ name: f.name, type: f.type, size: f.size, path: '' }))} // Basic info for optimistic render
-                    variant="user-message"
-                  />
-                </div>
-              )
-            }
-
-            const optimisticId = generateMessageId("msg-user-optimistic")
-            // Store ID to prevent clearing it when task loads
-            pendingOptimisticMessageId.current = optimisticId
-
-            dispatch({
-              type: "ADD_MESSAGE",
-              payload: {
-                id: optimisticId,
-                role: "user",
-                content: content,
-                timestamp: Date.now().toString(),
-              }
-            })
-          }
+          // Do not clear the composer until the newly connected task socket
+          // confirms that the message was durably accepted.
+          await queuePendingMessage({
+            message,
+            files,
+            targetTaskId: newTaskId,
+            force: config?.force,
+            clientMessageId,
+          })
         } else {
           const parsed = await parseApiResponse(response)
           const errorMessage = getApiErrorMessage(
@@ -4291,7 +4292,11 @@ export function AppProvider({
         taskId: state.taskId
       })
 
-      // If task is completed, mark it as running immediately to update sidebar
+      // Wait for the server's durable-delivery acknowledgement. If the socket
+      // is disconnected or the backend rejects the turn, this throws and the
+      // composer keeps both its text and attached files.
+      await sendChatMessage(message, files, config?.force, clientMessageId)
+
       if (state.currentTask?.status === 'completed') {
         dispatch({
           type: "UPDATE_TASK_STATUS",
@@ -4300,7 +4305,9 @@ export function AppProvider({
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
       }
 
-      // Optimistically add the user message to the UI
+      // The user_message trace usually arrives before the acknowledgement. If
+      // it has not, add a local copy now; the normal dedupe path reconciles the
+      // later trace without displaying a duplicate.
       if (!isDuplicateMessage(message, 'user-message', config?.force)) {
         let content: React.ReactNode = message
         if (files && files.length > 0) {
@@ -4324,15 +4331,9 @@ export function AppProvider({
             timestamp: Date.now().toString(),
           }
         })
-
-        // Send chat message - backend will handle user message via trace event
-        // Only send if not a duplicate
-        sendChatMessage(message, files, config?.force)
-      } else {
-        console.log('⚠️ Duplicate message blocked from sending:', message)
       }
     }
-  }, [state.taskId, sendChatMessage, wsExecuteTask, state.currentTask?.status])
+  }, [state.taskId, sendChatMessage, wsExecuteTask, state.currentTask?.status, queuePendingMessage])
 
   // Initialize the replay scheduler function
   const initializeReplayScheduler = useCallback(() => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -516,7 +516,6 @@ type AppAction =
   | {
     type: "CLEAR_MESSAGES";
     payload?: {
-      keepMessageId?: string | null;
       preserveUserMessages?: boolean;
       preserveStreamingFinalAnswers?: boolean;
     };
@@ -849,14 +848,10 @@ function appReducer(state: AppState, action: AppAction): AppState {
     case "CLEAR_MESSAGES":
       if (action.payload) {
         const {
-          keepMessageId,
           preserveUserMessages,
           preserveStreamingFinalAnswers,
         } = action.payload
         const messagesToKeep = state.messages.filter(message => {
-          if (keepMessageId && message.id === keepMessageId) {
-            return true
-          }
           if (preserveUserMessages && message.role === "user") {
             return true
           }

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -178,6 +178,39 @@ describe("useWebSocket message delivery", () => {
     })
   })
 
+  it("allows the same text to be sent again after the first ack", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const first = result.current.sendChatMessage("ok")
+    const firstPayload = JSON.parse(socket.send.mock.calls[0][0])
+    act(() => {
+      socket.receive({
+        type: "message_accepted",
+        client_message_id: firstPayload.client_message_id,
+      })
+    })
+    await first
+
+    const second = result.current.sendChatMessage("ok")
+    expect(socket.send).toHaveBeenCalledTimes(2)
+    const secondPayload = JSON.parse(socket.send.mock.calls[1][0])
+    expect(secondPayload.client_message_id).not.toBe(firstPayload.client_message_id)
+    act(() => {
+      socket.receive({
+        type: "message_accepted",
+        client_message_id: secondPayload.client_message_id,
+      })
+    })
+    await second
+  })
+
   it("rejects a pending delivery when the socket closes", async () => {
     const { result } = renderHook(() => useWebSocket({
       url: "ws://localhost",

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -1,0 +1,144 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useWebSocket } from "./use-websocket"
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token", refreshToken: vi.fn() }),
+}))
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+
+  readyState = 0
+  onopen: (() => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  send = vi.fn()
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+  }
+
+  close() {
+    this.readyState = 3
+  }
+}
+
+describe("useWebSocket message delivery", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal("WebSocket", MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("rejects without clearing the caller when the socket is not open", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+      autoConnect: false,
+    }))
+
+    await expect(result.current.sendChatMessage("keep this draft")).rejects.toThrow(
+      "connection is not ready",
+    )
+  })
+
+  it("resolves only after the server accepts the durable message", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    let delivery!: Promise<{ client_message_id: string; turn_id: string }>
+    act(() => {
+      delivery = result.current.sendChatMessage("durable guidance")
+    })
+    expect(socket.send).toHaveBeenCalledOnce()
+    const sent = JSON.parse(socket.send.mock.calls[0][0])
+    expect(sent.client_message_id).toBeTruthy()
+
+    let settled = false
+    void delivery.finally(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    act(() => {
+      socket.receive({
+        type: "message_accepted",
+        client_message_id: sent.client_message_id,
+        turn_id: sent.client_message_id,
+      })
+    })
+
+    await expect(delivery).resolves.toEqual({
+      client_message_id: sent.client_message_id,
+      turn_id: sent.client_message_id,
+    })
+  })
+
+  it("allows an unacknowledged draft to retry with the same id", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const first = result.current.sendChatMessage(
+      "retry me",
+      undefined,
+      false,
+      "stable-turn-1",
+    )
+    act(() => {
+      socket.receive({
+        type: "message_rejected",
+        client_message_id: "stable-turn-1",
+        message: "temporary failure",
+      })
+    })
+    await expect(first).rejects.toThrow("temporary failure")
+
+    const retry = result.current.sendChatMessage(
+      "retry me",
+      undefined,
+      false,
+      "stable-turn-1",
+    )
+    expect(socket.send).toHaveBeenCalledTimes(2)
+    act(() => {
+      socket.receive({
+        type: "message_accepted",
+        client_message_id: "stable-turn-1",
+        turn_id: "stable-turn-1",
+      })
+    })
+    await expect(retry).resolves.toEqual({
+      client_message_id: "stable-turn-1",
+      turn_id: "stable-turn-1",
+    })
+  })
+})

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -34,6 +34,11 @@ class MockWebSocket {
   close() {
     this.readyState = 3
   }
+
+  triggerClose(code = 1006, reason = "network lost") {
+    this.readyState = 3
+    this.onclose?.({ code, reason } as CloseEvent)
+  }
 }
 
 describe("useWebSocket message delivery", () => {
@@ -140,5 +145,75 @@ describe("useWebSocket message delivery", () => {
       client_message_id: "stable-turn-1",
       turn_id: "stable-turn-1",
     })
+  })
+
+  it("marks definitive rejections so the composer can use a fresh id", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const delivery = result.current.sendChatMessage(
+      "retry with a new id",
+      undefined,
+      false,
+      "failed-turn-1",
+    )
+    act(() => {
+      socket.receive({
+        type: "message_rejected",
+        client_message_id: "failed-turn-1",
+        message: "previous delivery failed",
+        retry_with_new_id: true,
+      })
+    })
+
+    await expect(delivery).rejects.toMatchObject({
+      message: "previous delivery failed",
+      retryWithNewId: true,
+    })
+  })
+
+  it("rejects a pending delivery when the socket closes", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const delivery = result.current.sendChatMessage("keep after disconnect")
+    act(() => socket.triggerClose())
+
+    await expect(delivery).rejects.toThrow("Connection closed")
+  })
+
+  it("rejects an unacknowledged delivery after 30 seconds", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+    vi.useFakeTimers()
+
+    try {
+      const delivery = result.current.sendChatMessage("timeout draft")
+      const rejection = expect(delivery).rejects.toThrow("not acknowledged")
+      await act(async () => {
+        vi.advanceTimersByTime(30000)
+      })
+      await rejection
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react"
 import { useAuth } from "@/contexts/auth-context"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
-import { getWsUrl, getUploadApiUrl } from "@/lib/utils"
+import { generateClientMessageId, getWsUrl, getUploadApiUrl } from "@/lib/utils"
 import { isFinalAnswerStreamEventType } from "@/lib/streaming-final-answer"
 
 // Duplicate message detection: record recently sent messages
@@ -246,7 +246,11 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
                   turn_id: typeof data.turn_id === 'string' ? data.turn_id : clientMessageId,
                 })
               } else {
-                pending.reject(new Error(data.message || 'Message was rejected.'))
+                const error = new Error(data.message || 'Message was rejected.')
+                Object.assign(error, {
+                  retryWithNewId: data.retry_with_new_id === true,
+                })
+                pending.reject(error)
               }
             }
             return
@@ -430,11 +434,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       throw new Error('Message not sent: the task connection is not ready.')
     }
 
-    const clientMessageId = requestedClientMessageId || (
-      typeof crypto !== 'undefined' && crypto.randomUUID
-        ? crypto.randomUUID()
-        : `msg-${timestamp}-${Math.random().toString(36).slice(2)}`
-    )
+    const clientMessageId = requestedClientMessageId || generateClientMessageId()
     const duplicateMessage = recentMessages.find(
       msg => (
         msg.taskId === currentTaskId

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -443,7 +443,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
         && (timestamp - msg.timestamp) < MESSAGE_DUPLICATE_THRESHOLD
       )
     )
-    if (!force && duplicateMessage) {
+    const duplicateIsPending = duplicateMessage
+      ? pendingDeliveriesRef.current.has(duplicateMessage.clientMessageId)
+      : false
+    if (!force && duplicateIsPending) {
       throw new Error('Duplicate message ignored while the previous send is pending.')
     }
 

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -3,12 +3,16 @@
 import { useEffect, useRef, useState, useCallback } from "react"
 import { useAuth } from "@/contexts/auth-context"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
-import { toast } from "@/components/ui/sonner"
 import { getWsUrl, getUploadApiUrl } from "@/lib/utils"
 import { isFinalAnswerStreamEventType } from "@/lib/streaming-final-answer"
 
 // Duplicate message detection: record recently sent messages
-const recentMessages: Array<{ message: string; timestamp: number; taskId: number }> = []
+const recentMessages: Array<{
+  message: string
+  timestamp: number
+  taskId: number
+  clientMessageId: string
+}> = []
 const MESSAGE_DUPLICATE_THRESHOLD = 2000 // Same message within 2 seconds is considered duplicate
 
 interface WebSocketMessage {
@@ -22,6 +26,11 @@ interface WebSocketMessage {
   message_id?: string
   delta?: string
   content?: string
+}
+
+interface MessageDeliveryAck {
+  client_message_id: string
+  turn_id: string
 }
 
 interface UseWebSocketOptions {
@@ -64,7 +73,20 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const reconnectAttemptsRef = useRef(0)
   const taskIdRef = useRef(taskId)
   const tokenRef = useRef(token || authToken) // Prioritize passed token, otherwise use auth token
+  const pendingDeliveriesRef = useRef(new Map<string, {
+    resolve: (ack: MessageDeliveryAck) => void
+    reject: (error: Error) => void
+    timeout: ReturnType<typeof setTimeout>
+  }>())
   const maxReconnectAttempts = 3
+
+  const rejectPendingDeliveries = useCallback((error: Error) => {
+    for (const pending of pendingDeliveriesRef.current.values()) {
+      clearTimeout(pending.timeout)
+      pending.reject(error)
+    }
+    pendingDeliveriesRef.current.clear()
+  }, [])
 
   // Update token ref when token changes
   useEffect(() => {
@@ -122,6 +144,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       }
 
       socket.onclose = (event) => {
+        rejectPendingDeliveries(new Error('Connection closed before the message was accepted.'))
         setIsConnected(false)
         isConnectingRef.current = false
         onDisconnect?.()
@@ -208,6 +231,26 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       socket.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data)
+
+          if (data.type === 'message_accepted' || data.type === 'message_rejected') {
+            const clientMessageId = data.client_message_id
+            const pending = typeof clientMessageId === 'string'
+              ? pendingDeliveriesRef.current.get(clientMessageId)
+              : undefined
+            if (pending) {
+              clearTimeout(pending.timeout)
+              pendingDeliveriesRef.current.delete(clientMessageId)
+              if (data.type === 'message_accepted') {
+                pending.resolve({
+                  client_message_id: clientMessageId,
+                  turn_id: typeof data.turn_id === 'string' ? data.turn_id : clientMessageId,
+                })
+              } else {
+                pending.reject(new Error(data.message || 'Message was rejected.'))
+              }
+            }
+            return
+          }
 
           // Handle different message types from the backend
           let message: WebSocketMessage
@@ -335,7 +378,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       setConnectionError(connectionError)
       onError?.(connectionError)
     }
-  }, [url, taskId, token, authToken, onConnect, onDisconnect, onError])
+  }, [url, taskId, token, authToken, onConnect, onDisconnect, onError, rejectPendingDeliveries])
 
   const disconnect = useCallback(() => {
     if (reconnectTimeoutRef.current) {
@@ -347,9 +390,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       socketRef.current.close()
       socketRef.current = null
     }
+    rejectPendingDeliveries(new Error('Disconnected before the message was accepted.'))
     setIsConnected(false)
     isConnectingRef.current = false
-  }, [])
+  }, [rejectPendingDeliveries])
 
   // Update taskId ref when taskId changes
   useEffect(() => {
@@ -373,136 +417,134 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     }
   }, [])
 
-  const sendChatMessage = useCallback((message: string, files?: File[], force: boolean = false) => {
+  const sendChatMessage = useCallback(async (
+    message: string,
+    files?: File[],
+    force: boolean = false,
+    requestedClientMessageId?: string,
+  ): Promise<MessageDeliveryAck> => {
     const timestamp = Date.now()
-
-    // Brute force duplicate message detection
     const currentTaskId = taskIdRef.current
-    const duplicateMessage = recentMessages.find(
-      msg => msg.taskId === currentTaskId && msg.message === message && (timestamp - msg.timestamp) < MESSAGE_DUPLICATE_THRESHOLD
+    const socket = socketRef.current
+    if (!currentTaskId || socket?.readyState !== WebSocket.OPEN) {
+      throw new Error('Message not sent: the task connection is not ready.')
+    }
+
+    const clientMessageId = requestedClientMessageId || (
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `msg-${timestamp}-${Math.random().toString(36).slice(2)}`
     )
-
+    const duplicateMessage = recentMessages.find(
+      msg => (
+        msg.taskId === currentTaskId
+        && msg.message === message
+        && msg.clientMessageId !== clientMessageId
+        && (timestamp - msg.timestamp) < MESSAGE_DUPLICATE_THRESHOLD
+      )
+    )
     if (!force && duplicateMessage) {
-      console.warn("Duplicate WebSocket chat message ignored")
-      return
+      throw new Error('Duplicate message ignored while the previous send is pending.')
     }
 
-    if (socketRef.current?.readyState === WebSocket.OPEN && taskIdRef.current) {
-      const messageData: any = {
-        type: "chat",
-        message,
-        task_id: taskIdRef.current,
-      }
+    const messageData: Record<string, unknown> = {
+      type: 'chat',
+      message,
+      task_id: currentTaskId,
+      client_message_id: clientMessageId,
+    }
 
-      // If there are files, upload them first via API, then send file_ids
-      if (files && files.length > 0) {
-        const filesToUpload = files.filter(f => !(f as any).file_id)
-        const preUploadedFiles = files.filter(f => (f as any).file_id).map(f => ({
-          file_id: (f as any).file_id,
-          name: f.name,
-          size: f.size,
-          type: f.type || ''
+    if (files && files.length > 0) {
+      type FileWithUploadId = File & { file_id?: string }
+      const filesWithUploadIds = files as FileWithUploadId[]
+      const filesToUpload = filesWithUploadIds.filter(file => !file.file_id)
+      const preUploadedFiles = filesWithUploadIds
+        .filter((file): file is FileWithUploadId & { file_id: string } => Boolean(file.file_id))
+        .map(file => ({
+          file_id: file.file_id,
+          name: file.name,
+          size: file.size,
+          type: file.type || '',
         }))
+      let uploadedFiles: Array<{ file_id: string; name?: string; size?: number; type?: string }> = []
 
-        if (filesToUpload.length > 0) {
-          const handleUploadedFiles = (uploadedFiles: Array<{ file_id: string; name?: string; size?: number; type?: string }>) => {
-            messageData.files = [...preUploadedFiles, ...uploadedFiles]
-            socketRef.current?.send(JSON.stringify(messageData))
-
-            recentMessages.push({ message, timestamp, taskId: currentTaskId! })
-            const cutoffTime = timestamp - 5000
-            const firstKeepIndex = recentMessages.findIndex(msg => msg.timestamp >= cutoffTime)
-            if (firstKeepIndex === -1) {
-              recentMessages.splice(0, recentMessages.length)
-            } else if (firstKeepIndex > 0) {
-              recentMessages.splice(0, firstKeepIndex)
-            }
-          }
-
-          if (uploadFiles) {
-            uploadFiles(filesToUpload, { taskId: taskIdRef.current, taskType: 'task' })
-              .then(handleUploadedFiles)
-              .catch(err => {
-                console.error('Failed to upload files:', err)
-                toast.error(err instanceof Error ? err.message : 'Upload failed')
-              })
-            return
-          }
-
-          const formData = new FormData()
-          filesToUpload.forEach(f => formData.append('files', f))
-          formData.append('task_type', 'task')
-          if (taskIdRef.current) {
-            formData.append('task_id', taskIdRef.current.toString())
-          }
-
-          apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
-            method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${token || localStorage.getItem('token') || ''}`
-            },
-            body: formData
-          })
-            .then(async res => ({ response: res, parsed: await parseApiResponse(res) }))
-            .then(({ response, parsed }) => {
-              if (!response.ok || !isJsonRecord(parsed.data)) {
-                throw new Error(getUploadErrorMessage(response, parsed, {
-                  generic: 'Upload failed',
-                  ...UPLOAD_ERROR_MESSAGES,
-                }))
-              }
-
-              const data = parsed.data
-              const newUploadedFiles = data.success && Array.isArray(data.files)
-                ? data.files
-                  .filter((f): f is { file_id: string; filename?: string; file_size?: number; mime_type?: string } => (
-                    isJsonRecord(f) && typeof f.file_id === 'string'
-                  ))
-                  .map((f) => ({
-                    file_id: f.file_id,
-                    name: typeof f.filename === 'string' ? f.filename : '',
-                    size: typeof f.file_size === 'number' ? f.file_size : 0,
-                    type: typeof f.mime_type === 'string' ? f.mime_type : ''
-                  }))
-                : []
-
-              handleUploadedFiles(newUploadedFiles)
-            })
-            .catch(err => {
-              console.error('Failed to upload files:', err)
-              toast.error(err instanceof Error ? err.message : 'Upload failed')
-            })
-        } else {
-          messageData.files = preUploadedFiles;
-          socketRef.current?.send(JSON.stringify(messageData))
-
-          // Record sent message
-          recentMessages.push({ message, timestamp, taskId: currentTaskId! })
-          // Clear records older than 5 seconds
-          const cutoffTime = timestamp - 5000
-          const firstKeepIndex = recentMessages.findIndex(msg => msg.timestamp >= cutoffTime)
-          if (firstKeepIndex === -1) {
-            recentMessages.splice(0, recentMessages.length)
-          } else if (firstKeepIndex > 0) {
-            recentMessages.splice(0, firstKeepIndex)
-          }
+      if (filesToUpload.length > 0 && uploadFiles) {
+        uploadedFiles = await uploadFiles(filesToUpload, {
+          taskId: currentTaskId,
+          taskType: 'task',
+        })
+      } else if (filesToUpload.length > 0) {
+        const formData = new FormData()
+        filesToUpload.forEach(file => formData.append('files', file))
+        formData.append('task_type', 'task')
+        formData.append('task_id', currentTaskId.toString())
+        const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${tokenRef.current || localStorage.getItem('token') || ''}`,
+          },
+          body: formData,
+        })
+        const parsed = await parseApiResponse(response)
+        if (!response.ok || !isJsonRecord(parsed.data)) {
+          throw new Error(getUploadErrorMessage(response, parsed, {
+            generic: 'Upload failed',
+            ...UPLOAD_ERROR_MESSAGES,
+          }))
         }
-      } else {
-        socketRef.current?.send(JSON.stringify(messageData))
-
-        // Record sent message
-        recentMessages.push({ message, timestamp, taskId: currentTaskId! })
-        // Clear records older than 5 seconds
-        const cutoffTime = timestamp - 5000
-        const firstKeepIndex = recentMessages.findIndex(msg => msg.timestamp >= cutoffTime)
-        if (firstKeepIndex === -1) {
-          recentMessages.splice(0, recentMessages.length)
-        } else if (firstKeepIndex > 0) {
-          recentMessages.splice(0, firstKeepIndex)
-        }
+        const data = parsed.data
+        uploadedFiles = data.success && Array.isArray(data.files)
+          ? data.files
+            .filter((file): file is { file_id: string; filename?: string; file_size?: number; mime_type?: string } => (
+              isJsonRecord(file) && typeof file.file_id === 'string'
+            ))
+            .map(file => ({
+              file_id: file.file_id,
+              name: typeof file.filename === 'string' ? file.filename : '',
+              size: typeof file.file_size === 'number' ? file.file_size : 0,
+              type: typeof file.mime_type === 'string' ? file.mime_type : '',
+            }))
+          : []
       }
+      messageData.files = [...preUploadedFiles, ...uploadedFiles]
     }
-  }, [taskId])
+
+    const delivery = new Promise<MessageDeliveryAck>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingDeliveriesRef.current.delete(clientMessageId)
+        reject(new Error('Message delivery was not acknowledged. Your draft was kept.'))
+      }, 30000)
+      pendingDeliveriesRef.current.set(clientMessageId, { resolve, reject, timeout })
+    })
+
+    try {
+      socket.send(JSON.stringify(messageData))
+    } catch (error) {
+      const pending = pendingDeliveriesRef.current.get(clientMessageId)
+      if (pending) {
+        clearTimeout(pending.timeout)
+        pendingDeliveriesRef.current.delete(clientMessageId)
+        pending.reject(error instanceof Error ? error : new Error(String(error)))
+      }
+      return delivery
+    }
+
+    recentMessages.push({
+      message,
+      timestamp,
+      taskId: currentTaskId,
+      clientMessageId,
+    })
+    const cutoffTime = timestamp - 5000
+    const firstKeepIndex = recentMessages.findIndex(item => item.timestamp >= cutoffTime)
+    if (firstKeepIndex === -1) {
+      recentMessages.splice(0, recentMessages.length)
+    } else if (firstKeepIndex > 0) {
+      recentMessages.splice(0, firstKeepIndex)
+    }
+
+    return delivery
+  }, [uploadFiles])
 
   const executeTask = useCallback((taskDescription: string, files?: Array<{ name: string; type: string; size: number; content?: string }>) => {
     if (socketRef.current?.readyState === WebSocket.OPEN && taskIdRef.current) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function generateClientMessageId(): string {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 export function getApiUrl(): string {
   // Client-side: use environment variable or fallback to relative path
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || ''

--- a/src/xagent/core/model/tts/elevenlabs.py
+++ b/src/xagent/core/model/tts/elevenlabs.py
@@ -374,13 +374,19 @@ class ElevenLabsTTS(BaseTTS):
 
         client = self._ensure_async_client()
         try:
-            response = await client.text_to_speech.convert(
+            response = client.text_to_speech.convert(
                 text=text,
                 voice_id=voice_id,
                 model_id=self.model,
                 output_format=final_output_format,
                 **request_kwargs,
             )
+            # ElevenLabs SDK 2.56+ exposes ``convert`` as an async generator,
+            # while older releases returned a coroutine that resolved to an
+            # async iterator. Support both contracts without awaiting a
+            # generator object directly.
+            if isawaitable(response):
+                response = await response
             chunks: list[bytes] = []
             async for chunk in response:
                 chunks.append(self._coerce_audio_bytes(chunk))

--- a/src/xagent/migrations/versions/20260710_add_chat_message_delivery_state.py
+++ b/src/xagent/migrations/versions/20260710_add_chat_message_delivery_state.py
@@ -1,7 +1,7 @@
 """add retry-safe chat message delivery state
 
 Revision ID: 20260710_add_chat_delivery_state
-Revises: 1c2ae61b5a6d
+Revises: 20260710_a2a_task_index
 Create Date: 2026-07-10 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260710_add_chat_delivery_state"
-down_revision: Union[str, None] = "1c2ae61b5a6d"
+down_revision: Union[str, None] = "20260710_a2a_task_index"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260710_add_chat_message_delivery_state.py
+++ b/src/xagent/migrations/versions/20260710_add_chat_message_delivery_state.py
@@ -1,0 +1,68 @@
+"""add retry-safe chat message delivery state
+
+Revision ID: 20260710_add_chat_delivery_state
+Revises: 1c2ae61b5a6d
+Create Date: 2026-07-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260710_add_chat_delivery_state"
+down_revision: Union[str, None] = "1c2ae61b5a6d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "task_chat_messages"
+INDEX = "uq_task_chat_messages_task_role_turn_id"
+
+
+def _columns() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(TABLE)}
+
+
+def _indexes() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(TABLE)}
+
+
+def upgrade() -> None:
+    if not _columns():
+        return
+    if "delivery_status" not in _columns():
+        op.add_column(TABLE, sa.Column("delivery_status", sa.String(32)))
+
+    # Old code allowed duplicate turn ids. Preserve every transcript row but
+    # detach duplicate identities before installing the cross-worker guard.
+    op.execute(
+        sa.text(
+            "UPDATE task_chat_messages SET turn_id = NULL "
+            "WHERE turn_id IS NOT NULL AND id NOT IN ("
+            "SELECT MIN(id) FROM task_chat_messages "
+            "WHERE turn_id IS NOT NULL GROUP BY task_id, role, turn_id)"
+        )
+    )
+    if INDEX not in _indexes():
+        op.create_index(
+            INDEX,
+            TABLE,
+            ["task_id", "role", "turn_id"],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    if not _columns():
+        return
+    if INDEX in _indexes():
+        op.drop_index(INDEX, table_name=TABLE)
+    if "delivery_status" in _columns():
+        op.drop_column(TABLE, "delivery_status")

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1341,7 +1341,10 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
     ) -> AgentService:
-        lock = self._agent_build_locks.setdefault(task_id, asyncio.Lock())
+        lock = self._agent_build_locks.get(task_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._agent_build_locks[task_id] = lock
         async with lock:
             return await self._get_agent_for_task_unlocked(
                 task_id,
@@ -2103,9 +2106,11 @@ class AgentServiceManager:
             # If agent is not in memory, clean up workspace directory directly
             self._cleanup_workspace_directory(task_id, user_id)
 
-        # The per-task lock has no purpose after eviction. Keeping it forever
-        # makes the manager grow with every task ever opened.
-        self._agent_build_locks.pop(task_id, None)
+        # Do not replace a lock held by an in-flight builder: a fresh lock would
+        # let a second caller bypass single-flight and race the existing build.
+        build_lock = self._agent_build_locks.get(task_id)
+        if build_lock is not None and not build_lock.locked():
+            self._agent_build_locks.pop(task_id, None)
 
         # LLM configuration is now stored in Task table, no need to clean up memory storage
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -626,6 +626,12 @@ class AgentServiceManager:
 
     def __init__(self, request: Optional[Any] = None) -> None:
         self._agents: Dict[int, AgentService] = {}
+        # Building an AgentService performs multiple awaits (snapshot/tool/
+        # sandbox setup). Two WebSocket connections can otherwise both observe
+        # a cache miss, build different execution registries for the same task,
+        # and leave pause/message control attached to the instance that loses
+        # the final cache assignment.
+        self._agent_build_locks: Dict[int, asyncio.Lock] = {}
         # Owner (runtime identity) each cached AgentService was built for. A
         # task_id-keyed cache must not silently hand back an instance built
         # under a different user (e.g. once built with the wrong identity).
@@ -1327,6 +1333,26 @@ class AgentServiceManager:
         )
 
     async def get_agent_for_task(
+        self,
+        task_id: int,
+        db: Optional[Session] = None,
+        user: Optional[User] = None,
+        task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
+        task_owner_user_id: Optional[int] = None,
+        connector_runtime_turn_id: Optional[str] = None,
+    ) -> AgentService:
+        lock = self._agent_build_locks.setdefault(task_id, asyncio.Lock())
+        async with lock:
+            return await self._get_agent_for_task_unlocked(
+                task_id,
+                db=db,
+                user=user,
+                task_setup_snapshot=task_setup_snapshot,
+                task_owner_user_id=task_owner_user_id,
+                connector_runtime_turn_id=connector_runtime_turn_id,
+            )
+
+    async def _get_agent_for_task_unlocked(
         self,
         task_id: int,
         db: Optional[Session] = None,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2103,6 +2103,10 @@ class AgentServiceManager:
             # If agent is not in memory, clean up workspace directory directly
             self._cleanup_workspace_directory(task_id, user_id)
 
+        # The per-task lock has no purpose after eviction. Keeping it forever
+        # makes the manager grow with every task ever opened.
+        self._agent_build_locks.pop(task_id, None)
+
         # LLM configuration is now stored in Task table, no need to clean up memory storage
 
     async def execute_task(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -130,6 +130,36 @@ def _task_error_payload(
     return payload
 
 
+def _client_message_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not re.fullmatch(r"[A-Za-z0-9._:-]{1,64}", normalized):
+        return None
+    return normalized
+
+
+async def _send_message_delivery(
+    websocket: WebSocket,
+    *,
+    client_message_id: str | None,
+    turn_id: str,
+    accepted: bool,
+    message: str | None = None,
+) -> None:
+    if client_message_id is None:
+        return
+    payload: dict[str, Any] = {
+        "type": "message_accepted" if accepted else "message_rejected",
+        "client_message_id": client_message_id,
+        "turn_id": turn_id,
+        "timestamp": datetime.now(timezone.utc).timestamp(),
+    }
+    if message:
+        payload["message"] = message
+    await manager.send_personal_message(payload, websocket)
+
+
 def _terminal_task_error_payload(
     task_id: int,
     message: str,
@@ -1790,11 +1820,44 @@ async def execute_task_background(
             pass
 
 
+def _latest_result_user_turn_id(result: Dict[str, Any]) -> str | None:
+    agent_result = result.get("agent_result")
+    if not isinstance(agent_result, dict):
+        return None
+    context = agent_result.get("context")
+    messages = (
+        context.get("messages")
+        if isinstance(context, dict)
+        else getattr(context, "messages", None)
+    )
+    if not isinstance(messages, list):
+        return None
+    for message in reversed(messages):
+        role = (
+            message.get("role")
+            if isinstance(message, dict)
+            else getattr(message, "role", None)
+        )
+        if role != "user":
+            continue
+        metadata = (
+            message.get("metadata")
+            if isinstance(message, dict)
+            else getattr(message, "metadata", None)
+        )
+        if isinstance(metadata, dict):
+            turn_id = metadata.get("turn_id")
+            if isinstance(turn_id, str) and turn_id:
+                return turn_id
+    return None
+
+
 async def execute_resume_background(
     task_id: int,
     agent_service: Any,
     task_owner_user_id: int | None,
     previous_task: Optional[asyncio.Task] = None,
+    pending_user_message: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
@@ -1827,6 +1890,30 @@ async def execute_resume_background(
             except Exception as e:
                 logger.warning(
                     f"Previous background task {task_id} ended before resume: {e}"
+                )
+
+        current_task = asyncio.current_task()
+        if current_task is None:
+            raise RuntimeError(f"Task {task_id} resume has no asyncio task")
+        background_task_manager.promote_resume_task(task_id, current_task)
+
+        # The task row can become RUNNING before the original AgentRunner has
+        # created a context/checkpoint. Retry an early failed injection only
+        # after that original execution has settled and persisted its state.
+        if pending_user_message is not None:
+            posted = await agent_service.post_user_message(
+                str(task_id),
+                execution_message=pending_user_message.get("execution_message"),
+                display_message=pending_user_message.get("display_message"),
+                files=pending_user_message.get("files"),
+                turn_id=pending_user_message.get("turn_id"),
+                request_interrupt=False,
+                reason="deferred websocket user message",
+            )
+            if not posted:
+                raise RuntimeError(
+                    "The user message was saved, but no resumable execution "
+                    "checkpoint became available."
                 )
 
         db_gen = get_db()
@@ -1862,18 +1949,40 @@ async def execute_resume_background(
             logger.info(
                 "Task %s resume skipped; another runner owns the lease", task_id
             )
+            await manager.broadcast_to_task(
+                {
+                    "type": "agent_error",
+                    "message": "Task is already running on another worker.",
+                    "task": {"id": task_id, "status": TaskStatus.RUNNING.value},
+                    "timestamp": datetime.now(timezone.utc).timestamp(),
+                },
+                task_id,
+            )
             return
         lease_stop_event = asyncio.Event()
         lease_heartbeat_task = asyncio.create_task(
             run_task_lease_heartbeat(lease, lease_stop_event)
         )
 
+        # Resume is now durable: lease acquisition committed RUNNING. Do not
+        # announce it earlier from the WebSocket request handler.
+        await manager.broadcast_to_task(
+            {
+                "type": "task_resumed",
+                "task_id": task_id,
+                "message": "Task resumed",
+                "timestamp": datetime.now(timezone.utc).timestamp(),
+            },
+            task_id,
+        )
+
         with UserContext(task_owner_user_id), turn_execution_scope(task_id):
             result = await agent_service.resume_execution_by_id(str(task_id))
 
         if result is None:
-            logger.warning(f"No resumable agent execution found for task {task_id}")
-            return
+            raise RuntimeError(
+                f"No resumable execution checkpoint was found for task {task_id}."
+            )
 
         status = str(result.get("status") or "")
         success = bool(result.get("success", False))
@@ -1924,6 +2033,27 @@ async def execute_resume_background(
                     final_task_status = TaskStatus.COMPLETED
                 else:
                     final_task_status = TaskStatus.FAILED
+
+                if success and output.strip() and task_owner_user_id is not None:
+                    from ..services.chat_history_service import (
+                        persist_assistant_message_no_commit,
+                    )
+
+                    persist_assistant_message_no_commit(
+                        db_new,
+                        task_id=task_id,
+                        user_id=int(task_owner_user_id),
+                        content=output,
+                        message_type="final_answer",
+                        turn_id=_latest_result_user_turn_id(result),
+                    )
+                    orm_task_updated = cast(Any, task_updated)
+                    orm_task_updated.output = output
+                    orm_task_updated.error_message = None
+                elif final_task_status == TaskStatus.FAILED:
+                    orm_task_updated = cast(Any, task_updated)
+                    orm_task_updated.output = None
+                    orm_task_updated.error_message = output or "Task execution failed."
                 lease_released = release_current_runner_task_lease_with_workforce_sync(
                     db_new, task_id, status=final_task_status
                 )
@@ -1975,11 +2105,16 @@ async def execute_resume_background(
         raise
     except Exception as e:
         logger.error(f"V2 resume background task {task_id} failed: {e}", exc_info=True)
+        error_message = str(e)
         await manager.broadcast_to_task(
             {
-                "type": "task_error",
+                **_terminal_task_error_payload(
+                    task_id,
+                    error_message,
+                    event_type="task_error",
+                ),
                 "task_id": task_id,
-                "error": str(e),
+                "error": error_message,
                 "timestamp": datetime.now(timezone.utc).timestamp(),
             },
             task_id,
@@ -2006,6 +2141,12 @@ class BackgroundTaskManager:
     def __init__(self) -> None:
         # task_id -> asyncio.Task
         self.running_tasks: Dict[int, asyncio.Task] = {}
+        # Resume coordinators are deliberately tracked separately while they
+        # wait for the current execution. Replacing ``running_tasks[task_id]``
+        # too early creates a cycle: the original execution waits for the new
+        # resume task while that resume task waits for the original execution.
+        self.resume_tasks: Dict[int, asyncio.Task] = {}
+        self._resume_reservations: set[int] = set()
 
     async def wait_for_previous(self, task_id: int) -> None:
         """Wait for previous background task of this task to complete"""
@@ -2031,20 +2172,64 @@ class BackgroundTaskManager:
         self.running_tasks[task_id] = task
         logger.info(f"Registered background task for task {task_id}")
 
+    def reserve_resume(self, task_id: int) -> bool:
+        """Atomically reserve the single live-control resume slot."""
+
+        existing = self.resume_tasks.get(task_id)
+        if task_id in self._resume_reservations or (
+            existing is not None and not existing.done()
+        ):
+            return False
+        self._resume_reservations.add(task_id)
+        return True
+
+    def register_reserved_resume(self, task_id: int, task: asyncio.Task) -> None:
+        if task_id not in self._resume_reservations:
+            raise RuntimeError(f"Task {task_id} has no reserved resume slot")
+        self._resume_reservations.discard(task_id)
+        self.resume_tasks[task_id] = task
+        logger.info("Registered resume coordinator for task %s", task_id)
+
+    def release_resume_reservation(self, task_id: int) -> None:
+        self._resume_reservations.discard(task_id)
+
+    def promote_resume_task(self, task_id: int, task: asyncio.Task) -> None:
+        existing = self.resume_tasks.get(task_id)
+        if existing is not None and existing is not task:
+            raise RuntimeError(
+                f"Task {task_id} resume coordinator is no longer current"
+            )
+        self.resume_tasks[task_id] = task
+        self.running_tasks[task_id] = task
+        logger.info("Promoted resume coordinator for task %s", task_id)
+
     def cleanup_task(self, task_id: int) -> None:
         """Clean up completed background task"""
-        if task_id in self.running_tasks:
-            task = self.running_tasks[task_id]
-            if task.done():
-                del self.running_tasks[task_id]
-                logger.info(f"Cleaned up background task for task {task_id}")
+        current = asyncio.current_task()
+        task = self.running_tasks.get(task_id)
+        if task is not None and (task.done() or task is current):
+            self.running_tasks.pop(task_id, None)
+            logger.info(f"Cleaned up background task for task {task_id}")
+        resume_task = self.resume_tasks.get(task_id)
+        if resume_task is not None and (resume_task.done() or resume_task is current):
+            self.resume_tasks.pop(task_id, None)
+            logger.info("Cleaned up resume coordinator for task %s", task_id)
 
     async def cancel_task(self, task_id: int, timeout_seconds: float = 0.5) -> None:
-        task = self.running_tasks.get(task_id)
-        if not task:
+        tasks = {
+            task
+            for task in (
+                self.running_tasks.get(task_id),
+                self.resume_tasks.get(task_id),
+            )
+            if task is not None
+        }
+        if not tasks:
             return
 
-        if not task.done():
+        for task in tasks:
+            if task.done():
+                continue
             task.cancel()
             try:
                 await asyncio.wait_for(task, timeout=timeout_seconds)
@@ -2064,6 +2249,8 @@ class BackgroundTaskManager:
                 )
 
         self.running_tasks.pop(task_id, None)
+        self.resume_tasks.pop(task_id, None)
+        self._resume_reservations.discard(task_id)
 
 
 # Global background task manager
@@ -2512,6 +2699,24 @@ async def handle_chat_message(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
     """Handle chat message"""
+    client_message_id = _client_message_id(message_data.get("client_message_id"))
+    turn_id = client_message_id or str(uuid.uuid4())
+    delivery_finished = False
+    delivery_persisted = False
+
+    async def finish_delivery(accepted: bool, message: str | None = None) -> None:
+        nonlocal delivery_finished
+        if delivery_finished:
+            return
+        delivery_finished = True
+        await _send_message_delivery(
+            websocket,
+            client_message_id=client_message_id,
+            turn_id=turn_id,
+            accepted=accepted,
+            message=message,
+        )
+
     try:
         user_message = message_data.get("message", "")
 
@@ -2705,6 +2910,36 @@ async def handle_chat_message(
 
                 authorized_task_id = int(task.id)
 
+                # A client retries with the same id when the socket closes or
+                # the acknowledgement is lost. If that turn is already in the
+                # durable transcript, acknowledge it without executing it a
+                # second time. Reject id reuse with different text so a stale
+                # composer attempt cannot silently alias a new message.
+                if client_message_id is not None:
+                    from ..models.chat_message import TaskChatMessage
+
+                    existing_delivery = (
+                        db.query(TaskChatMessage)
+                        .filter(
+                            TaskChatMessage.task_id == task_id,
+                            TaskChatMessage.role == "user",
+                            TaskChatMessage.turn_id == turn_id,
+                        )
+                        .first()
+                    )
+                    if existing_delivery is not None:
+                        expected_content = _display_message_for_user(
+                            str(user_message), bool(files)
+                        ).strip()
+                        if str(existing_delivery.content) != expected_content:
+                            await finish_delivery(
+                                False,
+                                "Message id was already used for different content.",
+                            )
+                        else:
+                            await finish_delivery(True)
+                        return
+
                 if not files and task.status == TaskStatus.PENDING:
                     files = _selected_file_refs_from_task(task, db)
                     if files:
@@ -2860,6 +3095,23 @@ async def handle_chat_message(
                     logger.info(f"Using continuation for running task {task_id}")
                     assert dag_pattern is not None  # for mypy type checking
 
+                    from ..services.chat_history_service import (
+                        persist_user_message_once,
+                    )
+
+                    persisted_delivery_message = persist_user_message_once(
+                        db,
+                        task_id=task_id,
+                        user_id=int(task.user_id),
+                        content=display_user_message,
+                        attachments=_normalize_attachments_for_persistence(
+                            file_info_list
+                        )
+                        or None,
+                        turn_id=turn_id,
+                    )
+                    delivery_persisted = persisted_delivery_message is not None
+
                     # Immediately send trace_user_message to display user message on interface
                     if hasattr(dag_pattern, "tracer") and hasattr(
                         dag_pattern, "task_id"
@@ -2869,6 +3121,7 @@ async def handle_chat_message(
                             "pattern": "DAG Plan-Execute Continuation",
                             "continuation": "true",
                             "files": display_file_refs,
+                            "turn_id": turn_id,
                         }
                         # Surface uploaded files at the top level so the
                         # frontend user-message renderer can show clickable
@@ -2900,6 +3153,7 @@ async def handle_chat_message(
                                 },
                                 websocket,
                             )
+                            await finish_delivery(True)
                             return
                         db.refresh(task)
                         if sync_workforce_run_status(db, task, task.status):
@@ -2943,10 +3197,18 @@ async def handle_chat_message(
                         logger.info(f"Task {task_id} status updated to RUNNING")
 
                     # Continuation will be handled by old task, return directly
+                    await finish_delivery(True)
                     return
                 if task_uses_live_control and supports_live_control:
                     logger.info(f"Using agent message control for task {task_id}")
                     assert agent_service is not None
+                    if not background_task_manager.reserve_resume(task_id):
+                        await finish_delivery(
+                            False,
+                            "A previous guidance message is still being applied. "
+                            "Please wait for it to finish.",
+                        )
+                        return
                     # Pass the user-typed bubble text + display-safe file refs
                     # alongside the LLM-augmented execution text. The runner
                     # persists them onto Message.metadata so its tracing
@@ -2961,30 +3223,69 @@ async def handle_chat_message(
                     # bubble twice in the live UI. The DAG Plan-Execute
                     # continuation path above is a separate code path and
                     # keeps its own immediate trace.
-                    posted = await agent_service.post_user_message(
-                        str(task_id),
-                        execution_message=user_message_for_llm,
-                        display_message=display_user_message,
-                        files=display_file_refs,
-                        request_interrupt=task.status == TaskStatus.RUNNING,
-                        reason="new websocket user message",
-                    )
-                    if not posted:
-                        logger.warning(
-                            f"agent execution {task_id} was not live; attempting resume from checkpoint"
+                    try:
+                        from ..services.chat_history_service import (
+                            persist_user_message_once,
                         )
 
-                    previous_task = background_task_manager.running_tasks.get(task_id)
-                    bg_task = asyncio.create_task(
-                        execute_resume_background(
+                        persisted_delivery_message = persist_user_message_once(
+                            db,
                             task_id=task_id,
-                            agent_service=agent_service,
-                            task_owner_user_id=int(task.user_id),
-                            previous_task=previous_task,
+                            user_id=int(task.user_id),
+                            content=display_user_message,
+                            attachments=_normalize_attachments_for_persistence(
+                                file_info_list
+                            )
+                            or None,
+                            turn_id=turn_id,
                         )
-                    )
-                    background_task_manager.register_task(task_id, bg_task)
+                        delivery_persisted = persisted_delivery_message is not None
 
+                        posted = await agent_service.post_user_message(
+                            str(task_id),
+                            execution_message=user_message_for_llm,
+                            display_message=display_user_message,
+                            files=display_file_refs,
+                            turn_id=turn_id,
+                            request_interrupt=task.status == TaskStatus.RUNNING,
+                            reason="new websocket user message",
+                        )
+                        if not posted:
+                            logger.warning(
+                                "Agent execution %s was not live; deferring the "
+                                "durable user message until its checkpoint is ready",
+                                task_id,
+                            )
+
+                        previous_task = background_task_manager.running_tasks.get(
+                            task_id
+                        )
+                        bg_task = asyncio.create_task(
+                            execute_resume_background(
+                                task_id=task_id,
+                                agent_service=agent_service,
+                                task_owner_user_id=int(task.user_id),
+                                previous_task=previous_task,
+                                pending_user_message=(
+                                    None
+                                    if posted
+                                    else {
+                                        "execution_message": user_message_for_llm,
+                                        "display_message": display_user_message,
+                                        "files": display_file_refs,
+                                        "turn_id": turn_id,
+                                    }
+                                ),
+                            )
+                        )
+                        background_task_manager.register_reserved_resume(
+                            task_id, bg_task
+                        )
+                    except BaseException:
+                        background_task_manager.release_resume_reservation(task_id)
+                        raise
+
+                    await finish_delivery(True)
                     return
                 elif task_uses_live_control and not has_continuation:
                     # Task is running but doesn't support continuation (shouldn't happen)
@@ -2997,6 +3298,9 @@ async def handle_chat_message(
                             "message": "Task does not support message continuation",
                         },
                         websocket,
+                    )
+                    await finish_delivery(
+                        False, "Task does not support message continuation."
                     )
                     return
                 else:
@@ -3031,6 +3335,10 @@ async def handle_chat_message(
                                     "timestamp": datetime.now(timezone.utc).timestamp(),
                                 },
                                 task_id,
+                            )
+                            await finish_delivery(
+                                False,
+                                "Task pause is still being applied; please retry shortly.",
                             )
                             return
                         _clear_task_pause_accepted(task_id)
@@ -3139,6 +3447,7 @@ async def handle_chat_message(
                         transcript_message=display_user_message,
                         execution_message=user_message_for_llm,
                         attachments=persisted_attachments or None,
+                        turn_id=turn_id,
                     )
                     # WS path has these legal entries into begin_turn:
                     #   PENDING                  → CREATE
@@ -3180,6 +3489,9 @@ async def handle_chat_message(
                             },
                             task_id,
                         )
+                        await finish_delivery(
+                            False, "Internal dispatch error; please retry."
+                        )
                         return
 
                     try:
@@ -3199,6 +3511,7 @@ async def handle_chat_message(
                             context=context,
                         )
                         logger.info(f"Task {task_id} started in background")
+                        await finish_delivery(True)
                     except TaskTurnNotFoundError:
                         # Task vanished or changed ownership between the
                         # resolve above and the atomic claim — surface it the
@@ -3219,6 +3532,7 @@ async def handle_chat_message(
                             },
                             task_id,
                         )
+                        await finish_delivery(False, "Task is no longer available.")
                     except TaskTurnError as busy_err:
                         # begin_turn's atomic transaction rolls back on
                         # bg_inflight / busy — neither the status flip
@@ -3246,6 +3560,11 @@ async def handle_chat_message(
                             },
                             task_id,
                         )
+                        await finish_delivery(
+                            False,
+                            "Task is currently busy; please wait for the previous "
+                            "turn to finish before sending another message.",
+                        )
 
             finally:
                 db.close()
@@ -3254,6 +3573,10 @@ async def handle_chat_message(
             # Data validation and format error
             message = f"Data validation error: {str(e)}"
             logger.error(f"Data validation error in agent execution: {e}")
+            await finish_delivery(
+                delivery_persisted,
+                None if delivery_persisted else message,
+            )
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
                 await manager.broadcast_to_task(
@@ -3276,6 +3599,10 @@ async def handle_chat_message(
             # Runtime error
             message = f"Runtime error: {str(e)}"
             logger.error(f"Runtime error in agent execution: {e}")
+            await finish_delivery(
+                delivery_persisted,
+                None if delivery_persisted else message,
+            )
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
                 await manager.broadcast_to_task(
@@ -3297,11 +3624,19 @@ async def handle_chat_message(
         except Exception as e:
             # Other unknown errors, re-raise
             logger.error(f"Unexpected error in agent execution: {e}")
+            await finish_delivery(
+                delivery_persisted,
+                None if delivery_persisted else str(e),
+            )
             raise
 
     except (ValueError, KeyError, TypeError) as e:
         # Message format error
         logger.error(f"Message format error: {e}")
+        await finish_delivery(
+            delivery_persisted,
+            None if delivery_persisted else f"Message format error: {str(e)}",
+        )
         await manager.send_personal_message(
             {"type": "error", "message": f"Message format error: {str(e)}"}, websocket
         )
@@ -3312,6 +3647,10 @@ async def handle_chat_message(
     except Exception as e:
         # Other errors, re-raise
         logger.error(f"Unexpected error handling chat message: {e}")
+        await finish_delivery(
+            delivery_persisted,
+            None if delivery_persisted else str(e),
+        )
         raise
 
 
@@ -4184,6 +4523,7 @@ async def handle_pause_task(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
     """Handle task pause request"""
+    db: Session | None = None
     try:
         logger.info(f"🔘 handle_pause_task called for task {task_id}")
         user = message_data.get("user")
@@ -4249,14 +4589,14 @@ async def handle_pause_task(
             # Send pause confirmation
             await manager.broadcast_to_task(
                 {
-                    "type": "task_paused",
+                    "type": "task_pause_requested",
                     "task_id": task_id,
-                    "message": "Task paused",
+                    "message": "Task pause requested",
                     "timestamp": datetime.now(timezone.utc).timestamp(),
                 },
                 task_id,
             )
-            logger.info(f"Task {task_id} paused successfully")
+            logger.info(f"Task {task_id} pause requested successfully")
         else:
             # If pause not supported, send error message
             await manager.send_personal_message(
@@ -4287,6 +4627,9 @@ async def handle_pause_task(
         # Other errors, re-raise
         logger.error(f"Unexpected error pausing task {task_id}: {e}")
         raise
+    finally:
+        if db is not None:
+            db.close()
 
 
 async def handle_resume_task(
@@ -4345,25 +4688,40 @@ async def handle_resume_task(
             return
 
         if getattr(agent_service, "supports_live_control", lambda: False)():
-            await manager.broadcast_to_task(
-                {
-                    "type": "task_resumed",
-                    "task_id": task_id,
-                    "message": "Task resumed",
-                    "timestamp": datetime.now(timezone.utc).timestamp(),
-                },
-                task_id,
-            )
-            previous_task = background_task_manager.running_tasks.get(task_id)
-            bg_task = asyncio.create_task(
-                execute_resume_background(
-                    task_id=task_id,
-                    agent_service=agent_service,
-                    task_owner_user_id=int(task.user_id),
-                    previous_task=previous_task,
+            if task.status not in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": "Task is not paused and cannot be resumed.",
+                        "task": {"id": task_id, "status": task.status.value},
+                    },
+                    websocket,
                 )
-            )
-            background_task_manager.register_task(task_id, bg_task)
+                return
+            if not background_task_manager.reserve_resume(task_id):
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": "Task resume is already in progress.",
+                        "task": {"id": task_id, "status": task.status.value},
+                    },
+                    websocket,
+                )
+                return
+            previous_task = background_task_manager.running_tasks.get(task_id)
+            try:
+                bg_task = asyncio.create_task(
+                    execute_resume_background(
+                        task_id=task_id,
+                        agent_service=agent_service,
+                        task_owner_user_id=int(task.user_id),
+                        previous_task=previous_task,
+                    )
+                )
+                background_task_manager.register_reserved_resume(task_id, bg_task)
+            except BaseException:
+                background_task_manager.release_resume_reservation(task_id)
+                raise
             logger.info(f"Task {task_id} v2 resume scheduled")
             return
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1942,34 +1942,6 @@ async def execute_resume_background(
             raise RuntimeError(f"Task {task_id} resume has no asyncio task")
         background_task_manager.promote_resume_task(task_id, current_task)
 
-        # The task row can become RUNNING before the original AgentRunner has
-        # created a context/checkpoint. Retry an early failed injection only
-        # after that original execution has settled and persisted its state.
-        if pending_user_message is not None:
-            posted = await agent_service.post_user_message(
-                str(task_id),
-                execution_message=pending_user_message.get("execution_message"),
-                display_message=pending_user_message.get("display_message"),
-                files=pending_user_message.get("files"),
-                turn_id=pending_user_message.get("turn_id"),
-                request_interrupt=False,
-                reason="deferred websocket user message",
-            )
-            if not posted:
-                raise RuntimeError(
-                    "The user message was saved, but no resumable execution "
-                    "checkpoint became available."
-                )
-            delivery_was_dispatched = True
-            if delivery_turn_id is not None:
-                await asyncio.to_thread(
-                    mark_user_message_delivery_sync,
-                    task_id,
-                    delivery_turn_id,
-                    DELIVERY_DISPATCHED,
-                )
-            await notify_deferred_delivery(True)
-
         db_gen = get_db()
         db_lease = next(db_gen)
         try:
@@ -2029,6 +2001,37 @@ async def execute_resume_background(
         lease_heartbeat_task = asyncio.create_task(
             run_task_lease_heartbeat(lease, lease_stop_event)
         )
+
+        # The task row can become RUNNING before the original AgentRunner has
+        # created a context/checkpoint. Retry an early failed injection only
+        # after that original execution has settled and persisted its state.
+        # Acquire the execution lease first: otherwise a non-owner worker could
+        # persist the injection and acknowledge it, then discover that it is
+        # not allowed to run the resume.
+        if pending_user_message is not None:
+            posted = await agent_service.post_user_message(
+                str(task_id),
+                execution_message=pending_user_message.get("execution_message"),
+                display_message=pending_user_message.get("display_message"),
+                files=pending_user_message.get("files"),
+                turn_id=pending_user_message.get("turn_id"),
+                request_interrupt=False,
+                reason="deferred websocket user message",
+            )
+            if not posted:
+                raise RuntimeError(
+                    "The user message was saved, but no resumable execution "
+                    "checkpoint became available."
+                )
+            delivery_was_dispatched = True
+            if delivery_turn_id is not None:
+                await asyncio.to_thread(
+                    mark_user_message_delivery_sync,
+                    task_id,
+                    delivery_turn_id,
+                    DELIVERY_DISPATCHED,
+                )
+            await notify_deferred_delivery(True)
 
         # Resume is now durable: lease acquisition committed RUNNING. Do not
         # announce it earlier from the WebSocket request handler.
@@ -3405,6 +3408,11 @@ async def handle_chat_message(
                                 turn_id=turn_id,
                                 status=DELIVERY_DISPATCHED,
                             )
+                        # ``post_user_message`` has already durably injected the
+                        # turn when it returns True. Preserve that fact even if
+                        # the resume reservation is concurrently withdrawn
+                        # before the coordinator can be registered.
+                        delivery_dispatched = posted
 
                         previous_task = background_task_manager.running_tasks.get(
                             task_id
@@ -3436,7 +3444,6 @@ async def handle_chat_message(
                         background_task_manager.register_reserved_resume(
                             task_id, bg_task
                         )
-                        delivery_dispatched = posted
                     except BaseException:
                         if bg_task is not None:
                             bg_task.cancel()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -53,6 +53,7 @@ from ..services.chat_history_service import (
     get_latest_waiting_question,
     inspect_user_message_delivery,
     mark_user_message_delivery,
+    mark_user_message_delivery_sync,
 )
 from ..services.hot_path_cache import (
     cache_get,
@@ -1864,20 +1865,6 @@ def _latest_result_user_turn_id(result: Dict[str, Any]) -> str | None:
     return None
 
 
-def _mark_user_message_delivery_sync(task_id: int, turn_id: str, status: str) -> None:
-    SessionLocal = get_session_local()
-    db = SessionLocal()
-    try:
-        mark_user_message_delivery(
-            db,
-            task_id=task_id,
-            turn_id=turn_id,
-            status=status,
-        )
-    finally:
-        db.close()
-
-
 async def execute_resume_background(
     task_id: int,
     agent_service: Any,
@@ -1885,6 +1872,9 @@ async def execute_resume_background(
     previous_task: Optional[asyncio.Task] = None,
     pending_user_message: Optional[Dict[str, Any]] = None,
     delivery_turn_id: str | None = None,
+    delivery_already_dispatched: bool = False,
+    delivery_websocket: WebSocket | None = None,
+    delivery_client_message_id: str | None = None,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
@@ -1910,7 +1900,34 @@ async def execute_resume_background(
     task_agent_id: int | None = None
     agent_name: str | None = None
     agent_logo_url: str | None = None
-    delivery_completed = False
+    delivery_was_dispatched = delivery_already_dispatched
+
+    async def notify_deferred_delivery(
+        accepted: bool,
+        message: str | None = None,
+        *,
+        retry_with_new_id: bool = False,
+    ) -> None:
+        if delivery_websocket is None or delivery_client_message_id is None:
+            return
+        try:
+            await _send_message_delivery(
+                delivery_websocket,
+                client_message_id=delivery_client_message_id,
+                turn_id=delivery_turn_id or delivery_client_message_id,
+                accepted=accepted,
+                message=message,
+                retry_with_new_id=retry_with_new_id,
+            )
+        except Exception:
+            # Delivery state is durable; a disconnected client will retry the
+            # same id and recover the result from that state.
+            logger.warning(
+                "Could not send deferred delivery acknowledgement for task %s",
+                task_id,
+                exc_info=True,
+            )
+
     try:
         if previous_task is not None and not previous_task.done():
             try:
@@ -1943,13 +1960,15 @@ async def execute_resume_background(
                     "The user message was saved, but no resumable execution "
                     "checkpoint became available."
                 )
+            delivery_was_dispatched = True
             if delivery_turn_id is not None:
                 await asyncio.to_thread(
-                    _mark_user_message_delivery_sync,
+                    mark_user_message_delivery_sync,
                     task_id,
                     delivery_turn_id,
                     DELIVERY_DISPATCHED,
                 )
+            await notify_deferred_delivery(True)
 
         db_gen = get_db()
         db_lease = next(db_gen)
@@ -1984,12 +2003,17 @@ async def execute_resume_background(
             logger.info(
                 "Task %s resume skipped; another runner owns the lease", task_id
             )
-            if delivery_turn_id is not None:
+            if delivery_turn_id is not None and not delivery_was_dispatched:
                 await asyncio.to_thread(
-                    _mark_user_message_delivery_sync,
+                    mark_user_message_delivery_sync,
                     task_id,
                     delivery_turn_id,
                     DELIVERY_FAILED,
+                )
+                await notify_deferred_delivery(
+                    False,
+                    "The deferred message could not be delivered. Please retry.",
+                    retry_with_new_id=True,
                 )
             await manager.broadcast_to_task(
                 {
@@ -2106,12 +2130,11 @@ async def execute_resume_background(
 
         if delivery_turn_id is not None:
             await asyncio.to_thread(
-                _mark_user_message_delivery_sync,
+                mark_user_message_delivery_sync,
                 task_id,
                 delivery_turn_id,
                 DELIVERY_COMPLETED,
             )
-            delivery_completed = True
 
         if status in {"interrupted", "waiting_for_user"}:
             await manager.broadcast_to_task(
@@ -2153,23 +2176,33 @@ async def execute_resume_background(
         )
     except asyncio.CancelledError:
         logger.info(f"V2 resume background task {task_id} cancelled")
-        if delivery_turn_id is not None and not delivery_completed:
+        if delivery_turn_id is not None and not delivery_was_dispatched:
             await asyncio.to_thread(
-                _mark_user_message_delivery_sync,
+                mark_user_message_delivery_sync,
                 task_id,
                 delivery_turn_id,
                 DELIVERY_FAILED,
+            )
+            await notify_deferred_delivery(
+                False,
+                "The deferred message was cancelled. Please retry.",
+                retry_with_new_id=True,
             )
         raise
     except Exception as e:
         logger.error(f"V2 resume background task {task_id} failed: {e}", exc_info=True)
         error_message = str(e)
-        if delivery_turn_id is not None and not delivery_completed:
+        if delivery_turn_id is not None and not delivery_was_dispatched:
             await asyncio.to_thread(
-                _mark_user_message_delivery_sync,
+                mark_user_message_delivery_sync,
                 task_id,
                 delivery_turn_id,
                 DELIVERY_FAILED,
+            )
+            await notify_deferred_delivery(
+                False,
+                error_message,
+                retry_with_new_id=True,
             )
         await manager.broadcast_to_task(
             {
@@ -2262,11 +2295,10 @@ class BackgroundTaskManager:
 
     def promote_resume_task(self, task_id: int, task: asyncio.Task) -> None:
         existing = self.resume_tasks.get(task_id)
-        if existing is not None and existing is not task:
+        if existing is not task:
             raise RuntimeError(
-                f"Task {task_id} resume coordinator is no longer current"
+                f"Task {task_id} resume coordinator is not registered or no longer current"
             )
-        self.resume_tasks[task_id] = task
         self.running_tasks[task_id] = task
         logger.info("Promoted resume coordinator for task %s", task_id)
 
@@ -2798,7 +2830,7 @@ async def handle_chat_message(
             return
         if delivery_claimed and not delivery_dispatched:
             await asyncio.to_thread(
-                _mark_user_message_delivery_sync,
+                mark_user_message_delivery_sync,
                 task_id,
                 turn_id,
                 DELIVERY_FAILED,
@@ -3247,6 +3279,10 @@ async def handle_chat_message(
                         turn_id=turn_id,
                         status=DELIVERY_DISPATCHED,
                     )
+                    # The existing DAG worker owns terminal execution and has
+                    # no per-continuation completion callback. For this path,
+                    # DISPATCHED is the terminal delivery state: it means the
+                    # continuation was accepted, not that the whole DAG ended.
                     delivery_dispatched = True
 
                     # If previously PAUSED/WAITING_FOR_USER, update status to RUNNING
@@ -3390,19 +3426,25 @@ async def handle_chat_message(
                                     }
                                 ),
                                 delivery_turn_id=turn_id,
+                                delivery_already_dispatched=posted,
+                                delivery_websocket=None if posted else websocket,
+                                delivery_client_message_id=(
+                                    None if posted else client_message_id
+                                ),
                             )
                         )
                         background_task_manager.register_reserved_resume(
                             task_id, bg_task
                         )
-                        delivery_dispatched = True
+                        delivery_dispatched = posted
                     except BaseException:
                         if bg_task is not None:
                             bg_task.cancel()
                         background_task_manager.release_resume_reservation(task_id)
                         raise
 
-                    await finish_delivery(True)
+                    if posted:
+                        await finish_delivery(True)
                     return
                 elif task_uses_live_control and not has_continuation:
                     # Task is running but doesn't support continuation (shouldn't happen)
@@ -4685,7 +4727,10 @@ async def handle_pause_task(
             logger.info("Agent pause_execution completed")
             _mark_task_pause_accepted(task_id)
 
-            # Send pause confirmation
+            # This confirms only that the control request was accepted. The
+            # frontend deliberately waits for the later durable ``task_info``
+            # PAUSED state before changing its pause UI; treating this event
+            # as ``task_paused`` would reintroduce the optimistic-state bug.
             await manager.broadcast_to_task(
                 {
                     "type": "task_pause_requested",
@@ -4808,6 +4853,7 @@ async def handle_resume_task(
                 )
                 return
             previous_task = background_task_manager.running_tasks.get(task_id)
+            bg_task: asyncio.Task[None] | None = None
             try:
                 bg_task = asyncio.create_task(
                     execute_resume_background(
@@ -4819,6 +4865,8 @@ async def handle_resume_task(
                 )
                 background_task_manager.register_reserved_resume(task_id, bg_task)
             except BaseException:
+                if bg_task is not None:
+                    bg_task.cancel()
                 background_task_manager.release_resume_reservation(task_id)
                 raise
             logger.info(f"Task {task_id} v2 resume scheduled")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -44,7 +44,16 @@ if TYPE_CHECKING:
     from ..services.task_setup_snapshot import TaskSetupSnapshot
 
 from ...core.file_storage.keys import build_task_output_storage_key
-from ..services.chat_history_service import get_latest_waiting_question
+from ..services.chat_history_service import (
+    DELIVERY_COMPLETED,
+    DELIVERY_DISPATCHED,
+    DELIVERY_FAILED,
+    UserMessageDeliveryClaim,
+    claim_user_message_delivery,
+    get_latest_waiting_question,
+    inspect_user_message_delivery,
+    mark_user_message_delivery,
+)
 from ..services.hot_path_cache import (
     cache_get,
     cache_set,
@@ -146,6 +155,7 @@ async def _send_message_delivery(
     turn_id: str,
     accepted: bool,
     message: str | None = None,
+    retry_with_new_id: bool = False,
 ) -> None:
     if client_message_id is None:
         return
@@ -157,6 +167,8 @@ async def _send_message_delivery(
     }
     if message:
         payload["message"] = message
+    if retry_with_new_id:
+        payload["retry_with_new_id"] = True
     await manager.send_personal_message(payload, websocket)
 
 
@@ -1852,12 +1864,27 @@ def _latest_result_user_turn_id(result: Dict[str, Any]) -> str | None:
     return None
 
 
+def _mark_user_message_delivery_sync(task_id: int, turn_id: str, status: str) -> None:
+    SessionLocal = get_session_local()
+    db = SessionLocal()
+    try:
+        mark_user_message_delivery(
+            db,
+            task_id=task_id,
+            turn_id=turn_id,
+            status=status,
+        )
+    finally:
+        db.close()
+
+
 async def execute_resume_background(
     task_id: int,
     agent_service: Any,
     task_owner_user_id: int | None,
     previous_task: Optional[asyncio.Task] = None,
     pending_user_message: Optional[Dict[str, Any]] = None,
+    delivery_turn_id: str | None = None,
 ) -> None:
     """Resume an agent execution after an interrupt/user-message checkpoint.
 
@@ -1883,6 +1910,7 @@ async def execute_resume_background(
     task_agent_id: int | None = None
     agent_name: str | None = None
     agent_logo_url: str | None = None
+    delivery_completed = False
     try:
         if previous_task is not None and not previous_task.done():
             try:
@@ -1914,6 +1942,13 @@ async def execute_resume_background(
                 raise RuntimeError(
                     "The user message was saved, but no resumable execution "
                     "checkpoint became available."
+                )
+            if delivery_turn_id is not None:
+                await asyncio.to_thread(
+                    _mark_user_message_delivery_sync,
+                    task_id,
+                    delivery_turn_id,
+                    DELIVERY_DISPATCHED,
                 )
 
         db_gen = get_db()
@@ -1949,6 +1984,13 @@ async def execute_resume_background(
             logger.info(
                 "Task %s resume skipped; another runner owns the lease", task_id
             )
+            if delivery_turn_id is not None:
+                await asyncio.to_thread(
+                    _mark_user_message_delivery_sync,
+                    task_id,
+                    delivery_turn_id,
+                    DELIVERY_FAILED,
+                )
             await manager.broadcast_to_task(
                 {
                     "type": "agent_error",
@@ -2062,6 +2104,15 @@ async def execute_resume_background(
         finally:
             db_new.close()
 
+        if delivery_turn_id is not None:
+            await asyncio.to_thread(
+                _mark_user_message_delivery_sync,
+                task_id,
+                delivery_turn_id,
+                DELIVERY_COMPLETED,
+            )
+            delivery_completed = True
+
         if status in {"interrupted", "waiting_for_user"}:
             await manager.broadcast_to_task(
                 create_stream_event(
@@ -2102,10 +2153,24 @@ async def execute_resume_background(
         )
     except asyncio.CancelledError:
         logger.info(f"V2 resume background task {task_id} cancelled")
+        if delivery_turn_id is not None and not delivery_completed:
+            await asyncio.to_thread(
+                _mark_user_message_delivery_sync,
+                task_id,
+                delivery_turn_id,
+                DELIVERY_FAILED,
+            )
         raise
     except Exception as e:
         logger.error(f"V2 resume background task {task_id} failed: {e}", exc_info=True)
         error_message = str(e)
+        if delivery_turn_id is not None and not delivery_completed:
+            await asyncio.to_thread(
+                _mark_user_message_delivery_sync,
+                task_id,
+                delivery_turn_id,
+                DELIVERY_FAILED,
+            )
         await manager.broadcast_to_task(
             {
                 **_terminal_task_error_payload(
@@ -2175,6 +2240,8 @@ class BackgroundTaskManager:
     def reserve_resume(self, task_id: int) -> bool:
         """Atomically reserve the single live-control resume slot."""
 
+        # Keep this check-and-add block synchronous: asyncio task switches can
+        # only happen at ``await``, so it is the in-process atomic guard.
         existing = self.resume_tasks.get(task_id)
         if task_id in self._resume_reservations or (
             existing is not None and not existing.done()
@@ -2702,9 +2769,15 @@ async def handle_chat_message(
     client_message_id = _client_message_id(message_data.get("client_message_id"))
     turn_id = client_message_id or str(uuid.uuid4())
     delivery_finished = False
-    delivery_persisted = False
+    delivery_dispatched = False
+    delivery_claimed = False
 
-    async def finish_delivery(accepted: bool, message: str | None = None) -> None:
+    async def finish_delivery(
+        accepted: bool,
+        message: str | None = None,
+        *,
+        retry_with_new_id: bool = False,
+    ) -> None:
         nonlocal delivery_finished
         if delivery_finished:
             return
@@ -2715,7 +2788,48 @@ async def handle_chat_message(
             turn_id=turn_id,
             accepted=accepted,
             message=message,
+            retry_with_new_id=retry_with_new_id,
         )
+
+    async def finish_delivery_failure(message: str) -> None:
+        """Reject pre-dispatch failures; never confuse persistence with delivery."""
+
+        if delivery_finished:
+            return
+        if delivery_claimed and not delivery_dispatched:
+            await asyncio.to_thread(
+                _mark_user_message_delivery_sync,
+                task_id,
+                turn_id,
+                DELIVERY_FAILED,
+            )
+        await finish_delivery(
+            delivery_dispatched,
+            None if delivery_dispatched else message,
+        )
+
+    async def finish_existing_delivery(
+        claim: UserMessageDeliveryClaim,
+    ) -> None:
+        if not claim.payload_matches:
+            await finish_delivery(
+                False,
+                "Message id was already used for different content or files.",
+                retry_with_new_id=True,
+            )
+        elif claim.failed:
+            await finish_delivery(
+                False,
+                "The previous delivery attempt failed. Please retry the draft.",
+                retry_with_new_id=True,
+            )
+        elif claim.pending:
+            await finish_delivery(
+                False,
+                "The message is still being applied. Please retry shortly.",
+            )
+        else:
+            await finish_delivery(True)
 
     try:
         user_message = message_data.get("message", "")
@@ -2910,36 +3024,6 @@ async def handle_chat_message(
 
                 authorized_task_id = int(task.id)
 
-                # A client retries with the same id when the socket closes or
-                # the acknowledgement is lost. If that turn is already in the
-                # durable transcript, acknowledge it without executing it a
-                # second time. Reject id reuse with different text so a stale
-                # composer attempt cannot silently alias a new message.
-                if client_message_id is not None:
-                    from ..models.chat_message import TaskChatMessage
-
-                    existing_delivery = (
-                        db.query(TaskChatMessage)
-                        .filter(
-                            TaskChatMessage.task_id == task_id,
-                            TaskChatMessage.role == "user",
-                            TaskChatMessage.turn_id == turn_id,
-                        )
-                        .first()
-                    )
-                    if existing_delivery is not None:
-                        expected_content = _display_message_for_user(
-                            str(user_message), bool(files)
-                        ).strip()
-                        if str(existing_delivery.content) != expected_content:
-                            await finish_delivery(
-                                False,
-                                "Message id was already used for different content.",
-                            )
-                        else:
-                            await finish_delivery(True)
-                        return
-
                 if not files and task.status == TaskStatus.PENDING:
                     files = _selected_file_refs_from_task(task, db)
                     if files:
@@ -3044,6 +3128,27 @@ async def handle_chat_message(
                 context["display_message"] = display_user_message
                 context["files"] = display_file_refs
 
+                persisted_attachments = _normalize_attachments_for_persistence(
+                    file_info_list
+                )
+
+                # Retry inspection happens after file normalization so the
+                # same text with different attachments cannot alias an older
+                # durable turn. Legacy rows with no delivery status are
+                # treated as delivered; failed handoffs are explicitly
+                # rejected so the frontend can retry with a fresh id.
+                if client_message_id is not None:
+                    existing_delivery = inspect_user_message_delivery(
+                        db,
+                        task_id,
+                        display_user_message,
+                        attachments=persisted_attachments or None,
+                        turn_id=turn_id,
+                    )
+                    if existing_delivery is not None:
+                        await finish_existing_delivery(existing_delivery)
+                        return
+
                 # DAG plan-execute will automatically send user_message trace event
 
                 # The user message is persisted inside
@@ -3095,22 +3200,18 @@ async def handle_chat_message(
                     logger.info(f"Using continuation for running task {task_id}")
                     assert dag_pattern is not None  # for mypy type checking
 
-                    from ..services.chat_history_service import (
-                        persist_user_message_once,
-                    )
-
-                    persisted_delivery_message = persist_user_message_once(
+                    delivery_claim = claim_user_message_delivery(
                         db,
                         task_id=task_id,
                         user_id=int(task.user_id),
                         content=display_user_message,
-                        attachments=_normalize_attachments_for_persistence(
-                            file_info_list
-                        )
-                        or None,
+                        attachments=persisted_attachments or None,
                         turn_id=turn_id,
                     )
-                    delivery_persisted = persisted_delivery_message is not None
+                    if not delivery_claim.claimed:
+                        await finish_existing_delivery(delivery_claim)
+                        return
+                    delivery_claimed = True
 
                     # Immediately send trace_user_message to display user message on interface
                     if hasattr(dag_pattern, "tracer") and hasattr(
@@ -3140,6 +3241,13 @@ async def handle_chat_message(
                         )
 
                     dag_pattern.request_continuation(user_message_for_llm, context)
+                    mark_user_message_delivery(
+                        db,
+                        task_id=task_id,
+                        turn_id=turn_id,
+                        status=DELIVERY_DISPATCHED,
+                    )
+                    delivery_dispatched = True
 
                     # If previously PAUSED/WAITING_FOR_USER, update status to RUNNING
                     if task.status in {TaskStatus.PAUSED, TaskStatus.WAITING_FOR_USER}:
@@ -3223,23 +3331,21 @@ async def handle_chat_message(
                     # bubble twice in the live UI. The DAG Plan-Execute
                     # continuation path above is a separate code path and
                     # keeps its own immediate trace.
+                    bg_task: asyncio.Task[None] | None = None
                     try:
-                        from ..services.chat_history_service import (
-                            persist_user_message_once,
-                        )
-
-                        persisted_delivery_message = persist_user_message_once(
+                        delivery_claim = claim_user_message_delivery(
                             db,
                             task_id=task_id,
                             user_id=int(task.user_id),
                             content=display_user_message,
-                            attachments=_normalize_attachments_for_persistence(
-                                file_info_list
-                            )
-                            or None,
+                            attachments=persisted_attachments or None,
                             turn_id=turn_id,
                         )
-                        delivery_persisted = persisted_delivery_message is not None
+                        if not delivery_claim.claimed:
+                            background_task_manager.release_resume_reservation(task_id)
+                            await finish_existing_delivery(delivery_claim)
+                            return
+                        delivery_claimed = True
 
                         posted = await agent_service.post_user_message(
                             str(task_id),
@@ -3255,6 +3361,13 @@ async def handle_chat_message(
                                 "Agent execution %s was not live; deferring the "
                                 "durable user message until its checkpoint is ready",
                                 task_id,
+                            )
+                        else:
+                            mark_user_message_delivery(
+                                db,
+                                task_id=task_id,
+                                turn_id=turn_id,
+                                status=DELIVERY_DISPATCHED,
                             )
 
                         previous_task = background_task_manager.running_tasks.get(
@@ -3276,12 +3389,16 @@ async def handle_chat_message(
                                         "turn_id": turn_id,
                                     }
                                 ),
+                                delivery_turn_id=turn_id,
                             )
                         )
                         background_task_manager.register_reserved_resume(
                             task_id, bg_task
                         )
+                        delivery_dispatched = True
                     except BaseException:
+                        if bg_task is not None:
+                            bg_task.cancel()
                         background_task_manager.release_resume_reservation(task_id)
                         raise
 
@@ -3440,9 +3557,6 @@ async def handle_chat_message(
                     # Strip absolute filesystem paths before the row hits
                     # disk — the attachments column is exposed to historical-
                     # replay clients, so paths must not leak.
-                    persisted_attachments = _normalize_attachments_for_persistence(
-                        file_info_list
-                    )
                     payload = TaskTurnPayload(
                         transcript_message=display_user_message,
                         execution_message=user_message_for_llm,
@@ -3573,10 +3687,7 @@ async def handle_chat_message(
             # Data validation and format error
             message = f"Data validation error: {str(e)}"
             logger.error(f"Data validation error in agent execution: {e}")
-            await finish_delivery(
-                delivery_persisted,
-                None if delivery_persisted else message,
-            )
+            await finish_delivery_failure(message)
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
                 await manager.broadcast_to_task(
@@ -3599,10 +3710,7 @@ async def handle_chat_message(
             # Runtime error
             message = f"Runtime error: {str(e)}"
             logger.error(f"Runtime error in agent execution: {e}")
-            await finish_delivery(
-                delivery_persisted,
-                None if delivery_persisted else message,
-            )
+            await finish_delivery_failure(message)
             timestamp = datetime.now(timezone.utc).timestamp()
             if authorized_task_id is not None:
                 await manager.broadcast_to_task(
@@ -3624,19 +3732,13 @@ async def handle_chat_message(
         except Exception as e:
             # Other unknown errors, re-raise
             logger.error(f"Unexpected error in agent execution: {e}")
-            await finish_delivery(
-                delivery_persisted,
-                None if delivery_persisted else str(e),
-            )
+            await finish_delivery_failure(str(e))
             raise
 
     except (ValueError, KeyError, TypeError) as e:
         # Message format error
         logger.error(f"Message format error: {e}")
-        await finish_delivery(
-            delivery_persisted,
-            None if delivery_persisted else f"Message format error: {str(e)}",
-        )
+        await finish_delivery_failure(f"Message format error: {str(e)}")
         await manager.send_personal_message(
             {"type": "error", "message": f"Message format error: {str(e)}"}, websocket
         )
@@ -3647,10 +3749,7 @@ async def handle_chat_message(
     except Exception as e:
         # Other errors, re-raise
         logger.error(f"Unexpected error handling chat message: {e}")
-        await finish_delivery(
-            delivery_persisted,
-            None if delivery_persisted else str(e),
-        )
+        await finish_delivery_failure(str(e))
         raise
 
 

--- a/src/xagent/web/models/chat_message.py
+++ b/src/xagent/web/models/chat_message.py
@@ -1,4 +1,4 @@
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -9,6 +9,15 @@ class TaskChatMessage(Base):  # type: ignore
     """Persisted transcript message for a task chat session."""
 
     __tablename__ = "task_chat_messages"
+    __table_args__ = (
+        Index(
+            "uq_task_chat_messages_task_role_turn_id",
+            "task_id",
+            "role",
+            "turn_id",
+            unique=True,
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     task_id = Column(
@@ -25,6 +34,9 @@ class TaskChatMessage(Base):  # type: ignore
     # by historical replay to reconcile trace rows with transcript rows without
     # collapsing distinct turns that happen to share text/attachments.
     turn_id = Column(String(64), nullable=True, index=True)
+    # Durable handoff outcome for retry-safe user-message delivery. Legacy
+    # rows remain NULL and are treated as already delivered.
+    delivery_status = Column(String(32), nullable=True)
     # Per-message attachments (uploaded files). For user messages this is the
     # list of files the user attached when sending this turn. Stored as JSON so
     # the original file metadata (file_id, name, size, type) is available for

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ...core.agent.transcript import (
@@ -14,6 +17,180 @@ from ...core.agent.transcript import (
 from ..models.chat_message import TaskChatMessage
 
 logger = logging.getLogger(__name__)
+
+DELIVERY_PENDING = "pending"
+DELIVERY_DISPATCHED = "dispatched"
+DELIVERY_COMPLETED = "completed"
+DELIVERY_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class UserMessageDeliveryClaim:
+    """Result of inspecting or atomically claiming a client turn id."""
+
+    message: TaskChatMessage
+    claimed: bool
+    payload_matches: bool
+
+    @property
+    def failed(self) -> bool:
+        return str(self.message.delivery_status) == DELIVERY_FAILED
+
+    @property
+    def pending(self) -> bool:
+        return str(self.message.delivery_status) == DELIVERY_PENDING
+
+    @property
+    def can_acknowledge(self) -> bool:
+        return self.payload_matches and not self.failed and not self.pending
+
+
+def _attachment_identity(
+    attachments: Optional[List[Dict[str, Any]]],
+) -> tuple[str, ...]:
+    identities: list[str] = []
+    for attachment in attachments or []:
+        file_id = str(attachment.get("file_id") or "").strip()
+        if file_id:
+            identity: Dict[str, Any] = {"file_id": file_id}
+        else:
+            identity = {
+                key: attachment.get(key)
+                for key in ("name", "size", "type")
+                if attachment.get(key) is not None
+            }
+        identities.append(json.dumps(identity, sort_keys=True, default=str))
+    return tuple(sorted(identities))
+
+
+def _delivery_payload_matches(
+    message: TaskChatMessage,
+    *,
+    content: str,
+    attachments: Optional[List[Dict[str, Any]]],
+) -> bool:
+    stored_attachments = (
+        message.attachments if isinstance(message.attachments, list) else None
+    )
+    return str(message.content) == content.strip() and _attachment_identity(
+        stored_attachments
+    ) == _attachment_identity(attachments)
+
+
+def inspect_user_message_delivery(
+    db: Session,
+    task_id: int,
+    content: str,
+    *,
+    attachments: Optional[List[Dict[str, Any]]],
+    turn_id: str,
+) -> Optional[UserMessageDeliveryClaim]:
+    """Return the durable outcome for ``turn_id`` without creating a row."""
+
+    existing = (
+        db.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == task_id,
+            TaskChatMessage.role == "user",
+            TaskChatMessage.turn_id == turn_id,
+        )
+        .first()
+    )
+    if existing is None:
+        return None
+    return UserMessageDeliveryClaim(
+        message=existing,
+        claimed=False,
+        payload_matches=_delivery_payload_matches(
+            existing,
+            content=content,
+            attachments=attachments,
+        ),
+    )
+
+
+def claim_user_message_delivery(
+    db: Session,
+    task_id: int,
+    user_id: int,
+    content: str,
+    *,
+    attachments: Optional[List[Dict[str, Any]]] = None,
+    turn_id: str,
+) -> UserMessageDeliveryClaim:
+    """Atomically claim a live-control turn before dispatching it.
+
+    The unique database index is the cross-worker serializer. A concurrent
+    loser rolls back its insert and returns the winner's durable row, so only
+    the claimant may inject the message into an active runtime.
+    """
+
+    existing = inspect_user_message_delivery(
+        db,
+        task_id,
+        content,
+        attachments=attachments,
+        turn_id=turn_id,
+    )
+    if existing is not None:
+        return existing
+
+    message = TaskChatMessage(
+        task_id=task_id,
+        user_id=user_id,
+        role="user",
+        content=content.strip(),
+        message_type="user_message",
+        interactions=None,
+        turn_id=turn_id,
+        delivery_status=DELIVERY_PENDING,
+        attachments=attachments,
+    )
+    db.add(message)
+    try:
+        db.commit()
+        db.refresh(message)
+        return UserMessageDeliveryClaim(
+            message=message,
+            claimed=True,
+            payload_matches=True,
+        )
+    except IntegrityError:
+        db.rollback()
+        raced = inspect_user_message_delivery(
+            db,
+            task_id,
+            content,
+            attachments=attachments,
+            turn_id=turn_id,
+        )
+        if raced is None:
+            raise
+        return raced
+
+
+def mark_user_message_delivery(
+    db: Session,
+    *,
+    task_id: int,
+    turn_id: str,
+    status: str,
+) -> None:
+    """Persist a delivery transition for a claimed user turn."""
+
+    if status not in {
+        DELIVERY_PENDING,
+        DELIVERY_DISPATCHED,
+        DELIVERY_COMPLETED,
+        DELIVERY_FAILED,
+    }:
+        raise ValueError(f"Unknown delivery status: {status}")
+    db.query(TaskChatMessage).filter(
+        TaskChatMessage.task_id == task_id,
+        TaskChatMessage.role == "user",
+        TaskChatMessage.turn_id == turn_id,
+    ).update({TaskChatMessage.delivery_status: status}, synchronize_session=False)
+    db.commit()
 
 
 def persist_user_message(
@@ -54,25 +231,14 @@ def persist_user_message_once(
     duplicate turn.
     """
 
-    existing = (
-        db.query(TaskChatMessage)
-        .filter(
-            TaskChatMessage.task_id == task_id,
-            TaskChatMessage.role == "user",
-            TaskChatMessage.turn_id == turn_id,
-        )
-        .first()
-    )
-    if existing is not None:
-        return existing
-    return persist_user_message(
+    return claim_user_message_delivery(
         db,
         task_id=task_id,
         user_id=user_id,
         content=content,
         attachments=attachments,
         turn_id=turn_id,
-    )
+    ).message
 
 
 def persist_user_message_no_commit(
@@ -83,6 +249,7 @@ def persist_user_message_no_commit(
     *,
     attachments: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
+    delivery_status: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     """``persist_user_message`` variant that stages the row but does NOT commit.
 
@@ -107,6 +274,7 @@ def persist_user_message_no_commit(
         message_type="user_message",
         interactions=None,
         turn_id=turn_id,
+        delivery_status=delivery_status,
         # Pass through ``attachments`` directly so an explicit empty list
         # round-trips as ``[]`` rather than being coerced to ``NULL`` —
         # callers may want to distinguish "no attachments specified" from
@@ -238,6 +406,7 @@ def _persist_message(
     interactions: Optional[List[Dict[str, Any]]] = None,
     attachments: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[str] = None,
+    delivery_status: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     normalized_content = content.strip()
     if not normalized_content and not attachments:
@@ -251,6 +420,7 @@ def _persist_message(
         message_type=message_type,
         interactions=interactions,
         turn_id=turn_id,
+        delivery_status=delivery_status,
         # Pass through ``attachments`` directly so an explicit empty list
         # round-trips as ``[]`` rather than being coerced to ``NULL``.
         attachments=attachments,

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -40,10 +39,6 @@ class UserMessageDeliveryClaim:
     def pending(self) -> bool:
         return str(self.message.delivery_status) == DELIVERY_PENDING
 
-    @property
-    def can_acknowledge(self) -> bool:
-        return self.payload_matches and not self.failed and not self.pending
-
 
 def _attachment_identity(
     attachments: Optional[List[Dict[str, Any]]],
@@ -51,15 +46,10 @@ def _attachment_identity(
     identities: list[str] = []
     for attachment in attachments or []:
         file_id = str(attachment.get("file_id") or "").strip()
-        if file_id:
-            identity: Dict[str, Any] = {"file_id": file_id}
-        else:
-            identity = {
-                key: attachment.get(key)
-                for key in ("name", "size", "type")
-                if attachment.get(key) is not None
-            }
-        identities.append(json.dumps(identity, sort_keys=True, default=str))
+        fallback = "\x1f".join(
+            str(attachment.get(key) or "") for key in ("name", "size", "type")
+        )
+        identities.append(file_id or f"legacy:{fallback}")
     return tuple(sorted(identities))
 
 
@@ -193,6 +183,25 @@ def mark_user_message_delivery(
     db.commit()
 
 
+def mark_user_message_delivery_sync(
+    task_id: int,
+    turn_id: str,
+    status: str,
+) -> None:
+    """Update one delivery from synchronous or ``asyncio.to_thread`` callers."""
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        mark_user_message_delivery(
+            db,
+            task_id=task_id,
+            turn_id=turn_id,
+            status=status,
+        )
+
+
 def persist_user_message(
     db: Session,
     task_id: int,
@@ -212,33 +221,6 @@ def persist_user_message(
         attachments=attachments,
         turn_id=turn_id,
     )
-
-
-def persist_user_message_once(
-    db: Session,
-    task_id: int,
-    user_id: int,
-    content: str,
-    *,
-    attachments: Optional[List[Dict[str, Any]]] = None,
-    turn_id: str,
-) -> Optional[TaskChatMessage]:
-    """Persist a user turn once for retry-safe live-control delivery.
-
-    WebSocket clients reuse ``turn_id`` while awaiting delivery acceptance. A
-    reconnect or an acknowledgement timeout may therefore submit the same turn
-    again. Reuse the durable transcript row instead of rendering/executing a
-    duplicate turn.
-    """
-
-    return claim_user_message_delivery(
-        db,
-        task_id=task_id,
-        user_id=user_id,
-        content=content,
-        attachments=attachments,
-        turn_id=turn_id,
-    ).message
 
 
 def persist_user_message_no_commit(

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -37,6 +37,44 @@ def persist_user_message(
     )
 
 
+def persist_user_message_once(
+    db: Session,
+    task_id: int,
+    user_id: int,
+    content: str,
+    *,
+    attachments: Optional[List[Dict[str, Any]]] = None,
+    turn_id: str,
+) -> Optional[TaskChatMessage]:
+    """Persist a user turn once for retry-safe live-control delivery.
+
+    WebSocket clients reuse ``turn_id`` while awaiting delivery acceptance. A
+    reconnect or an acknowledgement timeout may therefore submit the same turn
+    again. Reuse the durable transcript row instead of rendering/executing a
+    duplicate turn.
+    """
+
+    existing = (
+        db.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == task_id,
+            TaskChatMessage.role == "user",
+            TaskChatMessage.turn_id == turn_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        return existing
+    return persist_user_message(
+        db,
+        task_id=task_id,
+        user_id=user_id,
+        content=content,
+        attachments=attachments,
+        turn_id=turn_id,
+    )
+
+
 def persist_user_message_no_commit(
     db: Session,
     task_id: int,
@@ -87,6 +125,7 @@ def persist_assistant_message(
     *,
     message_type: str = "assistant_message",
     interactions: Optional[List[Dict[str, Any]]] = None,
+    turn_id: Optional[str] = None,
 ) -> Optional[TaskChatMessage]:
     transcript_content = build_assistant_transcript_content(content, interactions)
     return _persist_message(
@@ -97,7 +136,38 @@ def persist_assistant_message(
         content=transcript_content,
         message_type=message_type,
         interactions=interactions,
+        turn_id=turn_id,
     )
+
+
+def persist_assistant_message_no_commit(
+    db: Session,
+    task_id: int,
+    user_id: int,
+    content: str,
+    *,
+    message_type: str = "assistant_message",
+    interactions: Optional[List[Dict[str, Any]]] = None,
+    turn_id: Optional[str] = None,
+) -> Optional[TaskChatMessage]:
+    """Stage an assistant transcript row for an atomic caller-owned commit."""
+
+    transcript_content = build_assistant_transcript_content(content, interactions)
+    normalized_content = transcript_content.strip()
+    if not normalized_content:
+        return None
+    message = TaskChatMessage(
+        task_id=task_id,
+        user_id=user_id,
+        role="assistant",
+        content=normalized_content,
+        message_type=message_type,
+        interactions=interactions,
+        turn_id=turn_id,
+        attachments=None,
+    )
+    db.add(message)
+    return message
 
 
 def load_task_transcript(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -322,7 +322,26 @@ class TaskTurnOrchestrator:
                     task_id,
                     "turn scheduling failed after claim commit",
                 )
+                try:
+                    await asyncio.to_thread(
+                        _mark_turn_delivery_status_sync,
+                        task_id,
+                        payload.turn_id,
+                        "failed",
+                    )
+                except Exception:
+                    logger.exception(
+                        "Could not mark failed delivery for task=%s turn=%s",
+                        task_id,
+                        payload.turn_id,
+                    )
                 raise
+            await asyncio.to_thread(
+                _mark_turn_delivery_status_sync,
+                task_id,
+                payload.turn_id,
+                "dispatched",
+            )
             return res, handle
 
         claimed, bg_task = await asyncio.shield(_claim_and_schedule())
@@ -395,7 +414,7 @@ def _begin_turn_atomic_sync(
     RUNNING, and any exception means it is not.
     """
     from ..models.database import get_session_local
-    from .chat_history_service import persist_user_message_no_commit
+    from .chat_history_service import DELIVERY_PENDING, persist_user_message_no_commit
 
     if kind == TurnKind.CREATE:
         status_filter = Task.status == TaskStatus.PENDING
@@ -450,6 +469,7 @@ def _begin_turn_atomic_sync(
             content=payload.transcript_message,
             attachments=payload.attachments,
             turn_id=payload.turn_id,
+            delivery_status=DELIVERY_PENDING,
         )
         if persisted_message is not None:
             db.flush()
@@ -570,6 +590,22 @@ def _mark_task_failed_if_running(task_id: int, error_message: str) -> None:
             task_id,
             e,
             exc_info=True,
+        )
+
+
+def _mark_turn_delivery_status_sync(task_id: int, turn_id: str, status: str) -> None:
+    """Advance the user-message handoff after scheduling succeeds or fails."""
+
+    from ..models.database import get_session_local
+    from .chat_history_service import mark_user_message_delivery
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        mark_user_message_delivery(
+            db,
+            task_id=task_id,
+            turn_id=turn_id,
+            status=status,
         )
 
 

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -53,6 +53,7 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from ..models.task import Task, TaskStatus
+from .chat_history_service import mark_user_message_delivery_sync
 from .hot_path_cache import invalidate_task_cache
 from .task_lease_service import (
     acquire_task_lease_isolated,
@@ -324,7 +325,7 @@ class TaskTurnOrchestrator:
                 )
                 try:
                     await asyncio.to_thread(
-                        _mark_turn_delivery_status_sync,
+                        mark_user_message_delivery_sync,
                         task_id,
                         payload.turn_id,
                         "failed",
@@ -337,7 +338,7 @@ class TaskTurnOrchestrator:
                     )
                 raise
             await asyncio.to_thread(
-                _mark_turn_delivery_status_sync,
+                mark_user_message_delivery_sync,
                 task_id,
                 payload.turn_id,
                 "dispatched",
@@ -590,22 +591,6 @@ def _mark_task_failed_if_running(task_id: int, error_message: str) -> None:
             task_id,
             e,
             exc_info=True,
-        )
-
-
-def _mark_turn_delivery_status_sync(task_id: int, turn_id: str, status: str) -> None:
-    """Advance the user-message handoff after scheduling succeeds or fails."""
-
-    from ..models.database import get_session_local
-    from .chat_history_service import mark_user_message_delivery
-
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        mark_user_message_delivery(
-            db,
-            task_id=task_id,
-            turn_id=turn_id,
-            status=status,
         )
 
 

--- a/tests/alembic/test_20260710_add_chat_message_delivery_state.py
+++ b/tests/alembic/test_20260710_add_chat_message_delivery_state.py
@@ -1,0 +1,51 @@
+from alembic import command
+from sqlalchemy import create_engine, inspect, text
+
+from xagent.db.config import create_alembic_config
+
+
+def test_upgrade_adds_delivery_state_and_deduplicates_turn_ids() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    config = create_alembic_config(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES ('1c2ae61b5a6d')")
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE task_chat_messages ("
+                "id INTEGER PRIMARY KEY, task_id INTEGER NOT NULL, "
+                "role VARCHAR(32) NOT NULL, turn_id VARCHAR(64))"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO task_chat_messages (id, task_id, role, turn_id) "
+                "VALUES (1, 7, 'user', 'same-turn'), "
+                "(2, 7, 'user', 'same-turn'), "
+                "(3, 7, 'assistant', 'same-turn')"
+            )
+        )
+
+        config.attributes["connection"] = connection
+        command.upgrade(config, "head")
+
+        columns = {
+            column["name"]
+            for column in inspect(connection).get_columns("task_chat_messages")
+        }
+        indexes = {
+            index["name"]: index
+            for index in inspect(connection).get_indexes("task_chat_messages")
+        }
+        rows = connection.execute(
+            text("SELECT id, turn_id FROM task_chat_messages ORDER BY id")
+        ).all()
+
+    assert "delivery_status" in columns
+    assert indexes["uq_task_chat_messages_task_role_turn_id"]["unique"] == 1
+    assert rows == [(1, "same-turn"), (2, None), (3, "same-turn")]

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -830,6 +830,7 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
         execution_message=execution_message,
         display_message="Read file",
         files=files,
+        turn_id="client-turn-123",
         request_interrupt=False,
     )
 
@@ -841,7 +842,7 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
     assert latest_user.metadata["display_message"] == "Read file"
     assert latest_user.metadata["files"] == files
     turn_id = latest_user.metadata.get("turn_id")
-    assert isinstance(turn_id, str) and turn_id
+    assert turn_id == "client-turn-123"
 
     checkpoint_messages = tracer.by_execution_id["exec-display-contract"]["context"][
         "messages"

--- a/tests/core/model/tts/test_elevenlabs.py
+++ b/tests/core/model/tts/test_elevenlabs.py
@@ -74,6 +74,27 @@ async def test_synthesize_uses_sdk_convert_and_joins_chunks(
     assert call["voice_settings"].stability == 0.5
 
 
+async def test_synthesize_supports_direct_async_generator_sdk_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def convert(**kwargs: object):
+        yield b"direct "
+        yield b"stream"
+
+    fake_client = SimpleNamespace(text_to_speech=SimpleNamespace(convert=convert))
+    monkeypatch.setattr(
+        ElevenLabsTTS,
+        "_create_async_client",
+        staticmethod(lambda api_key, base_url=None: fake_client),
+    )
+
+    tts = ElevenLabsTTS(api_key="test-key")
+
+    result = await tts.synthesize("Hello")
+
+    assert result == b"direct stream"
+
+
 async def test_synthesize_maps_pcm_sample_rate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/api/test_agent_service_manager_singleflight.py
+++ b/tests/web/api/test_agent_service_manager_singleflight.py
@@ -68,3 +68,17 @@ def test_remove_agent_releases_per_task_build_lock() -> None:
     manager.remove_agent(42)
 
     assert 42 not in manager._agent_build_locks
+
+
+@pytest.mark.asyncio
+async def test_remove_agent_keeps_inflight_build_lock() -> None:
+    manager = AgentServiceManager()
+    lock = asyncio.Lock()
+    await lock.acquire()
+    manager._agent_build_locks[42] = lock
+    manager._cleanup_workspace_directory = MagicMock()
+
+    manager.remove_agent(42)
+
+    assert manager._agent_build_locks[42] is lock
+    lock.release()

--- a/tests/web/api/test_agent_service_manager_singleflight.py
+++ b/tests/web/api/test_agent_service_manager_singleflight.py
@@ -1,0 +1,60 @@
+"""Concurrency regression tests for task-scoped AgentService construction."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+
+
+@pytest.mark.asyncio
+async def test_get_agent_for_task_serializes_builds_for_same_task() -> None:
+    manager = AgentServiceManager()
+    active_builds = 0
+    max_active_builds = 0
+
+    async def _build(*args, **kwargs):
+        nonlocal active_builds, max_active_builds
+        active_builds += 1
+        max_active_builds = max(max_active_builds, active_builds)
+        await asyncio.sleep(0)
+        active_builds -= 1
+        return object()
+
+    manager._get_agent_for_task_unlocked = AsyncMock(side_effect=_build)
+
+    await asyncio.gather(
+        manager.get_agent_for_task(42),
+        manager.get_agent_for_task(42),
+    )
+
+    assert max_active_builds == 1
+    assert manager._get_agent_for_task_unlocked.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_agent_for_task_allows_different_tasks_to_build_concurrently() -> (
+    None
+):
+    manager = AgentServiceManager()
+    both_started = asyncio.Event()
+    started: set[int] = set()
+
+    async def _build(task_id: int, **kwargs):
+        started.add(task_id)
+        if len(started) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+        return object()
+
+    manager._get_agent_for_task_unlocked = AsyncMock(side_effect=_build)
+
+    await asyncio.gather(
+        manager.get_agent_for_task(42),
+        manager.get_agent_for_task(43),
+    )
+
+    assert started == {42, 43}

--- a/tests/web/api/test_agent_service_manager_singleflight.py
+++ b/tests/web/api/test_agent_service_manager_singleflight.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -58,3 +58,13 @@ async def test_get_agent_for_task_allows_different_tasks_to_build_concurrently()
     )
 
     assert started == {42, 43}
+
+
+def test_remove_agent_releases_per_task_build_lock() -> None:
+    manager = AgentServiceManager()
+    manager._agent_build_locks[42] = asyncio.Lock()
+    manager._cleanup_workspace_directory = MagicMock()
+
+    manager.remove_agent(42)
+
+    assert 42 not in manager._agent_build_locks

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -267,6 +267,9 @@ async def test_resumed_turn_re_resolves_scope() -> None:
                 "xagent.web.api.websocket.manager",
                 MagicMock(broadcast_to_task=AsyncMock()),
             ),
+            patch(
+                "xagent.web.api.websocket.background_task_manager.promote_resume_task"
+            ),
         ]
     ):
         await execute_resume_background(

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -26,7 +26,11 @@ from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
-from xagent.web.services.chat_history_service import DELIVERY_FAILED, DELIVERY_PENDING
+from xagent.web.services.chat_history_service import (
+    DELIVERY_DISPATCHED,
+    DELIVERY_FAILED,
+    DELIVERY_PENDING,
+)
 
 
 @pytest.fixture()
@@ -247,7 +251,7 @@ async def test_deferred_chat_message_waits_for_real_injection_before_ack(
 
 
 @pytest.mark.asyncio
-async def test_resume_registration_failure_cancels_created_coordinator(
+async def test_resume_registration_failure_preserves_dispatched_delivery(
     db_session,
 ) -> None:
     owner = _user(db_session, "owner")
@@ -295,13 +299,13 @@ async def test_resume_registration_failure_cancels_created_coordinator(
         .filter(TaskChatMessage.turn_id == "registration-failure-turn")
         .one()
     )
-    assert stored.delivery_status == DELIVERY_FAILED
-    rejected = [
+    assert stored.delivery_status == DELIVERY_DISPATCHED
+    accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
-        if call.args[0].get("type") == "message_rejected"
+        if call.args[0].get("type") == "message_accepted"
     ]
-    assert len(rejected) == 1
+    assert len(accepted) == 1
 
 
 @pytest.mark.asyncio
@@ -769,6 +773,70 @@ async def test_deferred_injection_failure_rejects_before_any_acceptance(
     delivery = (
         db_session.query(TaskChatMessage)
         .filter(TaskChatMessage.turn_id == "deferred-injection-failure")
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_FAILED
+
+
+@pytest.mark.asyncio
+async def test_deferred_injection_rejects_before_post_when_lease_is_denied(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-lease-denied",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    agent = MagicMock(
+        post_user_message=AsyncMock(return_value=True),
+        resume_execution_by_id=AsyncMock(),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+
+    with (
+        patch("xagent.web.api.websocket.acquire_task_lease", return_value=None),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-lease-denied",
+            },
+            delivery_turn_id="deferred-lease-denied",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-lease-denied",
+        )
+
+    agent.post_user_message.assert_not_awaited()
+    delivery_events = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") in {"message_accepted", "message_rejected"}
+    ]
+    assert [event["type"] for event in delivery_events] == ["message_rejected"]
+    assert delivery_events[0]["retry_with_new_id"] is True
+    db_session.expire_all()
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == "deferred-lease-denied")
         .one()
     )
     assert delivery.delivery_status == DELIVERY_FAILED

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -24,6 +24,7 @@ from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+from xagent.web.services.chat_history_service import DELIVERY_FAILED, DELIVERY_PENDING
 
 
 @pytest.fixture()
@@ -190,6 +191,64 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
 
 
 @pytest.mark.asyncio
+async def test_resume_registration_failure_cancels_created_coordinator(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+    bg_mgr.register_reserved_resume.side_effect = RuntimeError("reservation lost")
+    bg_handle = MagicMock()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", MagicMock()),
+        patch(
+            "xagent.web.api.websocket.asyncio.create_task",
+            return_value=bg_handle,
+        ),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Apply this safely",
+                "client_message_id": "registration-failure-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    bg_handle.cancel.assert_called_once()
+    db_session.expire_all()
+    stored = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == "registration-failure-turn")
+        .one()
+    )
+    assert stored.delivery_status == DELIVERY_FAILED
+    rejected = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_rejected"
+    ]
+    assert len(rejected) == 1
+
+
+@pytest.mark.asyncio
 async def test_retried_durable_message_is_accepted_without_reexecution(
     db_session,
 ) -> None:
@@ -243,6 +302,107 @@ async def test_retried_durable_message_is_accepted_without_reexecution(
         if call.args[0].get("type") == "message_accepted"
     ]
     assert len(accepted) == 1
+
+
+@pytest.mark.asyncio
+async def test_reusing_client_id_with_different_content_is_rejected(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Original content",
+            message_type="user_message",
+            turn_id="stable-turn-1",
+        )
+    )
+    db_session.commit()
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    begin_turn = AsyncMock()
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Different content",
+                "client_message_id": "stable-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    begin_turn.assert_not_awaited()
+    rejected = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_rejected"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["retry_with_new_id"] is True
+
+
+@pytest.mark.asyncio
+async def test_failed_durable_delivery_is_not_silently_accepted(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.FAILED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Retry after checkpoint failure",
+            message_type="user_message",
+            turn_id="failed-turn-1",
+            delivery_status=DELIVERY_FAILED,
+        )
+    )
+    db_session.commit()
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    begin_turn = AsyncMock()
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch(
+            "xagent.web.services.task_orchestrator.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Retry after checkpoint failure",
+                "client_message_id": "failed-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    begin_turn.assert_not_awaited()
+    rejected = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_rejected"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["retry_with_new_id"] is True
 
 
 @pytest.mark.asyncio
@@ -425,6 +585,18 @@ async def test_execute_resume_background_persists_missing_checkpoint_failure(
     agent = MagicMock(
         resume_execution_by_id=AsyncMock(return_value=None),
     )
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-failure-turn",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
     ws_manager = MagicMock(broadcast_to_task=AsyncMock())
 
     with patch("xagent.web.api.websocket.manager", ws_manager):
@@ -432,12 +604,19 @@ async def test_execute_resume_background_persists_missing_checkpoint_failure(
             task_id=int(task.id),
             agent_service=agent,
             task_owner_user_id=int(owner.id),
+            delivery_turn_id="deferred-failure-turn",
         )
 
     db_session.expire_all()
     db_session.refresh(task)
     assert task.status == TaskStatus.FAILED
     assert "No resumable execution checkpoint" in str(task.error_message)
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == "deferred-failure-turn")
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_FAILED
     failures = [
         call.args[0]
         for call in ws_manager.broadcast_to_task.call_args_list

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -9,6 +9,7 @@ isolation; here we exercise the handlers end to end).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,7 @@ from xagent.web.api.websocket import (
     handle_pause_task,
     handle_resume_task,
 )
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
@@ -110,11 +112,137 @@ async def test_chat_admin_append_to_other_users_task_claims_as_owner(
         await handle_chat_message(
             MagicMock(),
             int(task.id),
-            {"message": "follow-up", "user": admin, "files": []},
+            {
+                "message": "follow-up",
+                "client_message_id": "client-turn-1",
+                "user": admin,
+                "files": [],
+            },
         )
 
     begin_turn.assert_awaited_once()
     assert begin_turn.await_args.kwargs["task_owner_user_id"] == int(owner.id)
+    assert begin_turn.await_args.kwargs["payload"].turn_id == "client-turn-1"
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0]["client_message_id"] == "client-turn-1"
+    assert accepted[0]["turn_id"] == "client-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_running_chat_message_is_persisted_before_resume(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    resume_bg = AsyncMock()
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Use the audio tool",
+                "client_message_id": "live-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    stored = (
+        db_session.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == int(task.id),
+            TaskChatMessage.role == "user",
+        )
+        .one()
+    )
+    assert stored.content == "Use the audio tool"
+    assert stored.turn_id == "live-turn-1"
+    assert agent.post_user_message.await_args.kwargs["turn_id"] == "live-turn-1"
+    bg_mgr.register_reserved_resume.assert_called_once()
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0]["client_message_id"] == "live-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_retried_durable_message_is_accepted_without_reexecution(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Already delivered",
+            message_type="user_message",
+            turn_id="stable-turn-1",
+        )
+    )
+    db_session.commit()
+    agent_manager = MagicMock()
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+    ):
+        await handle_chat_message(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Already delivered",
+                "client_message_id": "stable-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    agent_manager.get_agent_for_task.assert_not_called()
+    stored = (
+        db_session.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == int(task.id),
+            TaskChatMessage.turn_id == "stable-turn-1",
+        )
+        .all()
+    )
+    assert len(stored) == 1
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
 
 
 @pytest.mark.asyncio
@@ -177,7 +305,7 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
     UserContext, i.e. ``task_owner_user_id`` is the owner, not the admin."""
     owner = _user(db_session, "owner")
     admin = _user(db_session, "admin", is_admin=True)
-    task = _task(db_session, owner.id)
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
     captured, agent, mgr, ws_manager = _patched_manager_and_agent()
     agent.supports_live_control = MagicMock(return_value=True)
 
@@ -197,6 +325,8 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
     assert captured["task_owner_user_id"] == int(owner.id)
     resume_bg.assert_called_once()
     assert resume_bg.call_args.kwargs["task_owner_user_id"] == int(owner.id)
+    bg_mgr.reserve_resume.assert_called_once_with(int(task.id))
+    bg_mgr.register_reserved_resume.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -236,6 +366,85 @@ async def test_execute_resume_background_rejects_owner_mismatch(db_session) -> N
         if isinstance(msg, dict)
     }
     assert "task_error" in error_types
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_background_persists_assistant_for_live_turn(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    agent = MagicMock()
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(
+                role="user",
+                metadata={"turn_id": "live-turn-1"},
+            )
+        ]
+    )
+    agent.resume_execution_by_id = AsyncMock(
+        return_value={
+            "status": "completed",
+            "success": True,
+            "output": "Guidance applied",
+            "agent_result": {"context": context},
+        }
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with patch("xagent.web.api.websocket.manager", ws_manager):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+        )
+
+    db_session.expire_all()
+    stored = (
+        db_session.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == int(task.id),
+            TaskChatMessage.role == "assistant",
+        )
+        .one()
+    )
+    assert stored.content == "Guidance applied"
+    assert stored.turn_id == "live-turn-1"
+    db_session.refresh(task)
+    assert task.status == TaskStatus.COMPLETED
+    assert task.output == "Guidance applied"
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_background_persists_missing_checkpoint_failure(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    agent = MagicMock(
+        resume_execution_by_id=AsyncMock(return_value=None),
+    )
+    ws_manager = MagicMock(broadcast_to_task=AsyncMock())
+
+    with patch("xagent.web.api.websocket.manager", ws_manager):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+        )
+
+    db_session.expire_all()
+    db_session.refresh(task)
+    assert task.status == TaskStatus.FAILED
+    assert "No resumable execution checkpoint" in str(task.error_message)
+    failures = [
+        call.args[0]
+        for call in ws_manager.broadcast_to_task.call_args_list
+        if call.args[0].get("type") == "task_error"
+    ]
+    assert len(failures) == 1
+    assert failures[0]["task"]["status"] == TaskStatus.FAILED.value
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -9,12 +9,14 @@ isolation; here we exercise the handlers end to end).
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from xagent.web.api.websocket import (
+    background_task_manager,
     execute_resume_background,
     handle_chat_message,
     handle_pause_task,
@@ -59,6 +61,12 @@ def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
     db.commit()
     db.refresh(t)
     return t
+
+
+def _register_current_resume(task_id: int) -> None:
+    current = asyncio.current_task()
+    assert current is not None
+    background_task_manager.resume_tasks[task_id] = current
 
 
 def _patched_manager_and_agent():
@@ -188,6 +196,54 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
     ]
     assert len(accepted) == 1
     assert accepted[0]["client_message_id"] == "live-turn-1"
+
+
+@pytest.mark.asyncio
+async def test_deferred_chat_message_waits_for_real_injection_before_ack(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=False)
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    resume_bg = AsyncMock()
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+    websocket = MagicMock()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", resume_bg),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_chat_message(
+            websocket,
+            int(task.id),
+            {
+                "message": "Wait for the checkpoint",
+                "client_message_id": "deferred-turn-1",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    assert not any(
+        call.args[0].get("type") == "message_accepted"
+        for call in ws_manager.send_personal_message.call_args_list
+    )
+    kwargs = resume_bg.call_args.kwargs
+    assert kwargs["delivery_already_dispatched"] is False
+    assert kwargs["delivery_websocket"] is websocket
+    assert kwargs["delivery_client_message_id"] == "deferred-turn-1"
 
 
 @pytest.mark.asyncio
@@ -490,6 +546,33 @@ async def test_resume_live_control_admin_runs_background_as_owner(db_session) ->
 
 
 @pytest.mark.asyncio
+async def test_resume_registration_failure_cancels_coordinator(db_session) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    captured, agent, mgr, ws_manager = _patched_manager_and_agent()
+    agent.supports_live_control = MagicMock(return_value=True)
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+    bg_mgr.register_reserved_resume.side_effect = RuntimeError("reservation lost")
+    bg_handle = MagicMock()
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.execute_resume_background", MagicMock()),
+        patch(
+            "xagent.web.api.websocket.asyncio.create_task",
+            return_value=bg_handle,
+        ),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+    ):
+        await handle_resume_task(MagicMock(), int(task.id), {"user": owner})
+
+    bg_handle.cancel.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_execute_resume_background_rejects_owner_mismatch(db_session) -> None:
     """``execute_resume_background`` runs the resume under
     ``UserContext(task_owner_user_id)``. If a caller passes an owner id that
@@ -510,6 +593,7 @@ async def test_execute_resume_background_rejects_owner_mismatch(db_session) -> N
         patch("xagent.web.api.websocket.stop_task_lease_heartbeat", new=AsyncMock()),
         patch("xagent.web.api.websocket.manager", ws_manager),
     ):
+        _register_current_resume(int(task.id))
         await execute_resume_background(
             task_id=int(task.id),
             agent_service=agent,
@@ -554,6 +638,7 @@ async def test_execute_resume_background_persists_assistant_for_live_turn(
     ws_manager = MagicMock(broadcast_to_task=AsyncMock())
 
     with patch("xagent.web.api.websocket.manager", ws_manager):
+        _register_current_resume(int(task.id))
         await execute_resume_background(
             task_id=int(task.id),
             agent_service=agent,
@@ -600,6 +685,7 @@ async def test_execute_resume_background_persists_missing_checkpoint_failure(
     ws_manager = MagicMock(broadcast_to_task=AsyncMock())
 
     with patch("xagent.web.api.websocket.manager", ws_manager):
+        _register_current_resume(int(task.id))
         await execute_resume_background(
             task_id=int(task.id),
             agent_service=agent,
@@ -624,6 +710,68 @@ async def test_execute_resume_background_persists_missing_checkpoint_failure(
     ]
     assert len(failures) == 1
     assert failures[0]["task"]["status"] == TaskStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_deferred_injection_failure_rejects_before_any_acceptance(
+    db_session,
+) -> None:
+    owner = _user(db_session, "owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-injection-failure",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    agent = MagicMock(
+        post_user_message=AsyncMock(return_value=False),
+        resume_execution_by_id=AsyncMock(),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-injection-failure",
+            },
+            delivery_turn_id="deferred-injection-failure",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-injection-failure",
+        )
+
+    delivery_events = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") in {"message_accepted", "message_rejected"}
+    ]
+    assert [event["type"] for event in delivery_events] == ["message_rejected"]
+    assert delivery_events[0]["retry_with_new_id"] is True
+    db_session.expire_all()
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == "deferred-injection-failure")
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -1,4 +1,9 @@
+import asyncio
+
+import pytest
+
 from xagent.web.api.websocket import (
+    BackgroundTaskManager,
     _clear_task_pause_accepted,
     _is_task_pause_accepted,
     _mark_task_pause_accepted,
@@ -42,3 +47,36 @@ def test_pause_accepted_marker_can_be_cleared() -> None:
 
     _clear_task_pause_accepted(task_id)
     assert not _is_task_pause_accepted(task_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_coordinator_does_not_replace_task_that_it_waits_for() -> None:
+    manager = BackgroundTaskManager()
+    allow_original_to_check = asyncio.Event()
+
+    async def original_runner() -> None:
+        await allow_original_to_check.wait()
+        await manager.wait_for_previous(7)
+
+    original = asyncio.create_task(original_runner())
+    manager.register_task(7, original)
+    assert manager.reserve_resume(7)
+
+    async def resume_runner() -> None:
+        await original
+        current = asyncio.current_task()
+        assert current is not None
+        manager.promote_resume_task(7, current)
+
+    resume = asyncio.create_task(resume_runner())
+    manager.register_reserved_resume(7, resume)
+
+    # The original remains the active execution until it finishes, so its
+    # wait_for_previous call sees itself instead of the resume coordinator.
+    assert manager.running_tasks[7] is original
+    assert manager.resume_tasks[7] is resume
+    assert not manager.reserve_resume(7)
+
+    allow_original_to_check.set()
+    await asyncio.wait_for(asyncio.gather(original, resume), timeout=1)
+    assert manager.running_tasks[7] is resume

--- a/tests/web/api/test_websocket_turn_routing.py
+++ b/tests/web/api/test_websocket_turn_routing.py
@@ -80,3 +80,15 @@ async def test_resume_coordinator_does_not_replace_task_that_it_waits_for() -> N
     allow_original_to_check.set()
     await asyncio.wait_for(asyncio.gather(original, resume), timeout=1)
     assert manager.running_tasks[7] is resume
+
+
+@pytest.mark.asyncio
+async def test_unregistered_resume_coordinator_cannot_promote_itself() -> None:
+    manager = BackgroundTaskManager()
+    current = asyncio.current_task()
+    assert current is not None
+
+    with pytest.raises(RuntimeError, match="not registered"):
+        manager.promote_resume_task(7, current)
+
+    assert 7 not in manager.running_tasks

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -27,6 +27,10 @@ from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
+from xagent.web.services.chat_history_service import (
+    DELIVERY_DISPATCHED,
+    DELIVERY_FAILED,
+)
 from xagent.web.services.connector_runtime import (
     get_ephemeral_runtime_values,
     pop_ephemeral_runtime_values,
@@ -165,10 +169,11 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
 ) -> None:
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+    payload = TaskTurnPayload("first turn")
 
     await TaskTurnOrchestrator.begin_turn(
         task_id=int(task.id),
-        payload=TaskTurnPayload("first turn"),
+        payload=payload,
         task_owner_user_id=int(user.id),
         kind=TurnKind.CREATE,
         force_fresh=False,
@@ -181,6 +186,12 @@ async def test_begin_turn_create_clears_no_terminal_fields_when_pending(
     assert task.error_message is None
     assert task.runner_id is None
     assert task.lease_expires_at is None
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == payload.turn_id)
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_DISPATCHED
 
 
 @pytest.mark.asyncio
@@ -463,6 +474,7 @@ async def test_begin_turn_marks_failed_when_schedule_raises(
     left RUNNING with no bg worker (zombie)."""
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
+    payload = TaskTurnPayload("x")
 
     with patch(
         "xagent.web.services.task_orchestrator._schedule_bg",
@@ -472,12 +484,18 @@ async def test_begin_turn_marks_failed_when_schedule_raises(
             await TaskTurnOrchestrator.begin_turn(
                 task_id=int(task.id),
                 task_owner_user_id=int(user.id),
-                payload=TaskTurnPayload("x"),
+                payload=payload,
                 kind=TurnKind.CREATE,
             )
 
     db_session.refresh(task)
     assert task.status == TaskStatus.FAILED
+    delivery = (
+        db_session.query(TaskChatMessage)
+        .filter(TaskChatMessage.turn_id == payload.turn_id)
+        .one()
+    )
+    assert delivery.delivery_status == DELIVERY_FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -12,12 +12,12 @@ from xagent.web.services.chat_history_service import (
     DELIVERY_FAILED,
     claim_user_message_delivery,
     get_latest_waiting_question,
+    inspect_user_message_delivery,
     load_task_transcript,
     persist_assistant_message,
     persist_assistant_message_no_commit,
     persist_user_message,
     persist_user_message_no_commit,
-    persist_user_message_once,
 )
 
 
@@ -203,33 +203,6 @@ def test_persist_user_message_stores_attachments_for_chip_replay():
         db_session.close()
 
 
-def test_persist_user_message_once_reuses_durable_turn() -> None:
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        first = persist_user_message_once(
-            db_session,
-            int(task.id),
-            int(task.user_id),
-            "Apply this guidance",
-            turn_id="client-turn-1",
-        )
-        retried = persist_user_message_once(
-            db_session,
-            int(task.id),
-            int(task.user_id),
-            "Apply this guidance",
-            turn_id="client-turn-1",
-        )
-
-        assert first is not None
-        assert retried is not None
-        assert retried.id == first.id
-        assert db_session.query(TaskChatMessage).count() == 1
-    finally:
-        db_session.close()
-
-
 def test_delivery_claim_rejects_same_turn_with_different_attachments() -> None:
     db_session = _create_db_session()
     try:
@@ -288,6 +261,47 @@ def test_database_rejects_duplicate_user_turn_claims() -> None:
         db_session.close()
 
 
+def test_delivery_claim_recovers_from_unique_constraint_race(monkeypatch) -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        winner = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Concurrent guidance",
+            turn_id="raced-turn",
+        )
+        inspection_count = 0
+
+        def hide_winner_on_initial_inspection(*args, **kwargs):
+            nonlocal inspection_count
+            inspection_count += 1
+            if inspection_count == 1:
+                return None
+            return inspect_user_message_delivery(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "xagent.web.services.chat_history_service.inspect_user_message_delivery",
+            hide_winner_on_initial_inspection,
+        )
+
+        loser = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Concurrent guidance",
+            turn_id="raced-turn",
+        )
+
+        assert loser.claimed is False
+        assert loser.message.id == winner.message.id
+        assert inspection_count == 2
+        assert db_session.query(TaskChatMessage).count() == 1
+    finally:
+        db_session.close()
+
+
 def test_delivery_claim_surfaces_failed_handoff() -> None:
     db_session = _create_db_session()
     try:
@@ -311,7 +325,6 @@ def test_delivery_claim_surfaces_failed_handoff() -> None:
         )
         assert retried.claimed is False
         assert retried.failed is True
-        assert retried.can_acknowledge is False
     finally:
         db_session.close()
 

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -10,8 +10,10 @@ from xagent.web.services.chat_history_service import (
     get_latest_waiting_question,
     load_task_transcript,
     persist_assistant_message,
+    persist_assistant_message_no_commit,
     persist_user_message,
     persist_user_message_no_commit,
+    persist_user_message_once,
 )
 
 
@@ -193,6 +195,55 @@ def test_persist_user_message_stores_attachments_for_chip_replay():
         assert row is not None
         assert row.turn_id == "turn-attachments"
         assert row.attachments == attachments
+    finally:
+        db_session.close()
+
+
+def test_persist_user_message_once_reuses_durable_turn() -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        first = persist_user_message_once(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Apply this guidance",
+            turn_id="client-turn-1",
+        )
+        retried = persist_user_message_once(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Apply this guidance",
+            turn_id="client-turn-1",
+        )
+
+        assert first is not None
+        assert retried is not None
+        assert retried.id == first.id
+        assert db_session.query(TaskChatMessage).count() == 1
+    finally:
+        db_session.close()
+
+
+def test_persist_assistant_message_no_commit_keeps_turn_id() -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        row = persist_assistant_message_no_commit(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Guidance applied",
+            message_type="final_answer",
+            turn_id="client-turn-1",
+        )
+        assert row is not None
+        assert db_session.query(TaskChatMessage).count() == 0
+
+        db_session.commit()
+        stored = db_session.query(TaskChatMessage).one()
+        assert stored.turn_id == "client-turn-1"
     finally:
         db_session.close()
 

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -1,4 +1,6 @@
+import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.transcript import build_assistant_transcript_content
@@ -7,6 +9,8 @@ from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.chat_history_service import (
+    DELIVERY_FAILED,
+    claim_user_message_delivery,
     get_latest_waiting_question,
     load_task_transcript,
     persist_assistant_message,
@@ -222,6 +226,92 @@ def test_persist_user_message_once_reuses_durable_turn() -> None:
         assert retried is not None
         assert retried.id == first.id
         assert db_session.query(TaskChatMessage).count() == 1
+    finally:
+        db_session.close()
+
+
+def test_delivery_claim_rejects_same_turn_with_different_attachments() -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        first = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Analyze this",
+            attachments=[{"file_id": "file-a", "name": "a.pdf"}],
+            turn_id="client-turn-files",
+        )
+        retried = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Analyze this",
+            attachments=[{"file_id": "file-b", "name": "b.pdf"}],
+            turn_id="client-turn-files",
+        )
+
+        assert first.claimed is True
+        assert retried.claimed is False
+        assert retried.payload_matches is False
+        assert db_session.query(TaskChatMessage).count() == 1
+    finally:
+        db_session.close()
+
+
+def test_database_rejects_duplicate_user_turn_claims() -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "First claimant",
+            turn_id="atomic-turn",
+        )
+        db_session.add(
+            TaskChatMessage(
+                task_id=int(task.id),
+                user_id=int(task.user_id),
+                role="user",
+                content="Racing claimant",
+                message_type="user_message",
+                turn_id="atomic-turn",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()
+        assert db_session.query(TaskChatMessage).count() == 1
+    finally:
+        db_session.close()
+
+
+def test_delivery_claim_surfaces_failed_handoff() -> None:
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        first = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Apply guidance",
+            turn_id="failed-turn",
+        )
+        first.message.delivery_status = DELIVERY_FAILED
+        db_session.commit()
+
+        retried = claim_user_message_delivery(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "Apply guidance",
+            turn_id="failed-turn",
+        )
+        assert retried.claimed is False
+        assert retried.failed is True
+        assert retried.can_acknowledge is False
     finally:
         db_session.close()
 


### PR DESCRIPTION
## Summary

- add end-to-end message delivery acknowledgements so the composer clears only after the backend durably accepts a turn
- persist live-control user and assistant messages with stable turn IDs and make reconnect retries idempotent
- serialize per-task agent construction and separate resume coordinators from active execution handles to prevent overwrite/deadlock cycles
- publish pause/resume UI state only after the durable task state actually changes

## Root cause

WebSocket sends were previously fire-and-forget: a closed socket silently dropped the payload while the UI optimistically rendered and cleared it. Messages injected into a running task also bypassed the durable transcript. At the same time, registering a resume coroutine replaced the active task handle before the original execution finished, which could make the two coroutines wait on each other or expose contradictory task state.

## Impact

Disconnected or rejected sends now keep the draft and attachments. Accepted messages survive reloads, retries reuse the same logical turn, and resumed assistant answers are stored in chat history. Concurrent resume guidance is explicitly rejected instead of overwriting the in-flight coordinator.

## Validation

- `pre-commit run` (Ruff, mypy, isort, codespell, npm lint, npm type-check)
- 163 focused backend tests passed across runner, registry, WebSocket routing, transcript persistence, execution scope, and task orchestration
- 30 focused frontend tests passed, including delivery ack/retry and draft retention coverage
- full frontend run: 309 tests passed; 8 unrelated existing workforce/KB tests failed outside this diff