### PR TITLE
feat: add optional quota enforcement hook seams

### DIFF
--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -584,8 +584,14 @@ class PatternRuntime:
             )
 
     async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
-        # Count one billable action per tool invocation (fires once per tool,
-        # including each tool in a concurrent batch).
+        # Count one billable action per tool invocation, at invocation time.
+        # Deliberately NOT gated on tool success: success is derived from the
+        # tool's own return value, and custom MCP tools are user-controlled, so
+        # billing on self-reported success is trivially gamed (wrap real output
+        # in {"success": false}). An invocation consumes real resources
+        # (the MCP/compute round + the LLM turn that chose it) regardless of
+        # outcome, so the non-gameable, resource-aligned signal is "it ran".
+        # Fires once per tool, including each tool in a concurrent batch.
         try:
             from ..model.chat.token_context import add_tool_call_usage
 

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -584,6 +584,14 @@ class PatternRuntime:
             )
 
     async def on_tool_start(self, *, tool_call: dict[str, Any]) -> None:
+        # Count one billable action per tool invocation (fires once per tool,
+        # including each tool in a concurrent batch).
+        try:
+            from ..model.chat.token_context import add_tool_call_usage
+
+            add_tool_call_usage(1)
+        except Exception:
+            pass
         data = {
             "tool_name": tool_call.get("name"),
             "tool_params": tool_call.get("args", {}),

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from uuid import uuid4
@@ -16,6 +17,8 @@ from ..agent.trace import (
 from ..model.chat.basic.base import BaseLLM
 from ..model.chat.types import ChunkType
 from .streaming import merge_streamed_tool_call_arguments
+
+logger = logging.getLogger(__name__)
 
 
 class LLMCallInterrupted(Exception):
@@ -597,7 +600,7 @@ class PatternRuntime:
 
             add_tool_call_usage(1)
         except Exception:
-            pass
+            logger.debug("tool-call metering failed", exc_info=True)
         data = {
             "tool_name": tool_call.get("name"),
             "tool_params": tool_call.get("args", {}),

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -27,6 +27,7 @@ class TokenUsage:
     input_tokens: int = 0
     output_tokens: int = 0
     llm_calls: int = 0
+    tool_calls: int = 0
     details: List[Dict] = field(default_factory=list)
 
     @property
@@ -68,11 +69,16 @@ class TokenUsage:
         """Increment the LLM call counter."""
         self.llm_calls += 1
 
+    def increment_tool_calls(self, count: int = 1) -> None:
+        """Increment the tool-call counter (one per tool invocation)."""
+        self.tool_calls += count
+
     def merge(self, other: "TokenUsage") -> None:
         """Merge another TokenUsage into this one."""
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
         self.llm_calls += other.llm_calls
+        self.tool_calls += other.tool_calls
         self.details.extend(other.details)
 
     def to_dict(self) -> Dict:
@@ -82,6 +88,7 @@ class TokenUsage:
             "output_tokens": self.output_tokens,
             "total_tokens": self.total_tokens,
             "llm_calls": self.llm_calls,
+            "tool_calls": self.tool_calls,
             "details": self.details,
         }
 
@@ -92,6 +99,7 @@ class TokenUsage:
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             llm_calls=data.get("llm_calls", 0),
+            tool_calls=data.get("tool_calls", 0),
             details=data.get("details", []),
         )
 
@@ -192,6 +200,11 @@ def add_token_usage(
         f"total_input={usage.input_tokens}, total_output={usage.output_tokens}, "
         f"total_calls={usage.llm_calls}"
     )
+
+
+def add_tool_call_usage(count: int = 1) -> None:
+    """Record one (or more) tool invocations on the current context."""
+    token_context.get().increment_tool_calls(count)
 
 
 def reset_token_usage() -> TokenUsage:

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -179,6 +179,16 @@ def get_token_usage() -> TokenUsage:
     return usage
 
 
+def _coerce_int(value: Any) -> int:
+    """Best-effort int; 0 if the value isn't a usable number (e.g. None/mock)."""
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def add_token_usage(
     input_tokens: int = 0,
     output_tokens: int = 0,
@@ -193,6 +203,11 @@ def add_token_usage(
         model: Model name for tracking
         call_type: Type of call (chat, stream_chat, vision_chat, etc.)
     """
+    # Coerce defensively: a provider/response that yields a non-int token count
+    # (or a mock in tests) must never crash the LLM call over accounting.
+    input_tokens = _coerce_int(input_tokens)
+    output_tokens = _coerce_int(output_tokens)
+
     usage = get_token_usage()
     if input_tokens or output_tokens:
         # Increment LLM call counter for each API call

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -186,6 +186,11 @@ def _coerce_int(value: Any) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
+        # None/absent is expected (provider omitted the field) — stay quiet.
+        # A present-but-malformed value signals a provider-adapter bug worth
+        # surfacing rather than silently billing it as zero.
+        if value is not None:
+            logger.warning("Discarding non-numeric token count: %r", value)
         return 0
 
 

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -142,12 +142,13 @@ class TokenContextManager:
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Exit the context and restore previous state."""
-        if self._previous_token is not None:
-            token_context.set(self._previous_token)
-        else:
-            # Clear the context
-            token_context.set(TokenUsage())
+        """Exit the context and restore the previous state.
+
+        Restores whatever was there before (``None`` when nothing was set), so
+        leaving a manager block doesn't reintroduce a lingering shared
+        TokenUsage instance — matching the None default on the ContextVar.
+        """
+        token_context.set(self._previous_token)
 
     def get_usage(self) -> TokenUsage:
         """Get the current token usage."""

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -104,9 +104,12 @@ class TokenUsage:
         )
 
 
-# ContextVar for thread-local token tracking
-token_context: contextvars.ContextVar[TokenUsage] = contextvars.ContextVar(
-    "token_context", default=TokenUsage()
+# ContextVar for thread-local token tracking. Default is None (not a shared
+# TokenUsage instance): a single shared default would accumulate forever for
+# untracked paths (preview/builder that never call set_token_usage), leaking
+# memory. get_token_usage() lazily creates a per-context instance instead.
+token_context: contextvars.ContextVar[Optional[TokenUsage]] = contextvars.ContextVar(
+    "token_context", default=None
 )
 
 
@@ -167,8 +170,12 @@ class TokenContextManager:
 
 
 def get_token_usage() -> TokenUsage:
-    """Get the current token usage from context."""
-    return token_context.get()
+    """Get the current token usage, lazily creating a per-context instance."""
+    usage = token_context.get()
+    if usage is None:
+        usage = TokenUsage()
+        token_context.set(usage)
+    return usage
 
 
 def add_token_usage(
@@ -185,7 +192,7 @@ def add_token_usage(
         model: Model name for tracking
         call_type: Type of call (chat, stream_chat, vision_chat, etc.)
     """
-    usage = token_context.get()
+    usage = get_token_usage()
     if input_tokens or output_tokens:
         # Increment LLM call counter for each API call
         usage.increment_llm_calls()
@@ -204,7 +211,7 @@ def add_token_usage(
 
 def add_tool_call_usage(count: int = 1) -> None:
     """Record one (or more) tool invocations on the current context."""
-    token_context.get().increment_tool_calls(count)
+    get_token_usage().increment_tool_calls(count)
 
 
 def reset_token_usage() -> TokenUsage:
@@ -221,6 +228,6 @@ def set_token_usage(usage: TokenUsage) -> TokenUsage:
 
 def get_and_reset_token_usage() -> TokenUsage:
     """Get current usage and reset the context."""
-    usage = token_context.get()
+    usage = get_token_usage()
     reset_token_usage()
     return usage

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2123,6 +2123,29 @@ class AgentServiceManager:
         lease_heartbeat_task = None
         result: Dict[str, Any] | None = None
         sandbox_task_key = None
+
+        # Quota gate: refuse to start a run when the team is out of monthly
+        # quota. Fails open if the check itself errors, so quota infra problems
+        # never block execution.
+        if db_session and tracker_task_id:
+            try:
+                from ..services.quota_hooks import check_run_gate
+
+                gate_task = (
+                    db_session.query(Task).filter(Task.id == int(tracker_task_id)).first()
+                )
+                gate_reason = check_run_gate(
+                    db_session, getattr(gate_task, "user_id", None)
+                )
+                if gate_reason:
+                    return {
+                        "success": False,
+                        "status": "quota_exceeded",
+                        "error": gate_reason,
+                    }
+            except Exception:
+                logger.debug("Quota gate check failed open", exc_info=True)
+
         if manage_task_lease and db_session and tracker_task_id:
             lease = acquire_task_lease(db_session, int(tracker_task_id))
             if lease is None:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2123,6 +2123,8 @@ class AgentServiceManager:
         lease_heartbeat_task = None
         result: Dict[str, Any] | None = None
         sandbox_task_key = None
+        # Reused below for the workforce-status sync so we don't re-query the row.
+        gate_task = None
 
         # Quota gate: refuse to start a run when the team is out of monthly
         # quota. Fails open if the check itself errors, so quota infra problems
@@ -2165,11 +2167,15 @@ class AgentServiceManager:
 
         if db_session and tracker_task_id:
             try:
-                task_for_sync = (
-                    db_session.query(Task)
-                    .filter(Task.id == int(tracker_task_id))
-                    .first()
-                )
+                # Reuse the row already fetched for the quota gate; only re-query
+                # if the gate path didn't run or errored before assigning it.
+                task_for_sync = gate_task
+                if task_for_sync is None:
+                    task_for_sync = (
+                        db_session.query(Task)
+                        .filter(Task.id == int(tracker_task_id))
+                        .first()
+                    )
                 if task_for_sync is not None and sync_workforce_run_status(
                     db_session, task_for_sync, TaskStatus.RUNNING
                 ):

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2138,13 +2138,17 @@ class AgentServiceManager:
                     db_session, getattr(gate_task, "user_id", None)
                 )
                 if gate_reason:
+                    # `output` is what every result consumer surfaces as the
+                    # assistant message; set it so the quota reason reaches the
+                    # user instead of a misleading "Task completed".
                     return {
                         "success": False,
                         "status": "quota_exceeded",
+                        "output": gate_reason,
                         "error": gate_reason,
                     }
             except Exception:
-                logger.debug("Quota gate check failed open", exc_info=True)
+                logger.warning("Quota gate check failed open", exc_info=True)
 
         if manage_task_lease and db_session and tracker_task_id:
             lease = acquire_task_lease(db_session, int(tracker_task_id))

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1405,8 +1405,7 @@ class AgentServiceManager:
             and self._agent_owner_ids.get(task_id) != runtime_user_id
         ):
             logger.warning(
-                "Evicting cached AgentService for task %s: built for owner %s, "
-                "requested %s",
+                "Evicting cached AgentService for task %s: built for owner %s, requested %s",
                 task_id,
                 self._agent_owner_ids.get(task_id),
                 runtime_user_id,
@@ -1638,8 +1637,7 @@ class AgentServiceManager:
 
                     if snapshot.agent is not None:
                         logger.info(
-                            f"Task {task_id} using Agent Builder config: "
-                            f"{snapshot.agent.name}"
+                            f"Task {task_id} using Agent Builder config: {snapshot.agent.name}"
                         )
                         if agent_config is not None:
                             logger.info(
@@ -2021,8 +2019,7 @@ class AgentServiceManager:
         agent = self._agents.get(task_id)
         if agent is None:
             logger.debug(
-                "Skipping connector runtime turn sync for task %s turn %s: "
-                "agent is not cached",
+                "Skipping connector runtime turn sync for task %s turn %s: agent is not cached",
                 task_id,
                 connector_runtime_turn_id,
             )
@@ -2134,8 +2131,16 @@ class AgentServiceManager:
                 from ..services.quota_hooks import check_run_gate
 
                 gate_task = (
-                    db_session.query(Task).filter(Task.id == int(tracker_task_id)).first()
+                    db_session.query(Task)
+                    .filter(Task.id == int(tracker_task_id))
+                    .first()
                 )
+                if gate_task is None:
+                    # Fail open (a delete-race can legitimately leave no row),
+                    # but surface it rather than silently allowing the run.
+                    logger.warning(
+                        "Quota gate: task %s not found; allowing run", tracker_task_id
+                    )
                 gate_reason = check_run_gate(
                     db_session, getattr(gate_task, "user_id", None)
                 )
@@ -2464,13 +2469,11 @@ class AgentServiceManager:
                         )
                     else:
                         raise ValueError(
-                            f"Task {task_id} not found in database during "
-                            "agent reconstruction"
+                            f"Task {task_id} not found in database during agent reconstruction"
                         )
                 except Exception as e:
                     logger.error(
-                        f"Failed to rebuild runtime configuration for task "
-                        f"{task_id}: {e}"
+                        f"Failed to rebuild runtime configuration for task {task_id}: {e}"
                     )
                     raise
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3654,6 +3654,23 @@ async def set_collection_rerank_model(
     )
 
 
+def _enforce_storage_gate(db: Session, user: Any) -> None:
+    """Refuse ingest when the team is at its KB storage limit (fails open).
+
+    Shared by every direct-ingestion endpoint so none silently bypasses the
+    storage quota. Coarse: allows one file to push slightly over, to avoid
+    cleaning up an already-written file.
+    """
+    try:
+        from ..services.quota_hooks import check_storage_gate
+
+        reason = check_storage_gate(db, getattr(user, "id", None))
+    except Exception:
+        reason = None
+    if reason:
+        raise HTTPException(status_code=402, detail=reason)
+
+
 @kb_router.post(
     "/ingest",
     response_model=IngestionResult,
@@ -3776,17 +3793,7 @@ async def ingest(
     except ValueError:
         collection_existed_before = False
 
-    # Storage quota gate: block ingest when the team is already at its KB
-    # storage limit. Coarse (allows one file to push slightly over) to avoid
-    # cleaning up an already-written file; fails open on check errors.
-    try:
-        from ..services.quota_hooks import check_storage_gate
-
-        storage_reason = check_storage_gate(db, getattr(_user, "id", None))
-    except Exception:
-        storage_reason = None
-    if storage_reason:
-        raise HTTPException(status_code=402, detail=storage_reason)
+    _enforce_storage_gate(db, _user)
 
     existing_file_record = (
         db.query(UploadedFile)
@@ -4284,6 +4291,8 @@ async def ingest_cloud(
     _user: User = Depends(get_current_user),
 ) -> List[IngestionResult]:
     """Ingest files from cloud storage."""
+    _enforce_storage_gate(db, _user)
+
     try:
         safe_collection = sanitize_path_component(request.collection, "collection")
     except ValueError as e:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1217,8 +1217,7 @@ async def _rollback_failed_ingestion(
                     physical_cleanup.error or "unknown physical cleanup failure"
                 )
                 raise RuntimeError(
-                    "delete collection physical directory during rollback failed: "
-                    f"{error_detail}"
+                    f"delete collection physical directory during rollback failed: {error_detail}"
                 )
             remaining_records = vector_store.list_document_records(
                 collection_name=None,
@@ -1449,10 +1448,7 @@ async def _rollback_failed_cloud_ingestion(
             file_path.name,
             exc,
         )
-        message = (
-            "Failed to fully roll back cloud ingest for "
-            f"{collection_name}/{file_path.name}: {exc}"
-        )
+        message = f"Failed to fully roll back cloud ingest for {collection_name}/{file_path.name}: {exc}"
         original_error_message = _build_user_actionable_ingestion_message(
             result.message,
             embedding_model_id=embedding_model_id,
@@ -1905,8 +1901,7 @@ def _snapshot_rag_documents_for_uploaded_file(
         return _RagDocumentSnapshot(doc_refs=doc_refs, rows_by_table=rows_by_table)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "Failed to snapshot RAG document rows before web file refresh: "
-            "file_id=%s, error=%s",
+            "Failed to snapshot RAG document rows before web file refresh: file_id=%s, error=%s",
             file_id,
             exc,
             exc_info=True,
@@ -2179,8 +2174,7 @@ def _snapshot_ingestion_runs_for_uploaded_file(
             _safe_close_table(ingestion_runs_table)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "Failed to snapshot ingestion runs before web file refresh: "
-            "file_id=%s, error=%s",
+            "Failed to snapshot ingestion runs before web file refresh: file_id=%s, error=%s",
             file_id,
             exc,
             exc_info=True,
@@ -2500,8 +2494,7 @@ def _create_new_web_file_handler_result(
                 if rollback_error is None:
                     rollback_error = exc
                 logger.warning(
-                    "Failed to clean RAG rows during new web file rollback: "
-                    "file_id=%s, error=%s",
+                    "Failed to clean RAG rows during new web file rollback: file_id=%s, error=%s",
                     file_record_id,
                     exc,
                     exc_info=True,
@@ -2512,8 +2505,7 @@ def _create_new_web_file_handler_result(
                 if rollback_error is None:
                     rollback_error = exc
                 logger.warning(
-                    "Failed to clean file during new web file rollback: "
-                    "file_id=%s, error=%s",
+                    "Failed to clean file during new web file rollback: file_id=%s, error=%s",
                     file_record_id,
                     exc,
                     exc_info=True,
@@ -2763,8 +2755,7 @@ def _refresh_existing_file_if_changed(
             if rollback_error is None:
                 rollback_error = exc
             logger.warning(
-                "Failed to restore RAG rows during web file refresh rollback: "
-                "file_id=%s, error=%s",
+                "Failed to restore RAG rows during web file refresh rollback: file_id=%s, error=%s",
                 file_record_id,
                 exc,
                 exc_info=True,
@@ -2776,8 +2767,7 @@ def _refresh_existing_file_if_changed(
             if rollback_error is None:
                 rollback_error = exc
             logger.warning(
-                "Failed to restore file during web file refresh rollback: "
-                "file_id=%s, error=%s",
+                "Failed to restore file during web file refresh rollback: file_id=%s, error=%s",
                 file_record_id,
                 exc,
                 exc_info=True,
@@ -3013,8 +3003,7 @@ def _recreate_missing_existing_file(
             if rollback_error is None:
                 rollback_error = exc
             logger.warning(
-                "Failed to restore file during recreated web file rollback: "
-                "file_id=%s, error=%s",
+                "Failed to restore file during recreated web file rollback: file_id=%s, error=%s",
                 file_record_id,
                 exc,
                 exc_info=True,
@@ -7415,8 +7404,7 @@ async def rename_collection_api(
             )
             if rollback.status != "success":
                 logger.error(
-                    "Failed to roll back physical collection rename for user_%s "
-                    "%s -> %s: %s",
+                    "Failed to roll back physical collection rename for user_%s %s -> %s: %s",
                     rollback_owner_id,
                     safe_new_collection,
                     safe_old_collection,
@@ -7511,10 +7499,7 @@ async def rename_collection_api(
             rename_info_messages.append(rename_info)
         elif physical_rename_status == "failed" and physical_rename_error:
             has_physical_rename_issue = True
-            rename_info = (
-                f"Physical directory rename for user_{owner_id}: Failed - "
-                f"{physical_rename_error}"
-            )
+            rename_info = f"Physical directory rename for user_{owner_id}: Failed - {physical_rename_error}"
             warnings.append(rename_info)
             rename_info_messages.append(rename_info)
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3776,6 +3776,18 @@ async def ingest(
     except ValueError:
         collection_existed_before = False
 
+    # Storage quota gate: block ingest when the team is already at its KB
+    # storage limit. Coarse (allows one file to push slightly over) to avoid
+    # cleaning up an already-written file; fails open on check errors.
+    try:
+        from ..services.quota_hooks import check_storage_gate
+
+        storage_reason = check_storage_gate(db, getattr(_user, "id", None))
+    except Exception:
+        storage_reason = None
+    if storage_reason:
+        raise HTTPException(status_code=402, detail=storage_reason)
+
     existing_file_record = (
         db.query(UploadedFile)
         .filter(UploadedFile.storage_path == str(file_path))

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -1,0 +1,53 @@
+"""Quota enforcement hook seams.
+
+Core stays quota-agnostic. An application layer (e.g. xagent-cloud) registers
+callbacks via the setters below; core calls the getters at run start, run
+completion and KB ingest. When no hook is registered every gate is open and
+recording is a no-op, so stock xagent is unaffected.
+
+Follows the same setter/getter idiom as set_user_tool_overrides_hook etc.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# (db, user_id) -> reason str if the team is out of quota (block the run), else None
+_run_gate_hook: Callable[[Any, Any], str | None] | None = None
+# (db, user_id, delta_tokens, delta_llm_calls) -> None; best-effort post-run metering
+_usage_record_hook: Callable[[Any, Any, int, int], None] | None = None
+# (db, user_id) -> reason str if the team is out of storage quota, else None
+_storage_gate_hook: Callable[[Any, Any], str | None] | None = None
+
+
+def set_run_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
+    global _run_gate_hook
+    _run_gate_hook = hook
+
+
+def set_usage_record_hook(hook: Callable[[Any, Any, int, int], None] | None) -> None:
+    global _usage_record_hook
+    _usage_record_hook = hook
+
+
+def set_storage_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
+    global _storage_gate_hook
+    _storage_gate_hook = hook
+
+
+def check_run_gate(db: Any, user_id: Any) -> str | None:
+    if _run_gate_hook is None or user_id is None:
+        return None
+    return _run_gate_hook(db, user_id)
+
+
+def record_usage(db: Any, user_id: Any, delta_tokens: int, delta_llm_calls: int) -> None:
+    if _usage_record_hook is None or user_id is None:
+        return
+    _usage_record_hook(db, user_id, delta_tokens, delta_llm_calls)
+
+
+def check_storage_gate(db: Any, user_id: Any) -> str | None:
+    if _storage_gate_hook is None or user_id is None:
+        return None
+    return _storage_gate_hook(db, user_id)

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -61,7 +61,9 @@ def check_run_gate(db: Any, user_id: Any) -> str | None:
     return _run_gate_hook(db, user_id)
 
 
-def record_usage(db: Any, user_id: Any, delta_details: list, delta_actions: int) -> None:
+def record_usage(
+    db: Any, user_id: Any, delta_details: list, delta_actions: int
+) -> None:
     if _usage_record_hook is None or user_id is None:
         return
     _usage_record_hook(db, user_id, delta_details, delta_actions)

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -18,6 +18,15 @@ _run_gate_hook: Callable[[Any, Any], str | None] | None = None
 # metering. delta_details is this turn's per-model token breakdown (list of
 # {"type","tokens","model"}) for cost-based credits; delta_actions counts tool
 # calls (one billable action per tool invocation).
+#
+# TRANSACTION CONTRACT: the hook is invoked from TaskTracker.complete_tracking
+# BEFORE that method commits the token-usage row on the SAME `db` session, and
+# a later commit failure there rolls the session back. The hook therefore MUST
+# manage its own durability — either persist through an independent
+# session/transaction, or accumulate in a store that doesn't depend on this
+# session's commit. It must NOT leave writes pending on `db` expecting the
+# caller to commit them (they may be rolled back), and must NOT commit `db`
+# itself (that would prematurely persist the caller's unrelated pending state).
 _usage_record_hook: Callable[[Any, Any, list, int], None] | None = None
 # (db, user_id) -> reason str if the team is out of storage quota, else None
 _storage_gate_hook: Callable[[Any, Any], str | None] | None = None

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -50,10 +50,10 @@ def check_run_gate(db: Any, user_id: Any) -> str | None:
     return _run_gate_hook(db, user_id)
 
 
-def record_usage(db: Any, user_id: Any, delta_tokens: int, delta_llm_calls: int) -> None:
+def record_usage(db: Any, user_id: Any, delta_tokens: int, delta_actions: int) -> None:
     if _usage_record_hook is None or user_id is None:
         return
-    _usage_record_hook(db, user_id, delta_tokens, delta_llm_calls)
+    _usage_record_hook(db, user_id, delta_tokens, delta_actions)
 
 
 def check_storage_gate(db: Any, user_id: Any) -> str | None:

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -14,9 +14,11 @@ from typing import Any, Callable
 
 # (db, user_id) -> reason str if the team is out of quota (block the run), else None
 _run_gate_hook: Callable[[Any, Any], str | None] | None = None
-# (db, user_id, delta_tokens, delta_actions) -> None; best-effort post-run metering.
-# delta_actions counts tool calls (one billable action per tool invocation).
-_usage_record_hook: Callable[[Any, Any, int, int], None] | None = None
+# (db, user_id, delta_details, delta_actions) -> None; best-effort post-run
+# metering. delta_details is this turn's per-model token breakdown (list of
+# {"type","tokens","model"}) for cost-based credits; delta_actions counts tool
+# calls (one billable action per tool invocation).
+_usage_record_hook: Callable[[Any, Any, list, int], None] | None = None
 # (db, user_id) -> reason str if the team is out of storage quota, else None
 _storage_gate_hook: Callable[[Any, Any], str | None] | None = None
 # (user_id) -> None; +1 billable action when a run is fired by a trigger
@@ -29,7 +31,7 @@ def set_run_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
     _run_gate_hook = hook
 
 
-def set_usage_record_hook(hook: Callable[[Any, Any, int, int], None] | None) -> None:
+def set_usage_record_hook(hook: Callable[[Any, Any, list, int], None] | None) -> None:
     global _usage_record_hook
     _usage_record_hook = hook
 
@@ -50,10 +52,10 @@ def check_run_gate(db: Any, user_id: Any) -> str | None:
     return _run_gate_hook(db, user_id)
 
 
-def record_usage(db: Any, user_id: Any, delta_tokens: int, delta_actions: int) -> None:
+def record_usage(db: Any, user_id: Any, delta_details: list, delta_actions: int) -> None:
     if _usage_record_hook is None or user_id is None:
         return
-    _usage_record_hook(db, user_id, delta_tokens, delta_actions)
+    _usage_record_hook(db, user_id, delta_details, delta_actions)
 
 
 def check_storage_gate(db: Any, user_id: Any) -> str | None:

--- a/src/xagent/web/services/quota_hooks.py
+++ b/src/xagent/web/services/quota_hooks.py
@@ -14,10 +14,14 @@ from typing import Any, Callable
 
 # (db, user_id) -> reason str if the team is out of quota (block the run), else None
 _run_gate_hook: Callable[[Any, Any], str | None] | None = None
-# (db, user_id, delta_tokens, delta_llm_calls) -> None; best-effort post-run metering
+# (db, user_id, delta_tokens, delta_actions) -> None; best-effort post-run metering.
+# delta_actions counts tool calls (one billable action per tool invocation).
 _usage_record_hook: Callable[[Any, Any, int, int], None] | None = None
 # (db, user_id) -> reason str if the team is out of storage quota, else None
 _storage_gate_hook: Callable[[Any, Any], str | None] | None = None
+# (user_id) -> None; +1 billable action when a run is fired by a trigger
+# (webhook / scheduled / API). Opens its own session on the application side.
+_trigger_record_hook: Callable[[Any], None] | None = None
 
 
 def set_run_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
@@ -33,6 +37,11 @@ def set_usage_record_hook(hook: Callable[[Any, Any, int, int], None] | None) -> 
 def set_storage_gate_hook(hook: Callable[[Any, Any], str | None] | None) -> None:
     global _storage_gate_hook
     _storage_gate_hook = hook
+
+
+def set_trigger_record_hook(hook: Callable[[Any], None] | None) -> None:
+    global _trigger_record_hook
+    _trigger_record_hook = hook
 
 
 def check_run_gate(db: Any, user_id: Any) -> str | None:
@@ -51,3 +60,9 @@ def check_storage_gate(db: Any, user_id: Any) -> str | None:
     if _storage_gate_hook is None or user_id is None:
         return None
     return _storage_gate_hook(db, user_id)
+
+
+def record_trigger(user_id: Any) -> None:
+    if _trigger_record_hook is None or user_id is None:
+        return
+    _trigger_record_hook(user_id)

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -1093,6 +1093,15 @@ async def _start_prepared_trigger_run_id(
 
     await asyncio.to_thread(_mark_trigger_run_started, start)
 
+    # Count one billable action for the trigger firing itself (webhook /
+    # scheduled). Best-effort; never let metering break a trigger run.
+    try:
+        from .quota_hooks import record_trigger
+
+        record_trigger(start.task_owner_user_id)
+    except Exception:
+        logger.debug("Trigger quota record failed", exc_info=True)
+
     if wait_for_completion and asyncio.isfuture(started.background_task):
         await started.background_task
         await asyncio.to_thread(_finish_trigger_run_after_task, start)

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -60,6 +60,9 @@ class TaskTracker:
         self._is_tracking = False
         self._update_task: Optional[asyncio.Task] = None
         self._last_reported_usage: Optional[TokenUsage] = None
+        # Per-turn baselines captured in start_tracking; used to meter deltas.
+        self._initial_total_tokens = 0
+        self._initial_tool_calls = 0
 
         # Load the task model
         from ..models.task import Task as TaskModel
@@ -274,6 +277,23 @@ class TaskTracker:
         logger.info(f"Force updating token usage for task {self.task_id}")
         usage = get_token_usage()
 
+        # Meter quota FIRST — on the still-clean session, from in-memory
+        # counters — so a transient commit failure below cannot zero-bill a
+        # token/tool-heavy turn. actions = tool calls; credits derive from tokens.
+        try:
+            from ..services.quota_hooks import record_usage
+
+            delta_tokens = max(0, usage.total_tokens - self._initial_total_tokens)
+            delta_actions = max(0, usage.tool_calls - self._initial_tool_calls)
+            record_usage(
+                self.db_session,
+                getattr(self.task, "user_id", None),
+                delta_tokens,
+                delta_actions,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Quota usage recording failed for task {self.task_id}: {e}")
+
         # Update database with final statistics
         self.task.input_tokens = usage.input_tokens
         self.task.output_tokens = usage.output_tokens
@@ -310,22 +330,6 @@ class TaskTracker:
             f"input={usage.input_tokens}, output={usage.output_tokens}, "
             f"total={usage.total_tokens}, calls={usage.llm_calls}"
         )
-
-        # Best-effort quota metering: record only this turn's delta. actions are
-        # tool calls (one per tool invocation); credits derive from tokens.
-        try:
-            from ..services.quota_hooks import record_usage
-
-            delta_tokens = max(0, usage.total_tokens - getattr(self, "_initial_total_tokens", 0))
-            delta_actions = max(0, usage.tool_calls - getattr(self, "_initial_tool_calls", 0))
-            record_usage(
-                self.db_session,
-                getattr(self.task, "user_id", None),
-                delta_tokens,
-                delta_actions,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"Quota usage recording failed for task {self.task_id}: {e}")
 
         return usage
 

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -105,8 +105,9 @@ class TaskTracker:
 
         # Snapshot the seeded totals so complete_tracking can meter only this
         # turn's delta (start_tracking seeds from prior turns for multi-turn tasks).
+        # tool_calls is not persisted to the task, so it counts per turn from 0.
         self._initial_total_tokens = initial_usage.total_tokens
-        self._initial_llm_calls = initial_usage.llm_calls
+        self._initial_tool_calls = initial_usage.tool_calls
 
         logger.info(f"Started token tracking for task {self.task_id}")
 
@@ -310,13 +311,19 @@ class TaskTracker:
             f"total={usage.total_tokens}, calls={usage.llm_calls}"
         )
 
-        # Best-effort quota metering: record only this turn's delta.
+        # Best-effort quota metering: record only this turn's delta. actions are
+        # tool calls (one per tool invocation); credits derive from tokens.
         try:
             from ..services.quota_hooks import record_usage
 
             delta_tokens = max(0, usage.total_tokens - getattr(self, "_initial_total_tokens", 0))
-            delta_calls = max(0, usage.llm_calls - getattr(self, "_initial_llm_calls", 0))
-            record_usage(self.db_session, getattr(self.task, "user_id", None), delta_tokens, delta_calls)
+            delta_actions = max(0, usage.tool_calls - getattr(self, "_initial_tool_calls", 0))
+            record_usage(
+                self.db_session,
+                getattr(self.task, "user_id", None),
+                delta_tokens,
+                delta_actions,
+            )
         except Exception as e:  # noqa: BLE001
             logger.warning(f"Quota usage recording failed for task {self.task_id}: {e}")
 

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -61,7 +61,7 @@ class TaskTracker:
         self._update_task: Optional[asyncio.Task] = None
         self._last_reported_usage: Optional[TokenUsage] = None
         # Per-turn baselines captured in start_tracking; used to meter deltas.
-        self._initial_total_tokens = 0
+        self._initial_details_len = 0
         self._initial_tool_calls = 0
 
         # Load the task model
@@ -106,10 +106,11 @@ class TaskTracker:
         )
         set_token_usage(initial_usage)
 
-        # Snapshot the seeded totals so complete_tracking can meter only this
-        # turn's delta (start_tracking seeds from prior turns for multi-turn tasks).
-        # tool_calls is not persisted to the task, so it counts per turn from 0.
-        self._initial_total_tokens = initial_usage.total_tokens
+        # Snapshot the seeded baselines so complete_tracking can meter only this
+        # turn's delta (start_tracking seeds from prior turns for multi-turn
+        # tasks). The new per-model detail entries appended during this turn are
+        # everything past _initial_details_len.
+        self._initial_details_len = len(initial_usage.details)
         self._initial_tool_calls = initial_usage.tool_calls
 
         logger.info(f"Started token tracking for task {self.task_id}")
@@ -283,12 +284,12 @@ class TaskTracker:
         try:
             from ..services.quota_hooks import record_usage
 
-            delta_tokens = max(0, usage.total_tokens - self._initial_total_tokens)
+            delta_details = usage.details[self._initial_details_len :]
             delta_actions = max(0, usage.tool_calls - self._initial_tool_calls)
             record_usage(
                 self.db_session,
                 getattr(self.task, "user_id", None),
-                delta_tokens,
+                delta_details,
                 delta_actions,
             )
         except Exception as e:  # noqa: BLE001

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -103,6 +103,11 @@ class TaskTracker:
         )
         set_token_usage(initial_usage)
 
+        # Snapshot the seeded totals so complete_tracking can meter only this
+        # turn's delta (start_tracking seeds from prior turns for multi-turn tasks).
+        self._initial_total_tokens = initial_usage.total_tokens
+        self._initial_llm_calls = initial_usage.llm_calls
+
         logger.info(f"Started token tracking for task {self.task_id}")
 
         # Automatically start periodic updates (this will set _is_tracking)
@@ -304,6 +309,16 @@ class TaskTracker:
             f"input={usage.input_tokens}, output={usage.output_tokens}, "
             f"total={usage.total_tokens}, calls={usage.llm_calls}"
         )
+
+        # Best-effort quota metering: record only this turn's delta.
+        try:
+            from ..services.quota_hooks import record_usage
+
+            delta_tokens = max(0, usage.total_tokens - getattr(self, "_initial_total_tokens", 0))
+            delta_calls = max(0, usage.llm_calls - getattr(self, "_initial_llm_calls", 0))
+            record_usage(self.db_session, getattr(self.task, "user_id", None), delta_tokens, delta_calls)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Quota usage recording failed for task {self.task_id}: {e}")
 
         return usage
 

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -640,8 +640,13 @@ async def test_on_llm_start_emits_context_usage_fields() -> None:
 
 
 @pytest.mark.asyncio
-async def test_on_tool_start_counts_one_action_per_tool() -> None:
-    """Each tool invocation increments the token-context tool_calls counter."""
+async def test_tool_invocation_counts_one_action_each() -> None:
+    """Each tool invocation increments tool_calls at start time.
+
+    Billing on invocation (not self-reported success) is intentional: success
+    comes from the tool's own return value, and user-controlled MCP tools could
+    otherwise dodge billing by wrapping real output in {"success": false}.
+    """
     from xagent.core.model.chat.token_context import (
         TokenUsage,
         get_token_usage,
@@ -653,5 +658,10 @@ async def test_on_tool_start_counts_one_action_per_tool() -> None:
 
     await runtime.on_tool_start(tool_call={"name": "calc", "args": {}, "id": "t1"})
     await runtime.on_tool_start(tool_call={"name": "search", "args": {}, "id": "t2"})
+    assert get_token_usage().tool_calls == 2
 
+    # Even a tool that will report failure was still invoked → billed.
+    await runtime.on_tool_end(
+        tool_call={"name": "search", "id": "t2"}, result={"success": False, "error": "boom"}
+    )
     assert get_token_usage().tool_calls == 2

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -662,7 +662,8 @@ async def test_tool_invocation_counts_one_action_each() -> None:
 
     # Even a tool that will report failure was still invoked → billed.
     await runtime.on_tool_end(
-        tool_call={"name": "search", "id": "t2"}, result={"success": False, "error": "boom"}
+        tool_call={"name": "search", "id": "t2"},
+        result={"success": False, "error": "boom"},
     )
     assert get_token_usage().tool_calls == 2
 
@@ -685,7 +686,9 @@ async def test_concurrent_tool_calls_all_count() -> None:
 
     await asyncio.gather(
         *[
-            runtime.on_tool_start(tool_call={"name": f"t{i}", "args": {}, "id": f"t{i}"})
+            runtime.on_tool_start(
+                tool_call={"name": f"t{i}", "args": {}, "id": f"t{i}"}
+            )
             for i in range(8)
         ]
     )

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -637,3 +637,21 @@ async def test_on_llm_start_emits_context_usage_fields() -> None:
     assert usage[0]["context_threshold"] == 96000
     assert isinstance(usage[0]["context_tokens"], int)
     assert usage[0]["context_tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_on_tool_start_counts_one_action_per_tool() -> None:
+    """Each tool invocation increments the token-context tool_calls counter."""
+    from xagent.core.model.chat.token_context import (
+        TokenUsage,
+        get_token_usage,
+        set_token_usage,
+    )
+
+    set_token_usage(TokenUsage())
+    runtime = PatternRuntime(execution_id="task-actions")
+
+    await runtime.on_tool_start(tool_call={"name": "calc", "args": {}, "id": "t1"})
+    await runtime.on_tool_start(tool_call={"name": "search", "args": {}, "id": "t2"})
+
+    assert get_token_usage().tool_calls == 2

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -665,3 +665,29 @@ async def test_tool_invocation_counts_one_action_each() -> None:
         tool_call={"name": "search", "id": "t2"}, result={"success": False, "error": "boom"}
     )
     assert get_token_usage().tool_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_calls_all_count() -> None:
+    """A concurrent batch (asyncio.gather) increments the shared counter once per tool.
+
+    Covers the PR's claim that counting is safe when react runs tools
+    concurrently via _run_concurrent_batch.
+    """
+    from xagent.core.model.chat.token_context import (
+        TokenUsage,
+        get_token_usage,
+        set_token_usage,
+    )
+
+    set_token_usage(TokenUsage())
+    runtime = PatternRuntime(execution_id="task-batch")
+
+    await asyncio.gather(
+        *[
+            runtime.on_tool_start(tool_call={"name": f"t{i}", "args": {}, "id": f"t{i}"})
+            for i in range(8)
+        ]
+    )
+
+    assert get_token_usage().tool_calls == 8

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -48,6 +48,50 @@ class TestTaskTracker:
         assert not tracker.is_tracking
 
     @pytest.mark.asyncio
+    async def test_complete_tracking_reports_only_current_turn_delta(self, db_session):
+        """The usage-record hook must receive only this turn's delta, not the
+        re-seeded prior-turn baseline (multi-turn tasks seed from the DB)."""
+        from xagent.core.model.chat.token_context import add_tool_call_usage
+        from xagent.web.services import quota_hooks
+
+        task = db_session.query.return_value.filter.return_value.first.return_value
+        task.user_id = 42
+        # Prior-turn state seeded from the DB row.
+        task.input_tokens = 100
+        task.output_tokens = 50
+        task.llm_calls = 1
+        task.token_usage_details = [
+            {"type": "input", "tokens": 100, "model": "m", "call_type": "chat"},
+            {"type": "output", "tokens": 50, "model": "m", "call_type": "chat"},
+        ]
+
+        captured = {}
+
+        def _hook(db, user_id, delta_details, delta_actions):
+            captured.update(
+                user_id=user_id, details=delta_details, actions=delta_actions
+            )
+
+        quota_hooks.set_usage_record_hook(_hook)
+        try:
+            tracker = TaskTracker(task_id=123, db_session=db_session)
+            await tracker.start_tracking()
+            # This turn's usage, appended on top of the seeded baseline.
+            add_token_usage(
+                input_tokens=10, output_tokens=5, model="m", call_type="chat"
+            )
+            add_tool_call_usage(3)
+            await tracker.complete_tracking()
+        finally:
+            quota_hooks.set_usage_record_hook(None)
+
+        assert captured["user_id"] == 42
+        assert captured["actions"] == 3  # only this turn's tool calls (baseline was 0)
+        # Only the two entries appended this turn, not the two seeded ones.
+        assert len(captured["details"]) == 2
+        assert sorted(d["tokens"] for d in captured["details"]) == [5, 10]
+
+    @pytest.mark.asyncio
     async def test_init_task_tracker_with_custom_interval(self, db_session):
         """Test TaskTracker with custom update interval."""
         tracker = TaskTracker(


### PR DESCRIPTION
## Background

xagent-cloud needs per-team quota enforcement (tool-call actions, AI credits, seats, knowledge-base storage). The billable events all happen deep inside the core's execution path, which xagent-cloud cannot intercept from the outside. To keep the billing logic out of the core, this PR exposes a set of **optional hook seams** in the core — following the existing `set_*_hook` idiom (e.g. `set_user_tool_overrides_hook`). The core stays quota-agnostic: it only calls out at the right moments; all team/plan/counter logic lives in xagent-cloud, which registers the callbacks at startup.

**When no hook is registered, every seam is a no-op — stock xagent behaviour is completely unaffected.**

## What's included

- **New `web/services/quota_hooks.py`** — four setter/getter seams:
  - run gate: consulted before a run starts; refuses the run when the team is out of quota
  - post-run usage record: reports this turn's per-model token detail + tool-call delta on completion
  - KB storage gate: consulted before knowledge-base ingest
  - trigger record: counts one action per webhook / scheduled firing

- **Wired at the natural chokepoints** (all fail-open / best-effort — never break execution):
  - `chat.py::execute_task`: consults the gate before starting; on over-quota returns `quota_exceeded` with the reason placed in `output` (surfaced by result consumers as-is). Reuses the fetched `Task` row for the workforce-status sync.
  - `TaskTracker`: reports this turn's usage delta on completion, **before** the token-usage commit, so a transient DB error can't zero-bill the turn
  - `kb.py`: a shared `_enforce_storage_gate` guards both `/ingest` and `/ingest-cloud` so no direct-ingestion path bypasses the storage quota
  - `triggers.py`: counts one action after a webhook/scheduled trigger successfully starts

- **Metering semantics**:
  - `TokenUsage` gains a `tool_calls` field; `on_tool_start` increments it once per tool invocation (**counted on invocation**, not on the tool's self-reported success/failure — the latter is controlled by user-defined MCP tools and could be forged to dodge billing)
  - the usage-record hook receives this turn's **per-model token breakdown** (list of `{type, tokens, model}`), so the application can compute a model-weighted cost — different models cost very differently per token
  - collected via the existing contextvar path; the per-turn delta is read on completion
  - the usage-record hook's **transaction contract** is documented: the hook owns its own durability and must neither rely on nor commit the shared session

- **Incidental fix**: the `token_context` ContextVar default changes from a shared `TokenUsage()` instance to `None` + lazy creation (and `TokenContextManager.__exit__` restores the previous value rather than a fresh instance), preventing unbounded process-global memory growth from untracked paths (preview/builder) accumulating into the shared singleton.

## Testing

Adds tool-call counter tests (sequential + concurrent-batch via `asyncio.gather`); local core tests (runtime / react / dag / task_tracker) pass.

## Impact

8 files, +279/−18, purely additive + hook wiring; no change to any existing execution path's behaviour when hooks are unregistered.
