### PR TITLE
feat(models): add model_id and prompt-cache-hit tokens to usage details

### DIFF
--- a/src/xagent/core/model/chat/basic/adapter.py
+++ b/src/xagent/core/model/chat/basic/adapter.py
@@ -56,7 +56,9 @@ def create_base_llm(
             downstream_resolver=downstream_resolver,
         )
         router.context_window = model.context_window
-        router._model_id = model.id
+        # No _model_id stamp here: RouterLLM delegates every call to a resolved
+        # downstream LLM (which carries its own id), so a value set here would
+        # never reach token-usage details.
         return router
     elif provider == "deepseek":
         llm = DeepSeekLLM(

--- a/src/xagent/core/model/chat/basic/adapter.py
+++ b/src/xagent/core/model/chat/basic/adapter.py
@@ -56,6 +56,7 @@ def create_base_llm(
             downstream_resolver=downstream_resolver,
         )
         router.context_window = model.context_window
+        router._model_id = model.id
         return router
     elif provider == "deepseek":
         llm = DeepSeekLLM(
@@ -156,6 +157,9 @@ def create_base_llm(
         raise TypeError(f"Unsupported LLM model type: {model.model_provider}")
 
     llm.context_window = model.context_window
+    # Stamp the unique model id so token-usage details can disambiguate models
+    # that share a model_name (e.g. a platform model vs a user's own).
+    llm._model_id = model.id
     return create_retry_wrapper(
         llm,
         BaseLLM,  # type: ignore[type-abstract]

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -19,6 +19,10 @@ class BaseLLM(ABC):
     # None means unknown; consumers fall back to their own default.
     context_window: int | None = None
 
+    # Unique model id, set from model config by create_base_llm. Threaded into
+    # token-usage details so identically-named models can be told apart.
+    _model_id: str | None = None
+
     @property
     @abstractmethod
     def abilities(self) -> List[str]:

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -24,6 +24,11 @@ class BaseLLM(ABC):
     _model_id: str | None = None
 
     @property
+    def model_id(self) -> str:
+        """Unique model id (``""`` when unset), for token-usage attribution."""
+        return self._model_id or ""
+
+    @property
     @abstractmethod
     def abilities(self) -> List[str]:
         """

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -632,7 +632,7 @@ class ClaudeLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="chat",
                 )
 
@@ -1017,7 +1017,7 @@ class ClaudeLLM(BaseLLM):
                             add_token_usage(
                                 input_tokens=usage.input_tokens,
                                 model=self._model_name,
-                                model_id=getattr(self, "_model_id", "") or "",
+                                model_id=self.model_id,
                                 call_type="stream_chat",
                             )
 
@@ -1030,7 +1030,7 @@ class ClaudeLLM(BaseLLM):
                             add_token_usage(
                                 output_tokens=usage.output_tokens,
                                 model=self._model_name,
-                                model_id=getattr(self, "_model_id", "") or "",
+                                model_id=self.model_id,
                                 call_type="stream_chat",
                             )
 

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -632,6 +632,7 @@ class ClaudeLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="chat",
                 )
 
@@ -1016,6 +1017,7 @@ class ClaudeLLM(BaseLLM):
                             add_token_usage(
                                 input_tokens=usage.input_tokens,
                                 model=self._model_name,
+                                model_id=getattr(self, "_model_id", "") or "",
                                 call_type="stream_chat",
                             )
 
@@ -1028,6 +1030,7 @@ class ClaudeLLM(BaseLLM):
                             add_token_usage(
                                 output_tokens=usage.output_tokens,
                                 model=self._model_name,
+                                model_id=getattr(self, "_model_id", "") or "",
                                 call_type="stream_chat",
                             )
 

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -491,6 +491,7 @@ class GeminiLLM(BaseLLM):
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         model=self._model_name,
+                        model_id=getattr(self, "_model_id", "") or "",
                         call_type="chat",
                     )
             else:
@@ -728,6 +729,7 @@ class GeminiLLM(BaseLLM):
                             input_tokens=input_tokens,
                             output_tokens=output_tokens,
                             model=self._model_name,
+                            model_id=getattr(self, "_model_id", "") or "",
                             call_type="stream_chat",
                         )
 

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -491,7 +491,7 @@ class GeminiLLM(BaseLLM):
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         model=self._model_name,
-                        model_id=getattr(self, "_model_id", "") or "",
+                        model_id=self.model_id,
                         call_type="chat",
                     )
             else:
@@ -729,7 +729,7 @@ class GeminiLLM(BaseLLM):
                             input_tokens=input_tokens,
                             output_tokens=output_tokens,
                             model=self._model_name,
-                            model_id=getattr(self, "_model_id", "") or "",
+                            model_id=self.model_id,
                             call_type="stream_chat",
                         )
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -373,6 +373,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=resp.usage.prompt_tokens,
                     output_tokens=resp.usage.completion_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="chat",
                 )
 
@@ -695,6 +696,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="chat",
                 )
 
@@ -1030,6 +1032,7 @@ class OpenAICompatibleLLM(BaseLLM):
                             input_tokens=input_tokens,
                             output_tokens=output_tokens,
                             model=self._model_name,
+                            model_id=getattr(self, "_model_id", "") or "",
                             call_type="stream_chat",
                         )
 
@@ -1119,6 +1122,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=raw_chunk.usage.prompt_tokens,
                     output_tokens=raw_chunk.usage.completion_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="stream_chat",
                 )
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -373,7 +373,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=resp.usage.prompt_tokens,
                     output_tokens=resp.usage.completion_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="chat",
                 )
 
@@ -696,7 +696,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="chat",
                 )
 
@@ -1032,7 +1032,7 @@ class OpenAICompatibleLLM(BaseLLM):
                             input_tokens=input_tokens,
                             output_tokens=output_tokens,
                             model=self._model_name,
-                            model_id=getattr(self, "_model_id", "") or "",
+                            model_id=self.model_id,
                             call_type="stream_chat",
                         )
 
@@ -1122,7 +1122,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_tokens=raw_chunk.usage.prompt_tokens,
                     output_tokens=raw_chunk.usage.completion_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="stream_chat",
                 )
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -19,6 +19,29 @@ logger = logging.getLogger(__name__)
 PROVIDER_STATE_METADATA_KEY = "_xagent_provider_state"
 
 
+def _cached_input_tokens(usage: Any) -> int:
+    """Prompt-cache-hit input tokens from an OpenAI-style usage object.
+
+    DeepSeek reports ``prompt_cache_hit_tokens``; OpenAI/DashScope report
+    ``prompt_tokens_details.cached_tokens``. Returns 0 when unavailable.
+    """
+    if usage is None:
+        return 0
+    hit = getattr(usage, "prompt_cache_hit_tokens", None)
+    if hit is not None:
+        try:
+            return int(hit)
+        except (TypeError, ValueError):
+            return 0
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is not None:
+        try:
+            return int(getattr(details, "cached_tokens", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
 def _truncate_error_detail(value: Any, limit: int = 4000) -> str:
     text = (
         value
@@ -374,6 +397,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=resp.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
+                    cached_input_tokens=_cached_input_tokens(resp.usage),
                     call_type="chat",
                 )
 
@@ -697,6 +721,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=response.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
+                    cached_input_tokens=_cached_input_tokens(response.usage),
                     call_type="chat",
                 )
 
@@ -1033,6 +1058,7 @@ class OpenAICompatibleLLM(BaseLLM):
                             output_tokens=output_tokens,
                             model=self._model_name,
                             model_id=self.model_id,
+                            cached_input_tokens=_cached_input_tokens(usage),
                             call_type="stream_chat",
                         )
 
@@ -1123,6 +1149,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     output_tokens=raw_chunk.usage.completion_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
+                    cached_input_tokens=_cached_input_tokens(raw_chunk.usage),
                     call_type="stream_chat",
                 )
 

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -246,7 +246,7 @@ class XinferenceLLM(BaseLLM):
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 model=self._model_name,
-                model_id=getattr(self, "_model_id", "") or "",
+                model_id=self.model_id,
                 call_type="chat",
             )
 
@@ -506,7 +506,7 @@ class XinferenceLLM(BaseLLM):
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 model=self._model_name,
-                model_id=getattr(self, "_model_id", "") or "",
+                model_id=self.model_id,
                 call_type="stream_chat",
             )
 

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -246,6 +246,7 @@ class XinferenceLLM(BaseLLM):
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 model=self._model_name,
+                model_id=getattr(self, "_model_id", "") or "",
                 call_type="chat",
             )
 
@@ -505,6 +506,7 @@ class XinferenceLLM(BaseLLM):
                 input_tokens=usage.get("prompt_tokens", 0),
                 output_tokens=usage.get("completion_tokens", 0),
                 model=self._model_name,
+                model_id=getattr(self, "_model_id", "") or "",
                 call_type="stream_chat",
             )
 

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -234,7 +234,7 @@ class ZhipuLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="chat",
                 )
 
@@ -689,7 +689,7 @@ class ZhipuLLM(BaseLLM):
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         model=self._model_name,
-                        model_id=getattr(self, "_model_id", "") or "",
+                        model_id=self.model_id,
                         call_type="stream_chat",
                     )
 
@@ -860,7 +860,7 @@ class ZhipuLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
-                    model_id=getattr(self, "_model_id", "") or "",
+                    model_id=self.model_id,
                     call_type="vision_chat",
                 )
 

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -234,6 +234,7 @@ class ZhipuLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="chat",
                 )
 
@@ -688,6 +689,7 @@ class ZhipuLLM(BaseLLM):
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
                         model=self._model_name,
+                        model_id=getattr(self, "_model_id", "") or "",
                         call_type="stream_chat",
                     )
 
@@ -858,6 +860,7 @@ class ZhipuLLM(BaseLLM):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
+                    model_id=getattr(self, "_model_id", "") or "",
                     call_type="vision_chat",
                 )
 

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -36,15 +36,25 @@ class TokenUsage:
         return self.input_tokens + self.output_tokens
 
     def add_input_tokens(
-        self, tokens: int, model: str = "", call_type: str = "", model_id: str = ""
+        self,
+        tokens: int,
+        model: str = "",
+        call_type: str = "",
+        model_id: str = "",
+        cached_tokens: int = 0,
     ) -> None:
-        """Add input tokens from a prompt."""
+        """Add input tokens from a prompt.
+
+        ``cached_tokens`` is the subset of ``tokens`` served from the provider's
+        prompt cache (usually billed cheaper); 0 when unknown/unsupported.
+        """
         self.input_tokens += tokens
         if model or call_type:
             self.details.append(
                 {
                     "type": "input",
                     "tokens": tokens,
+                    "cached_tokens": cached_tokens,
                     "model": model,
                     "model_id": model_id,
                     "call_type": call_type,
@@ -202,6 +212,7 @@ def add_token_usage(
     model: str = "",
     call_type: str = "",
     model_id: str = "",
+    cached_input_tokens: int = 0,
 ) -> None:
     """Add token usage to the current context.
 
@@ -211,18 +222,22 @@ def add_token_usage(
         model: Model name for tracking
         call_type: Type of call (chat, stream_chat, vision_chat, etc.)
         model_id: Unique model id (disambiguates identically-named models)
+        cached_input_tokens: Subset of input_tokens served from prompt cache
     """
     # Coerce defensively: a provider/response that yields a non-int token count
     # (or a mock in tests) must never crash the LLM call over accounting.
     input_tokens = _coerce_int(input_tokens)
     output_tokens = _coerce_int(output_tokens)
+    cached_input_tokens = _coerce_int(cached_input_tokens)
 
     usage = get_token_usage()
     if input_tokens or output_tokens:
         # Increment LLM call counter for each API call
         usage.increment_llm_calls()
     if input_tokens:
-        usage.add_input_tokens(input_tokens, model, call_type, model_id)
+        usage.add_input_tokens(
+            input_tokens, model, call_type, model_id, cached_input_tokens
+        )
     if output_tokens:
         usage.add_output_tokens(output_tokens, model, call_type, model_id)
 

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -228,7 +228,7 @@ def add_token_usage(
 
     logger.debug(
         f"Token usage added: input={input_tokens}, output={output_tokens}, "
-        f"model={model}, call_type={call_type}, "
+        f"model={model}, model_id={model_id}, call_type={call_type}, "
         f"total_input={usage.input_tokens}, total_output={usage.output_tokens}, "
         f"total_calls={usage.llm_calls}"
     )

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -36,7 +36,7 @@ class TokenUsage:
         return self.input_tokens + self.output_tokens
 
     def add_input_tokens(
-        self, tokens: int, model: str = "", call_type: str = ""
+        self, tokens: int, model: str = "", call_type: str = "", model_id: str = ""
     ) -> None:
         """Add input tokens from a prompt."""
         self.input_tokens += tokens
@@ -46,12 +46,13 @@ class TokenUsage:
                     "type": "input",
                     "tokens": tokens,
                     "model": model,
+                    "model_id": model_id,
                     "call_type": call_type,
                 }
             )
 
     def add_output_tokens(
-        self, tokens: int, model: str = "", call_type: str = ""
+        self, tokens: int, model: str = "", call_type: str = "", model_id: str = ""
     ) -> None:
         """Add output tokens from a completion."""
         self.output_tokens += tokens
@@ -61,6 +62,7 @@ class TokenUsage:
                     "type": "output",
                     "tokens": tokens,
                     "model": model,
+                    "model_id": model_id,
                     "call_type": call_type,
                 }
             )
@@ -199,6 +201,7 @@ def add_token_usage(
     output_tokens: int = 0,
     model: str = "",
     call_type: str = "",
+    model_id: str = "",
 ) -> None:
     """Add token usage to the current context.
 
@@ -207,6 +210,7 @@ def add_token_usage(
         output_tokens: Number of output tokens
         model: Model name for tracking
         call_type: Type of call (chat, stream_chat, vision_chat, etc.)
+        model_id: Unique model id (disambiguates identically-named models)
     """
     # Coerce defensively: a provider/response that yields a non-int token count
     # (or a mock in tests) must never crash the LLM call over accounting.
@@ -218,9 +222,9 @@ def add_token_usage(
         # Increment LLM call counter for each API call
         usage.increment_llm_calls()
     if input_tokens:
-        usage.add_input_tokens(input_tokens, model, call_type)
+        usage.add_input_tokens(input_tokens, model, call_type, model_id)
     if output_tokens:
-        usage.add_output_tokens(output_tokens, model, call_type)
+        usage.add_output_tokens(output_tokens, model, call_type, model_id)
 
     logger.debug(
         f"Token usage added: input={input_tokens}, output={output_tokens}, "

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -1,6 +1,22 @@
 """Token-usage details carry model_id, disambiguating identically-named models."""
 
+from xagent.core.model import ChatModelConfig
+from xagent.core.model.chat.basic.adapter import create_base_llm
 from xagent.core.model.chat.token_context import TokenContextManager, add_token_usage
+
+
+def test_create_base_llm_stamps_model_id():
+    """create_base_llm stamps ChatModelConfig.id so adapters report it."""
+    config = ChatModelConfig(
+        id="deepseek-plat-abc",
+        model_provider="deepseek",
+        model_name="deepseek-v4-flash",
+        api_key="test-api-key",
+    )
+    llm = create_base_llm(config)
+    # The retry wrapper delegates attribute access to the inner LLM.
+    assert llm._inner.model_id == "deepseek-plat-abc"
+    assert llm.model_id == "deepseek-plat-abc"
 
 
 def test_add_token_usage_records_model_id():

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -42,3 +42,41 @@ def test_model_id_defaults_empty_when_absent():
         details = mgr.get_usage().details
 
     assert details[0]["model_id"] == ""
+    assert details[0]["cached_tokens"] == 0
+
+
+def test_add_token_usage_records_cached_tokens():
+    with TokenContextManager() as mgr:
+        add_token_usage(
+            input_tokens=100,
+            model="m",
+            model_id="platform/x",
+            call_type="chat",
+            cached_input_tokens=40,
+        )
+        details = mgr.get_usage().details
+
+    inp = next(d for d in details if d["type"] == "input")
+    assert inp["tokens"] == 100
+    assert inp["cached_tokens"] == 40
+
+
+def test_cached_input_tokens_helper():
+    from xagent.core.model.chat.basic.openai import _cached_input_tokens
+
+    class DeepSeekUsage:
+        prompt_cache_hit_tokens = 30
+
+    class Details:
+        cached_tokens = 25
+
+    class OpenAIUsage:
+        prompt_tokens_details = Details()
+
+    class NoCache:
+        pass
+
+    assert _cached_input_tokens(DeepSeekUsage()) == 30  # deepseek field
+    assert _cached_input_tokens(OpenAIUsage()) == 25  # openai/dashscope field
+    assert _cached_input_tokens(NoCache()) == 0
+    assert _cached_input_tokens(None) == 0

--- a/tests/core/model/chat/test_token_usage_model_id.py
+++ b/tests/core/model/chat/test_token_usage_model_id.py
@@ -1,0 +1,28 @@
+"""Token-usage details carry model_id, disambiguating identically-named models."""
+
+from xagent.core.model.chat.token_context import TokenContextManager, add_token_usage
+
+
+def test_add_token_usage_records_model_id():
+    with TokenContextManager() as mgr:
+        add_token_usage(
+            input_tokens=10,
+            output_tokens=5,
+            model="deepseek-v4-flash",
+            model_id="platform-ds",
+            call_type="chat",
+        )
+        details = mgr.get_usage().details
+
+    by_type = {d["type"]: d for d in details}
+    assert by_type["input"]["model_id"] == "platform-ds"
+    assert by_type["input"]["model"] == "deepseek-v4-flash"
+    assert by_type["output"]["model_id"] == "platform-ds"
+
+
+def test_model_id_defaults_empty_when_absent():
+    with TokenContextManager() as mgr:
+        add_token_usage(input_tokens=3, model="m", call_type="chat")
+        details = mgr.get_usage().details
+
+    assert details[0]["model_id"] == ""


### PR DESCRIPTION
## What
Token usage details now carry, per model call:
- the model's unique `model_id` (alongside its `model_name`), and
- the prompt-cache-hit subset of input tokens (`cached_tokens`).

## Why
Usage details only had `model_name`. When the same base model is configured
more than once — the same model served through different channels or API keys —
those entries are indistinguishable, so per-model usage accounting or cost
statistics can't attribute them correctly; `model_id` is the unique identifier
that tells them apart. Separately, providers bill cache-hit input tokens far
cheaper than uncached ones, so recording the cache-hit count lets cost
accounting reflect that instead of overcounting input.

## How
- `create_base_llm` stamps `llm._model_id = model.id` (common path); the
  auto-router's downstream target keeps its own id. `BaseLLM.model_id` exposes it.
- `add_token_usage` gains optional `model_id` and `cached_input_tokens`, threaded
  into each usage detail entry.
- The OpenAI-family adapter reads the cache-hit count from the provider usage
  (DeepSeek `prompt_cache_hit_tokens`; OpenAI/DashScope
  `prompt_tokens_details.cached_tokens`), so every `OpenAILLM` subclass
  (DeepSeek, DashScope, OpenRouter, Azure) is covered in one place.

## Compatibility
Purely additive. New fields default to `""` / `0`; the existing `model` (name)
field is unchanged and name-based consumers keep working.

## Tests
`tests/core/model/chat/test_token_usage_model_id.py` — model_id lands in details
and defaults to empty; cached_tokens is recorded; the cache-hit extraction
helper reads both provider field shapes; plus `create_base_llm` stamping.
